### PR TITLE
Implement Rule 712.8a

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CantBeCounteredComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
@@ -188,6 +189,39 @@ abstract class ScenarioTestBase : FunSpec() {
                 val staticHandler = StaticAbilityHandler(cardRegistry)
                 container = staticHandler.addContinuousEffectComponent(container, cardDef)
                 container = staticHandler.addReplacementEffectComponent(container, cardDef)
+
+                // Rule 712.8a: if placing a DFC back face directly on the battlefield, add
+                // DoubleFacedComponent with the saved front-face card so ZoneTransitionService
+                // can restore it when the entity leaves.
+                val frontFaceDef = cardRegistry.getFrontFace(cardName)
+                if (frontFaceDef != null) {
+                    val frontFaceCard = state.getEntity(cardId)?.get<CardComponent>()?.let {
+                        CardComponent(
+                            cardDefinitionId = frontFaceDef.name,
+                            name = frontFaceDef.name,
+                            manaCost = frontFaceDef.manaCost,
+                            typeLine = frontFaceDef.typeLine,
+                            oracleText = frontFaceDef.oracleText,
+                            colors = frontFaceDef.colors,
+                            baseKeywords = frontFaceDef.keywords,
+                            baseFlags = frontFaceDef.flags,
+                            baseStats = frontFaceDef.creatureStats,
+                            ownerId = it.ownerId,
+                            spellEffect = frontFaceDef.spellEffect,
+                            imageUri = frontFaceDef.metadata.imageUri,
+                        )
+                    }
+                    if (frontFaceCard != null) {
+                        container = container.with(
+                            DoubleFacedComponent(
+                                frontCardDefinitionId = frontFaceDef.name,
+                                backCardDefinitionId = cardName,
+                                currentFace = DoubleFacedComponent.Face.BACK,
+                                frontFaceCard = frontFaceCard
+                            )
+                        )
+                    }
+                }
             }
 
             state = state.withEntity(cardId, container)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/GrubStoriedMatriarchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/GrubStoriedMatriarchScenarioTest.kt
@@ -77,6 +77,96 @@ class GrubStoriedMatriarchScenarioTest : ScenarioTestBase() {
                     game.state.grantedTriggeredAbilities.any { it.entityId == tokenCopy } shouldBe true
                 }
             }
+
+            test("Grub, Notorious Auntie transforms to Grub, Storied Matriarch when returned to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grub, Notorious Auntie", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Island", tapped = false) // Mana source
+                    .withCardOnBattlefield(1, "Island", tapped = false) // Another mana source
+                    .withCardInHand(1, "Force Away")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val grubEntity = game.findPermanent("Grub, Notorious Auntie")!!
+
+                // Cast Force Away to return Grub to hand (auto-pay mana)
+                val castResult = game.castSpell(1, "Force Away", grubEntity)
+                withClue("Force Away cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                // Check that Grub is now in hand as Grub, Storied Matriarch (front face)
+                val handCards = game.state.getHand(game.player1Id)
+                val handCardNames = handCards.map { entityId ->
+                    val card = game.state.getEntity(entityId)?.get<CardComponent>()
+                    card?.name ?: "Unknown"
+                }
+                println("Cards in hand: $handCardNames")
+                println("Number of cards in hand: ${handCards.size}")
+                handCards.forEach { entityId ->
+                    val card = game.state.getEntity(entityId)?.get<CardComponent>()
+                    println("Card entity $entityId: $card")
+                }
+                
+                val grubInHand = handCards.find { entityId ->
+                    val card = game.state.getEntity(entityId)?.get<CardComponent>()
+                    card?.name == "Grub, Storied Matriarch"
+                }
+                withClue("Grub should be in hand as Grub, Storied Matriarch (front face). Found cards: $handCardNames") {
+                    grubInHand.shouldNotBeNull()
+                }
+            }
+
+            test("Grub, Notorious Auntie transforms to Grub, Storied Matriarch when going to graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grub, Notorious Auntie", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Plains", tapped = false) // Mana source for Protective Response
+                    .withCardOnBattlefield(2, "Plains", tapped = false) // Another mana source
+                    .withCardOnBattlefield(2, "Plains", tapped = false) // Third mana source
+                    .withCardInHand(2, "Protective Response")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1) // Start with player 1 so they can attack
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val grubEntity = game.findPermanent("Grub, Notorious Auntie")!!
+
+                // First, make Grub an attacking creature so Protective Response can target it
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attackResult = game.declareAttackers(mapOf("Grub, Notorious Auntie" to 2))
+                withClue("Attack declaration should succeed: ${attackResult.error}") {
+                    attackResult.error shouldBe null
+                }
+
+                // Pass priority to player 2 so they can cast spells
+                game.passPriority()
+
+                // Cast Protective Response to destroy Grub (it's now attacking, auto-pay mana)
+                val castResult = game.castSpell(2, "Protective Response", grubEntity)
+                withClue("Protective Response cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                // Check that Grub is now in graveyard as Grub, Storied Matriarch (front face)
+                val graveyardCards = game.state.getGraveyard(game.player1Id)
+                val grubInGraveyard = graveyardCards.find { entityId ->
+                    val card = game.state.getEntity(entityId)?.get<CardComponent>()
+                    card?.name == "Grub, Storied Matriarch"
+                }
+                withClue("Grub should be in graveyard as Grub, Storied Matriarch (front face)") {
+                    grubInGraveyard.shouldNotBeNull()
+                }
+            }
         }
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lorwyneclipsed/cards/GrubStoriedMatriarch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lorwyneclipsed/cards/GrubStoriedMatriarch.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.effects.AddCountersToCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.Chooser

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.battlefield.*
 import com.wingedsheep.engine.state.components.combat.*
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
@@ -237,6 +238,21 @@ object ZoneTransitionService {
             else -> {
                 // HAND, GRAVEYARD, STACK — simple addToZone
                 newState = newState.addToZone(destZoneKey, entityId)
+            }
+        }
+
+        // 7b. Rule 712.8a: while a DFC is in a zone other than the battlefield or stack, it has
+        // only the characteristics of its front face. Restore the saved front-face CardComponent.
+        if (actualDestZone != Zone.BATTLEFIELD && actualDestZone != Zone.STACK) {
+            val entityContainer = newState.getEntity(entityId)
+            if (entityContainer != null) {
+                val dfc = entityContainer.get<DoubleFacedComponent>()
+                if (dfc != null && dfc.isBack && dfc.frontFaceCard != null) {
+                    newState = newState.updateEntity(entityId) { c ->
+                        c.with(dfc.frontFaceCard)
+                            .with(dfc.copy(currentFace = DoubleFacedComponent.Face.FRONT, frontFaceCard = null))
+                    }
+                }
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
@@ -74,10 +74,18 @@ class TransformEffectExecutor(
 
         val controllerId = container.get<ControllerComponent>()?.playerId ?: context.controllerId
 
+        // Rule 712.8a: save the front face card so ZoneTransitionService can restore it
+        // without a registry lookup when the DFC leaves the battlefield on its back face.
+        val updatedDfc = if (intoBackFace) {
+            dfc.copy(currentFace = nextFace, frontFaceCard = currentCard)
+        } else {
+            dfc.copy(currentFace = nextFace, frontFaceCard = null)
+        }
+
         val newState = state.updateEntity(targetId) { c ->
             var updated = c
                 .with(swappedCard)
-                .with(dfc.copy(currentFace = nextFace))
+                .with(updatedDfc)
                 // Strip stale static-ability effect components so the layer projector stops
                 // applying the old face's static abilities on the very next projection.
                 .without<ContinuousEffectSourceComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/CardRegistry.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/CardRegistry.kt
@@ -19,6 +19,8 @@ class CardRegistry {
     private val cardsByName = mutableMapOf<String, CardDefinition>()
     // Secondary index: "CardName#CollectorNumber" -> CardDefinition (for variants like basic lands)
     private val cardsByNameAndNumber = mutableMapOf<String, CardDefinition>()
+    // Reverse DFC index: back face name -> front face name
+    private val backFaceToFrontFace = mutableMapOf<String, String>()
 
     /**
      * Register a single card definition.
@@ -49,6 +51,8 @@ class CardRegistry {
             if (!cardsByName.containsKey(backFace.name)) {
                 cardsByName[backFace.name] = backFace
             }
+            // Track the reverse mapping so scenario builders can find the front face.
+            backFaceToFrontFace[backFace.name] = card.name
         }
     }
 
@@ -117,10 +121,19 @@ class CardRegistry {
     val size: Int get() = cardsByName.size
 
     /**
+     * Look up the front face of a DFC given its back face name.
+     * Returns null if the name is not a registered back face.
+     */
+    fun getFrontFace(backFaceName: String): CardDefinition? {
+        return backFaceToFrontFace[backFaceName]?.let { cardsByName[it] }
+    }
+
+    /**
      * Clear all registered cards.
      */
     fun clear() {
         cardsByName.clear()
         cardsByNameAndNumber.clear()
+        backFaceToFrontFace.clear()
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/DoubleFacedComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/DoubleFacedComponent.kt
@@ -12,9 +12,11 @@ import kotlinx.serialization.Serializable
  * counters/damage/attachments/controller persist, and only the identity characteristics
  * (name, type line, P/T, keywords, colors, oracle text, abilities) change.
  *
- * Rule 712.4: "A double-faced card that is outside the battlefield is considered to have
- * only the characteristics of its front face." If a DFC leaves the battlefield while on its
- * back face, it is reset to its front face.
+ * Rule 712.8a: while a double-faced card is outside the game or in a zone other than the
+ * battlefield or stack, it has only the characteristics of its front face. [frontFaceCard]
+ * stores the saved front-face [CardComponent] so
+ * [com.wingedsheep.engine.handlers.effects.ZoneTransitionService] can restore it without
+ * needing a registry lookup.
  */
 @Serializable
 data class DoubleFacedComponent(
@@ -23,7 +25,9 @@ data class DoubleFacedComponent(
     /** Card definition id of the back face. */
     val backCardDefinitionId: String,
     /** Which face is currently up. */
-    val currentFace: Face = Face.FRONT
+    val currentFace: Face = Face.FRONT,
+    /** Saved front-face card data used to restore Rule 712.8a when leaving the battlefield. */
+    val frontFaceCard: CardComponent? = null
 ) : Component {
     @Serializable
     enum class Face { FRONT, BACK }


### PR DESCRIPTION
712.8a While a double-faced card is outside the game or in a zone other than the battlefield or stack, it has only the characteristics of its front face.

Fixes: https://github.com/wingedsheep/argentum-engine/issues/21