### PR TITLE
Add Sacrificed trigger for self-sacrifice detection

### DIFF
--- a/manual-scenarios/cards/h/heaped-harvest-test.json
+++ b/manual-scenarios/cards/h/heaped-harvest-test.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Naturalize", "Naturalize"],
+    "battlefield": [
+      {"name": "Heaped Harvest"},
+      {"name": "Heaped Harvest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Naturalize", "Naturalize"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -999,6 +999,16 @@ object Triggers {
         binding = TriggerBinding.ANY
     )
 
+    /**
+     * When you sacrifice this permanent.
+     * Distinct from [PutIntoGraveyardFromBattlefield] / [Dies], which fire on any
+     * battlefield-to-graveyard transition (including destruction).
+     */
+    val Sacrificed: TriggerSpec = TriggerSpec(
+        event = PermanentsSacrificedEvent(),
+        binding = TriggerBinding.SELF
+    )
+
     // =========================================================================
     // Leave Battlefield Without Dying Triggers
     // =========================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bloomburrow/cards/HeapedHarvest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bloomburrow/cards/HeapedHarvest.kt
@@ -18,10 +18,6 @@ import com.wingedsheep.sdk.scripting.effects.MayEffect
  * When this artifact enters and when you sacrifice it, you may search your
  * library for a basic land card, put it onto the battlefield tapped, then shuffle.
  * {2}, {T}, Sacrifice this artifact: You gain 3 life.
- *
- * Note: The "when you sacrifice it" trigger is approximated using
- * PutIntoGraveyardFromBattlefield (also fires on destruction, a minor
- * simplification vs. sacrifice-only).
  */
 val HeapedHarvest = card("Heaped Harvest") {
     manaCost = "{2}{G}"
@@ -44,9 +40,8 @@ val HeapedHarvest = card("Heaped Harvest") {
     }
 
     // When you sacrifice it, you may search for a basic land
-    // (approximated as "when put into graveyard from battlefield")
     triggeredAbility {
-        trigger = Triggers.PutIntoGraveyardFromBattlefield
+        trigger = Triggers.Sacrificed
         effect = MayEffect(
             EffectPatterns.searchLibrary(
                 filter = GameObjectFilter.BasicLand,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1101,10 +1101,16 @@ class TriggerDetector(
     }
 
     /**
-     * Detect "whenever you sacrifice one or more [permanents]" batching triggers.
+     * Detect "whenever you sacrifice one or more [permanents]" batching triggers
+     * (ANY binding) and "when you sacrifice this" self-targeted triggers (SELF binding).
      *
-     * Groups PermanentsSacrificedEvent by controller and fires the trigger at most once
-     * per controller, regardless of how many sacrifice events occurred.
+     * For ANY binding: groups PermanentsSacrificedEvent by controller and fires the
+     * trigger at most once per controller, regardless of how many sacrifice events
+     * occurred.
+     *
+     * For SELF binding: fires once per sacrificed permanent that has a matching trigger.
+     * The source has already moved to the graveyard by the time detection runs, so it
+     * is not in the trigger index — abilities are looked up directly by card definition.
      */
     private fun detectSacrificeBatchTriggers(
         state: GameState,
@@ -1121,11 +1127,12 @@ class TriggerDetector(
         }
         if (sacrificeByController.isEmpty()) return
 
-        // Check battlefield permanents with sacrifice batch triggers
+        // ANY binding: check battlefield permanents with sacrifice batch triggers
         for (entry in index.getEntitiesForCategory(TriggerCategory.SACRIFICE)) {
             for (ability in entry.abilities) {
                 val trigger = ability.trigger
                 if (trigger !is GameEvent.PermanentsSacrificedEvent) continue
+                if (ability.binding != TriggerBinding.ANY) continue
 
                 // This trigger watches the controller's own sacrifices
                 val controllerId = entry.controllerId
@@ -1134,23 +1141,7 @@ class TriggerDetector(
                 // Check if any of the sacrificed permanents match the filter
                 val hasMatch = controllerEvents.any { event ->
                     event.permanentIds.any { permanentId ->
-                        if (trigger.filter == GameObjectFilter.Any) return@any true
-                        // Look up the entity (should be in graveyard or still accessible)
-                        val entity = state.getEntity(permanentId)
-                        val cardComponent = entity?.get<CardComponent>()
-                        if (cardComponent != null) {
-                            trigger.filter.cardPredicates.all { predicate ->
-                                when (predicate) {
-                                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->
-                                        cardComponent.typeLine.isCreature
-                                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact ->
-                                        cardComponent.typeLine.isArtifact
-                                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
-                                        cardComponent.typeLine.hasSubtype(predicate.subtype)
-                                    else -> true
-                                }
-                            }
-                        } else false
+                        sacrificedPermanentMatchesFilter(state, permanentId, trigger.filter)
                     }
                 }
 
@@ -1165,6 +1156,60 @@ class TriggerDetector(
                         )
                     )
                 }
+            }
+        }
+
+        // SELF binding: source has left the battlefield, so it isn't in the index.
+        // Look up triggered abilities directly from each sacrificed permanent.
+        for ((controllerId, controllerEvents) in sacrificeByController) {
+            for (event in controllerEvents) {
+                for (permanentId in event.permanentIds) {
+                    val container = state.getEntity(permanentId) ?: continue
+                    if (container.has<FaceDownComponent>()) continue
+                    val cardComponent = container.get<CardComponent>() ?: continue
+
+                    val abilities = abilityResolver.getTriggeredAbilities(
+                        permanentId, cardComponent.cardDefinitionId, state
+                    )
+                    for (ability in abilities) {
+                        if (ability.binding != TriggerBinding.SELF) continue
+                        val trigger = ability.trigger
+                        if (trigger !is GameEvent.PermanentsSacrificedEvent) continue
+                        if (ability.activeZone != Zone.BATTLEFIELD) continue
+                        if (!sacrificedPermanentMatchesFilter(state, permanentId, trigger.filter)) continue
+
+                        triggers.add(
+                            PendingTrigger(
+                                ability = ability,
+                                sourceId = permanentId,
+                                sourceName = cardComponent.name,
+                                controllerId = controllerId,
+                                triggerContext = TriggerContext()
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun sacrificedPermanentMatchesFilter(
+        state: GameState,
+        permanentId: EntityId,
+        filter: GameObjectFilter
+    ): Boolean {
+        if (filter == GameObjectFilter.Any) return true
+        val entity = state.getEntity(permanentId) ?: return false
+        val cardComponent = entity.get<CardComponent>() ?: return false
+        return filter.cardPredicates.all { predicate ->
+            when (predicate) {
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->
+                    cardComponent.typeLine.isCreature
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact ->
+                    cardComponent.typeLine.isArtifact
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
+                    cardComponent.typeLine.hasSubtype(predicate.subtype)
+                else -> true
             }
         }
     }


### PR DESCRIPTION
Introduces Triggers.Sacrificed (SELF-bound PermanentsSacrificedEvent) to distinguish "when you sacrifice this" from generic graveyard transitions (destruction, death, etc.). Previously, Heaped Harvest approximated this with PutIntoGraveyardFromBattlefield, which also fired on destruction.

- Add Triggers.Sacrificed constant in mtg-sdk/dsl/Triggers.kt
- Wire SELF binding support in TriggerDetector.detectSacrificeBatchTriggers() by looking up triggered abilities directly on sacrificed permanents (which have moved to graveyard and are no longer in TriggerIndex)
- Update HeapedHarvest to use the new trigger

Fixes the semantic difference between sacrifice and destruction.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Fixes #44 