### PR TITLE
Implement some of the cards in Standard G Landfall

### DIFF
--- a/manual-scenarios/cards/s/springbloom-druid-test.json
+++ b/manual-scenarios/cards/s/springbloom-druid-test.json
@@ -1,0 +1,33 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Springbloom Druid", "Springbloom Druid"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/FoundationsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/FoundationsSet.kt
@@ -24,5 +24,6 @@ object FoundationsSet {
      */
     val allCards = listOf(
         Negate,
+        SpringbloomDruid,
     )
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/FoundationsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/FoundationsSet.kt
@@ -24,6 +24,7 @@ object FoundationsSet {
      */
     val allCards = listOf(
         Negate,
+        SnakeskinVeil,
         SpringbloomDruid,
     )
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/FoundationsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/FoundationsSet.kt
@@ -24,6 +24,7 @@ object FoundationsSet {
      */
     val allCards = listOf(
         Bushwhack,
+        MossbornHydra,
         Negate,
         SnakeskinVeil,
         SpringbloomDruid,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/FoundationsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/FoundationsSet.kt
@@ -23,6 +23,7 @@ object FoundationsSet {
      * All cards implemented from this set.
      */
     val allCards = listOf(
+        Bushwhack,
         Negate,
         SnakeskinVeil,
         SpringbloomDruid,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/cards/Bushwhack.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/cards/Bushwhack.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.foundations.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Bushwhack
+ * {G}
+ * Sorcery
+ * Choose one —
+ * • Search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+ * • Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)
+ */
+val Bushwhack = card("Bushwhack") {
+    manaCost = "{G}"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n" +
+        "• Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)"
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Search your library for a basic land card, reveal it, put it into your hand, then shuffle") {
+                effect = EffectPatterns.searchLibrary(
+                    filter = GameObjectFilter.BasicLand,
+                    count = 1,
+                    destination = SearchDestination.HAND,
+                    reveal = true,
+                    shuffleAfter = true
+                )
+            }
+            mode("Target creature you control fights target creature you don't control") {
+                val yourCreature = target("creature you control", TargetCreature(
+                    filter = TargetFilter(GameObjectFilter.Creature.youControl())
+                ))
+                val theirCreature = target("creature you don't control", TargetCreature(
+                    filter = TargetFilter(GameObjectFilter.Creature.opponentControls())
+                ))
+                effect = Effects.Fight(yourCreature, theirCreature)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "215"
+        artist = "Artur Nakhodkin"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03ebdb36-55e0-49dd-a514-785fbeb4ae19.jpg?1730489398"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/cards/MossbornHydra.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/cards/MossbornHydra.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.foundations.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Mossborn Hydra
+ * {2}{G}
+ * Creature — Elemental Hydra
+ * 0/0
+ * Trample
+ * This creature enters with a +1/+1 counter on it.
+ * Landfall — Whenever a land you control enters, double the number of +1/+1 counters on this creature.
+ */
+val MossbornHydra = card("Mossborn Hydra") {
+    manaCost = "{2}{G}"
+    typeLine = "Creature — Elemental Hydra"
+    power = 0
+    toughness = 0
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nThis creature enters with a +1/+1 counter on it.\nLandfall — Whenever a land you control enters, double the number of +1/+1 counters on this creature."
+
+    keywords(Keyword.TRAMPLE)
+
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 1,
+        selfOnly = true
+    ))
+
+    // Landfall: double +1/+1 counters on this creature
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            amount = DynamicAmount.EntityProperty(
+                EntityReference.Source,
+                EntityNumericProperty.CounterCount(CounterTypeFilter.PlusOnePlusOne)
+            ),
+            target = EffectTarget.Self
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "107"
+        artist = "Monztre"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/7054a0d7-396f-40b4-ab24-db591c3b08f0.jpg?1730488992"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/cards/SnakeskinVeil.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/cards/SnakeskinVeil.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.foundations.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+
+/**
+ * Snakeskin Veil
+ * {G}
+ * Instant
+ * Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)
+ */
+val SnakeskinVeil = card("Snakeskin Veil") {
+    manaCost = "{G}"
+    typeLine = "Instant"
+    oracleText = "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)"
+
+    spell {
+        val target = target("target creature you control", Targets.CreatureYouControl)
+        effect = CompositeEffect(listOf(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, target),
+            Effects.GrantKeyword(Keyword.HEXPROOF, target)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Dan Murayama Scott"
+        flavorText = "Most travelers panic when they stumble upon the skin of a giant rattlewurm. Landry saw it as a gift."
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6cc4c21d-9bdc-4490-9203-17f51db0ddd1.jpg?1730489471"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/cards/SpringbloomDruid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/foundations/cards/SpringbloomDruid.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.foundations.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Springbloom Druid
+ * {2}{G}
+ * Creature — Elf Druid
+ * 1/1
+ * When this creature enters, you may sacrifice a land. If you do, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.
+ */
+val SpringbloomDruid = card("Springbloom Druid") {
+    manaCost = "{2}{G}"
+    typeLine = "Creature — Elf Druid"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, you may sacrifice a land. If you do, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Effects.Sacrifice(GameObjectFilter.Land, count = 1, target = EffectTarget.Controller)
+                .then(EffectPatterns.searchLibrary(
+                    filter = GameObjectFilter.BasicLand,
+                    count = 2,
+                    destination = SearchDestination.BATTLEFIELD,
+                    entersTapped = true,
+                    shuffleAfter = true
+                ))
+        )
+        description = "When this creature enters, you may sacrifice a land. If you do, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "646"
+        artist = "Randy Gallegos"
+        flavorText = "\"New growth applies a healing poultice to wounds long scabbed over.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa87cb5f-4dc9-49a4-9ae6-ebc7fedac018.jpg?1730491047"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/MurdersAtKarlovManorSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/MurdersAtKarlovManorSet.kt
@@ -16,6 +16,7 @@ object MurdersAtKarlovManorSet {
     val allCards = listOf(
         CommercialDistrict,
         ElegantParlor,
+        HardHittingQuestion,
         HedgeMaze,
         LushPortico,
         MeticulousArchive,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/MurdersAtKarlovManorSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/MurdersAtKarlovManorSet.kt
@@ -16,6 +16,7 @@ object MurdersAtKarlovManorSet {
     val allCards = listOf(
         CommercialDistrict,
         ElegantParlor,
+        EscapeTunnel,
         HardHittingQuestion,
         HedgeMaze,
         LushPortico,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EscapeTunnel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EscapeTunnel.kt
@@ -27,7 +27,7 @@ val EscapeTunnel = card("Escape Tunnel") {
             Costs.SacrificeSelf
         )
         effect = EffectPatterns.searchLibrary(
-            filter = GameObjectFilter.Land,
+            filter = GameObjectFilter.BasicLand,
             count = 1,
             destination = SearchDestination.BATTLEFIELD,
             entersTapped = true,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EscapeTunnel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EscapeTunnel.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Escape Tunnel
+ * Land
+ * {T}, Sacrifice this land: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
+ * {T}, Sacrifice this land: Target creature with power 2 or less can't be blocked this turn.
+ */
+val EscapeTunnel = card("Escape Tunnel") {
+    typeLine = "Land"
+    oracleText = "{T}, Sacrifice this land: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n{T}, Sacrifice this land: Target creature with power 2 or less can't be blocked this turn."
+
+    // First ability: Search for basic land
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.Land,
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true,
+            reveal = true,
+            shuffleAfter = true
+        )
+        manaAbility = false
+        description = "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle."
+    }
+
+    // Second ability: Make creature unblockable
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        val target = target("target creature with power 2 or less", Targets.CreatureWithPowerAtMost(2))
+        effect = GrantKeywordEffect(AbilityFlag.CANT_BE_BLOCKED.name, target)
+        manaAbility = false
+        description = "Target creature with power 2 or less can't be blocked this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "261"
+        artist = "Carlos Palma Cruchaga"
+        flavorText = "No self-respecting criminal has a basement with only one exit."
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/93ddde4f-d35e-4128-8f43-d0eadbd715de.jpg?1706242339"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HardHittingQuestion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HardHittingQuestion.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Hard-Hitting Question
+ * {G}
+ * Sorcery
+ * Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.
+ */
+val HardHittingQuestion = card("Hard-Hitting Question") {
+    manaCost = "{G}"
+    typeLine = "Sorcery"
+    oracleText = "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control."
+
+    spell {
+        val myCreature = target("creature you control", Targets.CreatureYouControl)
+        val theirTarget = target("creature or planeswalker you don't control", TargetPermanent(
+            filter = TargetFilter(com.wingedsheep.sdk.scripting.GameObjectFilter.CreatureOrPlaneswalker.opponentControls())
+        ))
+        effect = DealDamageEffect(
+            amount = DynamicAmount.EntityProperty(
+                EntityReference.Target(0),
+                EntityNumericProperty.Power
+            ),
+            target = theirTarget,
+            damageSource = myCreature
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "164"
+        artist = "Nicholas Gregory"
+        flavorText = "\"Keen eyes and an analytical mind are some of a detective's most important tools. As is a mean left hook.\"\n—Senior Inspector Holjo"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8ad807c2-14a7-4464-bf57-c323fb3c0bd0.jpg?1706242021"
+    }
+}


### PR DESCRIPTION
Decklist:
14 Forest
4 Llanowar Elves
1 Evolving Wilds
4 Fabled Passage
2 Springbloom Druid
3 Snakeskin Veil
2 Bushwhack
3 Hard-Hitting Question
4 Escape Tunnel
4 Mossborn Hydra

Missing cards:
4 Ordeal of Nylea
3 Bristly Bill, Spine Sower
4 Sazh's Chocobo
4 Tifa Lockhart
4 Traveling Chocobo
