### PR TITLE
Ordeal of Nylea (FDN) — fix counter placement and sacrifice trigger

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/OrdealOfNyleaScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/OrdealOfNyleaScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Ordeal of Nylea.
+ *
+ * Card reference:
+ * - Ordeal of Nylea ({1}{G}): Enchantment — Aura
+ *   "Enchant creature"
+ *   "Whenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice this Aura."
+ *   "When you sacrifice this Aura, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle."
+ */
+class OrdealOfNyleaScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Ordeal of Nylea basic functionality") {
+            test("enchanted creature gets +1/+1 counter when attacking") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Ordeal of Nylea")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 creature
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast Ordeal of Nylea targeting Grizzly Bears
+                val grizzlyBearsID = game.findPermanent("Grizzly Bears")!!
+                val castResult = game.castSpell(1, "Ordeal of Nylea", grizzlyBearsID)
+                withClue("Cast should succeed") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Advance to combat
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                // Attack with Grizzly Bears
+                val attackResult = game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                withClue("Declaring Grizzly Bears as attacker should succeed") {
+                    attackResult.error shouldBe null
+                }
+
+                // Trigger should fire and resolve
+                game.resolveStack()
+
+                // Advance through combat
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                // Check if Grizzly Bears has a +1/+1 counter
+                val grizzlyBearsAfter = game.findPermanent("Grizzly Bears")!!
+                val counters = game.state.getEntity(grizzlyBearsAfter)?.get<CountersComponent>()
+                counters shouldNotBe null
+                counters!!.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+            }
+
+        }
+    }
+}

--- a/manual-scenarios/cards/o/ordeal-of-nylea-test.json
+++ b/manual-scenarios/cards/o/ordeal-of-nylea-test.json
@@ -1,0 +1,89 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears",
+      "Ordeal of Nylea",
+      "Biosynthic Burst",
+      "Biosynthic Burst",
+      "Biosynthic Burst"
+    ],
+    "battlefield": [
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Ordeal of Nylea",
+        "attachedTo": "Grizzly Bears"
+      },
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
@@ -28,6 +28,7 @@ object FoundationsSet : MtgSet {
         Bushwhack,
         MossbornHydra,
         Negate,
+        OrdealOfNylea,
         SnakeskinVeil,
         SpringbloomDruid,
     )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/OrdealOfNylea.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/OrdealOfNylea.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.foundations.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ordeal of Nylea
+ * {1}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * Whenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice this Aura.
+ * When you sacrifice this Aura, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.
+ */
+val OrdealOfNylea = card("Ordeal of Nylea") {
+    manaCost = "{1}{G}"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice this Aura.\nWhen you sacrifice this Aura, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle."
+
+    // Aura target
+    auraTarget = Targets.Creature
+
+    // Whenever enchanted creature attacks, put a +1/+1 counter on it.
+    // Then if it has three or more +1/+1 counters on it, sacrifice this Aura.
+    triggeredAbility {
+        trigger = Triggers.EnchantedCreatureAttacks
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.EnchantedCreature) then
+            ConditionalEffect(
+                condition = Compare(
+                    left = DynamicAmount.EntityProperty(
+                        entity = EntityReference.Triggering,
+                        numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.PLUS_ONE_PLUS_ONE))
+                    ),
+                    operator = ComparisonOperator.GTE,
+                    right = DynamicAmount.Fixed(3)
+                ),
+                effect = Effects.SacrificeTarget(EffectTarget.Self)
+            )
+        description = "Whenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice this Aura."
+    }
+
+    // When you sacrifice this Aura, search your library for up to two basic land cards,
+    // put them onto the battlefield tapped, then shuffle.
+    triggeredAbility {
+        trigger = Triggers.Sacrificed
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            count = 2,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true,
+            shuffleAfter = true
+        )
+        description = "When you sacrifice this Aura, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "641"
+        artist = "David Palumbo"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a70424d-86a7-44a3-acda-4463d7ac503b.jpg?1730491029"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersExecutor.kt
@@ -27,7 +27,7 @@ class AddCountersExecutor : EffectExecutor<AddCountersEffect> {
         effect: AddCountersEffect,
         context: EffectContext
     ): EffectResult {
-        val targetId = context.resolveTarget(effect.target)
+        val targetId = context.resolveTarget(effect.target, state)
             ?: return EffectResult.error(state, "No valid target for counters")
 
         if (state.projectedState.hasKeyword(targetId, AbilityFlag.CANT_RECEIVE_COUNTERS)) {


### PR DESCRIPTION
Fix two bugs found during implementation:

1. AddCountersExecutor used the stateless context.resolveTarget() overload, which returns null for EffectTarget.EnchantedCreature (needs AttachedToComponent lookup). Switch to context.resolveTarget(effect.target, state).

2. The ConditionalEffect checking for 3+ counters used EntityReference.AffectedEntity, which is only populated during layer/projection — null during trigger resolution. Changed to EntityReference.Triggering, which AttachmentTriggerDetector sets to the enchanted creature when EnchantedCreatureAttacks fires.