### PR TITLE
Add Bristly Bill, Spine Sower (OTJ) with EntityReference.IterationEntity

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.mtg.sets.definitions.ecl.LorwynEclipsedSet
 import com.wingedsheep.mtg.sets.definitions.lci.LostCavernsOfIxalanSet
 import com.wingedsheep.mtg.sets.definitions.fdn.FoundationsSet
 import com.wingedsheep.mtg.sets.definitions.one.PhyrexiaAllWillBeOneSet
+import com.wingedsheep.mtg.sets.definitions.otj.OutlawsOfThunderJunctionSet
 import com.wingedsheep.mtg.sets.definitions.scg.ScourgeSet
 import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
 import com.wingedsheep.engine.state.ComponentContainer
@@ -78,6 +79,7 @@ abstract class ScenarioTestBase : FunSpec() {
         register(LostCavernsOfIxalanSet.cards)
         register(FoundationsSet.cards)
         register(PhyrexiaAllWillBeOneSet.cards)
+        register(OutlawsOfThunderJunctionSet.cards)
     }
     protected val actionProcessor = ActionProcessor(cardRegistry)
     protected val stateTransformer = ClientStateTransformer(cardRegistry)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BristlyBillSpineSowerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BristlyBillSpineSowerScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Bristly Bill, Spine Sower (OTJ).
+ *
+ * {1}{G} Legendary Creature — Plant Druid, 2/2.
+ * Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature.
+ * {3}{G}{G}: Double the number of +1/+1 counters on each creature you control.
+ */
+class BristlyBillSpineSowerScenarioTest : ScenarioTestBase() {
+
+    private fun activateDoublingAbility(game: TestGame) {
+        val billId = game.findPermanent("Bristly Bill, Spine Sower")!!
+        val cardDef = cardRegistry.getCard("Bristly Bill, Spine Sower")!!
+        val ability = cardDef.script.activatedAbilities.first()
+
+        val result = game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = billId,
+                abilityId = ability.id
+            )
+        )
+        withClue("Activation should succeed: ${result.error}") {
+            result.error shouldBe null
+        }
+    }
+
+    private fun addManaForDoublingAbility(game: TestGame) {
+        // Cost is {3}{G}{G}: 3 colorless + 2 green
+        game.state = game.state.updateEntity(game.player1Id) { container ->
+            container.with(ManaPoolComponent(green = 2, colorless = 3))
+        }
+    }
+
+    private fun plusOneCounters(game: TestGame, cardName: String): Int =
+        game.findPermanent(cardName)?.let { id ->
+            game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE)
+        } ?: 0
+
+    init {
+        context("Bristly Bill — Landfall trigger") {
+
+            test("puts a +1/+1 counter on target creature when a land enters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bristly Bill, Spine Sower")
+                    .withCardInHand(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val billId = game.findPermanent("Bristly Bill, Spine Sower")!!
+                val forestId = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                }
+                game.execute(PlayLand(game.player1Id, forestId))
+
+                withClue("Landfall should pause for target selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(billId))
+                game.resolveStack()
+
+                withClue("Bristly Bill should have 1 +1/+1 counter from Landfall") {
+                    plusOneCounters(game, "Bristly Bill, Spine Sower") shouldBe 1
+                }
+            }
+        }
+
+        context("Bristly Bill — activated ability doubles counters via EntityReference.IterationEntity") {
+
+            test("doubles +1/+1 counters on each creature independently") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bristly Bill, Spine Sower")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val billId = game.findPermanent("Bristly Bill, Spine Sower")!!
+                val bearsId = game.findPermanent("Grizzly Bears")!!
+
+                // Manually place counters: Bill gets 1, Bears gets 3
+                game.state = game.state
+                    .updateEntity(billId) { c -> c.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, 1)) }
+                    .updateEntity(bearsId) { c -> c.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, 3)) }
+
+                addManaForDoublingAbility(game)
+                activateDoublingAbility(game)
+                game.resolveStack()
+
+                // Bill: 1 counter → doubled → 2; Bears: 3 counters → doubled → 6
+                withClue("Bill should have 2 counters after doubling (was 1)") {
+                    plusOneCounters(game, "Bristly Bill, Spine Sower") shouldBe 2
+                }
+                withClue("Bears should have 6 counters after doubling (was 3)") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 6
+                }
+            }
+
+            test("doubling 0 counters is a no-op") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bristly Bill, Spine Sower")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                addManaForDoublingAbility(game)
+                activateDoublingAbility(game)
+                game.resolveStack()
+
+                withClue("Bill with no counters should remain at 0 after doubling") {
+                    plusOneCounters(game, "Bristly Bill, Spine Sower") shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/b/bristly-bill-spine-sower-scenario.json
+++ b/manual-scenarios/cards/b/bristly-bill-spine-sower-scenario.json
@@ -1,0 +1,64 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Escape Tunnel",
+      "Springbloom Druid",
+      "Biosynthic Burst",
+      "Biosynthic Burst"
+    ],
+    "battlefield": [
+      {"name": "Bristly Bill, Spine Sower"},
+      {"name": "Grizzly Bears"},
+      {"name": "Grizzly Bears"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -837,6 +837,7 @@ constructors.
   `.sumManaValue()`
 - Math: `DynamicAmount.Add(l, r)` / `.Subtract(l, r)` / `.Multiply(amt, n)` / `.Max(l, r)` / `.Min(l, r)` /
   `.IfPositive(amt)`
+- `DynamicAmount.EntityProperty(EntityReference.IterationEntity, property)` — read a property of the current iteration entity inside `ForEachInGroupEffect` (e.g., counter count for doubling)
 
 ---
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityReference.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityReference.kt
@@ -55,4 +55,11 @@ sealed interface EntityReference {
     data object AffectedEntity : EntityReference {
         override val description: String = "it"
     }
+
+    /** The current entity being iterated in a ForEachInGroupEffect. */
+    @SerialName("IterationEntity")
+    @Serializable
+    data object IterationEntity : EntityReference {
+        override val description: String = "it"
+    }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.mtg.sets.definitions.one.PhyrexiaAllWillBeOneSet
 import com.wingedsheep.mtg.sets.definitions.ons.OnslaughtSet
 import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.definitions.scg.ScourgeSet
+import com.wingedsheep.mtg.sets.definitions.otj.OutlawsOfThunderJunctionSet
 import com.wingedsheep.mtg.sets.definitions.spm.SpiderManSet
 import com.wingedsheep.mtg.sets.definitions.woe.WildsOfEldrainSet
 import com.wingedsheep.sdk.model.MtgSet
@@ -51,6 +52,7 @@ object MtgSetCatalog {
         AetherdriftSet,
         EdgeOfEternitiesSet,
         LorwynEclipsedSet,
+        OutlawsOfThunderJunctionSet,
         SpiderManSet,
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/OutlawsOfThunderJunctionSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/OutlawsOfThunderJunctionSet.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.otj
+
+import com.wingedsheep.mtg.sets.definitions.otj.cards.*
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+
+/**
+ * Outlaws of Thunder Junction (2024)
+ *
+ * Set Code: OTJ
+ * Release Date: April 19, 2024
+ */
+object OutlawsOfThunderJunctionSet : MtgSet {
+
+    override val code = "OTJ"
+    override val displayName = "Outlaws of Thunder Junction"
+
+    override val cards: List<CardDefinition> = listOf(
+        BristlyBillSpineSower,
+    )
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BristlyBillSpineSower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BristlyBillSpineSower.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Bristly Bill, Spine Sower
+ * {1}{G}
+ * Legendary Creature — Plant Druid
+ * 2/2
+ *
+ * Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature.
+ * {3}{G}{G}: Double the number of +1/+1 counters on each creature you control.
+ */
+val BristlyBillSpineSower = card("Bristly Bill, Spine Sower") {
+    manaCost = "{1}{G}"
+    typeLine = "Legendary Creature — Plant Druid"
+    power = 2
+    toughness = 2
+    oracleText = "Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature.\n{3}{G}{G}: Double the number of +1/+1 counters on each creature you control."
+
+    // Landfall: whenever a land you control enters, put a +1/+1 counter on target creature
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+    }
+
+    // {3}{G}{G}: Double the number of +1/+1 counters on each creature you control
+    activatedAbility {
+        cost = Costs.Mana("{3}{G}{G}")
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter.AllCreaturesYouControl,
+            effect = Effects.AddDynamicCounters(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                amount = DynamicAmount.EntityProperty(
+                    EntityReference.IterationEntity,
+                    EntityNumericProperty.CounterCount(CounterTypeFilter.PlusOnePlusOne)
+                ),
+                target = EffectTarget.Self
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "157"
+        artist = "Daniel Zrom"
+        flavorText = "\"Wake up, little ones. There's a new day ahead.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52eef0d6-24b7-40b7-8403-e8e863d0cd55.jpg?1712355894"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -540,6 +540,7 @@ class DynamicAmountEvaluator(
             is EntityReference.TappedAsCost -> context.tappedPermanents.getOrNull(ref.index)
             is EntityReference.Triggering -> context.triggeringEntityId
             is EntityReference.AffectedEntity -> context.affectedEntityId
+            is EntityReference.IterationEntity -> context.pipeline.iterationTarget
         }
 
     // =========================================================================

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -691,6 +691,7 @@ class PredicateEvaluator {
             is EntityReference.Sacrificed -> null
             is EntityReference.TappedAsCost -> null
             is EntityReference.AffectedEntity -> null // Only available during projection
+            is EntityReference.IterationEntity -> null // Only available during ForEachInGroup iteration
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/FilterCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/FilterCollectionExecutor.kt
@@ -140,5 +140,6 @@ class FilterCollectionExecutor : EffectExecutor<FilterCollectionEffect> {
             is EntityReference.TappedAsCost -> context.tappedPermanents.getOrNull(ref.index)
             is EntityReference.Triggering -> context.triggeringEntityId
             is EntityReference.AffectedEntity -> context.affectedEntityId
+            is EntityReference.IterationEntity -> context.pipeline.iterationTarget
         }
 }


### PR DESCRIPTION
Introduces EntityReference.IterationEntity to allow DynamicAmount.EntityProperty to read a property (e.g. counter count) from the current entity being iterated inside a ForEachInGroupEffect, enabling the activated ability to double each creature's own +1/+1 counters independently.