### PR TITLE
Added some cards to a MonoW Lifegain deck

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/HaliyaGuidedByLight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/HaliyaGuidedByLight.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.GameEvent.*
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Haliya, Guided by Light
+ * {2}{W}
+ * Legendary Creature — Human Soldier
+ * 3/3
+ *
+ * Whenever Haliya or another creature or artifact you control enters, you gain 1 life.
+ * At the beginning of your end step, draw a card if you've gained 3 or more life this turn.
+ * Warp {W} (You may cast this card from your hand for its warp cost. Exile this creature at the
+ * beginning of the next end step, then you may cast it from exile on a later turn.)
+ */
+val HaliyaGuidedByLight = card("Haliya, Guided by Light") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier"
+    oracleText = "Whenever Haliya or another creature or artifact you control enters, you gain 1 life.\n" +
+        "At the beginning of your end step, draw a card if you've gained 3 or more life this turn.\n" +
+        "Warp {W} (You may cast this card from your hand for its warp cost. Exile this creature at the beginning of the next end step, then you may cast it from exile on a later turn.)"
+    power = 3
+    toughness = 3
+
+    // Whenever Haliya or another creature or artifact you control enters, you gain 1 life.
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.CreatureOrArtifact.youControl(),
+                to = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.GainLife(1)
+    }
+
+    // At the beginning of your end step, draw a card if you've gained 3 or more life this turn.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Compare(
+            DynamicAmounts.lifeGainedThisTurn(),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(3)
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    warp = "{W}"
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "19"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f7c63ae-5df3-410f-8643-b8c69133ca9d.jpg?1752946628"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AjanisPridemate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AjanisPridemate.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ajani's Pridemate
+ * {1}{W}
+ * Creature — Cat Soldier
+ * 2/2
+ *
+ * Whenever you gain life, put a +1/+1 counter on this creature.
+ */
+val AjanisPridemate = card("Ajani's Pridemate") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you gain life, put a +1/+1 counter on this creature."
+
+    // Whenever you gain life, put a +1/+1 counter on this creature
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "135"
+        artist = "Kevin Sidharta"
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/222c1a68-e34c-4103-b1be-17d4ceaef6ce.jpg?1730489107"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ExemplarOfLight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ExemplarOfLight.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.CountersPlacedEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Exemplar of Light
+ * {2}{W}{W}
+ * Creature — Angel
+ * 3/3
+ *
+ * Flying
+ * Whenever you gain life, put a +1/+1 counter on this creature.
+ * Whenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.
+ */
+val ExemplarOfLight = card("Exemplar of Light") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\nWhenever you gain life, put a +1/+1 counter on this creature.\nWhenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn."
+
+    keywords(Keyword.FLYING)
+
+    // Whenever you gain life, put a +1/+1 counter on this creature
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    // Whenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = CountersPlacedEvent(
+                counterType = "+1/+1",
+                filter = GameObjectFilter.Any
+            ),
+            binding = TriggerBinding.SELF
+        )
+        effect = Effects.DrawCards(1)
+        oncePerTurn = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "733"
+        artist = "Ekaterina Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7393efb-da40-4b55-a6ff-ce774f0815f9.jpg?1775599652"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HealersHawk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HealersHawk.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Healer's Hawk
+ * {W}
+ * Creature — Bird
+ * 1/1
+ *
+ * Flying
+ * Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+ */
+val HealersHawk = card("Healer's Hawk") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)"
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "734"
+        artist = "Milivoj Ćeran"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/069cfaa5-bba4-4503-b54e-b98fa9f0a0fc.jpg?1775599663"
+        flavorText = "The wounded see the glow of its vials long before they see its wings diving out of the clouds."
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HinterlandSanctifier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HinterlandSanctifier.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hinterland Sanctifier
+ * {W}
+ * Creature — Rabbit Cleric
+ * 1/2
+ *
+ * Whenever another creature you control enters, you gain 1 life.
+ */
+val HinterlandSanctifier = card("Hinterland Sanctifier") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Rabbit Cleric"
+    power = 1
+    toughness = 2
+    oracleText = "Whenever another creature you control enters, you gain 1 life."
+
+    // Whenever another creature you control enters, you gain 1 life
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "730"
+        artist = "Justine Cruz"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/632df69e-6377-43d0-bba5-65518a320aa5.jpg?1751043344"
+        flavorText = "\"You can learn a lot about a place just by asking the land how it's doing.\""
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/LeoninVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/LeoninVanguard.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Leonin Vanguard
+ * {W}
+ * Creature — Cat Soldier
+ * 1/1
+ *
+ * At the beginning of combat on your turn, if you control three or more creatures, this creature gets +1/+1 until end of turn and you gain 1 life.
+ */
+val LeoninVanguard = card("Leonin Vanguard") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "At the beginning of combat on your turn, if you control three or more creatures, this creature gets +1/+1 until end of turn and you gain 1 life."
+
+    // At the beginning of combat on your turn, if you control three or more creatures, this creature gets +1/+1 until end of turn and you gain 1 life.
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.ControlCreaturesAtLeast(3)
+        effect = CompositeEffect(
+            listOf(
+                Effects.ModifyStats(1, 1, EffectTarget.Self),
+                Effects.GainLife(1)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "499"
+        artist = "Aaron Miller"
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/17b25850-f1bd-4410-beec-603b2a77f264.jpg?1730490494"
+        flavorText = "The best fighters are skilled in both harming and healing."
+    }
+}


### PR DESCRIPTION
Decklist:
20 Plains
2 Banishing Light
4 Ajani's Pridemate
4 Healer's Hawk
4 Essence Channeler
4 Sheltered by Ghosts
4 Hinterland Sanctifier
2 Exemplar of Light
4 Leonin Vanguard
4 Haliya, Guided by Light


Still missing:
4 Ruin-Lurker Bat - need `descended` trigger
4 Leyline of Hope - `If this card is in your opening hand` ability

