### PR TITLE
Add Memory Deluge (INR) with DynamicAmount.TotalManaSpent support

### DIFF
--- a/manual-scenarios/cards/m/memory-deluge.json
+++ b/manual-scenarios/cards/m/memory-deluge.json
@@ -1,0 +1,51 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Memory Deluge"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": ["Memory Deluge"],
+    "library": [
+      "Island",
+      "Swamp",
+      "Forest",
+      "Plains",
+      "Mountain",
+      "Smother",
+      "Fact or Fiction",
+      "Island",
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -814,7 +814,7 @@ constructors.
 
 ### Raw DynamicAmount types
 
-- `DynamicAmount.XValue` / `DynamicAmount.Fixed(n)` / `DynamicAmount.YourLifeTotal`
+- `DynamicAmount.XValue` / `DynamicAmount.Fixed(n)` / `DynamicAmount.YourLifeTotal` / `DynamicAmount.TotalManaSpent` (total mana paid to cast current spell — for "where X is the mana spent" effects)
 - `DynamicAmount.SacrificedPermanentPower` / `.SacrificedPermanentToughness`
 - `DynamicAmount.SourcePower` / `.SourceToughness` / `.TriggerDamageAmount` / `.TriggerLifeGainAmount` / `.LastKnownCounterCount`
 - `DynamicAmount.ColorsAmongPermanentsYouControl` / `.CardTypesInAllGraveyards` / `.CardTypesInLinkedExile`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -160,6 +160,17 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
+     * The total amount of mana spent to cast the current spell (sum of all colors + colorless + X).
+     * Used for effects like Memory Deluge: "where X is the amount of mana spent to cast this spell."
+     */
+    @SerialName("TotalManaSpent")
+    @Serializable
+    data object TotalManaSpent : DynamicAmount {
+        override val description: String = "the total mana spent to cast this spell"
+        override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
+    }
+
+    /**
      * Reference to a stored variable by name.
      * Used for effects that need to reference a previously computed/stored value.
      * Example: Scapeshift stores "sacrificedCount" and SearchLibrary reads it.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.mtg.sets.definitions.eoe.EdgeOfEternitiesSet
 import com.wingedsheep.mtg.sets.definitions.fdn.FoundationsSet
 import com.wingedsheep.mtg.sets.definitions.fin.FinalFantasySet
 import com.wingedsheep.mtg.sets.definitions.inv.InvasionSet
+import com.wingedsheep.mtg.sets.definitions.inr.InnistradRemasteredSet
 import com.wingedsheep.mtg.sets.definitions.mid.InnistradMidnightHuntSet
 import com.wingedsheep.mtg.sets.definitions.vow.InnistradCrimsonVowSet
 import com.wingedsheep.mtg.sets.definitions.ktk.KhansOfTarkirSet
@@ -49,6 +50,7 @@ object MtgSetCatalog {
         DominariaUnitedSet,
         PhyrexiaAllWillBeOneSet,
         BrothersWarSet,
+        InnistradRemasteredSet,
         InnistradMidnightHuntSet,
         InnistradCrimsonVowSet,
         MarchOfTheMachineSet,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/InnistradRemasteredSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/InnistradRemasteredSet.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.inr
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+
+/**
+ * Innistrad Remastered (2025)
+ *
+ * Set Code: INR
+ * Release Date: January 24, 2025
+ */
+object InnistradRemasteredSet : MtgSet {
+
+    override val code = "INR"
+    override val displayName = "Innistrad Remastered"
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.inr.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MemoryDeluge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MemoryDeluge.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+val MemoryDeluge = card("Memory Deluge") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Look at the top X cards of your library, where X is the amount of mana spent to cast this spell. Put two of them into your hand and the rest on the bottom of your library in a random order.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.TotalManaSpent),
+                    storeAs = "looked"
+                ),
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(2)),
+                    storeSelected = "kept",
+                    storeRemainder = "rest",
+                    selectedLabel = "Put in hand",
+                    remainderLabel = "Put on bottom"
+                ),
+                MoveCollectionEffect(
+                    from = "kept",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{5}{U}{U}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Lake Hurwitz"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edcd3802-ddb3-4eb6-9b6e-a26d76557662.jpg?1736467777"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -62,6 +62,8 @@ class DynamicAmountEvaluator(
 
             is DynamicAmount.XValue -> context.xValue ?: 0
 
+            is DynamicAmount.TotalManaSpent -> context.totalManaSpent
+
             is DynamicAmount.YourLifeTotal -> {
                 state.getEntity(context.controllerId)?.get<LifeTotalComponent>()?.life ?: 0
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -27,6 +27,8 @@ data class EffectContext(
     val opponentId: EntityId?,
     val targets: List<ChosenTarget> = emptyList(),
     val xValue: Int? = null,
+    /** Total mana spent to cast this spell (sum of all colors + colorless + X). Used by DynamicAmount.TotalManaSpent. */
+    val totalManaSpent: Int = 0,
     val wasKicked: Boolean = false,
     /** True if the spell's optional Blight additional cost was paid (BlightOrPay path chosen). */
     val wasBlightPaid: Boolean = false,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -164,7 +165,27 @@ class MoveCollectionExecutor(
             }
         }
 
-        return moveCardsToZone(state, context, cards, destination, destPlayerId, revealed, moveType, faceDown, noRegenerate, storeMovedAs, underOwnersControl, revealToSelf)
+        // Random ordering: shuffle the cards before placing them (player has no knowledge of order)
+        val orderedCards = if (order == CardOrder.Random) cards.shuffled() else cards
+
+        val result = moveCardsToZone(state, context, orderedCards, destination, destPlayerId, revealed, moveType, faceDown, noRegenerate, storeMovedAs, underOwnersControl, revealToSelf)
+
+        // After random-order library placement, strip any reveal markers from the moved cards.
+        // moveCardsToZone marks them as revealed to the controller (so the UI can show "you know
+        // this card"), but for random placement the player doesn't know positions — clearing
+        // prevents the frontend from exposing the shuffled order. Analogous to how ZonePlacement.Shuffled
+        // calls clearLibraryReveals() after a full shuffle.
+        if (order == CardOrder.Random && destination.zone == Zone.LIBRARY && result.isSuccess) {
+            var clearedState = result.state
+            for (cardId in orderedCards) {
+                if (clearedState.getEntity(cardId)?.has<RevealedToComponent>() == true) {
+                    clearedState = clearedState.updateEntity(cardId) { c -> c.without<RevealedToComponent>() }
+                }
+            }
+            return result.copy(state = clearedState)
+        }
+
+        return result
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1017,6 +1017,9 @@ class StackResolver(
                 opponentId = newState.getOpponent(spellComponent.casterId),
                 targets = targets,
                 xValue = spellComponent.xValue,
+                totalManaSpent = spellComponent.manaSpentWhite + spellComponent.manaSpentBlue +
+                    spellComponent.manaSpentBlack + spellComponent.manaSpentRed +
+                    spellComponent.manaSpentGreen + spellComponent.manaSpentColorless,
                 wasKicked = spellComponent.wasKicked,
                 wasBlightPaid = spellComponent.wasBlightPaid,
                 sacrificedPermanents = spellComponent.sacrificedPermanents,


### PR DESCRIPTION
Introduces DynamicAmount.TotalManaSpent for "where X is the mana spent to cast this spell" effects, wires it through EffectContext and DynamicAmountEvaluator, and fixes CardOrder.Random to shuffle cards and strip reveal markers before bottom-of-library placement so the order stays hidden. Also creates the Innistrad Remastered (INR) set.