### PR TITLE
Add Blue Sun's Twilight (ONE) with ManaValueAtMostX targeting support

### DIFF
--- a/backlog/magezero-coverage.md
+++ b/backlog/magezero-coverage.md
@@ -69,7 +69,7 @@ one enchantment (Unholy Annex) are double-faced / modal DFCs and depend on DFC s
 - [x] Tolarian Terror ×3
 
 ### Sorceries (1)
-- [ ] Blue Sun's Twilight ×1
+- [x] Blue Sun's Twilight ×1
 
 ### Instants (25)
 - [x] Consider ×4 *(Innistrad: Midnight Hunt)*

--- a/manual-scenarios/cards/b/blue-suns-twilight.json
+++ b/manual-scenarios/cards/b/blue-suns-twilight.json
@@ -1,0 +1,39 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Blue Sun's Twilight"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Hinterland Sanctifier"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Healer's Hawk"},
+      {"name": "Ajani's Pridemate"},
+      {"name": "Exemplar of Light"},
+      {"name": "Ancestor's Prophet"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -699,7 +699,7 @@ constructors.
 - `Filters.Unified.any` / `.creature` / `.land` / `.basicLand` / `.artifact` / `.enchantment` / `.planeswalker`
 - `Filters.Unified.instant` / `.sorcery` / `.permanent` / `.nonlandPermanent` / `.instantOrSorcery`
 - `Filters.Unified.withColor(color)` / `.withSubtype(subtype)` / `.withAnyOfSubtypes(listOf(Subtype("A"), Subtype("B")))` / `.withKeyword(keyword)`
-- `Filters.Unified.manaValueAtMost(max)` / `.manaValueAtLeast(min)`
+- `Filters.Unified.manaValueAtMost(max)` / `.manaValueAtLeast(min)` / `.manaValueAtMostX()` (reads X from source spell; use `TargetFilter.Creature.manaValueAtMostX()` for X-cost targeting)
 - `GameObjectFilter.Creature.totalPowerAndToughnessAtMost(max)` — creature cards/permanents with combined P/T at most `max`
 
 ---

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -200,6 +200,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.ManaValueAtMost(max)
     )
 
+    /** Mana value at most X (reads X from the source spell on the stack) */
+    fun manaValueAtMostX() = copy(
+        cardPredicates = cardPredicates + CardPredicate.ManaValueAtMostX
+    )
+
     /** Mana value at least */
     fun manaValueAtLeast(min: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.ManaValueAtLeast(min)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -237,6 +237,9 @@ data class TargetFilter(
     /** Mana value at most */
     fun manaValueAtMost(max: Int) = copy(baseFilter = baseFilter.manaValueAtMost(max))
 
+    /** Mana value at most X (reads X from the source spell on the stack) */
+    fun manaValueAtMostX() = copy(baseFilter = baseFilter.manaValueAtMostX())
+
     /** Mana value at least */
     fun manaValueAtLeast(min: Int) = copy(baseFilter = baseFilter.manaValueAtLeast(min))
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -279,6 +279,14 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
     }
 
+    /** Mana value ≤ X, where X is the X value of the source spell on the stack. */
+    @SerialName("ManaValueAtMostX")
+    @Serializable
+    data object ManaValueAtMostX : CardPredicate {
+        override val description: String = "with mana value X or less"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
     // =============================================================================
     // Power/Toughness Predicates
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/BlueSunsTwilight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/BlueSunsTwilight.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+val BlueSunsTwilight = card("Blue Sun's Twilight") {
+    manaCost = "{X}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Gain control of target creature with mana value X or less. If X is 5 or more, create a token that's a copy of that creature."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.manaValueAtMostX()))
+        effect = Effects.GainControl(t) then
+            ConditionalEffect(
+                condition = Compare(DynamicAmount.XValue, ComparisonOperator.GTE, DynamicAmount.Fixed(5)),
+                effect = Effects.CreateTokenCopyOfTarget(t)
+            )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "43"
+        artist = "Piotr Dura"
+        flavorText = "\"Where once there was ignorance, Jin-Gitaxias brought knowledge, and an age of progress dawned.\"\n—Monument inscription"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a836e6b-6854-4f6f-bc78-2da1fd4dd224.jpg?1675956948"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -254,6 +254,16 @@ class PredicateEvaluator {
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc >= predicate.min
             }
+            CardPredicate.ManaValueAtMostX -> {
+                val xValue = context?.xValue
+                    ?: context?.sourceId?.let { srcId ->
+                        state.getEntity(srcId)?.get<SpellOnStackComponent>()?.xValue
+                            ?: state.getEntity(srcId)?.get<TriggeredAbilityOnStackComponent>()?.xValue
+                            ?: state.getEntity(srcId)?.get<ActivatedAbilityOnStackComponent>()?.xValue
+                    } ?: return true // X not yet determined (pre-cast enumeration); allow all
+                val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
+                cmc <= xValue
+            }
 
             // Power/toughness predicates - use projected P/T
             is CardPredicate.PowerEquals -> {
@@ -538,6 +548,15 @@ class PredicateEvaluator {
             is CardPredicate.ManaValueEquals -> card.manaValue == predicate.value
             is CardPredicate.ManaValueAtMost -> card.manaValue <= predicate.max
             is CardPredicate.ManaValueAtLeast -> card.manaValue >= predicate.min
+            CardPredicate.ManaValueAtMostX -> {
+                val xValue = context?.xValue
+                    ?: context?.sourceId?.let { srcId ->
+                        state.getEntity(srcId)?.get<SpellOnStackComponent>()?.xValue
+                            ?: state.getEntity(srcId)?.get<TriggeredAbilityOnStackComponent>()?.xValue
+                            ?: state.getEntity(srcId)?.get<ActivatedAbilityOnStackComponent>()?.xValue
+                    } ?: return true // X not yet determined (pre-cast enumeration); allow all
+                card.manaValue <= xValue
+            }
 
             // Power/toughness predicates
             is CardPredicate.PowerEquals -> {
@@ -923,6 +942,7 @@ class PredicateEvaluator {
             is CardPredicate.ManaValueEquals -> record.manaValue == predicate.value
             is CardPredicate.ManaValueAtMost -> record.manaValue <= predicate.max
             is CardPredicate.ManaValueAtLeast -> record.manaValue >= predicate.min
+            CardPredicate.ManaValueAtMostX -> false // no spell context available for cast records
 
             // Power/toughness — not meaningful for cast records
             is CardPredicate.PowerEquals, is CardPredicate.PowerAtMost, is CardPredicate.PowerAtLeast,
@@ -968,6 +988,8 @@ data class PredicateContext(
     val ownerId: EntityId? = null,
     /** The entity that caused the trigger to fire (for SharesCreatureTypeWithTriggeringEntity) */
     val triggeringEntityId: EntityId? = null,
+    /** X value for X-cost spells; set during cast-time target validation to enforce ManaValueAtMostX. */
+    val xValue: Int? = null,
     /** Named values chosen by the player during pipeline execution (e.g., creature type, color). */
     val chosenValues: Map<String, String> = emptyMap(),
     /** Named string lists stored by pipeline effects (e.g., chosen creature types). */
@@ -1018,6 +1040,7 @@ data class PredicateContext(
                 targetOpponentId = context.opponentId,
                 targetPlayerId = chosenPlayerTarget ?: context.opponentId,
                 sourceId = context.sourceId,
+                xValue = context.xValue,
                 triggeringEntityId = context.triggeringEntityId,
                 chosenValues = context.pipeline.chosenValues,
                 storedStringLists = context.pipeline.storedStringLists,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -430,7 +430,8 @@ class CastSpellHandler(
                     action.playerId,
                     sourceColors = cardDef.colors,
                     sourceSubtypes = cardDef.typeLine.subtypes.map { it.value }.toSet(),
-                    sourceId = action.cardId
+                    sourceId = action.cardId,
+                    xValue = action.xValue
                 )
                 if (targetError != null) {
                     return targetError

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -794,6 +794,7 @@ class CostCalculator(
 
             CardPredicate.IsActivatedOrTriggeredAbility -> false
             CardPredicate.IsTriggeredAbility -> false
+            CardPredicate.ManaValueAtMostX -> true // no spell context at cost-calculation time; allow all
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -51,7 +51,8 @@ class TargetValidator {
         casterId: EntityId,
         sourceColors: Set<Color> = emptySet(),
         sourceSubtypes: Set<String> = emptySet(),
-        sourceId: EntityId? = null
+        sourceId: EntityId? = null,
+        xValue: Int? = null
     ): String? {
         // Use the game state for validation
         // StateProjector is used for P/T checks to account for continuous effects
@@ -74,7 +75,7 @@ class TargetValidator {
 
             // Validate each target against the requirement
             for (target in targetsForReq) {
-                val error = validateSingleTarget(state, target, requirement, casterId, sourceColors, sourceSubtypes, sourceId)
+                val error = validateSingleTarget(state, target, requirement, casterId, sourceColors, sourceSubtypes, sourceId, xValue)
                 if (error != null) return error
             }
 
@@ -102,7 +103,8 @@ class TargetValidator {
         casterId: EntityId,
         sourceColors: Set<Color> = emptySet(),
         sourceSubtypes: Set<String> = emptySet(),
-        sourceId: EntityId? = null
+        sourceId: EntityId? = null,
+        xValue: Int? = null
     ): String? {
         val error = when (requirement) {
             is TargetPlayer -> validatePlayerTarget(state, target, casterId)
@@ -113,8 +115,8 @@ class TargetValidator {
             is TargetPlayerOrPlaneswalker -> validatePlayerOrPlaneswalkerTarget(state, target, casterId)
             is TargetCreatureOrPlaneswalker -> validateCreatureOrPlaneswalkerTarget(state, target)
             is TargetSpellOrPermanent -> validateSpellOrPermanentTarget(state, target, requirement, casterId, sourceId)
-            is TargetObject -> validateObjectTarget(state, target, requirement.filter, casterId, sourceId)
-            is TargetOther -> validateSingleTarget(state, target, requirement.baseRequirement, casterId, sourceColors, sourceSubtypes, sourceId)
+            is TargetObject -> validateObjectTarget(state, target, requirement.filter, casterId, sourceId, xValue)
+            is TargetOther -> validateSingleTarget(state, target, requirement.baseRequirement, casterId, sourceColors, sourceSubtypes, sourceId, xValue)
         }
         if (error != null) return error
 
@@ -267,7 +269,8 @@ class TargetValidator {
         target: ChosenTarget,
         filter: TargetFilter,
         casterId: EntityId,
-        sourceId: EntityId? = null
+        sourceId: EntityId? = null,
+        xValue: Int? = null
     ): String? {
         if (target !is ChosenTarget.Permanent) {
             return "Target must be a permanent"
@@ -283,7 +286,7 @@ class TargetValidator {
 
         // Use unified filter with projection (face-down creatures have CMC 0 per Rule 708.2)
         val projected = state.projectedState
-        val predicateContext = PredicateContext(controllerId = casterId, sourceId = sourceId)
+        val predicateContext = PredicateContext(controllerId = casterId, sourceId = sourceId, xValue = xValue)
         val matches = predicateEvaluator.matchesWithProjection(state, projected, target.entityId, filter.baseFilter, predicateContext)
         if (!matches) {
             return "Target does not match filter: ${filter.description}"
@@ -443,7 +446,8 @@ class TargetValidator {
         target: ChosenTarget,
         filter: TargetFilter,
         casterId: EntityId,
-        sourceId: EntityId? = null
+        sourceId: EntityId? = null,
+        xValue: Int? = null
     ): String? {
         if (target !is ChosenTarget.Card) {
             return "Target must be a card in a graveyard"
@@ -462,7 +466,7 @@ class TargetValidator {
         }
 
         // Use unified filter - OwnedByYou predicate handles "your graveyard" restriction
-        val predicateContext = PredicateContext(controllerId = casterId, ownerId = target.ownerId, sourceId = sourceId)
+        val predicateContext = PredicateContext(controllerId = casterId, ownerId = target.ownerId, sourceId = sourceId, xValue = xValue)
         val matches = predicateEvaluator.matches(state, target.cardId, filter.baseFilter, predicateContext)
         if (!matches) {
             return "Target does not match filter: ${filter.description}"
@@ -500,11 +504,12 @@ class TargetValidator {
         target: ChosenTarget,
         filter: TargetFilter,
         casterId: EntityId,
-        sourceId: EntityId? = null
+        sourceId: EntityId? = null,
+        xValue: Int? = null
     ): String? {
         return when (filter.zone) {
-            Zone.GRAVEYARD -> validateGraveyardTarget(state, target, filter, casterId, sourceId)
-            Zone.BATTLEFIELD -> validatePermanentTarget(state, target, filter, casterId, sourceId)
+            Zone.GRAVEYARD -> validateGraveyardTarget(state, target, filter, casterId, sourceId, xValue)
+            Zone.BATTLEFIELD -> validatePermanentTarget(state, target, filter, casterId, sourceId, xValue)
             Zone.STACK -> validateSpellTarget(state, target, filter, casterId)
             else -> validateCardInZoneTarget(state, target, filter, casterId)
         }


### PR DESCRIPTION
Introduces CardPredicate.ManaValueAtMostX for targeting restrictions that depend on the spell's X value. At cast-time validation the predicate reads xValue from the cast action via PredicateContext; at resolution it reads from SpellOnStackComponent. During legal-action enumeration (X unknown) it conservatively allows all targets.

xValue is now threaded through TargetValidator.validateTargets → validatePermanentTarget / validateGraveyardTarget → PredicateContext, and populated from EffectContext in PredicateContext.fromEffectContext.

It's still a bit wonky:

```
❯ I still can target creatures with a too low X value, but it now says: "Target does not match filter",
   and then it get's cancelled when casting.

⏺ That's the expected behavior given the engine's architecture. The server correctly rejects the illegal
   combination with a clear error — the cast doesn't go through and no state changes. The UI showing all
   creatures as selectable is an architectural limitation: legal targets are computed when the game
  presents available actions, before the player has chosen X, so the engine has no X value to filter by
  yet.

  To properly filter the UI you'd need a two-step cast flow for X spells — announce the spell + pay mana
   (which determines X), then the server computes filtered legal targets and presents a second targeting
   decision. That's a meaningful engine change to the casting pipeline. The current behavior (server
  rejects + "Target does not match filter" error) is the practical middle ground.

  Want me to implement the two-step flow, or is the server-side rejection acceptable for now?
```

<img width="550" height="408" alt="image" src="https://github.com/user-attachments/assets/b61bca47-3865-46c7-bbba-df7d54c784b7" />


<img width="582" height="78" alt="image" src="https://github.com/user-attachments/assets/aaa61c58-af08-45f2-8d94-89a4404d2b50" />

