### PR TITLE
Fix summoning sickness on control change (Rule 302.6)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByActivePlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByActivePlayerExecutor.kt
@@ -44,8 +44,9 @@ class GainControlByActivePlayerExecutor : EffectExecutor<GainControlByActivePlay
         val newControllerId = state.activePlayerId
             ?: return EffectResult.error(state, "No active player")
 
-        // If that player already controls the target, no-op
-        val currentControllerId = targetContainer.get<ControllerComponent>()?.playerId
+        // Use projected controller so floating-effect-based control changes are respected
+        val currentControllerId = state.projectedState.getController(targetId)
+            ?: targetContainer.get<ControllerComponent>()?.playerId
         if (currentControllerId == newControllerId) return EffectResult.success(state)
 
         // Remove any previous Layer.CONTROL floating effects from the same source on the same target

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByActivePlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByActivePlayerExecutor.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.scripting.effects.GainControlByActivePlayerEffect
@@ -64,9 +65,9 @@ class GainControlByActivePlayerExecutor : EffectExecutor<GainControlByActivePlay
             context = controlContext
         )
 
-        val newState = state.copy(
-            floatingEffects = filteredEffects + floatingEffect
-        )
+        // Rule 302.6: new controller hasn't had this permanent since their most recent turn began.
+        val newState = state.copy(floatingEffects = filteredEffects + floatingEffect)
+            .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
 
         val events = listOf(
             ControlChangedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostOfSubtypeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostOfSubtypeExecutor.kt
@@ -55,8 +55,9 @@ class GainControlByMostOfSubtypeExecutor : EffectExecutor<GainControlByMostOfSub
 
         val newControllerId = playersWithMax.keys.first()
 
-        // If that player already controls the target, no-op
-        val currentControllerId = targetContainer.get<ControllerComponent>()?.playerId
+        // Use projected controller so floating-effect-based control changes are respected
+        val currentControllerId = state.projectedState.getController(targetId)
+            ?: targetContainer.get<ControllerComponent>()?.playerId
         if (currentControllerId == newControllerId) return EffectResult.success(state)
 
         // Remove any previous Layer.CONTROL floating effects from the same source on the same target

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostOfSubtypeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostOfSubtypeExecutor.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.scripting.Duration
@@ -75,9 +76,9 @@ class GainControlByMostOfSubtypeExecutor : EffectExecutor<GainControlByMostOfSub
             context = controlContext
         )
 
-        val newState = state.copy(
-            floatingEffects = filteredEffects + floatingEffect
-        )
+        // Rule 302.6: new controller hasn't had this permanent since their most recent turn began.
+        val newState = state.copy(floatingEffects = filteredEffects + floatingEffect)
+            .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
 
         val events = listOf(
             ControlChangedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
@@ -39,8 +39,9 @@ class GainControlExecutor : EffectExecutor<GainControlEffect> {
 
         val newControllerId = context.controllerId
 
-        // If that player already controls the target, no-op
-        val currentControllerId = targetContainer.get<ControllerComponent>()?.playerId
+        // Use projected controller so floating-effect-based control changes are respected
+        val currentControllerId = state.projectedState.getController(targetId)
+            ?: targetContainer.get<ControllerComponent>()?.playerId
         if (currentControllerId == newControllerId) return EffectResult.success(state)
 
         // Remove any previous Layer.CONTROL floating effects from the same source on the same target

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.scripting.effects.GainControlEffect
@@ -58,9 +59,11 @@ class GainControlExecutor : EffectExecutor<GainControlEffect> {
             context = context
         )
 
-        val newState = state.copy(
-            floatingEffects = filteredEffects + floatingEffect
-        )
+        // Rule 302.6: the new controller hasn't had this creature continuously since their
+        // most recent turn began, so it gains summoning sickness until their next untap step.
+        val stateWithSickness = state.copy(floatingEffects = filteredEffects + floatingEffect)
+            .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
+        val newState = stateWithSickness
 
         val events = listOf(
             ControlChangedEvent(


### PR DESCRIPTION
Stolen permanents can now attack in the same turn they were stolen. All three GainControl executors now add SummoningSicknessComponent to the taken permanent so the new controller must wait until their next untap step before attacking with it.

Remaining problem:
Other permanents for instance Spacecrafts and Soulstone Sanctuary can attack on the first turn.

```
⏺ The unfixed problem: Non-creature permanents (lands, artifacts) do not receive
  SummoningSicknessComponent when they enter the battlefield, because ZoneTransitionService.kt only adds
   it when cardComponent.typeLine.isCreature is true.

  When such a permanent becomes a creature mid-turn (Soulstone Sanctuary animating via its {4} ability,
  or a Spacecraft crossing the 20-counter threshold via Station), the SummoningSicknessAttackRule finds
  no SummoningSicknessComponent on the entity and allows it to attack — even though it entered the
  battlefield this same turn.

  Per rule 302.6, what matters is whether the permanent has been under its controller's control
  continuously since their most recent turn began, not whether it was a creature the whole time. A land
  played this turn that then becomes a creature still has summoning sickness because the land itself is
  new. The fix is to give SummoningSicknessComponent to all permanents on entry, not just creatures.
```