### PR TITLE
Add Earthbending Lesson (TLA) with Earthbend mechanic

### DIFF
--- a/manual-scenarios/cards/e/earthbending-lesson.json
+++ b/manual-scenarios/cards/e/earthbending-lesson.json
@@ -1,0 +1,42 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Earthbending Lesson", "Earthbending Lesson"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Smother", "Gravkill"],
+    "battlefield": [
+      {"name": "Dawnhand Dissident"},
+      {"name": "Serra Angel"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -87,6 +87,7 @@ constructors.
 - `Effects.AddCountersToCollection(collectionName, counterType, count)` — add counters to all entities in a named collection
 - `Effects.SetBasePower(target = Self, power: DynamicAmount, duration = Permanent)` — set creature's base power
 - `Effects.AnimateLand(target, power, toughness, duration)` — turn land into creature
+- `Effects.Earthbend(amount: Int, target)` — animate land as 0/0 creature-land with haste (permanent) + `amount` +1/+1 counters + grant `EARTHBENDED` keyword so the trigger detector returns it tapped when it dies or is exiled
 - `Effects.DistributeCountersFromSelf(counterType)` — move counters from self to other creatures (player chooses)
 - `Effects.DistributeCountersAmongTargets(totalCounters, counterType, minPerTarget)` — distribute N counters among targets from context (deterministic distribution)
 - `Effects.Proliferate()` — choose any number of permanents and/or players that have a counter, then give each another counter of each kind already there

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -68,6 +68,12 @@ enum class Keyword(val displayName: String) {
     WITHER("Wither"),
     TOXIC("Toxic"),
 
+    // ── Avatar: The Last Airbender mechanics ──────────────
+    /** Earthbend N — animate a land as 0/0 creature-land with haste and N +1/+1 counters. */
+    EARTHBEND("Earthbend"),
+    /** Internal marker granted to earthbended lands; triggers return from death or exile. */
+    EARTHBENDED("Earthbended"),
+
     // ── Numeric (parameterized by N) ──────────────────────
     ANNIHILATOR("Annihilator"),
     BUSHIDO("Bushido"),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1661,6 +1661,17 @@ object Effects {
     ): Effect = AnimateLandEffect(target, power, toughness, duration)
 
     /**
+     * Earthbend N — target land becomes a 0/0 creature-land with haste; put N +1/+1 counters on it;
+     * and it gains the EARTHBENDED internal keyword so the trigger detector returns it when it dies or is exiled.
+     */
+    fun Earthbend(amount: Int, target: EffectTarget): Effect = CompositeEffect(listOf(
+        AnimateLandEffect(target, 0, 0, com.wingedsheep.sdk.scripting.Duration.Permanent),
+        GrantKeywordEffect(com.wingedsheep.sdk.core.Keyword.HASTE, target, com.wingedsheep.sdk.scripting.Duration.Permanent),
+        AddCountersEffect(com.wingedsheep.sdk.core.Counters.PLUS_ONE_PLUS_ONE, amount, target),
+        GrantKeywordEffect(com.wingedsheep.sdk.core.Keyword.EARTHBENDED, target, com.wingedsheep.sdk.scripting.Duration.Permanent)
+    ))
+
+    /**
      * Target permanent becomes a creature with specified characteristics.
      * More general than AnimateLand — can remove types, grant keywords, set subtypes, change color.
      */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/EarthbendingLesson.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/EarthbendingLesson.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+val EarthbendingLesson = card("Earthbending Lesson") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery — Lesson"
+    oracleText = "Earthbend 4. (Target land you control becomes a 0/0 creature with haste that's still a land. Put four +1/+1 counters on it. When it dies or is exiled, return it to the battlefield tapped.)"
+
+    spell {
+        val t = target("target land you control", TargetObject(filter = TargetFilter.Land.youControl()))
+        effect = Effects.Earthbend(4, t)
+    }
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.EARTHBEND, 4))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "176"
+        artist = "Toni Infante"
+        flavorText = "\"Rock is a stubborn element. If you're going to move it, you've got to be like a rock yourself.\"\n—Toph"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/eccd63b3-3a3a-4661-9d6e-fb8152429bdb.jpg?1764121195"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
 
@@ -291,6 +292,50 @@ class DeathAndLeaveTriggerDetector(
         triggers.add(
             PendingTrigger(
                 ability = persistAbility,
+                sourceId = event.entityId,
+                sourceName = info.name,
+                controllerId = event.ownerId,
+                triggerContext = TriggerContext.fromEvent(event)
+            )
+        )
+    }
+
+    /**
+     * Detect earthbend-return triggers (TLA Earthbend mechanic).
+     *
+     * When a permanent marked with the EARTHBENDED keyword dies or is exiled from the battlefield,
+     * it returns to the battlefield tapped. Fires for both graveyard and exile destinations.
+     */
+    fun detectEarthbendReturnTriggers(
+        state: GameState,
+        event: ZoneChangeEvent,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        if (event.fromZone != Zone.BATTLEFIELD) return
+        if (event.toZone != Zone.GRAVEYARD && event.toZone != Zone.EXILE) return
+        if (event.lastKnownWasToken) return
+        if (Keyword.EARTHBENDED.name !in event.lastKnownKeywords) return
+
+        val info = resolveDyingEntity(state, event) ?: return
+
+        val returnAbility = TriggeredAbility.create(
+            trigger = GameEvent.ZoneChangeEvent(from = Zone.BATTLEFIELD, to = event.toZone),
+            binding = TriggerBinding.SELF,
+            // fromZone ensures the return only fires if the card is still in the zone it
+            // entered when it left the battlefield. If exiled from the graveyard before this
+            // trigger resolves, the move is skipped (card stays in exile per MTG rules).
+            effect = MoveToZoneEffect(
+                target = EffectTarget.Self,
+                destination = Zone.BATTLEFIELD,
+                placement = ZonePlacement.Tapped,
+                fromZone = event.toZone
+            ),
+            descriptionOverride = "Earthbend — Return ${info.name} to the battlefield tapped"
+        )
+
+        triggers.add(
+            PendingTrigger(
+                ability = returnAbility,
                 sourceId = event.entityId,
                 sourceName = info.name,
                 controllerId = event.ownerId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -804,11 +804,17 @@ class TriggerDetector(
             deathAndLeaveDetector.detectDeadAuraAttachmentTriggers(state, event, triggers)
             // Handle persist (CR 702.79) — nontoken creature with persist dies with no -1/-1 counter
             deathAndLeaveDetector.detectPersistTriggers(state, event, triggers)
+            // Handle earthbend return — EARTHBENDED land dies, return to battlefield tapped
+            deathAndLeaveDetector.detectEarthbendReturnTriggers(state, event, triggers)
         }
 
         // Handle leaves-the-battlefield triggers (source is no longer on battlefield)
         if (event is ZoneChangeEvent && event.fromZone == Zone.BATTLEFIELD) {
             deathAndLeaveDetector.detectLeavesBattlefieldTriggers(state, event, triggers)
+            // Handle earthbend return for exile (death case is handled in the graveyard block above)
+            if (event.toZone == Zone.EXILE) {
+                deathAndLeaveDetector.detectEarthbendReturnTriggers(state, event, triggers)
+            }
         }
 
         // Handle cycling triggers on the cycled card itself (e.g., Renewed Faith)

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -194,6 +194,8 @@ export enum Keyword {
   PERSIST = 'PERSIST',
   // Ability words
   EERIE = 'EERIE',
+  // Avatar: The Last Airbender
+  EARTHBEND = 'EARTHBEND',
 }
 
 export const KeywordDisplayNames: Record<Keyword, string> = {
@@ -239,6 +241,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.TOXIC]: 'Toxic',
   [Keyword.PERSIST]: 'Persist',
   [Keyword.EERIE]: 'Eerie',
+  [Keyword.EARTHBEND]: 'Earthbend',
 }
 
 /**


### PR DESCRIPTION
Earthbend N: animate target land you control as a 0/0 creature-land with haste (permanent), put N +1/+1 counters on it, and grant it the EARTHBENDED internal keyword so that when it dies or is exiled from the battlefield it returns to the battlefield tapped.

Engine changes:
- Keyword.EARTHBEND (display) + Keyword.EARTHBENDED (internal return marker)
- Effects.Earthbend(amount, target) facade composing AnimateLand + GrantKeyword(HASTE)
  + AddCounters + GrantKeyword(EARTHBENDED)
- DeathAndLeaveTriggerDetector.detectEarthbendReturnTriggers fires on BATTLEFIELD→GRAVEYARD and BATTLEFIELD→EXILE; uses fromZone = event.toZone so the return is skipped if the card is moved out of that zone before the trigger resolves (e.g. exiling the card from the graveyard)
- TriggerDetector wires the new detector into both the death and exile paths