### PR TITLE
Add Explore mechanic, Map token, and Sentinel of the Nameless City (LCI)

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ExploreScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ExploreScenarioTest.kt
@@ -1,0 +1,238 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the Map token and Explore mechanic.
+ *
+ * Map token: Artifact — Map
+ *   "{1}, {T}, Sacrifice this token: Target creature you control explores.
+ *    Activate only as a sorcery."
+ *
+ * Explore: "Reveal the top card of your library. If it's a land card, put it into your hand.
+ *   Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into
+ *   your graveyard."
+ *
+ * Test cases:
+ * 1. Sentinel of the Nameless City creates a Map token on ETB
+ * 2. Sentinel of the Nameless City creates a Map token when attacking
+ * 3. Explore with a land on top → land goes directly to hand, no counter
+ * 4. Explore with a non-land on top → +1/+1 counter placed, player puts it back on top of library
+ * 5. Explore with a non-land on top → +1/+1 counter placed, player puts it in graveyard
+ */
+class ExploreScenarioTest : ScenarioTestBase() {
+
+    // -------------------------------------------------------------------------
+    // Helper: activate the first activated ability of the Map token
+    // -------------------------------------------------------------------------
+    private fun activateMapToken(
+        game: TestGame,
+        mapId: com.wingedsheep.sdk.model.EntityId,
+        creatureId: com.wingedsheep.sdk.model.EntityId
+    ) {
+        val mapCardDef = cardRegistry.getCard("Map")!!
+        val ability = mapCardDef.script.activatedAbilities.first()
+        val result = game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = mapId,
+                abilityId = ability.id,
+                targets = listOf(ChosenTarget.Permanent(creatureId))
+            )
+        )
+        withClue("Map ability should activate without error: ${result.error}") {
+            result.error shouldBe null
+        }
+    }
+
+    private fun plusOneCounters(game: TestGame, entityId: com.wingedsheep.sdk.model.EntityId): Int =
+        game.state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE)
+            ?: 0
+
+    init {
+        // ------------------------------------------------------------------
+        // Map token creation via Sentinel of the Nameless City
+        // ------------------------------------------------------------------
+        context("Map token creation") {
+
+            test("Sentinel creates a Map token when it enters the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sentinel of the Nameless City")
+                    .withLandsOnBattlefield(1, "Forest", 3) // {2}{G}
+                    .withCardInLibrary(2, "Forest") // prevent draw-loss
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Sentinel of the Nameless City")
+                game.resolveStack()
+
+                withClue("Sentinel should be on battlefield") {
+                    game.isOnBattlefield("Sentinel of the Nameless City") shouldBe true
+                }
+                withClue("Exactly one Map token should be created on ETB") {
+                    game.findAllPermanents("Map").size shouldBe 1
+                }
+            }
+
+            test("Sentinel creates a Map token when it attacks") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sentinel of the Nameless City")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Sentinel of the Nameless City" to 2))
+                game.resolveStack()
+
+                withClue("Map token should be created on attack") {
+                    game.findAllPermanents("Map").size shouldBe 1
+                }
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Explore: land on top of library
+        // ------------------------------------------------------------------
+        context("Explore with land on top") {
+
+            test("land goes to hand and no counter is placed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Map")       // Map token
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2 Human Soldier to explore
+                    .withLandsOnBattlefield(1, "Forest", 1) // {1} for Map activation
+                    .withCardInLibrary(1, "Forest")         // land on top → goes to hand
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mapId = game.findPermanent("Map")!!
+                val creatureId = game.findPermanent("Glory Seeker")!!
+
+                activateMapToken(game, mapId, creatureId)
+
+                withClue("Map token should be sacrificed as part of cost") {
+                    game.isOnBattlefield("Map") shouldBe false
+                }
+
+                // No decision expected — land path is automatic
+                game.resolveStack()
+
+                withClue("No pending decision expected for land path") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("Land card should go to hand") {
+                    game.isInHand(1, "Forest") shouldBe true
+                }
+                withClue("Library should be empty after explore") {
+                    game.librarySize(1) shouldBe 0
+                }
+                withClue("Exploring creature should have no +1/+1 counter (land path)") {
+                    plusOneCounters(game, creatureId) shouldBe 0
+                }
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Explore: non-land on top of library
+        // ------------------------------------------------------------------
+        context("Explore with non-land on top") {
+
+            test("player puts the revealed non-land card back on top of library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Map")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(1, "Hill Giant")    // non-land on top
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mapId = game.findPermanent("Map")!!
+                val creatureId = game.findPermanent("Glory Seeker")!!
+
+                activateMapToken(game, mapId, creatureId)
+                game.resolveStack() // pauses at yes/no
+
+                withClue("Should have pending yes/no decision (top of library vs graveyard)") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                game.answerYesNo(true) // "Yes" = put back on top of library
+
+                withClue("Non-land card should be back on top of library") {
+                    game.librarySize(1) shouldBe 1
+                }
+                withClue("Non-land card should NOT be in graveyard") {
+                    game.isInGraveyard(1, "Hill Giant") shouldBe false
+                }
+                withClue("Non-land card should NOT be in hand") {
+                    game.isInHand(1, "Hill Giant") shouldBe false
+                }
+                withClue("Exploring creature should receive a +1/+1 counter") {
+                    plusOneCounters(game, creatureId) shouldBe 1
+                }
+                withClue("Exploring creature should be 3/3 after the +1/+1 counter") {
+                    val clientState = game.getClientState(1)
+                    val creatureInfo = clientState.cards[creatureId]
+                    creatureInfo shouldNotBe null
+                    creatureInfo!!.power shouldBe 3
+                    creatureInfo.toughness shouldBe 3
+                }
+            }
+
+            test("player puts the revealed non-land card in graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Map")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mapId = game.findPermanent("Map")!!
+                val creatureId = game.findPermanent("Glory Seeker")!!
+
+                activateMapToken(game, mapId, creatureId)
+                game.resolveStack() // pauses at yes/no
+
+                withClue("Should have pending yes/no decision") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                game.answerYesNo(false) // "No" = put in graveyard
+
+                withClue("Revealed non-land card should be in graveyard") {
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                }
+                withClue("Library should be empty after explore (graveyard path)") {
+                    game.librarySize(1) shouldBe 0
+                }
+                withClue("Exploring creature should receive a +1/+1 counter") {
+                    plusOneCounters(game, creatureId) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/s/sentinel-of-nameless-city-explore.json
+++ b/manual-scenarios/cards/s/sentinel-of-nameless-city-explore.json
@@ -1,0 +1,51 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Sentinel of the Nameless City",
+      "Sentinel of the Nameless City"
+    ],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Sentinel of the Nameless City",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP", "DRAW", "PRECOMBAT_MAIN", "BEGIN_COMBAT", "DECLARE_ATTACKERS", "DECLARE_BLOCKERS", "COMBAT_DAMAGE", "END_COMBAT", "POSTCOMBAT_MAIN", "END", "CLEANUP"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -26,6 +26,7 @@ import com.wingedsheep.sdk.scripting.effects.AddSubtypeEffect
 import com.wingedsheep.sdk.scripting.effects.AddCountersToCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.AnimateLandEffect
+import com.wingedsheep.sdk.scripting.effects.ExploreEffect
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureEffect
 import com.wingedsheep.sdk.scripting.effects.EachPermanentBecomesCopyOfTargetEffect
 import com.wingedsheep.sdk.scripting.effects.SetBasePowerEffect
@@ -1121,6 +1122,28 @@ object Effects {
      */
     fun Incubate(amount: com.wingedsheep.sdk.scripting.values.DynamicAmount): Effect =
         EffectPatterns.incubate(amount)
+
+    /**
+     * Target creature explores.
+     *
+     * "Reveal the top card of your library. If it's a land card, put it into your hand.
+     * Otherwise, put a +1/+1 counter on this creature, then put the revealed card into
+     * your hand or graveyard."
+     *
+     * @param target The creature that explores (default: context target 0)
+     */
+    fun Explore(target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
+        ExploreEffect(target)
+
+    /**
+     * Create a Map artifact token.
+     * "{1}, {T}, Sacrifice this token: Target creature you control explores.
+     *  Activate only as a sorcery."
+     *
+     * @param count Number of tokens to create
+     */
+    fun CreateMapToken(count: Int = 1): Effect =
+        CreatePredefinedTokenEffect("Map", count)
 
     // =========================================================================
     // Protection Effects

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PermanentEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PermanentEffects.kt
@@ -185,3 +185,28 @@ data object IncrementAbilityResolutionCountEffect : Effect {
     override val description: String = "Track ability resolution"
     override fun applyTextReplacement(replacer: TextReplacer): Effect = this
 }
+
+// =============================================================================
+// Explore
+// =============================================================================
+
+/**
+ * Target creature explores.
+ *
+ * "Reveal the top card of your library. If it's a land card, put it into your hand.
+ * Otherwise, put a +1/+1 counter on this creature, then put the revealed card into
+ * your hand or graveyard."
+ *
+ * The exploring player is the controller of the effect (the Map token's controller).
+ * The exploring creature is [target].
+ *
+ * @property target The creature that is exploring.
+ */
+@SerialName("Explore")
+@Serializable
+data class ExploreEffect(
+    val target: EffectTarget = EffectTarget.ContextTarget(0)
+) : Effect {
+    override val description: String = "${target.description} explores"
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SentinelOfTheNamelessCity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SentinelOfTheNamelessCity.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sentinel of the Nameless City — {2}{G}
+ * Creature — Merfolk Warrior Scout
+ * 3/4
+ * Vigilance
+ * Whenever this creature enters or attacks, create a Map token.
+ * (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control
+ *  explores. Activate only as a sorcery.")
+ */
+val SentinelOfTheNamelessCity = card("Sentinel of the Nameless City") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Merfolk Warrior Scout"
+    oracleText = "Vigilance\nWhenever this creature enters or attacks, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMapToken()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.CreateMapToken()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "211"
+        artist = "Josu Hernaiz"
+        flavorText = "\"Halt, traveler. Whatever you seek, you will not find it here.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eeeffc0b-dc92-458e-ad58-86ff6077a508.jpg?1699044484"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -276,6 +276,32 @@ object PredefinedTokens {
     )
 
     /**
+     * Map token — an artifact with:
+     * "{1}, {T}, Sacrifice this token: Target creature you control explores.
+     *  Activate only as a sorcery."
+     */
+    val Map = card("Map") {
+        typeLine = "Artifact — Map"
+
+        activatedAbility {
+            val creature = target("target creature you control", Targets.CreatureYouControl)
+            cost = Costs.Composite(
+                Costs.Mana("{1}"),
+                Costs.Tap,
+                Costs.SacrificeSelf
+            )
+            effect = Effects.Explore(creature)
+            timing = TimingRule.SorcerySpeed
+        }
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/6/4/64839118-09d2-4645-9d3c-f80755ac781f.jpg?1698873927"
+            artist = "Francesca Baerald"
+            collectorNumber = "17"
+        }
+    }
+
+    /**
      * All predefined token definitions.
      * Register these in the CardRegistry so token abilities are resolved.
      */
@@ -284,6 +310,7 @@ object PredefinedTokens {
         Food,
         Lander,
         JustOneGlass,
+        Map,
         Sword,
         Cragflame,
         Mutavault,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/ExploreEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/ExploreEffectExecutor.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.engine.handlers.effects.permanent
+
+import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ExploreEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import java.util.UUID
+import kotlin.reflect.KClass
+
+/**
+ * Executor for ExploreEffect.
+ *
+ * "Reveal the top card of your library. If it's a land card, put it into your hand.
+ * Otherwise, put a +1/+1 counter on this creature, then put the card back on top of your
+ * library or put it into your graveyard."
+ *
+ * The exploring player is the effect controller. The exploring creature is [ExploreEffect.target].
+ */
+class ExploreEffectExecutor : EffectExecutor<ExploreEffect> {
+
+    override val effectType: KClass<ExploreEffect> = ExploreEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ExploreEffect,
+        context: EffectContext
+    ): EffectResult {
+        val exploringCreatureId = context.resolveTarget(effect.target, state)
+            ?: return EffectResult.success(state)
+
+        val explorerId = context.controllerId
+        val library = state.getLibrary(explorerId)
+        if (library.isEmpty()) return EffectResult.success(state)
+
+        val topCardId = library.first()
+        val topCardContainer = state.getEntity(topCardId)
+            ?: return EffectResult.success(state)
+        val topCardComponent = topCardContainer.get<CardComponent>()
+            ?: return EffectResult.success(state)
+
+        val topCardName = topCardComponent.name
+        val topCardImageUri = topCardComponent.imageUri
+        val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+
+        val revealEvent = CardsRevealedEvent(
+            revealingPlayerId = explorerId,
+            cardIds = listOf(topCardId),
+            cardNames = listOf(topCardName),
+            imageUris = listOf(topCardImageUri),
+            source = sourceName
+        )
+
+        return if (topCardComponent.typeLine.isLand) {
+            // Land: move directly to hand
+            val transition = ZoneTransitionService.moveToZone(state, topCardId, Zone.HAND)
+            EffectResult.success(transition.state, listOf(revealEvent) + transition.events)
+        } else {
+            // Non-land: mark card revealed to all players, add +1/+1 counter, then ask:
+            // back to top of library (stays visible) or graveyard?
+            val revealedComponent = state.turnOrder.fold(RevealedToComponent(emptySet())) { acc, pid ->
+                acc.withPlayer(pid)
+            }
+            val stateWithRevealed = state.updateEntity(topCardId) { it.with(revealedComponent) }
+
+            val (stateAfterCounter, counterEvents) = addPlusOneCounter(stateWithRevealed, exploringCreatureId, context)
+
+            // Store the card in pipeline so RevealCollectionEffect can reference it when the
+            // player puts it back on top, confirming visibility to both players.
+            val contextWithCard = context.copy(
+                pipeline = context.pipeline.copy(
+                    storedCollections = context.pipeline.storedCollections +
+                        ("explore_revealed" to listOf(topCardId))
+                )
+            )
+
+            val decisionId = UUID.randomUUID().toString()
+            val decision = YesNoDecision(
+                id = decisionId,
+                playerId = explorerId,
+                prompt = "Put $topCardName back on top of your library? (No = graveyard)",
+                context = DecisionContext(
+                    sourceId = context.sourceId,
+                    sourceName = sourceName,
+                    phase = DecisionPhase.RESOLUTION
+                ),
+                yesText = "Library (top)",
+                noText = "Graveyard"
+            )
+
+            val continuation = MayAbilityContinuation(
+                decisionId = decisionId,
+                playerId = explorerId,
+                sourceName = sourceName,
+                effectIfYes = CompositeEffect(listOf(
+                    MoveToZoneEffect(
+                        target = EffectTarget.SpecificEntity(topCardId),
+                        destination = Zone.LIBRARY,
+                        placement = ZonePlacement.Top
+                    )
+                )),
+                effectIfNo = MoveToZoneEffect(
+                    target = EffectTarget.SpecificEntity(topCardId),
+                    destination = Zone.GRAVEYARD
+                ),
+                effectContext = contextWithCard
+            )
+
+            val stateWithContinuation = stateAfterCounter
+                .withPendingDecision(decision)
+                .pushContinuation(continuation)
+
+            EffectResult.paused(
+                stateWithContinuation,
+                decision,
+                listOf(revealEvent) + counterEvents + listOf(
+                    DecisionRequestedEvent(
+                        decisionId = decisionId,
+                        playerId = explorerId,
+                        decisionType = "YES_NO",
+                        prompt = decision.prompt
+                    )
+                )
+            )
+        }
+    }
+
+    private fun addPlusOneCounter(
+        state: GameState,
+        creatureId: EntityId,
+        context: EffectContext
+    ): Pair<GameState, List<GameEvent>> {
+        if (state.projectedState.hasKeyword(creatureId, AbilityFlag.CANT_RECEIVE_COUNTERS)) {
+            return state to emptyList()
+        }
+        val current = state.getEntity(creatureId)?.get<CountersComponent>() ?: CountersComponent()
+        val count = ReplacementEffectUtils.applyCounterPlacementModifiers(
+            state, creatureId, CounterType.PLUS_ONE_PLUS_ONE, 1, placerId = context.controllerId
+        )
+        val newState = state.updateEntity(creatureId) {
+            it.with(current.withAdded(CounterType.PLUS_ONE_PLUS_ONE, count))
+        }
+        val name = state.getEntity(creatureId)?.get<CardComponent>()?.name ?: ""
+        return newState to listOf(CountersAddedEvent(creatureId, "PLUS_ONE_PLUS_ONE", count, name))
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.ExecutorModule
+import com.wingedsheep.engine.handlers.effects.permanent.ExploreEffectExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.abilities.GrantActivatedAbilityExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.abilities.GrantActivatedAbilityToGroupExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.abilities.GrantKeywordExecutor
@@ -139,6 +140,7 @@ class PermanentExecutors(
         RemoveAllAbilitiesExecutor(),
         LevelUpClassExecutor(staticAbilityHandler),
         IncrementAbilityResolutionCountExecutor(),
+        ExploreEffectExecutor(),
         // tapping
         TapUntapExecutor(),
         TapTargetCreaturesExecutor(),


### PR DESCRIPTION
Implement the Explore keyword action and its predefined Map artifact token, then use them for Sentinel of the Nameless City.

Explore (ExploreEffect + ExploreEffectExecutor):
- Land on top → put into hand automatically
- Non-land → add +1/+1 counter on exploring creature; mark card revealed to all players via RevealedToComponent so it stays visible on top of library; yes/no decision: back to library top (re-emits CardsRevealedEvent) or graveyard

Map token (PredefinedTokens):
- "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery."
- Image URI from tlci token set (Francesca Baerald art)

Effects.Explore(target) and Effects.CreateMapToken() facades added.

ExploreScenarioTest covers: Sentinel ETB/attack token creation, land path, non-land back-to-library path, non-land graveyard path.