### PR TITLE
Add Diligent Zookeeper (TLA) with BonusPerCreatureType engine mechanic

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DiligentZookeeperScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DiligentZookeeperScenarioTest.kt
@@ -1,0 +1,174 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Diligent Zookeeper's static ability:
+ * "Each non-Human creature you control gets +1/+1 for each of its creature types,
+ *  to a maximum of 10."
+ *
+ * Test cases:
+ * 1. Single-type non-Human (Hill Giant — Giant) → +1/+1
+ * 2. Two-type non-Human (Elvish Warrior — Elf Warrior) → +2/+2
+ * 3. Human creature (Glory Seeker — Human Soldier) → no bonus
+ * 4. Changeling (Feisty Spikeling — all types, including Human) → no bonus
+ * 5. Dummy creature with 11 non-Human types → bonus capped at +10/+10
+ */
+class DiligentZookeeperScenarioTest : ScenarioTestBase() {
+
+    // 11 non-Human creature types — bonus would be 11 without cap, but Zookeeper caps at 10.
+    private val manyTypesCreature = CardDefinition.creature(
+        name = "Many-Type Beast",
+        manaCost = ManaCost.parse("{5}"),
+        subtypes = setOf(
+            Subtype.WOLF, Subtype.BEAR, Subtype.CAT, Subtype.BIRD, Subtype.FISH,
+            Subtype.SNAKE, Subtype.FROG, Subtype.BEAST, Subtype.ELF, Subtype.DRAGON,
+            Subtype.TURTLE      // 11th type — no Human
+        ),
+        power = 1,
+        toughness = 1
+    )
+
+    init {
+        cardRegistry.register(AvatarTheLastAirbenderSet.cards)
+        cardRegistry.register(manyTypesCreature)
+        context("Diligent Zookeeper bonus per creature type") {
+
+            test("single-type non-Human creature gets +1/+1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Diligent Zookeeper")
+                    .withCardOnBattlefield(1, "Hill Giant")   // 3/3 Giant — 1 creature type
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val clientState = game.getClientState(1)
+                val giantInfo = clientState.cards[giant]
+
+                withClue("Giant should have its projected P/T visible") {
+                    giantInfo shouldNotBe null
+                }
+                withClue("Hill Giant (3/3 Giant, 1 type) should become 4/4 with Zookeeper") {
+                    giantInfo!!.power shouldBe 4
+                    giantInfo.toughness shouldBe 4
+                }
+            }
+
+            test("two-type non-Human creature gets +2/+2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Diligent Zookeeper")
+                    .withCardOnBattlefield(1, "Elvish Warrior")  // 2/3 Elf Warrior — 2 creature types
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elf = game.findPermanent("Elvish Warrior")!!
+                val clientState = game.getClientState(1)
+                val elfInfo = clientState.cards[elf]
+
+                withClue("Elvish Warrior (2/3 Elf Warrior, 2 types) should become 4/5 with Zookeeper") {
+                    elfInfo shouldNotBe null
+                    elfInfo!!.power shouldBe 4
+                    elfInfo.toughness shouldBe 5
+                }
+            }
+
+            test("Human creature gets no bonus") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Diligent Zookeeper")
+                    .withCardOnBattlefield(1, "Glory Seeker")   // 2/2 Human Soldier — Human, excluded
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val soldier = game.findPermanent("Glory Seeker")!!
+                val clientState = game.getClientState(1)
+                val soldierInfo = clientState.cards[soldier]
+
+                withClue("Glory Seeker (Human Soldier) should not get a bonus from Zookeeper") {
+                    soldierInfo shouldNotBe null
+                    soldierInfo!!.power shouldBe 2
+                    soldierInfo.toughness shouldBe 2
+                }
+            }
+
+            test("Changeling (has Human type) gets no bonus") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Diligent Zookeeper")
+                    .withCardOnBattlefield(1, "Feisty Spikeling")  // 2/1 Changeling — all types, including Human
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val changeling = game.findPermanent("Feisty Spikeling")!!
+                val clientState = game.getClientState(1)
+                val changelingInfo = clientState.cards[changeling]
+
+                withClue("Feisty Spikeling (Changeling, has Human) should get no bonus — stays 2/1") {
+                    changelingInfo shouldNotBe null
+                    changelingInfo!!.power shouldBe 2
+                    changelingInfo.toughness shouldBe 1
+                }
+            }
+
+            test("bonus is capped at +10/+10 for a creature with 11 non-Human types") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Diligent Zookeeper")
+                    .withCardOnBattlefield(1, "Many-Type Beast")  // 11 types, no Human → cap at 10
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val beast = game.findPermanent("Many-Type Beast")!!
+                val clientState = game.getClientState(1)
+                val beastInfo = clientState.cards[beast]
+
+                withClue("Many-Type Beast (11 types, base 1/1) should be capped at +10/+10 → 11/11") {
+                    beastInfo shouldNotBe null
+                    beastInfo!!.power shouldBe 11
+                    beastInfo.toughness shouldBe 11
+                }
+            }
+
+            test("no bonus when Zookeeper is not on battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Elvish Warrior")  // 2/3 Elf Warrior — without Zookeeper
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elf = game.findPermanent("Elvish Warrior")!!
+                val clientState = game.getClientState(1)
+                val elfInfo = clientState.cards[elf]
+
+                withClue("Elvish Warrior should be base 2/3 without Zookeeper") {
+                    elfInfo shouldNotBe null
+                    elfInfo!!.power shouldBe 2
+                    elfInfo.toughness shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/StatsStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/StatsStaticAbilities.kt
@@ -98,3 +98,26 @@ data class SetBasePowerToughnessStatic(
     override val description: String = "has base power and toughness $power/$toughness"
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
 }
+
+/**
+ * Permanents matching [filter] get +[bonusPerType]/+[bonusPerType] for each of their own
+ * creature types, up to a maximum of [maxBonus].
+ *
+ * Each affected creature is evaluated individually — a creature with 3 types gets +3/+3,
+ * one with 1 type gets +1/+1, a Changeling (all types) is capped at [maxBonus].
+ *
+ * @property filter Creatures to affect (e.g., non-Human creatures you control)
+ * @property bonusPerType P/T bonus per creature type (usually 1)
+ * @property maxBonus Maximum total P/T bonus
+ */
+@SerialName("BonusPerCreatureType")
+@Serializable
+data class BonusPerCreatureType(
+    val filter: GroupFilter,
+    val bonusPerType: Int = 1,
+    val maxBonus: Int = 10
+) : StaticAbility {
+    override val description: String =
+        "gets +$bonusPerType/+$bonusPerType for each of its creature types (max +$maxBonus/+$maxBonus)"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
@@ -50,4 +50,14 @@ sealed interface EntityNumericProperty {
     data object BlockerCount : EntityNumericProperty {
         override val description: String = "the number of creatures blocking"
     }
+
+    /**
+     * The number of distinct creature types this entity has (from projected state).
+     * Used by BonusPerCreatureType static ability (e.g., Diligent Zookeeper).
+     */
+    @SerialName("CreatureTypeCount")
+    @Serializable
+    data object CreatureTypeCount : EntityNumericProperty {
+        override val description: String = "the number of its creature types"
+    }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/DiligentZookeeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/DiligentZookeeper.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.BonusPerCreatureType
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Diligent Zookeeper — {3}{G}
+ * Creature — Human Citizen Ally
+ * 4/4
+ * Each non-Human creature you control gets +1/+1 for each of its creature types,
+ * to a maximum of 10.
+ */
+val DiligentZookeeper = card("Diligent Zookeeper") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Citizen Ally"
+    oracleText = "Each non-Human creature you control gets +1/+1 for each of its creature types, to a maximum of 10."
+    power = 4
+    toughness = 4
+
+    staticAbility {
+        ability = BonusPerCreatureType(
+            filter = GroupFilter(GameObjectFilter.Creature.notSubtype(Subtype.HUMAN).youControl()),
+            bonusPerType = 1,
+            maxBonus = 10
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "171"
+        artist = "Maojin Lee"
+        flavorText = "\"I wish I could get her a big, open prairie like she likes. I'd let her hop her way to happiness.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21f52564-9820-42dc-a08d-459d51afc397.jpg?1771532900"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -168,6 +168,16 @@ class DynamicAmountEvaluator(
                     }
                     return resolveNumericProperty(state, entityId, amount.numericProperty, context, useProjected = false)
                 }
+                // CreatureTypeCount uses the projectedState passed in (e.g., intermediate
+                // projected state from EffectApplicator) to read post-layer-4 subtypes, then
+                // falls back to base card subtypes if projection is unavailable.
+                if (amount.numericProperty is EntityNumericProperty.CreatureTypeCount) {
+                    val subtypes = projectedState?.getSubtypes(entityId)
+                        ?: state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.subtypes
+                            ?.map { it.value }?.toSet()
+                        ?: emptySet()
+                    return subtypes.size
+                }
                 resolveNumericProperty(state, entityId, amount.numericProperty, context, useProjected = true)
             }
 
@@ -657,6 +667,11 @@ class DynamicAmountEvaluator(
                 state.getEntity(entityId)
                     ?.get<com.wingedsheep.engine.state.components.combat.BlockedComponent>()
                     ?.blockerIds?.size ?: 0
+
+            // Handled earlier in evaluate() where projectedState is available.
+            // This fallback uses base subtypes only (projected path is in evaluate()).
+            is EntityNumericProperty.CreatureTypeCount ->
+                state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.subtypes?.size ?: 0
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -61,6 +61,10 @@ import com.wingedsheep.sdk.scripting.conditions.SourceIsUntapped
 import com.wingedsheep.sdk.scripting.GrantKeyword
 import com.wingedsheep.sdk.scripting.RemoveKeywordStatic
 import com.wingedsheep.sdk.scripting.GrantCantBeBlockedToSmallCreatures
+import com.wingedsheep.sdk.scripting.BonusPerCreatureType
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
 import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
 import com.wingedsheep.sdk.scripting.GrantWard
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
@@ -326,6 +330,23 @@ class StaticAbilityHandler(
             is GrantDynamicStatsEffect -> {
                 ContinuousEffectData(
                     modification = Modification.ModifyPowerToughnessDynamic(ability.powerBonus, ability.toughnessBonus),
+                    affectsFilter = convertGroupFilter(ability.filter)
+                )
+            }
+            is BonusPerCreatureType -> {
+                // +bonusPerType/+bonusPerType per creature type of the affected entity, capped at maxBonus.
+                // EntityReference.AffectedEntity resolves to the entity being pumped (set by EffectApplicator),
+                // so each creature is evaluated against its own type count.
+                val typeCountAmount = DynamicAmount.EntityProperty(
+                    entity = EntityReference.AffectedEntity,
+                    numericProperty = EntityNumericProperty.CreatureTypeCount
+                )
+                val bonusAmount = DynamicAmount.Min(
+                    left = DynamicAmount.Multiply(typeCountAmount, ability.bonusPerType),
+                    right = DynamicAmount.Fixed(ability.maxBonus)
+                )
+                ContinuousEffectData(
+                    modification = Modification.ModifyPowerToughnessDynamic(bonusAmount, bonusAmount),
                     affectsFilter = convertGroupFilter(ability.filter)
                 )
             }


### PR DESCRIPTION
New static ability: BonusPerCreatureType(filter, bonusPerType, maxBonus)
- Each affected creature gets +bonusPerType/+bonusPerType per creature type it has, capped at maxBonus.
- Evaluated per-entity via EntityReference.AffectedEntity (set by EffectApplicator per creature), so each creature sees its own type count — no StateProjector changes needed.

Engine changes:
- EntityNumericProperty.CreatureTypeCount — counts projected subtypes of the affected entity; resolved in evaluate() where projectedState is available, falls back to base subtypes
- StatsStaticAbilities.BonusPerCreatureType — new StaticAbility data class
- StaticAbilityHandler — converts BonusPerCreatureType to ModifyPowerToughnessDynamic( Min(Multiply(EntityProperty(AffectedEntity, CreatureTypeCount), bonusPerType), maxBonus))
- DynamicAmountEvaluator — handles CreatureTypeCount using the intermediate projected state passed from EffectApplicator; Changeling (Human via all types) correctly gets no bonus

Card: Diligent Zookeeper {3}{G} 4/4 — "Each non-Human creature you control gets +1/+1 for each of its creature types, to a maximum of 10."

Tests cover: +1/+1 for 1-type, +2/+2 for 2-type, no bonus for Human, no bonus for Changeling (has Human), cap at +10/+10 via dummy 11-type creature.