### PR TITLE
Add Badgermole Cub (TLA) with AdditionalManaFromCreatureTap mechanic

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BadgermoleCubScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BadgermoleCubScenarioTest.kt
@@ -1,0 +1,243 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Badgermole Cub.
+ *
+ * Card reference:
+ * - Badgermole Cub {1}{G} — Creature — Badger Mole 2/2
+ *   When this creature enters, earthbend 1.
+ *   Whenever you tap a creature for mana, add an additional {G}.
+ *
+ * Test cases:
+ * 1. ETB earthbend 1 — animates a land into a 0/0 creature with a +1/+1 counter
+ * 2. Additional {G} when a creature is tapped for mana
+ * 3. No additional {G} when a land is tapped for mana (only creatures trigger it)
+ */
+class BadgermoleCubScenarioTest : ScenarioTestBase() {
+
+    // A simple creature with {T}: Add {G} — used to test the "tap creature for mana" trigger.
+    private val tapForGreenCreature = card("Tap-for-Green Creature") {
+        manaCost = "{G}"
+        colorIdentity = "G"
+        typeLine = "Creature — Elf"
+        power = 1
+        toughness = 1
+        oracleText = "{T}: Add {G}."
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.AddMana(Color.GREEN, 1)
+            manaAbility = true
+        }
+    }
+
+    init {
+        cardRegistry.register(AvatarTheLastAirbenderSet.cards)
+        cardRegistry.register(tapForGreenCreature)
+
+        // ------------------------------------------------------------------
+        // Earthbend 1 on ETB
+        // ------------------------------------------------------------------
+        context("ETB earthbend 1") {
+
+            test("animates a land you control into a 1/1 creature with haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Badgermole Cub")
+                    .withLandsOnBattlefield(1, "Forest", 3) // {1}{G} + earthbend target
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast Badgermole Cub, ETB trigger fires for earthbend 1
+                game.castSpell(1, "Badgermole Cub")
+                game.resolveStack() // resolves spell; ETB trigger goes on stack, then pauses for target
+
+                // Pick one of the Forests as the earthbend target
+                val forests = game.findAllPermanents("Forest")
+                val targetForest = forests.first()
+
+                withClue("Should pause for earthbend target selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(targetForest))
+                game.resolveStack() // earthbend effect resolves
+
+                // The targeted Forest is now a 0/0 creature + 1 +1/+1 counter = 1/1
+                val clientState = game.getClientState(1)
+                val forestInfo = clientState.cards[targetForest]
+                withClue("Earthbended land should be visible as a creature") {
+                    forestInfo shouldNotBe null
+                }
+                withClue("Earthbended land should be 1/1 (0/0 base + 1 counter)") {
+                    forestInfo!!.power shouldBe 1
+                    forestInfo.toughness shouldBe 1
+                }
+                withClue("Badgermole Cub should be on the battlefield") {
+                    game.isOnBattlefield("Badgermole Cub") shouldBe true
+                }
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Additional {G} when tapping a creature for mana
+        // ------------------------------------------------------------------
+        context("Additional {G} from creature mana tap") {
+
+            test("adds 1 extra {G} when tapping a creature for mana") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Badgermole Cub")
+                    .withCardOnBattlefield(1, "Tap-for-Green Creature")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val creatureId = game.findPermanent("Tap-for-Green Creature")!!
+                val cardDef = cardRegistry.getCard("Tap-for-Green Creature")!!
+                val ability = cardDef.script.activatedAbilities.first()
+
+                // Activate {T}: Add {G}
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = creatureId,
+                        abilityId = ability.id,
+                        targets = emptyList()
+                    )
+                )
+
+                withClue("Mana ability should activate without error: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                val manaPool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("Player should have 2 {G}: 1 from creature + 1 from Badgermole Cub") {
+                    manaPool?.green shouldBe 2
+                }
+            }
+
+            test("no extra {G} when tapping a land for mana") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Badgermole Cub")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forestId = game.findPermanent("Forest")!!
+                val forestDef = cardRegistry.getCard("Forest")!!
+                val manaAbility = forestDef.script.activatedAbilities.first()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = forestId,
+                        abilityId = manaAbility.id,
+                        targets = emptyList()
+                    )
+                )
+
+                val manaPool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("Tapping a land should produce exactly 1 {G} (Badgermole Cub doesn't trigger on lands)") {
+                    manaPool?.green shouldBe 1
+                }
+            }
+
+            test("adds 1 extra {G} when tapping an earthbended creature-land for mana") {
+                // Cast Badgermole Cub — its ETB earthbends a Forest into a creature-land.
+                // Then tap that creature-land for its Forest mana ability.
+                // Since it is projected as a creature, Badgermole Cub should trigger.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Badgermole Cub")
+                    .withLandsOnBattlefield(1, "Forest", 3) // 2 for casting, 1 stays for earthbend
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast Badgermole Cub: auto-taps 2 Forests, ETB fires, pauses for earthbend target
+                game.castSpell(1, "Badgermole Cub")
+                game.resolveStack()
+
+                withClue("Should pause for earthbend target selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                // Find the remaining untapped Forest to earthbend
+                val allForests = game.findAllPermanents("Forest")
+                val untappedForest = allForests.first { fid ->
+                    game.state.getEntity(fid)?.has<TappedComponent>() == false
+                }
+
+                game.selectTargets(listOf(untappedForest))
+                game.resolveStack() // earthbend resolves: Forest → 1/1 creature-land
+
+                // Tap the now-creature-land for its Forest mana ability
+                val forestDef = cardRegistry.getCard("Forest")!!
+                val forestManaAbilityId = forestDef.script.activatedAbilities.first().id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = untappedForest,
+                        abilityId = forestManaAbilityId,
+                        targets = emptyList()
+                    )
+                )
+
+                val manaPool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("Earthbended Forest (creature-land) should produce 2 {G}: 1 from land + 1 from Badgermole Cub") {
+                    manaPool?.green shouldBe 2
+                }
+            }
+
+            test("no extra {G} without Badgermole Cub") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tap-for-Green Creature")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val creatureId = game.findPermanent("Tap-for-Green Creature")!!
+                val cardDef = cardRegistry.getCard("Tap-for-Green Creature")!!
+                val ability = cardDef.script.activatedAbilities.first()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = creatureId,
+                        abilityId = ability.id,
+                        targets = emptyList()
+                    )
+                )
+
+                val manaPool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("Without Badgermole Cub, creature tap produces exactly 1 {G}") {
+                    manaPool?.green shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -127,6 +127,29 @@ data class AdditionalManaOnLandTap(
 }
 
 /**
+ * Whenever the controller taps a creature for mana, add [amount] mana of [color].
+ * Used for Badgermole Cub: "Whenever you tap a creature for mana, add an additional {G}."
+ *
+ * Triggered mana ability — resolves immediately without using the stack.
+ *
+ * @property color The color of bonus mana to add
+ * @property amount How many additional mana to add per creature tap
+ */
+@SerialName("AdditionalManaFromCreatureTap")
+@Serializable
+data class AdditionalManaFromCreatureTap(
+    val color: Color,
+    val amount: DynamicAmount = DynamicAmount.Fixed(1)
+) : StaticAbility {
+    override val description: String =
+        "Whenever you tap a creature for mana, add an additional ${color.symbol} mana"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newAmount = amount.applyTextReplacement(replacer)
+        return if (newAmount !== amount) copy(amount = newAmount) else this
+    }
+}
+
+/**
  * Play with the top card of your library revealed.
  * You may play lands and cast spells from the top of your library.
  * Used for Future Sight.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/BadgermoleCub.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/BadgermoleCub.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalManaFromCreatureTap
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Badgermole Cub — {1}{G}
+ * Creature — Badger Mole
+ * 2/2
+ * When this creature enters, earthbend 1.
+ * Whenever you tap a creature for mana, add an additional {G}.
+ */
+val BadgermoleCub = card("Badgermole Cub") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Badger Mole"
+    oracleText = "When this creature enters, earthbend 1. (Target land you control becomes a 0/0 creature with haste that's still a land. Put a +1/+1 counter on it. When it dies or is exiled, return it to the battlefield tapped.)\nWhenever you tap a creature for mana, add an additional {G}."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val land = target("target land you control", TargetObject(filter = TargetFilter.Land.youControl()))
+        effect = Effects.Earthbend(1, land)
+        description = "When this creature enters, earthbend 1."
+    }
+
+    staticAbility {
+        ability = AdditionalManaFromCreatureTap(color = Color.GREEN)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "167"
+        artist = "Nathaniel Himawan"
+        flavorText = "Every mountain starts as a molehill."
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/340c5799-4964-44dd-8c48-8f3f3aba5211.jpg?1764121140"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -60,6 +60,7 @@ import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaOfColorAmongEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaOfColorLandsCouldProduceEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.AdditionalManaFromCreatureTap
 import com.wingedsheep.sdk.scripting.AdditionalManaOnLandTap
 import com.wingedsheep.sdk.scripting.AdditionalManaOnTap
 import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
@@ -836,7 +837,13 @@ class ActivateAbilityHandler(
                 currentState, action.sourceId, action.playerId, manaEvent, additionalManaResult.events
             )
             currentState = onLandTapResult.state
-            val allManaEvents = onLandTapResult.events
+
+            // Check for "additional mana whenever you tap a creature for mana" (e.g., Badgermole Cub)
+            val onCreatureTapResult = resolveAdditionalManaOnCreatureTap(
+                currentState, action.sourceId, action.playerId, onLandTapResult.events
+            )
+            currentState = onCreatureTapResult.state
+            val allManaEvents = onCreatureTapResult.events
 
             return ExecutionResult.success(currentState, allManaEvents)
         }
@@ -1458,6 +1465,78 @@ class ActivateAbilityHandler(
                         red = if (bonusColor == Color.RED) bonusAmount else 0,
                         green = if (bonusColor == Color.GREEN) bonusAmount else 0,
                         colorless = if (bonusColorless) bonusAmount else 0
+                    ))
+                }
+            }
+        }
+
+        return AdditionalManaResult(currentState, events)
+    }
+
+    /**
+     * After a creature's mana ability resolves, check for permanents on the controller's
+     * battlefield with [AdditionalManaFromCreatureTap]. Each matching ability adds bonus
+     * mana to the pool (e.g., Badgermole Cub: "Whenever you tap a creature for mana,
+     * add an additional {G}").
+     *
+     * Only fires when the mana source is a creature (not a land, not a non-creature artifact).
+     * Triggered mana ability — resolves immediately without using the stack.
+     */
+    private fun resolveAdditionalManaOnCreatureTap(
+        state: GameState,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        existingEvents: List<GameEvent>
+    ): AdditionalManaResult {
+        state.getEntity(sourceId) ?: return AdditionalManaResult(state, existingEvents)
+        // Use projected state so animated lands (e.g., earthbended Forest) are recognised as
+        // creatures even though their base typeLine is Land, not Creature.
+        if (!state.projectedState.isCreature(sourceId)) return AdditionalManaResult(state, existingEvents)
+
+        var currentState = state
+        val events = existingEvents.toMutableList()
+
+        for (entityId in currentState.getBattlefield()) {
+            val container = currentState.getEntity(entityId) ?: continue
+            val controllerComp = container.get<ControllerComponent>() ?: continue
+            if (controllerComp.playerId != controllerId) continue
+
+            val card = container.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+
+            for (staticAbility in cardDef.script.staticAbilities) {
+                val onCreatureTap = staticAbility as? AdditionalManaFromCreatureTap ?: continue
+
+                val opponentId = currentState.turnOrder.firstOrNull { it != controllerId }
+                val context = EffectContext(
+                    sourceId = entityId,
+                    controllerId = controllerId,
+                    opponentId = opponentId,
+                    targets = emptyList(),
+                    xValue = null
+                )
+
+                val bonusAmount = dynamicAmountEvaluator.evaluate(currentState, onCreatureTap.amount, context)
+                if (bonusAmount <= 0) continue
+
+                val extraFirings = countAdditionalSourceTriggerDoublers(currentState, entityId, controllerId)
+                val firings = 1 + extraFirings
+                repeat(firings) {
+                    currentState = currentState.updateEntity(controllerId) { c ->
+                        val pool = c.get<ManaPoolComponent>() ?: ManaPoolComponent()
+                        c.with(pool.add(onCreatureTap.color, bonusAmount))
+                    }
+
+                    events.add(ManaAddedEvent(
+                        playerId = controllerId,
+                        sourceId = entityId,
+                        sourceName = card.name,
+                        white = if (onCreatureTap.color == Color.WHITE) bonusAmount else 0,
+                        blue = if (onCreatureTap.color == Color.BLUE) bonusAmount else 0,
+                        black = if (onCreatureTap.color == Color.BLACK) bonusAmount else 0,
+                        red = if (onCreatureTap.color == Color.RED) bonusAmount else 0,
+                        green = if (onCreatureTap.color == Color.GREEN) bonusAmount else 0,
+                        colorless = 0
                     ))
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -36,6 +36,7 @@ import com.wingedsheep.sdk.scripting.effects.LandControllerScope
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.ManaRestriction
 import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.AdditionalManaFromCreatureTap
 import com.wingedsheep.sdk.scripting.AdditionalManaOnLandTap
 import com.wingedsheep.sdk.scripting.AdditionalManaOnTap
 import com.wingedsheep.sdk.scripting.DampLandManaProduction
@@ -844,6 +845,7 @@ class ManaSolver(
             )
         }.map { source -> augmentWithAuraBonusMana(state, source, playerId) }
             .map { source -> augmentWithGlobalLandTapBonusMana(state, source) }
+            .map { source -> augmentWithCreatureTapBonusMana(state, source, playerId) }
             .let { sources ->
                 if (hasDampLandManaProduction(state)) applyLandManaDampening(sources) else sources
             }
@@ -1055,6 +1057,63 @@ class ManaSolver(
             source.copy(
                 bonusManaPerTap = source.bonusManaPerTap + totalBonus,
                 bonusManaColor = source.bonusManaColor ?: landColor
+            )
+        } else {
+            source
+        }
+    }
+
+    /**
+     * If any permanent the player controls has [AdditionalManaFromCreatureTap], add bonus
+     * mana to creature mana sources. Mirrors [augmentWithGlobalLandTapBonusMana] but for
+     * creatures. Also fires for projected creatures (e.g., earthbended lands).
+     */
+    private fun augmentWithCreatureTapBonusMana(
+        state: GameState,
+        source: ManaSource,
+        playerId: EntityId
+    ): ManaSource {
+        // Only augment sources that are tapped as creatures (projected creature check)
+        val isProjectedCreature = state.projectedState.isCreature(source.entityId)
+        if (!isProjectedCreature) return source
+
+        val sourceController = state.getEntity(source.entityId)
+            ?.get<ControllerComponent>()?.playerId ?: return source
+        if (sourceController != playerId) return source
+
+        var totalBonus = 0
+        var bonusColor: Color? = null
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val controller = container.get<ControllerComponent>()?.playerId ?: continue
+            if (controller != playerId) continue
+
+            val card = container.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+
+            for (staticAbility in cardDef.script.staticAbilities) {
+                val onCreatureTap = staticAbility as? AdditionalManaFromCreatureTap ?: continue
+                val opponentId = state.turnOrder.firstOrNull { it != playerId }
+                val context = EffectContext(
+                    sourceId = entityId,
+                    controllerId = playerId,
+                    opponentId = opponentId,
+                    targets = emptyList(),
+                    xValue = null
+                )
+                val amount = dynamicAmountEvaluator.evaluate(state, onCreatureTap.amount, context)
+                if (amount > 0) {
+                    totalBonus += amount
+                    bonusColor = onCreatureTap.color
+                }
+            }
+        }
+
+        return if (totalBonus > 0 && bonusColor != null) {
+            source.copy(
+                bonusManaPerTap = source.bonusManaPerTap + totalBonus,
+                bonusManaColor = source.bonusManaColor ?: bonusColor,
+                producesColors = source.producesColors + bonusColor
             )
         } else {
             source


### PR DESCRIPTION
New static ability: AdditionalManaFromCreatureTap(color, amount)
- Fires whenever the controller taps a creature for mana (not a land).
- Triggered mana ability — resolves immediately without the stack.
- Implemented by adding resolveAdditionalManaOnCreatureTap() to ActivateAbilityHandler, following the same pattern as the existing resolveAdditionalManaOnLandTap (Lavaleaper) and resolveAdditionalManaOnTap (Elvish Guidance). Only fires when the mana source is a creature.

Card: Badgermole Cub {1}{G} 2/2 — ETB earthbend 1 (targets a land you control), plus the creature-tap mana bonus.

Tests cover: earthbend 1 animates a land into 1/1, +1 {G} on creature tap, no bonus on land tap, no bonus without the Cub.

Mana resolver does not understand that the creatures can give extra mana.