### PR TITLE
Add Requiem Monolith (EOE) with delegated may decision-maker

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 137 / 261
+**Implemented:** 138 / 261
 
 ---
 
@@ -174,7 +174,7 @@
 - [ ] Rayblade Trooper
 - [x] Red Tiger Mechan
 - [x] Remnant Elemental
-- [ ] Requiem Monolith
+- [x] Requiem Monolith
 - [x] Reroute Systems
 - [ ] Rescue Skiff
 - [x] Rig for War

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RequiemMonolithScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RequiemMonolithScenarioTest.kt
@@ -1,0 +1,151 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Requiem Monolith.
+ *
+ * Card reference:
+ * - Requiem Monolith ({2}{B}): Artifact
+ *   "{T}: Until end of turn, target creature gains 'Whenever this creature is dealt damage,
+ *    you draw that many cards and lose that much life.' That creature's controller may have
+ *    this artifact deal 1 damage to it. Activate only as a sorcery."
+ *
+ * Exercises the new `MayEffect.decisionMaker` field — the may decision is delegated to the
+ * targeted creature's controller rather than the activator.
+ */
+class RequiemMonolithScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Requiem Monolith granted trigger + delegated may") {
+
+            test("targeting own creature, accept may: draw 1, lose 1 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Requiem Monolith")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val initialHand = game.handSize(1)
+                val initialLife = game.getLifeTotal(1)
+
+                val monolithId = game.findPermanent("Requiem Monolith")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+                val ability = cardRegistry.getCard("Requiem Monolith")!!.script.activatedAbilities.first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monolithId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(seekerId))
+                    )
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+
+                game.resolveStack()
+
+                withClue("May decision should be pending") { game.hasPendingDecision() shouldBe true }
+                withClue("Player1 controls Glory Seeker, so player1 decides") {
+                    game.state.pendingDecision?.playerId shouldBe game.player1Id
+                }
+
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Player1 draws 1 from granted trigger") { game.handSize(1) shouldBe initialHand + 1 }
+                withClue("Player1 loses 1 life from granted trigger") { game.getLifeTotal(1) shouldBe initialLife - 1 }
+                withClue("Glory Seeker survives 1 damage") { game.isOnBattlefield("Glory Seeker") shouldBe true }
+            }
+
+            test("targeting own creature, decline may: no damage, no draw, no life loss") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Requiem Monolith")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val initialHand = game.handSize(1)
+                val initialLife = game.getLifeTotal(1)
+
+                val monolithId = game.findPermanent("Requiem Monolith")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+                val ability = cardRegistry.getCard("Requiem Monolith")!!.script.activatedAbilities.first()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monolithId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(seekerId))
+                    )
+                )
+                game.resolveStack()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                game.handSize(1) shouldBe initialHand
+                game.getLifeTotal(1) shouldBe initialLife
+                game.isOnBattlefield("Glory Seeker") shouldBe true
+            }
+
+            test("targeting opponent's creature: opponent makes the may decision") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Requiem Monolith")
+                    .withCardOnBattlefield(2, "Glory Seeker") // opponent controls
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val p2InitialHand = game.handSize(2)
+                val p2InitialLife = game.getLifeTotal(2)
+
+                val monolithId = game.findPermanent("Requiem Monolith")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+                val ability = cardRegistry.getCard("Requiem Monolith")!!.script.activatedAbilities.first()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monolithId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(seekerId))
+                    )
+                )
+                game.resolveStack()
+
+                withClue("Opponent (target's controller) is asked the may, not the activator") {
+                    game.state.pendingDecision?.playerId shouldBe game.player2Id
+                }
+
+                // Opponent accepts to demonstrate the granted trigger reaches them.
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Opponent draws 1 from the granted trigger they now control") {
+                    game.handSize(2) shouldBe p2InitialHand + 1
+                }
+                withClue("Opponent loses 1 life") { game.getLifeTotal(2) shouldBe p2InitialLife - 1 }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RequiemMonolithScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RequiemMonolithScenarioTest.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Scenario tests for Requiem Monolith.
@@ -145,6 +146,91 @@ class RequiemMonolithScenarioTest : ScenarioTestBase() {
                     game.handSize(2) shouldBe p2InitialHand + 1
                 }
                 withClue("Opponent loses 1 life") { game.getLifeTotal(2) shouldBe p2InitialLife - 1 }
+            }
+
+            test("cannot activate at instant speed (during opponent's turn)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Requiem Monolith")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(2) // Player 2's turn — Player 1 cannot activate at sorcery speed
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val monolithId = game.findPermanent("Requiem Monolith")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+                val ability = cardRegistry.getCard("Requiem Monolith")!!.script.activatedAbilities.first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monolithId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(seekerId))
+                    )
+                )
+
+                withClue("Activation should be rejected at instant speed") {
+                    result.error shouldNotBe null
+                }
+            }
+
+            test("granted trigger fires when an opposing spell deals damage to the granted creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Requiem Monolith")
+                    .withCardOnBattlefield(1, "Towering Baloth") // 7/6 — easily survives 2 damage
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val monolithId = game.findPermanent("Requiem Monolith")!!
+                val balothId = game.findPermanent("Towering Baloth")!!
+                val ability = cardRegistry.getCard("Requiem Monolith")!!.script.activatedAbilities.first()
+
+                // Player 1 grants the trigger to their Baloth, declines the self-ping.
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monolithId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(balothId))
+                    )
+                )
+                game.resolveStack()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                val handAfterGrant = game.handSize(1)
+                val lifeAfterGrant = game.getLifeTotal(1)
+
+                // Pass priority to P2 so they can cast Shock at instant speed.
+                game.passPriority()
+
+                // Player 2 casts Shock targeting the Baloth while it still carries the granted trigger.
+                val shockResult = game.castSpell(2, "Shock", balothId)
+                withClue("Player 2 should be able to cast Shock: ${shockResult.error}") {
+                    shockResult.error shouldBe null
+                }
+                game.resolveStack() // Shock resolves → 2 damage → granted trigger fires → resolve
+
+                withClue("Granted trigger fires from a different damage source (Shock, not the artifact)") {
+                    game.handSize(1) shouldBe handAfterGrant + 2
+                }
+                withClue("Player1 loses 2 life — equal to damage taken") {
+                    game.getLifeTotal(1) shouldBe lifeAfterGrant - 2
+                }
+                withClue("Towering Baloth (7/6) survives 2 damage from Shock") {
+                    game.isOnBattlefield("Towering Baloth") shouldBe true
+                }
             }
         }
     }

--- a/manual-scenarios/cards/r/requiem-monolith.json
+++ b/manual-scenarios/cards/r/requiem-monolith.json
@@ -1,0 +1,50 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Swamp"
+    ],
+    "battlefield": [
+      {"name": "Requiem Monolith"},
+      {"name": "Towering Baloth"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Shock"
+    ],
+    "battlefield": [
+      {"name": "Glory Seeker"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -382,7 +382,7 @@ constructors.
 | Effect                       | Parameters                                            | Purpose                        |
 |------------------------------|-------------------------------------------------------|--------------------------------|
 | `CompositeEffect`            | `effects: List<Effect>`                               | Chain multiple effects         |
-| `MayEffect`                  | `effect, descriptionOverride?`                        | "You may..."                   |
+| `MayEffect`                  | `effect, descriptionOverride?, decisionMaker?: EffectTarget` | "You may..." (set `decisionMaker` for "that creature's controller may ..." — Requiem Monolith) |
 | `ModalEffect`                | `modes: List<Mode>, chooseCount`                      | "Choose one/two..."            |
 | `BudgetModalEffect`          | `budget: Int, modes: List<BudgetMode>`                | "Choose up to N worth of modes" (Season cycle) |
 | `OptionalCostEffect`         | `cost, ifPaid, ifNotPaid?`                            | "You may [cost]. If you do..." |

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -68,6 +68,11 @@ data class CompositeEffect(
  *
  * Use this to compose optional parts of abilities rather than creating
  * specific optional variants of each effect.
+ *
+ * @property decisionMaker Optional override for who answers the yes/no question.
+ *   Defaults to the ability's controller. Set to e.g. [EffectTarget.TargetController]
+ *   for "that creature's controller may ..." (Requiem Monolith) — only the prompt
+ *   is delegated; the inner effect still resolves under the original controller.
  */
 @SerialName("May")
 @Serializable
@@ -77,7 +82,8 @@ data class MayEffect(
     val sourceRequiredZone: Zone? = null,
     val inlineOnTrigger: Boolean = false,
     /** Optional hint text shown below the prompt (e.g., keyword reminder text) */
-    val hint: String? = null
+    val hint: String? = null,
+    val decisionMaker: EffectTarget? = null
 ) : Effect {
     override val description: String = descriptionOverride ?: "You may ${effect.description.lowercase()}"
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/RequiemMonolith.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/RequiemMonolith.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Requiem Monolith
+ * {2}{B}
+ * Artifact
+ * {T}: Until end of turn, target creature gains "Whenever this creature is dealt damage,
+ * you draw that many cards and lose that much life." That creature's controller may have
+ * this artifact deal 1 damage to it. Activate only as a sorcery.
+ */
+val RequiemMonolith = card("Requiem Monolith") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "{T}: Until end of turn, target creature gains \"Whenever this creature is dealt damage, you draw that many cards and lose that much life.\" That creature's controller may have this artifact deal 1 damage to it. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        timing = TimingRule.SorcerySpeed
+        val creature = target("target creature", Targets.Creature)
+
+        val damage = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+        val grantedAbility = TriggeredAbility.create(
+            trigger = Triggers.TakesDamage.event,
+            binding = Triggers.TakesDamage.binding,
+            effect = CompositeEffect(
+                listOf(
+                    DrawCardsEffect(damage, EffectTarget.Controller),
+                    LoseLifeEffect(damage, EffectTarget.Controller)
+                )
+            ),
+            descriptionOverride = "Whenever this creature is dealt damage, you draw that many cards and lose that much life"
+        )
+
+        effect = CompositeEffect(
+            listOf(
+                GrantTriggeredAbilityEffect(ability = grantedAbility, target = creature),
+                MayEffect(
+                    effect = DealDamageEffect(amount = 1, target = creature, damageSource = EffectTarget.Self),
+                    descriptionOverride = "Have Requiem Monolith deal 1 damage to that creature?",
+                    decisionMaker = EffectTarget.TargetController
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "113"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/837d710a-652f-4c60-a52d-d786231160a4.jpg?1752947010"
+        ruling("2025-07-25", "If lethal damage is dealt to a creature that has been granted the listed ability by Requiem Monolith's ability, the granted ability will still trigger.")
+        ruling("2025-07-25", "If multiple sources deal damage to a creature that has been granted the listed ability by Requiem Monolith's ability (probably because multiple creatures blocked that creature), the granted ability triggers only once. When it resolves, the creature's controller draws cards and loses life equal to the total amount of damage dealt to that creature by those sources.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/MayEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/MayEffectExecutor.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.handlers.effects.composite
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
@@ -47,7 +48,9 @@ class MayEffectExecutor(
             if (!anyFeasible) return EffectResult.success(state)
         }
 
-        val playerId = context.controllerId
+        val playerId = effect.decisionMaker
+            ?.let { TargetResolutionUtils.resolvePlayerTarget(it, context, state) }
+            ?: context.controllerId
 
         // Get source name for the prompt
         val sourceName = context.sourceId?.let { sourceId ->


### PR DESCRIPTION
## Summary

- Add **Requiem Monolith** ({2}{B}, EOE 113, Rare). The artifact's `{T}` ability grants a target creature a "whenever this creature is dealt damage" trigger for the turn, then offers the *target's* controller a one-shot ping.
- Generalize `MayEffect` with a new optional `decisionMaker: EffectTarget?` so the yes/no can be routed to a player other than the ability's controller — without affecting the inner effect's resolution. Default behavior is unchanged.
- 5 scenario tests covering: self-target accept, self-target decline, opponent-target (verifies opponent is the decision-maker), instant-speed activation rejected, and the granted trigger firing from a non-Monolith damage source (Shock).

The `decisionMaker` parameter is the only API surface added; nothing else needed new types or executors. The frontend's existing per-player decision masking (`GameSession.kt:624`) routes the prompt automatically — no client changes required.

## Test plan

- [x] `./gradlew :rules-engine:test` — all green
- [x] `./gradlew :game-server:test` — all green, including the new `RequiemMonolithScenarioTest` (5 tests)
- [x] `./gradlew :mtg-sdk:test` — all green
- [x] Manual scenario fixture added at `manual-scenarios/cards/r/requiem-monolith.json` for live UI smoke testing
- [x] Scryfall verification (name, mana cost, type line, oracle text, rarity, collector number, artist, image URI all match the EOE printing)
- [x] Both rulings from the official Scryfall rulings list captured in metadata