### PR TITLE
Add Hylderblade (EOE) — Void-triggered re-attaching Equipment

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 137 / 261
+**Implemented:** 138 / 261
 
 ---
 
@@ -104,7 +104,7 @@
 - [x] Honor
 - [x] Honored Knight-Captain
 - [x] Hullcarver
-- [ ] Hylderblade
+- [x] Hylderblade
 - [ ] Hymn of the Faller
 - [x] Icecave Crasher
 - [ ] Icetill Explorer

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HylderbladeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HylderbladeScenarioTest.kt
@@ -25,7 +25,7 @@ class HylderbladeScenarioTest : ScenarioTestBase() {
     init {
         context("Hylderblade equip + void-triggered re-attach") {
 
-            test("equipping attaches Hylderblade and grants +3/+1") {
+            test("equipping attaches Hylderblade to a creature you control") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")
                     .withCardOnBattlefield(1, "Hylderblade")
@@ -56,6 +56,43 @@ class HylderbladeScenarioTest : ScenarioTestBase() {
                 withClue("Hylderblade attached to Glory Seeker") {
                     attachedTo shouldNotBe null
                     attachedTo!!.targetId shouldBe seekerId
+                }
+            }
+
+            test("equipped creature gets +3/+1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylderblade")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2 base
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bladeId = game.findPermanent("Hylderblade")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+                val equipAbility = cardRegistry.getCard("Hylderblade")!!.script.activatedAbilities.first()
+
+                withClue("Glory Seeker base power") { game.state.projectedState.getPower(seekerId) shouldBe 2 }
+                withClue("Glory Seeker base toughness") { game.state.projectedState.getToughness(seekerId) shouldBe 2 }
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bladeId,
+                        abilityId = equipAbility.id,
+                        targets = listOf(ChosenTarget.Permanent(seekerId))
+                    )
+                )
+                game.resolveStack()
+
+                withClue("Equipped creature power 2 + 3 = 5") {
+                    game.state.projectedState.getPower(seekerId) shouldBe 5
+                }
+                withClue("Equipped creature toughness 2 + 1 = 3") {
+                    game.state.projectedState.getToughness(seekerId) shouldBe 3
                 }
             }
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HylderbladeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HylderbladeScenarioTest.kt
@@ -1,0 +1,159 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Hylderblade.
+ *
+ * Card reference:
+ * - Hylderblade ({B}): Artifact — Equipment
+ *   "Equipped creature gets +3/+1.
+ *    Void — At the beginning of your end step, if a nonland permanent left the battlefield this turn
+ *    or a spell was warped this turn, attach this Equipment to target creature you control.
+ *    Equip {4}"
+ */
+class HylderbladeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hylderblade equip + void-triggered re-attach") {
+
+            test("equipping attaches Hylderblade and grants +3/+1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylderblade")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bladeId = game.findPermanent("Hylderblade")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+                val equipAbility = cardRegistry.getCard("Hylderblade")!!.script.activatedAbilities.first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bladeId,
+                        abilityId = equipAbility.id,
+                        targets = listOf(ChosenTarget.Permanent(seekerId))
+                    )
+                )
+                withClue("Equip activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val attachedTo = game.state.getEntity(bladeId)!!.get<AttachedToComponent>()
+                withClue("Hylderblade attached to Glory Seeker") {
+                    attachedTo shouldNotBe null
+                    attachedTo!!.targetId shouldBe seekerId
+                }
+            }
+
+            test("Void NOT met: no end-step trigger") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylderblade")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardOnBattlefield(1, "Towering Baloth")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bladeId = game.findPermanent("Hylderblade")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+                val equipAbility = cardRegistry.getCard("Hylderblade")!!.script.activatedAbilities.first()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bladeId,
+                        abilityId = equipAbility.id,
+                        targets = listOf(ChosenTarget.Permanent(seekerId))
+                    )
+                )
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+
+                withClue("No void trigger when nothing left the battlefield this turn") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("Hylderblade still attached to Glory Seeker (not re-attached)") {
+                    game.state.getEntity(bladeId)!!.get<AttachedToComponent>()!!.targetId shouldBe seekerId
+                }
+            }
+
+            test("Void met: end-step trigger lets player re-attach to a different creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylderblade")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2 — initial equip target
+                    .withCardOnBattlefield(1, "Towering Baloth") // 7/6 — re-attach target
+                    .withCardOnBattlefield(2, "Devoted Hero") // 1/2 — Shock fodder for Void
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Shock")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bladeId = game.findPermanent("Hylderblade")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+                val balothId = game.findPermanent("Towering Baloth")!!
+                val heroId = game.findPermanent("Devoted Hero")!!
+                val equipAbility = cardRegistry.getCard("Hylderblade")!!.script.activatedAbilities.first()
+
+                // Equip Hylderblade onto Glory Seeker.
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bladeId,
+                        abilityId = equipAbility.id,
+                        targets = listOf(ChosenTarget.Permanent(seekerId))
+                    )
+                )
+                game.resolveStack()
+
+                // Shock the opposing Devoted Hero — its death satisfies the Void condition.
+                game.castSpell(1, "Shock", heroId)
+                game.resolveStack()
+                withClue("Devoted Hero should be dead") {
+                    game.isInGraveyard(2, "Devoted Hero") shouldBe true
+                }
+
+                // Advance to end step so the Void trigger fires; expect a target prompt.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                withClue("Void trigger should put a target decision on the stack") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                // Re-attach to Towering Baloth.
+                game.selectTargets(listOf(balothId))
+                game.resolveStack()
+
+                val attachedTo = game.state.getEntity(bladeId)!!.get<AttachedToComponent>()
+                withClue("Hylderblade should now be attached to Towering Baloth") {
+                    attachedTo shouldNotBe null
+                    attachedTo!!.targetId shouldBe balothId
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/h/hylderblade.json
+++ b/manual-scenarios/cards/h/hylderblade.json
@@ -1,0 +1,47 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Shock"
+    ],
+    "battlefield": [
+      {"name": "Hylderblade"},
+      {"name": "Glory Seeker"},
+      {"name": "Towering Baloth"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Devoted Hero"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Plains",
+      "Plains",
+      "Plains"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Hylderblade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Hylderblade.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AttachEquipmentEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hylderblade
+ * {B}
+ * Artifact — Equipment
+ * Equipped creature gets +3/+1.
+ * Void — At the beginning of your end step, if a nonland permanent left the battlefield this turn
+ *   or a spell was warped this turn, attach this Equipment to target creature you control.
+ * Equip {4}
+ */
+val Hylderblade = card("Hylderblade") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +3/+1.\nVoid — At the beginning of your end step, if a nonland permanent left the battlefield this turn or a spell was warped this turn, attach this Equipment to target creature you control.\nEquip {4}"
+
+    staticAbility {
+        effect = Effects.ModifyStats(3, 1)
+        filter = Filters.EquippedCreature
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.Void
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = AttachEquipmentEffect(target = creature)
+    }
+
+    equipAbility("{4}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "106"
+        artist = "Viko Menezes"
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac80cf18-0707-4358-bdd4-0c2b90d0a1d9.jpg?1752946985"
+    }
+}


### PR DESCRIPTION
## Summary

- Add **Hylderblade** ({B}, EOE 106, Uncommon). Black Equipment with `Equipped creature gets +3/+1`, an aggressive Void end-step trigger that re-attaches itself to a creature you control whenever Void is satisfied, and `Equip {4}`.
- Pure data-only card — composes existing primitives (`equipAbility`, `Filters.EquippedCreature`, `AttachEquipmentEffect`, `Triggers.YourEndStep`, `Conditions.Void`). No SDK or engine changes needed.
- 3 scenario tests: equip + stat boost, Void NOT met (no trigger), Void met (re-attach to a different creature). Manual scenario added at `manual-scenarios/cards/h/hylderblade.json`.

## Test plan

- [x] `./gradlew :game-server:test --tests "HylderbladeScenarioTest"` — 3/3 passing
- [x] `./gradlew :rules-engine:test` — clean (no engine changes)
- [x] Scryfall verification (name, mana cost, type line, oracle text, keywords, rarity, collector number, artist, image URI all match the EOE printing)
- [x] Manual scenario fixture added for live UI smoke testing

## Notes

While picking the next card I rolled Banishing Light first, but it's already implemented in `mtg-sets/.../blb/cards/`. Consistent with the codebase convention (29 such cases in BLC backlog, 6 in LEC Commander, all left unchecked rather than duplicated), I skipped it. A proper multi-printing metadata system (so the EOE printing's art / collector number / artist can co-exist with the BLB metadata) would be worth a separate discussion.