### PR TITLE
Add Insatiable Skittermaw (EOE)

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 138 / 261
+**Implemented:** 139 / 261
 
 ---
 
@@ -113,7 +113,7 @@
 - [x] Illvoi Light Jammer
 - [x] Illvoi Operative
 - [ ] Infinite Guideline Station
-- [ ] Insatiable Skittermaw
+- [x] Insatiable Skittermaw
 - [ ] Interceptor Mechan
 - [x] Intrepid Tenderfoot
 - [x] Invasive Maneuvers

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -891,6 +891,12 @@ abstract class ScenarioTestBase : FunSpec() {
          * Advance the game to a specific phase and step by passing priority.
          * Both players pass priority repeatedly until the target phase/step is reached.
          * This goes through the actual game flow including combat damage processing.
+         *
+         * Note: this stops *at* the target step's priority window. If the target step has
+         * begin-of-step triggers (e.g., "At the beginning of your end step, ..."), they
+         * are queued on the stack but not yet resolved when this returns. Call
+         * [resolveStack] afterward to drain them. Triggers that pause for player input
+         * (target selection, may decisions) will surface as `pendingDecision` instead.
          */
         fun passUntilPhase(phase: Phase, step: Step): GameState {
             var iterations = 0

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InsatiableSkittermawScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InsatiableSkittermawScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Insatiable Skittermaw.
+ *
+ * Card reference:
+ * - Insatiable Skittermaw ({2}{B}): 2/2 Creature — Insect Horror
+ *   "Menace.
+ *    Void — At the beginning of your end step, if a nonland permanent left the battlefield this turn
+ *    or a spell was warped this turn, put a +1/+1 counter on this creature."
+ */
+class InsatiableSkittermawScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Insatiable Skittermaw void trigger") {
+
+            test("Void NOT met: no +1/+1 counter at end step") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Insatiable Skittermaw")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val skittermawId = game.findPermanent("Insatiable Skittermaw")!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+
+                withClue("No +1/+1 counter when Void not met") {
+                    val counters = game.state.getEntity(skittermawId)!!.get<CountersComponent>()
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+                }
+                withClue("Skittermaw remains 2/2") {
+                    game.state.projectedState.getPower(skittermawId) shouldBe 2
+                    game.state.projectedState.getToughness(skittermawId) shouldBe 2
+                }
+            }
+
+            test("Void met: +1/+1 counter at end step grows Skittermaw to 3/3") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Insatiable Skittermaw")
+                    .withCardOnBattlefield(2, "Devoted Hero") // 1/2 — Shock fodder for Void
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Shock")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val skittermawId = game.findPermanent("Insatiable Skittermaw")!!
+                val heroId = game.findPermanent("Devoted Hero")!!
+
+                // Shock the opposing Hero — its death satisfies Void.
+                game.castSpell(1, "Shock", heroId)
+                game.resolveStack()
+                withClue("Devoted Hero should be dead") { game.isInGraveyard(2, "Devoted Hero") shouldBe true }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Skittermaw should have 1 +1/+1 counter") {
+                    val counters = game.state.getEntity(skittermawId)!!.get<CountersComponent>()
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+                }
+                withClue("Skittermaw projected power 2 + 1 = 3") {
+                    game.state.projectedState.getPower(skittermawId) shouldBe 3
+                }
+                withClue("Skittermaw projected toughness 2 + 1 = 3") {
+                    game.state.projectedState.getToughness(skittermawId) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/i/insatiable-skittermaw.json
+++ b/manual-scenarios/cards/i/insatiable-skittermaw.json
@@ -1,0 +1,43 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Shock"
+    ],
+    "battlefield": [
+      {"name": "Insatiable Skittermaw"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Devoted Hero"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Plains",
+      "Plains",
+      "Plains"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/InsatiableSkittermaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/InsatiableSkittermaw.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Insatiable Skittermaw
+ * {2}{B}
+ * Creature — Insect Horror
+ * 2/2
+ * Menace
+ * Void — At the beginning of your end step, if a nonland permanent left the battlefield this turn
+ *   or a spell was warped this turn, put a +1/+1 counter on this creature.
+ */
+val InsatiableSkittermaw = card("Insatiable Skittermaw") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect Horror"
+    power = 2
+    toughness = 2
+    oracleText = "Menace\nVoid — At the beginning of your end step, if a nonland permanent left the battlefield this turn or a spell was warped this turn, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.Void
+        effect = AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "108"
+        artist = "Diego Gisbert"
+        flavorText = "\"Redd's gone. And the chittering—it won't stop!\"\n—Decrypted log 3.88"
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e9d30cca-ea33-418f-bba3-5103f1dbd751.jpg?1752946993"
+    }
+}


### PR DESCRIPTION
## Summary

- Add **Insatiable Skittermaw** ({2}{B}, EOE 108, Common). 2/2 Insect Horror with **Menace** and a Void-triggered self-growth ability — at the beginning of your end step, if Void is satisfied, put a +1/+1 counter on it.
- Pure data-only card: composes `keywords(Keyword.MENACE)`, `Triggers.YourEndStep`, `triggerCondition = Conditions.Void`, `AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)`. Zero SDK changes, no new effect types.
- 2 scenario tests: Void NOT met (no counter, base 2/2), Void met (counter applied, projected 3/3). Manual scenario added at `manual-scenarios/cards/i/insatiable-skittermaw.json`.

## Test plan

- [x] `./gradlew :game-server:test --tests "InsatiableSkittermawScenarioTest"` — 2/2 passing
- [x] `./gradlew :mtg-sets:compileKotlin` — clean
- [x] Scryfall verification (name, mana cost, type line, P/T, oracle text, keywords, rarity, collector number, artist, image URI, flavor text all match the EOE printing)
- [x] Manual scenario fixture for live UI smoke testing

## Notes

Opening as draft per repo collaboration norms — promote to ready once approved.