### PR TITLE
Add Nowhere to Run (DSK) with hexproof/ward suppression mechanics

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/NowhereToRunScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/NowhereToRunScenarioTest.kt
@@ -1,0 +1,174 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Nowhere to Run (DSK).
+ *
+ * Card reference:
+ * - Nowhere to Run ({1}{B}): Enchantment, Flash
+ *   "When this enchantment enters, target creature an opponent controls gets -3/-3 until end of turn."
+ *   "Creatures your opponents control can be the targets of spells and abilities as though they
+ *    didn't have hexproof. Ward abilities of those creatures don't trigger."
+ */
+class NowhereToRunScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("ETB trigger — target creature gets -3/-3") {
+
+            test("target creature gets -3/-3 until end of turn on entry") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Nowhere to Run")
+                    .withCardOnBattlefield(2, "Grizzly Bears")   // 2/2
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearsId = game.findPermanent("Grizzly Bears")!!
+
+                // Nowhere to Run is an enchantment with no cast-time targets — targets for
+                // the ETB triggered ability are chosen when the trigger resolves.
+                val castResult = game.castSpell(1, "Nowhere to Run")
+                withClue("Should cast Nowhere to Run: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                // Spell resolves → NtR enters battlefield → ETB trigger fires, waiting for target
+                game.resolveStack()
+                withClue("Should have pending decision for ETB trigger target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(bearsId))
+
+                // ETB trigger resolves: Grizzly Bears gets -3/-3 → 2/2 becomes -1/-1 → dies from SBA
+                game.resolveStack()
+                withClue("Grizzly Bears should be in graveyard after -3/-3 lethal reduction") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+        }
+
+        context("Static — hexproof bypass") {
+
+            test("opponent's hexproof creature can be targeted while Nowhere to Run is on battlefield") {
+                // Sagu Mauler has hexproof — normally can't be targeted by opponents
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Nowhere to Run")
+                    .withCardInHand(1, "Cast Down")
+                    .withCardOnBattlefield(2, "Sagu Mauler")   // 6/6 hexproof
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val maulerId = game.findPermanent("Sagu Mauler")!!
+
+                val castResult = game.castSpell(1, "Cast Down", maulerId)
+                withClue("Cast Down should target Sagu Mauler while Nowhere to Run suppresses hexproof: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Sagu Mauler should be destroyed after Cast Down resolved") {
+                    game.isOnBattlefield("Sagu Mauler") shouldBe false
+                }
+            }
+
+            test("opponent's hexproof creature cannot be targeted WITHOUT Nowhere to Run") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Cast Down")
+                    .withCardOnBattlefield(2, "Sagu Mauler")   // 6/6 hexproof — no suppression
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val maulerId = game.findPermanent("Sagu Mauler")!!
+
+                val castResult = game.castSpell(1, "Cast Down", maulerId)
+                withClue("Cast Down should fail to target hexproof Sagu Mauler without suppression") {
+                    castResult.error shouldNotBe null
+                }
+            }
+        }
+
+        context("Static — ward suppression") {
+
+            test("ward does not trigger when targeting opponent's creature while Nowhere to Run is on battlefield") {
+                // Long River Lurker has ward {1}
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Nowhere to Run")
+                    .withCardInHand(1, "Cast Down")
+                    .withCardOnBattlefield(2, "Long River Lurker")  // 4/4 ward {1}
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lurkerId = game.findPermanent("Long River Lurker")!!
+
+                val castResult = game.castSpell(1, "Cast Down", lurkerId)
+                withClue("Cast Down should target Long River Lurker: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                // Resolve — ward should NOT fire; Cast Down resolves and destroys the lurker
+                game.resolveStack()
+
+                withClue("Long River Lurker should be destroyed (ward was suppressed by Nowhere to Run)") {
+                    game.isOnBattlefield("Long River Lurker") shouldBe false
+                }
+            }
+
+            test("ward triggers normally WITHOUT Nowhere to Run") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Cast Down")
+                    .withCardOnBattlefield(2, "Long River Lurker")  // 4/4 ward {1}
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(2, "Island", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lurkerId = game.findPermanent("Long River Lurker")!!
+
+                val castResult = game.castSpell(1, "Cast Down", lurkerId)
+                withClue("Cast Down should target Long River Lurker: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                // Ward triggers — opponent has mana to pay
+                game.resolveStack()
+
+                withClue("Long River Lurker should still be on battlefield (ward countered Cast Down)") {
+                    game.isOnBattlefield("Long River Lurker") shouldBe true
+                }
+                withClue("Cast Down should be in graveyard (countered by ward)") {
+                    game.isInGraveyard(1, "Cast Down") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -1101,6 +1101,8 @@ Set via `staticAbility { ability = ... }`:
 - `GrantShroudToController` — controller has shroud
 - `GrantHexproofToController` — controller has hexproof (opponents can't target; self-targeting still allowed)
 - `GrantCantLoseGame` — controller can't lose the game (Lich's Mastery, Platinum Angel)
+- `SuppressHexproofForGroup(filter: GroupFilter)` — creatures matching the filter can be targeted as though they didn't have hexproof; filter evaluated with this permanent's controller as context; does NOT suppress shroud (Nowhere to Run). Engine stores a `SuppressesHexproofForGroupComponent` tag on the permanent; `TargetEnumerationUtils` and `TargetValidator` consult it.
+- `SuppressWardForGroup(filter: GroupFilter)` — ward abilities of creatures matching the filter don't trigger (Nowhere to Run). Engine stores a `SuppressesWardForGroupComponent` tag; `TriggerAbilityResolver.getWardTriggeredAbilities()` returns empty when suppressed.
 - `ExtraLoyaltyActivation` — activate loyalty abilities of planeswalkers you control twice each turn (Oath of Teferi)
 - `AdditionalETBTriggers(creatureFilter)` — when a creature matching the filter ETBs under your control, triggered abilities of your permanents that fired from that event trigger an additional time (Naban, Dean of Iteration)
 - `AdditionalSourceTriggers(sourceFilter, excludeSelf = true)` — if a triggered ability of a permanent matching the filter you control triggers, it triggers an additional time (Twinflame Travelers — "another Elemental"). Works for *all* triggers (not just ETB). `excludeSelf` skips the doubler's own source to honour "another" wording.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
@@ -140,3 +140,49 @@ data object GrantCantLoseGame : StaticAbility {
     override val description: String = "You can't lose the game"
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
 }
+
+/**
+ * Creatures matching [filter] can be the targets of spells and abilities as though
+ * they didn't have hexproof.
+ *
+ * Used for Nowhere to Run: "Creatures your opponents control can be the targets of
+ * spells and abilities as though they didn't have hexproof."
+ *
+ * The filter is evaluated with the controller of this permanent as the "you" context,
+ * so [GroupFilter.AllCreaturesOpponentsControl] means "creatures opponents of the
+ * controller of this permanent control" — which is what "your opponents" means.
+ *
+ * Does NOT suppress shroud (shroud still prevents targeting by all players).
+ */
+@SerialName("SuppressHexproofForGroup")
+@Serializable
+data class SuppressHexproofForGroup(
+    val filter: GroupFilter = GroupFilter.AllCreaturesOpponentsControl
+) : StaticAbility {
+    override val description: String = "${filter.description} can be targeted as though they didn't have hexproof"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
+ * Ward abilities of creatures matching [filter] don't trigger.
+ *
+ * Used for Nowhere to Run: "Ward abilities of those creatures don't trigger."
+ *
+ * The filter is evaluated with the controller of this permanent as the "you" context.
+ * Suppresses both intrinsic ward (from the creature's own keywords) and granted ward
+ * (from GrantWard static abilities) for affected creatures.
+ */
+@SerialName("SuppressWardForGroup")
+@Serializable
+data class SuppressWardForGroup(
+    val filter: GroupFilter = GroupFilter.AllCreaturesOpponentsControl
+) : StaticAbility {
+    override val description: String = "Ward abilities of ${filter.description} don't trigger"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/NowhereToRun.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/NowhereToRun.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.SuppressHexproofForGroup
+import com.wingedsheep.sdk.scripting.SuppressWardForGroup
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Nowhere to Run
+ * {1}{B}
+ * Enchantment
+ *
+ * Flash
+ * When this enchantment enters, target creature an opponent controls gets -3/-3 until end of turn.
+ * Creatures your opponents control can be the targets of spells and abilities as though they didn't
+ * have hexproof. Ward abilities of those creatures don't trigger.
+ *
+ * Ruling: Ward is suppressed regardless of whether the creature has hexproof.
+ * Ruling: If Nowhere to Run leaves the battlefield, hexproof and ward are immediately restored —
+ * any spell already targeting an opponent's creature that had hexproof fizzles if the target
+ * regains hexproof and becomes illegal.
+ */
+val NowhereToRun = card("Nowhere to Run") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Flash\nWhen this enchantment enters, target creature an opponent controls gets -3/-3 until end of turn.\nCreatures your opponents control can be the targets of spells and abilities as though they didn't have hexproof. Ward abilities of those creatures don't trigger."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature", Targets.CreatureOpponentControls)
+        effect = Effects.ModifyStats(-3, -3, t)
+        description = "When this enchantment enters, target creature an opponent controls gets -3/-3 until end of turn."
+    }
+
+    staticAbility {
+        ability = SuppressHexproofForGroup(filter = GroupFilter.AllCreaturesOpponentsControl)
+    }
+
+    staticAbility {
+        ability = SuppressWardForGroup(filter = GroupFilter.AllCreaturesOpponentsControl)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "111"
+        artist = "Jodie Muir"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fee60e9d-9ee7-444a-88f3-c1929e1888fb.jpg?1726286262"
+        ruling("2024-09-20", "If a spell or ability you control targets a creature an opponent controls with hexproof and Nowhere to Run leaves the battlefield while that spell or ability is on the stack, that creature becomes an illegal target for that spell or ability. This includes Nowhere to Run's own triggered ability.")
+        ruling("2024-09-20", "If a spell or ability targeting a creature an opponent controls with a ward ability is on the stack, causing Nowhere to Run to leave the battlefield won't cause that ward ability to trigger.")
+        ruling("2024-09-20", "Ward abilities of creatures your opponents control won't trigger as long as Nowhere to Run is on the battlefield. It doesn't matter whether or not they have hexproof.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -312,6 +312,8 @@ val engineSerializersModule = SerializersModule {
         subclass(GrantsCantLoseGameComponent::class)
         subclass(GrantsControllerHexproofComponent::class)
         subclass(GrantsControllerShroudComponent::class)
+        subclass(SuppressesHexproofForGroupComponent::class)
+        subclass(SuppressesWardForGroupComponent::class)
         subclass(GraveyardEntryTurnComponent::class)
         subclass(GraveyardPlayPermissionUsedComponent::class)
         subclass(ExileEntryTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -3,7 +3,10 @@ package com.wingedsheep.engine.event
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.SuppressesWardForGroupComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
@@ -33,6 +36,7 @@ class TriggerAbilityResolver(
     private val cardRegistry: CardRegistry,
     private val abilityRegistry: AbilityRegistry
 ) {
+    private val predicateEvaluator = PredicateEvaluator()
 
     /**
      * Get triggered abilities for a card, checking both the AbilityRegistry
@@ -278,6 +282,15 @@ class TriggerAbilityResolver(
     ): List<TriggeredAbility> {
         val result = mutableListOf<TriggeredAbility>()
 
+        val targetContainer = state.getEntity(entityId) ?: return result
+        val targetCard = targetContainer.get<CardComponent>() ?: return result
+        val projected = state.projectedState
+        val targetControllerId = projected.getController(entityId)
+
+        // Check suppression before generating any ward triggers — suppresses both intrinsic
+        // and granted ward (Nowhere to Run: "Ward abilities of those creatures don't trigger.")
+        if (isWardSuppressed(entityId, targetControllerId, state, projected)) return result
+
         // 1. Intrinsic ward from card definition
         val cardDef = cardRegistry.getCard(cardDefinitionId)
         if (cardDef != null) {
@@ -289,10 +302,6 @@ class TriggerAbilityResolver(
         }
 
         // 2. Ward granted by battlefield-scoped GrantWard static abilities
-        val targetContainer = state.getEntity(entityId) ?: return result
-        val targetCard = targetContainer.get<CardComponent>() ?: return result
-        val projected = state.projectedState
-        val targetControllerId = projected.getController(entityId)
 
         for (permanentId in state.getBattlefield()) {
             val container = state.getEntity(permanentId) ?: continue
@@ -427,5 +436,31 @@ class TriggerAbilityResolver(
             binding = TriggerBinding.SELF,
             effect = WardCounterEffect(cost)
         )
+    }
+
+    /**
+     * Returns true if any opponent of [targetControllerId] controls a permanent that
+     * suppresses ward triggers for [entityId] (e.g. Nowhere to Run).
+     *
+     * The filter stored on [SuppressesWardForGroupComponent] is evaluated with the
+     * suppressor's controller as the "you" context using [PredicateEvaluator].
+     */
+    private fun isWardSuppressed(
+        entityId: EntityId,
+        targetControllerId: EntityId?,
+        state: GameState,
+        projected: com.wingedsheep.engine.mechanics.layers.ProjectedState
+    ): Boolean {
+        if (targetControllerId == null) return false
+        return state.getBattlefield().any { suppressorId ->
+            val suppressorController = projected.getController(suppressorId) ?: return@any false
+            if (suppressorController == targetControllerId) return@any false  // Must be an opponent
+            val suppressComponent = state.getEntity(suppressorId)
+                ?.get<SuppressesWardForGroupComponent>() ?: return@any false
+            val ctx = PredicateContext(controllerId = suppressorController, sourceId = suppressorId)
+            suppressComponent.filters.any { filter ->
+                predicateEvaluator.matchesWithProjection(state, projected, entityId, filter, ctx)
+            }
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerHexproofComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
+import com.wingedsheep.engine.state.components.battlefield.SuppressesHexproofForGroupComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.PlayerHexproofComponent
@@ -83,7 +84,8 @@ class TargetEnumerationUtils(
                         val container = state.getEntity(entityId) ?: return@filter false
                         val entityController = container.get<ControllerComponent>()?.playerId
                         if (projected.hasKeyword(entityId, Keyword.HEXPROOF) &&
-                            entityController != playerId
+                            entityController != playerId &&
+                            !isHexproofSuppressedForCaster(state, projected, entityId, playerId)
                         ) return@filter false
                         if (projected.hasKeyword(entityId, Keyword.SHROUD)) return@filter false
                         predicateEvaluator.matchesWithProjection(state, projected, entityId, permanentFilter, context)
@@ -117,7 +119,9 @@ class TargetEnumerationUtils(
         return battlefield.filter { entityId ->
             if (filter.excludeSelf && entityId == sourceId) return@filter false
             val entityController = state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
-            if (projected.hasKeyword(entityId, Keyword.HEXPROOF) && entityController != playerId) return@filter false
+            if (projected.hasKeyword(entityId, Keyword.HEXPROOF) && entityController != playerId &&
+                !isHexproofSuppressedForCaster(state, projected, entityId, playerId)
+            ) return@filter false
             if (projected.hasKeyword(entityId, Keyword.SHROUD)) return@filter false
             predicateEvaluator.matchesWithProjection(state, projected, entityId, filter.baseFilter, context)
         }
@@ -256,5 +260,31 @@ class TargetEnumerationUtils(
 
     fun playerHasHexproofAgainst(state: GameState, playerId: EntityId, controllerId: EntityId): Boolean {
         return playerId != controllerId && playerHasHexproof(state, playerId)
+    }
+
+    /**
+     * Returns true if any permanent the [casterId] controls suppresses hexproof for [targetId].
+     *
+     * Used to implement "Creatures your opponents control can be targeted as though they
+     * didn't have hexproof" (Nowhere to Run). The filter stored on
+     * [SuppressesHexproofForGroupComponent] is evaluated with the suppressor's controller
+     * as context, so [GameObjectFilter.opponentControls()] correctly matches opponent creatures.
+     */
+    private fun isHexproofSuppressedForCaster(
+        state: GameState,
+        projected: com.wingedsheep.engine.mechanics.layers.ProjectedState,
+        targetId: EntityId,
+        casterId: EntityId
+    ): Boolean {
+        return state.getBattlefield().any { suppressorId ->
+            val suppressorController = projected.getController(suppressorId)
+            if (suppressorController != casterId) return@any false
+            val suppressComponent = state.getEntity(suppressorId)
+                ?.get<SuppressesHexproofForGroupComponent>() ?: return@any false
+            val ctx = PredicateContext(controllerId = casterId, sourceId = suppressorId)
+            suppressComponent.filters.any { filter ->
+                predicateEvaluator.matchesWithProjection(state, projected, targetId, filter, ctx)
+            }
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -9,6 +9,8 @@ import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameCom
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerHexproofComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
+import com.wingedsheep.engine.state.components.battlefield.SuppressesHexproofForGroupComponent
+import com.wingedsheep.engine.state.components.battlefield.SuppressesWardForGroupComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.DoubleDamage
@@ -150,6 +152,22 @@ class StaticAbilityHandler(
             .firstOrNull()
         if (smallCreaturesAbility != null) {
             result = result.with(GrantCantBeBlockedToSmallCreaturesComponent(smallCreaturesAbility.maxValue))
+        }
+
+        // Add component for "creatures matching filter can be targeted as though they didn't have hexproof"
+        val suppressHexproofFilters = allStaticAbilities
+            .filterIsInstance<com.wingedsheep.sdk.scripting.SuppressHexproofForGroup>()
+            .map { it.filter.baseFilter }
+        if (suppressHexproofFilters.isNotEmpty()) {
+            result = result.with(SuppressesHexproofForGroupComponent(suppressHexproofFilters))
+        }
+
+        // Add component for "ward abilities of creatures matching filter don't trigger"
+        val suppressWardFilters = allStaticAbilities
+            .filterIsInstance<com.wingedsheep.sdk.scripting.SuppressWardForGroup>()
+            .map { it.filter.baseFilter }
+        if (suppressWardFilters.isNotEmpty()) {
+            result = result.with(SuppressesWardForGroupComponent(suppressWardFilters))
         }
 
         return result

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.EffectHandler
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
@@ -55,6 +56,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.TargetingSourceType
 import com.wingedsheep.engine.state.components.battlefield.CantBeTargetedByOpponentAbilitiesComponent
+import com.wingedsheep.engine.state.components.battlefield.SuppressesHexproofForGroupComponent
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.*
@@ -1816,11 +1818,13 @@ class StackResolver(
                     if (projected.hasKeyword(target.entityId, "SHROUD")) return@filterIndexed false
 
                     // Check hexproof — can't be targeted by opponents (Rule 702.11)
-                    val entityController = state.getEntity(target.entityId)?.get<ControllerComponent>()?.playerId
-                    if (projected.hasKeyword(target.entityId, "HEXPROOF") && entityController != controllerId) return@filterIndexed false
+                    val entityController = projected.getController(target.entityId)
+                        ?: state.getEntity(target.entityId)?.get<ControllerComponent>()?.playerId
+                    val hexproofSuppressed = isHexproofSuppressedForCaster(state, projected, target.entityId, controllerId)
+                    if (!hexproofSuppressed && projected.hasKeyword(target.entityId, "HEXPROOF") && entityController != controllerId) return@filterIndexed false
 
                     // Check hexproof from color (Rule 702.11b)
-                    if (entityController != controllerId) {
+                    if (!hexproofSuppressed && entityController != controllerId) {
                         for (color in sourceColors) {
                             if (projected.hasKeyword(target.entityId, "HEXPROOF_FROM_${color.name}")) {
                                 return@filterIndexed false
@@ -2163,6 +2167,29 @@ class StackResolver(
                     .pushContinuation(continuation)
                     .withPendingDecision(decision)
                 ExecutionResult.paused(pausedState, decision)
+            }
+        }
+    }
+
+    /**
+     * Returns true if any permanent the [casterId] controls suppresses hexproof for [targetId].
+     * Mirrors the same helper in TargetValidator and TargetEnumerationUtils so that
+     * resolution-time target legality respects Nowhere to Run–style suppression.
+     */
+    private fun isHexproofSuppressedForCaster(
+        state: GameState,
+        projected: com.wingedsheep.engine.mechanics.layers.ProjectedState,
+        targetId: EntityId,
+        casterId: EntityId
+    ): Boolean {
+        return state.getBattlefield().any { suppressorId ->
+            val suppressorController = projected.getController(suppressorId)
+            if (suppressorController != casterId) return@any false
+            val suppressComponent = state.getEntity(suppressorId)
+                ?.get<SuppressesHexproofForGroupComponent>() ?: return@any false
+            val ctx = PredicateContext(controllerId = casterId, sourceId = suppressorId)
+            suppressComponent.filters.any { filter ->
+                predicateEvaluator.matchesWithProjection(state, projected, targetId, filter, ctx)
             }
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.handlers.TargetingSourceType
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.CantBeTargetedByOpponentAbilitiesComponent
+import com.wingedsheep.engine.state.components.battlefield.SuppressesHexproofForGroupComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerHexproofComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
 import com.wingedsheep.engine.state.components.player.PlayerHexproofComponent
@@ -159,7 +160,9 @@ class TargetValidator {
             val cardName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: "target"
             return "$cardName has shroud"
         }
-        if (projected.hasKeyword(entityId, Keyword.HEXPROOF) && entityController != casterId) {
+        if (projected.hasKeyword(entityId, Keyword.HEXPROOF) && entityController != casterId &&
+            !isHexproofSuppressedForCaster(state, projected, entityId, casterId)
+        ) {
             val cardName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: "target"
             return "$cardName has hexproof"
         }
@@ -192,10 +195,13 @@ class TargetValidator {
         if (entityController == casterId) return null
 
         val projected = state.projectedState
-        for (color in sourceColors) {
-            if (projected.hasKeyword(entityId, "HEXPROOF_FROM_${color.name}")) {
-                val cardName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: "target"
-                return "$cardName has hexproof from ${color.displayName.lowercase()}"
+        val hexproofSuppressed = isHexproofSuppressedForCaster(state, projected, entityId, casterId)
+        if (!hexproofSuppressed) {
+            for (color in sourceColors) {
+                if (projected.hasKeyword(entityId, "HEXPROOF_FROM_${color.name}")) {
+                    val cardName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: "target"
+                    return "$cardName has hexproof from ${color.displayName.lowercase()}"
+                }
             }
         }
         return null
@@ -618,5 +624,30 @@ class TargetValidator {
 
     private fun playerHasHexproofAgainst(state: GameState, playerId: EntityId, casterId: EntityId): Boolean {
         return playerId != casterId && playerHasHexproof(state, playerId)
+    }
+
+    /**
+     * Returns true if any permanent the [casterId] controls suppresses hexproof for [targetId].
+     *
+     * Implements "creatures can be targeted as though they didn't have hexproof" (Nowhere to Run).
+     * The filter stored on [SuppressesHexproofForGroupComponent] is evaluated with the
+     * suppressor's controller as context.
+     */
+    private fun isHexproofSuppressedForCaster(
+        state: GameState,
+        projected: com.wingedsheep.engine.mechanics.layers.ProjectedState,
+        targetId: EntityId,
+        casterId: EntityId
+    ): Boolean {
+        return state.getBattlefield().any { suppressorId ->
+            val suppressorController = projected.getController(suppressorId)
+            if (suppressorController != casterId) return@any false
+            val suppressComponent = state.getEntity(suppressorId)
+                ?.get<SuppressesHexproofForGroupComponent>() ?: return@any false
+            val ctx = PredicateContext(controllerId = casterId, sourceId = suppressorId)
+            suppressComponent.filters.any { filter ->
+                predicateEvaluator.matchesWithProjection(state, projected, targetId, filter, ctx)
+            }
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.state.Component
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.ReplacementEffect
 import kotlinx.serialization.Serializable
 
@@ -362,6 +363,34 @@ data object CantBeTargetedByOpponentAbilitiesComponent : Component
  */
 @Serializable
 data class GrantCantBeBlockedToSmallCreaturesComponent(val maxValue: Int) : Component
+
+/**
+ * Marks a permanent as suppressing hexproof for creatures matching any of [filters].
+ *
+ * Stores one filter per [SuppressHexproofForGroup] static ability on the permanent so
+ * multiple such abilities stack correctly. Each filter is evaluated with the permanent's
+ * controller as the "you" context.
+ *
+ * Created by [StaticAbilityHandler] from [SuppressHexproofForGroup] static abilities.
+ */
+@Serializable
+data class SuppressesHexproofForGroupComponent(
+    val filters: List<GameObjectFilter>
+) : Component
+
+/**
+ * Marks a permanent as suppressing ward triggers for creatures matching any of [filters].
+ *
+ * Stores one filter per [SuppressWardForGroup] static ability on the permanent so
+ * multiple such abilities stack correctly. Each filter is evaluated with the permanent's
+ * controller as the "you" context.
+ *
+ * Created by [StaticAbilityHandler] from [SuppressWardForGroup] static abilities.
+ */
+@Serializable
+data class SuppressesWardForGroupComponent(
+    val filters: List<GameObjectFilter>
+) : Component
 
 /**
  * Tracks entity IDs of cards exiled by this permanent, so they can be


### PR DESCRIPTION
Introduces two new general-purpose static abilities:
- SuppressHexproofForGroup: lets a player target opponent creatures as though they didn't have hexproof; wired into TargetEnumerationUtils, TargetValidator, and StackResolver (cast-time + resolution-time checks).
- SuppressWardForGroup: prevents ward triggered abilities from firing for matching creatures (both intrinsic and granted ward); wired into TriggerAbilityResolver with suppression check before all ward generation.

Both abilities store List<GameObjectFilter> so multiple instances stack. Components use projected controller for correct control-change handling.