### PR TITLE
Add Strategic Betrayal to Tarkir: Dragonstorm

### DIFF
--- a/manual-scenarios/cards/s/strategic-betrayal-test.json
+++ b/manual-scenarios/cards/s/strategic-betrayal-test.json
@@ -1,0 +1,31 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Strategic Betrayal"],
+    "battlefield": [
+      {"name": "Temple of Deceit", "tapped": false},
+      {"name": "Gloomlake Verge", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Healer's Hawk", "Negate"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Healer's Hawk"},
+      {"name": "Optimistic Scavenger"}
+    ],
+    "graveyard": ["Negate", "Temple of Deceit"],
+    "library": ["Strategic Betrayal", "Healer's Hawk"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -26,6 +26,7 @@ import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.definitions.scg.ScourgeSet
 import com.wingedsheep.mtg.sets.definitions.otj.OutlawsOfThunderJunctionSet
 import com.wingedsheep.mtg.sets.definitions.spm.SpiderManSet
+import com.wingedsheep.mtg.sets.definitions.tdm.TarkirDragonstormSet
 import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
 import com.wingedsheep.mtg.sets.definitions.woe.WildsOfEldrainSet
 import com.wingedsheep.sdk.model.MtgSet
@@ -67,6 +68,7 @@ object MtgSetCatalog {
         LorwynEclipsedSet,
         OutlawsOfThunderJunctionSet,
         SpiderManSet,
+        TarkirDragonstormSet,
         AvatarTheLastAirbenderSet,
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/TarkirDragonstormSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/TarkirDragonstormSet.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.tdm
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+
+/**
+ * Tarkir: Dragonstorm (2025)
+ *
+ * Set Code: TDM
+ * Release Date: April 11, 2025
+ */
+object TarkirDragonstormSet : MtgSet {
+
+    override val code = "TDM"
+    override val displayName = "Tarkir: Dragonstorm"
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.tdm.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StrategicBetrayal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StrategicBetrayal.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Strategic Betrayal — Tarkir: Dragonstorm #94
+ * {1}{B} · Sorcery
+ *
+ * Target opponent exiles a creature they control and their graveyard.
+ *
+ * Ruling: the opponent chooses which creature. If they control no creatures,
+ * they simply exile their graveyard.
+ */
+val StrategicBetrayal = card("Strategic Betrayal") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent exiles a creature they control and their graveyard."
+
+    spell {
+        target("target opponent", Targets.Opponent)
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.BattlefieldMatching(
+                        filter = GameObjectFilter.Creature,
+                        player = Player.ContextPlayer(0)
+                    ),
+                    storeAs = "creaturesCanExile"
+                ),
+                ConditionalOnCollectionEffect(
+                    collection = "creaturesCanExile",
+                    ifNotEmpty = CompositeEffect(
+                        listOf(
+                            SelectFromCollectionEffect(
+                                from = "creaturesCanExile",
+                                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                                chooser = Chooser.TargetPlayer,
+                                storeSelected = "chosenCreature",
+                                prompt = "Choose a creature to exile",
+                                useTargetingUI = true
+                            ),
+                            MoveCollectionEffect(
+                                from = "chosenCreature",
+                                destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0))
+                            )
+                        )
+                    )
+                ),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    storeAs = "opponentGraveyard"
+                ),
+                MoveCollectionEffect(
+                    from = "opponentGraveyard",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0))
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "94"
+        artist = "Flavio Greco Paglia"
+        flavorText = "As Sultai blades threatened Qatros city walls, Mehtma of House Fenzala turned her weapons on her political rivals."
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95617742-548d-464a-bb89-a858ffa9018f.jpg?1743204340"
+        ruling("2025-04-04", "The opponent chooses which creature to exile as Strategic Betrayal resolves. If they don't control any creatures at that time, they simply exile their graveyard.")
+    }
+}


### PR DESCRIPTION
Introduces the TDM set (TarkirDragonstormSet) and implements Strategic Betrayal using the existing GatherCards/ConditionalOnCollection/ SelectFromCollection/MoveCollection pipeline — no new effects needed.