### PR TITLE
Lint backlog/sets card-count headers (with auto-fix)

### DIFF
--- a/.claude/skills/add-card/SKILL.md
+++ b/.claude/skills/add-card/SKILL.md
@@ -395,7 +395,9 @@ script. When a deck pins `PrintingRef("2X2", "117")`, `GameInitializer` resolves
 
 If `backlog/sets/{set-name}/cards.md` exists:
 - Mark card as implemented: `- [ ] Card Name` → `- [x] Card Name`
-- Update implementation count in header if present
+- Run `just fix-backlog` to resync the `**Implemented:** N / M` header (the script
+  rewrites the header to match the actual `[x]` count and full checklist size).
+- `just check-backlog` is the read-only verification mode used in CI / manual review.
 
 ## Step 12: Commit Changes
 

--- a/backlog/sets/bloomburrow-commander/cards.md
+++ b/backlog/sets/bloomburrow-commander/cards.md
@@ -2,8 +2,7 @@
 
 **Set Size:** 312 cards
 **Release Date:** August 2, 2024
-**Implemented:** 11 / 312
-
+**Implemented:** 13 / 312
 | Color      | Total | Done |
 |------------|-------|------|
 | White      | 37    | 0    |

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,8 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 139 / 261
-
+**Implemented:** 141 / 261
 ---
 
 - [x] Adagia, Windswept Bastion

--- a/justfile
+++ b/justfile
@@ -50,6 +50,16 @@ clean:
 check:
     ./gradlew check
 
+# Verify backlog/sets/*/cards.md headers match actual [x] / [x]+[ ] counts
+[group: 'build']
+check-backlog:
+    scripts/check-card-counts.py --check
+
+# Rewrite backlog/sets/*/cards.md headers to match actual [x] / [x]+[ ] counts
+[group: 'build']
+fix-backlog:
+    scripts/check-card-counts.py --fix
+
 # Start the game server (loads .env if present)
 [group: 'dev']
 server:

--- a/scripts/check-card-counts.py
+++ b/scripts/check-card-counts.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Verify (and optionally fix) the `**Implemented:** N / M` header in every
+`backlog/sets/*/cards.md` file against the actual `[x]` and `[ ]` checkbox counts.
+
+Two assertions per file:
+  1. Header N must equal the count of `- [x] ...` lines.
+  2. Header M must equal `[x] + [ ]` total (the full checklist size).
+
+Usage:
+  scripts/check-card-counts.py            # equivalent to --check
+  scripts/check-card-counts.py --check    # report drift, exit 1 if any
+  scripts/check-card-counts.py --fix      # rewrite headers in place
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKLOG_GLOB = "backlog/sets/*/cards.md"
+
+HEADER_RE = re.compile(r"^\*\*Implemented:\*\*\s*(\d+)\s*/\s*(\d+)\s*$", re.MULTILINE)
+CHECKED_RE = re.compile(r"^- \[x\] ")
+UNCHECKED_RE = re.compile(r"^- \[ \] ")
+
+
+@dataclass
+class Report:
+    path: Path
+    header_implemented: int | None
+    header_total: int | None
+    checked: int
+    unchecked: int
+
+    @property
+    def actual_total(self) -> int:
+        return self.checked + self.unchecked
+
+    @property
+    def has_header(self) -> bool:
+        return self.header_implemented is not None
+
+    @property
+    def implemented_drift(self) -> bool:
+        return self.has_header and self.header_implemented != self.checked
+
+    @property
+    def total_drift(self) -> bool:
+        return self.has_header and self.header_total != self.actual_total
+
+    @property
+    def drifts(self) -> bool:
+        return self.implemented_drift or self.total_drift
+
+
+def scan(path: Path) -> Report:
+    header_impl: int | None = None
+    header_total: int | None = None
+    checked = 0
+    unchecked = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if header_impl is None:
+            m = HEADER_RE.match(line)
+            if m:
+                header_impl = int(m.group(1))
+                header_total = int(m.group(2))
+                continue
+        if CHECKED_RE.match(line):
+            checked += 1
+        elif UNCHECKED_RE.match(line):
+            unchecked += 1
+    return Report(path, header_impl, header_total, checked, unchecked)
+
+
+def fix(report: Report) -> None:
+    """Rewrite the header line in place. Caller must have verified `report.drifts`."""
+    text = report.path.read_text(encoding="utf-8")
+    new_header = f"**Implemented:** {report.checked} / {report.actual_total}"
+    new_text, count = HEADER_RE.subn(new_header, text, count=1)
+    if count != 1:
+        raise RuntimeError(f"Could not locate header to rewrite in {report.path}")
+    report.path.write_text(new_text, encoding="utf-8")
+
+
+def format_drift(report: Report) -> str:
+    rel = report.path.relative_to(REPO_ROOT)
+    parts = []
+    if report.implemented_drift:
+        parts.append(
+            f"implemented: header={report.header_implemented} actual=[x]={report.checked}"
+        )
+    if report.total_drift:
+        parts.append(
+            f"total: header={report.header_total} actual=[x]+[ ]={report.actual_total}"
+        )
+    return f"{rel}: " + "; ".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="report drift, exit 1 if any (default)")
+    group.add_argument("--fix", action="store_true", help="rewrite drifting headers in place")
+    args = parser.parse_args()
+
+    files = sorted(REPO_ROOT.glob(BACKLOG_GLOB))
+    if not files:
+        print(f"No files matched {BACKLOG_GLOB}", file=sys.stderr)
+        return 1
+
+    reports = [scan(p) for p in files]
+
+    missing_header = [r for r in reports if not r.has_header]
+    drifting = [r for r in reports if r.drifts]
+
+    if args.fix:
+        for r in drifting:
+            fix(r)
+            print(f"fixed: {r.path.relative_to(REPO_ROOT)} → {r.checked} / {r.actual_total}")
+        if missing_header:
+            for r in missing_header:
+                print(
+                    f"skipped (no header): {r.path.relative_to(REPO_ROOT)} (would need manual init)",
+                    file=sys.stderr,
+                )
+        if not drifting and not missing_header:
+            print("all card-count headers in sync; nothing to fix")
+        return 0
+
+    # --check (default)
+    if drifting:
+        for r in drifting:
+            print(format_drift(r))
+        print(
+            f"\n{len(drifting)} file(s) drift. Run `just fix-backlog` to sync.",
+            file=sys.stderr,
+        )
+        return 1
+    if missing_header:
+        for r in missing_header:
+            print(f"warning: no `**Implemented:**` header in {r.path.relative_to(REPO_ROOT)}")
+    print(f"all {len(reports)} card-count headers in sync")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/check-card-counts.py` to verify every `backlog/sets/*/cards.md` file's
`**Implemented:** N / M` header matches the actual checkbox counts. The drift you
spot in code review every few weeks (e.g. \"says 139 but I count 142\") is now a
one-line check.

Two assertions per file:
1. Header N == count of `- [x]` lines
2. Header M == `[x] + [ ]` (full checklist size)

Two modes:
- `--check` (default): report drift, exit 1. Ready for CI.
- `--fix`: rewrite the header in place.

Exposed as `just check-backlog` / `just fix-backlog`. The `add-card` skill's
Step 11 now points at `just fix-backlog` so future card additions stay in sync.

## Drift fixed in this PR

The audit caught two stale headers on `main`:
- `backlog/sets/bloomburrow-commander/cards.md`: 11 / 312 → **13 / 312**
- `backlog/sets/edge-of-eternities/cards.md`:    139 / 261 → **141 / 261**

After the fix: `just check-backlog` reports \"all 10 card-count headers in sync\".

## Why script + just (no pre-commit, no CI yet)

Per discussion: this repo doesn't currently use pre-commit hooks, so adding one
would only catch authors who opted in. The script is ready for CI — drop
`just check-backlog` into `ci.yml` whenever that move makes sense — but that's
left for a follow-up so reviewers can vet the tool first.

## Test plan

- [x] `just check-backlog` exits 0 after the fix
- [x] `just check-backlog` exits 1 with a readable diff when a header is wrong (verified against the original drift)
- [x] `just fix-backlog` reports each rewritten file
- [x] Idempotent: running `--fix` a second time produces no changes