### PR TITLE
Add Demon Wall (FIN) with CanAttackDespiteDefender mechanic

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.mtg.sets.definitions.blb.BloomburrowSet
 import com.wingedsheep.mtg.sets.definitions.blc.BloomburrowCommanderSet
 import com.wingedsheep.mtg.sets.definitions.bro.BrothersWarSet
 import com.wingedsheep.mtg.sets.definitions.dsk.DuskmournSet
+import com.wingedsheep.mtg.sets.definitions.fin.FinalFantasySet
 import com.wingedsheep.mtg.sets.definitions.spm.SpiderManSet
 import com.wingedsheep.mtg.sets.definitions.woe.WildsOfEldrainSet
 import com.wingedsheep.mtg.sets.definitions.eoe.EdgeOfEternitiesSet
@@ -80,6 +81,7 @@ abstract class ScenarioTestBase : FunSpec() {
         register(BloomburrowCommanderSet.cards); register(BloomburrowCommanderSet.basicLands)
         register(BrothersWarSet.cards)
         register(DuskmournSet.cards)
+        register(FinalFantasySet.cards)
         register(SpiderManSet.cards)
         register(WildsOfEldrainSet.cards)
         register(EdgeOfEternitiesSet.cards); register(EdgeOfEternitiesSet.basicLands)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DemonWallScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DemonWallScenarioTest.kt
@@ -43,6 +43,30 @@ class DemonWallScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("can attack when it has any counter type (finality counter)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Demon Wall")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val demonWallId = game.findPermanent("Demon Wall")!!
+                game.state = game.state.updateEntity(demonWallId) { container ->
+                    val counters = container.get<CountersComponent>() ?: CountersComponent()
+                    container.with(counters.withAdded(CounterType.FINALITY, 1))
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Demon Wall" to 2))
+                withClue("Demon Wall with a finality counter should be able to attack") {
+                    result.error shouldBe null
+                }
+            }
+
             test("can attack when it has a +1/+1 counter") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DemonWallScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DemonWallScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Demon Wall (FIN #97).
+ *
+ * Card reference:
+ * - Demon Wall {1}{B} — Artifact Creature — Demon Wall 3/3
+ *   Defender
+ *   Menace
+ *   As long as this creature has a counter on it, it can attack as though it didn't have defender.
+ *   {5}{B}: Put two +1/+1 counters on this creature.
+ */
+class DemonWallScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Demon Wall - CanAttackDespiteDefender") {
+
+            test("cannot attack when it has no counters (defender restriction applies)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Demon Wall")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Demon Wall" to 2))
+                withClue("Demon Wall with no counters should not be able to attack") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("can attack when it has a +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Demon Wall")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val demonWallId = game.findPermanent("Demon Wall")!!
+                game.state = game.state.updateEntity(demonWallId) { container ->
+                    val counters = container.get<CountersComponent>() ?: CountersComponent()
+                    container.with(counters.withAdded(CounterType.PLUS_ONE_PLUS_ONE, 1))
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Demon Wall" to 2))
+                withClue("Demon Wall with a counter should be able to attack") {
+                    result.error shouldBe null
+                }
+            }
+        }
+
+        context("Demon Wall - activated ability") {
+
+            test("{5}{B} puts two +1/+1 counters on the creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Demon Wall")
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val demonWallId = game.findPermanent("Demon Wall")!!
+                val cardDef = cardRegistry.getCard("Demon Wall")!!
+                val pumpAbility = cardDef.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = demonWallId,
+                        abilityId = pumpAbility.id
+                    )
+                )
+                withClue("Ability activation should succeed") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                val counters = game.state.getEntity(demonWallId)?.get<CountersComponent>()
+                withClue("Demon Wall should have 2 +1/+1 counters after activation") {
+                    counters shouldNotBe null
+                    counters!!.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+            }
+
+            test("two +1/+1 counters allow attacking despite defender") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Demon Wall")
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val demonWallId = game.findPermanent("Demon Wall")!!
+                val cardDef = cardRegistry.getCard("Demon Wall")!!
+                val pumpAbility = cardDef.script.activatedAbilities[0]
+
+                game.execute(ActivateAbility(game.player1Id, demonWallId, pumpAbility.id))
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val attackResult = game.declareAttackers(mapOf("Demon Wall" to 2))
+                withClue("Demon Wall with counters from ability should be able to attack") {
+                    attackResult.error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/d/demon-wall-test.json
+++ b/manual-scenarios/cards/d/demon-wall-test.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Demon Wall"},
+      {"name": "Swamp", "tapped": false},
+      {"name": "Swamp", "tapped": false},
+      {"name": "Swamp", "tapped": false},
+      {"name": "Swamp", "tapped": false},
+      {"name": "Swamp", "tapped": false},
+      {"name": "Swamp", "tapped": false},
+      {"name": "Swamp", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Demon Wall", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Healer's Hawk"}
+    ],
+    "graveyard": [],
+    "library": ["Healer's Hawk", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -1066,6 +1066,7 @@ Set via `staticAbility { ability = ... }`:
 - `MustAttackForCreatureGroup(filter: GroupFilter)` — forces creatures matching filter to attack each combat if able
 - `MustBlockForCreatureGroup(filter: GroupFilter)` — forces creatures matching filter to block each combat if able
 - `CantAttackUnless(condition: Condition, target)` — conditional attack restriction (use `Conditions.ControlMoreCreatures`, `Conditions.OpponentControlsLandType(landType)`)
+- `CanAttackDespiteDefender(condition: Condition, filter)` — creature can attack as though it didn't have defender while condition is met (e.g., `Conditions.SourceHasCounter(CounterTypeFilter.Any)` for "as long as this creature has a counter on it")
 - `CantBlockUnless(condition: Condition, target)` — conditional block restriction (uses any `Condition`)
 - `CantBlockCreaturesWithGreaterPower(target)`
 - `CanOnlyBlockCreaturesWith(blockerFilter: GameObjectFilter, filter: GroupFilter)` — can block only creatures matching filter (e.g., Cloud Spirit: flying-only blockers, Spirit token: "can't block non-Spirit creatures")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -203,6 +203,29 @@ data class AttackTax(
 }
 
 /**
+ * This creature can attack as though it didn't have defender, as long as a condition is met.
+ * "As long as this creature has a counter on it, it can attack as though it didn't have defender."
+ *
+ * Checked at attack declaration time. The condition is evaluated with "you" = the creature's
+ * controller. The filter defaults to the source creature itself.
+ *
+ * @property condition The condition under which the defender restriction is bypassed
+ * @property filter What this ability applies to
+ */
+@SerialName("CanAttackDespiteDefender")
+@Serializable
+data class CanAttackDespiteDefender(
+    val condition: Condition,
+    val filter: GroupFilter = GroupFilter.source()
+) : StaticAbility {
+    override val description: String = "can attack as though it didn't have defender as long as ${condition.description}"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Creatures without a specified keyword can't attack the controller of this permanent.
  * Used for Form of the Dragon: "Creatures without flying can't attack you."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DemonWall.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DemonWall.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Demon Wall — Final Fantasy #97
+ * {1}{B} · Artifact Creature — Demon Wall · 3/3
+ *
+ * Defender
+ * Menace
+ * As long as this creature has a counter on it, it can attack as though it didn't have defender.
+ * {5}{B}: Put two +1/+1 counters on this creature.
+ */
+val DemonWall = card("Demon Wall") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact Creature — Demon Wall"
+    power = 3
+    toughness = 3
+    oracleText = "Defender\nMenace\nAs long as this creature has a counter on it, it can attack as though it didn't have defender.\n{5}{B}: Put two +1/+1 counters on this creature."
+
+    keywords(Keyword.DEFENDER, Keyword.MENACE)
+
+    staticAbility {
+        ability = CanAttackDespiteDefender(
+            condition = Conditions.SourceHasCounter(CounterTypeFilter.Any)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{B}")
+        effect = AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "97"
+        artist = "Anton Solovianchyk"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13abd96c-d1af-43d0-b3a4-ac3db20e3b51.jpg?1748706126"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
 import com.wingedsheep.sdk.scripting.CantAttackUnless
 import com.wingedsheep.sdk.scripting.CantBeAttackedWithout
 
@@ -75,15 +76,32 @@ class SummoningSicknessAttackRule : AttackRestrictionRule {
 }
 
 /**
- * Cannot have defender keyword.
+ * Cannot have defender keyword, unless a CanAttackDespiteDefender ability's condition is met.
  */
 class DefenderAttackRule : AttackRestrictionRule {
     override fun check(ctx: AttackCheckContext): String? {
-        if (ctx.projected.hasKeyword(ctx.attackerId, Keyword.DEFENDER)) {
-            val name = ctx.state.getEntity(ctx.attackerId)?.get<CardComponent>()?.name ?: "Creature"
-            return "$name has defender and cannot attack"
-        }
-        return null
+        if (!ctx.projected.hasKeyword(ctx.attackerId, Keyword.DEFENDER)) return null
+
+        val container = ctx.state.getEntity(ctx.attackerId) ?: return errorMsg(ctx)
+        val cardComp = container.get<CardComponent>() ?: return errorMsg(ctx)
+        val cardDef = ctx.cardRegistry.getCard(cardComp.cardDefinitionId) ?: return errorMsg(ctx)
+
+        val effectContext = EffectContext(sourceId = ctx.attackerId, controllerId = ctx.attackingPlayer, opponentId = null)
+        val canAttackDespite = cardDef.staticAbilities
+            .filterIsInstance<CanAttackDespiteDefender>()
+            .any { conditionEvaluator.evaluate(ctx.state, it.condition, effectContext) }
+
+        if (canAttackDespite) return null
+        return errorMsg(ctx)
+    }
+
+    private fun errorMsg(ctx: AttackCheckContext): String {
+        val name = ctx.state.getEntity(ctx.attackerId)?.get<CardComponent>()?.name ?: "Creature"
+        return "$name has defender and cannot attack"
+    }
+
+    companion object {
+        private val conditionEvaluator = ConditionEvaluator()
     }
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
 import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import com.wingedsheep.sdk.scripting.CantBeAttackedWithout
 
 // =========================================================================
@@ -76,7 +77,7 @@ class SummoningSicknessAttackRule : AttackRestrictionRule {
 }
 
 /**
- * Cannot have defender keyword, unless a CanAttackDespiteDefender ability's condition is met.
+ * Cannot have defender keyword, unless the creature has a conditional ability to bypass defender.
  */
 class DefenderAttackRule : AttackRestrictionRule {
     override fun check(ctx: AttackCheckContext): String? {
@@ -89,6 +90,7 @@ class DefenderAttackRule : AttackRestrictionRule {
         val effectContext = EffectContext(sourceId = ctx.attackerId, controllerId = ctx.attackingPlayer, opponentId = null)
         val canAttackDespite = cardDef.staticAbilities
             .filterIsInstance<CanAttackDespiteDefender>()
+            .filter { it.filter.scope is Scope.Self }
             .any { conditionEvaluator.evaluate(ctx.state, it.condition, effectContext) }
 
         if (canAttackDespite) return null


### PR DESCRIPTION
New general-purpose StaticAbility CanAttackDespiteDefender(condition) allows a creature with Defender to attack when its condition is met. DefenderAttackRule now checks for this ability before blocking the attack.

Demon Wall uses Conditions.SourceHasCounter(CounterTypeFilter.Any) so it can attack once the {5}{B} activated ability puts counters on it.