### PR TITLE
Fix warp MayPlayPermission leaking to graveyard after creature re-cast

### DIFF
--- a/manual-scenarios/cards/a/anticausal-vestige-ltb.json
+++ b/manual-scenarios/cards/a/anticausal-vestige-ltb.json
@@ -3,7 +3,7 @@
   "player2Name": "Bob",
   "player1": {
     "lifeTotal": 20,
-    "hand": ["Protective Response", "Smother", "Serra Angel", "Leonin Vanguard", "Fading Hope"],
+    "hand": ["Protective Response", "Smother", "Serra Angel", "Leonin Vanguard", "Fading Hope", "Anticausal Vestige"],
     "battlefield": [
       {"name": "Anticausal Vestige"},
       {"name": "Plains"},
@@ -11,9 +11,12 @@
       {"name": "Swamp"},
       {"name": "Island"}
     ],
-    "graveyard": [],
+    "graveyard": ["Serra Angel", "Leonin Vanguard"],
     "library": [
       "Scarblade Scout",
+      "Plains",
+      "Plains",
+      "Plains",
       "Plains",
       "Plains",
       "Plains",
@@ -22,11 +25,23 @@
   },
   "player2": {
     "lifeTotal": 20,
-    "hand": [],
-    "battlefield": [],
+    "hand": ["Eviscerate", "Path of Peace", "Smother"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
     "graveyard": [],
     "library": [
-      "Plains",
+      "Swamp",
+      "Eviscerate",
+      "Eviscerate",
+      "Swamp",
+      "Swamp",
+      "Swamp",
       "Plains",
       "Plains",
       "Plains"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1015,7 +1015,9 @@ class StackResolver(
             }
         }
 
-        // Add to battlefield
+        // Add to battlefield — clean up any may-play permission first (mirrors the same
+        // cleanup done in resolveNonPermanentSpell before the card goes to the graveyard).
+        newState = newState.removeMayPlayPermissionsForCard(spellId)
         val battlefieldZone = ZoneKey(controllerId, Zone.BATTLEFIELD)
         newState = newState.addToZone(battlefieldZone, spellId)
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WarpMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WarpMechanicTest.kt
@@ -5,12 +5,14 @@ import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.state.components.battlefield.WarpedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.WarpExiledComponent
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
@@ -300,5 +302,82 @@ class WarpMechanicTest : FunSpec({
         permanent shouldNotBe null
         driver.state.getEntity(permanent!!)?.has<WarpedComponent>() shouldBe false
         driver.state.spellWarpedThisTurn shouldBe false
+    }
+
+    test("warped creature killed after re-cast from exile cannot be cast from graveyard") {
+        // Bug regression: after warp exile + re-cast from exile, the MayPlayPermission
+        // was not cleaned up when the permanent entered the battlefield. When the creature
+        // was subsequently killed it ended up in the graveyard while the permission was
+        // still active, making it castable from the graveyard.
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.gotoMainPhase()
+
+        val player = driver.activePlayer!!
+        val cardId = driver.putCardInHand(player, "Warp Test Creature")
+        driver.giveMana(player, Color.RED, 2)
+
+        // Step 1: cast with warp cost
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = cardId,
+                useAlternativeCost = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        driver.bothPass()
+
+        // Step 2: advance to end step — warp exile trigger fires
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        val exiledCardId = driver.getExile(player).first {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Warp Test Creature"
+        }
+        driver.state.getEntity(exiledCardId)?.has<WarpExiledComponent>() shouldBe true
+
+        // Step 3: advance to player's next main phase
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Step 4: re-cast from exile at regular cost
+        driver.giveMana(player, Color.RED, 5)
+        val recastResult = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = exiledCardId,
+                useAlternativeCost = false,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        recastResult.isSuccess shouldBe true
+        driver.bothPass()
+
+        val permanent = driver.findPermanent(player, "Warp Test Creature")
+        permanent shouldNotBe null
+
+        // Step 5: kill the creature (send it directly to the graveyard)
+        val transitionResult = ZoneTransitionService.moveToZone(
+            state = driver.state,
+            entityId = permanent!!,
+            destinationZone = Zone.GRAVEYARD
+        )
+        driver.replaceState(transitionResult.state)
+
+        driver.findPermanent(player, "Warp Test Creature") shouldBe null
+        driver.getGraveyardCardNames(player).contains("Warp Test Creature") shouldBe true
+
+        // Step 6: the creature must NOT be castable from the graveyard
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val legalActions = enumerator.enumerate(driver.state, player)
+        val castFromGraveyard = legalActions.firstOrNull { action ->
+            (action.action as? CastSpell)?.cardId == permanent &&
+                action.sourceZone == "GRAVEYARD"
+        }
+        castFromGraveyard shouldBe null
     }
 })


### PR DESCRIPTION
When a warped creature was exiled by the warp trigger and then re-cast from exile, the MayPlayPermission was never removed when the permanent entered the battlefield. If the creature was subsequently killed, the stale permission allowed casting it from the graveyard via enumerateExileCards (which checks both exile and graveyard zones).

Fix: call removeMayPlayPermissionsForCard in enterPermanentOnBattlefield, mirroring the same cleanup already done in resolveNonPermanentSpell.