### PR TITLE
Add Desculpting Blast to Edge of Eternities with Drone token

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 142 / 261
+**Implemented:** 143 / 261
 
 - [x] Adagia, Windswept Bastion
 - [x] All-Fates Scroll
@@ -51,7 +51,7 @@
 - [x] Debris Field Crusher
 - [ ] Decode Transmissions
 - [x] Depressurize
-- [ ] Desculpting Blast
+- [x] Desculpting Blast
 - [ ] Devastating Onslaught
 - [x] Diplomatic Relations
 - [ ] Divert Disaster

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -49,9 +49,6 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Fungal Colossus
 - [ ] Survey Mechan
 
-## Legendary token:
-- [x] Adagia, Windswept Bastion
-
 ## NthSpell static ability
 - [x] Brightspear Zealot
 
@@ -59,7 +56,7 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Cosmogoyf
 
 ## Drone token:
-- [ ] Desculpting Blast
+- [x] Desculpting Blast
 - [ ] Station Monitor
 - [ ] Pinnacle Emissary
 

--- a/manual-scenarios/cards/d/desculpting-blast.json
+++ b/manual-scenarios/cards/d/desculpting-blast.json
@@ -1,0 +1,44 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Desculpting Blast",
+      "Desculpting Blast"
+    ],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Hill Giant"},
+      {"name": "Grizzly Bears"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": ["DECLARE_ATTACKERS"],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1152,7 +1152,7 @@ object Effects {
      *
      * @param count Number of tokens to create
      */
-    fun CreateDrone(count: Int = 1): Effect =
+    fun CreateDroneToken(count: Int = 1): Effect =
         CreatePredefinedTokenEffect("Drone", count)
 
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1146,6 +1146,15 @@ object Effects {
     fun CreateMapToken(count: Int = 1): Effect =
         CreatePredefinedTokenEffect("Map", count)
 
+    /**
+     * Create Drone artifact creature tokens.
+     * "Flying. This token can block only creatures with flying."
+     *
+     * @param count Number of tokens to create
+     */
+    fun CreateDrone(count: Int = 1): Effect =
+        CreatePredefinedTokenEffect("Drone", count)
+
     // =========================================================================
     // Protection Effects
     // =========================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DesculptingBlast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DesculptingBlast.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Desculpting Blast
+ * {1}{U}
+ * Instant
+ * Return target nonland permanent to its owner's hand. If it was attacking,
+ * create a 1/1 colorless Drone artifact creature token with flying and
+ * "This token can block only creatures with flying."
+ */
+val DesculptingBlast = card("Desculpting Blast") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target nonland permanent to its owner's hand. If it was attacking, create a 1/1 colorless Drone artifact creature token with flying and \"This token can block only creatures with flying.\""
+
+    spell {
+        val permanent = target("target nonland permanent", Targets.NonlandPermanent)
+        // Check attacking status before the return so the permanent is still on the battlefield
+        effect = Effects.Composite(
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(GameObjectFilter.Permanent.attacking()),
+                effect = Effects.CreateDrone()
+            ),
+            Effects.ReturnToHand(permanent)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "54"
+        artist = "Jeremy Wilson"
+        flavorText = "\"Your atoms will serve my ambitions in a much more useful form.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/77fdbf32-b5f4-4346-846d-d8e0e53e6e53.jpg?1752946764"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DesculptingBlast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DesculptingBlast.kt
@@ -28,7 +28,7 @@ val DesculptingBlast = card("Desculpting Blast") {
         effect = Effects.Composite(
             ConditionalEffect(
                 condition = Conditions.TargetMatchesFilter(GameObjectFilter.Permanent.attacking()),
-                effect = Effects.CreateDrone()
+                effect = Effects.CreateDroneToken()
             ),
             Effects.ReturnToHand(permanent)
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.model.CardDefinition.Companion.doubleFacedPermanent
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureEffect
 import com.wingedsheep.sdk.scripting.effects.SearchDestination
 import com.wingedsheep.sdk.scripting.effects.TransformEffect
@@ -302,6 +303,31 @@ object PredefinedTokens {
     }
 
     /**
+     * Drone token — a 1/1 colorless artifact creature token with:
+     * Flying
+     * "This token can block only creatures with flying."
+     * Created by Desculpting Blast and other cards.
+     */
+    val Drone = card("Drone") {
+        typeLine = "Artifact Creature — Drone"
+        power = 1
+        toughness = 1
+
+        keywords(Keyword.FLYING)
+
+        staticAbility {
+            ability = CanOnlyBlockCreaturesWith(
+                blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING)
+            )
+        }
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/3/f/3fcf8950-117a-4587-8522-79001dffa500.jpg?1752946472"
+            artist = "Artur Nakhodkin"
+        }
+    }
+
+    /**
      * All predefined token definitions.
      * Register these in the CardRegistry so token abilities are resolved.
      */
@@ -315,6 +341,7 @@ object PredefinedTokens {
         Cragflame,
         Mutavault,
         SorcererRole,
-        Incubator
+        Incubator,
+        Drone
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
@@ -71,6 +71,9 @@ class CreatePredefinedTokenExecutor(
                 name = effect.tokenType,
                 manaCost = ManaCost.ZERO,
                 typeLine = cardDef.typeLine,
+                baseStats = cardDef.creatureStats,
+                baseKeywords = cardDef.keywords,
+                colors = cardDef.colors,
                 ownerId = tokenControllerId,
                 imageUri = cardDef.metadata.imageUri
             )


### PR DESCRIPTION
Implements Desculpting Blast ({1}{U} instant): returns target nonland permanent
to owner's hand; if it was attacking, creates a 1/1 colorless Drone artifact
creature token with flying and can block only creatures with flying.

Also fixes CreatePredefinedTokenExecutor to copy baseStats, baseKeywords, and
colors from the CardDefinition into the token's CardComponent — without this,
creature tokens created via Effects.CreatePredefinedToken had null toughness
and were immediately killed by the zero-toughness SBA.