### PR TITLE
Fix Evendo conditional mana ability gating and mana count

### DIFF
--- a/backlog/sets/edge-of-eternities/bugs.md
+++ b/backlog/sets/edge-of-eternities/bugs.md
@@ -1,5 +1,4 @@
 - Kavaron Harrier (exile, not sacrifice)
-- Evendo, Waking Haven (available before 12)
 - Diplomatic Relations gives +1/+0 to TO creature if FROM creature is dead
 - Secluded Starforge: 2,T: can not tap artifacts.
 - Chrome Companion should keep the bottom of the library visible.

--- a/manual-scenarios/cards/e/evendo-waking-haven.json
+++ b/manual-scenarios/cards/e/evendo-waking-haven.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Evendo, Waking Haven"],
+    "battlefield": [
+      {"name": "Evendo, Waking Haven", "counters": {"CHARGE": 12}},
+      {"name": "Forest"},
+      {"name": "Seedship Agrarian"},
+      {"name": "Gravpack Monoist"},
+      {"name": "Beamsaw Prospector"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Gravblade Heavy"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/EvendoWakingHaven.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/EvendoWakingHaven.kt
@@ -13,10 +13,8 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.conditions.Compare
 import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
-import com.wingedsheep.sdk.scripting.AbilityId
-import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
-import com.wingedsheep.sdk.scripting.effects.GrantActivatedAbilityEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
@@ -69,16 +67,18 @@ val EvendoWakingHaven = card("Evendo, Waking Haven") {
             Costs.Mana("{G}"),
             Costs.Tap
         )
-        effect = com.wingedsheep.sdk.scripting.effects.ConditionalEffect(
-            condition = Compare(
-                left = DynamicAmount.EntityProperty(
-                    entity = EntityReference.Source,
-                    numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
-                ),
-                operator = ComparisonOperator.GTE,
-                right = DynamicAmount.Fixed(12)
-            ),
-            effect = Effects.AddMana(Color.GREEN, DynamicAmounts.otherCreaturesYouControl())
+        effect = Effects.AddMana(Color.GREEN, DynamicAmounts.creaturesYouControl())
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Compare(
+                    left = DynamicAmount.EntityProperty(
+                        entity = EntityReference.Source,
+                        numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+                    ),
+                    operator = ComparisonOperator.GTE,
+                    right = DynamicAmount.Fixed(12)
+                )
+            )
         )
         manaAbility = true
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -225,6 +225,15 @@ class ManaAbilityEnumerator : ActionEnumerator {
                     }
                 }
 
+                var restrictionsMet = true
+                for (restriction in ability.restrictions) {
+                    if (!context.castPermissionUtils.checkActivationRestriction(state, playerId, restriction, entityId, ability.id)) {
+                        restrictionsMet = false
+                        break
+                    }
+                }
+                if (!restrictionsMet) continue
+
                 val costInfo = if (tapTargets != null && tapCost != null) {
                     AdditionalCostData(
                         description = tapCost.description,


### PR DESCRIPTION
Use ActivationRestriction.OnlyIfCondition instead of ConditionalEffect so the 12+ charge counter ability is hidden entirely when the condition isn't met. ManaAbilityEnumerator was not checking restrictions at all — add the same restriction loop that ActivatedAbilityEnumerator already has. Also fix creaturesYouControl (was otherCreaturesYouControl, which subtracts 1).