### PR TITLE
Auth backlog: scope tables to a Postgres `auth` schema; drop league refs

### DIFF
--- a/backlog/google-oauth2-accounts.md
+++ b/backlog/google-oauth2-accounts.md
@@ -1,27 +1,39 @@
-# Google OAuth2 Accounts & Persistent Identity
+# OAuth2 Accounts & Persistent Identity
 
-A direct Google OAuth2 + Spring Security implementation that replaces the current ephemeral
+A direct OAuth2 / OIDC + Spring Security implementation that replaces the current ephemeral
 `PlayerIdentity` (random UUID in `localStorage`) with persistent user accounts backed by Postgres.
-Provides a durable cross-session identity for any feature that needs one — while preserving
-anonymous guest play for casual games and dev scenario E2E tests.
+**Google** is the first wired-up provider; **GitHub** and **Microsoft** are designed-for follow-ups
+that drop in via a new `ClientRegistration` and a per-provider claim mapper. Provides a durable
+cross-session identity for any feature that needs one — while preserving anonymous guest play for
+casual games and dev scenario E2E tests.
 
-## Why direct Google OAuth (not Keycloak)
+## Why direct OAuth (not Keycloak)
 
-We use a direct Google OAuth2 integration via `spring-boot-starter-oauth2-client` /
-`spring-boot-starter-oauth2-resource-server` rather than fronting Google with Keycloak.
+We use direct OAuth2 / OIDC integration via `spring-boot-starter-oauth2-client` /
+`spring-boot-starter-oauth2-resource-server` rather than fronting providers with Keycloak.
 
-| Concern              | Keycloak                                            | Direct Google OAuth                                 |
+| Concern              | Keycloak                                            | Direct OAuth                                        |
 |----------------------|-----------------------------------------------------|-----------------------------------------------------|
-| Infra cost           | Extra service to deploy, upgrade, back up           | None — Google is the IdP                            |
-| Dev ergonomics       | Docker Compose service + realm/client config        | Two env vars (`client-id`, `client-secret`)         |
-| User experience      | Google login via intermediate Keycloak redirect     | One redirect, no extra branding                     |
-| Multi-provider later | Trivial (Keycloak federates Discord/GitHub natively) | Requires per-provider Spring registration           |
-| Token model          | Keycloak issues JWTs, we validate via JWKS          | We issue our own session/JWT after OAuth callback   |
-| Lock-in              | Keycloak schema, admin API                          | Standard Spring Security; provider is swappable     |
+| Infra cost           | Extra service to deploy, upgrade, back up           | None — the IdPs do the work                         |
+| Dev ergonomics       | Docker Compose service + realm/client config        | One env-var pair per provider                       |
+| User experience      | Provider login via intermediate Keycloak redirect   | One redirect, no extra branding                     |
+| Multi-provider later | Trivial (Keycloak federates Discord/GitHub natively) | One `ClientRegistration` + claim mapper per provider |
+| Token model          | Keycloak issues JWTs, we validate via JWKS          | We issue our own session JWT after OAuth callback   |
+| Lock-in              | Keycloak schema, admin API                          | Standard Spring Security; providers are swappable   |
 
-For a small player base with one realistic IdP for now (Google), the operational simplicity of
-direct OAuth outweighs the federation flexibility Keycloak offers. If we later want Discord/GitHub
-login we add another `ClientRegistration` — Spring Security supports N providers out of the box.
+Spring Security supports N providers out of the box; adding GitHub or Microsoft is a small follow-up
+once Google is in place. Keycloak's federation advantage is real but the per-provider overhead in
+Spring is low, and the ops cost of running a Keycloak instance is not.
+
+## Scope
+
+- **Phase 1 ships Google sign-in end-to-end.**
+- **Schema and abstractions are provider-agnostic from day one.** Each provider is identified by a
+  `(provider, subject)` tuple; the JIT-provisioning flow goes through a `ProviderClaimMapper`
+  abstraction so adding GitHub / Microsoft is purely additive (no migrations, no rewiring).
+- **Each provider gets a separate account.** Signing in with Google produces one
+  `auth.user_accounts` row; later signing in with GitHub as the same human produces a second row.
+  See [Open Questions](#open-questions--risks) for the rationale and the linking-as-follow-up note.
 
 ## Dependencies
 
@@ -89,16 +101,22 @@ implementation("com.auth0:java-jwt:4.x")    // for issuing our own session JWTs 
 
 ```kotlin
 @Entity
-@Table(name = "user_accounts", schema = "auth")
+@Table(
+    name = "user_accounts",
+    schema = "auth",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["provider", "subject"])]
+)
 class UserAccount(
     @Id val id: UUID,                            // our own UUID, generated on JIT provision
-    @Column(nullable = false, unique = true)
-    val googleSubject: String,                   // Google `sub` claim — stable per-Google-account
     @Column(nullable = false)
-    var email: String,                           // mutable: Google can change primary email
+    val provider: String,                        // 'google' (Phase 1), 'github', 'microsoft', ...
     @Column(nullable = false)
-    var displayName: String,                     // editable by user; defaults to Google name
-    var avatarUrl: String?,                      // Google `picture` claim
+    val subject: String,                         // provider's stable per-user ID (Google sub, GitHub id, MS oid)
+    @Column(nullable = false)
+    var email: String,                           // provider's email at last login (may change over time)
+    @Column(nullable = false)
+    var displayName: String,                     // editable by user; defaults to provider's name
+    var avatarUrl: String?,                      // provider's avatar (may be null, e.g. MS personal)
     val createdAt: Instant,
     var lastLoginAt: Instant,
     @Enumerated(EnumType.STRING)
@@ -112,24 +130,28 @@ CREATE SCHEMA IF NOT EXISTS auth;
 
 CREATE TABLE auth.user_accounts (
     id              UUID PRIMARY KEY,
-    google_subject  VARCHAR(64)  NOT NULL UNIQUE,
+    provider        VARCHAR(32)  NOT NULL,
+    subject         VARCHAR(128) NOT NULL,
     email           VARCHAR(320) NOT NULL,
     display_name    VARCHAR(80)  NOT NULL,
     avatar_url      TEXT,
     created_at      TIMESTAMPTZ  NOT NULL,
     last_login_at   TIMESTAMPTZ  NOT NULL,
-    status          VARCHAR(16)  NOT NULL DEFAULT 'ACTIVE'
+    status          VARCHAR(16)  NOT NULL DEFAULT 'ACTIVE',
+    UNIQUE (provider, subject)
 );
 CREATE INDEX idx_user_accounts_email ON auth.user_accounts (lower(email));
 ```
 
-`UserAccountRepository : JpaRepository<UserAccount, UUID>` exposes `findByGoogleSubject(sub)`.
+`UserAccountRepository : JpaRepository<UserAccount, UUID>` exposes
+`findByProviderAndSubject(provider: String, subject: String)`.
 
 ### 1.5 OAuth2 Login Flow (Spring Security)
 
 Configure two Spring Security filter chains:
 
-1. **OAuth2 login chain** — `/auth/**` endpoints handle the browser-initiated Google OAuth2 flow.
+1. **OAuth2 login chain** — `/oauth2/**` and `/login/oauth2/**` handle the browser-initiated flow
+   for any registered provider.
 2. **API/WebSocket chain** — `/api/**` and `/game` validate our own session token (see 1.6).
 
 `SecurityConfig.kt`:
@@ -142,9 +164,8 @@ class SecurityConfig(
 ) {
     @Bean @Order(1)
     fun authChain(http: HttpSecurity): SecurityFilterChain = http
-        .securityMatcher("/auth/**", "/login/**", "/oauth2/**")
+        .securityMatcher("/oauth2/**", "/login/oauth2/**", "/auth/**")
         .oauth2Login { o -> o
-            .userInfoEndpoint { it.userService(googleOidcUserService()) }
             .successHandler(::onLoginSuccess)
             .failureHandler(::onLoginFailure)
         }
@@ -166,7 +187,8 @@ class SecurityConfig(
 }
 ```
 
-Spring `application.yml`:
+Spring `application.yml` — Phase 1 wires only Google; the `github:` / `microsoft:` blocks slot in
+later without other changes:
 ```yaml
 spring:
   security:
@@ -178,40 +200,66 @@ spring:
             client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET:}
             scope: openid, profile, email
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+          # github:        # add when wiring GitHub login
+          #   client-id: ${GITHUB_OAUTH_CLIENT_ID:}
+          #   client-secret: ${GITHUB_OAUTH_CLIENT_SECRET:}
+          #   scope: read:user, user:email
+          # microsoft:     # add when wiring Microsoft login
+          #   client-id: ${MS_OAUTH_CLIENT_ID:}
+          #   client-secret: ${MS_OAUTH_CLIENT_SECRET:}
+          #   scope: openid, profile, email
+          #   provider: microsoft
+        # provider:
+        #   microsoft:
+        #     issuer-uri: https://login.microsoftonline.com/common/v2.0
 ```
 
 ### 1.6 JIT Provisioning & Session Token Issuance
 
-When a user completes Google OAuth2 the success handler runs:
-
 ```
-1. Spring's oauth2Login filter validates the Google id_token and gives us an OidcUser.
-2. AccountProvisioner.findOrCreate(oidcUser):
-     - lookup auth.user_accounts.google_subject = oidcUser.sub
+1. Spring's oauth2Login filter validates the provider's response and gives us an OAuth2User /
+   OidcUser plus the OAuth2AuthenticationToken (carries `registrationId`, e.g. "google").
+
+2. ProviderClaimMapper.map(registrationId, oauth2User) -> ProviderIdentity(
+       provider:     registrationId,
+       subject:      provider's stable user ID,
+       email:        primary verified email (may require a follow-up call, see Provider Notes),
+       displayName:  provider's name (fallback: provider's login/handle),
+       avatarUrl:    provider's picture/avatar URL (nullable)
+   )
+   Phase 1 registers only a Google mapper. The interface is the only thing GitHub/Microsoft need
+   to implement when they land.
+
+3. AccountProvisioner.findOrCreate(identity):
+     - lookup auth.user_accounts WHERE provider = identity.provider AND subject = identity.subject
      - if missing: insert new row (id = UUID.randomUUID(), createdAt = now)
-     - if present: update email/avatarUrl if changed, set lastLoginAt = now
-3. SessionTokenService.issue(userAccount):
+     - if present: update email/displayName/avatarUrl from latest claims, set lastLoginAt = now
+
+4. SessionTokenService.issue(userAccount):
      - sign a self-issued JWT (HS256 with a server-side secret, or RS256 if we want key rotation)
-     - claims: sub = userAccount.id, name = displayName, exp = now+12h, iss = "argentum"
-4. Set the JWT as an HttpOnly, Secure, SameSite=Lax cookie `argentum_session`.
-     (HttpOnly so JS can't read it; SameSite=Lax so it survives the redirect from Google.)
-5. Redirect to the SPA: 302 -> https://app/<original_target_or_/>
+     - claims: sub = userAccount.id, name = displayName, prv = userAccount.provider,
+               exp = now+12h, iss = "argentum"
+
+5. Set the JWT as an HttpOnly, Secure, SameSite=Lax cookie `argentum_session`.
+     (HttpOnly so JS can't read it; SameSite=Lax so it survives the redirect from the provider.)
+
+6. Redirect to the SPA: 302 -> https://app/<original_target_or_/>
 ```
 
-We issue **our own JWT** rather than passing Google's `id_token` to the SPA. Reasons:
-- The id_token contains PII (email) that we don't want exposed to the frontend cookie surface beyond
-  what we choose; our session JWT only carries `userAccountId` + `displayName`.
-- We control rotation and revocation. (See 1.10 — a revocation list in Redis for forced logout.)
-- Refresh is decoupled from Google: a long-lived refresh token isn't needed in the browser; the
-  user re-authenticates with Google after the session JWT expires.
+We issue **our own JWT** rather than passing the provider's `id_token`/access token to the SPA:
+- The provider token contains PII and provider-specific claims that we don't want on the frontend
+  cookie surface; our session JWT only carries `userAccountId`, `displayName`, and `provider`.
+- We control rotation and revocation. (See 1.10 — revocation list in Redis for forced logout.)
+- Refresh is decoupled from the provider: a long-lived refresh token isn't needed in the browser;
+  the user re-authenticates when the session JWT expires (one click).
 
 ### 1.7 WebSocket Authentication Bridge
 
 This is the trickiest part. `WebSocketConfig` registers `/game` with `setAllowedOrigins("*")` and
 `GameWebSocketHandler` currently authenticates on the first `ClientMessage.Connect`. WebSocket
-upgrades cannot easily participate in the OAuth2 redirect flow (browsers don't expose `Authorization`
-headers to `new WebSocket()`), so we keep auth in-message but **read the session cookie at upgrade
-time** and attach the resolved account.
+upgrades cannot easily participate in the OAuth2 redirect flow (browsers don't expose
+`Authorization` headers to `new WebSocket()`), so we keep auth in-message but **read the session
+cookie at upgrade time** and attach the resolved account.
 
 Implementation:
 
@@ -274,19 +322,24 @@ This preserves:
 
 ### 1.9 REST Endpoints
 
+Spring's defaults handle the OAuth dance per registration; the per-provider URLs are derived from
+`registrationId`:
+
 ```
-GET    /auth/login/google          Initiates Google OAuth2 (Spring redirects to Google)
-GET    /login/oauth2/code/google   OAuth2 callback (Spring handles, we run successHandler)
-POST   /auth/logout                Clears argentum_session cookie + revokes JWT (Redis blocklist)
-GET    /api/me                     Returns the current UserAccount (or 401 if guest)
-PATCH  /api/me                     Update displayName (only mutable field by user)
-DELETE /api/me                     Soft-delete: status=DELETED, anonymize email/displayName
+GET    /oauth2/authorization/google     Initiates Google OAuth2 (Spring redirects)
+GET    /login/oauth2/code/google        Callback (Spring handles, we run successHandler)
+                                        (mirror routes appear automatically for /github, /microsoft)
+POST   /auth/logout                     Clears argentum_session cookie + revokes JWT (Redis blocklist)
+GET    /api/me                          Returns the current UserAccount (or 401 if guest)
+PATCH  /api/me                          Update displayName (only mutable field by user)
+DELETE /api/me                          Soft-delete: status=DELETED, anonymize email/displayName
 ```
 
 `/api/me` shape:
 ```json
 {
   "id": "uuid",
+  "provider": "google",
   "displayName": "string",
   "email": "string",
   "avatarUrl": "string|null",
@@ -299,8 +352,9 @@ DELETE /api/me                     Soft-delete: status=DELETED, anonymize email/
 - Add `auth.user_accounts.roles VARCHAR[]` (Postgres array) or an `auth.user_roles` join table for `ADMIN`.
 - The `X-Admin-Password` check in `AdminController.checkAuth()` is preserved as a fallback during
   rollout but is deprecated; admin access also accepts a session JWT with the `ADMIN` role.
-- A bootstrap admin can be promoted via a one-time `SQL` migration referencing their `google_subject`,
-  or via an env-configured allowlist `GAME_ADMIN_EMAILS` checked at JIT-provision time.
+- A bootstrap admin can be promoted via a one-time SQL migration referencing their
+  `(provider, subject)`, or via env-configured allowlists (e.g. `GAME_ADMIN_GOOGLE_EMAILS`) checked
+  at JIT-provision time.
 - Schedule removal of the `X-Admin-Password` header as a separate cleanup item once at least one
   admin account exists and the admin UI sends the session cookie.
 
@@ -309,20 +363,46 @@ DELETE /api/me                     Soft-delete: status=DELETED, anonymize email/
 `web-client` changes (`src/store/slices/connectionSlice.ts`, `connectionHandlers.ts`,
 `src/components/landing/`):
 
-- **Login button**: top-right "Sign in with Google" → `window.location.href = '/auth/login/google'`.
-  Spring handles the redirect dance; the SPA never sees Google.
-- **Session detection**: on app boot, `GET /api/me`. 200 → store user in a new `authSlice`. 401 →
-  user is a guest (current behaviour).
+- **Login button(s)**: Phase 1 shows "Sign in with Google" →
+  `window.location.href = '/oauth2/authorization/google'`. The button list is data-driven so adding
+  GitHub / Microsoft is a one-line change (target URL: `/oauth2/authorization/{provider}`).
+- **Session detection**: on app boot, `GET /api/me`. 200 → store user (incl. `provider`) in a new
+  `authSlice`. 401 → user is a guest (current behaviour).
 - **WebSocket connect**: drop the `?token=` URL param for authenticated users — the cookie travels
   on the WS upgrade automatically. Guests keep the current `localStorage['argentum-token']` path.
 - **Display name**: pre-fill the player-name input with `me.displayName` for authenticated users
   (still editable for the session — though we should consider whether per-game name override is
   desirable now that accounts exist).
 - **Logout**: `POST /auth/logout` → clear `authSlice` → reload to drop the WebSocket session.
-- **Reverse proxy**: in dev, the Vite proxy (`/game`, `/api`) must also proxy `/auth` and
+- **Reverse proxy**: in dev, the Vite proxy (`/game`, `/api`) must also proxy `/oauth2` and
   `/login/oauth2` and forward cookies (`Set-Cookie` rewriting for the `localhost:5173` origin).
-  The Google OAuth client must whitelist `http://localhost:5173/login/oauth2/code/google` and
-  the prod origin.
+  Each OAuth provider's console must whitelist
+  `http://localhost:5173/login/oauth2/code/{provider}` and the prod equivalent.
+
+---
+
+## Provider Notes
+
+Each new provider needs three small additions: a `ClientRegistration` in `application.yml`, a
+`ProviderClaimMapper` implementation, and a button on the frontend. The quirks below are the only
+non-obvious bits.
+
+- **Google (Phase 1).** OIDC standard. Claims used: `sub` → `subject`, `email`, `name` →
+  `displayName`, `picture` → `avatarUrl`. Spring auto-configures everything via
+  `CommonOAuth2Provider.GOOGLE`.
+
+- **GitHub (follow-up).** OAuth2, not OIDC. Userinfo from `GET https://api.github.com/user`. Map
+  `id` (stringify the integer) → `subject`, `name ?? login` → `displayName`, `avatar_url` →
+  `avatarUrl`. **Email may be null** if the user keeps it private — request the `user:email` scope
+  and call `GET /user/emails` to find the primary verified address. Fallback for fully-private
+  users: `{login}@users.noreply.github.com` (synthetic but stable).
+
+- **Microsoft (follow-up).** OIDC via Microsoft identity platform / Entra ID. Use
+  `issuer-uri: https://login.microsoftonline.com/common/v2.0` to accept both personal and
+  work/school accounts. Subject: prefer `oid` (object ID, cross-tenant stable) and fall back to
+  `sub` if absent. Email lives in `email` or `preferred_username`. **Profile picture is not in the
+  ID token** — getting it requires a Microsoft Graph call (`GET /me/photo/$value`) with the
+  `User.Read` scope; skip it on first cut and leave `avatarUrl` null.
 
 ---
 
@@ -330,12 +410,12 @@ DELETE /api/me                     Soft-delete: status=DELETED, anonymize email/
 
 ### Infrastructure Additions
 
-| Component    | Purpose                                            | Dev Setup                 | Prod Setup                  |
-|--------------|----------------------------------------------------|---------------------------|-----------------------------|
-| **Postgres** | UserAccount + future relational data               | Docker Compose            | Managed Postgres            |
-| **Flyway**   | Schema migrations                                  | Bundled in `bootRun`      | Bundled in deploy           |
-| **Google**   | OAuth2 identity provider                           | OAuth Client Secret in `.env` | Same, in deploy secret store |
-| **Redis**    | Game cache (already present) + JWT revocation list | Already configured        | Already configured           |
+| Component        | Purpose                                                       | Dev Setup                       | Prod Setup                       |
+|------------------|---------------------------------------------------------------|---------------------------------|----------------------------------|
+| **Postgres**     | UserAccount + future relational data                          | Docker Compose                  | Managed Postgres                 |
+| **Flyway**       | Schema migrations                                             | Bundled in `bootRun`            | Bundled in deploy                |
+| **OAuth IdPs**   | Identity providers (Google now; GitHub / Microsoft to follow) | OAuth client secret(s) in `.env` | Same, in deploy secret store    |
+| **Redis**        | Game cache (already present) + JWT revocation list            | Already configured              | Already configured               |
 
 ### Migration Strategy from Ephemeral PlayerIdentity
 
@@ -370,9 +450,12 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
   Switch to `setAllowedOriginPatterns(env-driven exact list)`.
 - **Open redirect**: the success handler must validate any post-login redirect URL against an
   allowlist of own-origin paths.
-- **Account takeover via email reuse**: do not trust `email` as the lookup key — always
-  `google_subject`. (Email can change; sub cannot.)
-- **Rate limiting**: `/auth/login/google` and `/api/me` PATCH — basic per-IP throttling via a
+- **Account takeover via email is not a thing here.** Accounts are keyed by `(provider, subject)`,
+  never by email. A new sign-in is **never auto-linked** to an existing account by matching email
+  — that would let a hostile IdP take over an account by claiming a victim's address. Different
+  providers → different accounts. If account-linking is added later it must require the user to be
+  authenticated with the first identity first.
+- **Rate limiting**: `/oauth2/authorization/*` and `PATCH /api/me` — basic per-IP throttling via a
   Spring filter.
 - **Logout revocation**: blocklist the JWT's `jti` in Redis with TTL = remaining lifetime; the
   resource-server JWT decoder consults the blocklist.
@@ -389,8 +472,8 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
 
 ### Scaling Notes
 
-- `auth.user_accounts` is tiny and read-heavy. A simple b-tree on `google_subject` + `lower(email)`
-  is sufficient indefinitely.
+- `auth.user_accounts` is tiny and read-heavy. A simple b-tree on `(provider, subject)` (the unique
+  constraint) plus `lower(email)` is sufficient indefinitely.
 - JWT validation is local (no DB hit per request) — only logout and admin-role check hit Postgres.
 - Postgres connection pool size: 10 is plenty for an auth-only workload.
 
@@ -398,11 +481,11 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
 
 ## Open Questions / Risks
 
-1. **Guest → account merge UX.** If a guest is mid-game when they hit "Sign in with Google", do we
+1. **Guest → account merge UX.** If a guest is mid-game when they hit "Sign in with …", do we
    (a) defer login until game-over, (b) silently swap the underlying identity (risky — `EntityId`
    for the player is engine-internal and may be referenced from `GameState`), or (c) finish the
    guest game and start the next session authenticated? Default proposed: (c). Decide before
-   shipping the login button.
+   shipping the login buttons.
 
 2. **WebSocket origin tightening breaks E2E?** Switching from `setAllowedOrigins("*")` to an exact
    list may break Playwright runs that connect to `localhost:8080` from arbitrary ports. Plan: add
@@ -413,25 +496,37 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    with `localStorage` data, then signs in, won't see their guest history. Documented behaviour:
    pre-account play is permanently anonymous, no claiming.
 
-4. **Display-name uniqueness.** Multiple Google accounts can share a display name. Do we enforce
-   uniqueness? Recommendation: **no** — display names are not identifiers, the UUID is. We can
-   show a `#1234` suffix or partial email in disambiguating contexts.
+4. **Same human across providers = separate accounts.** Signing in with Google then later with
+   GitHub creates two `auth.user_accounts` rows. Trade-off: a simpler, safer model than
+   email-based auto-linking (which is exploitable — see Security Notes). If we later want a single
+   account with multiple linked sign-ins, it's a follow-up feature: an authenticated user adds
+   another identity, which inserts a row into a separate `auth.linked_identities` table; the
+   schema added in Phase 1 stays compatible.
 
-5. **Email change handling.** If Google's primary email changes between logins, we update the row
-   in JIT provisioning. This is silent; surface it in `/api/me` so the user sees it on next view.
+5. **Display-name uniqueness.** Multiple accounts can share a display name (especially across
+   providers). Do we enforce uniqueness? Recommendation: **no** — display names are not
+   identifiers, the UUID is. We can show a `#1234` suffix or provider badge in disambiguating
+   contexts.
 
-6. **Admin migration cutover.** Until we promote at least one admin to a `UserAccount` with the
+6. **Email change handling.** If the provider's primary email changes between logins, we update
+   the row in JIT provisioning. This is silent; surface it in `/api/me` so the user sees it on
+   next view.
+
+7. **Admin migration cutover.** Until we promote at least one admin to a `UserAccount` with the
    `ADMIN` role, the `X-Admin-Password` header is the only admin path. Don't remove the header
    check in Phase 1 — schedule its removal as a separate cleanup item once an admin account exists
    and the replay UI sends the session cookie.
 
-7. **Refresh tokens.** We intentionally do **not** store Google refresh tokens — re-auth at session
-   expiry is acceptable for a game (re-login takes one click). Revisit only if 12-hour sessions
-   become annoying.
+8. **Refresh tokens.** We intentionally do **not** store provider refresh tokens — re-auth at
+   session expiry is acceptable for a game (re-login takes one click). Revisit only if 12-hour
+   sessions become annoying.
 
-8. **Multiple browser tabs.** Each tab opens its own WebSocket. Today this works because identities
+9. **Multiple browser tabs.** Each tab opens its own WebSocket. Today this works because identities
    are token-keyed. With cookie-keyed auth, all tabs share an account; the `SessionRegistry`
    needs to decide whether to allow multiple concurrent WebSockets per `userAccountId` (probably
    yes — spectating one game while in another lobby) or enforce single-session (kick the older
    socket). Recommendation: allow multiple, but route `GameSession` participation through the
    `currentGameSessionId` field on `PlayerIdentity` so only one tab is the player.
+
+10. **Filename.** The file is still named `google-oauth2-accounts.md` for now even though the scope
+    broadened. Renaming to `oauth2-accounts.md` is a one-line `git mv` whenever convenient.

--- a/backlog/google-oauth2-accounts.md
+++ b/backlog/google-oauth2-accounts.md
@@ -2,17 +2,13 @@
 
 A direct Google OAuth2 + Spring Security implementation that replaces the current ephemeral
 `PlayerIdentity` (random UUID in `localStorage`) with persistent user accounts backed by Postgres.
-Provides the account foundation needed for leagues, seasons, player profiles, and any other feature
-that requires durable cross-session identity — while preserving anonymous guest play for casual
-games and dev scenario E2E tests.
+Provides a durable cross-session identity for any feature that needs one — while preserving
+anonymous guest play for casual games and dev scenario E2E tests.
 
-## Supersedes
+## Why direct Google OAuth (not Keycloak)
 
-This backlog item **replaces Phase 1 of [league-season-system.md](league-season-system.md)** —
-the original plan called for Keycloak SSO. We are dropping Keycloak in favour of a direct Google
-OAuth2 integration using `spring-boot-starter-oauth2-client` / `spring-boot-starter-oauth2-resource-server`.
-
-**Rationale for direct Google OAuth over Keycloak:**
+We use a direct Google OAuth2 integration via `spring-boot-starter-oauth2-client` /
+`spring-boot-starter-oauth2-resource-server` rather than fronting Google with Keycloak.
 
 | Concern              | Keycloak                                            | Direct Google OAuth                                 |
 |----------------------|-----------------------------------------------------|-----------------------------------------------------|
@@ -26,7 +22,6 @@ OAuth2 integration using `spring-boot-starter-oauth2-client` / `spring-boot-star
 For a small player base with one realistic IdP for now (Google), the operational simplicity of
 direct OAuth outweighs the federation flexibility Keycloak offers. If we later want Discord/GitHub
 login we add another `ClientRegistration` — Spring Security supports N providers out of the box.
-`league-season-system.md` Phase 1 has been updated to point at this file as the authoritative auth plan.
 
 ## Dependencies
 
@@ -37,10 +32,8 @@ This feature depends on:
   ([architecture #6](archived/game-server-architecture.md#6-formalize-playeridentity-state-machine)) —
   the auth flow needs a cleaner identity lifecycle than the current ad-hoc model.
 
-This feature is a prerequisite for:
-- Leagues & seasons ([league-season-system.md](league-season-system.md) Phase 2+)
-- Player profiles, deck library, match history
-- Any feature that needs durable cross-device identity
+This feature is a prerequisite for any feature that needs durable cross-device identity (player
+profiles, deck library, match history, etc.).
 
 ---
 
@@ -50,6 +43,9 @@ This feature is a prerequisite for:
 
 - Add Postgres service to `docker-compose.local.yml` (and prod `docker-compose.yml`) alongside Redis.
 - Dev defaults: `postgres:16-alpine`, port `5432`, db `argentum`, user `argentum`, password from env.
+- **One shared database, per-feature Postgres schemas (namespaces).** Auth tables live in an `auth`
+  schema; future features get their own schema. Keeps related tables grouped, makes migrations
+  per-feature, and lets us grant scoped DB roles later without splitting databases.
 - Spring Boot config (`application.yml`):
   ```yaml
   spring:
@@ -67,8 +63,10 @@ This feature is a prerequisite for:
 
 - Add `flyway-core` + `flyway-database-postgresql` to `game-server/build.gradle.kts`.
 - Migration directory: `game-server/src/main/resources/db/migration/`.
-- First migration `V1__user_accounts.sql` creates the schema described in Phase 1.4.
-- All future schema (leagues, seasons, etc.) live as further `V*__*.sql` files in the same dir.
+- First migration `V1__auth_schema.sql` creates the `auth` schema and the `user_accounts` table
+  (see Phase 1.4 for the DDL).
+- Future migrations live as further `V*__*.sql` files in the same directory, each creating and
+  populating its own Postgres schema for the feature it owns.
 
 ### 1.3 Data Access Layer
 
@@ -91,7 +89,7 @@ implementation("com.auth0:java-jwt:4.x")    // for issuing our own session JWTs 
 
 ```kotlin
 @Entity
-@Table(name = "user_accounts")
+@Table(name = "user_accounts", schema = "auth")
 class UserAccount(
     @Id val id: UUID,                            // our own UUID, generated on JIT provision
     @Column(nullable = false, unique = true)
@@ -108,9 +106,11 @@ class UserAccount(
 )
 ```
 
-Initial migration (`V1__user_accounts.sql`):
+Initial migration (`V1__auth_schema.sql`):
 ```sql
-CREATE TABLE user_accounts (
+CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE TABLE auth.user_accounts (
     id              UUID PRIMARY KEY,
     google_subject  VARCHAR(64)  NOT NULL UNIQUE,
     email           VARCHAR(320) NOT NULL,
@@ -120,7 +120,7 @@ CREATE TABLE user_accounts (
     last_login_at   TIMESTAMPTZ  NOT NULL,
     status          VARCHAR(16)  NOT NULL DEFAULT 'ACTIVE'
 );
-CREATE INDEX idx_user_accounts_email ON user_accounts (lower(email));
+CREATE INDEX idx_user_accounts_email ON auth.user_accounts (lower(email));
 ```
 
 `UserAccountRepository : JpaRepository<UserAccount, UUID>` exposes `findByGoogleSubject(sub)`.
@@ -187,7 +187,7 @@ When a user completes Google OAuth2 the success handler runs:
 ```
 1. Spring's oauth2Login filter validates the Google id_token and gives us an OidcUser.
 2. AccountProvisioner.findOrCreate(oidcUser):
-     - lookup user_accounts.google_subject = oidcUser.sub
+     - lookup auth.user_accounts.google_subject = oidcUser.sub
      - if missing: insert new row (id = UUID.randomUUID(), createdAt = now)
      - if present: update email/avatarUrl if changed, set lastLoginAt = now
 3. SessionTokenService.issue(userAccount):
@@ -262,8 +262,8 @@ Anonymous play continues to work and is explicitly supported:
 - The client sends `ClientMessage.Connect(playerName, token=…)` exactly as today.
 - `PlayerIdentity.userAccountId` is null; `SessionRegistry` still indexes by `token`.
 - Server-issued token is returned in `ServerMessage.Connected` and stored in `localStorage`.
-- League/season/profile REST endpoints **reject** unauthenticated requests (`401`); gameplay
-  endpoints (lobby create, quick-game, dev scenarios) remain open.
+- Account-scoped REST endpoints (`/api/me`, etc.) **reject** unauthenticated requests (`401`);
+  gameplay endpoints (lobby create, quick-game, dev scenarios) remain open.
 
 This preserves:
 - Drop-in casual play (no account barrier).
@@ -296,7 +296,7 @@ DELETE /api/me                     Soft-delete: status=DELETED, anonymize email/
 
 ### 1.10 Roles & Admin Migration
 
-- Add `user_accounts.roles VARCHAR[]` (Postgres array) or a `user_roles` join table for `ADMIN`.
+- Add `auth.user_accounts.roles VARCHAR[]` (Postgres array) or an `auth.user_roles` join table for `ADMIN`.
 - The `X-Admin-Password` check in `AdminController.checkAuth()` is preserved as a fallback during
   rollout but is deprecated; admin access also accepts a session JWT with the `ADMIN` role.
 - A bootstrap admin can be promoted via a one-time `SQL` migration referencing their `google_subject`,
@@ -349,9 +349,9 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    `userAccountId`-keyed identity, or to start a fresh authenticated identity and let the in-flight
    game finish under the guest token. Recommended default: **start a fresh authenticated identity
    on next connect; let the in-flight guest session complete naturally**.
-3. **League/season features (Phase 2+ of league-season-system.md)** require an authenticated
-   account — there is no upgrade path for past anonymous match history to be claimed (acceptable
-   trade-off; pre-account games stay anonymous forever).
+3. **Future authenticated features** (profiles, match history, etc.) require an account — there is
+   no upgrade path for past anonymous play to be claimed (acceptable trade-off; pre-account games
+   stay anonymous forever).
 4. **E2E scenarios** keep using the existing `?token=` + `DevScenarioController.preRegisterIdentity()`
    path verbatim; that is the guest path. No test rewrites required.
 
@@ -362,8 +362,8 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
   want zero-downtime rotation built in.)
 - **Cookie flags**: `HttpOnly`, `Secure` (prod), `SameSite=Lax`, `Path=/`, 12-hour `Max-Age`.
 - **CSRF**: REST + WebSocket are stateless and bearer-token-like via the cookie. Lax SameSite blocks
-  cross-site form posts. State-changing endpoints (`PATCH /api/me`, `DELETE /api/me`, league
-  mutations later) should additionally require a `X-Requested-With: XMLHttpRequest` header to
+  cross-site form posts. State-changing endpoints (`PATCH /api/me`, `DELETE /api/me`, and other
+  account mutations) should additionally require an `X-Requested-With: XMLHttpRequest` header to
   defeat SameSite=Lax loopholes via top-level GET redirects (which we don't accept POSTs for anyway).
 - **CORS**: the current `setAllowedOrigins("*")` on the WebSocket handler is **incompatible with
   cookie-bearing upgrades** — browsers refuse to send cookies cross-origin to wildcard origins.
@@ -389,10 +389,10 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
 
 ### Scaling Notes
 
-- `user_accounts` is tiny and read-heavy. A simple b-tree on `google_subject` + `lower(email)` is
-  sufficient indefinitely.
+- `auth.user_accounts` is tiny and read-heavy. A simple b-tree on `google_subject` + `lower(email)`
+  is sufficient indefinitely.
 - JWT validation is local (no DB hit per request) — only logout and admin-role check hit Postgres.
-- Postgres connection pool size: 10 is plenty until leagues launch.
+- Postgres connection pool size: 10 is plenty for an auth-only workload.
 
 ---
 
@@ -410,13 +410,12 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    `dev-endpoints.enabled=true`.
 
 3. **Single device / single account during transition.** A user who has been playing as a guest
-   with `localStorage` data, then signs in, won't see their guest history (there is no history
-   yet, but this matters once leagues exist). Documented behaviour: pre-account play is
-   permanently anonymous, no claiming.
+   with `localStorage` data, then signs in, won't see their guest history. Documented behaviour:
+   pre-account play is permanently anonymous, no claiming.
 
 4. **Display-name uniqueness.** Multiple Google accounts can share a display name. Do we enforce
    uniqueness? Recommendation: **no** — display names are not identifiers, the UUID is. We can
-   show a `#1234` suffix or partial email in disambiguating contexts (e.g. league member list).
+   show a `#1234` suffix or partial email in disambiguating contexts.
 
 5. **Email change handling.** If Google's primary email changes between logins, we update the row
    in JIT provisioning. This is silent; surface it in `/api/me` so the user sees it on next view.
@@ -436,10 +435,3 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    yes — spectating one game while in another lobby) or enforce single-session (kick the older
    socket). Recommendation: allow multiple, but route `GameSession` participation through the
    `currentGameSessionId` field on `PlayerIdentity` so only one tab is the player.
-
----
-
-## Phase 2+
-
-Phases 2 (Leagues), 3 (Seasons & Standings), and 4 (Social & Polish) from
-[league-season-system.md](league-season-system.md) remain valid and depend on this phase.

--- a/backlog/league-season-system.md
+++ b/backlog/league-season-system.md
@@ -13,7 +13,7 @@ This feature depends on:
 
 ## Phase 1 — Accounts & Authentication
 
-**Superseded by [google-oauth2-accounts.md](google-oauth2-accounts.md).** That document is the
+**Superseded by [oauth2-accounts.md](oauth2-accounts.md).** That document is the
 authoritative plan for the account system. It drops Keycloak in favour of direct Spring Security +
 Google OAuth2, adds Postgres + Flyway, defines the `UserAccount` entity and JIT provisioning, and
 specifies how the session cookie bridges into the WebSocket handshake while preserving guest mode.

--- a/backlog/oauth2-accounts.md
+++ b/backlog/oauth2-accounts.md
@@ -527,6 +527,3 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    yes — spectating one game while in another lobby) or enforce single-session (kick the older
    socket). Recommendation: allow multiple, but route `GameSession` participation through the
    `currentGameSessionId` field on `PlayerIdentity` so only one tab is the player.
-
-10. **Filename.** The file is still named `google-oauth2-accounts.md` for now even though the scope
-    broadened. Renaming to `oauth2-accounts.md` is a one-line `git mv` whenever convenient.

--- a/backlog/oauth2-accounts.md
+++ b/backlog/oauth2-accounts.md
@@ -2,10 +2,10 @@
 
 A direct OAuth2 / OIDC + Spring Security implementation that replaces the current ephemeral
 `PlayerIdentity` (random UUID in `localStorage`) with persistent user accounts backed by Postgres,
-and moves the client-side deck library to a server-side store keyed by the new account. **Google**
-is the first wired-up provider; **GitHub** and **Microsoft** are designed-for follow-ups that drop
-in via a new `ClientRegistration` and a per-provider claim mapper. Anonymous guest play stays
-intact for casual games and dev scenario E2E tests.
+and starts recording per-account game outcomes so logged-in users can see their win/loss record
+over time. **Google** is the first wired-up provider; **GitHub** and **Microsoft** are
+designed-for follow-ups that drop in via a new `ClientRegistration` and a per-provider claim
+mapper. Anonymous guest play stays intact for casual games and dev scenario E2E tests.
 
 ## Why direct OAuth (not Keycloak)
 
@@ -28,20 +28,24 @@ Spring is low, and the ops cost of running a Keycloak instance is not.
 ## Scope
 
 - **Phase 1 — Google sign-in + persistent accounts** (Postgres-backed, schema `auth`).
-- **Phase 2 — Deck library moves server-side** (Postgres schema `decks`, keyed by `userAccountId`),
-  with a one-shot upload on first sign-in that imports any existing `localStorage["argentum.decks"]`
-  entries.
+- **Phase 2 — Per-account stats tracking** (Postgres schema `stats`): one row per completed game
+  per authenticated participant, with simple aggregation endpoints. Guests don't record stats.
 - **Schema and abstractions are provider-agnostic from day one.** Each provider is identified by a
   `(provider, subject)` tuple; the JIT-provisioning flow goes through a `ProviderClaimMapper`
   abstraction so adding GitHub / Microsoft is purely additive (no migrations, no rewiring).
 - **Each provider gets a separate account.** Signing in with Google produces one
   `auth.user_accounts` row; later signing in with GitHub as the same human produces a second row.
   See [Open Questions](#open-questions--risks) for the rationale and the linking-as-follow-up note.
-- **Session token lives in `localStorage` for V1.** The JWT is delivered to the SPA via a URL
-  fragment on the OAuth callback redirect, then stored at `localStorage["argentum-session"]` and
-  attached to REST requests as `Authorization: Bearer <jwt>` and to the WebSocket via the existing
-  `ClientMessage.Connect.token` field. **No browser cookies.** Cookies are tracked as a hardening
-  follow-up; see Security Notes.
+- **Session tokens live in `localStorage` for V1.** The browser holds a short-lived access JWT
+  (`localStorage["argentum-session"]`, 1h) plus an opaque refresh token
+  (`localStorage["argentum-refresh"]`, 30-day sliding). Both are delivered to the SPA via a URL
+  fragment on the OAuth callback redirect. The access JWT is attached to REST as
+  `Authorization: Bearer <jwt>` and to the WebSocket via the existing
+  `ClientMessage.Connect.token` field; the refresh token only ever hits `POST /auth/refresh`.
+  **No browser cookies.** Cookies are tracked as a hardening follow-up; see Security Notes.
+- **Decks stay on the client.** Migrating the deck library (`localStorage["argentum.decks"]`) to
+  a server-side store keyed by `userAccountId` is **deferred to a dedicated deck-library backlog
+  item**, which will define both the server schema and the one-shot upload-on-first-login flow.
 
 ## Dependencies
 
@@ -53,7 +57,7 @@ This feature depends on:
   the auth flow needs a cleaner identity lifecycle than the current ad-hoc model.
 
 This feature is a prerequisite for any feature that needs durable cross-device identity (player
-profiles, match history, leagues, etc.).
+profiles, deck library, match history, leagues, etc.).
 
 ---
 
@@ -62,8 +66,8 @@ profiles, match history, leagues, etc.).
 The codebase today persists everything (game sessions, lobbies, tournament state) in **Redis with a
 24-hour TTL**, via the pattern `interface XRepository` + `RedisXRepository` + `InMemoryXRepository`
 gated by `cache.redis.enabled` (see `RedisGameRepository`, `RedisLobbyRepository`, and their
-in-memory counterparts). **No durable, no-TTL data exists yet** — auth accounts and (Phase 2) decks
-would be the first.
+in-memory counterparts). **No durable, no-TTL data exists yet** — auth accounts and (Phase 2) stats
+rows would be the first.
 
 Two plausible approaches:
 
@@ -81,8 +85,8 @@ Two plausible approaches:
 **We choose Postgres.** Auth is the first piece of a relational backbone the project will need
 anyway (profiles, deck library, match history, leagues). Paying the infra cost once now is cheaper
 than running auth on Redis and migrating later, and SQL constraints (`UNIQUE`, foreign keys for
-future tables — including the Phase 2 deck table) are exactly the integrity guarantees we want for
-user data.
+future tables — including the Phase 2 stats table and the eventual deck table) are exactly the
+integrity guarantees we want for user data.
 
 Redis-backed auth stays a sensible Plan B if this feature ships alone for longer than expected and
 we'd rather defer the "first relational store" decision until a second persistent feature lands —
@@ -97,7 +101,7 @@ the `UserAccountRepository` interface in Phase 1.3 keeps that swap localized.
 - Add Postgres service to `docker-compose.local.yml` (and prod `docker-compose.yml`) alongside Redis.
 - Dev defaults: `postgres:16-alpine`, port `5432`, db `argentum`, user `argentum`, password from env.
 - **One shared database, per-feature Postgres schemas (namespaces).** Auth tables live in an `auth`
-  schema; the Phase 2 deck tables live in a `decks` schema. Future features get their own schema.
+  schema; the Phase 2 stats tables live in a `stats` schema. Future features get their own schema.
   Keeps related tables grouped, makes migrations per-feature, and lets us grant scoped DB roles
   later without splitting databases.
 - Spring Boot config (`application.yml`):
@@ -118,7 +122,7 @@ the `UserAccountRepository` interface in Phase 1.3 keeps that swap localized.
 - Add `flyway-core` + `flyway-database-postgresql` to `game-server/build.gradle.kts`.
 - Migration directory: `game-server/src/main/resources/db/migration/`.
 - `V1__auth_schema.sql` creates the `auth` schema and `auth.user_accounts` (Phase 1.4).
-- `V2__decks_schema.sql` creates the `decks` schema and `decks.decks` (Phase 2.1).
+- `V2__stats_schema.sql` creates the `stats` schema and `stats.game_results` (Phase 2.1).
 - Future migrations live as further `V*__*.sql` files in the same directory, each creating and
   populating its own Postgres schema for the feature it owns.
 
@@ -127,7 +131,7 @@ the `UserAccountRepository` interface in Phase 1.3 keeps that swap localized.
 Use **Spring Data JPA**. The codebase has no existing relational data-access layer to match, so the
 choice is between JPA, Exposed, jOOQ, and raw JDBC. JPA is the most familiar option in Spring-land
 and the simplest fit for the small set of tables in this feature. Wrap it behind
-`UserAccountRepository` / `DeckRepository` interfaces so the Postgres ↔ Redis decision in the
+`UserAccountRepository` / `GameResultRepository` interfaces so the Postgres ↔ Redis decision in the
 Persistence section above stays reversible.
 
 Add to `game-server/build.gradle.kts`:
@@ -281,28 +285,59 @@ spring:
      - if missing: insert new row (id = UUID.randomUUID(), createdAt = now)
      - if present: update email/displayName/avatarUrl from latest claims, set lastLoginAt = now
 
-4. SessionTokenService.issue(userAccount):
-     - sign a self-issued JWT via Spring Security's JwtEncoder (Nimbus, transitively present)
-     - HS256 with a server-side secret (env `GAME_SESSION_SECRET`); easy to swap to RS256/JWKS later
-     - claims: sub = userAccount.id, name = displayName, prv = userAccount.provider,
-               jti = UUID.randomUUID() (used by the revocation list — see Security Notes),
-               exp = now+12h, iss = "argentum"
-     - matching JwtDecoder bean (sessionJwtDecoder) is wired into the API/WebSocket filter chain.
+4. SessionTokenService.issuePair(userAccount):
+     - **Access JWT** (short-lived, ~1h):
+       - sign via Spring Security's JwtEncoder (Nimbus, transitively present)
+       - HS256 with a server-side secret (env `GAME_SESSION_SECRET`); easy to swap to RS256/JWKS later
+       - claims: sub = userAccount.id, name = displayName, prv = userAccount.provider,
+                 jti = UUID.randomUUID() (used by the revocation list — see Security Notes),
+                 exp = now+1h, iss = "argentum"
+       - matching JwtDecoder bean (sessionJwtDecoder) is wired into the API/WebSocket filter chain.
+     - **Refresh token** (long-lived, opaque):
+       - 256-bit random, URL-safe encoded.
+       - stored in Redis at `auth:refresh:{token}` as JSON
+         `{ userAccountId, family: UUID, issuedAt: Instant }` with **30-day sliding TTL**
+         (reset on each successful use).
+       - `family` is a UUID shared across every refresh in the rotation chain; used for theft
+         detection (see refresh flow below).
+       - also indexed at `auth:refresh-by-account:{userAccountId}` (SADD the token) so we can
+         revoke all of a user's sessions in one shot.
 
-5. Redirect the browser to the SPA with the JWT in a URL fragment:
-       302 -> https://app/#auth_token=<jwt>
-   Fragment (not query string) so the JWT isn't sent on the redirect request and isn't logged in
-   access logs. The SPA reads `window.location.hash`, persists the JWT to
-   `localStorage["argentum-session"]`, and clears the fragment via `history.replaceState` so the
-   token doesn't linger in browser history or get accidentally copy-pasted.
+5. Redirect the browser to the SPA with both tokens in a URL fragment:
+       302 -> https://app/#auth_token=<jwt>&refresh_token=<refresh>
+   Fragment (not query string) so neither token is sent on the redirect request or logged in
+   access logs. The SPA reads `window.location.hash`, persists the access JWT to
+   `localStorage["argentum-session"]` and the refresh token to `localStorage["argentum-refresh"]`,
+   then clears the fragment via `history.replaceState` so the tokens don't linger in browser
+   history or get accidentally copy-pasted.
 ```
 
-We issue **our own JWT** rather than passing the provider's `id_token`/access token to the SPA:
+We issue **our own tokens** rather than passing the provider's `id_token`/access token to the SPA:
 - The provider token carries PII and provider-specific claims we don't want on the client; our
-  session JWT only carries `userAccountId`, `displayName`, and `provider`.
-- We control rotation and revocation (Redis `jti` blocklist — Security Notes).
-- Refresh is decoupled from the provider: we don't store provider refresh tokens. When the session
-  JWT expires (12h) the user re-authenticates with one click.
+  access JWT only carries `userAccountId`, `displayName`, and `provider`.
+- We control rotation and revocation (Redis `jti` blocklist + refresh-token family — Security Notes).
+- We don't store **provider** refresh tokens; we issue our own server-side refresh tokens instead.
+  When our refresh token's sliding 30-day TTL runs out, the user re-authenticates with the provider
+  (one click).
+
+**Token refresh flow** (`POST /auth/refresh`, body `{ refreshToken: "..." }`):
+
+1. Look up `auth:refresh:{token}` in Redis.
+   - **Missing** → check `auth:refresh-tombstone:{token}`. If a tombstone exists, see step 3
+     (reuse). Otherwise → 401, client clears both local tokens and drops to the guest flow.
+   - **Found** → continue to step 2.
+2. **Rotate**: delete the old refresh token, write a tombstone
+   `auth:refresh-tombstone:{token} = family` with the family's remaining TTL, issue a fresh access
+   JWT and a new refresh token **in the same `family`**, update the per-account index. Return
+   `{ accessToken, refreshToken, expiresIn: 3600 }`.
+3. **Family-reuse detection.** A presented token that's missing but tombstoned was rotated away —
+   the legitimate client should already be carrying the new token, so reuse means theft. Revoke
+   **every refresh token in that family** (delete all members of
+   `auth:refresh-by-account:{userAccountId}` whose stored `family` matches) and force re-auth on
+   every device. Also blocklist any currently outstanding access JWT in that family by `jti`.
+
+Sliding TTL means a user who visits at least monthly stays logged in indefinitely; one who doesn't
+gets bounced back to the OAuth flow.
 
 ### 1.7 WebSocket Authentication
 
@@ -341,6 +376,10 @@ Reconnect resolution order in `handleConnect()`:
 2. Else `token` matches an existing guest UUID → existing token-based reconnect.
 3. Else → fresh guest identity.
 
+If the WebSocket close is triggered server-side by an expired JWT (or the server rejects a
+`Connect` carrying an expired one), the SPA hits `/auth/refresh`, then reconnects with the new
+JWT. See 1.11.
+
 No `HandshakeInterceptor`, no cookies, no CORS-with-credentials. The existing
 `setAllowedOrigins("*")` stays as-is for V1 — bearer tokens in a custom message field aren't
 subject to the cookie auto-attachment risk that wildcard CORS otherwise enables. (Origin tightening
@@ -356,8 +395,9 @@ Anonymous play continues to work and is explicitly supported:
 - `PlayerIdentity.userAccountId` is null for guests; `SessionRegistry` still indexes guests by `token`.
 - Server-issued UUID token is returned in `ServerMessage.Connected` and stored in
   `localStorage["argentum-token"]` (the existing key, untouched by this feature).
-- Account-scoped REST endpoints (`/api/me`, `/api/decks/**`) **reject** unauthenticated requests
-  (`401`); gameplay endpoints (lobby create, quick-game, dev scenarios) remain open.
+- Account-scoped REST endpoints (`/api/me`, `/api/me/stats`, `/api/me/games`) **reject**
+  unauthenticated requests (`401`); gameplay endpoints (lobby create, quick-game, dev scenarios)
+  remain open.
 
 This preserves:
 - Drop-in casual play (no account barrier).
@@ -376,12 +416,15 @@ Spring's defaults handle the OAuth dance per registration; the per-provider URLs
 GET    /oauth2/authorization/google     Initiates Google OAuth2 (Spring redirects)
 GET    /login/oauth2/code/google        Callback (Spring handles, we run successHandler)
                                         (mirror routes appear automatically for /github, /microsoft)
-POST   /auth/logout                     Revokes the JWT via the Redis jti blocklist; client clears
-                                        localStorage["argentum-session"] on success.
+POST   /auth/refresh                    Exchange refresh token for a new access+refresh pair
+                                        (body: { refreshToken }; see 1.6 refresh flow)
+POST   /auth/logout                     Revokes the current access JWT (jti blocklist) AND every
+                                        refresh token in its family; client clears both localStorage
+                                        keys on success.
 GET    /api/me                          Returns the current UserAccount (or 401 if no/invalid JWT)
 PATCH  /api/me                          Update displayName (only mutable field by user)
 DELETE /api/me                          Soft-delete: status=DELETED, anonymize email/displayName,
-                                        cascade-delete decks (see Phase 2)
+                                        cascade-delete stats rows (see Phase 2)
 ```
 
 `/api/me` shape:
@@ -413,158 +456,160 @@ DELETE /api/me                          Soft-delete: status=DELETED, anonymize e
 `web-client` changes (`src/store/slices/connectionSlice.ts`, `connectionHandlers.ts`,
 `src/components/landing/`, plus a new `authSlice`):
 
-- **OAuth callback bootstrap**: on app load, `App.tsx` (or root effect) checks
-  `window.location.hash` for `#auth_token=<jwt>`. If present:
-  1. Write to `localStorage["argentum-session"]`.
+- **OAuth callback bootstrap**: on app load, the root effect checks `window.location.hash` for
+  `#auth_token=<jwt>&refresh_token=<refresh>`. If present:
+  1. Write the JWT to `localStorage["argentum-session"]` and the refresh token to
+     `localStorage["argentum-refresh"]`.
   2. `history.replaceState(null, '', window.location.pathname + window.location.search)` to scrub.
 - **Login button(s)**: Phase 1 shows "Sign in with Google" →
   `window.location.href = '/oauth2/authorization/google'`. The button list is data-driven so adding
   GitHub / Microsoft is a one-line change.
 - **Session detection**: on boot, if a JWT exists in localStorage, `GET /api/me` with
-  `Authorization: Bearer <jwt>` → store user in `authSlice`. 401 (expired/revoked) → clear the
-  JWT, fall through to guest.
-- **WebSocket connect**: include the JWT (if present) as the `token` field in
+  `Authorization: Bearer <jwt>` → store user in `authSlice`. 401 → fall through to the refresh
+  flow below.
+- **Auto-refresh on 401** (REST): a shared `apiFetch()` wrapper retries once. On `401`, call
+  `POST /auth/refresh` with the stored refresh token; on success, persist the new pair and retry
+  the original request. On refresh failure (401 from `/auth/refresh`), clear both localStorage
+  keys + `authSlice` and demote to guest. **Single retry only** — no infinite loops.
+- **WebSocket connect**: include the current access JWT (if present) as the `token` field in
   `ClientMessage.Connect`. Guests keep using `localStorage["argentum-token"]`. The dev-scenario
   `?token=` URL param keeps working as it does today (server side decides whether the value is a
   JWT or a guest UUID).
+- **WebSocket expiry**: if the server rejects `Connect` with a token-expired reason (or closes the
+  WS with the same), the SPA runs the refresh flow once and reconnects. Same single-retry rule.
 - **Display name**: pre-fill the player-name input with `me.displayName` for authenticated users
   (still editable for the session — open question whether we want per-game name override now that
   accounts exist).
-- **Logout**: `POST /auth/logout` (with the JWT) → clear `localStorage["argentum-session"]` and
-  the `authSlice` → close + reopen the WebSocket so it reconnects as a guest.
+- **Logout**: `POST /auth/logout` (with the access JWT) → clear both localStorage keys and the
+  `authSlice` → close + reopen the WebSocket so it reconnects as a guest.
 - **Reverse proxy**: in dev, the Vite proxy must cover `/oauth2/**` and `/login/oauth2/**` so the
   redirect dance works from `localhost:5173`. No cookie forwarding needed. The Google OAuth client
   must whitelist `http://localhost:5173/login/oauth2/code/google` and the prod equivalent.
 
 ---
 
-## Phase 2 — Deck Library Migration
+## Phase 2 — Player Stats
 
-Move the saved deck library from per-device `localStorage["argentum.decks"]` to a Postgres-backed
-table keyed by `userAccountId`, and run a one-shot upload on first sign-in so existing users don't
-lose what they've built.
+Persist per-account game outcomes so logged-in users can see their record over time. Append-only:
+each completed game inserts one row per authenticated participant. Guests don't track stats.
 
-### 2.1 `decks.decks` Schema
+### 2.1 `stats.game_results` Schema
 
 ```sql
-CREATE SCHEMA IF NOT EXISTS decks;
+CREATE SCHEMA IF NOT EXISTS stats;
 
-CREATE TABLE decks.decks (
-    id                 UUID PRIMARY KEY,
-    user_account_id    UUID NOT NULL REFERENCES auth.user_accounts(id) ON DELETE CASCADE,
-    name               VARCHAR(120) NOT NULL,
-    format             VARCHAR(32),                 -- nullable; matches client's optional field
-    set_code           VARCHAR(8),                  -- for sealed/limited decks
-    commander          VARCHAR(200),                -- nullable
-    commander_printing VARCHAR(64),                 -- nullable
-    cards              TEXT NOT NULL,               -- serialized deck body (see 2.2)
-    schema_version     SMALLINT NOT NULL,           -- 1 or 2, preserving the client envelope
-    created_at         TIMESTAMPTZ NOT NULL,
-    updated_at         TIMESTAMPTZ NOT NULL
+CREATE TABLE stats.game_results (
+    id                UUID PRIMARY KEY,
+    user_account_id   UUID NOT NULL REFERENCES auth.user_accounts(id) ON DELETE CASCADE,
+    game_session_id   VARCHAR(64) NOT NULL,         -- the existing in-memory game session id
+    outcome           VARCHAR(16) NOT NULL,         -- WON, LOST, DRAW, CONCEDED
+    format            VARCHAR(32),                  -- constructed, sealed, draft, commander, ...
+    opponents_count   SMALLINT NOT NULL,
+    duration_seconds  INTEGER,
+    played_at         TIMESTAMPTZ NOT NULL
 );
-CREATE INDEX idx_decks_user ON decks.decks (user_account_id);
+CREATE INDEX idx_game_results_user_played_at
+    ON stats.game_results (user_account_id, played_at DESC);
 ```
 
 Notes:
-- **`cards` is `TEXT` storing `kotlinx.serialization` JSON.** Keeps wire-compat with the existing
-  client `SavedDeck` shape (`Record<cardName, count>` for v1, the entries array with per-card
-  printing pins for v2). Promote to `JSONB` later (`ALTER TABLE … USING (cards::jsonb)`) when we
-  need server-side card-level queries — none in scope here.
-- **`ON DELETE CASCADE`** ties deck lifetime to the account. Account soft-delete (Phase 1.9
-  `DELETE /api/me`) also cascade-deletes decks rather than orphaning them; same effect, no DB-level
-  trigger needed.
-- **`schema_version`** preserves the client's v1↔v2 envelope so we don't have to do a forced
-  upgrade on import. Server treats `cards` as opaque blob; only the client cares about the inner
-  shape.
+- **Append-only, no aggregation table for now.** Aggregations (`games_played`, `win_rate`, etc.)
+  are computed at read time via SQL `GROUP BY`. With current player counts this is well under a
+  millisecond; we can add a materialized view later if it stops being free.
+- **`game_session_id` is `VARCHAR(64)` and not a foreign key** — game sessions live in Redis with
+  a 24h TTL, so there's no durable referent for an FK.
+- **`outcome` enum** — `WON`, `LOST`, `DRAW`, `CONCEDED`. Concedes are tracked separately from a
+  clean loss because the future UI may want to surface "completion rate" alongside "win rate".
+- **`ON DELETE CASCADE`** on the account FK so soft-deleting an account also drops its stats rows.
+  (`DELETE /api/me` in Phase 1.9 mentions this cascade.)
 
 ### 2.2 Entity & Repository
 
 ```kotlin
 @Entity
-@Table(name = "decks", schema = "decks", indexes = [Index(columnList = "userAccountId")])
-class Deck(
+@Table(name = "game_results", schema = "stats")
+class GameResult(
     @Id val id: UUID,
     @Column(nullable = false) val userAccountId: UUID,
-    @Column(nullable = false) var name: String,
-    var format: String?,
-    var setCode: String?,
-    var commander: String?,
-    var commanderPrinting: String?,
-    @Column(nullable = false, columnDefinition = "TEXT") var cards: String,   // kotlinx-serialized
-    @Column(nullable = false) val schemaVersion: Short,
-    val createdAt: Instant,
-    var updatedAt: Instant
+    @Column(nullable = false) val gameSessionId: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false) val outcome: GameOutcome,   // WON, LOST, DRAW, CONCEDED
+    val format: String?,
+    @Column(nullable = false) val opponentsCount: Short,
+    val durationSeconds: Int?,
+    @Column(nullable = false) val playedAt: Instant
 )
+
+enum class GameOutcome { WON, LOST, DRAW, CONCEDED }
 ```
 
-`DeckRepository : JpaRepository<Deck, UUID>` with:
-- `findAllByUserAccountId(userId: UUID): List<Deck>`
-- `findByIdAndUserAccountId(id: UUID, userId: UUID): Deck?` (so handlers can fail-closed without
-  cross-user leaks even if the controller forgets to filter)
+`GameResultRepository : JpaRepository<GameResult, UUID>` with:
+- `findAllByUserAccountIdOrderByPlayedAtDesc(userId: UUID, pageable: Pageable): Page<GameResult>`
+- a `@Query` aggregation projection used by `/api/me/stats` — `count(*) FILTER (WHERE outcome = ?)`
+  grouped per outcome, plus `max(played_at)`.
 
-`DeckService` converts between the entity's `cards: String` and the client-facing `SavedDeck` DTO
-via `kotlinx.serialization` (same `persistenceJson` instance the Redis repos use). No new
-serializer.
+### 2.3 Recording Game Outcomes
 
-### 2.3 REST Endpoints
+A new `StatsRecorder` listens for game-completion and writes one `GameResult` row per
+authenticated participant. The hook sits next to the existing game-end handling in `game-server`
+(wherever the engine signals "game over"). For each player in the final state:
+
+- If `PlayerIdentity.userAccountId != null` → insert a `GameResult` row.
+- Otherwise → skip (guests don't track stats).
+
+The write is **best-effort and asynchronous** — it doesn't gate game-end notifications to clients,
+and a failure logs an error but doesn't roll back the game outcome on the client. Concedes vs
+clean wins are distinguished by reading the existing end-state reason; the engine already produces
+this distinction for spectator UI.
+
+Format is read from the lobby's configured format (where present); null otherwise. Duration is
+`endedAt - startedAt` from the existing game-session metadata.
+
+### 2.4 REST Endpoints
 
 ```
-GET    /api/decks                     List the current user's decks (lightweight summary)
-GET    /api/decks/{id}                Get one deck's full content
-POST   /api/decks                     Create a new deck
-PUT    /api/decks/{id}                Replace a deck (atomic; updatedAt bumped)
-DELETE /api/decks/{id}                Delete a deck
-POST   /api/decks/import              Bulk import — used by the first-login upload flow (see 2.4)
+GET    /api/me/stats                    Aggregated stats for the current user
+GET    /api/me/games                    Recent game history (paginated)
 ```
 
-All under the API chain (require a valid bearer JWT). 404 (not 403) when a deck ID doesn't belong
-to the caller, to avoid leaking existence.
-
-Summary shape (`GET /api/decks`):
+`GET /api/me/stats`:
 ```json
-{ "id": "uuid", "name": "string", "format": "string|null", "cardCount": 60, "updatedAt": "iso8601" }
+{
+  "gamesPlayed": 42,
+  "gamesWon": 23,
+  "gamesLost": 16,
+  "gamesDrawn": 1,
+  "gamesConceded": 2,
+  "lastPlayedAt": "iso8601|null"
+}
 ```
 
-Full shape (`GET /api/decks/{id}` and `PUT /api/decks/{id}` body): mirrors the existing client
-`SavedDeck` so the SPA can swap the storage backend without changing the shape it consumes.
+`GET /api/me/games?cursor=…` (default page size 20):
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "outcome": "WON",
+      "format": "constructed",
+      "opponentsCount": 1,
+      "durationSeconds": 1340,
+      "playedAt": "iso8601"
+    }
+  ],
+  "nextCursor": "string|null"
+}
+```
 
-### 2.4 First-Login Upload Flow
+Both endpoints require a valid bearer JWT (the API chain rejects anonymous). Pagination uses an
+opaque cursor (base64-encoded `(playedAt, id)`) rather than offsets so new games landing during
+pagination don't shift the window.
 
-Triggered the first time the SPA sees a brand-new authenticated session **and** has non-empty
-`localStorage["argentum.decks"]`:
+### 2.5 Frontend (light)
 
-1. After `GET /api/me` succeeds, the SPA reads `localStorage["argentum.decks"]` and parses the
-   envelope.
-2. The SPA calls `GET /api/decks` once. If the server-side library is empty, it sends `POST
-   /api/decks/import` with the full local library as the body.
-3. On success the SPA marks `localStorage["argentum.decks.uploaded_to_account"] = userAccountId`
-   so we don't re-upload on every login. We do **not** delete the local copy — see migration
-   strategy below.
-4. From this point on, the SPA reads decks from the server (`GET /api/decks` / `GET /api/decks/{id}`)
-   instead of from `localStorage["argentum.decks"]`.
-
-Import endpoint is idempotent per `(userAccountId, deck.name)`: if a deck with the same name already
-exists, the import skips it. Cheaper than UUID collision handling, and the v1/v2 deck IDs from the
-client are device-local so we wouldn't trust them anyway. The server mints fresh UUIDs.
-
-### 2.5 Frontend Refactor
-
-- `web-client/src/store/deckLibrary.ts` — the existing Zustand store grows a backend mode.
-  Authenticated users hit the new REST endpoints; guests keep their localStorage-only flow
-  unchanged. Pseudocode:
-  ```ts
-  const isAuthed = !!useAuthSlice.getState().user
-  saveDeck = isAuthed
-      ? (d) => fetch('/api/decks', { method: 'POST', headers: bearer(), body: JSON.stringify(d) })
-      : saveDeckLocally
-  ```
-- `DeckPicker` and `DeckBuilderOverlay` — no API changes required; they consume the Zustand store,
-  which now decides where to read from.
-- **Guest decks stay local.** Guests get the same per-device deck library as today
-  (`localStorage["argentum.decks"]`). Logging in triggers the upload-on-first-login flow above.
-- **Sealed/draft autosave** (`sessionStorage["argentum-deck-state"]`) stays purely client-side for
-  both guests and authenticated users — it's an in-flight build, not a saved deck, and migrating it
-  buys nothing.
+Phase 2 ships the data plumbing only — no stats UI. A profile badge or sidebar section showing
+win/loss can land in a follow-up; the endpoints above unblock that work without adding any new
+WebSocket plumbing.
 
 ---
 
@@ -597,12 +642,12 @@ non-obvious bits.
 
 ### Infrastructure Additions
 
-| Component        | Purpose                                                       | Dev Setup                       | Prod Setup                       |
-|------------------|---------------------------------------------------------------|---------------------------------|----------------------------------|
-| **Postgres**     | `auth.user_accounts`, `decks.decks`, + future relational data | Docker Compose                  | Managed Postgres                 |
-| **Flyway**       | Schema migrations                                             | Bundled in `bootRun`            | Bundled in deploy                |
-| **OAuth IdPs**   | Identity providers (Google now; GitHub / Microsoft to follow) | OAuth client secret(s) in `.env` | Same, in deploy secret store    |
-| **Redis**        | Game cache (already present) + JWT revocation list            | Already configured              | Already configured               |
+| Component        | Purpose                                                                  | Dev Setup                       | Prod Setup                       |
+|------------------|--------------------------------------------------------------------------|---------------------------------|----------------------------------|
+| **Postgres**     | `auth.user_accounts`, `stats.game_results`, + future relational data     | Docker Compose                  | Managed Postgres                 |
+| **Flyway**       | Schema migrations                                                        | Bundled in `bootRun`            | Bundled in deploy                |
+| **OAuth IdPs**   | Identity providers (Google now; GitHub / Microsoft to follow)            | OAuth client secret(s) in `.env` | Same, in deploy secret store    |
+| **Redis**        | Game cache (already present) + JWT revocation list + refresh-token store | Already configured              | Already configured               |
 
 ### Migration Strategy from Ephemeral PlayerIdentity
 
@@ -616,17 +661,16 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    `userAccountId`-keyed identity, or to start a fresh authenticated identity and let the in-flight
    game finish under the guest token. Recommended default: **start a fresh authenticated identity
    on next connect; let the in-flight guest session complete naturally**.
-3. **Future authenticated features** (profiles, match history, etc.) require an account — there is
-   no server-side history to claim, so pre-account games stay anonymous forever.
-4. **Deck library** is the exception (Phase 2): on first sign-in we upload the contents of
-   `localStorage["argentum.decks"]` to the server via `POST /api/decks/import` and mark the local
-   copy as "uploaded". The local copy is **not deleted** — kept as a read-only fallback for now in
-   case the user logs out, and as belt-and-braces if the upload partially fails.
-5. **Other client localStorage data is left in place.** Preferences (`argentum-auto-tap`,
-   `argentum-stop-overrides`), display name (`argentum-player-name`), last lobby
-   (`argentum-lobby-id`), background (`argentum-bg`) remain per-device. Moving these is not in
-   scope; later features can migrate them individually.
-6. **E2E scenarios** keep using the existing `?token=` + `DevScenarioController.preRegisterIdentity()`
+3. **Pre-account games stay anonymous.** Phase 2 only records stats for games completed *after*
+   the player's account exists; there's no backfill path for past anonymous play.
+4. **Client localStorage data is left in place.** Per-device data already exists today: saved
+   decks at `localStorage["argentum.decks"]` (`web-client/src/store/deckLibrary.ts`), preferences
+   at `argentum-auto-tap` / `argentum-stop-overrides`, plus `argentum-player-name`,
+   `argentum-token`, `argentum-lobby-id`, `argentum-bg`. This feature does **not** touch any of it
+   on first sign-in; decks and preferences remain per-device. Migrating the deck library to a
+   server-side store (keyed by `userAccountId`) is **deferred to a dedicated deck-library backlog
+   item**, which will define both the server schema and the one-shot upload-on-first-login flow.
+5. **E2E scenarios** keep using the existing `?token=` + `DevScenarioController.preRegisterIdentity()`
    path verbatim; that is the guest path. No test rewrites required.
 
 ### Security Notes
@@ -634,18 +678,26 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
 - **Session JWT signing key**: HMAC secret in env (`GAME_SESSION_SECRET`), rotated by writing a new
   secret and accepting both old + new during a grace window. (Or RS256 with a JWKS endpoint if we
   want zero-downtime rotation built in.)
-- **JWT in `localStorage` is XSS-exposed.** Any script running on our origin can read the JWT and
-  exfiltrate it. We accept this risk for V1 because:
+- **Tokens in `localStorage` are XSS-exposed.** Any script running on our origin can read both the
+  access JWT and the refresh token. We accept this risk for V1 because:
   - The product surface today is small (no payments, no third-party scripts).
   - React with the existing render patterns (no `dangerouslySetInnerHTML` on user input) gives
     decent baseline protection.
-  - JWT lifetime is capped at 12h, limiting blast radius.
-  - The server has a revocation list (Redis `jti` blocklist) so a leaked token can be killed.
+  - Access JWT lifetime is capped at 1h — a stolen access token gives an attacker at most an hour
+    of activity (or until `/auth/logout` blocklists the `jti`).
+  - Refresh tokens **rotate on every use**; reuse of a rotated-out token triggers family-wide
+    revocation, which means a stealthy attacker still trips a tripwire the moment the legitimate
+    client refreshes (or vice-versa). Worst case is a stolen refresh token used silently until the
+    legitimate client next refreshes — typically minutes to hours.
   Tracked follow-up: migrate to `HttpOnly`, `Secure`, `SameSite=Lax` cookies. That requires
   tightening WebSocket origins (today `setAllowedOrigins("*")` — incompatible with cookie-bearing
   upgrades), exposing a `HandshakeInterceptor` to read the cookie at upgrade, and adding a
   `Set-Cookie` step to the success handler. Worth the work when we add anything sensitive
   (payments, real-time chat history, etc.).
+- **Refresh tokens** are opaque, stored only in Redis (never in the JWT signing material), rotated
+  on each `/auth/refresh`, and family-tagged so a single theft event invalidates the whole chain.
+  Per-account index (`auth:refresh-by-account:{userAccountId}`) supports global "sign out
+  everywhere" without scanning.
 - **CSRF**: not applicable in V1. Bearer tokens in `Authorization` headers don't auto-attach
   cross-origin and aren't sent on form posts. When we eventually move to cookies, revisit.
 - **Open redirect**: the success handler must validate any post-login redirect target against an
@@ -655,30 +707,36 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
   — that would let a hostile IdP take over an account by claiming a victim's address. Different
   providers → different accounts. If account-linking is added later it must require the user to be
   authenticated with the first identity first.
-- **Rate limiting**: `/oauth2/authorization/*`, `PATCH /api/me`, and `POST /api/decks/import` —
-  basic per-IP throttling via a Spring filter.
-- **Logout revocation**: blocklist the JWT's `jti` in Redis with TTL = remaining lifetime; the
-  resource-server JWT decoder consults the blocklist on each request.
+- **Rate limiting**: `/oauth2/authorization/*`, `POST /auth/refresh`, and `PATCH /api/me` — basic
+  per-IP throttling via a Spring filter. The refresh endpoint is the most attractive brute-force
+  target so it should be the tightest.
+- **Logout revocation**: blocklist the access JWT's `jti` in Redis with TTL = remaining lifetime
+  AND delete every refresh token in the same family. The resource-server JWT decoder consults the
+  blocklist on each request; the refresh endpoint already checks family membership.
 
 ### Reconnection Semantics
 
 | Scenario                                            | Outcome                                                                                                                                                                                  |
 |-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Authenticated reconnect, same browser               | JWT in `localStorage["argentum-session"]` → included in `ClientMessage.Connect.token` → decoded → `PlayerIdentity` found via `identityByAccountId` → in-flight game/lobby restored.       |
+| Authenticated reconnect, same browser, JWT fresh    | JWT in `localStorage["argentum-session"]` → included in `ClientMessage.Connect.token` → decoded → `PlayerIdentity` found via `identityByAccountId` → in-flight game/lobby restored.       |
+| Authenticated reconnect, JWT expired                | Connect rejected (or server closes WS) → SPA hits `/auth/refresh`, stores the new pair, reconnects with the new JWT. Silent to the user.                                                  |
 | Authenticated reconnect, different browser/device   | The new device has no JWT until the user logs in there too. After login it has its own JWT pointing at the same `userAccountId`, so the server-side `PlayerIdentity` is resumed.          |
+| Refresh token also expired (>30d inactive)          | `/auth/refresh` returns 401 → SPA clears tokens → user is back to the landing page guest flow → must click "Sign in with Google" again.                                                   |
 | Guest reconnect                                     | `localStorage["argentum-token"]` (legacy UUID) → existing token-based reconnect, unchanged from today.                                                                                    |
-| Authenticated user clears `localStorage` mid-game   | Next `Connect` has no JWT → treated as guest → cannot resume; game auto-concedes after the existing grace period.                                                                         |
+| Authenticated user clears `localStorage` mid-game   | Next `Connect` has no token → treated as guest → cannot resume; game auto-concedes after the existing grace period.                                                                       |
 | Guest logs in mid-game                              | See Migration Strategy #2 — current game finishes as guest, next session is authenticated.                                                                                                |
 
 ### Scaling Notes
 
 - `auth.user_accounts` is tiny and read-heavy. The `(provider, subject)` unique constraint and
   `lower(email)` index are sufficient indefinitely.
-- `decks.decks` grows linearly with active users × decks-per-user. The `(user_account_id)` index
-  handles the only access pattern (list-my-decks). Decks are small JSON blobs (a few KB each).
-- JWT validation is local (no DB hit per request) — only logout and admin-role check hit Postgres;
-  every request consults the Redis `jti` blocklist (single GET, sub-ms).
-- Postgres connection pool size: 10 is plenty for auth + decks workload.
+- `stats.game_results` grows linearly with games × authenticated participants. The composite index
+  on `(user_account_id, played_at DESC)` covers both `/api/me/stats` and `/api/me/games`. Rows are
+  small; we can keep history indefinitely until volume becomes a reason to partition by month.
+- JWT validation is local (no DB hit per request) — only `/auth/refresh`, logout, and admin-role
+  checks hit Postgres / Redis; every request consults the Redis `jti` blocklist (single GET,
+  sub-ms).
+- Postgres connection pool size: 10 is plenty for auth + stats workload.
 
 ---
 
@@ -711,29 +769,29 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    check in Phase 1 — schedule its removal as a separate cleanup item once an admin account exists
    and the admin UI sends the session JWT.
 
-6. **Refresh tokens.** We intentionally do **not** store provider refresh tokens — re-auth at
-   session expiry is acceptable for a game (re-login takes one click). Revisit only if 12-hour
-   sessions become annoying.
-
-7. **Multiple browser tabs.** Each tab opens its own WebSocket. Today this works because identities
+6. **Multiple browser tabs.** Each tab opens its own WebSocket. Today this works because identities
    are token-keyed. With account-keyed auth, all tabs share an account; the `SessionRegistry`
    needs to decide whether to allow multiple concurrent WebSockets per `userAccountId` (probably
    yes — spectating one game while in another lobby) or enforce single-session (kick the older
    socket). Recommendation: allow multiple, but route `GameSession` participation through the
    `currentGameSessionId` field on `PlayerIdentity` so only one tab is the player.
 
-8. **Deck upload conflict on first login.** If a user has already done first-login on device A and
-   built decks server-side, then signs in on device B which still has its own
-   `localStorage["argentum.decks"]` from before, what do we do? Default: import the local decks if
-   they don't conflict by name; otherwise skip them and show a "couldn't import N decks (name
-   conflict)" toast. Don't merge automatically — name conflicts almost certainly mean different
-   decks despite the shared name.
-
-9. **`AccountStatus.SUSPENDED`.** Listed in the enum for future use but no V1 trigger
+7. **`AccountStatus.SUSPENDED`.** Listed in the enum for future use but no V1 trigger
    (admin action vs auto-abuse-detection). Drop the value from V1 and reintroduce when there's a
    real use case, or keep it as a placeholder. Currently leaning toward **drop until needed.**
 
-10. **GDPR right-to-be-forgotten vs soft-delete.** `DELETE /api/me` is currently soft-delete +
-    anonymize, which is generally accepted as compliant when PII fields are nulled. If we ever
-    need hard deletion (e.g. explicit right-to-erasure request that doesn't accept anonymization),
-    add a separate admin path that cascades through `auth.user_accounts` and any FK-linked tables.
+8. **GDPR right-to-be-forgotten vs soft-delete.** `DELETE /api/me` is currently soft-delete +
+   anonymize, which is generally accepted as compliant when PII fields are nulled. If we ever
+   need hard deletion (e.g. explicit right-to-erasure request that doesn't accept anonymization),
+   add a separate admin path that cascades through `auth.user_accounts` and any FK-linked tables
+   (`stats.game_results` already cascades).
+
+9. **Stats for AI/bot opponents.** Should games against the AI count toward `games_played` and
+   `gamesWon`? Default proposed: **yes, all completed games count** — simpler, and bot-vs-human
+   is already tagged by `PlayerIdentity.isAi`, so we can filter at the UI level later if we want a
+   "vs humans only" view. Decide before shipping the stats endpoints.
+
+10. **Refresh-token horizon vs forced re-login policy.** 30-day sliding TTL is generous; some
+    products bake in a hard maximum (e.g. 90 days absolute, regardless of activity) to force
+    occasional re-auth. Keep the simple sliding model for V1; revisit if a security incident
+    demands a hard ceiling.

--- a/backlog/oauth2-accounts.md
+++ b/backlog/oauth2-accounts.md
@@ -1,11 +1,11 @@
 # OAuth2 Accounts & Persistent Identity
 
 A direct OAuth2 / OIDC + Spring Security implementation that replaces the current ephemeral
-`PlayerIdentity` (random UUID in `localStorage`) with persistent user accounts backed by Postgres.
-**Google** is the first wired-up provider; **GitHub** and **Microsoft** are designed-for follow-ups
-that drop in via a new `ClientRegistration` and a per-provider claim mapper. Provides a durable
-cross-session identity for any feature that needs one — while preserving anonymous guest play for
-casual games and dev scenario E2E tests.
+`PlayerIdentity` (random UUID in `localStorage`) with persistent user accounts backed by Postgres,
+and moves the client-side deck library to a server-side store keyed by the new account. **Google**
+is the first wired-up provider; **GitHub** and **Microsoft** are designed-for follow-ups that drop
+in via a new `ClientRegistration` and a per-provider claim mapper. Anonymous guest play stays
+intact for casual games and dev scenario E2E tests.
 
 ## Why direct OAuth (not Keycloak)
 
@@ -27,13 +27,21 @@ Spring is low, and the ops cost of running a Keycloak instance is not.
 
 ## Scope
 
-- **Phase 1 ships Google sign-in end-to-end.**
+- **Phase 1 — Google sign-in + persistent accounts** (Postgres-backed, schema `auth`).
+- **Phase 2 — Deck library moves server-side** (Postgres schema `decks`, keyed by `userAccountId`),
+  with a one-shot upload on first sign-in that imports any existing `localStorage["argentum.decks"]`
+  entries.
 - **Schema and abstractions are provider-agnostic from day one.** Each provider is identified by a
   `(provider, subject)` tuple; the JIT-provisioning flow goes through a `ProviderClaimMapper`
   abstraction so adding GitHub / Microsoft is purely additive (no migrations, no rewiring).
 - **Each provider gets a separate account.** Signing in with Google produces one
   `auth.user_accounts` row; later signing in with GitHub as the same human produces a second row.
   See [Open Questions](#open-questions--risks) for the rationale and the linking-as-follow-up note.
+- **Session token lives in `localStorage` for V1.** The JWT is delivered to the SPA via a URL
+  fragment on the OAuth callback redirect, then stored at `localStorage["argentum-session"]` and
+  attached to REST requests as `Authorization: Bearer <jwt>` and to the WebSocket via the existing
+  `ClientMessage.Connect.token` field. **No browser cookies.** Cookies are tracked as a hardening
+  follow-up; see Security Notes.
 
 ## Dependencies
 
@@ -45,7 +53,7 @@ This feature depends on:
   the auth flow needs a cleaner identity lifecycle than the current ad-hoc model.
 
 This feature is a prerequisite for any feature that needs durable cross-device identity (player
-profiles, deck library, match history, etc.).
+profiles, match history, leagues, etc.).
 
 ---
 
@@ -54,7 +62,8 @@ profiles, deck library, match history, etc.).
 The codebase today persists everything (game sessions, lobbies, tournament state) in **Redis with a
 24-hour TTL**, via the pattern `interface XRepository` + `RedisXRepository` + `InMemoryXRepository`
 gated by `cache.redis.enabled` (see `RedisGameRepository`, `RedisLobbyRepository`, and their
-in-memory counterparts). **No durable, no-TTL data exists yet** — auth accounts would be the first.
+in-memory counterparts). **No durable, no-TTL data exists yet** — auth accounts and (Phase 2) decks
+would be the first.
 
 Two plausible approaches:
 
@@ -72,7 +81,8 @@ Two plausible approaches:
 **We choose Postgres.** Auth is the first piece of a relational backbone the project will need
 anyway (profiles, deck library, match history, leagues). Paying the infra cost once now is cheaper
 than running auth on Redis and migrating later, and SQL constraints (`UNIQUE`, foreign keys for
-future tables) are exactly the integrity guarantees we want for user data.
+future tables — including the Phase 2 deck table) are exactly the integrity guarantees we want for
+user data.
 
 Redis-backed auth stays a sensible Plan B if this feature ships alone for longer than expected and
 we'd rather defer the "first relational store" decision until a second persistent feature lands —
@@ -80,15 +90,16 @@ the `UserAccountRepository` interface in Phase 1.3 keeps that swap localized.
 
 ---
 
-## Phase 1 — Infrastructure & Persistence
+## Phase 1 — Accounts & Sign-in
 
 ### 1.1 Postgres Setup
 
 - Add Postgres service to `docker-compose.local.yml` (and prod `docker-compose.yml`) alongside Redis.
 - Dev defaults: `postgres:16-alpine`, port `5432`, db `argentum`, user `argentum`, password from env.
 - **One shared database, per-feature Postgres schemas (namespaces).** Auth tables live in an `auth`
-  schema; future features get their own schema. Keeps related tables grouped, makes migrations
-  per-feature, and lets us grant scoped DB roles later without splitting databases.
+  schema; the Phase 2 deck tables live in a `decks` schema. Future features get their own schema.
+  Keeps related tables grouped, makes migrations per-feature, and lets us grant scoped DB roles
+  later without splitting databases.
 - Spring Boot config (`application.yml`):
   ```yaml
   spring:
@@ -106,8 +117,8 @@ the `UserAccountRepository` interface in Phase 1.3 keeps that swap localized.
 
 - Add `flyway-core` + `flyway-database-postgresql` to `game-server/build.gradle.kts`.
 - Migration directory: `game-server/src/main/resources/db/migration/`.
-- First migration `V1__auth_schema.sql` creates the `auth` schema and the `user_accounts` table
-  (see Phase 1.4 for the DDL).
+- `V1__auth_schema.sql` creates the `auth` schema and `auth.user_accounts` (Phase 1.4).
+- `V2__decks_schema.sql` creates the `decks` schema and `decks.decks` (Phase 2.1).
 - Future migrations live as further `V*__*.sql` files in the same directory, each creating and
   populating its own Postgres schema for the feature it owns.
 
@@ -115,8 +126,9 @@ the `UserAccountRepository` interface in Phase 1.3 keeps that swap localized.
 
 Use **Spring Data JPA**. The codebase has no existing relational data-access layer to match, so the
 choice is between JPA, Exposed, jOOQ, and raw JDBC. JPA is the most familiar option in Spring-land
-and the simplest fit for a handful of small auth tables. Wrap it behind a `UserAccountRepository`
-interface so the Postgres ↔ Redis decision in the Persistence section above stays reversible.
+and the simplest fit for the small set of tables in this feature. Wrap it behind
+`UserAccountRepository` / `DeckRepository` interfaces so the Postgres ↔ Redis decision in the
+Persistence section above stays reversible.
 
 Add to `game-server/build.gradle.kts`:
 ```kotlin
@@ -127,7 +139,8 @@ implementation("org.springframework.boot:spring-boot-starter-security")
 runtimeOnly("org.postgresql:postgresql")
 implementation("org.flywaydb:flyway-core")
 runtimeOnly("org.flywaydb:flyway-database-postgresql")
-implementation("com.auth0:java-jwt:4.x")    // for issuing our own session JWTs (see 1.6)
+// Session JWTs use Spring Security's built-in Nimbus JOSE+JWT support
+// (already transitive via spring-boot-starter-oauth2-resource-server) — no extra JWT library.
 ```
 
 ### 1.4 UserAccount Entity
@@ -153,7 +166,7 @@ class UserAccount(
     val createdAt: Instant,
     var lastLoginAt: Instant,
     @Enumerated(EnumType.STRING)
-    var status: AccountStatus = AccountStatus.ACTIVE   // ACTIVE, SUSPENDED, DELETED
+    var status: AccountStatus = AccountStatus.ACTIVE   // ACTIVE, DELETED  (SUSPENDED is a future addition)
 )
 ```
 
@@ -185,7 +198,7 @@ Configure two Spring Security filter chains:
 
 1. **OAuth2 login chain** — `/oauth2/**` and `/login/oauth2/**` handle the browser-initiated flow
    for any registered provider.
-2. **API/WebSocket chain** — `/api/**` and `/game` validate our own session token (see 1.6).
+2. **API/WebSocket chain** — `/api/**` and `/game` validate our own session JWT (see 1.6).
 
 `SecurityConfig.kt`:
 ```kotlin
@@ -202,7 +215,7 @@ class SecurityConfig(
             .successHandler(::onLoginSuccess)
             .failureHandler(::onLoginFailure)
         }
-        .csrf { it.disable() }      // SPA — CSRF handled via SameSite cookie + token
+        .csrf { it.disable() }      // SPA — no session cookies; bearer tokens are CSRF-safe
         .build()
 
     @Bean @Order(2)
@@ -269,103 +282,106 @@ spring:
      - if present: update email/displayName/avatarUrl from latest claims, set lastLoginAt = now
 
 4. SessionTokenService.issue(userAccount):
-     - sign a self-issued JWT (HS256 with a server-side secret, or RS256 if we want key rotation)
+     - sign a self-issued JWT via Spring Security's JwtEncoder (Nimbus, transitively present)
+     - HS256 with a server-side secret (env `GAME_SESSION_SECRET`); easy to swap to RS256/JWKS later
      - claims: sub = userAccount.id, name = displayName, prv = userAccount.provider,
+               jti = UUID.randomUUID() (used by the revocation list — see Security Notes),
                exp = now+12h, iss = "argentum"
+     - matching JwtDecoder bean (sessionJwtDecoder) is wired into the API/WebSocket filter chain.
 
-5. Set the JWT as an HttpOnly, Secure, SameSite=Lax cookie `argentum_session`.
-     (HttpOnly so JS can't read it; SameSite=Lax so it survives the redirect from the provider.)
-
-6. Redirect to the SPA: 302 -> https://app/<original_target_or_/>
+5. Redirect the browser to the SPA with the JWT in a URL fragment:
+       302 -> https://app/#auth_token=<jwt>
+   Fragment (not query string) so the JWT isn't sent on the redirect request and isn't logged in
+   access logs. The SPA reads `window.location.hash`, persists the JWT to
+   `localStorage["argentum-session"]`, and clears the fragment via `history.replaceState` so the
+   token doesn't linger in browser history or get accidentally copy-pasted.
 ```
 
 We issue **our own JWT** rather than passing the provider's `id_token`/access token to the SPA:
-- The provider token contains PII and provider-specific claims that we don't want on the frontend
-  cookie surface; our session JWT only carries `userAccountId`, `displayName`, and `provider`.
-- We control rotation and revocation. (See 1.10 — revocation list in Redis for forced logout.)
-- Refresh is decoupled from the provider: a long-lived refresh token isn't needed in the browser;
-  the user re-authenticates when the session JWT expires (one click).
+- The provider token carries PII and provider-specific claims we don't want on the client; our
+  session JWT only carries `userAccountId`, `displayName`, and `provider`.
+- We control rotation and revocation (Redis `jti` blocklist — Security Notes).
+- Refresh is decoupled from the provider: we don't store provider refresh tokens. When the session
+  JWT expires (12h) the user re-authenticates with one click.
 
-### 1.7 WebSocket Authentication Bridge
+### 1.7 WebSocket Authentication
 
-This is the trickiest part. `WebSocketConfig` registers `/game` with `setAllowedOrigins("*")` and
-`GameWebSocketHandler` currently authenticates on the first `ClientMessage.Connect`. WebSocket
-upgrades cannot easily participate in the OAuth2 redirect flow (browsers don't expose
-`Authorization` headers to `new WebSocket()`), so we keep auth in-message but **read the session
-cookie at upgrade time** and attach the resolved account.
+**The WebSocket flow stays the same as today** — auth happens on the first
+`ClientMessage.Connect(playerName, token)`. The only change: `token` can now be a signed JWT
+(authenticated path) instead of a random UUID (legacy guest path). The server tries to decode and
+validate; if the JWT is valid, the connection is authenticated, otherwise it falls back to the
+existing UUID-token reconnect or fresh-guest paths.
 
-Implementation:
+`ConnectionHandler.handleConnect()` becomes:
+```kotlin
+val accountId: UUID? = message.token?.let(sessionTokenService::tryDecodeAccountId)
+when {
+    accountId != null     -> handleAuthenticatedConnect(session, accountId, message)
+    message.token != null -> handleLegacyTokenReconnect(session, message)   // existing UUID path
+    else                  -> handleGuestConnect(session, message)            // fresh guest
+}
+```
 
-1. Add a `HandshakeInterceptor` to `WebSocketConfig`:
-   ```kotlin
-   registry.addHandler(gameWebSocketHandler, "/game")
-       .addInterceptors(SessionCookieHandshakeInterceptor(sessionTokenService))
-       .setAllowedOriginPatterns(...)        // tightened from "*" — must be exact origins for cookies
-   ```
-   The interceptor reads the `argentum_session` cookie from the upgrade request, validates it, and
-   stashes the resolved `UserAccount` in `WebSocketSession.attributes["account"]`. If the cookie is
-   absent/invalid the WebSocket still opens — the connection becomes a **guest session**.
+`PlayerIdentity` gains a nullable account link (keeping all its existing fields —
+`playerId`, `playerName`, `isAi`, `aiModelOverride`, `webSocketSession`, `currentGameSessionId`,
+`currentLobbyId`, `currentQuickGameLobbyId`, `currentSpectatingGameId`, the two disconnect timers):
+```kotlin
+class PlayerIdentity(
+    val token: String = UUID.randomUUID().toString(),
+    val userAccountId: UUID? = null,        // null for guests
+    /* ...existing fields unchanged... */
+)
+```
+`SessionRegistry` gains a secondary index `identityByAccountId: ConcurrentHashMap<UUID, PlayerIdentity>`
+alongside the existing `playerIdentities` and `wsToToken` maps, so an authenticated reconnect from a
+different browser still resolves to the same identity once the new device has its own JWT.
 
-2. `ConnectionHandler.handleConnect()` becomes:
-   ```kotlin
-   val account = session.attributes["account"] as UserAccount?
-   when {
-       account != null     -> handleAuthenticatedConnect(session, account, message)
-       message.token != null -> handleLegacyTokenReconnect(session, message)   // existing path
-       else                -> handleGuestConnect(session, message)              // new explicit path
-   }
-   ```
+Reconnect resolution order in `handleConnect()`:
+1. JWT decodes successfully → look up identity by `userAccountId` (cross-device works).
+2. Else `token` matches an existing guest UUID → existing token-based reconnect.
+3. Else → fresh guest identity.
 
-3. For authenticated connects the `PlayerIdentity` is keyed by `account.id` instead of a random
-   UUID. We add a new field:
-   ```kotlin
-   class PlayerIdentity(
-       val token: String = UUID.randomUUID().toString(),
-       val userAccountId: UUID? = null,        // null for guests
-       ...
-   )
-   ```
-   `SessionRegistry` gains an `identityByAccountId: ConcurrentHashMap<UUID, PlayerIdentity>`
-   index so an authenticated reconnect on a new browser still finds the same identity (rather than
-   relying on `localStorage` survival).
-
-4. Reconnect resolution order:
-   1. If `session.attributes["account"]` set → look up identity by `userAccountId` (cross-device
-      reconnect works).
-   2. Else if `ClientMessage.Connect.token` present → existing token-based reconnect (guest path).
-   3. Else → fresh guest identity.
+No `HandshakeInterceptor`, no cookies, no CORS-with-credentials. The existing
+`setAllowedOrigins("*")` stays as-is for V1 — bearer tokens in a custom message field aren't
+subject to the cookie auto-attachment risk that wildcard CORS otherwise enables. (Origin tightening
+becomes necessary when we migrate to cookies — see Security Notes.)
 
 ### 1.8 Guest Mode
 
 Anonymous play continues to work and is explicitly supported:
 
-- WebSocket upgrade without a session cookie is allowed.
-- The client sends `ClientMessage.Connect(playerName, token=…)` exactly as today.
-- `PlayerIdentity.userAccountId` is null; `SessionRegistry` still indexes by `token`.
-- Server-issued token is returned in `ServerMessage.Connected` and stored in `localStorage`.
-- Account-scoped REST endpoints (`/api/me`, etc.) **reject** unauthenticated requests (`401`);
-  gameplay endpoints (lobby create, quick-game, dev scenarios) remain open.
+- WebSocket upgrade works as today; no JWT required.
+- The client sends `ClientMessage.Connect(playerName, token=…)` with whatever it has — JWT for
+  authenticated users, the legacy `argentum-token` UUID for guests, or no token for fresh sessions.
+- `PlayerIdentity.userAccountId` is null for guests; `SessionRegistry` still indexes guests by `token`.
+- Server-issued UUID token is returned in `ServerMessage.Connected` and stored in
+  `localStorage["argentum-token"]` (the existing key, untouched by this feature).
+- Account-scoped REST endpoints (`/api/me`, `/api/decks/**`) **reject** unauthenticated requests
+  (`401`); gameplay endpoints (lobby create, quick-game, dev scenarios) remain open.
 
 This preserves:
 - Drop-in casual play (no account barrier).
 - Existing E2E scenario flows in `e2e-scenarios/` that rely on `?token=` URL params and pre-registered
-  identities via `DevScenarioController`.
+  identities via `DevScenarioController.preRegisterIdentity()` / `SessionRegistry.preRegisterIdentity()`.
 - The `X-Admin-Password` flow on `/api/admin/**` continues to work in parallel for now (see 1.10
   for the admin migration plan).
 
 ### 1.9 REST Endpoints
 
 Spring's defaults handle the OAuth dance per registration; the per-provider URLs are derived from
-`registrationId`:
+`registrationId`. All `/api/**` endpoints require `Authorization: Bearer <jwt>` (the API chain's
+`oauth2ResourceServer.jwt(...)` rejects anonymous calls except those explicitly `permitAll`).
 
 ```
 GET    /oauth2/authorization/google     Initiates Google OAuth2 (Spring redirects)
 GET    /login/oauth2/code/google        Callback (Spring handles, we run successHandler)
                                         (mirror routes appear automatically for /github, /microsoft)
-POST   /auth/logout                     Clears argentum_session cookie + revokes JWT (Redis blocklist)
-GET    /api/me                          Returns the current UserAccount (or 401 if guest)
+POST   /auth/logout                     Revokes the JWT via the Redis jti blocklist; client clears
+                                        localStorage["argentum-session"] on success.
+GET    /api/me                          Returns the current UserAccount (or 401 if no/invalid JWT)
 PATCH  /api/me                          Update displayName (only mutable field by user)
-DELETE /api/me                          Soft-delete: status=DELETED, anonymize email/displayName
+DELETE /api/me                          Soft-delete: status=DELETED, anonymize email/displayName,
+                                        cascade-delete decks (see Phase 2)
 ```
 
 `/api/me` shape:
@@ -384,33 +400,171 @@ DELETE /api/me                          Soft-delete: status=DELETED, anonymize e
 
 - Add `auth.user_accounts.roles VARCHAR[]` (Postgres array) or an `auth.user_roles` join table for `ADMIN`.
 - The `X-Admin-Password` check in `AdminController.checkAuth()` is preserved as a fallback during
-  rollout but is deprecated; admin access also accepts a session JWT with the `ADMIN` role.
+  rollout but is deprecated; admin access also accepts a session JWT with the `ADMIN` role
+  (`Authorization: Bearer <jwt>`).
 - A bootstrap admin can be promoted via a one-time SQL migration referencing their
   `(provider, subject)`, or via env-configured allowlists (e.g. `GAME_ADMIN_GOOGLE_EMAILS`) checked
   at JIT-provision time.
 - Schedule removal of the `X-Admin-Password` header as a separate cleanup item once at least one
-  admin account exists and the admin UI sends the session cookie.
+  admin account exists and the admin UI sends the session JWT.
 
 ### 1.11 Frontend Integration
 
 `web-client` changes (`src/store/slices/connectionSlice.ts`, `connectionHandlers.ts`,
-`src/components/landing/`):
+`src/components/landing/`, plus a new `authSlice`):
 
+- **OAuth callback bootstrap**: on app load, `App.tsx` (or root effect) checks
+  `window.location.hash` for `#auth_token=<jwt>`. If present:
+  1. Write to `localStorage["argentum-session"]`.
+  2. `history.replaceState(null, '', window.location.pathname + window.location.search)` to scrub.
 - **Login button(s)**: Phase 1 shows "Sign in with Google" →
   `window.location.href = '/oauth2/authorization/google'`. The button list is data-driven so adding
-  GitHub / Microsoft is a one-line change (target URL: `/oauth2/authorization/{provider}`).
-- **Session detection**: on app boot, `GET /api/me`. 200 → store user (incl. `provider`) in a new
-  `authSlice`. 401 → user is a guest (current behaviour).
-- **WebSocket connect**: drop the `?token=` URL param for authenticated users — the cookie travels
-  on the WS upgrade automatically. Guests keep the current `localStorage['argentum-token']` path.
+  GitHub / Microsoft is a one-line change.
+- **Session detection**: on boot, if a JWT exists in localStorage, `GET /api/me` with
+  `Authorization: Bearer <jwt>` → store user in `authSlice`. 401 (expired/revoked) → clear the
+  JWT, fall through to guest.
+- **WebSocket connect**: include the JWT (if present) as the `token` field in
+  `ClientMessage.Connect`. Guests keep using `localStorage["argentum-token"]`. The dev-scenario
+  `?token=` URL param keeps working as it does today (server side decides whether the value is a
+  JWT or a guest UUID).
 - **Display name**: pre-fill the player-name input with `me.displayName` for authenticated users
-  (still editable for the session — though we should consider whether per-game name override is
-  desirable now that accounts exist).
-- **Logout**: `POST /auth/logout` → clear `authSlice` → reload to drop the WebSocket session.
-- **Reverse proxy**: in dev, the Vite proxy (`/game`, `/api`) must also proxy `/oauth2` and
-  `/login/oauth2` and forward cookies (`Set-Cookie` rewriting for the `localhost:5173` origin).
-  Each OAuth provider's console must whitelist
-  `http://localhost:5173/login/oauth2/code/{provider}` and the prod equivalent.
+  (still editable for the session — open question whether we want per-game name override now that
+  accounts exist).
+- **Logout**: `POST /auth/logout` (with the JWT) → clear `localStorage["argentum-session"]` and
+  the `authSlice` → close + reopen the WebSocket so it reconnects as a guest.
+- **Reverse proxy**: in dev, the Vite proxy must cover `/oauth2/**` and `/login/oauth2/**` so the
+  redirect dance works from `localhost:5173`. No cookie forwarding needed. The Google OAuth client
+  must whitelist `http://localhost:5173/login/oauth2/code/google` and the prod equivalent.
+
+---
+
+## Phase 2 — Deck Library Migration
+
+Move the saved deck library from per-device `localStorage["argentum.decks"]` to a Postgres-backed
+table keyed by `userAccountId`, and run a one-shot upload on first sign-in so existing users don't
+lose what they've built.
+
+### 2.1 `decks.decks` Schema
+
+```sql
+CREATE SCHEMA IF NOT EXISTS decks;
+
+CREATE TABLE decks.decks (
+    id                 UUID PRIMARY KEY,
+    user_account_id    UUID NOT NULL REFERENCES auth.user_accounts(id) ON DELETE CASCADE,
+    name               VARCHAR(120) NOT NULL,
+    format             VARCHAR(32),                 -- nullable; matches client's optional field
+    set_code           VARCHAR(8),                  -- for sealed/limited decks
+    commander          VARCHAR(200),                -- nullable
+    commander_printing VARCHAR(64),                 -- nullable
+    cards              TEXT NOT NULL,               -- serialized deck body (see 2.2)
+    schema_version     SMALLINT NOT NULL,           -- 1 or 2, preserving the client envelope
+    created_at         TIMESTAMPTZ NOT NULL,
+    updated_at         TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_decks_user ON decks.decks (user_account_id);
+```
+
+Notes:
+- **`cards` is `TEXT` storing `kotlinx.serialization` JSON.** Keeps wire-compat with the existing
+  client `SavedDeck` shape (`Record<cardName, count>` for v1, the entries array with per-card
+  printing pins for v2). Promote to `JSONB` later (`ALTER TABLE … USING (cards::jsonb)`) when we
+  need server-side card-level queries — none in scope here.
+- **`ON DELETE CASCADE`** ties deck lifetime to the account. Account soft-delete (Phase 1.9
+  `DELETE /api/me`) also cascade-deletes decks rather than orphaning them; same effect, no DB-level
+  trigger needed.
+- **`schema_version`** preserves the client's v1↔v2 envelope so we don't have to do a forced
+  upgrade on import. Server treats `cards` as opaque blob; only the client cares about the inner
+  shape.
+
+### 2.2 Entity & Repository
+
+```kotlin
+@Entity
+@Table(name = "decks", schema = "decks", indexes = [Index(columnList = "userAccountId")])
+class Deck(
+    @Id val id: UUID,
+    @Column(nullable = false) val userAccountId: UUID,
+    @Column(nullable = false) var name: String,
+    var format: String?,
+    var setCode: String?,
+    var commander: String?,
+    var commanderPrinting: String?,
+    @Column(nullable = false, columnDefinition = "TEXT") var cards: String,   // kotlinx-serialized
+    @Column(nullable = false) val schemaVersion: Short,
+    val createdAt: Instant,
+    var updatedAt: Instant
+)
+```
+
+`DeckRepository : JpaRepository<Deck, UUID>` with:
+- `findAllByUserAccountId(userId: UUID): List<Deck>`
+- `findByIdAndUserAccountId(id: UUID, userId: UUID): Deck?` (so handlers can fail-closed without
+  cross-user leaks even if the controller forgets to filter)
+
+`DeckService` converts between the entity's `cards: String` and the client-facing `SavedDeck` DTO
+via `kotlinx.serialization` (same `persistenceJson` instance the Redis repos use). No new
+serializer.
+
+### 2.3 REST Endpoints
+
+```
+GET    /api/decks                     List the current user's decks (lightweight summary)
+GET    /api/decks/{id}                Get one deck's full content
+POST   /api/decks                     Create a new deck
+PUT    /api/decks/{id}                Replace a deck (atomic; updatedAt bumped)
+DELETE /api/decks/{id}                Delete a deck
+POST   /api/decks/import              Bulk import — used by the first-login upload flow (see 2.4)
+```
+
+All under the API chain (require a valid bearer JWT). 404 (not 403) when a deck ID doesn't belong
+to the caller, to avoid leaking existence.
+
+Summary shape (`GET /api/decks`):
+```json
+{ "id": "uuid", "name": "string", "format": "string|null", "cardCount": 60, "updatedAt": "iso8601" }
+```
+
+Full shape (`GET /api/decks/{id}` and `PUT /api/decks/{id}` body): mirrors the existing client
+`SavedDeck` so the SPA can swap the storage backend without changing the shape it consumes.
+
+### 2.4 First-Login Upload Flow
+
+Triggered the first time the SPA sees a brand-new authenticated session **and** has non-empty
+`localStorage["argentum.decks"]`:
+
+1. After `GET /api/me` succeeds, the SPA reads `localStorage["argentum.decks"]` and parses the
+   envelope.
+2. The SPA calls `GET /api/decks` once. If the server-side library is empty, it sends `POST
+   /api/decks/import` with the full local library as the body.
+3. On success the SPA marks `localStorage["argentum.decks.uploaded_to_account"] = userAccountId`
+   so we don't re-upload on every login. We do **not** delete the local copy — see migration
+   strategy below.
+4. From this point on, the SPA reads decks from the server (`GET /api/decks` / `GET /api/decks/{id}`)
+   instead of from `localStorage["argentum.decks"]`.
+
+Import endpoint is idempotent per `(userAccountId, deck.name)`: if a deck with the same name already
+exists, the import skips it. Cheaper than UUID collision handling, and the v1/v2 deck IDs from the
+client are device-local so we wouldn't trust them anyway. The server mints fresh UUIDs.
+
+### 2.5 Frontend Refactor
+
+- `web-client/src/store/deckLibrary.ts` — the existing Zustand store grows a backend mode.
+  Authenticated users hit the new REST endpoints; guests keep their localStorage-only flow
+  unchanged. Pseudocode:
+  ```ts
+  const isAuthed = !!useAuthSlice.getState().user
+  saveDeck = isAuthed
+      ? (d) => fetch('/api/decks', { method: 'POST', headers: bearer(), body: JSON.stringify(d) })
+      : saveDeckLocally
+  ```
+- `DeckPicker` and `DeckBuilderOverlay` — no API changes required; they consume the Zustand store,
+  which now decides where to read from.
+- **Guest decks stay local.** Guests get the same per-device deck library as today
+  (`localStorage["argentum.decks"]`). Logging in triggers the upload-on-first-login flow above.
+- **Sealed/draft autosave** (`sessionStorage["argentum-deck-state"]`) stays purely client-side for
+  both guests and authenticated users — it's an in-flight build, not a saved deck, and migrating it
+  buys nothing.
 
 ---
 
@@ -445,7 +599,7 @@ non-obvious bits.
 
 | Component        | Purpose                                                       | Dev Setup                       | Prod Setup                       |
 |------------------|---------------------------------------------------------------|---------------------------------|----------------------------------|
-| **Postgres**     | UserAccount + future relational data                          | Docker Compose                  | Managed Postgres                 |
+| **Postgres**     | `auth.user_accounts`, `decks.decks`, + future relational data | Docker Compose                  | Managed Postgres                 |
 | **Flyway**       | Schema migrations                                             | Bundled in `bootRun`            | Bundled in deploy                |
 | **OAuth IdPs**   | Identity providers (Google now; GitHub / Microsoft to follow) | OAuth client secret(s) in `.env` | Same, in deploy secret store    |
 | **Redis**        | Game cache (already present) + JWT revocation list            | Already configured              | Already configured               |
@@ -454,9 +608,9 @@ non-obvious bits.
 
 The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coexist during transition:
 
-1. **Phase 1 ships both paths**: cookie-bearing connections become authenticated identities;
-   cookie-less connections remain guest identities backed by the `localStorage` token. No data
-   migration is needed because no per-user durable data exists yet.
+1. **Phase 1 ships both paths**: JWT-bearing connections become authenticated identities;
+   token-less or UUID-token connections remain guest identities. No data migration is needed in
+   Phase 1 because there's no server-side per-user data yet.
 2. **Guest → Account merge**: when a guest player logs in, we have an open question (see Risks)
    about whether to migrate the current `PlayerIdentity.token` mapping to the new
    `userAccountId`-keyed identity, or to start a fresh authenticated identity and let the in-flight
@@ -464,14 +618,15 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    on next connect; let the in-flight guest session complete naturally**.
 3. **Future authenticated features** (profiles, match history, etc.) require an account — there is
    no server-side history to claim, so pre-account games stay anonymous forever.
-4. **Client localStorage data is left in place.** Per-device data already exists today: saved
-   decks at `localStorage["argentum.decks"]` (`web-client/src/store/deckLibrary.ts`), preferences
-   at `argentum-auto-tap` / `argentum-stop-overrides`, plus `argentum-player-name`,
-   `argentum-token`, `argentum-lobby-id`, `argentum-bg`. This feature does **not** touch any of it
-   on first sign-in; decks and preferences remain per-device. Migrating the deck library to a
-   server-side store (keyed by `userAccountId`) is deferred to a dedicated deck-library backlog
-   item, which will define both the server schema and the one-shot upload-on-first-login flow.
-5. **E2E scenarios** keep using the existing `?token=` + `DevScenarioController.preRegisterIdentity()`
+4. **Deck library** is the exception (Phase 2): on first sign-in we upload the contents of
+   `localStorage["argentum.decks"]` to the server via `POST /api/decks/import` and mark the local
+   copy as "uploaded". The local copy is **not deleted** — kept as a read-only fallback for now in
+   case the user logs out, and as belt-and-braces if the upload partially fails.
+5. **Other client localStorage data is left in place.** Preferences (`argentum-auto-tap`,
+   `argentum-stop-overrides`), display name (`argentum-player-name`), last lobby
+   (`argentum-lobby-id`), background (`argentum-bg`) remain per-device. Moving these is not in
+   scope; later features can migrate them individually.
+6. **E2E scenarios** keep using the existing `?token=` + `DevScenarioController.preRegisterIdentity()`
    path verbatim; that is the guest path. No test rewrites required.
 
 ### Security Notes
@@ -479,42 +634,51 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
 - **Session JWT signing key**: HMAC secret in env (`GAME_SESSION_SECRET`), rotated by writing a new
   secret and accepting both old + new during a grace window. (Or RS256 with a JWKS endpoint if we
   want zero-downtime rotation built in.)
-- **Cookie flags**: `HttpOnly`, `Secure` (prod), `SameSite=Lax`, `Path=/`, 12-hour `Max-Age`.
-- **CSRF**: REST + WebSocket are stateless and bearer-token-like via the cookie. Lax SameSite blocks
-  cross-site form posts. State-changing endpoints (`PATCH /api/me`, `DELETE /api/me`, and other
-  account mutations) should additionally require an `X-Requested-With: XMLHttpRequest` header to
-  defeat SameSite=Lax loopholes via top-level GET redirects (which we don't accept POSTs for anyway).
-- **CORS**: the current `setAllowedOrigins("*")` on the WebSocket handler is **incompatible with
-  cookie-bearing upgrades** — browsers refuse to send cookies cross-origin to wildcard origins.
-  Switch to `setAllowedOriginPatterns(env-driven exact list)`.
-- **Open redirect**: the success handler must validate any post-login redirect URL against an
+- **JWT in `localStorage` is XSS-exposed.** Any script running on our origin can read the JWT and
+  exfiltrate it. We accept this risk for V1 because:
+  - The product surface today is small (no payments, no third-party scripts).
+  - React with the existing render patterns (no `dangerouslySetInnerHTML` on user input) gives
+    decent baseline protection.
+  - JWT lifetime is capped at 12h, limiting blast radius.
+  - The server has a revocation list (Redis `jti` blocklist) so a leaked token can be killed.
+  Tracked follow-up: migrate to `HttpOnly`, `Secure`, `SameSite=Lax` cookies. That requires
+  tightening WebSocket origins (today `setAllowedOrigins("*")` — incompatible with cookie-bearing
+  upgrades), exposing a `HandshakeInterceptor` to read the cookie at upgrade, and adding a
+  `Set-Cookie` step to the success handler. Worth the work when we add anything sensitive
+  (payments, real-time chat history, etc.).
+- **CSRF**: not applicable in V1. Bearer tokens in `Authorization` headers don't auto-attach
+  cross-origin and aren't sent on form posts. When we eventually move to cookies, revisit.
+- **Open redirect**: the success handler must validate any post-login redirect target against an
   allowlist of own-origin paths.
 - **Account takeover via email is not a thing here.** Accounts are keyed by `(provider, subject)`,
   never by email. A new sign-in is **never auto-linked** to an existing account by matching email
   — that would let a hostile IdP take over an account by claiming a victim's address. Different
   providers → different accounts. If account-linking is added later it must require the user to be
   authenticated with the first identity first.
-- **Rate limiting**: `/oauth2/authorization/*` and `PATCH /api/me` — basic per-IP throttling via a
-  Spring filter.
+- **Rate limiting**: `/oauth2/authorization/*`, `PATCH /api/me`, and `POST /api/decks/import` —
+  basic per-IP throttling via a Spring filter.
 - **Logout revocation**: blocklist the JWT's `jti` in Redis with TTL = remaining lifetime; the
-  resource-server JWT decoder consults the blocklist.
+  resource-server JWT decoder consults the blocklist on each request.
 
 ### Reconnection Semantics
 
-| Scenario                                           | Outcome                                                    |
-|----------------------------------------------------|------------------------------------------------------------|
-| Authenticated reconnect, same browser              | Cookie present → resolved at upgrade → `PlayerIdentity` found by `userAccountId` → existing in-flight game/lobby restored |
-| Authenticated reconnect, different browser/device  | Cookie present (after re-login) → same `userAccountId` → same `PlayerIdentity` resumed (works today only if `localStorage` survived; now works cross-device) |
-| Guest reconnect                                    | `localStorage` token → existing `PlayerIdentity` (unchanged from today) |
-| Authenticated user clears cookies mid-game         | Treated as guest on reconnect → cannot resume; game auto-concedes after grace period (current behaviour) |
-| Guest logs in mid-game                             | See Migration Strategy point 2 — current game finishes as guest, future connects authenticated |
+| Scenario                                            | Outcome                                                                                                                                                                                  |
+|-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Authenticated reconnect, same browser               | JWT in `localStorage["argentum-session"]` → included in `ClientMessage.Connect.token` → decoded → `PlayerIdentity` found via `identityByAccountId` → in-flight game/lobby restored.       |
+| Authenticated reconnect, different browser/device   | The new device has no JWT until the user logs in there too. After login it has its own JWT pointing at the same `userAccountId`, so the server-side `PlayerIdentity` is resumed.          |
+| Guest reconnect                                     | `localStorage["argentum-token"]` (legacy UUID) → existing token-based reconnect, unchanged from today.                                                                                    |
+| Authenticated user clears `localStorage` mid-game   | Next `Connect` has no JWT → treated as guest → cannot resume; game auto-concedes after the existing grace period.                                                                         |
+| Guest logs in mid-game                              | See Migration Strategy #2 — current game finishes as guest, next session is authenticated.                                                                                                |
 
 ### Scaling Notes
 
-- `auth.user_accounts` is tiny and read-heavy. A simple b-tree on `(provider, subject)` (the unique
-  constraint) plus `lower(email)` is sufficient indefinitely.
-- JWT validation is local (no DB hit per request) — only logout and admin-role check hit Postgres.
-- Postgres connection pool size: 10 is plenty for an auth-only workload.
+- `auth.user_accounts` is tiny and read-heavy. The `(provider, subject)` unique constraint and
+  `lower(email)` index are sufficient indefinitely.
+- `decks.decks` grows linearly with active users × decks-per-user. The `(user_account_id)` index
+  handles the only access pattern (list-my-decks). Decks are small JSON blobs (a few KB each).
+- JWT validation is local (no DB hit per request) — only logout and admin-role check hit Postgres;
+  every request consults the Redis `jti` blocklist (single GET, sub-ms).
+- Postgres connection pool size: 10 is plenty for auth + decks workload.
 
 ---
 
@@ -526,43 +690,50 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    guest game and start the next session authenticated? Default proposed: (c). Decide before
    shipping the login buttons.
 
-2. **WebSocket origin tightening breaks E2E?** Switching from `setAllowedOrigins("*")` to an exact
-   list may break Playwright runs that connect to `localhost:8080` from arbitrary ports. Plan: add
-   a `game.dev-endpoints.allowedWsOrigins` config and default to `["*"]` only when
-   `dev-endpoints.enabled=true`.
-
-3. **Single device / single account during transition.** A user who has been playing as a guest
-   with `localStorage` data, then signs in, won't see their guest history. Documented behaviour:
-   pre-account play is permanently anonymous, no claiming.
-
-4. **Same human across providers = separate accounts.** Signing in with Google then later with
+2. **Same human across providers = separate accounts.** Signing in with Google then later with
    GitHub creates two `auth.user_accounts` rows. Trade-off: a simpler, safer model than
    email-based auto-linking (which is exploitable — see Security Notes). If we later want a single
    account with multiple linked sign-ins, it's a follow-up feature: an authenticated user adds
    another identity, which inserts a row into a separate `auth.linked_identities` table; the
    schema added in Phase 1 stays compatible.
 
-5. **Display-name uniqueness.** Multiple accounts can share a display name (especially across
+3. **Display-name uniqueness.** Multiple accounts can share a display name (especially across
    providers). Do we enforce uniqueness? Recommendation: **no** — display names are not
    identifiers, the UUID is. We can show a `#1234` suffix or provider badge in disambiguating
    contexts.
 
-6. **Email change handling.** If the provider's primary email changes between logins, we update
+4. **Email change handling.** If the provider's primary email changes between logins, we update
    the row in JIT provisioning. This is silent; surface it in `/api/me` so the user sees it on
    next view.
 
-7. **Admin migration cutover.** Until we promote at least one admin to a `UserAccount` with the
+5. **Admin migration cutover.** Until we promote at least one admin to a `UserAccount` with the
    `ADMIN` role, the `X-Admin-Password` header is the only admin path. Don't remove the header
    check in Phase 1 — schedule its removal as a separate cleanup item once an admin account exists
-   and the replay UI sends the session cookie.
+   and the admin UI sends the session JWT.
 
-8. **Refresh tokens.** We intentionally do **not** store provider refresh tokens — re-auth at
+6. **Refresh tokens.** We intentionally do **not** store provider refresh tokens — re-auth at
    session expiry is acceptable for a game (re-login takes one click). Revisit only if 12-hour
    sessions become annoying.
 
-9. **Multiple browser tabs.** Each tab opens its own WebSocket. Today this works because identities
-   are token-keyed. With cookie-keyed auth, all tabs share an account; the `SessionRegistry`
+7. **Multiple browser tabs.** Each tab opens its own WebSocket. Today this works because identities
+   are token-keyed. With account-keyed auth, all tabs share an account; the `SessionRegistry`
    needs to decide whether to allow multiple concurrent WebSockets per `userAccountId` (probably
    yes — spectating one game while in another lobby) or enforce single-session (kick the older
    socket). Recommendation: allow multiple, but route `GameSession` participation through the
    `currentGameSessionId` field on `PlayerIdentity` so only one tab is the player.
+
+8. **Deck upload conflict on first login.** If a user has already done first-login on device A and
+   built decks server-side, then signs in on device B which still has its own
+   `localStorage["argentum.decks"]` from before, what do we do? Default: import the local decks if
+   they don't conflict by name; otherwise skip them and show a "couldn't import N decks (name
+   conflict)" toast. Don't merge automatically — name conflicts almost certainly mean different
+   decks despite the shared name.
+
+9. **`AccountStatus.SUSPENDED`.** Listed in the enum for future use but no V1 trigger
+   (admin action vs auto-abuse-detection). Drop the value from V1 and reintroduce when there's a
+   real use case, or keep it as a placeholder. Currently leaning toward **drop until needed.**
+
+10. **GDPR right-to-be-forgotten vs soft-delete.** `DELETE /api/me` is currently soft-delete +
+    anonymize, which is generally accepted as compliant when PII fields are nulled. If we ever
+    need hard deletion (e.g. explicit right-to-erasure request that doesn't accept anonymization),
+    add a separate admin path that cascades through `auth.user_accounts` and any FK-linked tables.

--- a/backlog/oauth2-accounts.md
+++ b/backlog/oauth2-accounts.md
@@ -49,6 +49,37 @@ profiles, deck library, match history, etc.).
 
 ---
 
+## Persistence approach — Postgres vs Redis
+
+The codebase today persists everything (game sessions, lobbies, tournament state) in **Redis with a
+24-hour TTL**, via the pattern `interface XRepository` + `RedisXRepository` + `InMemoryXRepository`
+gated by `cache.redis.enabled` (see `RedisGameRepository`, `RedisLobbyRepository`, and their
+in-memory counterparts). **No durable, no-TTL data exists yet** — auth accounts would be the first.
+
+Two plausible approaches:
+
+| Concern              | Postgres + JPA (this plan)                                       | Redis-backed `UserAccountRepository`                                   |
+|----------------------|------------------------------------------------------------------|------------------------------------------------------------------------|
+| New infra            | Postgres + Flyway                                                | None — Redis is already deployed                                       |
+| Convention fit       | First JPA + first relational store in the project                | Matches the existing `RedisXRepository` + `InMemoryXRepository` shape  |
+| Uniqueness           | DB-enforced `UNIQUE(provider, subject)`                          | App-enforced via a secondary-index key + MULTI/WATCH                   |
+| Future queries       | SQL — admin lists, signup metrics, joins to future tables        | SCAN, or hand-rolled indexes per query                                 |
+| TTL story            | No TTL by default — straightforward                              | First-ever non-expiring keys; ops must be careful with FLUSHDB/backups |
+| Migrations           | Flyway-versioned SQL                                             | One-off scripts                                                        |
+| Serializer           | JPA-managed entities                                             | `kotlinx.serialization` (matches the rest of the codebase)             |
+| Audit posture        | Standard                                                         | Auditors / future-you side-eye user accounts in Redis                  |
+
+**We choose Postgres.** Auth is the first piece of a relational backbone the project will need
+anyway (profiles, deck library, match history, leagues). Paying the infra cost once now is cheaper
+than running auth on Redis and migrating later, and SQL constraints (`UNIQUE`, foreign keys for
+future tables) are exactly the integrity guarantees we want for user data.
+
+Redis-backed auth stays a sensible Plan B if this feature ships alone for longer than expected and
+we'd rather defer the "first relational store" decision until a second persistent feature lands —
+the `UserAccountRepository` interface in Phase 1.3 keeps that swap localized.
+
+---
+
 ## Phase 1 — Infrastructure & Persistence
 
 ### 1.1 Postgres Setup
@@ -82,8 +113,10 @@ profiles, deck library, match history, etc.).
 
 ### 1.3 Data Access Layer
 
-Choose **Spring Data JPA** (rather than Exposed) for consistency with the existing Spring stack and
-because there is no incumbent Kotlin DSL preference in the codebase.
+Use **Spring Data JPA**. The codebase has no existing relational data-access layer to match, so the
+choice is between JPA, Exposed, jOOQ, and raw JDBC. JPA is the most familiar option in Spring-land
+and the simplest fit for a handful of small auth tables. Wrap it behind a `UserAccountRepository`
+interface so the Postgres ↔ Redis decision in the Persistence section above stays reversible.
 
 Add to `game-server/build.gradle.kts`:
 ```kotlin

--- a/backlog/oauth2-accounts.md
+++ b/backlog/oauth2-accounts.md
@@ -463,9 +463,15 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    game finish under the guest token. Recommended default: **start a fresh authenticated identity
    on next connect; let the in-flight guest session complete naturally**.
 3. **Future authenticated features** (profiles, match history, etc.) require an account — there is
-   no upgrade path for past anonymous play to be claimed (acceptable trade-off; pre-account games
-   stay anonymous forever).
-4. **E2E scenarios** keep using the existing `?token=` + `DevScenarioController.preRegisterIdentity()`
+   no server-side history to claim, so pre-account games stay anonymous forever.
+4. **Client localStorage data is left in place.** Per-device data already exists today: saved
+   decks at `localStorage["argentum.decks"]` (`web-client/src/store/deckLibrary.ts`), preferences
+   at `argentum-auto-tap` / `argentum-stop-overrides`, plus `argentum-player-name`,
+   `argentum-token`, `argentum-lobby-id`, `argentum-bg`. This feature does **not** touch any of it
+   on first sign-in; decks and preferences remain per-device. Migrating the deck library to a
+   server-side store (keyed by `userAccountId`) is deferred to a dedicated deck-library backlog
+   item, which will define both the server schema and the one-shot upload-on-first-login flow.
+5. **E2E scenarios** keep using the existing `?token=` + `DevScenarioController.preRegisterIdentity()`
    path verbatim; that is the guest path. No test rewrites required.
 
 ### Security Notes

--- a/backlog/oauth2-accounts.md
+++ b/backlog/oauth2-accounts.md
@@ -2,10 +2,11 @@
 
 A direct OAuth2 / OIDC + Spring Security implementation that replaces the current ephemeral
 `PlayerIdentity` (random UUID in `localStorage`) with persistent user accounts backed by Postgres,
-and starts recording per-account game outcomes so logged-in users can see their win/loss record
-over time. **Google** is the first wired-up provider; **GitHub** and **Microsoft** are
-designed-for follow-ups that drop in via a new `ClientRegistration` and a per-provider claim
-mapper. Anonymous guest play stays intact for casual games and dev scenario E2E tests.
+and starts recording rich per-account game stats — overall W/L, color and format breakdowns,
+streaks, and life-margin — surfaced through a dedicated Stats page in the web client. **Google**
+is the first wired-up provider; **GitHub** and **Microsoft** are designed-for follow-ups that drop
+in via a new `ClientRegistration` and a per-provider claim mapper. Anonymous guest play stays
+intact for casual games and dev scenario E2E tests.
 
 ## Why direct OAuth (not Keycloak)
 
@@ -28,8 +29,14 @@ Spring is low, and the ops cost of running a Keycloak instance is not.
 ## Scope
 
 - **Phase 1 — Google sign-in + persistent accounts** (Postgres-backed, schema `auth`).
-- **Phase 2 — Per-account stats tracking** (Postgres schema `stats`): one row per completed game
-  per authenticated participant, with simple aggregation endpoints. Guests don't record stats.
+- **Phase 2 — Per-account stats** (Postgres schema `stats`): one row per completed game per
+  authenticated participant, capturing outcome, colors, format, life margin, streak-relevant
+  metadata, and a head-to-head opponent link. Aggregation endpoints + a Stats page in the web
+  client expose them. Guests don't record stats.
+- **Display names are non-unique with Discord-style discriminators.** Each account gets an
+  auto-assigned `discriminator` (e.g. `Alice#0042`) at JIT-provision time. Display names alone are
+  not identifiers — the UUID is — but the discriminator gives head-to-head views a stable
+  human-readable label that survives collisions.
 - **Schema and abstractions are provider-agnostic from day one.** Each provider is identified by a
   `(provider, subject)` tuple; the JIT-provisioning flow goes through a `ProviderClaimMapper`
   abstraction so adding GitHub / Microsoft is purely additive (no migrations, no rewiring).
@@ -166,12 +173,17 @@ class UserAccount(
     var email: String,                           // provider's email at last login (may change over time)
     @Column(nullable = false)
     var displayName: String,                     // editable by user; defaults to provider's name
+    @Column(nullable = false)
+    var discriminator: Short,                    // 1..9999, auto-assigned; unique within (lower(displayName))
     var avatarUrl: String?,                      // provider's avatar (may be null, e.g. MS personal)
     val createdAt: Instant,
     var lastLoginAt: Instant,
     @Enumerated(EnumType.STRING)
     var status: AccountStatus = AccountStatus.ACTIVE   // ACTIVE, DELETED  (SUSPENDED is a future addition)
-)
+) {
+    /** Stable human-readable handle: `Alice#0042`. */
+    val handle: String get() = "$displayName#${discriminator.toString().padStart(4, '0')}"
+}
 ```
 
 Initial migration (`V1__auth_schema.sql`):
@@ -184,6 +196,7 @@ CREATE TABLE auth.user_accounts (
     subject         VARCHAR(128) NOT NULL,
     email           VARCHAR(320) NOT NULL,
     display_name    VARCHAR(80)  NOT NULL,
+    discriminator   SMALLINT     NOT NULL CHECK (discriminator BETWEEN 1 AND 9999),
     avatar_url      TEXT,
     created_at      TIMESTAMPTZ  NOT NULL,
     last_login_at   TIMESTAMPTZ  NOT NULL,
@@ -191,10 +204,28 @@ CREATE TABLE auth.user_accounts (
     UNIQUE (provider, subject)
 );
 CREATE INDEX idx_user_accounts_email ON auth.user_accounts (lower(email));
+-- handle uniqueness: case-insensitive on display_name, paired with discriminator
+CREATE UNIQUE INDEX uq_user_accounts_handle
+    ON auth.user_accounts (lower(display_name), discriminator);
 ```
 
-`UserAccountRepository : JpaRepository<UserAccount, UUID>` exposes
-`findByProviderAndSubject(provider: String, subject: String)`.
+`UserAccountRepository : JpaRepository<UserAccount, UUID>` exposes:
+- `findByProviderAndSubject(provider: String, subject: String)`
+- `findFirstByDisplayNameIgnoreCaseAndDiscriminator(displayName: String, discriminator: Short)`
+  (for `/api/users/by-handle/{handle}` lookups used by head-to-head pages).
+
+**Discriminator allocation.** On insert (JIT provision) or display-name change,
+`DiscriminatorAllocator.allocate(displayName)` runs:
+1. Take the lowest unused `discriminator` in `[1..9999]` for that
+   `lower(display_name)`.
+2. Attempt insert. On unique-constraint violation (concurrent allocator picked the same number),
+   retry up to 5 times by re-running step 1.
+3. If all 9999 are taken for a name (vanishingly unlikely for the foreseeable user count), fail
+   the request with a `409` and ask the user to pick a different name.
+
+A Postgres advisory lock keyed by `hashtext(lower(display_name))` during the allocator's
+read+insert window is a cheaper alternative to retries — fine to use either. The retry path is
+simpler to reason about; pick that unless contention becomes measurable.
 
 ### 1.5 OAuth2 Login Flow (Spring Security)
 
@@ -282,8 +313,10 @@ spring:
 
 3. AccountProvisioner.findOrCreate(identity):
      - lookup auth.user_accounts WHERE provider = identity.provider AND subject = identity.subject
-     - if missing: insert new row (id = UUID.randomUUID(), createdAt = now)
+     - if missing: assign a discriminator via DiscriminatorAllocator (Phase 1.4), then insert a
+       new row (id = UUID.randomUUID(), createdAt = now)
      - if present: update email/displayName/avatarUrl from latest claims, set lastLoginAt = now
+       (displayName change → re-allocate discriminator for the new name)
 
 4. SessionTokenService.issuePair(userAccount):
      - **Access JWT** (short-lived, ~1h):
@@ -432,12 +465,18 @@ DELETE /api/me                          Soft-delete: status=DELETED, anonymize e
 {
   "id": "uuid",
   "provider": "google",
-  "displayName": "string",
+  "displayName": "Alice",
+  "discriminator": 42,
+  "handle": "Alice#0042",
   "email": "string",
   "avatarUrl": "string|null",
   "createdAt": "iso8601"
 }
 ```
+
+`PATCH /api/me` body accepts `{ "displayName": "..." }`; the server reassigns the discriminator for
+the new name and returns the updated shape. The old `displayName#discriminator` slot is freed for
+other users.
 
 ### 1.10 Roles & Admin Migration
 
@@ -490,8 +529,10 @@ DELETE /api/me                          Soft-delete: status=DELETED, anonymize e
 
 ## Phase 2 — Player Stats
 
-Persist per-account game outcomes so logged-in users can see their record over time. Append-only:
-each completed game inserts one row per authenticated participant. Guests don't track stats.
+Persist rich per-account game outcomes so logged-in users can browse their record over time:
+overall W/L, win-rate breakdowns by color and format, current and longest streaks, life-margin
+on wins/losses, and head-to-head vs other authenticated players. Append-only: each completed
+game inserts one row per authenticated participant. Guests don't track stats.
 
 ### 2.1 `stats.game_results` Schema
 
@@ -499,29 +540,49 @@ each completed game inserts one row per authenticated participant. Guests don't 
 CREATE SCHEMA IF NOT EXISTS stats;
 
 CREATE TABLE stats.game_results (
-    id                UUID PRIMARY KEY,
-    user_account_id   UUID NOT NULL REFERENCES auth.user_accounts(id) ON DELETE CASCADE,
-    game_session_id   VARCHAR(64) NOT NULL,         -- the existing in-memory game session id
-    outcome           VARCHAR(16) NOT NULL,         -- WON, LOST, DRAW, CONCEDED
-    format            VARCHAR(32),                  -- constructed, sealed, draft, commander, ...
-    opponents_count   SMALLINT NOT NULL,
-    duration_seconds  INTEGER,
-    played_at         TIMESTAMPTZ NOT NULL
+    id                    UUID PRIMARY KEY,
+    user_account_id       UUID NOT NULL REFERENCES auth.user_accounts(id) ON DELETE CASCADE,
+    opponent_account_id   UUID REFERENCES auth.user_accounts(id) ON DELETE SET NULL,
+    game_session_id       VARCHAR(64)  NOT NULL,
+    outcome               VARCHAR(16)  NOT NULL,         -- WON, LOST, DRAW, CONCEDED
+    format                VARCHAR(32),                    -- constructed, sealed, draft, commander, ...
+    opponents_count       SMALLINT     NOT NULL,
+    on_the_play           BOOLEAN,                        -- nullable: not all formats expose this cleanly
+    starting_life         SMALLINT     NOT NULL,          -- 20 standard, 40 Commander, etc.
+    final_life_self       SMALLINT     NOT NULL,          -- can be negative (took lethal damage)
+    final_life_opponent   SMALLINT,                       -- 1v1 only; null for multiplayer
+    colors                VARCHAR(5),                     -- deck color identity, WUBRG-alphabetized, e.g. "BR"
+    commander_name        VARCHAR(200),                   -- Commander format only
+    opponent_is_ai        BOOLEAN      NOT NULL,
+    turn_count            INTEGER,
+    duration_seconds      INTEGER,
+    played_at             TIMESTAMPTZ  NOT NULL
 );
-CREATE INDEX idx_game_results_user_played_at
-    ON stats.game_results (user_account_id, played_at DESC);
+CREATE INDEX idx_game_results_user_played_at ON stats.game_results (user_account_id, played_at DESC);
+CREATE INDEX idx_game_results_user_colors    ON stats.game_results (user_account_id, colors);
+CREATE INDEX idx_game_results_user_format    ON stats.game_results (user_account_id, format);
+CREATE INDEX idx_game_results_user_opponent  ON stats.game_results (user_account_id, opponent_account_id)
+    WHERE opponent_account_id IS NOT NULL;
 ```
 
 Notes:
-- **Append-only, no aggregation table for now.** Aggregations (`games_played`, `win_rate`, etc.)
-  are computed at read time via SQL `GROUP BY`. With current player counts this is well under a
-  millisecond; we can add a materialized view later if it stops being free.
-- **`game_session_id` is `VARCHAR(64)` and not a foreign key** — game sessions live in Redis with
-  a 24h TTL, so there's no durable referent for an FK.
-- **`outcome` enum** — `WON`, `LOST`, `DRAW`, `CONCEDED`. Concedes are tracked separately from a
-  clean loss because the future UI may want to surface "completion rate" alongside "win rate".
+- **`opponent_account_id`** is recorded when the opponent is also a logged-in user. Drives the
+  head-to-head section (2.4). Nullable for guests, AI, or multiplayer. Uses `ON DELETE SET NULL`
+  rather than `CASCADE` so deleting one account doesn't lose history rows from games where the
+  deleted account was the opponent — those rows just lose their H2H link.
+- **`final_life_self`** is signed — a player who takes lethal damage finishes below 0. Useful for
+  "how close was it" margins; the UI clamps to 0 for display if it wants.
+- **`final_life_opponent`** is only meaningful in 1v1 games. Multiplayer leaves it null; the UI
+  shows `—` rather than a margin.
+- **`colors`** is the deck's color identity (5-char max, alphabetized WUBRG, empty string =
+  colorless). Picked from the deck definition or the post-build registered deck for sealed/draft.
+  Stored as a string for cheap equality grouping in `GROUP BY colors`.
+- **Append-only, no aggregation table for now.** Aggregations are computed at read time via SQL.
+  Per-user row count is low (single-digit thousands at most); even with window functions for
+  streaks, response times stay sub-millisecond. Add a materialized view later if needed.
+- **`game_session_id` is `VARCHAR(64)` and not an FK** — game sessions live in Redis with a 24h
+  TTL, so there's no durable referent.
 - **`ON DELETE CASCADE`** on the account FK so soft-deleting an account also drops its stats rows.
-  (`DELETE /api/me` in Phase 1.9 mentions this cascade.)
 
 ### 2.2 Entity & Repository
 
@@ -531,11 +592,20 @@ Notes:
 class GameResult(
     @Id val id: UUID,
     @Column(nullable = false) val userAccountId: UUID,
+    val opponentAccountId: UUID?,
     @Column(nullable = false) val gameSessionId: String,
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false) val outcome: GameOutcome,   // WON, LOST, DRAW, CONCEDED
+    @Column(nullable = false) val outcome: GameOutcome,
     val format: String?,
     @Column(nullable = false) val opponentsCount: Short,
+    val onThePlay: Boolean?,
+    @Column(nullable = false) val startingLife: Short,
+    @Column(nullable = false) val finalLifeSelf: Short,
+    val finalLifeOpponent: Short?,
+    val colors: String?,
+    val commanderName: String?,
+    @Column(nullable = false) val opponentIsAi: Boolean,
+    val turnCount: Int?,
     val durationSeconds: Int?,
     @Column(nullable = false) val playedAt: Instant
 )
@@ -543,73 +613,199 @@ class GameResult(
 enum class GameOutcome { WON, LOST, DRAW, CONCEDED }
 ```
 
-`GameResultRepository : JpaRepository<GameResult, UUID>` with:
-- `findAllByUserAccountIdOrderByPlayedAtDesc(userId: UUID, pageable: Pageable): Page<GameResult>`
-- a `@Query` aggregation projection used by `/api/me/stats` — `count(*) FILTER (WHERE outcome = ?)`
-  grouped per outcome, plus `max(played_at)`.
+`GameResultRepository : JpaRepository<GameResult, UUID>` exposes:
+- `findAllByUserAccountIdOrderByPlayedAtDesc(userId, pageable): Page<GameResult>` — history list.
+- A `@Query` aggregation projection for the summary in `/api/me/stats` — `count(*) FILTER (WHERE
+  outcome = ?)` grouped by `outcome`, `format`, and `colors`; plus aggregates over
+  `final_life_self`, `duration_seconds`, and `on_the_play`.
+- A head-to-head aggregation joining to `auth.user_accounts` for opponent display names:
+  ```sql
+  SELECT a.id, a.display_name, a.discriminator,
+         COUNT(*)                                       AS games,
+         COUNT(*) FILTER (WHERE r.outcome = 'WON')      AS wins
+  FROM stats.game_results r
+  JOIN auth.user_accounts a ON a.id = r.opponent_account_id
+  WHERE r.user_account_id = :userId
+  GROUP BY a.id, a.display_name, a.discriminator
+  ORDER BY games DESC
+  LIMIT 20;
+  ```
+- A streak query using window functions to find consecutive same-outcome runs:
+  ```sql
+  WITH ordered AS (
+    SELECT outcome, played_at,
+           ROW_NUMBER() OVER (ORDER BY played_at) -
+           ROW_NUMBER() OVER (PARTITION BY outcome ORDER BY played_at) AS grp
+    FROM stats.game_results
+    WHERE user_account_id = :userId
+  )
+  SELECT outcome, COUNT(*) AS streak_len, MAX(played_at) AS last_played
+  FROM ordered
+  GROUP BY outcome, grp;
+  ```
+  The service layer picks the most recent group (current streak) and the per-outcome maxima
+  (longest win/loss streaks).
 
 ### 2.3 Recording Game Outcomes
 
-A new `StatsRecorder` listens for game-completion and writes one `GameResult` row per
-authenticated participant. The hook sits next to the existing game-end handling in `game-server`
-(wherever the engine signals "game over"). For each player in the final state:
+A new `StatsRecorder` listens for game-completion and writes one `GameResult` per authenticated
+participant. The hook sits next to the existing game-end handling in `game-server`. For each
+player in the final game state, if `PlayerIdentity.userAccountId != null`, capture:
 
-- If `PlayerIdentity.userAccountId != null` → insert a `GameResult` row.
-- Otherwise → skip (guests don't track stats).
+| Field                  | Source                                                                            |
+|------------------------|-----------------------------------------------------------------------------------|
+| `outcome`              | End-of-game reason from the engine (`WON` / `LOST` / `DRAW` / `CONCEDED`).        |
+| `final_life_self`      | `gameState.lifeTotals[playerEntityId]` (may be negative).                         |
+| `final_life_opponent`  | Other player's life, if 1v1; else null.                                           |
+| `starting_life`        | From the format/lobby config (20 / 40 / etc.).                                    |
+| `on_the_play`          | First-player flag captured at game start.                                         |
+| `turn_count`           | `gameState.turn` at game end.                                                     |
+| `format`               | Lobby's configured format, if any.                                                |
+| `colors`               | Deck's color identity from the deck definition; alphabetized WUBRG.               |
+| `commander_name`       | From the deck, Commander-format only.                                             |
+| `opponents_count`      | Number of opponent players in this game.                                          |
+| `opponent_is_ai`       | `opponent.PlayerIdentity.isAi` (true if any opponent is AI in multiplayer).       |
+| `opponent_account_id`  | `opponent.PlayerIdentity.userAccountId` (1v1 only; null for guest/AI/multiplayer).|
+| `duration_seconds`     | `endedAt - startedAt` from the game-session metadata.                             |
+| `played_at`            | `endedAt`.                                                                        |
 
-The write is **best-effort and asynchronous** — it doesn't gate game-end notifications to clients,
-and a failure logs an error but doesn't roll back the game outcome on the client. Concedes vs
-clean wins are distinguished by reading the existing end-state reason; the engine already produces
-this distinction for spectator UI.
+All of this is already present in the engine's final state or the game-session metadata; no new
+in-engine tracking is needed.
 
-Format is read from the lobby's configured format (where present); null otherwise. Duration is
-`endedAt - startedAt` from the existing game-session metadata.
+Writes are **best-effort and asynchronous** — they don't gate game-end notifications to clients,
+and a failure logs an error without affecting the game outcome on the client.
 
 ### 2.4 REST Endpoints
 
 ```
 GET    /api/me/stats                    Aggregated stats for the current user
-GET    /api/me/games                    Recent game history (paginated)
+GET    /api/me/games                    Recent game history (cursor-paginated)
+GET    /api/users/by-handle/{handle}    Public profile lookup by displayName#discriminator
+                                        (returns id + handle + avatarUrl; used to deep-link H2H)
 ```
 
 `GET /api/me/stats`:
 ```json
 {
-  "gamesPlayed": 42,
-  "gamesWon": 23,
-  "gamesLost": 16,
-  "gamesDrawn": 1,
-  "gamesConceded": 2,
-  "lastPlayedAt": "iso8601|null"
+  "gamesPlayed":          42,
+  "gamesWon":             23,
+  "gamesLost":            16,
+  "gamesDrawn":           1,
+  "gamesConceded":        2,
+  "winRate":              0.55,
+  "lastPlayedAt":         "iso8601|null",
+  "totalPlayTimeSeconds": 56000,
+  "currentStreak":        { "type": "WIN", "length": 3 },
+  "longestWinStreak":     7,
+  "longestLossStreak":    4,
+  "averageLifeOnWin":     12.5,
+  "averageLifeOnLoss":    -2.1,
+  "onThePlayWinRate":     0.62,
+  "onTheDrawWinRate":     0.48,
+  "byFormat": [
+    { "format": "constructed", "gamesPlayed": 30, "gamesWon": 18, "winRate": 0.60 },
+    { "format": "sealed",      "gamesPlayed": 12, "gamesWon": 5,  "winRate": 0.42 }
+  ],
+  "byColors": [
+    { "colors": "UR", "gamesPlayed": 12, "gamesWon": 8, "winRate": 0.67 },
+    { "colors": "BG", "gamesPlayed": 5,  "gamesWon": 1, "winRate": 0.20 }
+  ],
+  "headToHead": [
+    {
+      "opponent": {
+        "id": "uuid",
+        "displayName": "Bob",
+        "discriminator": 7,
+        "handle": "Bob#0007"
+      },
+      "gamesPlayed": 9,
+      "gamesWon":    5,
+      "winRate":     0.56,
+      "lastPlayedAt": "iso8601"
+    }
+  ]
 }
 ```
+
+- `winRate` is `gamesWon / max(gamesPlayed, 1)`. Concedes count as `gamesPlayed` and as a loss
+  (`gamesLost`).
+- `currentStreak.type` is `WIN` | `LOSS`; length is 0 when the most recent result is a draw.
+- `averageLifeOnWin` / `averageLifeOnLoss` use `final_life_self`; multiplayer wins use the same
+  field. Draws are excluded.
+- `byFormat`, `byColors`, and `headToHead` are sorted by `gamesPlayed DESC` and clipped to the
+  top 10 (top 20 for `headToHead`) on the server to keep the payload small.
 
 `GET /api/me/games?cursor=…` (default page size 20):
 ```json
 {
   "items": [
     {
-      "id": "uuid",
-      "outcome": "WON",
-      "format": "constructed",
-      "opponentsCount": 1,
-      "durationSeconds": 1340,
-      "playedAt": "iso8601"
+      "id":                 "uuid",
+      "outcome":            "WON",
+      "format":             "constructed",
+      "opponentsCount":     1,
+      "onThePlay":          true,
+      "finalLifeSelf":      8,
+      "finalLifeOpponent":  -3,
+      "colors":             "UR",
+      "commanderName":      null,
+      "opponentIsAi":       false,
+      "opponent": {
+        "id": "uuid",
+        "displayName": "Bob",
+        "discriminator": 7,
+        "handle": "Bob#0007"
+      },
+      "turnCount":          11,
+      "durationSeconds":    1340,
+      "playedAt":           "iso8601"
     }
   ],
   "nextCursor": "string|null"
 }
 ```
+The `opponent` object is present only when `opponentAccountId IS NOT NULL` (i.e. the opponent was
+also authenticated). Joined in via the same handle projection used by head-to-head.
 
-Both endpoints require a valid bearer JWT (the API chain rejects anonymous). Pagination uses an
-opaque cursor (base64-encoded `(playedAt, id)`) rather than offsets so new games landing during
-pagination don't shift the window.
+All `/api/me/**` endpoints require a valid bearer JWT. `/api/users/by-handle/{handle}` requires
+auth too (no public discovery in V1). Pagination uses an opaque cursor (base64-encoded
+`(playedAt, id)`) rather than offsets so new games landing mid-pagination don't shift the window.
 
-### 2.5 Frontend (light)
+### 2.5 Frontend — Stats View
 
-Phase 2 ships the data plumbing only — no stats UI. A profile badge or sidebar section showing
-win/loss can land in a follow-up; the endpoints above unblock that work without adding any new
-WebSocket plumbing.
+A new authenticated-only **Stats** page (route `/stats`, reachable from the user menu and from a
+sidebar item that shows only when logged in) renders the data above. Sketch of the sections:
+
+- **Header card** — large numbers: games played, win rate, current streak (W/L badge + length),
+  total play time formatted as "Xh Ym".
+- **Streaks row** — best win streak, best loss streak (small captions).
+- **Breakdown grid** —
+  - Format breakdown table (one row per format, with `gamesPlayed`, win-rate bar, W-L-D split).
+  - Color breakdown grid: deck color identity rendered as colored pip badges (reusing the existing
+    card-color pip components from the deck builder), each tile showing `gamesPlayed` and
+    `winRate`.
+- **On-the-play vs on-the-draw** — small two-row comparison: `onThePlayWinRate` vs
+  `onTheDrawWinRate`.
+- **Life margin** — two compact stats: average life remaining on win, average life on loss
+  (rendered as e.g. `+12.5 ❤` and `-2.1 💀`).
+- **Head-to-head** — table of opponents with `displayName#discriminator`, avatar, games played,
+  W-L, and win-rate bar. Each row links to a per-opponent detail view that filters
+  `/api/me/games` by `opponentAccountId` (`/stats/vs/{handle}`); the detail view shows recent
+  matchups, color matchup grid, and average life margin against that opponent.
+- **Recent games** — paginated list using `/api/me/games`. Each row shows outcome chip, colors
+  pips, format tag, opponent handle (or "vs AI"/"guest"), life-margin badge (e.g. `8 → -3`),
+  turn count, and played-at relative time.
+
+Implementation notes:
+- Two new Zustand slices: `statsSlice` (summary, cached) and `gamesSlice` (paginated, infinite
+  scroll).
+- A small `<ColorPips colors="UR" />` reused from the deck builder for color rendering — no new
+  asset work.
+- Opponent handles are click-through to `/stats/vs/{handle}`; the route resolves via
+  `/api/users/by-handle/{handle}` so users can share H2H links directly.
+- Empty state: friendly "play your first ranked game" copy + a CTA to "Find a match".
+- The stats page survives stale auth: if the access JWT 401s, the `apiFetch()` wrapper from Phase
+  1.11 silently refreshes; if refresh fails, the user lands back on the guest landing page.
 
 ---
 
@@ -755,10 +951,12 @@ The current ephemeral `PlayerIdentity` (random UUID in `localStorage`) must coex
    another identity, which inserts a row into a separate `auth.linked_identities` table; the
    schema added in Phase 1 stays compatible.
 
-3. **Display-name uniqueness.** Multiple accounts can share a display name (especially across
-   providers). Do we enforce uniqueness? Recommendation: **no** — display names are not
-   identifiers, the UUID is. We can show a `#1234` suffix or provider badge in disambiguating
-   contexts.
+3. ~~**Display-name uniqueness.**~~ Resolved: display names are **not** unique. Each account
+   gets a Discord-style `discriminator` (1–9999, auto-assigned per `lower(display_name)`) so the
+   handle `Alice#0042` is uniquely addressable while the bare display name stays
+   collision-friendly. See Phase 1.4 for the allocator and uniqueness index. (If a user hits the
+   9999 ceiling for some massively popular display name we'll revisit — extremely unlikely at
+   foreseeable user counts.)
 
 4. **Email change handling.** If the provider's primary email changes between logins, we update
    the row in JIT provisioning. This is silent; surface it in `/api/me` so the user sees it on


### PR DESCRIPTION
Draft — still iterating.

Refines `backlog/google-oauth2-accounts.md`:

- Auth tables live in a dedicated `auth` Postgres schema (`auth.user_accounts`) inside the shared `argentum` database, so future features can each own a schema without splitting databases. Updates the Flyway migration, JPA `@Table`, and DDL accordingly.
- Strips league/season references so the auth doc stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)