### PR TITLE
Auth slice 1: persistence foundation (Postgres + Flyway + auth.user_accounts)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,20 @@ REDIS_PORT=6379
 REDIS_TTL_MINUTES=1440
 
 # =============================================================================
+# Postgres Configuration (auth + stats)
+# =============================================================================
+# Start the dev Postgres with: docker compose -f docker-compose.local.yml up -d postgres
+# The server runs Flyway migrations on startup; no manual schema setup needed.
+POSTGRES_PORT=5432
+POSTGRES_DB=argentum
+POSTGRES_USER=argentum
+POSTGRES_PASSWORD=argentum
+# JDBC URL the backend uses to connect (override if you point at a different host).
+DB_URL=jdbc:postgresql://localhost:5432/argentum
+DB_USER=argentum
+DB_PASSWORD=argentum
+
+# =============================================================================
 # Server Configuration
 # =============================================================================
 # Enable development endpoints (Swagger UI, debug routes)

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -7,6 +7,22 @@ services:
       - redis_data:/data
     command: redis-server --appendonly yes
 
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-argentum}
+      POSTGRES_USER: ${POSTGRES_USER:-argentum}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-argentum}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-argentum} -d ${POSTGRES_DB:-argentum}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   ollama:
     image: ollama/ollama:latest
     ports:
@@ -18,4 +34,5 @@ services:
 
 volumes:
   redis_data:
+  postgres_data:
   ollama_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,39 @@ services:
       - redis_data:/data
     command: redis-server --appendonly yes
 
+  postgres:
+    image: postgres:16-alpine
+    restart: always
+    networks:
+      - app_network
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-argentum}
+      POSTGRES_USER: ${POSTGRES_USER:-argentum}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env for prod}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-argentum} -d ${POSTGRES_DB:-argentum}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   backend:
     image: ${IMAGE_REPO}/backend:latest
     restart: always
     depends_on:
-      - redis
+      redis:
+        condition: service_started
+      postgres:
+        condition: service_healthy
     environment:
       - CACHE_REDIS_ENABLED=${CACHE_REDIS_ENABLED:-true}
       - CACHE_REDIS_HOST=redis
       - CACHE_REDIS_PORT=6379
       - CACHE_REDIS_TTL_MINUTES=${CACHE_REDIS_TTL_MINUTES:-1440}
+      - DB_URL=jdbc:postgresql://postgres:5432/${POSTGRES_DB:-argentum}
+      - DB_USER=${POSTGRES_USER:-argentum}
+      - DB_PASSWORD=${POSTGRES_PASSWORD}
       - GAME_ADMIN_PASSWORD=${GAME_ADMIN_PASSWORD:-}
       - GAME_AI_ENABLED=${GAME_AI_ENABLED:-false}
       - GAME_AI_BASE_URL=${GAME_AI_BASE_URL:-https://openrouter.ai/api/v1}
@@ -59,3 +82,4 @@ networks:
 
 volumes:
   redis_data:
+  postgres_data:

--- a/game-server/build.gradle.kts
+++ b/game-server/build.gradle.kts
@@ -16,6 +16,10 @@ dependencies {
     implementation(libs.bundles.kotlinxEcosystem)
     implementation(libs.bundles.springBootWeb)
     implementation(libs.springBootStarterDataRedis)
+    implementation(libs.springBootStarterDataJpa)
+    implementation(libs.flywayCore)
+    runtimeOnly(libs.flywayPostgresql)
+    runtimeOnly(libs.postgresql)
     implementation(libs.springdocOpenapi)
     implementation(kotlin("reflect"))
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/DiscriminatorAllocator.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/DiscriminatorAllocator.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.gameserver.auth
+
+import org.springframework.stereotype.Service
+
+/**
+ * Picks the next unused discriminator for a given display name, producing Discord-style
+ * `Alice#0042` handles. Display-name matching is case-insensitive — `Alice` and `alice`
+ * share a discriminator pool.
+ *
+ * Concurrency: the read-then-allocate is **not** transactional, so two concurrent allocators
+ * racing for the same display name could both pick the same number. The caller (typically
+ * `AccountProvisioner` — slice 2) handles the resulting unique-constraint violation by retrying
+ * via [allocate]; a small retry loop is sufficient for practical contention. If contention ever
+ * becomes measurable we can replace the loop with a `pg_advisory_xact_lock(hashtext(...))`
+ * around insert; not needed now.
+ */
+@Service
+class DiscriminatorAllocator(
+    private val repository: UserAccountRepository
+) {
+
+    /**
+     * @throws DiscriminatorPoolExhaustedException if all 9999 slots for [displayName] are taken
+     *         (practically impossible at foreseeable user counts; revisit if anyone hits it).
+     */
+    fun allocate(displayName: String): Short {
+        val inUse = repository.findDiscriminatorsInUseFor(displayName)
+        for (candidate in MIN_DISCRIMINATOR..MAX_DISCRIMINATOR) {
+            val short = candidate.toShort()
+            if (short !in inUse) return short
+        }
+        throw DiscriminatorPoolExhaustedException(displayName)
+    }
+
+    companion object {
+        const val MIN_DISCRIMINATOR = 1
+        const val MAX_DISCRIMINATOR = 9999
+    }
+}
+
+class DiscriminatorPoolExhaustedException(displayName: String) :
+    RuntimeException("All discriminators 1..9999 exhausted for displayName \"$displayName\"")

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/InMemoryUserAccountRepository.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/InMemoryUserAccountRepository.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.gameserver.auth
+
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory [UserAccountRepository] used by unit tests (and as the Plan-B fallback documented in
+ * backlog/oauth2-accounts.md "Persistence approach"). Not a Spring bean — instantiate directly.
+ *
+ * Thread-safe enough for concurrent test workloads via [ConcurrentHashMap]; not optimized.
+ */
+class InMemoryUserAccountRepository : UserAccountRepository {
+
+    private val byId = ConcurrentHashMap<UUID, UserAccount>()
+
+    override fun findById(id: UUID): UserAccount? = byId[id]
+
+    override fun findByProviderAndSubject(provider: String, subject: String): UserAccount? =
+        byId.values.firstOrNull { it.provider == provider && it.subject == subject }
+
+    override fun findByDisplayNameIgnoreCaseAndDiscriminator(
+        displayName: String,
+        discriminator: Short
+    ): UserAccount? = byId.values.firstOrNull {
+        it.displayName.equals(displayName, ignoreCase = true) && it.discriminator == discriminator
+    }
+
+    override fun findDiscriminatorsInUseFor(displayName: String): Set<Short> =
+        byId.values
+            .filter { it.displayName.equals(displayName, ignoreCase = true) }
+            .mapTo(mutableSetOf()) { it.discriminator }
+
+    override fun save(account: UserAccount): UserAccount {
+        byId[account.id] = account
+        return account
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/PostgresUserAccountRepository.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/PostgresUserAccountRepository.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.gameserver.auth
+
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * Production [UserAccountRepository] backed by Postgres via Spring Data JPA. Thin delegating
+ * wrapper around [UserAccountJpaRepository] so callers stay decoupled from the JPA types and
+ * the storage decision is reversible (see backlog/oauth2-accounts.md "Persistence approach").
+ */
+@Component
+class PostgresUserAccountRepository(
+    private val jpa: UserAccountJpaRepository
+) : UserAccountRepository {
+
+    override fun findById(id: UUID): UserAccount? =
+        jpa.findById(id).orElse(null)
+
+    override fun findByProviderAndSubject(provider: String, subject: String): UserAccount? =
+        jpa.findByProviderAndSubject(provider, subject)
+
+    override fun findByDisplayNameIgnoreCaseAndDiscriminator(
+        displayName: String,
+        discriminator: Short
+    ): UserAccount? = jpa.findByDisplayNameIgnoreCaseAndDiscriminator(displayName, discriminator)
+
+    override fun findDiscriminatorsInUseFor(displayName: String): Set<Short> =
+        jpa.findDiscriminatorsInUseFor(displayName).toSet()
+
+    override fun save(account: UserAccount): UserAccount = jpa.save(account)
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/UserAccount.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/UserAccount.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.gameserver.auth
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Persistent user account, keyed by (provider, subject) — Google's `sub`, GitHub's numeric `id`,
+ * Microsoft's `oid`, etc. Each OAuth provider yields a separate account row per human;
+ * email-based auto-linking is intentionally not supported (see backlog/oauth2-accounts.md
+ * Security Notes).
+ *
+ * Display names are not unique; the [discriminator] (1..9999, auto-assigned by
+ * [DiscriminatorAllocator]) disambiguates collisions, producing handles like `Alice#0042`.
+ */
+@Entity
+@Table(
+    name = "user_accounts",
+    schema = "auth",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_user_accounts_provider_subject", columnNames = ["provider", "subject"])
+    ]
+)
+class UserAccount(
+    @Id
+    val id: UUID,
+    @Column(nullable = false, length = 32)
+    val provider: String,
+    @Column(nullable = false, length = 128)
+    val subject: String,
+    @Column(nullable = false, length = 320)
+    var email: String,
+    @Column(name = "display_name", nullable = false, length = 80)
+    var displayName: String,
+    @Column(nullable = false)
+    var discriminator: Short,
+    @Column(name = "avatar_url", columnDefinition = "TEXT")
+    var avatarUrl: String?,
+    @Column(name = "created_at", nullable = false)
+    val createdAt: Instant,
+    @Column(name = "last_login_at", nullable = false)
+    var lastLoginAt: Instant,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    var status: AccountStatus = AccountStatus.ACTIVE
+) {
+    /** Stable human-readable handle: `Alice#0042`. */
+    val handle: String
+        get() = "$displayName#${discriminator.toString().padStart(HANDLE_PAD_WIDTH, '0')}"
+
+    companion object {
+        private const val HANDLE_PAD_WIDTH = 4
+    }
+}
+
+enum class AccountStatus {
+    ACTIVE,
+
+    /**
+     * Soft-deleted: PII fields (`email`, `displayName`) have been anonymized.
+     * The row is kept so foreign keys (e.g. `stats.game_results.opponent_account_id`)
+     * don't break for the deleted user's prior opponents.
+     */
+    DELETED
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/UserAccountJpaRepository.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/UserAccountJpaRepository.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.gameserver.auth
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+/**
+ * Spring Data JPA bindings for [UserAccount]. Application code uses
+ * [UserAccountRepository] (via [PostgresUserAccountRepository]) rather than depending
+ * on this directly — keeps the storage-engine swap a single-bean change.
+ */
+interface UserAccountJpaRepository : JpaRepository<UserAccount, UUID> {
+
+    fun findByProviderAndSubject(provider: String, subject: String): UserAccount?
+
+    @Query(
+        """
+        SELECT a FROM UserAccount a
+        WHERE LOWER(a.displayName) = LOWER(:displayName) AND a.discriminator = :discriminator
+        """
+    )
+    fun findByDisplayNameIgnoreCaseAndDiscriminator(
+        @Param("displayName") displayName: String,
+        @Param("discriminator") discriminator: Short
+    ): UserAccount?
+
+    @Query(
+        """
+        SELECT a.discriminator FROM UserAccount a
+        WHERE LOWER(a.displayName) = LOWER(:displayName)
+        """
+    )
+    fun findDiscriminatorsInUseFor(@Param("displayName") displayName: String): List<Short>
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/UserAccountRepository.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/UserAccountRepository.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.gameserver.auth
+
+import java.util.UUID
+
+/**
+ * Storage abstraction for [UserAccount]. Wraps the underlying persistence (currently
+ * Spring Data JPA against Postgres, see [PostgresUserAccountRepository]) so the
+ * Postgres ↔ Redis decision documented in backlog/oauth2-accounts.md stays localized
+ * to a single bean swap.
+ */
+interface UserAccountRepository {
+
+    /** Find an account by its server-issued UUID. */
+    fun findById(id: UUID): UserAccount?
+
+    /**
+     * Find by `(provider, subject)` — the natural OAuth identity key. Used at every
+     * sign-in to decide whether to JIT-provision a fresh row or update an existing one.
+     */
+    fun findByProviderAndSubject(provider: String, subject: String): UserAccount?
+
+    /**
+     * Find by full handle — case-insensitive on display name + exact match on discriminator.
+     * Used by `/api/users/by-handle/{handle}` and head-to-head deep links.
+     */
+    fun findByDisplayNameIgnoreCaseAndDiscriminator(displayName: String, discriminator: Short): UserAccount?
+
+    /**
+     * Return the set of discriminators currently in use for the given display name
+     * (case-insensitively). Used by [DiscriminatorAllocator] to pick the next free slot.
+     */
+    fun findDiscriminatorsInUseFor(displayName: String): Set<Short>
+
+    /** Insert or update. */
+    fun save(account: UserAccount): UserAccount
+}

--- a/game-server/src/main/resources/application.yml
+++ b/game-server/src/main/resources/application.yml
@@ -4,6 +4,27 @@ server:
 spring:
   application:
     name: argentum-game-server
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/argentum}
+    username: ${DB_USER:argentum}
+    password: ${DB_PASSWORD:argentum}
+    hikari:
+      maximum-pool-size: 10
+      pool-name: argentum-pool
+  jpa:
+    hibernate:
+      ddl-auto: validate   # Flyway owns the schema; Hibernate validates only.
+    open-in-view: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    schemas: auth, stats
+    default-schema: public      # version-history table lives in public; per-feature schemas hold actual data.
+    create-schemas: true
 
 cache:
   redis:

--- a/game-server/src/main/resources/db/migration/V1__auth_schema.sql
+++ b/game-server/src/main/resources/db/migration/V1__auth_schema.sql
@@ -1,0 +1,29 @@
+-- Auth schema: persistent user accounts keyed by (provider, subject).
+-- Each OAuth provider gets a separate account row per human; display names are not unique,
+-- but the (lower(display_name), discriminator) pair is — Discord-style handles like "Alice#0042".
+-- See backlog/oauth2-accounts.md for the full design.
+
+CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE TABLE auth.user_accounts (
+    id              UUID PRIMARY KEY,
+    provider        VARCHAR(32)  NOT NULL,
+    subject         VARCHAR(128) NOT NULL,
+    email           VARCHAR(320) NOT NULL,
+    display_name    VARCHAR(80)  NOT NULL,
+    discriminator   SMALLINT     NOT NULL CHECK (discriminator BETWEEN 1 AND 9999),
+    avatar_url      TEXT,
+    created_at      TIMESTAMPTZ  NOT NULL,
+    last_login_at   TIMESTAMPTZ  NOT NULL,
+    status          VARCHAR(16)  NOT NULL DEFAULT 'ACTIVE',
+    UNIQUE (provider, subject)
+);
+
+-- Case-insensitive email lookup (provisional admin allowlist + future tooling).
+CREATE INDEX idx_user_accounts_email
+    ON auth.user_accounts (lower(email));
+
+-- The full handle "displayName#discriminator" must be unique. Display name is matched
+-- case-insensitively so "Alice" and "alice" share the same discriminator pool.
+CREATE UNIQUE INDEX uq_user_accounts_handle
+    ON auth.user_accounts (lower(display_name), discriminator);

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/DiscriminatorAllocatorTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/DiscriminatorAllocatorTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.gameserver.auth
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+import java.util.UUID
+
+class DiscriminatorAllocatorTest : FunSpec({
+
+    test("first allocation for a fresh display name returns 1") {
+        val repo = InMemoryUserAccountRepository()
+        val allocator = DiscriminatorAllocator(repo)
+
+        allocator.allocate("Alice") shouldBe 1.toShort()
+    }
+
+    test("subsequent allocations fill 1..N as accounts are saved") {
+        val repo = InMemoryUserAccountRepository()
+        val allocator = DiscriminatorAllocator(repo)
+
+        repo.save(account("Alice", 1.toShort()))
+        repo.save(account("Alice", 2.toShort()))
+
+        allocator.allocate("Alice") shouldBe 3.toShort()
+    }
+
+    test("allocator picks the lowest gap, not the next-after-max") {
+        val repo = InMemoryUserAccountRepository()
+        repo.save(account("Alice", 1.toShort()))
+        repo.save(account("Alice", 3.toShort()))   // gap at 2
+        repo.save(account("Alice", 4.toShort()))
+
+        DiscriminatorAllocator(repo).allocate("Alice") shouldBe 2.toShort()
+    }
+
+    test("display-name matching is case-insensitive — Alice and alice share a pool") {
+        val repo = InMemoryUserAccountRepository()
+        repo.save(account("Alice", 1.toShort()))
+        repo.save(account("ALICE", 2.toShort()))
+        repo.save(account("alice", 3.toShort()))
+
+        DiscriminatorAllocator(repo).allocate("alice") shouldBe 4.toShort()
+    }
+
+    test("different display names get independent pools") {
+        val repo = InMemoryUserAccountRepository()
+        repo.save(account("Alice", 1.toShort()))
+
+        // Bob's pool is untouched — Bob#0001 is still free.
+        DiscriminatorAllocator(repo).allocate("Bob") shouldBe 1.toShort()
+    }
+
+    test("exhausted pool (all 9999 slots taken) throws DiscriminatorPoolExhaustedException") {
+        // Pre-populate every slot. Done with a fake repo to avoid 9999 inserts in a test.
+        val exhaustedRepo = object : UserAccountRepository by InMemoryUserAccountRepository() {
+            override fun findDiscriminatorsInUseFor(displayName: String): Set<Short> =
+                (1..9999).mapTo(mutableSetOf()) { it.toShort() }
+        }
+
+        shouldThrow<DiscriminatorPoolExhaustedException> {
+            DiscriminatorAllocator(exhaustedRepo).allocate("Alice")
+        }
+    }
+
+    test("handle is zero-padded to four digits") {
+        val account = account("Alice", 42.toShort())
+        account.handle shouldBe "Alice#0042"
+    }
+
+    test("handle preserves display-name casing exactly as stored") {
+        account("aLiCe", 7.toShort()).handle shouldBe "aLiCe#0007"
+    }
+})
+
+private fun account(displayName: String, discriminator: Short): UserAccount = UserAccount(
+    id = UUID.randomUUID(),
+    provider = "test",
+    subject = UUID.randomUUID().toString(),
+    email = "$displayName@example.com",
+    displayName = displayName,
+    discriminator = discriminator,
+    avatarUrl = null,
+    createdAt = Instant.now(),
+    lastLoginAt = Instant.now()
+)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/InMemoryUserAccountRepositoryTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/InMemoryUserAccountRepositoryTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.gameserver.auth
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+import java.util.UUID
+
+class InMemoryUserAccountRepositoryTest : FunSpec({
+
+    test("save then findById round-trips an account") {
+        val repo = InMemoryUserAccountRepository()
+        val account = newAccount("Alice", 1.toShort())
+
+        repo.save(account)
+
+        repo.findById(account.id) shouldBe account
+    }
+
+    test("findById returns null for an unknown id") {
+        InMemoryUserAccountRepository().findById(UUID.randomUUID()).shouldBeNull()
+    }
+
+    test("findByProviderAndSubject locates by the natural key") {
+        val repo = InMemoryUserAccountRepository()
+        val google = newAccount("Alice", 1.toShort(), provider = "google", subject = "g-123")
+        val github = newAccount("Alice", 2.toShort(), provider = "github", subject = "gh-456")
+        repo.save(google)
+        repo.save(github)
+
+        repo.findByProviderAndSubject("google", "g-123") shouldBe google
+        repo.findByProviderAndSubject("github", "gh-456") shouldBe github
+        repo.findByProviderAndSubject("google", "missing").shouldBeNull()
+    }
+
+    test("findByDisplayNameIgnoreCaseAndDiscriminator matches case-insensitively") {
+        val repo = InMemoryUserAccountRepository()
+        val alice = newAccount("Alice", 42.toShort())
+        repo.save(alice)
+
+        repo.findByDisplayNameIgnoreCaseAndDiscriminator("alice", 42.toShort()) shouldBe alice
+        repo.findByDisplayNameIgnoreCaseAndDiscriminator("ALICE", 42.toShort()) shouldBe alice
+        repo.findByDisplayNameIgnoreCaseAndDiscriminator("Alice", 99.toShort()).shouldBeNull()
+    }
+
+    test("findDiscriminatorsInUseFor collects all discriminators for a name (any case)") {
+        val repo = InMemoryUserAccountRepository()
+        repo.save(newAccount("Alice", 1.toShort()))
+        repo.save(newAccount("alice", 7.toShort()))
+        repo.save(newAccount("ALICE", 42.toShort()))
+        repo.save(newAccount("Bob", 1.toShort()))
+
+        repo.findDiscriminatorsInUseFor("Alice")
+            .shouldContainExactlyInAnyOrder(1.toShort(), 7.toShort(), 42.toShort())
+        repo.findDiscriminatorsInUseFor("alice")
+            .shouldContainExactlyInAnyOrder(1.toShort(), 7.toShort(), 42.toShort())
+        repo.findDiscriminatorsInUseFor("Bob")
+            .shouldContainExactlyInAnyOrder(1.toShort())
+        repo.findDiscriminatorsInUseFor("Charlie") shouldBe emptySet()
+    }
+
+    test("save with the same id overwrites the existing row") {
+        val repo = InMemoryUserAccountRepository()
+        val id = UUID.randomUUID()
+        val original = newAccount("Alice", 1.toShort(), id = id)
+        repo.save(original)
+
+        val renamed = newAccount("Bob", 1.toShort(), id = id)
+        repo.save(renamed)
+
+        repo.findById(id)?.displayName shouldBe "Bob"
+    }
+})
+
+private fun newAccount(
+    displayName: String,
+    discriminator: Short,
+    id: UUID = UUID.randomUUID(),
+    provider: String = "google",
+    subject: String = UUID.randomUUID().toString()
+): UserAccount = UserAccount(
+    id = id,
+    provider = provider,
+    subject = subject,
+    email = "$displayName@example.com",
+    displayName = displayName,
+    discriminator = discriminator,
+    avatarUrl = null,
+    createdAt = Instant.now(),
+    lastLoginAt = Instant.now()
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ springBoot = "4.0.5"
 springdocOpenapi = "3.0.2"
 kover = "0.9.1"
 classgraph = "4.8.179"
+postgresql = "42.7.4"
+flyway = "11.5.0"
 
 [libraries]
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -33,6 +35,12 @@ springBootStarterWeb = { module = "org.springframework.boot:spring-boot-starter-
 springBootStarterWebsocket = { module = "org.springframework.boot:spring-boot-starter-websocket", version.ref = "springBoot" }
 springBootStarterTest = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springBoot" }
 springBootStarterDataRedis = { module = "org.springframework.boot:spring-boot-starter-data-redis", version.ref = "springBoot" }
+springBootStarterDataJpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "springBoot" }
+
+# Persistence
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
+flywayCore = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
+flywayPostgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 
 # SpringDoc OpenAPI (Swagger UI)
 springdocOpenapi = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdocOpenapi" }


### PR DESCRIPTION
First implementation slice of the OAuth2 accounts backlog item (spec: PR #102 / `backlog/oauth2-accounts.md`). Establishes the persistence backbone with **zero behavior change for users**: no Spring Security, no OAuth endpoints, no WebSocket auth changes — those land in slice 2.

## What's in

- **Postgres + Flyway + Spring Data JPA** pulled into `game-server`. `docker-compose.local.yml` and `docker-compose.yml` both get a `postgres:16-alpine` service with a healthcheck; prod compose's `backend` waits on `postgres` healthy before starting.
- **`V1__auth_schema.sql`** creates the `auth` schema and `auth.user_accounts` (id, provider, subject, email, display_name, discriminator, avatar_url, created_at, last_login_at, status). `UNIQUE(provider, subject)` is the natural OAuth key; a functional unique index on `(lower(display_name), discriminator)` makes `Alice#0042` handles globally unique while bare display names stay collision-friendly.
- **`UserAccount` JPA entity** exposing a derived `handle` property (`Alice#0042`, zero-padded). `UserAccountRepository` interface + `PostgresUserAccountRepository` (delegates to `UserAccountJpaRepository`) + `InMemoryUserAccountRepository` for tests, matching the existing `RedisXRepository` / `InMemoryXRepository` pattern.
- **`DiscriminatorAllocator`** picks the lowest unused `1..9999` for a case-insensitive `displayName`. Concurrent-allocator races are punted to the caller — slice 2's `AccountProvisioner` will retry on unique-constraint violation; a `pg_advisory_xact_lock` alternative is documented inline.
- **`.env.example`** gains a Postgres block (`POSTGRES_*`, `DB_URL`/`DB_USER`/`DB_PASSWORD`).
- **Unit tests** (Kotest) for the allocator (gap-filling, case-insensitive pools, independent pools per name, exhausted-pool exception, handle formatting) and the in-memory repo (round-trip, natural-key lookup, case-insensitive handle lookup, discriminator collection, overwrite-on-save).

## What's deferred

- Spring Security, OAuth2 client/resource-server, JWT issuance & refresh tokens → **slice 2**
- `PlayerIdentity.userAccountId`, `SessionRegistry.identityByAccountId`, WebSocket auth bridge → **slice 3**
- `stats.game_results` + `StatsRecorder` → **slice 4**
- `/api/me/stats` + `/api/me/games` + frontend Stats page (with H2H) → **slice 5**

## Test plan

- [ ] `just test-server` passes locally on JDK 21 (couldn't verify on my JDK 26 — the gradle Kotlin DSL parser throws on `JavaVersion.parse("26.0.1")`, a pre-existing environment issue unrelated to this slice).
- [ ] `docker compose -f docker-compose.local.yml up -d postgres` boots cleanly; `psql -U argentum -d argentum -c "\dt auth.*"` lists `user_accounts` after the server runs Flyway on startup.
- [ ] Spring Boot starts with the new datasource pointed at the local Postgres; `hibernate.ddl-auto: validate` passes (i.e. the migration's columns match the entity).
- [ ] Manual: insert a row via SQL with `discriminator = 0` → CHECK constraint rejects. With `discriminator = 1` → accepted. Insert a second row with same `(lower(display_name), discriminator)` → unique-violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)