### PR TITLE
Add Terror of the Peaks to Outlaws of Thunder Junction

### DIFF
--- a/manual-scenarios/cards/t/terror-of-the-peaks.json
+++ b/manual-scenarios/cards/t/terror-of-the-peaks.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Goblin Bully"],
+    "battlefield": [
+      {"name": "Terror of the Peaks"},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 4,
+    "hand": ["Shock", "Nowhere to Run", "Smother"],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Swamp", "tapped": false},
+      {"name": "Mountain", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": []
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -1097,6 +1097,7 @@ Set via `staticAbility { ability = ... }`:
 
 ### Other
 
+- `SpellTargetingLifeCost(amount: Int)` — spells opponents cast that target this permanent cost an additional `amount` life to cast; enforced as a casting cost in `CostCalculator.calculateTargetingLifeCost` + `CastSpellHandler`; cast is rejected if caster can't afford the life; unlike ward, there is no counter-or-pay choice and the spell never goes on the stack without payment (Terror of the Peaks)
 - `CantReceiveCounters(target)` — target can't have counters put on it (grants `AbilityFlag.CANT_RECEIVE_COUNTERS`; checked by `AddCountersExecutor`)
 - `ControlEnchantedPermanent` — control the enchanted permanent
 - `GrantShroudToController` — controller has shroud

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
@@ -88,6 +88,25 @@ data class CantReceiveCounters(
 }
 
 /**
+ * Spells opponents cast that target this permanent cost an additional [amount] life to cast.
+ * "Spells your opponents cast that target this creature cost an additional 3 life to cast."
+ *
+ * Unlike ward, this is a mandatory additional cast cost — there is no counter-or-pay choice.
+ * If the opponent cannot pay the life, their targeting spell is countered instead.
+ * Only applies to spells (not activated or triggered abilities).
+ *
+ * @property amount Life opponents must pay when targeting this permanent with a spell
+ */
+@SerialName("SpellTargetingLifeCost")
+@Serializable
+data class SpellTargetingLifeCost(
+    val amount: Int
+) : StaticAbility {
+    override val description: String = "Spells your opponents cast that target this permanent cost an additional $amount life to cast"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}
+
+/**
  * You have shroud. (You can't be the target of spells or abilities.)
  * Grants shroud to the permanent's controller (player-level shroud).
  * Used for True Believer.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TerrorOfThePeaks.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TerrorOfThePeaks.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.SpellTargetingLifeCost
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+val TerrorOfThePeaks = card("Terror of the Peaks") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 5
+    toughness = 4
+    oracleText = "Flying\nSpells your opponents cast that target this creature cost an additional 3 life to cast.\nWhenever another creature you control enters, this creature deals damage equal to that creature's power to any target."
+
+    keywords(Keyword.FLYING)
+
+    // Spells your opponents cast that target this creature cost an additional 3 life to cast.
+    staticAbility {
+        ability = SpellTargetingLifeCost(3)
+    }
+
+    // Whenever another creature you control enters, this creature deals damage equal to
+    // that creature's power to any target.
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.DealDamage(
+            DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.Power),
+            anyTarget
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "149"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/904ff94a-4db4-44a6-8593-89c32905b3fc.jpg?1712355862"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -490,6 +490,22 @@ class CastSpellHandler(
             }
         }
 
+        // Validate that the caster can afford the targeting life cost imposed by opponent
+        // permanents (e.g. Terror of the Peaks: "Spells your opponents cast that target this
+        // creature cost an additional 3 life to cast.").
+        if (action.targets.isNotEmpty()) {
+            val targetingLifeCost = costCalculator.calculateTargetingLifeCost(
+                state, action.playerId, action.targets
+            )
+            if (targetingLifeCost > 0) {
+                val currentLife = state.getEntity(action.playerId)
+                    ?.get<LifeTotalComponent>()?.life ?: 0
+                if (currentLife < targetingLifeCost) {
+                    return "Not enough life to pay targeting cost ($targetingLifeCost life required)"
+                }
+            }
+        }
+
         return null
     }
 
@@ -1709,6 +1725,24 @@ class CastSpellHandler(
             }
             events.add(LifeChangedEvent(action.playerId, currentLife, newLife, LifeChangeReason.LIFE_LOSS))
             currentState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(currentState, action.playerId)
+        }
+
+        // Pay targeting life cost imposed by opponent permanents (e.g. Terror of the Peaks).
+        // "Spells your opponents cast that target this creature cost an additional 3 life to cast."
+        if (action.targets.isNotEmpty()) {
+            val targetingLifeCost = costCalculator.calculateTargetingLifeCost(
+                currentState, action.playerId, action.targets
+            )
+            if (targetingLifeCost > 0) {
+                val currentLife = currentState.getEntity(action.playerId)
+                    ?.get<LifeTotalComponent>()?.life ?: 0
+                val newLife = currentLife - targetingLifeCost
+                currentState = currentState.updateEntity(action.playerId) { container ->
+                    container.with(LifeTotalComponent(newLife))
+                }
+                events.add(LifeChangedEvent(action.playerId, currentLife, newLife, LifeChangeReason.PAYMENT))
+                currentState = DamageUtils.markLifeLostThisTurn(currentState, action.playerId)
+            }
         }
 
         // Compute target requirements for resolution-time re-validation (Rule 608.2b).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -24,7 +24,9 @@ import com.wingedsheep.sdk.scripting.GrantAlternativeCastingCost
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.SpellTargetingLifeCost
 import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 
@@ -942,6 +944,35 @@ class CostCalculator(
             }
         }
         return increaseGenericCost(alternativeCost, totalIncrease)
+    }
+
+    /**
+     * Calculate the additional life an opponent must pay for a spell that targets
+     * permanents with [SpellTargetingLifeCost] static abilities (e.g. Terror of the Peaks).
+     *
+     * Only applies to targets whose controller is an opponent of [casterId].
+     * Called from [CastSpellHandler] to validate affordability and collect payment.
+     */
+    fun calculateTargetingLifeCost(
+        state: GameState,
+        casterId: EntityId,
+        targets: List<ChosenTarget>
+    ): Int {
+        val projected = state.projectedState
+        var total = 0
+        for (target in targets) {
+            if (target !is ChosenTarget.Permanent) continue
+            val targetController = projected.getController(target.entityId) ?: continue
+            if (targetController == casterId) continue
+            val card = state.getEntity(target.entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            val classLevel = state.getEntity(target.entityId)
+                ?.get<ClassLevelComponent>()?.currentLevel
+            for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
+                if (ability is SpellTargetingLifeCost) total += ability.amount
+            }
+        }
+        return total
     }
 
     companion object {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TerrorOfThePeaksTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TerrorOfThePeaksTest.kt
@@ -1,0 +1,189 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.TerrorOfThePeaks
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Terror of the Peaks.
+ *
+ * Terror of the Peaks: {3}{R}{R}
+ * Creature — Dragon (5/4)
+ * Flying
+ * Spells your opponents cast that target this creature cost an additional 3 life to cast.
+ * Whenever another creature you control enters, this creature deals damage equal to that
+ * creature's power to any target.
+ */
+class TerrorOfThePeaksTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TerrorOfThePeaks))
+        return driver
+    }
+
+    // =========================================================================
+    // ETB trigger: "Whenever another creature you control enters, deal damage
+    // equal to that creature's power to any target."
+    // =========================================================================
+
+    test("ETB trigger deals damage equal to entering creature's power (2/1 deals 2)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(player1, "Terror of the Peaks")
+
+        // Cast Goblin Guide (2/1, {R}) to trigger Terror's ETB ability
+        val bears = driver.putCardInHand(player1, "Goblin Guide")
+        driver.giveMana(player1, Color.RED, 1)
+        driver.castSpell(player1, bears)
+
+        // Bears spell resolves → enters battlefield → Terror's trigger fires and pauses for target
+        driver.bothPass()
+        driver.submitTargetSelection(player1, listOf(player2))
+
+        // Trigger resolves — deal 2 damage (Grizzly Bears' power) to player2
+        driver.bothPass()
+
+        driver.getLifeTotal(player2) shouldBe 18
+    }
+
+    test("ETB trigger deals damage equal to entering creature's power (5/5 deals 5)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(player1, "Terror of the Peaks")
+
+        // Cast Force of Nature (5/5, {3}{G}{G}) to trigger Terror for 5 damage
+        val fon = driver.putCardInHand(player1, "Force of Nature")
+        driver.giveMana(player1, Color.GREEN, 5)
+        driver.castSpell(player1, fon)  // {3}{G}{G}: 5 green covers all
+
+        driver.bothPass()
+        driver.submitTargetSelection(player1, listOf(player2))
+        driver.bothPass()
+
+        driver.getLifeTotal(player2) shouldBe 15
+    }
+
+    test("ETB trigger does not fire for opponents' creatures entering") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(player1, "Terror of the Peaks")
+        // Opponent's creature entering should not trigger Terror (trigger filters youControl)
+        driver.putCreatureOnBattlefield(player2, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.END)
+
+        driver.getLifeTotal(player2) shouldBe 20
+    }
+
+    test("ETB trigger does not fire when Terror itself enters (OTHER binding)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // Terror entering via putCreatureOnBattlefield does not emit events,
+        // but even if cast, TriggerBinding.OTHER ensures Terror doesn't trigger itself.
+        driver.putCreatureOnBattlefield(player1, "Terror of the Peaks")
+
+        driver.passPriorityUntil(Step.END)
+
+        driver.getLifeTotal(player2) shouldBe 20
+    }
+
+    // =========================================================================
+    // SpellTargetingLifeCost: "Spells your opponents cast that target this
+    // creature cost an additional 3 life to cast."
+    //
+    // In these tests Terror belongs to the NON-ACTIVE player (player2) so that
+    // the ACTIVE player (player1, who already has priority) can cast a targeting
+    // spell — mirroring the WardLifeCounterTest pattern.
+    // =========================================================================
+
+    test("opponent pays 3 mandatory life when casting spell targeting Terror") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // Terror belongs to player2 (the non-active player/opponent of the caster)
+        val terror = driver.putCreatureOnBattlefield(player2, "Terror of the Peaks")
+
+        // Player1 (active, has priority) casts Lightning Bolt targeting player2's Terror
+        // The 3 life is paid as part of the casting cost (not a trigger)
+        driver.giveMana(player1, Color.RED, 1)
+        val bolt = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.castSpellWithTargets(player1, bolt, listOf(ChosenTarget.Permanent(terror)))
+
+        // 3 life deducted from player1 at cast time — before the spell even goes on the stack
+        driver.getLifeTotal(player1) shouldBe 17
+
+        // Resolve Bolt: deals 3 damage to Terror (5/4 survives)
+        driver.bothPass()
+        driver.findPermanent(player2, "Terror of the Peaks") shouldNotBe null
+    }
+
+    test("targeting spell is countered when opponent cannot pay 3 life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 2)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val terror = driver.putCreatureOnBattlefield(player2, "Terror of the Peaks")
+
+        // Player1 at 2 life can't pay 3 life — cast is rejected entirely (spell never goes on stack)
+        driver.giveMana(player1, Color.RED, 1)
+        val bolt = driver.putCardInHand(player1, "Lightning Bolt")
+        val castResult = driver.castSpellWithTargets(player1, bolt, listOf(ChosenTarget.Permanent(terror)))
+
+        // Cast fails validation: not enough life to pay targeting cost
+        castResult.isSuccess shouldBe false
+
+        // Terror is unharmed, player1 life unchanged (cast was rejected)
+        driver.findPermanent(player2, "Terror of the Peaks") shouldNotBe null
+        driver.getLifeTotal(player1) shouldBe 2
+    }
+
+    test("controller's own spells targeting Terror do not trigger the life cost") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player1 = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // Terror belongs to player1 (active); player1 casts bolt at own Terror — no life cost
+        val terror = driver.putCreatureOnBattlefield(player1, "Terror of the Peaks")
+
+        driver.giveMana(player1, Color.RED, 1)
+        val bolt = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.castSpellWithTargets(player1, bolt, listOf(ChosenTarget.Permanent(terror)))
+
+        // Bolt resolves: deals 3 damage to Terror (5/4), no life cost triggered
+        driver.bothPass()
+
+        driver.getLifeTotal(player1) shouldBe 20
+        // Terror survives: 3 damage < 4 toughness
+        driver.findPermanent(player1, "Terror of the Peaks") shouldNotBe null
+    }
+})


### PR DESCRIPTION
Implements all three abilities:
- Flying
- New SpellTargetingLifeCost(3) static ability: opponents casting spells that target this creature pay 3 life as an additional casting cost, enforced in CostCalculator.calculateTargetingLifeCost and paid upfront in CastSpellHandler before the spell goes on the stack (not a triggered ability like ward — cast is rejected outright if the caster can't pay)
- ETB trigger: whenever another creature you control enters, deal damage equal to that creature's power to any target, using DynamicAmount.EntityProperty(EntityReference.Triggering, Power)