### PR TITLE
feat(sdk): add IsModified + OnePerCardName primitives

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -287,6 +287,19 @@ sealed interface SelectionRestriction {
             }
         }
     }
+
+    /**
+     * At most one card of each name may be selected. Cards with the same name
+     * are treated as interchangeable; only the first such card (in response order)
+     * is kept.
+     *
+     * Used for "creature cards with different names" effects like Behold the Sinister Six!.
+     */
+    @SerialName("OnePerCardName")
+    @Serializable
+    data object OnePerCardName : SelectionRestriction {
+        override val description: String = "at most one card of each name"
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -160,6 +160,13 @@ sealed interface StatePredicate {
         override val description: String = "equipped"
     }
 
+    /** Has an Equipment attached, an Aura attached, or any counter (MTG "modified" definition) */
+    @SerialName("IsModified")
+    @Serializable
+    data object IsModified : StatePredicate {
+        override val description: String = "modified"
+    }
+
     // =============================================================================
     // Composite / Logical Combinators
     // =============================================================================

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -147,7 +147,9 @@ data class SelectCardsDecision(
      * (e.g., Sanar's Vivid trigger). One pip per colour name (e.g., ["WHITE","BLUE"]). When null
      * or empty, the UI falls back to a generic five-colour list.
      */
-    val availableColors: List<String>? = null
+    val availableColors: List<String>? = null,
+    /** When true, at most one card of each name may be selected */
+    val onePerCardName: Boolean = false
 ) : PendingDecision
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -799,6 +799,8 @@ class PredicateEvaluator {
                 }
             }
 
+            StatePredicate.IsModified -> com.wingedsheep.engine.handlers.predicates.isModified(state, entityId)
+
             // Relative power
             StatePredicate.HasGreatestPower -> {
                 val projected = state.projectedState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -370,6 +370,7 @@ class LibraryAndZoneContinuationResumer(
             val kept = mutableSetOf<EntityId>()
             val claimedTypes = mutableSetOf<com.wingedsheep.sdk.core.CardType>()
             val claimedColors = mutableSetOf<com.wingedsheep.sdk.core.Color>()
+            val claimedNames = mutableSetOf<String>()
             for (cardId in response.selectedCards) {
                 val acceptsAllRestrictions = continuation.restrictions.all { restriction ->
                     when (restriction) {
@@ -385,6 +386,12 @@ class LibraryAndZoneContinuationResumer(
                                 ?.colors ?: emptySet()
                             // Colourless cards are not constrained by this restriction.
                             cardColors.isEmpty() || cardColors.none { it in claimedColors }
+                        }
+                        is SelectionRestriction.OnePerCardName -> {
+                            val cardName = state.getEntity(cardId)
+                                ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                                ?.name
+                            cardName == null || cardName !in claimedNames
                         }
                     }
                 }
@@ -402,6 +409,12 @@ class LibraryAndZoneContinuationResumer(
                                 claimedColors += state.getEntity(cardId)
                                     ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
                                     ?.colors ?: emptySet()
+                            }
+                            is SelectionRestriction.OnePerCardName -> {
+                                val cardName = state.getEntity(cardId)
+                                    ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                                    ?.name
+                                if (cardName != null) claimedNames += cardName
                             }
                         }
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -254,6 +254,11 @@ class SelectFromCollectionExecutor : EffectExecutor<SelectFromCollectionEffect> 
                         distinctColors.size + colourlessCount
                     }
                 }
+                is SelectionRestriction.OnePerCardName -> {
+                    eligibleCards.mapNotNull { cardId ->
+                        state.getEntity(cardId)?.get<CardComponent>()?.name
+                    }.toSet().size.coerceAtLeast(0)
+                }
             }
             if (limit < ceiling) ceiling = limit
         }
@@ -324,7 +329,8 @@ class SelectFromCollectionExecutor : EffectExecutor<SelectFromCollectionEffect> 
             nonSelectableOptions = nonSelectableCards,
             onePerCardType = effect.restrictions.any { it is SelectionRestriction.OnePerCardType },
             onePerColor = effect.restrictions.any { it is SelectionRestriction.OnePerColor },
-            availableColors = controllerPermanentColors?.map { it.name }
+            availableColors = controllerPermanentColors?.map { it.name },
+            onePerCardName = effect.restrictions.any { it is SelectionRestriction.OnePerCardName }
         )
 
         val continuation = SelectFromCollectionContinuation(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/predicates/ModifiedCreaturePredicate.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/predicates/ModifiedCreaturePredicate.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.engine.handlers.predicates
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.model.EntityId
+
+fun isModified(state: GameState, entityId: EntityId): Boolean {
+    val container = state.getEntity(entityId) ?: return false
+    val attachments = container.get<AttachmentsComponent>()
+    val hasEquipmentOrAura = attachments != null && attachments.attachedIds.any { attachId ->
+        val card = state.getEntity(attachId)?.get<CardComponent>()
+        card?.typeLine?.isEquipment == true || card?.typeLine?.isAura == true
+    }
+    val hasCounter = container.get<CountersComponent>()?.counters?.values?.any { it > 0 } == true
+    return hasEquipmentOrAura || hasCounter
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -331,6 +331,7 @@ internal class AffectsFilterResolver {
                 state.getEntity(attachId)?.get<CardComponent>()?.typeLine?.isEquipment == true
             }
         }
+        StatePredicate.IsModified -> com.wingedsheep.engine.handlers.predicates.isModified(state, entityId)
         StatePredicate.HasGreatestPower -> hasGreatestPowerInProjection(state, entityId, container, projectedValues)
         StatePredicate.HasAnyCounter -> {
             val counters = container.get<CountersComponent>()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/predicates/ModifiedCreatureFilterEquipmentAurasCountersTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/predicates/ModifiedCreatureFilterEquipmentAurasCountersTest.kt
@@ -1,0 +1,156 @@
+package com.wingedsheep.engine.predicates
+
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * BDD test for the 'modified creature you control' predicate.
+ *
+ * GIVEN Player A controls:
+ *   C1 — creature with an Equipment (controlled by A) attached
+ *   C2 — creature with an Aura (controlled by A) attached
+ *   C3 — creature with a +1/+1 counter
+ *   C4 — vanilla creature with no attachments and no counters
+ * AND Player A also controls an Aura attached to Player B's creature C5
+ * WHEN the engine evaluates StatePredicate.IsModified with ControlledByYou (playerA) via matchesWithProjection
+ * THEN C1, C2, C3 match (count == 3)
+ * AND  C4 does not match (vanilla, unmodified)
+ * AND  C5 does not match (controlled by playerB, not playerA)
+ */
+class ModifiedCreatureFilterEquipmentAurasCountersTest : FunSpec({
+
+    val evaluator = PredicateEvaluator()
+    val playerA = EntityId.generate()
+    val playerB = EntityId.generate()
+
+    test("IsModified matches creatures with Equipment, Aura, or counters and excludes vanilla and non-controlled") {
+        val c1Id = EntityId.generate()
+        val c2Id = EntityId.generate()
+        val c3Id = EntityId.generate()
+        val c4Id = EntityId.generate()
+        val c5Id = EntityId.generate()
+        val equipment1Id = EntityId.generate()
+        val aura1Id = EntityId.generate()
+        val aura2Id = EntityId.generate()
+
+        fun creatureContainer(owner: EntityId, controller: EntityId): ComponentContainer =
+            ComponentContainer()
+                .with(CardComponent(
+                    cardDefinitionId = "Creature",
+                    name = "Creature",
+                    manaCost = ManaCost(emptyList()),
+                    typeLine = TypeLine(cardTypes = setOf(CardType.CREATURE)),
+                    ownerId = owner,
+                    baseStats = CreatureStats(2, 2)
+                ))
+                .with(OwnerComponent(owner))
+                .with(ControllerComponent(controller))
+
+        val equipment1Container = ComponentContainer()
+            .with(CardComponent(
+                cardDefinitionId = "Equipment",
+                name = "Equipment",
+                manaCost = ManaCost(emptyList()),
+                typeLine = TypeLine(cardTypes = setOf(CardType.ARTIFACT), subtypes = setOf(Subtype.EQUIPMENT)),
+                ownerId = playerA
+            ))
+            .with(OwnerComponent(playerA))
+            .with(ControllerComponent(playerA))
+            .with(AttachedToComponent(c1Id))
+
+        val aura1Container = ComponentContainer()
+            .with(CardComponent(
+                cardDefinitionId = "Aura1",
+                name = "Aura1",
+                manaCost = ManaCost(emptyList()),
+                typeLine = TypeLine(cardTypes = setOf(CardType.ENCHANTMENT), subtypes = setOf(Subtype.AURA)),
+                ownerId = playerA
+            ))
+            .with(OwnerComponent(playerA))
+            .with(ControllerComponent(playerA))
+            .with(AttachedToComponent(c2Id))
+
+        // Aura controlled by playerA but attached to playerB's creature C5
+        val aura2Container = ComponentContainer()
+            .with(CardComponent(
+                cardDefinitionId = "Aura2",
+                name = "Aura2",
+                manaCost = ManaCost(emptyList()),
+                typeLine = TypeLine(cardTypes = setOf(CardType.ENCHANTMENT), subtypes = setOf(Subtype.AURA)),
+                ownerId = playerA
+            ))
+            .with(OwnerComponent(playerA))
+            .with(ControllerComponent(playerA))
+            .with(AttachedToComponent(c5Id))
+
+        val c1Container = creatureContainer(playerA, playerA).with(AttachmentsComponent(listOf(equipment1Id)))
+        val c2Container = creatureContainer(playerA, playerA).with(AttachmentsComponent(listOf(aura1Id)))
+        val c3Container = creatureContainer(playerA, playerA)
+            .with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+        val c4Container = creatureContainer(playerA, playerA)
+        val c5Container = creatureContainer(playerB, playerB).with(AttachmentsComponent(listOf(aura2Id)))
+
+        var state = GameState()
+            .withEntity(playerA, ComponentContainer())
+            .withEntity(playerB, ComponentContainer())
+
+        for ((id, container) in listOf(
+            c1Id to c1Container,
+            c2Id to c2Container,
+            c3Id to c3Container,
+            c4Id to c4Container,
+            equipment1Id to equipment1Container,
+            aura1Id to aura1Container,
+            aura2Id to aura2Container
+        )) {
+            state = state.withEntity(id, container).addToZone(ZoneKey(playerA, Zone.BATTLEFIELD), id)
+        }
+        for ((id, container) in listOf(c5Id to c5Container)) {
+            state = state.withEntity(id, container).addToZone(ZoneKey(playerB, Zone.BATTLEFIELD), id)
+        }
+
+        val modifiedFilter = GameObjectFilter(
+            statePredicates = listOf(StatePredicate.IsModified),
+            controllerPredicate = ControllerPredicate.ControlledByYou
+        )
+        val context = PredicateContext(controllerId = playerA)
+        val projected = state.projectedState
+
+        // C1: equipment attached — should match
+        evaluator.matchesWithProjection(state, projected, c1Id, modifiedFilter, context) shouldBe true
+
+        // C2: aura attached — should match
+        evaluator.matchesWithProjection(state, projected, c2Id, modifiedFilter, context) shouldBe true
+
+        // C3: +1/+1 counter — should match
+        evaluator.matchesWithProjection(state, projected, c3Id, modifiedFilter, context) shouldBe true
+
+        // C4: vanilla, nothing attached, no counters — should NOT match
+        evaluator.matchesWithProjection(state, projected, c4Id, modifiedFilter, context) shouldBe false
+
+        // C5: not controlled by playerA — should NOT match even though playerA's aura is attached
+        evaluator.matchesWithProjection(state, projected, c5Id, modifiedFilter, context) shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary
- Adds `IsModified` state predicate for matching modified creatures (those with auras, equipment, or counters) — mirrors the MTG definition in CR 700.4.
- Adds `OnePerCardName` filter primitive for "one per card name" selection patterns.
- Wires into `PredicateEvaluator`, `AffectsFilterResolver`, and the library/zone selection pipeline.

## Test plan
- [x] New unit tests: `ModifiedCreatureFilterEquipmentAurasCountersTest` covers equipment / aura / counter triggers.
- [ ] Reviewer: run `just test-rules`.