### PR TITLE
Add Romantic Rendezvous (SPM)

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -1,0 +1,195 @@
+# Marvel's Spider-Man (SPM) - Card Checklist
+
+**Set Size:** 188 booster cards (excluding basic lands and tokens)
+**Release Date:** September 26, 2025
+**Implemented:** 0 / 188
+---
+
+- [ ] Agent Venom
+- [ ] Alien Symbiosis
+- [ ] Amazing Acrobatics
+- [ ] Angry Rabble
+- [ ] Anti-Venom, Horrifying Healer
+- [ ] Arachne, Psionic Weaver
+- [ ] Araña, Heart of the Spider
+- [ ] Aunt May
+- [ ] Bagel and Schmear
+- [ ] Beetle, Legacy Criminal
+- [ ] Behold the Sinister Six!
+- [ ] Biorganic Carapace
+- [ ] Black Cat, Cunning Thief
+- [ ] Carnage, Crimson Chaos
+- [ ] Chameleon, Master of Disguise
+- [ ] Cheering Crowd
+- [ ] City Pigeon
+- [ ] Common Crook
+- [ ] Cosmic Spider-Man
+- [ ] Costume Closet
+- [ ] Daily Bugle Building
+- [ ] Daily Bugle Reporters
+- [ ] Damage Control Crew
+- [ ] Doc Ock's Henchmen
+- [ ] Doc Ock's Tentacles
+- [ ] Doc Ock, Sinister Scientist
+- [ ] Doctor Octopus, Master Planner
+- [ ] Eddie Brock // Venom, Lethal Protector
+- [ ] Eerie Gravestone
+- [ ] Electro's Bolt
+- [ ] Electro, Assaulting Battery
+- [ ] Ezekiel Sims, Spider-Totem
+- [ ] Flash Thompson, Spider-Fan
+- [ ] Flying Octobot
+- [ ] Friendly Neighborhood
+- [ ] Gallant Citizen
+- [ ] Green Goblin, Revenant
+- [ ] Grow Extra Arms
+- [ ] Guy in the Chair
+- [ ] Gwen Stacy // Ghost-Spider
+- [ ] Gwenom, Remorseless
+- [ ] Heroes' Hangout
+- [ ] Hide on the Ceiling
+- [ ] Hobgoblin, Mantled Marauder
+- [ ] Hot Dog Cart
+- [ ] Hydro-Man, Fluid Felon
+- [ ] Impostor Syndrome
+- [ ] Inner Demons Gangsters
+- [ ] Interdimensional Web Watch
+- [ ] Iron Spider, Stark Upgrade
+- [ ] J. Jonah Jameson
+- [ ] Jackal, Genius Geneticist
+- [ ] Kapow!
+- [ ] Kraven the Hunter
+- [ ] Kraven's Cats
+- [ ] Kraven's Last Hunt
+- [ ] Kraven, Proud Predator
+- [ ] Lady Octopus, Inspired Inventor
+- [ ] Living Brain, Mechanical Marvel
+- [ ] Lizard, Connors's Curse
+- [ ] Lurking Lizards
+- [ ] Madame Web, Clairvoyant
+- [ ] Mary Jane Watson
+- [ ] Masked Meower
+- [ ] Maximum Carnage
+- [ ] Mechanical Mobster
+- [ ] Merciless Enforcers
+- [ ] Miles Morales // Ultimate Spider-Man
+- [ ] Mister Negative
+- [ ] Mob Lookout
+- [ ] Molten Man, Inferno Incarnate
+- [ ] Morbius the Living Vampire
+- [ ] Morlun, Devourer of Spiders
+- [ ] Multiversal Passage
+- [ ] Mysterio's Phantasm
+- [ ] Mysterio, Master of Illusion
+- [ ] News Helicopter
+- [ ] Norman Osborn // Green Goblin
+- [ ] Ominous Asylum
+- [ ] Origin of Spider-Man
+- [ ] Oscorp Industries
+- [ ] Oscorp Research Team
+- [ ] Parker Luck
+- [ ] Passenger Ferry
+- [ ] Peter Parker // Amazing Spider-Man
+- [ ] Peter Parker's Camera
+- [ ] Pictures of Spider-Man
+- [ ] Prison Break
+- [ ] Professional Wrestler
+- [ ] Prowler, Clawed Thief
+- [ ] Pumpkin Bombardment
+- [ ] Radioactive Spider
+- [ ] Raging Goblinoids
+- [ ] Rent Is Due
+- [ ] Rhino's Rampage
+- [ ] Rhino, Barreling Brute
+- [ ] Risky Research
+- [ ] Robotics Mastery
+- [ ] Rocket-Powered Goblin Glider
+- [ ] Romantic Rendezvous
+- [ ] SP//dr, Piloted by Peni
+- [ ] Sandman's Quicksand
+- [ ] Sandman, Shifting Scoundrel
+- [ ] Savage Mansion
+- [ ] Scarlet Spider, Ben Reilly
+- [ ] Scarlet Spider, Kaine
+- [ ] School Daze
+- [ ] Scorpion's Sting
+- [ ] Scorpion, Seething Striker
+- [ ] Scout the City
+- [ ] Secret Identity
+- [ ] Selfless Police Captain
+- [ ] Shadow of the Goblin
+- [ ] Shock
+- [ ] Shocker, Unshakable
+- [ ] Shriek, Treblemaker
+- [ ] Silk, Web Weaver
+- [ ] Silver Sable, Mercenary Leader
+- [ ] Sinister Hideout
+- [ ] Skyward Spider
+- [ ] Spectacular Spider-Man
+- [ ] Spectacular Tactics
+- [ ] Spider Manifestation
+- [ ] Spider-Bot
+- [ ] Spider-Byte, Web Warden
+- [ ] Spider-Girl, Legacy Hero
+- [ ] Spider-Gwen, Free Spirit
+- [ ] Spider-Ham, Peter Porker
+- [ ] Spider-Islanders
+- [ ] Spider-Man 2099
+- [ ] Spider-Man India
+- [ ] Spider-Man No More
+- [ ] Spider-Man Noir
+- [ ] Spider-Man, Brooklyn Visionary
+- [ ] Spider-Man, Web-Slinger
+- [ ] Spider-Mobile
+- [ ] Spider-Punk
+- [ ] Spider-Rex, Daring Dino
+- [ ] Spider-Sense
+- [ ] Spider-Slayer, Hatred Honed
+- [ ] Spider-Suit
+- [ ] Spider-UK
+- [ ] Spider-Verse
+- [ ] Spider-Woman, Stunning Savior
+- [ ] Spiders-Man, Heroic Horde
+- [ ] Spinneret and Spiderling
+- [ ] Starling, Aerial Ally
+- [ ] Steel Wrecking Ball
+- [ ] Stegron the Dinosaur Man
+- [ ] Strength of Will
+- [ ] Suburban Sanctuary
+- [ ] Subway Train
+- [ ] Sudden Strike
+- [ ] Sun-Spider, Nimble Webber
+- [ ] Superior Foes of Spider-Man
+- [ ] Superior Spider-Man
+- [ ] Supportive Parents
+- [ ] Swarm, Being of Bees
+- [ ] Symbiote Spider-Man
+- [ ] Taxi Driver
+- [ ] Terrific Team-Up
+- [ ] The Clone Saga
+- [ ] The Death of Gwen Stacy
+- [ ] The Soul Stone
+- [ ] The Spot's Portal
+- [ ] The Spot, Living Portal
+- [ ] Thwip!
+- [ ] Tombstone, Career Criminal
+- [ ] Ultimate Green Goblin
+- [ ] University Campus
+- [ ] Unstable Experiment
+- [ ] Urban Retreat
+- [ ] Venom's Hunger
+- [ ] Venom, Evil Unleashed
+- [ ] Venomized Cat
+- [ ] Vibrant Cityscape
+- [ ] Villainous Wrath
+- [ ] Vulture, Scheming Scavenger
+- [ ] Wall Crawl
+- [ ] Web Up
+- [ ] Web of Life and Destiny
+- [ ] Web-Shooters
+- [ ] Web-Warriors
+- [ ] Whoosh!
+- [ ] Wild Pack Squad
+- [ ] Wisecrack
+- [ ] With Great Power . . .
+- [ ] Wraith, Vicious Vigilante

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -104,7 +104,7 @@
 - [ ] Risky Research
 - [ ] Robotics Mastery
 - [ ] Rocket-Powered Goblin Glider
-- [ ] Romantic Rendezvous
+- [x] Romantic Rendezvous
 - [ ] SP//dr, Piloted by Peni
 - [ ] Sandman's Quicksand
 - [ ] Sandman, Shifting Scoundrel

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RomanticRendezvousScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RomanticRendezvousScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CardsDiscardedEvent
+import com.wingedsheep.engine.core.CardsDrawnEvent
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Romantic Rendezvous.
+ *
+ * Card reference:
+ * - Romantic Rendezvous ({1}{R}): Sorcery
+ *   "Discard a card, then draw two cards."
+ */
+class RomanticRendezvousScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Romantic Rendezvous — discard a card, draw two") {
+
+            test("discards one card then draws two after resolution") {
+                // Starting hand: [Romantic Rendezvous, Grizzly Bears, Glory Seeker] = 3 cards
+                // Expected hand after: 3 - 1 (cast RR) - 1 (discard GB) + 2 (draw) = 3 cards
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Romantic Rendezvous")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Island")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val initialOpponentHandSize = game.handSize(2)
+                val initialOpponentLibrarySize = game.librarySize(2)
+                val initialOpponentLife = game.getLifeTotal(2)
+
+                // Accumulate events across every action so we can assert ordering below.
+                val emittedEvents = mutableListOf<GameEvent>()
+
+                val castResult = game.castSpell(1, "Romantic Rendezvous")
+                emittedEvents += castResult.events
+                withClue("Casting Romantic Rendezvous should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                // Spell resolves; engine presents a SelectCardsDecision for the discard
+                val resolveResults = game.resolveStack()
+                resolveResults.forEach { emittedEvents += it.events }
+
+                withClue("Engine should present a discard selection decision") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                // Player 1 discards Grizzly Bears
+                val bearInHand = game.findCardsInHand(1, "Grizzly Bears")
+                withClue("Grizzly Bears should still be in hand when discard decision is presented") {
+                    bearInHand.isNotEmpty() shouldBe true
+                }
+                val selectResult = game.selectCards(bearInHand)
+                emittedEvents += selectResult.events
+
+                // After discard, the engine automatically draws two cards
+                withClue("Romantic Rendezvous should be in the caster's graveyard after resolution") {
+                    game.isInGraveyard(1, "Romantic Rendezvous") shouldBe true
+                }
+                withClue("Grizzly Bears should be in the caster's graveyard (discarded)") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Hand size should be 3: started 3, cast RR (−1), discard GB (−1), draw two (+2)") {
+                    game.handSize(1) shouldBe 3
+                }
+                withClue("Opponent's hand should be unchanged") {
+                    game.handSize(2) shouldBe initialOpponentHandSize
+                }
+                withClue("Opponent's library should be unchanged") {
+                    game.librarySize(2) shouldBe initialOpponentLibrarySize
+                }
+                withClue("Opponent's life total should be unchanged") {
+                    game.getLifeTotal(2) shouldBe initialOpponentLife
+                }
+
+                // CR sequential resolution: 'A, then B' means A fully resolves before B.
+                // The discard's CardsDiscardedEvent MUST be emitted before CardsDrawnEvent
+                // so that 'whenever you discard' triggers, madness, and dredge see the
+                // correct intermediate state.
+                val discardIdx = emittedEvents.indexOfFirst {
+                    it is CardsDiscardedEvent && it.playerId == game.player1Id
+                }
+                val drawIdx = emittedEvents.indexOfFirst {
+                    it is CardsDrawnEvent && it.playerId == game.player1Id && it.count == 2
+                }
+                withClue("Caster should have emitted a CardsDiscardedEvent") {
+                    (discardIdx >= 0) shouldBe true
+                }
+                withClue("Caster should have emitted a CardsDrawnEvent for 2 cards") {
+                    (drawIdx >= 0) shouldBe true
+                }
+                withClue("Discard must emit before draw so 'whenever you discard' triggers see correct state") {
+                    (discardIdx < drawIdx) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -311,6 +311,13 @@ object Effects {
     fun ReadTheRunes(): Effect = ReadTheRunesEffect
 
     /**
+     * Target player discards N cards (controller chooses, mandatory).
+     * Delegates to the EffectPatterns pipeline: Gather → Select → Move (Discard).
+     */
+    fun Discard(count: Int = 1, target: EffectTarget = EffectTarget.Controller): Effect =
+        EffectPatterns.discardCards(count, target)
+
+    /**
      * Each opponent discards N cards.
      * Delegates to the EffectPatterns pipeline: ForEachPlayer(EachOpponent) → Gather → Select → Move.
      */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RomanticRendezvous.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RomanticRendezvous.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Romantic Rendezvous
+ * {1}{R}
+ * Sorcery
+ * Discard a card, then draw two cards.
+ */
+val RomanticRendezvous = card("Romantic Rendezvous") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Discard a card, then draw two cards."
+
+    spell {
+        effect = Effects.Discard() then Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7e1c2ef-6e83-4b87-84c6-7dbf5dec8e50.jpg?1757377869"
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Romantic Rendezvous from Marvel's Spider-Man (SPM).
- Minor `Effects.kt` facade additions to support the card.
- Includes scenario test `RomanticRendezvousScenarioTest`.

Depends on #112 (SPM checklist).

## Test plan
- [x] New `RomanticRendezvousScenarioTest` covers the card.
- [ ] Reviewer: run `just test-class RomanticRendezvousScenarioTest`.