### PR TITLE
Add Angry Rabble (SPM)

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -8,7 +8,7 @@
 - [ ] Agent Venom
 - [ ] Alien Symbiosis
 - [ ] Amazing Acrobatics
-- [ ] Angry Rabble
+- [x] Angry Rabble
 - [ ] Anti-Venom, Horrifying Healer
 - [ ] Arachne, Psionic Weaver
 - [ ] Araña, Heart of the Spider

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AngryRabbleScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AngryRabbleScenarioTest.kt
@@ -1,0 +1,194 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Angry Rabble.
+ *
+ * Card reference:
+ * - Angry Rabble ({1}{R}): Creature — Human Citizen, 2/2
+ *   "Trample"
+ *   "Whenever a player casts a spell with mana value 4 or greater, Angry Rabble deals 1 damage to each opponent."
+ *   "{5}{R}: Put two +1/+1 counters on Angry Rabble. Activate only as a sorcery."
+ */
+class AngryRabbleScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Angry Rabble activated ability — {5}{R} sorcery speed") {
+
+            test("puts two +1/+1 counters when activated at sorcery speed in main phase") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Angry Rabble")
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val permanentId = game.findPermanent("Angry Rabble")!!
+                val ability = cardRegistry.getCard("Angry Rabble")!!.script.activatedAbilities.first()
+
+                val activateResult = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = permanentId,
+                        abilityId = ability.id
+                    )
+                )
+                withClue("Activating {5}{R} ability should succeed: ${activateResult.error}") {
+                    activateResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val counters = game.state.getEntity(permanentId)?.get<CountersComponent>()
+                withClue("Angry Rabble should have 2 +1/+1 counters (making it 4/4)") {
+                    counters!!.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+            }
+
+            test("activation is not a legal action outside the active player's main phase") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Angry Rabble")
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                    .build()
+
+                val permanentId = game.findPermanent("Angry Rabble")!!
+                val ability = cardRegistry.getCard("Angry Rabble")!!.script.activatedAbilities.first()
+
+                val activateResult = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = permanentId,
+                        abilityId = ability.id
+                    )
+                )
+                withClue("Activating sorcery-speed ability during upkeep should be rejected") {
+                    activateResult.error shouldNotBe null
+                }
+            }
+        }
+
+        context("Angry Rabble trigger — cast-spell with mana value 4+ (2-player coverage; trigger fires for any player)") {
+
+            test("deals 1 damage to the opponent when the controller casts a spell with mana value 4 or greater") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Angry Rabble")
+                    .withCardInHand(1, "Fire Elemental")      // {3}{R}{R}, MV 5
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Fire Elemental")
+                withClue("Casting Fire Elemental should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Opponent should be at 19 life after Angry Rabble's trigger") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+            }
+
+            test("triggers when the opponent casts a spell with mana value 4 or greater — dealing 1 damage to the opponent") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Angry Rabble")
+                    .withCardInHand(2, "Fire Elemental")      // {3}{R}{R}, MV 5 — cast by the opponent
+                    .withLandsOnBattlefield(2, "Mountain", 5)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(2, "Fire Elemental")
+                withClue("Opponent casting Fire Elemental should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Trigger uses Player.Each, so the opponent casting still fires it — opponent should take 1 damage") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("Angry Rabble's controller is not an opponent of itself and should remain at 20 life") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+
+            test("does not trigger when a spell with mana value 3 or less is cast") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Angry Rabble")
+                    .withCardInHand(1, "Glory Seeker")         // {1}{W}, MV 2
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Glory Seeker")
+                withClue("Casting Glory Seeker should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Opponent should remain at 20 life (trigger did not fire for MV <= 3)") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+        }
+
+        context("Angry Rabble — casting") {
+
+            test("enters the battlefield as a 2/2 Trample Human Citizen when cast for {1}{R}") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Angry Rabble")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Angry Rabble")
+                withClue("Casting Angry Rabble for {1}{R} should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Angry Rabble should be on the battlefield") {
+                    game.isOnBattlefield("Angry Rabble") shouldBe true
+                }
+                withClue("Angry Rabble should no longer be in the caster's hand") {
+                    game.isInHand(1, "Angry Rabble") shouldBe false
+                }
+
+                val permanentId = game.findPermanent("Angry Rabble")!!
+                val card = game.state.getEntity(permanentId)?.get<CardComponent>()!!
+
+                withClue("Angry Rabble type line should be 'Creature — Human Citizen'") {
+                    card.typeLine.toString() shouldBe "Creature — Human Citizen"
+                }
+                withClue("Angry Rabble should have Trample") {
+                    card.baseKeywords shouldContain Keyword.TRAMPLE
+                }
+                withClue("Angry Rabble should be a 2/2") {
+                    card.baseStats?.basePower shouldBe 2
+                    card.baseStats?.baseToughness shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/AngryRabble.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/AngryRabble.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.SpellCastEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Angry Rabble
+ * {1}{R}
+ * Creature — Human Citizen, 2/2
+ * Trample
+ * Whenever a player casts a spell with mana value 4 or greater, Angry Rabble deals 1 damage to each opponent.
+ * {5}{R}: Put two +1/+1 counters on Angry Rabble. Activate only as a sorcery.
+ */
+val AngryRabble = card("Angry Rabble") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Citizen"
+    power = 2
+    toughness = 2
+    oracleText = "Trample\nWhenever a player casts a spell with mana value 4 or greater, Angry Rabble deals 1 damage to each opponent.\n{5}{R}: Put two +1/+1 counters on Angry Rabble. Activate only as a sorcery."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = SpellCastEvent(spellFilter = GameObjectFilter.Any.manaValueAtLeast(4), player = Player.Each),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{R}")
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "75"
+        artist = "Bartek Fedyczak"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/938730fa-496f-4871-80ec-3e9843ecb219.jpg?1757377232"
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Angry Rabble from Marvel's Spider-Man (SPM): 2/2 Human Citizen for {1}{R} with Trample, a "whenever any player casts a spell with mana value 4+" damage trigger, and a {5}{R} sorcery-speed +1/+1 counter ability.
- Includes scenario test `AngryRabbleScenarioTest` covering cast, both halves of the trigger (own + opponent casts; MV<4 no-trigger), and the activated ability (sorcery-speed gate, counter placement).

Depends on #112 (SPM checklist).

## Test plan
- [x] New `AngryRabbleScenarioTest` covers cast, trigger, and ability.
- [ ] Reviewer: run `just test-class AngryRabbleScenarioTest`.