### PR TITLE
Add Scorpion, Seething Striker

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ProwlerClawedThief.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ProwlerClawedThief.kt
@@ -24,5 +24,6 @@ val ProwlerClawedThief = card("Prowler, Clawed Thief") {
 
     metadata {
         rarity = Rarity.RARE
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd31953a-7259-44e3-a94f-013bda68006d.jpg?1757377763"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ProwlerClawedThief.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ProwlerClawedThief.kt
@@ -23,7 +23,10 @@ val ProwlerClawedThief = card("Prowler, Clawed Thief") {
     keywords(Keyword.MENACE)
 
     metadata {
-        rarity = Rarity.RARE
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "138"
+        artist = "Anthony Devine"
+        flavorText = "\"It's nothing personal, kid. It's just money.\""
         imageUri = "https://cards.scryfall.io/normal/front/b/d/bd31953a-7259-44e3-a94f-013bda68006d.jpg?1757377763"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RentIsDue.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RentIsDue.kt
@@ -59,9 +59,10 @@ val RentIsDue = card("Rent Is Due") {
     }
 
     metadata {
-        rarity = Rarity.UNCOMMON
-        collectorNumber = "20"
-        artist = "Kekai Kotaki"
+        rarity = Rarity.RARE
+        collectorNumber = "11"
+        artist = "Gal Or"
+        flavorText = "\"You're a month late again, Parker! Give me my money or you're out on the street!\""
         imageUri = "https://cards.scryfall.io/normal/front/b/3/b3f8d221-081f-49f5-a501-07e5eb21a840.jpg?1757376808"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RentIsDue.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RentIsDue.kt
@@ -62,6 +62,6 @@ val RentIsDue = card("Rent Is Due") {
         rarity = Rarity.UNCOMMON
         collectorNumber = "20"
         artist = "Kekai Kotaki"
-        imageUri = "https://cards.scryfall.io/normal/front/b/e/be1f9d67-6a34-4a20-ad59-e0fd0fa0eb70.jpg?1757376788"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3f8d221-081f-49f5-a501-07e5eb21a840.jpg?1757376808"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RhinoBarrelingBrute.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RhinoBarrelingBrute.kt
@@ -33,5 +33,6 @@ val RhinoBarrelingBrute = card("Rhino, Barreling Brute") {
 
     metadata {
         rarity = Rarity.RARE
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b8ac400-1e98-49fc-94be-00386d15f2ae.jpg?1757377784"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RhinoBarrelingBrute.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RhinoBarrelingBrute.kt
@@ -32,7 +32,10 @@ val RhinoBarrelingBrute = card("Rhino, Barreling Brute") {
     }
 
     metadata {
-        rarity = Rarity.RARE
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "140"
+        artist = "Filipe Pagliuso"
+        flavorText = "\"I'm Rhino. I knock things down. That's what I do. That's who I am.\"\n—Rhino, Aleksei Sytsevich"
         imageUri = "https://cards.scryfall.io/normal/front/4/b/4b8ac400-1e98-49fc-94be-00386d15f2ae.jpg?1757377784"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RiskyResearch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RiskyResearch.kt
@@ -23,9 +23,10 @@ val RiskyResearch = card("Risky Research") {
     }
 
     metadata {
-        rarity = Rarity.UNCOMMON
-        collectorNumber = "84"
-        artist = "David Rapoza"
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Rafater"
+        flavorText = "\"Though others fear radiation, I alone am able to make it my servant!\""
         imageUri = "https://cards.scryfall.io/normal/front/1/f/1f8aa705-6177-42e9-95cb-e7f880c186e3.jpg?1757377145"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RiskyResearch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RiskyResearch.kt
@@ -26,6 +26,6 @@ val RiskyResearch = card("Risky Research") {
         rarity = Rarity.UNCOMMON
         collectorNumber = "84"
         artist = "David Rapoza"
-        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c2bc8a4-cd50-4f3e-a09f-0a6a93736ae7.jpg?1757377863"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f8aa705-6177-42e9-95cb-e7f880c186e3.jpg?1757377145"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ScorpionSeethingStriker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ScorpionSeethingStriker.kt
@@ -38,6 +38,6 @@ val ScorpionSeethingStriker = card("Scorpion, Seething Striker") {
         rarity = Rarity.UNCOMMON
         collectorNumber = "64"
         artist = "Simon Dominic"
-        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c3d1b79-c203-4afa-989e-ccff47fc76f8.jpg?1757378029"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cf407e08-b27f-42ba-b824-75846a80e238.jpg?1757377158"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ScorpionSeethingStriker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ScorpionSeethingStriker.kt
@@ -38,6 +38,7 @@ val ScorpionSeethingStriker = card("Scorpion, Seething Striker") {
         rarity = Rarity.UNCOMMON
         collectorNumber = "64"
         artist = "Simon Dominic"
+        flavorText = "The scorpion is the natural predator of the spider, and so Mac Gargan hunts."
         imageUri = "https://cards.scryfall.io/normal/front/c/f/cf407e08-b27f-42ba-b824-75846a80e238.jpg?1757377158"
     }
 }


### PR DESCRIPTION
## Card

- **Name:** Scorpion, Seething Striker
- **Set:** Marvel's Spider-Man (spm)
- **Collector number:** 64
- **Scryfall:** https://scryfall.com/card/spm/64/scorpion-seething-striker?utm_source=api

## BDD scenarios

### S1: Cast Scorpion, Seething Striker — forces card-definition path (mana cost, type line, P/T, deathtouch)

**Given**
- Active player has Scorpion, Seething Striker in hand
- Active player controls four untapped lands producing {3}{B}
- It is the active player's main phase with an empty stack

**When** Active player casts Scorpion, Seething Striker paying {3}{B} and the spell resolves

**Then**
- Scorpion, Seething Striker is on the battlefield under the active player's control
- It is a 3/3 black Legendary Creature — Scorpion Human Villain
- It has deathtouch
- Its printed metadata (rarity uncommon, collector number 64, artist Simon Dominic, image URI, oracle text) matches the Scryfall source

### S2: End-step connive trigger — forces intervening-if death-this-turn gated triggered ability + connive path

**Given**
- Active player controls Scorpion, Seething Striker and another creature they control
- A creature died earlier this turn
- Active player has at least one card in their library and at least one nonland card in hand

**When** The active player's end step begins and the triggered ability resolves targeting the other creature they control

**Then**
- The targeted creature connives: its controller draws a card then discards a card
- If the discarded card was a nonland, the targeted creature gains a +1/+1 counter
- If the discarded card was a land, no counter is placed

### S3: No-death end step — forces intervening-if gating to suppress trigger when no creature died this turn

**Given**
- Active player controls Scorpion, Seething Striker and another creature they control
- No creature has died this turn

**When** The active player's end step begins

**Then**
- Scorpion, Seething Striker's triggered ability does not trigger
- No connive occurs and no card is drawn or discarded from the ability
- No +1/+1 counter is placed on any creature from the ability


---
Generated by `queue-next-card.sh` from plan `2.json`.

---
Reviewed and forwarded from nymann/argentum-engine#45 (original author: @nymann).

Review fixes applied on top of the original PR:
- `CreatureDiedThisTurn` intervening-if check was per-controller; ZoneTransitionService increments the dying creature's controller, so the condition wouldn't fire when only an opponent's creature died. Now sums across all players, with a regression test.
- Renamed `ConviveContinuation` -> `ConniveContinuation` (typo in a `@Serializable` class name).
- Routed the connive auto-discard and resumer through `ZoneTransitionService.discardCard` so the hand -> graveyard transition emits the canonical `CardsDiscardedEvent` + `ZoneChangeEvent` pair.
- Exposed `CreatureDiedThisTurn` through the `Conditions` DSL facade so card definitions don't import `scripting.conditions` directly.