### PR TITLE
Add Scorpion's Sting

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 4 / 188
+**Implemented:** 5 / 188
 ---
 
 - [x] Agent Venom
@@ -112,7 +112,7 @@
 - [ ] Scarlet Spider, Ben Reilly
 - [ ] Scarlet Spider, Kaine
 - [ ] School Daze
-- [ ] Scorpion's Sting
+- [x] Scorpion's Sting
 - [ ] Scorpion, Seething Striker
 - [ ] Scout the City
 - [ ] Secret Identity

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ScorpionsStingScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ScorpionsStingScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Scorpion's Sting.
+ *
+ * Card reference:
+ * - Scorpion's Sting ({1}{B}): Instant
+ *   "Target creature gets -3/-3 until end of turn."
+ */
+class ScorpionsStingScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Scorpion's Sting applies -3/-3 until end of turn") {
+
+            test("reduces a 4/4 creature to 1/1 and places the spell in graveyard on resolution") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Scorpion's Sting")
+                    .withCardOnBattlefield(2, "Barkhide Mauler")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Barkhide Mauler")!!
+                val castResult = game.castSpell(1, "Scorpion's Sting", target)
+                withClue("Casting Scorpion's Sting should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Scorpion's Sting should be in caster's graveyard after resolution") {
+                    game.isInGraveyard(1, "Scorpion's Sting") shouldBe true
+                }
+                withClue("Barkhide Mauler (4/4) should survive -3/-3") {
+                    game.isOnBattlefield("Barkhide Mauler") shouldBe true
+                }
+
+                val clientState = game.getClientState(1)
+                val maulerInfo = clientState.cards[target]
+                withClue("Barkhide Mauler should be 1/1 after -3/-3") {
+                    maulerInfo shouldNotBe null
+                    maulerInfo!!.power shouldBe 1
+                    maulerInfo.toughness shouldBe 1
+                }
+            }
+
+            test("kills a 3/3 creature via state-based actions when toughness reaches 0") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Scorpion's Sting")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Hill Giant")!!
+                val castResult = game.castSpell(1, "Scorpion's Sting", target)
+                withClue("Casting Scorpion's Sting should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Hill Giant should not be on the battlefield after -3/-3 reduces toughness to 0") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("Hill Giant should be in its owner's graveyard") {
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+            }
+
+            test("-3/-3 modification expires at end of turn, restoring creature to base stats") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Scorpion's Sting")
+                    .withCardOnBattlefield(2, "Barkhide Mauler")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Barkhide Mauler")!!
+                val castResult = game.castSpell(1, "Scorpion's Sting", target)
+                withClue("Casting Scorpion's Sting should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val clientStateAfterCast = game.getClientState(1)
+                withClue("Barkhide Mauler should be 1/1 immediately after -3/-3 resolves") {
+                    clientStateAfterCast.cards[target]?.power shouldBe 1
+                    clientStateAfterCast.cards[target]?.toughness shouldBe 1
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.CLEANUP)
+
+                val clientStateAfterCleanup = game.getClientState(1)
+                withClue("Barkhide Mauler should return to 4/4 after the cleanup step") {
+                    clientStateAfterCleanup.cards[target]?.power shouldBe 4
+                    clientStateAfterCleanup.cards[target]?.toughness shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ScorpionsSting.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ScorpionsSting.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scorpion's Sting
+ * {1}{B}
+ * Instant
+ * "Target creature gets -3/-3 until end of turn."
+ */
+val ScorpionsSting = card("Scorpion's Sting") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -3/-3 until end of turn."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-3, -3, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Lee Woo-chul"
+        flavorText = "\"I'm going to kill you, bug.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0fb03437-32cf-4c97-bf91-ea8b2ad3f964.jpg?1757377164"
+    }
+}


### PR DESCRIPTION
## Card

- **Name:** Scorpion's Sting
- **Set:** Marvel's Spider-Man (spm)
- **Collector number:** 65
- **Scryfall:** https://scryfall.com/card/spm/65/scorpions-sting?utm_source=api

## BDD scenarios

### S1: Cast Scorpion's Sting and apply -3/-3 — forces card-definition + targeted -N/-N until-end-of-turn effect path

**Given**
- Active player has Scorpion's Sting in hand
- Active player has at least {1}{B} of available mana
- Opponent controls a 4/4 creature on the battlefield
- It is the active player's main phase with priority

**When** Active player casts Scorpion's Sting targeting the opponent's 4/4 creature and the spell resolves

**Then**
- Scorpion's Sting is placed on the stack while being cast, then moved to its owner's graveyard on resolution
- The targeted creature's power and toughness are reduced by 3 until end of turn, becoming 1/1
- If the targeted creature is a 3/3 or smaller, its toughness becomes 0 or less and state-based actions move it to its owner's graveyard
- At the end of the turn, the -3/-3 modification expires (verified by the until-end-of-turn cleanup if the creature survives)


---
Generated by `queue-next-card.sh` from plan `1.json`.

---
Reviewed and forwarded from nymann/argentum-engine#44 (original author: @nymann).