### PR TITLE
Add Rent Is Due + Risky Research (SPM)

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 4 / 188
+**Implemented:** 6 / 188
 ---
 
 - [x] Agent Venom
@@ -98,10 +98,10 @@
 - [ ] Pumpkin Bombardment
 - [ ] Radioactive Spider
 - [ ] Raging Goblinoids
-- [ ] Rent Is Due
+- [x] Rent Is Due
 - [ ] Rhino's Rampage
 - [ ] Rhino, Barreling Brute
-- [ ] Risky Research
+- [x] Risky Research
 - [ ] Robotics Mastery
 - [ ] Rocket-Powered Goblin Glider
 - [x] Romantic Rendezvous

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RentIsDueScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RentIsDueScenarioTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rent Is Due.
+ *
+ * Card reference:
+ * - Rent Is Due ({W}): Enchantment
+ *   At the beginning of your upkeep, tap two untapped creatures and/or Treasures you control.
+ *   If you do, draw a card. Otherwise, sacrifice Rent Is Due.
+ */
+class RentIsDueScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rent Is Due — cast and enter the battlefield") {
+
+            test("resolves and enters battlefield as an Enchantment when cast for {W}") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Rent Is Due")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Rent Is Due")
+                withClue("Casting Rent Is Due for {W} should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Rent Is Due should be on the battlefield") {
+                    game.isOnBattlefield("Rent Is Due") shouldBe true
+                }
+                withClue("Rent Is Due should no longer be in the caster's hand") {
+                    game.isInHand(1, "Rent Is Due") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RiskyResearchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RiskyResearchScenarioTest.kt
@@ -1,0 +1,184 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Risky Research.
+ *
+ * Card reference:
+ * - Risky Research ({2}{B}): Sorcery
+ *   "Surveil 2, then draw two cards, then you lose 2 life."
+ */
+class RiskyResearchScenarioTest : ScenarioTestBase() {
+
+    // Library (top → bottom): Forest (pos 1), Island (pos 2), Mountain (pos 3), Plains (pos 4)
+    private fun ScenarioBuilder.withStandardLibrary(): ScenarioBuilder =
+        withCardInLibrary(1, "Forest")
+            .withCardInLibrary(1, "Island")
+            .withCardInLibrary(1, "Mountain")
+            .withCardInLibrary(1, "Plains")
+
+    init {
+        context("Risky Research — Surveil 2, draw 2, lose 2 life") {
+
+            test("mills both surveiled cards then draws the next two and loses 2 life") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Risky Research")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withStandardLibrary()
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Risky Research")
+                withClue("Casting Risky Research should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Surveil 2: choose which of the top 2 library cards go to the graveyard
+                withClue("Engine should present a Surveil selection decision") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val surveilDecision = game.getPendingDecision()
+                surveilDecision.shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("Surveil 2 should offer exactly 2 cards") {
+                    surveilDecision.options.size shouldBe 2
+                }
+
+                // Put both surveiled cards (Forest and Island) into the graveyard
+                game.selectCards(surveilDecision.options)
+
+                // When the entire surveiled collection is milled there are no cards left to
+                // put back, so no ReorderLibraryDecision is presented.
+                withClue("No pending decision after milling all surveiled cards") {
+                    game.hasPendingDecision() shouldBe false
+                }
+
+                withClue("Risky Research should be in the caster's graveyard") {
+                    game.isInGraveyard(1, "Risky Research") shouldBe true
+                }
+                withClue("Forest (surveiled — milled) should be in the graveyard") {
+                    game.isInGraveyard(1, "Forest") shouldBe true
+                }
+                withClue("Island (surveiled — milled) should be in the graveyard") {
+                    game.isInGraveyard(1, "Island") shouldBe true
+                }
+                withClue("Mountain (library position 3) should be drawn into hand") {
+                    game.isInHand(1, "Mountain") shouldBe true
+                }
+                withClue("Plains (library position 4) should be drawn into hand") {
+                    game.isInHand(1, "Plains") shouldBe true
+                }
+                withClue("Hand size should be 2 after drawing two cards") {
+                    game.handSize(1) shouldBe 2
+                }
+                withClue("Caster should lose exactly 2 life") {
+                    game.getLifeTotal(1) shouldBe 18
+                }
+                withClue("Opponent's life total should be unchanged") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+
+            test("keeping both surveiled cards on top means they are the two drawn cards") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Risky Research")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withStandardLibrary()
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Risky Research")
+                game.resolveStack()
+
+                // Surveil 2: keep both on top — submit empty selection
+                val surveilDecision = game.getPendingDecision() as SelectCardsDecision
+                game.selectCards(emptyList())
+
+                // Engine must ask the player to arrange the two kept cards
+                withClue("Engine should present a reorder decision for the two kept cards") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val reorderDecision = game.getPendingDecision()
+                reorderDecision.shouldBeInstanceOf<ReorderLibraryDecision>()
+                // Keep original order: Forest first (to be drawn first), Island second
+                game.submitDecision(OrderedResponse(reorderDecision.id, reorderDecision.cards))
+
+                withClue("Forest (kept on top, drawn first) should be in hand") {
+                    game.isInHand(1, "Forest") shouldBe true
+                }
+                withClue("Island (kept second, drawn second) should be in hand") {
+                    game.isInHand(1, "Island") shouldBe true
+                }
+                withClue("Mountain (library position 3) should remain in library") {
+                    game.isInHand(1, "Mountain") shouldBe false
+                }
+                withClue("Graveyard should contain only Risky Research from this resolution") {
+                    game.isInGraveyard(1, "Risky Research") shouldBe true
+                    game.isInGraveyard(1, "Forest") shouldBe false
+                    game.isInGraveyard(1, "Island") shouldBe false
+                }
+                withClue("Caster should lose exactly 2 life") {
+                    game.getLifeTotal(1) shouldBe 18
+                }
+            }
+
+            test("milling one surveiled card and keeping one draws the kept card then the next library card") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Risky Research")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withStandardLibrary()
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Risky Research")
+                game.resolveStack()
+
+                // Surveil 2: mill Forest (options[0] = top card), keep Island (options[1])
+                val surveilDecision = game.getPendingDecision() as SelectCardsDecision
+                val forestId = surveilDecision.options[0]
+                game.selectCards(listOf(forestId))
+
+                // One card remains to be placed back on top — engine asks for ordering
+                withClue("Engine should present a reorder decision for the one kept card") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val reorderDecision = game.getPendingDecision() as ReorderLibraryDecision
+                game.submitDecision(OrderedResponse(reorderDecision.id, reorderDecision.cards))
+
+                withClue("Forest (milled) should be in the graveyard") {
+                    game.isInGraveyard(1, "Forest") shouldBe true
+                }
+                withClue("Island (kept on top, drawn first) should be in hand") {
+                    game.isInHand(1, "Island") shouldBe true
+                }
+                withClue("Mountain (library position 3, drawn second) should be in hand") {
+                    game.isInHand(1, "Mountain") shouldBe true
+                }
+                withClue("Plains (library position 4) should remain in library") {
+                    game.isInHand(1, "Plains") shouldBe false
+                }
+                withClue("Caster should lose exactly 2 life") {
+                    game.getLifeTotal(1) shouldBe 18
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RentIsDue.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RentIsDue.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.TapUntapCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Rent Is Due
+ * {W}
+ * Enchantment
+ *
+ * At the beginning of your upkeep, tap two untapped creatures and/or Treasures
+ * you control. If you do, draw a card. Otherwise, sacrifice Rent Is Due.
+ */
+val RentIsDue = card("Rent Is Due") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, tap two untapped creatures and/or Treasures you control. If you do, draw a card. Otherwise, sacrifice Rent Is Due."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        val tapCost = CompositeEffect(listOf(
+            GatherCardsEffect(
+                source = CardSource.ControlledPermanents(
+                    player = Player.You,
+                    filter = (GameObjectFilter.Creature or GameObjectFilter.Artifact.withSubtype("Treasure")).untapped()
+                ),
+                storeAs = "rentTargets"
+            ),
+            SelectFromCollectionEffect(
+                from = "rentTargets",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(2)),
+                storeSelected = "toTap",
+                prompt = "Tap two untapped creatures and/or Treasures you control",
+                useTargetingUI = true
+            ),
+            TapUntapCollectionEffect("toTap", tap = true)
+        ))
+        effect = OptionalCostEffect(
+            cost = tapCost,
+            ifPaid = Effects.DrawCards(1),
+            ifNotPaid = SacrificeSelfEffect,
+            descriptionOverride = "Tap two untapped creatures and/or Treasures you control. If you do, draw a card. Otherwise, sacrifice Rent Is Due."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "20"
+        artist = "Kekai Kotaki"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be1f9d67-6a34-4a20-ad59-e0fd0fa0eb70.jpg?1757376788"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RiskyResearch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/RiskyResearch.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Risky Research
+ * {2}{B}
+ * Sorcery
+ * Surveil 2, then draw two cards, then you lose 2 life.
+ */
+val RiskyResearch = card("Risky Research") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Surveil 2, then draw two cards, then you lose 2 life."
+
+    spell {
+        effect = EffectPatterns.surveil(2) then Effects.DrawCards(2) then Effects.LoseLife(2, EffectTarget.Controller)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "David Rapoza"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c2bc8a4-cd50-4f3e-a09f-0a6a93736ae7.jpg?1757377863"
+    }
+}


### PR DESCRIPTION
## Summary

Forwarded from `nymann/argentum-engine#43` (original author: @nymann). Adds two new Marvel's Spider-Man (SPM) cards:

- **Rent Is Due** ({W} Enchantment) — upkeep trigger: tap two creatures/Treasures to draw a card, otherwise sacrifice itself.
- **Risky Research** ({2}{B} Sorcery) — Surveil 2, then draw two cards, then lose 2 life.

## Notes on review

The source PR was titled "Add Sandman, Shifting Scoundrel" but Sandman was never actually implemented — only a backlog `[x]` mark and an orphan `Effect` type were added. During the review I:

1. **Dropped the orphan `ReturnSelfAndTargetLandCardFromGraveyardToBattlefieldTappedEffect`** and its handler/test. No card in this PR (or upstream) referenced it; per `docs/architecture-principles.md` §1.5 we prefer atomic pipeline effects composed via `EffectPatterns` over monolithic card-specific Effect types. When Sandman is properly implemented, the right shape is two composed atomic moves (self + targeted land, both tapped) rather than a bespoke type.
2. **Corrected the backlog file**: Sandman is no longer marked as implemented; Rent Is Due and Risky Research are. The count is now 6 / 188.
3. **Reframed the PR scope** to match what's actually delivered.

## Known follow-ups (not blockers for this PR)

- `RentIsDue.kt` constructs `CompositeEffect(listOf(...))`, `GatherCardsEffect(...)`, `SelectFromCollectionEffect(...)`, `TapUntapCollectionEffect(...)` and `OptionalCostEffect(...)` directly. Should ideally compose through an `EffectPatterns` recipe (e.g. `EffectPatterns.optionalTapCost(...)`); deferring until a second card with the same "tap N permanents as cost" shape exists, then extract.
- `RentIsDueScenarioTest` covers cast + ETB only. Deeper coverage of the upkeep trigger's two branches (tap-and-draw vs sacrifice) would be valuable; the underlying primitives are already covered by other cards using `OptionalCostEffect`.

## Test plan

- [x] `./gradlew :game-server:test --tests "RentIsDueScenarioTest" --tests "RiskyResearchScenarioTest"` — 4 tests pass.
- [x] `./gradlew :game-server:test :rules-engine:test :mtg-sdk:test` — full suite passes, no regressions.