### PR TITLE
test(rules-engine): cover Surveil 2 graveyard-partition + reorder flow

### DIFF
--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/SurveilNTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/SurveilNTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.handlers.effects
+
+import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.*
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.UUID
+
+/**
+ * Surveil N: look at the top N cards; send any chosen subset to the graveyard,
+ * then put the rest back on top in controller-chosen order.
+ *
+ * Covered scenario: Surveil 2 — player puts the top card (A) into the graveyard
+ * and keeps the second card (B) on top; the cards below (C, D) must remain in
+ * their original relative positions immediately beneath B.
+ */
+class SurveilNTest : FunSpec({
+
+    val surveilAbilityId = AbilityId(UUID.randomUUID().toString())
+
+    val SurveilArchmage = CardDefinition(
+        name = "Surveil Archmage",
+        manaCost = ManaCost.parse("{3}{U}"),
+        typeLine = TypeLine.creature(setOf(Subtype("Human"), Subtype("Wizard"))),
+        oracleText = "{2}{U}: Surveil 2.",
+        creatureStats = CreatureStats(2, 2),
+        script = CardScript.permanent(
+            ActivatedAbility(
+                id = surveilAbilityId,
+                cost = AbilityCost.Mana(ManaCost.parse("{2}{U}")),
+                effect = EffectPatterns.surveil(2)
+            )
+        )
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SurveilArchmage))
+        return driver
+    }
+
+    test("surveil 2 - chosen card goes to graveyard, kept card is new library top, cards below are undisturbed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 30, "Mountain" to 30),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Build library top [A, B, C, D] from top by inserting bottom-first
+        val cardD = driver.putCardOnTopOfLibrary(activePlayer, "Mountain")
+        val cardC = driver.putCardOnTopOfLibrary(activePlayer, "Island")
+        val cardB = driver.putCardOnTopOfLibrary(activePlayer, "Mountain")
+        val cardA = driver.putCardOnTopOfLibrary(activePlayer, "Grizzly Bears")
+
+        // Verify initial library order before the effect
+        val libraryZone = ZoneKey(activePlayer, Zone.LIBRARY)
+        val libraryBefore = driver.state.getZone(libraryZone)
+        libraryBefore[0] shouldBe cardA
+        libraryBefore[1] shouldBe cardB
+        libraryBefore[2] shouldBe cardC
+        libraryBefore[3] shouldBe cardD
+
+        val surveilSource = driver.putCreatureOnBattlefield(activePlayer, "Surveil Archmage")
+        driver.removeSummoningSickness(surveilSource)
+        driver.giveMana(activePlayer, Color.BLUE, 3)
+
+        // Activate Surveil 2
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = surveilSource,
+                abilityId = surveilAbilityId
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        // Engine pauses: player chooses which of the top 2 cards go to the graveyard
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+
+        val selectDecision = driver.pendingDecision as SelectCardsDecision
+        selectDecision.options.size shouldBe 2
+
+        // Player sends card A to the graveyard; card B stays on top
+        driver.submitDecision(
+            activePlayer,
+            CardsSelectedResponse(
+                decisionId = selectDecision.id,
+                selectedCards = listOf(cardA)
+            )
+        )
+
+        // Engine pauses: controller orders the remaining card(s) back on top
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<ReorderLibraryDecision>()
+        val reorderDecision = driver.pendingDecision as ReorderLibraryDecision
+        reorderDecision.cards.size shouldBe 1
+        reorderDecision.cards[0] shouldBe cardB
+        driver.submitOrderedResponse(activePlayer, reorderDecision.cards)
+
+        driver.isPaused shouldBe false
+
+        // Card A is now in the graveyard
+        val graveyardZone = ZoneKey(activePlayer, Zone.GRAVEYARD)
+        val graveyard = driver.state.getZone(graveyardZone)
+        graveyard.contains(cardA) shouldBe true
+
+        // Card A is no longer in the library
+        val libraryAfter = driver.state.getZone(libraryZone)
+        libraryAfter.contains(cardA) shouldBe false
+
+        // Card B is the new top of library; C and D are immediately beneath it, unchanged
+        libraryAfter[0] shouldBe cardB
+        libraryAfter[1] shouldBe cardC
+        libraryAfter[2] shouldBe cardD
+    }
+})


### PR DESCRIPTION
## Summary

Adds `SurveilNTest` to the rules-engine test suite, exercising the Surveil 2 flow end-to-end via the existing `EffectPatterns.surveil(2)` primitive. The test defines an inline `Surveil Archmage` card with an activated ability `{2}{U}: Surveil 2.`, then drives the full continuation chain:

- `SelectCardsDecision` — controller chooses which of the top N cards go to the graveyard
- `ReorderLibraryDecision` — controller orders the kept cards back on top

It verifies that:

1. The card sent to the graveyard actually lands there.
2. The kept card becomes the new library top.
3. Cards beneath the surveil window retain their original relative order.

The test passes against existing code — no engine changes were required. It's a regression test pinning the current behaviour of the `Gather → Select → Move` pipeline that backs Surveil.

## Test plan

- [x] `./gradlew :rules-engine:test --tests SurveilNTest` → green
- [x] `./gradlew :rules-engine:test` → full module suite green

---

Reviewed and forwarded from nymann/argentum-engine#41 (original author: @nymann).

**Note on scope divergence from the source PR:** the original PR was titled *"Add Risky Research"* and included two additional changes that did not pass review:

1. A `RentIsDueScenarioTest` that failed at runtime with `Card not found in registry: Rent Is Due` (no `Rent Is Due` card definition exists). Dropped.
2. A backlog edit marking *Risky Research* as implemented and bumping the SPM counter, despite no `RiskyResearch.kt` definition being added in this branch. Reverted.

Only the `SurveilNTest` portion of the original PR is forwarded here, with a corrected title.