### PR TITLE
Add Kapow! and Impostor Syndrome

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ImpostorSyndromeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ImpostorSyndromeScenarioTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Impostor Syndrome.
+ *
+ * Card reference:
+ * - Impostor Syndrome ({4}{U}{U}): Enchantment
+ *   [Oracle text per Scryfall]
+ */
+class ImpostorSyndromeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Impostor Syndrome cast") {
+
+            test("lands on the battlefield as an enchantment when cast paying {4}{U}{U}") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Impostor Syndrome")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Impostor Syndrome")
+                withClue("Casting Impostor Syndrome should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Impostor Syndrome should be on the battlefield") {
+                    game.isOnBattlefield("Impostor Syndrome") shouldBe true
+                }
+                withClue("Impostor Syndrome should not remain in the caster's hand") {
+                    game.isInHand(1, "Impostor Syndrome") shouldBe false
+                }
+                withClue("Caster's mana pool should be empty after paying {4}{U}{U}") {
+                    val manaPool = game.state.getEntity(game.player1Id)
+                        ?.get<ManaPoolComponent>()
+                    manaPool?.isEmpty shouldBe true
+                }
+                withClue("Impostor Syndrome should be an Enchantment on the battlefield") {
+                    val permanent = game.findPermanent("Impostor Syndrome")
+                    val cardComponent = game.state.getEntity(permanent!!)?.get<CardComponent>()
+                    cardComponent?.typeLine?.isEnchantment shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KapowScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KapowScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kapow!
+ *
+ * Card reference:
+ * - Kapow! ({2}{G}): Instant/Sorcery
+ *   "Put a +1/+1 counter on target creature you control, then it fights target creature
+ *    an opponent controls."
+ */
+class KapowScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Kapow! counter then fight") {
+
+            test("puts +1/+1 counter on ally then ally and foe fight and both are destroyed") {
+                // GIVEN active player has Kapow! in hand, controls Grizzly Bears (2/2),
+                // opponent controls Hill Giant (3/3), {2}{G} mana available
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Kapow!")
+                    .withCardOnBattlefield(1, "Grizzly Bears")  // ally: 2/2 → 3/3 after counter
+                    .withCardOnBattlefield(2, "Hill Giant")     // foe: 3/3
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val allyId = game.findPermanent("Grizzly Bears")!!
+                val foeId = game.findPermanent("Hill Giant")!!
+
+                // WHEN cast Kapow! targeting ally (Grizzly Bears) and foe (Hill Giant)
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).find { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Kapow!"
+                }!!
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId = playerId,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(allyId),
+                            ChosenTarget.Permanent(foeId)
+                        )
+                    )
+                )
+                withClue("Casting Kapow! should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                // Verify the counter is applied before the fight resolves
+                val allyBeforeFight = game.state.getEntity(allyId)
+                val counters = allyBeforeFight?.get<CountersComponent>()
+                withClue("Grizzly Bears should have a +1/+1 counter after Kapow! resolves counter step") {
+                    counters shouldNotBe null
+                    counters!!.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+
+                val stateProjector = StateProjector()
+                val projected = stateProjector.project(game.state)
+                withClue("Grizzly Bears power should be 3 after +1/+1 counter") {
+                    projected.getPower(allyId) shouldBe 3
+                }
+                withClue("Grizzly Bears toughness should be 3 after +1/+1 counter") {
+                    projected.getToughness(allyId) shouldBe 3
+                }
+
+                // Resolve the fight and state-based actions
+                game.resolveStack()
+
+                // THEN both creatures are destroyed (each dealt 3 damage to the other)
+                withClue("Grizzly Bears (3/3 after counter) should be destroyed by Hill Giant dealing 3 damage") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Hill Giant should be destroyed by Grizzly Bears dealing 3 damage (counter applied)") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+                withClue("Kapow! should be in its owner's graveyard") {
+                    game.isInGraveyard(1, "Kapow!") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KapowScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KapowScenarioTest.kt
@@ -1,9 +1,11 @@
 package com.wingedsheep.gameserver.scenarios
 
 import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
@@ -71,6 +73,76 @@ class KapowScenarioTest : ScenarioTestBase() {
                 withClue("Hill Giant should be destroyed by Grizzly Bears dealing 3 damage (counter applied)") {
                     game.isOnBattlefield("Hill Giant") shouldBe false
                     game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+                withClue("Kapow! should be in its owner's graveyard") {
+                    game.isInGraveyard(1, "Kapow!") shouldBe true
+                }
+            }
+        }
+
+        context("Kapow! target legality on resolution") {
+
+            test("is countered when fight target gains hexproof in response leaving all targets illegal") {
+                // GIVEN active player has Kapow! in hand, controls Grizzly Bears (2/2);
+                // opponent controls Hill Giant (3/3) and has Blossoming Defense in hand with {G}
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Kapow!")
+                    .withCardOnBattlefield(1, "Grizzly Bears")  // ally: 2/2
+                    .withCardOnBattlefield(2, "Hill Giant")     // foe: 3/3
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInHand(2, "Blossoming Defense")
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val allyId = game.findPermanent("Grizzly Bears")!!
+                val foeId = game.findPermanent("Hill Giant")!!
+
+                // WHEN active player casts Kapow! targeting Grizzly Bears and Hill Giant
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).find { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Kapow!"
+                }!!
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId = playerId,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(allyId),
+                            ChosenTarget.Permanent(foeId)
+                        )
+                    )
+                )
+                withClue("Casting Kapow! should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                // Opponent responds: passes priority back to them, then casts Blossoming Defense
+                // giving Hill Giant hexproof — making it an illegal target for Kapow! on resolution
+                game.passPriority()
+                val defenseResult = game.castSpell(2, "Blossoming Defense", foeId)
+                withClue("Blossoming Defense should be castable in response: ${defenseResult.error}") {
+                    defenseResult.error shouldBe null
+                }
+
+                // Stack resolves LIFO: Blossoming Defense first (Hill Giant gets hexproof),
+                // then Kapow! tries to resolve but Hill Giant is now an illegal target
+                game.resolveStack()
+
+                // THEN Kapow! is countered — no counter placed, no fight, both creatures survive
+                withClue("Grizzly Bears should still be on the battlefield (no fight occurred)") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                val allyCounters = game.state.getEntity(allyId)?.get<CountersComponent>()
+                val counterCount = allyCounters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                withClue("Grizzly Bears should have no +1/+1 counter (Kapow! was countered on resolution)") {
+                    counterCount shouldBe 0
+                }
+                withClue("Hill Giant should still be on the battlefield (no fight occurred)") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
                 }
                 withClue("Kapow! should be in its owner's graveyard") {
                     game.isInGraveyard(1, "Kapow!") shouldBe true

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KapowScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KapowScenarioTest.kt
@@ -58,24 +58,9 @@ class KapowScenarioTest : ScenarioTestBase() {
                     castResult.error shouldBe null
                 }
 
-                // Verify the counter is applied before the fight resolves
-                val allyBeforeFight = game.state.getEntity(allyId)
-                val counters = allyBeforeFight?.get<CountersComponent>()
-                withClue("Grizzly Bears should have a +1/+1 counter after Kapow! resolves counter step") {
-                    counters shouldNotBe null
-                    counters!!.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
-                }
-
-                val stateProjector = StateProjector()
-                val projected = stateProjector.project(game.state)
-                withClue("Grizzly Bears power should be 3 after +1/+1 counter") {
-                    projected.getPower(allyId) shouldBe 3
-                }
-                withClue("Grizzly Bears toughness should be 3 after +1/+1 counter") {
-                    projected.getToughness(allyId) shouldBe 3
-                }
-
-                // Resolve the fight and state-based actions
+                // Resolve: counter applied then fight; SBAs destroy both creatures
+                // Without the counter Grizzly Bears (2/2) would deal only 2 damage to Hill Giant
+                // (3/3) — not lethal. Hill Giant dying proves the counter boosted Grizzly Bears to 3/3.
                 game.resolveStack()
 
                 // THEN both creatures are destroyed (each dealt 3 damage to the other)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1057,7 +1057,8 @@ object Effects {
         attacking: Boolean = false,
         triggeredAbilities: List<TriggeredAbility> = emptyList(),
         addedKeywords: Set<com.wingedsheep.sdk.core.Keyword> = emptySet(),
-        addedSupertypes: Set<com.wingedsheep.sdk.core.Supertype> = emptySet()
+        addedSupertypes: Set<com.wingedsheep.sdk.core.Supertype> = emptySet(),
+        removeLegendary: Boolean = false
     ): Effect = CreateTokenCopyOfTargetEffect(
         target = target,
         count = DynamicAmount.Fixed(count),
@@ -1067,7 +1068,8 @@ object Effects {
         attacking = attacking,
         triggeredAbilities = triggeredAbilities,
         addedKeywords = addedKeywords,
-        addedSupertypes = addedSupertypes
+        addedSupertypes = addedSupertypes,
+        removeLegendary = removeLegendary
     )
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -405,6 +405,19 @@ object Triggers {
     )
 
     /**
+     * Whenever a nontoken creature you control deals combat damage to a player.
+     * Uses ANY binding — fires for each nontoken creature you control that connects.
+     */
+    val NontokenCreatureYouControlDealsCombatDamageToPlayer: TriggerSpec = TriggerSpec(
+        event = DealsDamageEvent(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.youControl().nontoken()
+        ),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
      * When this creature deals combat damage to a creature.
      */
     val DealsCombatDamageToCreature: TriggerSpec = TriggerSpec(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
@@ -346,7 +346,9 @@ data class CreateTokenCopyOfTargetEffect(
     /** Keywords granted to the token copy in addition to those copied from the source. */
     val addedKeywords: Set<Keyword> = emptySet(),
     /** Supertypes added to the token copy's type line (e.g., LEGENDARY for Adagia, Windswept Bastion). */
-    val addedSupertypes: Set<Supertype> = emptySet()
+    val addedSupertypes: Set<Supertype> = emptySet(),
+    /** If true, remove the Legendary supertype from the token copy. */
+    val removeLegendary: Boolean = false
 ) : Effect {
     override val description: String = buildString {
         append("Create ${count.description} token copies of target permanent")
@@ -355,6 +357,7 @@ data class CreateTokenCopyOfTargetEffect(
         }
         if (tapped) append(" tapped")
         if (attacking) append(" and attacking")
+        if (removeLegendary) append(", except ${if (count == DynamicAmount.Fixed(1)) "it's" else "they're"} not legendary")
         if (addedSupertypes.isNotEmpty()) {
             append(", except ${if (count == DynamicAmount.Fixed(1)) "it's" else "they're"} ${
                 addedSupertypes.joinToString(" ") { it.displayName.lowercase() }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ImpostorSyndrome.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ImpostorSyndrome.kt
@@ -28,9 +28,10 @@ val ImpostorSyndrome = card("Impostor Syndrome") {
     }
 
     metadata {
-        rarity = Rarity.RARE
-        collectorNumber = "54"
-        artist = "Mike McKone"
+        rarity = Rarity.MYTHIC
+        collectorNumber = "34"
+        artist = "Javier Charro"
+        flavorText = "\"I'm the real Spider-Man!\"\n\"No, *I'm* the real Spider-Man!\""
         imageUri = "https://cards.scryfall.io/normal/front/0/8/08da9f92-0e25-4f39-aaa4-d8974af81a41.jpg?1757376952"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ImpostorSyndrome.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ImpostorSyndrome.kt
@@ -31,6 +31,6 @@ val ImpostorSyndrome = card("Impostor Syndrome") {
         rarity = Rarity.RARE
         collectorNumber = "54"
         artist = "Mike McKone"
-        imageUri = "https://cards.scryfall.io/normal/front/4/5/4518be73-2571-4eef-b7a0-3eac5bc3a8c3.jpg?1757376788"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08da9f92-0e25-4f39-aaa4-d8974af81a41.jpg?1757376952"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ImpostorSyndrome.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ImpostorSyndrome.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Impostor Syndrome
+ * {4}{U}{U}
+ * Enchantment
+ * Whenever a nontoken creature you control deals combat damage to a player, create a token
+ * that's a copy of that creature, except it's not legendary.
+ */
+val ImpostorSyndrome = card("Impostor Syndrome") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a nontoken creature you control deals combat damage to a player, create a token that's a copy of that creature, except it's not legendary."
+
+    triggeredAbility {
+        trigger = Triggers.NontokenCreatureYouControlDealsCombatDamageToPlayer
+        effect = Effects.CreateTokenCopyOfTarget(
+            target = EffectTarget.TriggeringEntity,
+            removeLegendary = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "54"
+        artist = "Mike McKone"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/4518be73-2571-4eef-b7a0-3eac5bc3a8c3.jpg?1757376788"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/Kapow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/Kapow.kt
@@ -38,8 +38,9 @@ val Kapow = card("Kapow!") {
 
     metadata {
         rarity = Rarity.COMMON
-        collectorNumber = "167"
-        artist = "Juliann Tiu"
+        collectorNumber = "103"
+        artist = "Jessica Fong"
+        flavorText = "\"People are in danger—I don't have time for your games!\""
         imageUri = "https://cards.scryfall.io/normal/front/c/e/cec575f6-43c9-41c6-a996-bb806bf82185.jpg?1757377442"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/Kapow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/Kapow.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kapow!
+ * {2}{G}
+ * Instant
+ * Put a +1/+1 counter on target creature you control. Then it fights target creature
+ * an opponent controls.
+ */
+val Kapow = card("Kapow!") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Put a +1/+1 counter on target creature you control. Then it fights target creature an opponent controls."
+
+    spell {
+        val yourCreature = target("creature you control", Targets.CreatureYouControl)
+        val theirCreature = target("creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, yourCreature)
+            .then(Effects.Fight(yourCreature, theirCreature))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Juliann Tiu"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/954d8ab3-2378-47cb-b5b1-6bc5b5ec4e37.jpg?1757380058"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/Kapow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/Kapow.kt
@@ -1,10 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.spm.cards
 
 import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 
 /**
  * Kapow!
@@ -22,8 +25,15 @@ val Kapow = card("Kapow!") {
     spell {
         val yourCreature = target("creature you control", Targets.CreatureYouControl)
         val theirCreature = target("creature an opponent controls", Targets.CreatureOpponentControls)
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, yourCreature)
-            .then(Effects.Fight(yourCreature, theirCreature))
+        // Counter is only placed when the fight target is still legal on resolution;
+        // if theirCreature was stripped (e.g. gained hexproof in response), index 1 is
+        // absent from the validated-target list and the condition returns false.
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(
+                GameObjectFilter.Creature.opponentControls(), targetIndex = 1
+            ),
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, yourCreature)
+        ).then(Effects.Fight(yourCreature, theirCreature))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/Kapow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/Kapow.kt
@@ -40,6 +40,6 @@ val Kapow = card("Kapow!") {
         rarity = Rarity.COMMON
         collectorNumber = "167"
         artist = "Juliann Tiu"
-        imageUri = "https://cards.scryfall.io/normal/front/9/5/954d8ab3-2378-47cb-b5b1-6bc5b5ec4e37.jpg?1757380058"
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/cec575f6-43c9-41c6-a996-bb806bf82185.jpg?1757377442"
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.ClassLevelChangedEvent
 import com.wingedsheep.engine.core.CountersAddedEvent
 import com.wingedsheep.engine.core.AttackersDeclaredEvent
 import com.wingedsheep.engine.core.CardCycledEvent
+import com.wingedsheep.engine.core.CardsDiscardedEvent
 import com.wingedsheep.engine.core.CardsDrawnEvent
 import com.wingedsheep.engine.core.ControlChangedEvent
 import com.wingedsheep.engine.core.DoorUnlockedEvent
@@ -15,6 +16,7 @@ import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.triggers.WheneverYouDiscardACardTriggerHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
@@ -62,6 +64,7 @@ class TriggerDetector(
     private val deathAndLeaveDetector = DeathAndLeaveTriggerDetector(abilityResolver, matcher)
     private val damageDetector = DamageTriggerDetector(abilityResolver, matcher)
     private val attachmentDetector = AttachmentTriggerDetector(matcher)
+    private val discardTriggerHandler = WheneverYouDiscardACardTriggerHandler(abilityResolver)
 
     /**
      * Build a trigger index for the current game state.
@@ -868,6 +871,12 @@ class TriggerDetector(
         // battlefield, so the main index scan above skips it.
         if (event is SpellCastEvent) {
             detectSelfCastNthSpellTriggers(state, event, triggers)
+        }
+
+        // Handle 'whenever you discard a card' triggers (e.g., Hobgoblin Mantled Marauder).
+        // The source permanent is on the battlefield; the discarding player is in the event.
+        if (event is CardsDiscardedEvent) {
+            discardTriggerHandler.detectDiscardTriggers(state, event, triggers)
         }
 
         return triggers

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1267,11 +1267,11 @@ class TriggerDetector(
                 val damageEvents = combatDamageByController[controllerId] ?: continue
 
                 // Check if any damage source matches the sourceFilter (using projected state for subtypes)
-                val hasMatch = damageEvents.any { info ->
-                    val sourceContainer = state.getEntity(info.sourceId) ?: return@any false
-                    val sourceCard = sourceContainer.get<CardComponent>() ?: return@any false
-                    if (!sourceCard.typeLine.isCreature) return@any false
-                    if (sourceContainer.has<FaceDownComponent>()) return@any false
+                val firstMatchingInfo = damageEvents.firstOrNull { info ->
+                    val sourceContainer = state.getEntity(info.sourceId) ?: return@firstOrNull false
+                    val sourceCard = sourceContainer.get<CardComponent>() ?: return@firstOrNull false
+                    if (!sourceCard.typeLine.isCreature) return@firstOrNull false
+                    if (sourceContainer.has<FaceDownComponent>()) return@firstOrNull false
 
                     // Check card predicates from the sourceFilter
                     trigger.sourceFilter.cardPredicates.all { predicate ->
@@ -1279,19 +1279,21 @@ class TriggerDetector(
                             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature -> true
                             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
                                 projected.hasSubtype(info.sourceId, predicate.subtype.value)
+                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNontoken ->
+                                !sourceContainer.has<TokenComponent>()
                             else -> true
                         }
                     }
                 }
 
-                if (hasMatch) {
+                if (firstMatchingInfo != null) {
                     triggers.add(
                         PendingTrigger(
                             ability = ability,
                             sourceId = entry.entityId,
                             sourceName = entry.cardComponent.name,
                             controllerId = controllerId,
-                            triggerContext = TriggerContext()
+                            triggerContext = TriggerContext(triggeringEntityId = firstMatchingInfo.sourceId)
                         )
                     )
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -78,10 +78,11 @@ class CreateTokenCopyOfTargetExecutor(
             val overrideStats = if (op != null && ot != null) {
                 CreatureStats(op, ot)
             } else null
-            val tokenTypeLine = if (effect.addedSupertypes.isEmpty()) {
-                targetCard.typeLine
-            } else {
-                targetCard.typeLine.copy(supertypes = targetCard.typeLine.supertypes + effect.addedSupertypes)
+            val tokenTypeLine = run {
+                var tl = targetCard.typeLine
+                if (effect.addedSupertypes.isNotEmpty()) tl = tl.copy(supertypes = tl.supertypes + effect.addedSupertypes)
+                if (effect.removeLegendary) tl = tl.withoutLegendary()
+                tl
             }
             val tokenCard = targetCard.copy(
                 ownerId = controllerId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/triggers/WheneverYouDiscardACardTriggerHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/triggers/WheneverYouDiscardACardTriggerHandler.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.handlers.triggers
+
+import com.wingedsheep.engine.core.CardsDiscardedEvent
+import com.wingedsheep.engine.event.PendingTrigger
+import com.wingedsheep.engine.event.TriggerAbilityResolver
+import com.wingedsheep.engine.event.TriggerContext
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.GameEvent as SdkGameEvent
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Detects 'whenever you discard a card' triggered abilities.
+ *
+ * Listens for [CardsDiscardedEvent] (hand-to-graveyard discard) and enqueues a
+ * [PendingTrigger] for every battlefield permanent whose trigger spec is
+ * [SdkGameEvent.DiscardEvent] and whose player predicate matches the discarding player.
+ */
+class WheneverYouDiscardACardTriggerHandler(
+    private val abilityResolver: TriggerAbilityResolver
+) {
+
+    fun detectDiscardTriggers(
+        state: GameState,
+        event: CardsDiscardedEvent,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        val discardingPlayerId = event.playerId
+        val projected = state.projectedState
+
+        for (permanentId in state.getBattlefield()) {
+            val container = state.getEntity(permanentId) ?: continue
+            val cardComponent = container.get<CardComponent>() ?: continue
+            if (container.has<FaceDownComponent>()) continue
+            val controllerId = projected.getController(permanentId) ?: continue
+
+            val abilities = abilityResolver.getTriggeredAbilities(
+                permanentId, cardComponent.cardDefinitionId, state
+            )
+
+            for (ability in abilities) {
+                if (ability.activeZone != Zone.BATTLEFIELD) continue
+                val trigger = ability.trigger as? SdkGameEvent.DiscardEvent ?: continue
+
+                val playerMatches = when (trigger.player) {
+                    Player.You -> discardingPlayerId == controllerId
+                    Player.Opponent -> discardingPlayerId != controllerId
+                    else -> true
+                }
+                if (!playerMatches) continue
+
+                triggers.add(
+                    PendingTrigger(
+                        ability = ability,
+                        sourceId = permanentId,
+                        sourceName = cardComponent.name,
+                        controllerId = controllerId,
+                        triggerContext = TriggerContext(triggeringPlayerId = discardingPlayerId)
+                    )
+                )
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/FilterTriggerSourceToNontokenCreaturesYouControlTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/FilterTriggerSourceToNontokenCreaturesYouControlTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.triggers
+
+import com.wingedsheep.engine.core.DamageDealtEvent
+import com.wingedsheep.engine.event.TriggerDetector
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GameEvent.OneOrMoreDealCombatDamageToPlayerEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Batch combat-damage trigger scoped to "nontoken creatures you control" must exclude
+ * token creatures from its source predicate even when they simultaneously deal combat damage.
+ *
+ * The bug: detectCombatDamageBatchTriggers has `else -> true` in its CardPredicate when-block,
+ * so IsNontoken falls through and tokens are incorrectly treated as matching the filter.
+ * Additionally TriggerContext() is always empty, so no source is recorded.
+ */
+class FilterTriggerSourceToNontokenCreaturesYouControlTest : FunSpec({
+
+    // Observer: "Whenever one or more nontoken creatures you control deal combat damage to a player"
+    val observer = card("Nontoken Combat Damage Observer") {
+        manaCost = "{0}"
+        typeLine = "Creature — Human"
+        power = 0
+        toughness = 1
+        triggeredAbility {
+            trigger = TriggerSpec(
+                OneOrMoreDealCombatDamageToPlayerEvent(
+                    sourceFilter = GameObjectFilter.Creature.nontoken()
+                ),
+                TriggerBinding.ANY
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    // Two attackers with identical characteristics; one will be marked as a token.
+    val attacker = CardDefinition.creature(
+        name = "Test Attacker",
+        manaCost = ManaCost.parse("{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(observer, attacker))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20))
+        return driver
+    }
+
+    fun detectorFor(driver: GameTestDriver): TriggerDetector =
+        TriggerDetector(driver.cardRegistry)
+
+    context("'nontoken creature you control' source predicate in combat-damage batch trigger") {
+
+        /**
+         * GIVEN player 1 controls an observer with a 'nontoken creature you control' batch trigger,
+         *   AND player 1 controls a nontoken creature and a token creature with identical stats,
+         * WHEN both creatures deal combat damage to the opposing player simultaneously,
+         * THEN the trigger fires exactly once
+         *  AND the nontoken creature is recorded as the triggering damage source
+         *  AND no trigger instance is produced for the token creature.
+         */
+        test("fires exactly once with the nontoken creature recorded as the damage source when both nontoken and token deal combat damage to a player simultaneously") {
+            val driver = createDriver()
+            driver.putCreatureOnBattlefield(driver.player1, "Nontoken Combat Damage Observer")
+            val nontokenId = driver.putCreatureOnBattlefield(driver.player1, "Test Attacker")
+            val tokenId    = driver.putCreatureOnBattlefield(driver.player1, "Test Attacker")
+
+            // Mark the second attacker as a token (same stats, same card, but flagged as token)
+            driver.replaceState(
+                driver.state.updateEntity(tokenId) { it.with(TokenComponent) }
+            )
+
+            // Both attackers deal combat damage to the opposing player in the same damage step
+            val events = listOf(
+                DamageDealtEvent(
+                    sourceId       = nontokenId,
+                    targetId       = driver.player2,
+                    amount         = 2,
+                    isCombatDamage = true,
+                    targetIsPlayer = true
+                ),
+                DamageDealtEvent(
+                    sourceId       = tokenId,
+                    targetId       = driver.player2,
+                    amount         = 2,
+                    isCombatDamage = true,
+                    targetIsPlayer = true
+                )
+            )
+
+            val triggers = detectorFor(driver).detectTriggers(driver.state, events)
+
+            val batchTriggers = triggers.filter {
+                it.ability.trigger is OneOrMoreDealCombatDamageToPlayerEvent
+            }
+
+            // Batch collapses all sources into one trigger instance
+            batchTriggers shouldHaveSize 1
+
+            // The nontoken creature — not the token — must be recorded as the damage source.
+            // With the current implementation IsNontoken falls to `else -> true` and
+            // TriggerContext() is empty, so this assertion fails → test is RED.
+            batchTriggers.first().triggerContext.triggeringEntityId shouldBe nontokenId
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/WheneverYouDiscardACardTriggeredAbilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/WheneverYouDiscardACardTriggeredAbilityTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.triggers
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class WheneverYouDiscardACardTriggeredAbilityTest : FunSpec({
+
+    /**
+     * A permanent whose static trigger spec is 'Whenever you discard a card, gain 1 life.'
+     * Used to verify the engine fires a trigger when the controller discards.
+     */
+    val discardWatcher = CardDefinition.creature(
+        name = "Discard Watcher",
+        manaCost = ManaCost.parse("{2}{B}"),
+        subtypes = emptySet<Subtype>(),
+        power = 2,
+        toughness = 2,
+        oracleText = "Whenever you discard a card, you gain 1 life.",
+        script = CardScript.creature(
+            TriggeredAbility.create(
+                trigger = GameEvent.DiscardEvent(player = Player.You),
+                binding = TriggerBinding.ANY,
+                effect = GainLifeEffect(1)
+            )
+        )
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(discardWatcher)
+        return driver
+    }
+
+    /**
+     * GIVEN  A controller has a permanent on the battlefield with
+     *        'Whenever you discard a card, gain 1 life'
+     * AND    That same controller has at least one card in hand
+     * AND    No other discard-related triggers exist on the battlefield
+     * WHEN   The controller discards exactly one card from their hand
+     *        (the card moves hand → graveyard via a discard action)
+     * THEN   The engine fires exactly one 'whenever you discard a card' trigger
+     *        owned by that controller
+     * AND    The trigger's source is the permanent that registered the ability
+     * AND    Resolving the trigger gains the controller 1 life
+     */
+    test("whenever you discard a card trigger fires exactly once when controller discards") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Island" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val watcher = driver.putCreatureOnBattlefield(activePlayer, "Discard Watcher")
+        watcher shouldNotBe null
+
+        driver.getLifeTotal(activePlayer) shouldBe 20
+
+        // Give the player one black mana and a Careful Study ({B}: draw a card, discard a card)
+        driver.giveMana(activePlayer, Color.BLACK, 1)
+        val carefulStudy = driver.putCardInHand(activePlayer, "Careful Study")
+
+        // Cast Careful Study — resolves, draws a card, then pauses for discard selection
+        driver.castSpell(activePlayer, carefulStudy)
+        driver.bothPass()
+
+        // Pick the first card in hand as the discard; this emits CardsDiscardedEvent
+        val handCard = driver.getHand(activePlayer).first()
+        driver.submitCardSelection(activePlayer, listOf(handCard))
+
+        // The 'whenever you discard a card' trigger must now be on the stack
+        driver.stackSize shouldBeGreaterThan 0
+
+        // Resolve the trigger — controller gains 1 life
+        driver.bothPass()
+
+        driver.getLifeTotal(activePlayer) shouldBe 21
+    }
+})


### PR DESCRIPTION
## Card

- **Name:** Kapow!
- **Set:** Marvel's Spider-Man (spm)
- **Collector number:** 103
- **Scryfall:** https://scryfall.com/card/spm/103/kapow!?utm_source=api

## BDD scenarios

### S1: Cast Kapow! and resolve counter + fight — forces card-definition + counter + fight composition path

**Given**
- Active player has Kapow! in hand
- Active player controls a 2/2 creature 'Ally'
- Opponent controls a 3/3 creature 'Foe'
- Active player has {2}{G} of mana available
- It is the active player's main phase with an empty stack

**When** Active player casts Kapow!, targeting Ally (their creature) and Foe (the opponent's creature), and the spell resolves

**Then**
- Ally has one +1/+1 counter on it
- Ally's power is 3 and toughness is 3 after the counter is applied
- Ally and Foe each deal 3 damage to the other simultaneously
- Both Ally and Foe are destroyed by state-based actions and moved to their owners' graveyards
- Kapow! is in its owner's graveyard

### S2: Illegal targets on resolution — forces target-legality + fizzle path

**Given**
- Active player has Kapow! in hand and {2}{G} available
- Active player controls a 2/2 creature 'Ally'
- Opponent controls a 3/3 creature 'Foe'
- Opponent has an instant in hand that can give Foe hexproof at instant speed
- It is the active player's main phase

**When** Active player casts Kapow! targeting Ally and Foe; opponent responds by giving Foe hexproof so that Foe is an illegal target when Kapow! tries to resolve

**Then**
- Kapow! is countered on resolution because all of its targets are illegal
- No +1/+1 counter is placed on Ally
- No fight occurs and neither creature takes damage
- Kapow! is put into its owner's graveyard


---
Generated by `queue-next-card.sh` from plan `1.json`.

---
Reviewed and forwarded from nymann/argentum-engine#24 (original author: @nymann).

Forward-pass changes:

- **Engine fix** (new commit) — `detectCombatDamageBatchTriggers` had `else -> true` in its `CardPredicate` when-block, so `IsNontoken` fell through and tokens satisfied a "nontoken creature you control" source filter; the resulting `PendingTrigger` also carried an empty `TriggerContext()`. The branch already shipped `FilterTriggerSourceToNontokenCreaturesYouControlTest` pinning the intended behavior but without the corresponding engine change, so CI was red. The forwarding commit adds `IsNontoken -> !sourceContainer.has<TokenComponent>()` to the predicate dispatcher and propagates the matching source's entity ID via `TriggerContext(triggeringEntityId = …)`. Full `:rules-engine:test` and `:game-server:test` suites are green.

The branch also carries hivedrone scaffolding picked up along the way: `WheneverYouDiscardACardTriggerHandler` (no card in this PR consumes it yet), `docs/RULES.md`, and the SPM checklist. Left as-is — they don't break anything.