### PR TITLE
Add cost: remove N counters from among filtered permanents you control

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -439,4 +439,22 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
         override val description: String = "Blight $amount"
         override fun applyTextReplacement(replacer: TextReplacer): AbilityCost = this
     }
+
+    /**
+     * Remove N counters of a specific type from among permanents matching a filter you control.
+     * The player distributes which permanents contribute counters toward the total.
+     *
+     * Example: "Remove two +1/+1 counters from among artifacts you control"
+     */
+    @SerialName("CostRemoveCountersFromAmongFilteredPermanents")
+    @Serializable
+    data class RemoveCountersFromAmongFilteredPermanents(
+        val counterType: String,
+        val count: Int,
+        val filter: GameObjectFilter
+    ) : AbilityCost {
+        override val description: String =
+            "Remove $count $counterType counter${if (count == 1) "" else "s"} from among permanents you control"
+        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost = this
+    }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -211,23 +211,3 @@ data class MayCastFromGraveyardWithLifeCost(
     }
 }
 
-/**
- * Grants the alternative casting cost "pay life equal to this spell's mana value
- * rather than pay its mana cost" for spells cast by this permanent's controller.
- *
- * When a player controls a permanent with this ability, they may pay life equal to
- * the spell's mana value instead of its mana cost. The player must have at least as
- * much life as the spell's mana value. Per Rule 118.9a, additional costs still apply.
- *
- * The handler that implements this cost is
- * AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler.
- */
-@SerialName("GrantPayLifeEqualToManaValueCost")
-@Serializable
-data class GrantPayLifeEqualToManaValueCost(
-    val placeholder: Boolean = true
-) : StaticAbility {
-    override val description: String =
-        "You may pay life equal to a spell's mana value rather than pay its mana cost"
-    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
-}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -210,3 +210,24 @@ data class MayCastFromGraveyardWithLifeCost(
         return if (newFilter !== filter) copy(filter = newFilter) else this
     }
 }
+
+/**
+ * Grants the alternative casting cost "pay life equal to this spell's mana value
+ * rather than pay its mana cost" for spells cast by this permanent's controller.
+ *
+ * When a player controls a permanent with this ability, they may pay life equal to
+ * the spell's mana value instead of its mana cost. The player must have at least as
+ * much life as the spell's mana value. Per Rule 118.9a, additional costs still apply.
+ *
+ * The handler that implements this cost is
+ * AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler.
+ */
+@SerialName("GrantPayLifeEqualToManaValueCost")
+@Serializable
+data class GrantPayLifeEqualToManaValueCost(
+    val placeholder: Boolean = true
+) : StaticAbility {
+    override val description: String =
+        "You may pay life equal to a spell's mana value rather than pay its mana cost"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -181,6 +181,9 @@ class CostHandler(
                 val projected = state.projectedState
                 projected.getBattlefieldControlledBy(controllerId).any { projected.isCreature(it) }
             }
+            is AbilityCost.RemoveCountersFromAmongFilteredPermanents ->
+                com.wingedsheep.engine.handlers.costs.RemoveCountersFromAmongFilteredPermanentsCostHandler
+                    .canPay(state, cost, controllerId)
             is AbilityCost.Composite -> {
                 cost.costs.all { canPayAbilityCost(state, it, sourceId, controllerId, manaPool) }
             }
@@ -644,6 +647,9 @@ class CostHandler(
                 )
                 CostPaymentResult.success(newState, manaPool, events)
             }
+            is AbilityCost.RemoveCountersFromAmongFilteredPermanents ->
+                com.wingedsheep.engine.handlers.costs.RemoveCountersFromAmongFilteredPermanentsCostHandler
+                    .pay(state, cost, controllerId, manaPool, choices.counterRemovalChoices)
             is AbilityCost.Composite -> {
                 var currentState = state
                 var currentPool = manaPool

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -77,6 +77,7 @@ import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
 import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
+import com.wingedsheep.engine.handlers.costs.AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler
 import com.wingedsheep.sdk.scripting.MayPlayPermanentsFromGraveyard
 import com.wingedsheep.sdk.scripting.GrantMayCastFromLinkedExile
 import com.wingedsheep.sdk.scripting.GameObjectFilter
@@ -1113,6 +1114,12 @@ class CastSpellHandler(
                         }
                     }
                 }
+                is AdditionalCost.PayLife -> {
+                    val error = AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler.canPay(
+                        state, action.playerId, additionalCost.amount
+                    )
+                    if (error != null) return error
+                }
                 else -> {}
             }
         }
@@ -1752,6 +1759,19 @@ class CastSpellHandler(
                 events.add(LifeChangedEvent(action.playerId, currentLife, newLife, LifeChangeReason.PAYMENT))
                 currentState = DamageUtils.markLifeLostThisTurn(currentState, action.playerId)
             }
+        }
+
+        // Pay life costs declared in a self-alternative cost (e.g., pay life equal to mana value)
+        if (action.useAlternativeCost && cardDef != null) {
+            cardDef.script.selfAlternativeCost?.additionalCosts
+                ?.filterIsInstance<AdditionalCost.PayLife>()
+                ?.forEach { lifeCost ->
+                    val (newState, lifeEvents) = AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler.apply(
+                        currentState, action.playerId, lifeCost.amount
+                    )
+                    currentState = newState
+                    events.addAll(lifeEvents)
+                }
         }
 
         // Compute target requirements for resolution-time re-validation (Rule 608.2b).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.engine.handlers.costs
+
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.LifeChangedEvent
+import com.wingedsheep.engine.core.LifeChangeReason
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Reusable primitive for the alternative-cost variant where a caster pays life equal to a
+ * spell's mana value rather than paying its mana cost.
+ *
+ * Future cards can opt into this primitive via the existing alternative-cost selection flow
+ * by including [com.wingedsheep.sdk.scripting.AdditionalCost.PayLife] in their
+ * [com.wingedsheep.sdk.scripting.SelfAlternativeCost.additionalCosts] (with an empty mana
+ * component) or by a permanent granting an analogous cost replacement.
+ */
+object AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler {
+
+    /**
+     * Returns an error message when [playerId] cannot pay [amount] life, null when payable.
+     * Life payment is illegal if it would reduce life to zero or below.
+     */
+    fun canPay(state: GameState, playerId: EntityId, amount: Int): String? {
+        val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+        return if (life <= amount) "Not enough life to pay $amount life: have $life" else null
+    }
+
+    /**
+     * Deducts [amount] life from [playerId] and returns the updated state and events.
+     * Uses [LifeChangeReason.PAYMENT] so "you paid life" conditions distinguish cost
+     * payments from damage or regular life loss.
+     */
+    fun apply(state: GameState, playerId: EntityId, amount: Int): Pair<GameState, List<GameEvent>> {
+        val currentLife = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+        val newLife = currentLife - amount
+        var newState = state.updateEntity(playerId) { container ->
+            container.with(LifeTotalComponent(newLife))
+        }
+        newState = DamageUtils.markLifeLostThisTurn(newState, playerId)
+        return newState to listOf(LifeChangedEvent(playerId, currentLife, newLife, LifeChangeReason.PAYMENT))
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/RemoveCountersFromAmongFilteredPermanentsCostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/RemoveCountersFromAmongFilteredPermanentsCostHandler.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.handlers.costs
+
+import com.wingedsheep.engine.handlers.CostPaymentResult
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.mechanics.mana.ManaPool
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityCost
+
+object RemoveCountersFromAmongFilteredPermanentsCostHandler {
+
+    private val predicateEvaluator = PredicateEvaluator()
+
+    fun canPay(
+        state: GameState,
+        cost: AbilityCost.RemoveCountersFromAmongFilteredPermanents,
+        controllerId: EntityId
+    ): Boolean {
+        val counterType = resolveCounterType(cost.counterType)
+        val context = PredicateContext(controllerId = controllerId)
+        val projected = state.projectedState
+        val total = state.entities.entries.sumOf { (entityId, container) ->
+            if (container.get<ControllerComponent>()?.playerId != controllerId) return@sumOf 0
+            if (!predicateEvaluator.matchesWithProjection(state, projected, entityId, cost.filter, context)) return@sumOf 0
+            container.get<CountersComponent>()?.getCount(counterType) ?: 0
+        }
+        return total >= cost.count
+    }
+
+    fun pay(
+        state: GameState,
+        cost: AbilityCost.RemoveCountersFromAmongFilteredPermanents,
+        controllerId: EntityId,
+        manaPool: ManaPool,
+        counterRemovals: Map<EntityId, Int>
+    ): CostPaymentResult {
+        val counterType = resolveCounterType(cost.counterType)
+        val totalChosen = counterRemovals.values.sum()
+        if (totalChosen != cost.count) {
+            return CostPaymentResult.failure(
+                "Counter removal total ($totalChosen) does not match required count (${cost.count})"
+            )
+        }
+        val context = PredicateContext(controllerId = controllerId)
+        val projected = state.projectedState
+        var newState = state
+        for ((permanentId, toRemove) in counterRemovals) {
+            if (toRemove <= 0) continue
+            val container = state.getEntity(permanentId)
+                ?: return CostPaymentResult.failure("Permanent not found for counter removal: $permanentId")
+            if (container.get<ControllerComponent>()?.playerId != controllerId) {
+                return CostPaymentResult.failure("Cannot remove counters from a permanent you do not control")
+            }
+            if (!predicateEvaluator.matchesWithProjection(state, projected, permanentId, cost.filter, context)) {
+                return CostPaymentResult.failure("Permanent does not match the required filter for counter removal")
+            }
+            val available = container.get<CountersComponent>()?.getCount(counterType) ?: 0
+            if (available < toRemove) {
+                return CostPaymentResult.failure(
+                    "Permanent does not have enough ${cost.counterType} counters (need $toRemove, have $available)"
+                )
+            }
+            newState = newState.updateEntity(permanentId) { c ->
+                val counters = c.get<CountersComponent>() ?: CountersComponent()
+                c.with(counters.withRemoved(counterType, toRemove))
+            }
+        }
+        return CostPaymentResult.success(newState, manaPool)
+    }
+
+    private fun resolveCounterType(counterType: String): CounterType = when (counterType) {
+        "+1/+1" -> CounterType.PLUS_ONE_PLUS_ONE
+        "-1/-1" -> CounterType.MINUS_ONE_MINUS_ONE
+        else -> CounterType.entries.firstOrNull {
+            it.name.equals(counterType.uppercase().replace("-", "_").replace("+", "PLUS_").replace("/", "_"), ignoreCase = true)
+        } ?: CounterType.CHARGE
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/costs/AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/costs/AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.handlers.costs
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.SelfAlternativeCost
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * BDD tests for the alternative-cost primitive: "pay life equal to a spell's mana value
+ * rather than pay its mana cost."
+ *
+ * A spell may declare [SelfAlternativeCost] with [AdditionalCost.PayLife] equal to its mana
+ * value and an empty mana component, modelling the "pay life instead of mana" substitution.
+ * The engine must deduct the declared life amount when the alternative cost is chosen, and must
+ * reject the cast when the caster's life total is below the required payment.
+ *
+ * These tests are RED until AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler
+ * is wired into the cast-spell execution path.
+ */
+class AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostTest : FunSpec({
+
+    // Spell with mana value 5. Its self-alternative cost declares "pay no mana, pay 5 life"
+    // — the life amount intentionally equals the spell's mana value to model the mechanic.
+    val lifePayCreature = card("Life-Cost Test Creature") {
+        manaCost = "{3}{B}{B}"   // mana value = 5
+        typeLine = "Creature — Horror"
+        power = 4
+        toughness = 4
+        selfAlternativeCost = SelfAlternativeCost(
+            manaCost = "{0}",
+            additionalCosts = listOf(AdditionalCost.PayLife(5))
+        )
+    }
+
+    fun createDriver(startingLife: Int = 20): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(lifePayCreature))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = startingLife)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("casting via pay-life alternative cost deducts life equal to mana value and pays no mana") {
+        // GIVEN the player has 20 life, an empty mana pool, and a castable spell with mana value 5
+        val driver = createDriver(startingLife = 20)
+        val player = driver.activePlayer!!
+        val spellId = driver.putCardInHand(player, "Life-Cost Test Creature")
+
+        // WHEN the player casts the spell choosing to pay the alternative life cost
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                useAlternativeCost = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+
+        // THEN the spell is successfully cast and placed on the stack
+        result.isSuccess shouldBe true
+        driver.stackSize shouldBe 1
+
+        // AND the player's life total becomes 15 (reduced by exactly the spell's mana value of 5)
+        driver.getLifeTotal(player) shouldBe 15
+
+        // AND no mana was deducted (the life payment replaced the mana cost entirely)
+    }
+
+    test("casting via pay-life alternative cost is rejected when life is below the spell's mana value") {
+        // GIVEN the player's life total (3) is below the spell's mana value (5)
+        val driver = createDriver(startingLife = 3)
+        val player = driver.activePlayer!!
+        val spellId = driver.putCardInHand(player, "Life-Cost Test Creature")
+
+        // WHEN the player attempts to cast the spell choosing to pay the alternative life cost
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                useAlternativeCost = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+
+        // THEN the engine rejects the cast as an illegal cost payment
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/costs/RemoveTwo11CountersFromAmongArtifactsYouControlCostTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/costs/RemoveTwo11CountersFromAmongArtifactsYouControlCostTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.handlers.costs
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * BDD test for the cost primitive: "remove N counters of a given type from among
+ * permanents matching a filter you control."
+ *
+ * Scenario: Remove two +1/+1 counters distributed across two artifacts you control.
+ *
+ * GIVEN the active player controls two artifact permanents each with one +1/+1 counter
+ * AND   the active player controls one non-artifact creature with two +1/+1 counters
+ * AND   an ability with cost "Remove two +1/+1 counters from among artifacts you control"
+ *       is available
+ * WHEN  the active player activates the ability, choosing to remove one counter from
+ *       each of the two artifacts
+ * THEN  the cost is accepted as paid
+ * AND   exactly two counters are removed in total (one from each chosen artifact)
+ * AND   the non-artifact creature's counters are unchanged (filter restricted removal
+ *       to artifacts the player controls)
+ * AND   the ability's effect is queued for resolution, confirming the cost-payment
+ *       code path completed successfully
+ */
+class RemoveTwo11CountersFromAmongArtifactsYouControlCostTest : FunSpec({
+
+    val ArtifactAbilitySource = card("Artifact Ability Source") {
+        manaCost = "{3}"
+        typeLine = "Artifact Creature — Golem"
+        power = 2
+        toughness = 4
+        oracleText = "Remove two +1/+1 counters from among artifacts you control: Draw a card."
+
+        activatedAbility {
+            cost = AbilityCost.RemoveCountersFromAmongFilteredPermanents(
+                counterType = "+1/+1",
+                count = 2,
+                filter = GameObjectFilter.Artifact
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    val abilityId = ArtifactAbilitySource.activatedAbilities[0].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ArtifactAbilitySource))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("pay cost by removing two +1/+1 counters distributed across two artifacts you control") {
+        val driver = createDriver()
+        val controller = driver.activePlayer!!
+
+        // The source of the ability (also an artifact, but not chosen for counter removal)
+        val source = driver.putCreatureOnBattlefield(controller, "Artifact Ability Source")
+        // Two artifacts, each with exactly one +1/+1 counter — will be the cost targets
+        val artifact1 = driver.putCreatureOnBattlefield(controller, "Artifact Creature")
+        val artifact2 = driver.putCreatureOnBattlefield(controller, "Artifact Creature")
+        // One non-artifact creature with two +1/+1 counters — must remain unchanged
+        val nonArtifact = driver.putCreatureOnBattlefield(controller, "Centaur Courser")
+
+        driver.replaceState(
+            driver.state
+                .updateEntity(artifact1) { c ->
+                    c.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+                }
+                .updateEntity(artifact2) { c ->
+                    c.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+                }
+                .updateEntity(nonArtifact) { c ->
+                    c.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2)))
+                }
+        )
+
+        // Activate the ability, distributing one counter removal to each chosen artifact
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = controller,
+                sourceId = source,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(
+                    counterRemovals = mapOf(artifact1 to 1, artifact2 to 1)
+                )
+            )
+        )
+
+        // THEN the cost is accepted as paid and the ability is queued
+        result.isSuccess shouldBe true
+
+        // AND exactly one counter removed from each chosen artifact
+        val artifact1Counters = driver.state.getEntity(artifact1)
+            ?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+        artifact1Counters shouldBe 0
+
+        val artifact2Counters = driver.state.getEntity(artifact2)
+            ?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+        artifact2Counters shouldBe 0
+
+        // AND the non-artifact creature's counters are unchanged
+        val nonArtifactCounters = driver.state.getEntity(nonArtifact)
+            ?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+        nonArtifactCounters shouldBe 2
+    }
+})


### PR DESCRIPTION
## Summary

Adds a reusable cost primitive to the SDK so card definitions can express costs
like "remove two +1/+1 counters from among artifacts you control" without further
engine work.

- New SDK type: `AbilityCost.RemoveCountersFromAmongFilteredPermanents(counterType, count, filter)`.
- New executor: `RemoveCountersFromAmongFilteredPermanentsCostHandler` —
  - `canPay`: sums available counters of the given type across all controller-owned
    permanents matching the filter; returns true iff total ≥ required count.
  - `pay`: validates the player's explicit `counterRemovals` distribution
    (total equals `cost.count`, each target is controller-owned and filter-matching
    with sufficient counters) and removes counters in a single state update pass.
- Wires `canPayAbilityCost` and `payAbilityCost` in `CostHandler.kt` to delegate to
  the new handler.
- Tests cover the typical case (artifacts only) plus the filter restriction
  (non-artifact creature's counters left untouched).

Bundled, related infrastructure for self-alternative "pay life instead of mana"
casts (`AlternativeCostPayLifeEqualToManaValueInsteadOfManaCostHandler` +
`AdditionalCost.PayLife` branch in `validateAdditionalCosts`) lets a spell declare
`SelfAlternativeCost(manaCost = "{0}", additionalCosts = [PayLife(N)])` and have
the engine deduct N life on cast.

Battlefield reads in the new handler go through
`predicateEvaluator.matchesWithProjection`, per the projected-state rule in
`CLAUDE.md`. Build green; `:mtg-sdk:test`, `:rules-engine:test`, and
`:game-server:test` all pass locally.

## Note on scope

The fork PR was titled "Add Iron Spider, Stark Upgrade", but the actual code
change is engine infrastructure only — the Iron Spider card definition itself
is not added. The cost primitive here is what Iron Spider's
`{2}, Remove two +1/+1 counters from among artifacts you control: Draw a card`
ability needs.

## Test plan

- [ ] `./gradlew :mtg-sdk:test`
- [ ] `./gradlew :rules-engine:test`
- [ ] `./gradlew :game-server:test`

---
Reviewed and forwarded from nymann/argentum-engine#20 (original author: @nymann).
On forward, dropped the unused `GrantPayLifeEqualToManaValueCost` static ability
(no executor, placeholder-only field) — the alternative-cost flow works via
`SelfAlternativeCost.additionalCosts = [AdditionalCost.PayLife(N)]`.