### PR TITLE
Add Rent Is Due

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -93,12 +93,12 @@
 - [ ] Peter Parker's Camera
 - [ ] Pictures of Spider-Man
 - [ ] Prison Break
-- [ ] Professional Wrestler
+- [x] Professional Wrestler
 - [ ] Prowler, Clawed Thief
 - [ ] Pumpkin Bombardment
 - [ ] Radioactive Spider
 - [ ] Raging Goblinoids
-- [x] Rent Is Due
+- [ ] Rent Is Due
 - [ ] Rhino's Rampage
 - [ ] Rhino, Barreling Brute
 - [ ] Risky Research

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 4 / 188
+**Implemented:** 5 / 188
 ---
 
 - [x] Agent Venom
@@ -98,7 +98,7 @@
 - [ ] Pumpkin Bombardment
 - [ ] Radioactive Spider
 - [ ] Raging Goblinoids
-- [ ] Rent Is Due
+- [x] Rent Is Due
 - [ ] Rhino's Rampage
 - [ ] Rhino, Barreling Brute
 - [ ] Risky Research

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ProfessionalWrestlerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ProfessionalWrestlerScenarioTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Professional Wrestler.
+ *
+ * Card reference:
+ * - Professional Wrestler ({3}{G}): Creature — Human Warrior Performer, 4/4
+ *   "When this creature enters, create a Treasure token."
+ *   "Professional Wrestler can't be blocked by more than one creature."
+ */
+class ProfessionalWrestlerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Professional Wrestler — cast and ETB") {
+
+            test("enters the battlefield as a 4/4 Human Warrior Performer when cast for {3}{G}") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Professional Wrestler")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Professional Wrestler")
+                withClue("Casting Professional Wrestler with {3}{G} should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Professional Wrestler should be on the battlefield") {
+                    game.isOnBattlefield("Professional Wrestler") shouldBe true
+                }
+
+                val permanentId = game.findPermanent("Professional Wrestler")!!
+                val card = game.state.getEntity(permanentId)!!.get<CardComponent>()!!
+
+                withClue("Professional Wrestler should be a 4/4") {
+                    card.baseStats?.basePower shouldBe 4
+                    card.baseStats?.baseToughness shouldBe 4
+                }
+
+                withClue("Professional Wrestler should be a Human") {
+                    card.typeLine.hasSubtype(Subtype.HUMAN) shouldBe true
+                }
+                withClue("Professional Wrestler should be a Warrior") {
+                    card.typeLine.hasSubtype(Subtype.WARRIOR) shouldBe true
+                }
+                withClue("Professional Wrestler should be a Performer") {
+                    card.typeLine.hasSubtype(Subtype("Performer")) shouldBe true
+                }
+
+                withClue("Professional Wrestler should be green") {
+                    card.colors shouldBe setOf(Color.GREEN)
+                }
+
+                withClue("Professional Wrestler should no longer be in the active player's hand") {
+                    game.isInHand(1, "Professional Wrestler") shouldBe false
+                }
+
+                withClue("All four lands should be tapped after paying {3}{G}") {
+                    val untappedLands = game.state.getBattlefield().count { entityId ->
+                        val container = game.state.getEntity(entityId) ?: return@count false
+                        val c = container.get<CardComponent>()
+                        val isLand = c?.typeLine?.isLand == true
+                        isLand && !container.has<TappedComponent>()
+                    }
+                    untappedLands shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ProfessionalWrestlerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ProfessionalWrestlerScenarioTest.kt
@@ -69,6 +69,10 @@ class ProfessionalWrestlerScenarioTest : ScenarioTestBase() {
                     game.isInHand(1, "Professional Wrestler") shouldBe false
                 }
 
+                withClue("ETB trigger should have created exactly one Treasure token") {
+                    game.findAllPermanents("Treasure").size shouldBe 1
+                }
+
                 withClue("All four lands should be tapped after paying {3}{G}") {
                     val untappedLands = game.state.getBattlefield().count { entityId ->
                         val container = game.state.getEntity(entityId) ?: return@count false

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ProfessionalWrestler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ProfessionalWrestler.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+
+/**
+ * Professional Wrestler
+ * {3}{G}
+ * Creature — Human Warrior Performer
+ * 4/4
+ * When this creature enters, create a Treasure token.
+ * Professional Wrestler can't be blocked by more than one creature.
+ */
+val ProfessionalWrestler = card("Professional Wrestler") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Warrior Performer"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, create a Treasure token.\nProfessional Wrestler can't be blocked by more than one creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateTreasure(1)
+    }
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(maxBlockers = 1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "175"
+        artist = "Igor Krstic"
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f4c85b1-8c5b-4c6e-8e4e-d4b2a4e5f7a9.jpg?1757377869"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/filters/UntappedCreaturesAndOrTreasuresFilter.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/filters/UntappedCreaturesAndOrTreasuresFilter.kt
@@ -1,0 +1,25 @@
+package com.wingedsheep.engine.handlers.filters
+
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+class UntappedCreaturesAndOrTreasuresFilter {
+
+    private val predicateEvaluator = PredicateEvaluator()
+
+    private val filter = (GameObjectFilter.Creature or GameObjectFilter.Any.withSubtype(Subtype("Treasure")))
+        .untapped()
+        .youControl()
+
+    fun findMatching(state: GameState, controllerId: EntityId): List<EntityId> {
+        val projected = state.projectedState
+        val context = PredicateContext(controllerId = controllerId)
+        return state.getBattlefield().filter { entityId ->
+            predicateEvaluator.matchesWithProjection(state, projected, entityId, filter, context)
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/filters/FilterSpanningMultipleTypesCreaturesAndOrTreasuresTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/filters/FilterSpanningMultipleTypesCreaturesAndOrTreasuresTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.filters
+
+import com.wingedsheep.engine.handlers.filters.UntappedCreaturesAndOrTreasuresFilter
+import com.wingedsheep.engine.state.Component
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+
+/**
+ * BDD specification for the untapped-creatures-and/or-Treasures filter primitive.
+ *
+ * The filter selects battlefield permanents that are:
+ *   - untapped, AND
+ *   - (a creature OR a permanent with the Treasure subtype), AND
+ *   - controlled by the querying player
+ */
+class FilterSpanningMultipleTypesCreaturesAndOrTreasuresTest : FunSpec({
+
+    val filter = UntappedCreaturesAndOrTreasuresFilter()
+    val activePlayer = EntityId.generate()
+    val opponent = EntityId.generate()
+
+    fun creature(owner: EntityId): CardComponent = CardComponent(
+        cardDefinitionId = "Test Creature",
+        name = "Test Creature",
+        manaCost = ManaCost(emptyList()),
+        typeLine = TypeLine(cardTypes = setOf(CardType.CREATURE)),
+        ownerId = owner,
+        baseStats = CreatureStats(2, 2)
+    )
+
+    fun treasureToken(owner: EntityId): CardComponent = CardComponent(
+        cardDefinitionId = "Treasure",
+        name = "Treasure",
+        manaCost = ManaCost(emptyList()),
+        typeLine = TypeLine(
+            cardTypes = setOf(CardType.ARTIFACT),
+            subtypes = setOf(Subtype("Treasure"))
+        ),
+        ownerId = owner
+    )
+
+    fun plains(owner: EntityId): CardComponent = CardComponent(
+        cardDefinitionId = "Plains",
+        name = "Plains",
+        manaCost = ManaCost(emptyList()),
+        typeLine = TypeLine(cardTypes = setOf(CardType.LAND)),
+        ownerId = owner
+    )
+
+    fun container(
+        controller: EntityId,
+        card: CardComponent,
+        vararg extras: Component
+    ): ComponentContainer {
+        var c = ComponentContainer()
+            .with(card)
+            .with(OwnerComponent(controller))
+            .with(ControllerComponent(controller))
+        extras.forEach { component ->
+            @Suppress("UNCHECKED_CAST")
+            c = c.copy(components = c.components + (component::class.qualifiedName!! to component))
+        }
+        return c
+    }
+
+    fun buildState(entities: List<Pair<EntityId, ComponentContainer>>): GameState {
+        var state = GameState()
+            .withEntity(activePlayer, ComponentContainer())
+            .withEntity(opponent, ComponentContainer())
+        entities.forEach { (id, cont) ->
+            state = state.withEntity(id, cont)
+            val controller = cont.get<ControllerComponent>()?.playerId ?: activePlayer
+            state = state.addToZone(ZoneKey(controller, Zone.BATTLEFIELD), id)
+        }
+        return state
+    }
+
+    test(
+        "filter returns exactly the active player's untapped creature and untapped Treasure, " +
+        "excluding tapped permanents, opponent permanents, and non-creature non-Treasure permanents"
+    ) {
+        // GIVEN
+        val yourUntappedCreature = EntityId.generate()
+        val yourTappedCreature = EntityId.generate()
+        val yourUntappedTreasure = EntityId.generate()
+        val yourTappedTreasure = EntityId.generate()
+        val yourUntappedPlains = EntityId.generate()
+        val opponentUntappedCreature = EntityId.generate()
+        val opponentUntappedTreasure = EntityId.generate()
+
+        val state = buildState(
+            listOf(
+                yourUntappedCreature to container(activePlayer, creature(activePlayer)),
+                yourTappedCreature to container(activePlayer, creature(activePlayer), TappedComponent),
+                yourUntappedTreasure to container(activePlayer, treasureToken(activePlayer)),
+                yourTappedTreasure to container(activePlayer, treasureToken(activePlayer), TappedComponent),
+                yourUntappedPlains to container(activePlayer, plains(activePlayer)),
+                opponentUntappedCreature to container(opponent, creature(opponent)),
+                opponentUntappedTreasure to container(opponent, treasureToken(opponent))
+            )
+        )
+
+        // WHEN
+        val result = filter.findMatching(state, activePlayer)
+
+        // THEN
+        result shouldContainExactlyInAnyOrder listOf(yourUntappedCreature, yourUntappedTreasure)
+    }
+})


### PR DESCRIPTION
## Card

- **Name:** Rent Is Due
- **Set:** Marvel's Spider-Man (spm)
- **Collector number:** 11
- **Scryfall:** https://scryfall.com/card/spm/11/rent-is-due?utm_source=api

## BDD scenarios

### S1: Cast Rent Is Due — forces card-definition + enchantment-ETB path

**Given**
- Active player has Rent Is Due in hand
- Active player controls a Plains that is untapped
- It is the active player's main phase with the stack empty

**When** Active player casts Rent Is Due paying {W}

**Then**
- Rent Is Due resolves and enters the battlefield under the active player's control
- Rent Is Due is on the battlefield as an Enchantment
- Rent Is Due is no longer in its controller's hand

### S2: End-step trigger paid — forces triggered-ability + tap-two-permanents-cost + draw path

**Given**
- Active player controls Rent Is Due on the battlefield
- Active player controls two untapped creatures (or one untapped creature and one untapped Treasure)
- Active player has an empty hand and a library of at least one card

**When** The active player's end step begins and the controller chooses to pay by tapping two qualifying permanents

**Then**
- Two of the controller's previously untapped creatures/Treasures become tapped
- The controller draws one card
- Rent Is Due remains on the battlefield

### S3: End-step trigger unpaid — forces sacrifice-otherwise branch

**Given**
- Active player controls Rent Is Due on the battlefield
- Active player controls no untapped creatures and no untapped Treasures (or declines to pay)

**When** The active player's end step begins and the controller does not tap two qualifying permanents

**Then**
- Rent Is Due is moved from the battlefield to its owner's graveyard via sacrifice
- The controller does not draw a card from Rent Is Due

### S4: Tap-cost selection filter — forces untapped-creature-or-Treasure target filter path

**Given**
- Active player controls Rent Is Due on the battlefield
- Active player controls an untapped creature, an already-tapped creature, an untapped Treasure, and an untapped non-Treasure artifact
- Active player has at least one card in library

**When** Rent Is Due's end-step trigger resolves and the controller is prompted for two permanents to tap

**Then**
- Only the untapped creature and the untapped Treasure are offered as legal selections
- The already-tapped creature and the non-Treasure artifact are not selectable
- After paying with the untapped creature and the untapped Treasure, the controller draws one card


---
Generated by `queue-next-card.sh` from plan `1.json`.

---
Reviewed and forwarded from nymann/argentum-engine#38 (original author: @nymann).

Note on scope: this branch was opened with the title "Add Rent Is Due" but the actual diff is accumulated SPM work (Agent Venom, Amazing Acrobatics, Angry Rabble, Professional Wrestler, Romantic Rendezvous, Alpharael Stonechosen) plus engine plumbing (IsNontoken trigger predicate fix, IsModified state predicate, OnePerCardName selection restriction, Ward random-discard cost, deterministic GameState.nextRandom(), shared ZoneTransitionService.discardCard, UntappedCreaturesAndOrTreasuresFilter primitive). There is no RentIsDue.kt card definition in this diff — the new filter primitive is what would back it. Reviewer flipped the backlog so Rent Is Due is back to `[ ]` and Professional Wrestler (the card that is actually added) is `[x]`. Also added a Treasure-token assertion to the Professional Wrestler scenario test so the ETB trigger is covered.

`just test` is green.