### PR TITLE
Add Icetill Explorer to Edge of Eternities with MayPlayLandsFromGraveyard support

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,11 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-<<<<<<< HEAD
 **Implemented:** 167 / 261
-=======
-**Implemented:** 168 / 261
->>>>>>> 4408d2830 (Add Icetill Explorer to Edge of Eternities with MayPlayLandsFromGraveyard support)
 ---
 
 - [x] Adagia, Windswept Bastion

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,11 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 166 / 261
+<<<<<<< HEAD
+**Implemented:** 167 / 261
+=======
+**Implemented:** 168 / 261
+>>>>>>> 4408d2830 (Add Icetill Explorer to Edge of Eternities with MayPlayLandsFromGraveyard support)
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -106,7 +110,7 @@
 - [x] Hylderblade
 - [x] Hymn of the Faller
 - [x] Icecave Crasher
-- [ ] Icetill Explorer
+- [x] Icetill Explorer
 - [x] Illvoi Galeblade
 - [x] Illvoi Infiltrator
 - [x] Illvoi Light Jammer

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/IcetillExplorerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/IcetillExplorerScenarioTest.kt
@@ -121,6 +121,7 @@ class IcetillExplorerScenarioTest : ScenarioTestBase() {
 
                 val forestId = findInGraveyard(game, 1, "Forest")
                 game.execute(PlayLand(game.player1Id, forestId))
+                game.resolveStack()
 
                 // Landfall trigger fires — one card should be milled
                 withClue("One card should have been milled from library to graveyard") {
@@ -149,6 +150,7 @@ class IcetillExplorerScenarioTest : ScenarioTestBase() {
                 // First land: from graveyard
                 val graveyardForest = findInGraveyard(game, 1, "Forest")
                 val result1 = game.execute(PlayLand(game.player1Id, graveyardForest))
+                game.resolveStack()  // resolve landfall trigger before playing the next land
                 withClue("First land (from graveyard) should succeed: ${result1.error}") {
                     result1.error shouldBe null
                 }
@@ -158,6 +160,7 @@ class IcetillExplorerScenarioTest : ScenarioTestBase() {
                     game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
                 }!!
                 val result2 = game.execute(PlayLand(game.player1Id, handForestId))
+                game.resolveStack()  // resolve second landfall trigger
                 withClue("Second land (from hand via bonus drop) should succeed: ${result2.error}") {
                     result2.error shouldBe null
                 }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/IcetillExplorerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/IcetillExplorerScenarioTest.kt
@@ -1,0 +1,178 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.LandDropsComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Icetill Explorer.
+ *
+ * Card reference:
+ * - Icetill Explorer ({2}{G}{G}): Creature — Insect Scout 2/4
+ *   You may play an additional land on each of your turns.
+ *   You may play lands from your graveyard.
+ *   Landfall — Whenever a land you control enters, mill a card.
+ */
+class IcetillExplorerScenarioTest : ScenarioTestBase() {
+
+    /** Find a land in a player's graveyard by name, returning its entity id. */
+    private fun findInGraveyard(game: TestGame, playerNumber: Int, cardName: String): EntityId {
+        val playerId = if (playerNumber == 1) game.player1Id else game.player2Id
+        return game.state.getGraveyard(playerId).find { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == cardName
+        } ?: error("'$cardName' not found in player $playerNumber's graveyard")
+    }
+
+    init {
+        context("MayPlayLandsFromGraveyard") {
+
+            test("can play a land from graveyard with Icetill Explorer on battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Icetill Explorer")
+                    .withCardInGraveyard(1, "Forest")
+                    .withCardInLibrary(1, "Forest")  // prevent draw-from-empty loss
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forestId = findInGraveyard(game, 1, "Forest")
+                val result = game.execute(PlayLand(game.player1Id, forestId))
+
+                withClue("Playing a land from graveyard should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Forest should now be on the battlefield") {
+                    game.isOnBattlefield("Forest") shouldBe true
+                }
+                withClue("Forest should no longer be in graveyard") {
+                    game.isInGraveyard(1, "Forest") shouldBe false
+                }
+            }
+
+            test("playing a graveyard land consumes a land drop") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Icetill Explorer")
+                    .withCardInGraveyard(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forestId = findInGraveyard(game, 1, "Forest")
+                game.execute(PlayLand(game.player1Id, forestId))
+
+                // The additional land drop from Icetill Explorer allows one more play,
+                // but we already used the base drop; so the effective remaining is still 1
+                // (remaining = 0, static bonus = 1).  A second play uses the bonus.
+                val landDrops = game.state.getEntity(game.player1Id)?.get<LandDropsComponent>()
+                withClue("One land drop should have been consumed") {
+                    landDrops shouldNotBe null
+                    landDrops!!.remaining shouldBe 0
+                }
+            }
+
+            test("cannot play land from graveyard without Icetill Explorer") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forestId = findInGraveyard(game, 1, "Forest")
+                val result = game.execute(PlayLand(game.player1Id, forestId))
+
+                withClue("Playing land from graveyard should fail without permission") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+
+        context("Landfall — mill a card when land enters") {
+
+            test("playing a land from graveyard triggers landfall and mills one card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Icetill Explorer")
+                    .withCardInGraveyard(1, "Forest")
+                    .withCardInLibrary(1, "Forest")  // the card that will be milled
+                    .withCardInLibrary(1, "Forest")  // prevent draw-from-empty loss
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libraryBefore = game.librarySize(1)
+                val graveyardBefore = game.graveyardSize(1)
+
+                val forestId = findInGraveyard(game, 1, "Forest")
+                game.execute(PlayLand(game.player1Id, forestId))
+
+                // Landfall trigger fires — one card should be milled
+                withClue("One card should have been milled from library to graveyard") {
+                    game.librarySize(1) shouldBe libraryBefore - 1
+                    // graveyard: lost the land (played to battlefield) but gained 1 milled card
+                    game.graveyardSize(1) shouldBe graveyardBefore - 1 + 1
+                }
+            }
+        }
+
+        context("GrantAdditionalLandDrop — play two lands per turn") {
+
+            test("can play two lands per turn with Icetill Explorer") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Icetill Explorer")
+                    .withCardInGraveyard(1, "Forest")
+                    .withCardInHand(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // First land: from graveyard
+                val graveyardForest = findInGraveyard(game, 1, "Forest")
+                val result1 = game.execute(PlayLand(game.player1Id, graveyardForest))
+                withClue("First land (from graveyard) should succeed: ${result1.error}") {
+                    result1.error shouldBe null
+                }
+
+                // Second land: from hand (using the bonus land drop)
+                val handForestId = game.state.getHand(game.player1Id).find { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                }!!
+                val result2 = game.execute(PlayLand(game.player1Id, handForestId))
+                withClue("Second land (from hand via bonus drop) should succeed: ${result2.error}") {
+                    result2.error shouldBe null
+                }
+
+                // Third land should fail — no more drops
+                val handForestIds = game.state.getHand(game.player1Id).filter { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                }
+                if (handForestIds.isNotEmpty()) {
+                    val result3 = game.execute(PlayLand(game.player1Id, handForestIds.first()))
+                    withClue("Third land should fail — no more land drops") {
+                        result3.error shouldNotBe null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/IcetillExplorerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/IcetillExplorerScenarioTest.kt
@@ -70,16 +70,17 @@ class IcetillExplorerScenarioTest : ScenarioTestBase() {
                     .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
                     .build()
 
+                val landDropsBefore = game.state.getEntity(game.player1Id)?.get<LandDropsComponent>()!!.remaining
                 val forestId = findInGraveyard(game, 1, "Forest")
                 game.execute(PlayLand(game.player1Id, forestId))
 
-                // The additional land drop from Icetill Explorer allows one more play,
-                // but we already used the base drop; so the effective remaining is still 1
-                // (remaining = 0, static bonus = 1).  A second play uses the bonus.
-                val landDrops = game.state.getEntity(game.player1Id)?.get<LandDropsComponent>()
-                withClue("One land drop should have been consumed") {
-                    landDrops shouldNotBe null
-                    landDrops!!.remaining shouldBe 0
+                // Playing a land from the graveyard must consume the same `remaining` counter
+                // a hand play would: the new Crucible-style permission shortcuts the Muldrotha
+                // tracker but still routes through `landDrops.use()`.
+                val landDropsAfter = game.state.getEntity(game.player1Id)?.get<LandDropsComponent>()
+                withClue("Graveyard land play should decrement LandDropsComponent.remaining by 1") {
+                    landDropsAfter shouldNotBe null
+                    landDropsAfter!!.remaining shouldBe landDropsBefore - 1
                 }
             }
 
@@ -140,6 +141,7 @@ class IcetillExplorerScenarioTest : ScenarioTestBase() {
                     .withCardOnBattlefield(1, "Icetill Explorer")
                     .withCardInGraveyard(1, "Forest")
                     .withCardInHand(1, "Forest")
+                    .withCardInHand(1, "Forest")  // third land — should fail to play
                     .withCardInLibrary(1, "Forest")
                     .withCardInLibrary(1, "Forest")
                     .withCardInLibrary(2, "Forest")
@@ -156,24 +158,22 @@ class IcetillExplorerScenarioTest : ScenarioTestBase() {
                 }
 
                 // Second land: from hand (using the bonus land drop)
-                val handForestId = game.state.getHand(game.player1Id).find { id ->
+                val handForestId = game.state.getHand(game.player1Id).first { id ->
                     game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
-                }!!
+                }
                 val result2 = game.execute(PlayLand(game.player1Id, handForestId))
                 game.resolveStack()  // resolve second landfall trigger
                 withClue("Second land (from hand via bonus drop) should succeed: ${result2.error}") {
                     result2.error shouldBe null
                 }
 
-                // Third land should fail — no more drops
-                val handForestIds = game.state.getHand(game.player1Id).filter { id ->
+                // Third land should fail — base drop + Icetill bonus is 2 per turn, both spent.
+                val remainingForest = game.state.getHand(game.player1Id).first { id ->
                     game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
                 }
-                if (handForestIds.isNotEmpty()) {
-                    val result3 = game.execute(PlayLand(game.player1Id, handForestIds.first()))
-                    withClue("Third land should fail — no more land drops") {
-                        result3.error shouldNotBe null
-                    }
+                val result3 = game.execute(PlayLand(game.player1Id, remainingForest))
+                withClue("Third land should fail — Icetill grants exactly one extra drop") {
+                    result3.error shouldNotBe null
                 }
             }
         }

--- a/manual-scenarios/cards/i/icetill-explorer.json
+++ b/manual-scenarios/cards/i/icetill-explorer.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Forest", "Forest"],
+    "battlefield": [
+      {"name": "Icetill Explorer"},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false}
+    ],
+    "graveyard": ["Forest"],
+    "library": ["Forest", "Forest", "Forest", "Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/i/icetill-explorer.json
+++ b/manual-scenarios/cards/i/icetill-explorer.json
@@ -3,7 +3,7 @@
   "player2Name": "Bob",
   "player1": {
     "lifeTotal": 20,
-    "hand": ["Forest", "Forest"],
+    "hand": ["Forest", "Evolving Wilds"],
     "battlefield": [
       {"name": "Icetill Explorer"},
       {"name": "Forest", "tapped": false},

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -1123,6 +1123,7 @@ Set via `staticAbility { ability = ... }`:
 - `MayCastSelfFromZones(zones: List<Zone>)` — intrinsic permission to cast this card from specified zones (e.g., graveyard, exile)
 - `MayCastFromGraveyardWithLifeCost(filter, lifeCost, duringYourTurnOnly)` — controller may cast matching spells from graveyard by paying life (e.g., Festival of Embers)
 - `MayPlayPermanentsFromGraveyard` — during each of your turns, play a land and cast a permanent spell of each type from your graveyard (Muldrotha). Tracks per-type usage via `GraveyardPlayPermissionUsedComponent` on the source permanent, cleared at end of turn.
+- `MayPlayLandsFromGraveyard` — you may play lands from your graveyard (Crucible of Worlds / Icetill Explorer style). No per-turn usage tracking; the land-drop counter already limits plays. Handled by `PlayLandEnumerator` and `PlayLandHandler` via `hasLandGraveyardPlayPermission()` — no interaction with `GraveyardPlayPermissionUsedComponent`.
 - `GrantMayCastFromLinkedExile(filter, duringYourTurnOnly = false, additionalCost = null)` — you may cast cards exiled with this permanent that match the filter (Rona, Disciple of Gix). `duringYourTurnOnly` restricts the permission to the controller's turn; `additionalCost` (any `AdditionalCost`) must be paid alongside the spell's normal costs (e.g., Dawnhand Dissident's `RemoveCountersFromYourCreatures(3)`). Works with `LinkedExileComponent`.
 - `LookAtFaceDownCreatures` — look at face-down creatures you don't control any time
 - `PreventCycling` — players can't cycle cards

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -267,6 +267,21 @@ data object MayPlayPermanentsFromGraveyard : StaticAbility {
 }
 
 /**
+ * You may play lands from your graveyard.
+ * Used for Crucible of Worlds / Icetill Explorer style effects.
+ *
+ * Unlike [MayPlayPermanentsFromGraveyard] (Muldrotha), no per-turn usage tracking
+ * is needed — the land-drop counter already limits how many lands can be played.
+ * Multiple copies are redundant.
+ */
+@SerialName("MayPlayLandsFromGraveyard")
+@Serializable
+data object MayPlayLandsFromGraveyard : StaticAbility {
+    override val description: String = "You may play lands from your graveyard"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}
+
+/**
  * Prevents all players from cycling cards.
  * Used for Stabilizer: "Players can't cycle cards."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/IcetillExplorer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/IcetillExplorer.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantAdditionalLandDrop
+import com.wingedsheep.sdk.scripting.MayPlayLandsFromGraveyard
+
+/**
+ * Icetill Explorer
+ * {2}{G}{G}
+ * Creature — Insect Scout
+ * You may play an additional land on each of your turns.
+ * You may play lands from your graveyard.
+ * Landfall — Whenever a land you control enters, mill a card.
+ * 2/4
+ */
+val IcetillExplorer = card("Icetill Explorer") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect Scout"
+    power = 2
+    toughness = 4
+    oracleText = "You may play an additional land on each of your turns.\nYou may play lands from your graveyard.\nLandfall — Whenever a land you control enters, mill a card."
+
+    staticAbility {
+        ability = GrantAdditionalLandDrop(count = 1)
+    }
+
+    staticAbility {
+        ability = MayPlayLandsFromGraveyard
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = EffectPatterns.mill(1)
+        description = "Landfall — Whenever a land you control enters, mill a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "192"
+        artist = "Warren Mahy"
+        flavorText = "\"Come! Join me in the sun!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d9482aab-6ddf-48e1-84fa-b13d5ff81e69.jpg?1752947338"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.scripting.ChoiceType
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.MayPlayLandsFromGraveyard
 import com.wingedsheep.sdk.scripting.MayPlayPermanentsFromGraveyard
 import com.wingedsheep.engine.legalactions.utils.LandDropUtils
 import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
@@ -371,8 +372,9 @@ class PlayLandHandler(
     }
 
     /**
-     * Check if a land card is in the player's graveyard and there's a Muldrotha-like permanent
-     * with unused land permission.
+     * Check if a land card is in the player's graveyard and there's permission to play it.
+     * Handles both Crucible-style (MayPlayLandsFromGraveyard, no usage tracking) and
+     * Muldrotha-style (MayPlayPermanentsFromGraveyard, per-type usage tracked).
      */
     private fun isInGraveyardWithPlayPermission(
         state: GameState,
@@ -381,7 +383,21 @@ class PlayLandHandler(
     ): Boolean {
         val graveyardZone = ZoneKey(playerId, Zone.GRAVEYARD)
         if (cardId !in state.getZone(graveyardZone)) return false
+        if (hasLandGraveyardPlayPermission(state, playerId)) return true
         return findGraveyardPlayPermissionSource(state, playerId, CardType.LAND.name) != null
+    }
+
+    /**
+     * Returns true if the player controls a permanent with [MayPlayLandsFromGraveyard]
+     * (Crucible of Worlds style — no per-turn usage tracking needed).
+     */
+    private fun hasLandGraveyardPlayPermission(state: GameState, playerId: EntityId): Boolean {
+        for (entityId in state.getBattlefield(playerId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            if (cardDef.script.staticAbilities.any { it is MayPlayLandsFromGraveyard }) return true
+        }
+        return false
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.ExtraLoyaltyActivation
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
+import com.wingedsheep.sdk.scripting.MayPlayLandsFromGraveyard
 import com.wingedsheep.sdk.scripting.MayPlayPermanentsFromGraveyard
 import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
@@ -242,6 +243,10 @@ class CastPermissionUtils(
                 if (tracker == null || !tracker.hasUsedType(typeName)) {
                     return true
                 }
+            }
+            // Crucible of Worlds style: unlimited land plays from graveyard (land-drop is the limit)
+            if (typeName == "LAND" && cardDef.script.staticAbilities.any { it is MayPlayLandsFromGraveyard }) {
+                return true
             }
         }
         return false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -245,7 +245,9 @@ class CastPermissionUtils(
                 }
             }
             // Crucible of Worlds style: unlimited land plays from graveyard (land-drop is the limit)
-            if (typeName == "LAND" && cardDef.script.staticAbilities.any { it is MayPlayLandsFromGraveyard }) {
+            if (typeName == com.wingedsheep.sdk.core.CardType.LAND.name &&
+                cardDef.script.staticAbilities.any { it is MayPlayLandsFromGraveyard }
+            ) {
                 return true
             }
         }

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -641,6 +641,9 @@ export function useGhostCards(playerId: EntityId | null): readonly ClientCard[] 
           if (!gyCardIds.has(action.cardId)) continue
           if (actionInfo.isAffordable === false) continue
           ghostCardIds.add(action.cardId)
+        } else if (action.type === 'PlayLand' && actionInfo.sourceZone === 'GRAVEYARD') {
+          if (!gyCardIds.has(action.cardId)) continue
+          ghostCardIds.add(action.cardId)
         }
       }
     }


### PR DESCRIPTION
Introduces the MayPlayLandsFromGraveyard static ability (Crucible of Worlds style):
lands in the graveyard can be played as though from hand, consuming the normal land
drop with no additional per-turn tracking. PlayLandHandler and CastPermissionUtils
both recognise the new ability independently of the Muldrotha (MayPlayPermanentsFromGraveyard)
path, so Icetill Explorer's graveyard play is unlimited within the land-drop budget.

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>