### PR TITLE
Add Tapestry Warden to Edge of Eternities with global toughness-as-damage and station support

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 166 / 261
+**Implemented:** 167 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -227,7 +227,7 @@
 - [x] Systems Override
 - [x] Tannuk, Memorial Ensign
 - [ ] Tannuk, Steadfast Second
-- [ ] Tapestry Warden
+- [x] Tapestry Warden
 - [x] Temporal Intervention
 - [ ] Terminal Velocity
 - [ ] Terrapact Intimidator

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -97,9 +97,6 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 ## up to one other target artifact you control becomes an artifact creature with base power and toughness 2/2 and gains flying until end of turn
 - [ ] Synthesizer Labship
 
-## power stations permanents using its toughness rather than its power
-- [ ] Tapestry Warden
-
 ## If the amount of mana spent to cast that spell was less than its mana value, you draw a card.
 - [ ] Unravel
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TapestryWardenScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TapestryWardenScenarioTest.kt
@@ -1,12 +1,15 @@
 package com.wingedsheep.gameserver.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.AbilityCost
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 
@@ -21,6 +24,21 @@ import io.kotest.matchers.shouldBe
  * using its toughness rather than its power.
  */
 class TapestryWardenScenarioTest : ScenarioTestBase() {
+
+    /**
+     * Manually wire an Aura that's already on the battlefield onto a target permanent.
+     * `In Bolas's Clutches` grants control via Layer 2; once attached, projected state
+     * reports the Aura's controller as the controller of the enchanted permanent.
+     */
+    private fun ScenarioTestBase.TestGame.attachTo(attachmentName: String, targetName: String) {
+        val attachmentId = findPermanent(attachmentName)!!
+        val targetId = findPermanent(targetName)!!
+        val attachment = state.getEntity(attachmentId)!!.with(AttachedToComponent(targetId))
+        state = state.withEntity(attachmentId, attachment)
+        val target = state.getEntity(targetId)!!
+        val existing = target.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        state = state.withEntity(targetId, target.with(AttachmentsComponent(existing + attachmentId)))
+    }
 
     init {
         context("Tapestry Warden — assigns damage as toughness") {
@@ -78,6 +96,32 @@ class TapestryWardenScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("stolen 1/2 creature assigns toughness damage — exercises projected controller") {
+                // Player 2 owns Devoted Hero; In Bolas's Clutches transfers control to player 1.
+                // Tapestry Warden's "creatures you control" filter must read the projected
+                // controller (player 1) of Devoted Hero, not its base ControllerComponent
+                // (still player 2), or the toughness-as-damage substitution silently drops.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Devoted Hero", summoningSickness = false) // owned by p2
+                    .withCardOnBattlefield(1, "In Bolas's Clutches")
+                    .withActivePlayer(1)
+                    .withLifeTotal(2, 20)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.attachTo("In Bolas's Clutches", "Devoted Hero")
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                game.declareAttackers(mapOf("Devoted Hero" to 2))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Stolen Devoted Hero (1/2) should deal 2 (toughness) damage under Tapestry Warden's effect") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+            }
+
             test("ability only applies to controller's creatures, not opponent's") {
                 val game = scenario()
                     .withPlayers("Player", "Opponent")
@@ -110,7 +154,7 @@ class TapestryWardenScenarioTest : ScenarioTestBase() {
                     .build()
 
                 val stationAbility = cardRegistry.getCard("Debris Field Crusher")!!
-                    .script.activatedAbilities.first()
+                    .script.activatedAbilities.first { it.cost is AbilityCost.TapPermanents }
                 val crusherId = game.findPermanent("Debris Field Crusher")!!
                 val devotedHeroId = game.findPermanent("Devoted Hero")!!
 
@@ -133,6 +177,48 @@ class TapestryWardenScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("stolen 1/2 creature stations using its toughness — exercises projected controller") {
+                // Tapestry Warden, Debris Field Crusher, and In Bolas's Clutches all start under
+                // player 1's control. Player 2's Devoted Hero is "stolen" via the Aura, so its
+                // projected controller is player 1 even though its base ControllerComponent
+                // still points at player 2. Reading base controllers in the station-toughness
+                // lookup would miss this and put only 1 charge counter on the Spacecraft.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Devoted Hero", summoningSickness = false) // owned by p2
+                    .withCardOnBattlefield(1, "Debris Field Crusher")
+                    .withCardOnBattlefield(1, "In Bolas's Clutches")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.attachTo("In Bolas's Clutches", "Devoted Hero")
+
+                val stationAbility = cardRegistry.getCard("Debris Field Crusher")!!
+                    .script.activatedAbilities.first { it.cost is AbilityCost.TapPermanents }
+                val crusherId = game.findPermanent("Debris Field Crusher")!!
+                val devotedHeroId = game.findPermanent("Devoted Hero")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crusherId,
+                        abilityId = stationAbility.id,
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(devotedHeroId))
+                    )
+                )
+                withClue("Station activation should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                val counters = game.state.getEntity(crusherId)?.get<CountersComponent>()
+                withClue("Stolen Devoted Hero should contribute 2 charge counters (toughness) under projected controller") {
+                    counters?.getCount(CounterType.CHARGE) shouldBe 2
+                }
+            }
+
             test("without Tapestry Warden, 1/2 creature contributes only 1 (power) charge counter") {
                 val game = scenario()
                     .withPlayers("Player", "Opponent")
@@ -143,7 +229,7 @@ class TapestryWardenScenarioTest : ScenarioTestBase() {
                     .build()
 
                 val stationAbility = cardRegistry.getCard("Debris Field Crusher")!!
-                    .script.activatedAbilities.first()
+                    .script.activatedAbilities.first { it.cost is AbilityCost.TapPermanents }
                 val crusherId = game.findPermanent("Debris Field Crusher")!!
                 val devotedHeroId = game.findPermanent("Devoted Hero")!!
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TapestryWardenScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TapestryWardenScenarioTest.kt
@@ -1,8 +1,12 @@
 package com.wingedsheep.gameserver.scenarios
 
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 
@@ -25,13 +29,12 @@ class TapestryWardenScenarioTest : ScenarioTestBase() {
                 val game = scenario()
                     .withPlayers("Player", "Opponent")
                     .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
-                    .withCardOnBattlefield(1, "Devoted Hero", summoningSickness = false) // 1/2 (T=2 > P=1)
+                    .withCardOnBattlefield(1, "Devoted Hero", summoningSickness = false) // 1/2 (T > P)
                     .withActivePlayer(1)
                     .withLifeTotal(2, 20)
                     .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
                     .build()
 
-                // Devoted Hero: 1/2, toughness > power → assigns 2 damage
                 game.declareAttackers(mapOf("Devoted Hero" to 2))
                 game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
 
@@ -61,7 +64,7 @@ class TapestryWardenScenarioTest : ScenarioTestBase() {
                 val game = scenario()
                     .withPlayers("Player", "Opponent")
                     .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
-                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2 (T=P)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2 (T == P)
                     .withActivePlayer(1)
                     .withLifeTotal(2, 20)
                     .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
@@ -85,12 +88,78 @@ class TapestryWardenScenarioTest : ScenarioTestBase() {
                     .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
                     .build()
 
-                // Opponent's 1/2 attacks — Tapestry Warden does NOT apply to opponent's creatures
                 game.declareAttackers(mapOf("Devoted Hero" to 1))
                 game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
 
                 withClue("Opponent's 1/2 Devoted Hero should deal 1 (power) damage, not 2 (toughness)") {
                     game.getLifeTotal(1) shouldBe 19
+                }
+            }
+        }
+
+        context("Tapestry Warden — stations using toughness") {
+
+            test("1/2 creature contributes 2 (toughness) charge counters when stationing with Tapestry Warden in play") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Devoted Hero", summoningSickness = false) // 1/2 tapper
+                    .withCardOnBattlefield(1, "Debris Field Crusher") // the Spacecraft being stationed
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stationAbility = cardRegistry.getCard("Debris Field Crusher")!!
+                    .script.activatedAbilities.first()
+                val crusherId = game.findPermanent("Debris Field Crusher")!!
+                val devotedHeroId = game.findPermanent("Devoted Hero")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crusherId,
+                        abilityId = stationAbility.id,
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(devotedHeroId))
+                    )
+                )
+                withClue("Station activation should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                val counters = game.state.getEntity(crusherId)?.get<CountersComponent>()
+                withClue("Debris Field Crusher should have 2 charge counters (Devoted Hero toughness), not 1 (power)") {
+                    counters?.getCount(CounterType.CHARGE) shouldBe 2
+                }
+            }
+
+            test("without Tapestry Warden, 1/2 creature contributes only 1 (power) charge counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Devoted Hero", summoningSickness = false) // 1/2 tapper
+                    .withCardOnBattlefield(1, "Debris Field Crusher")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stationAbility = cardRegistry.getCard("Debris Field Crusher")!!
+                    .script.activatedAbilities.first()
+                val crusherId = game.findPermanent("Debris Field Crusher")!!
+                val devotedHeroId = game.findPermanent("Devoted Hero")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crusherId,
+                        abilityId = stationAbility.id,
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(devotedHeroId))
+                    )
+                )
+                game.resolveStack()
+
+                val counters = game.state.getEntity(crusherId)?.get<CountersComponent>()
+                withClue("Without Tapestry Warden, Debris Field Crusher should have 1 charge counter (power)") {
+                    counters?.getCount(CounterType.CHARGE) shouldBe 1
                 }
             }
         }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TapestryWardenScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TapestryWardenScenarioTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.gameserver.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
@@ -8,6 +9,7 @@ import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import com.wingedsheep.sdk.scripting.AbilityCost
 import io.kotest.assertions.withClue
@@ -216,6 +218,112 @@ class TapestryWardenScenarioTest : ScenarioTestBase() {
                 val counters = game.state.getEntity(crusherId)?.get<CountersComponent>()
                 withClue("Stolen Devoted Hero should contribute 2 charge counters (toughness) under projected controller") {
                     counters?.getCount(CounterType.CHARGE) shouldBe 2
+                }
+            }
+
+            test("tapped creature that left the battlefield still contributes toughness (last known information)") {
+                // Per the 2025-07-25 ruling: "If a station ability you control resolves while you
+                // control Tapestry Warden, but the creature tapped to pay the cost of that station
+                // ability is no longer on the battlefield, check the characteristics of that creature
+                // as it last existed on the battlefield. If its toughness was greater than its power,
+                // use its toughness to determine how many counters are put on the permanent with
+                // station."
+                //
+                // Simulates Devoted Hero (1/2) being killed in response to the station activation —
+                // by manually moving it from battlefield to graveyard while the station ability is
+                // on the stack. The station should still place 2 charge counters (its LKI toughness).
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Devoted Hero", summoningSickness = false) // 1/2 tapper
+                    .withCardOnBattlefield(1, "Debris Field Crusher")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stationAbility = cardRegistry.getCard("Debris Field Crusher")!!
+                    .script.activatedAbilities.first { it.cost is AbilityCost.TapPermanents }
+                val crusherId = game.findPermanent("Debris Field Crusher")!!
+                val devotedHeroId = game.findPermanent("Devoted Hero")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crusherId,
+                        abilityId = stationAbility.id,
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(devotedHeroId))
+                    )
+                )
+                withClue("Station activation should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                // Simulate Devoted Hero being killed in response (e.g., a Lightning Bolt) — it
+                // leaves the battlefield before the station ability resolves.
+                game.state = game.state.moveToZone(
+                    devotedHeroId,
+                    ZoneKey(game.player1Id, Zone.BATTLEFIELD),
+                    ZoneKey(game.player1Id, Zone.GRAVEYARD)
+                )
+
+                game.resolveStack()
+
+                val counters = game.state.getEntity(crusherId)?.get<CountersComponent>()
+                withClue("Tapped creature left the battlefield; per LKI ruling Crusher should still get 2 charge counters (toughness), not 1 (power) or 0") {
+                    counters?.getCount(CounterType.CHARGE) shouldBe 2
+                }
+            }
+
+            test("losing control of Tapestry Warden mid-resolution drops back to power") {
+                // Per the 2025-07-25 ruling: "If you activate a station ability while you control
+                // Tapestry Warden, but you no longer control Tapestry Warden at the time that
+                // ability resolves, use the power of the creature tapped to pay the cost of the
+                // station ability to determine how many counters are put on the permanent with
+                // station."
+                //
+                // Simulates removing Tapestry Warden after the station ability is on the stack:
+                // the override evaluator checks the current battlefield at resolution time, so the
+                // tapped 1/2 should now contribute 1 (power) charge counter.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Devoted Hero", summoningSickness = false) // 1/2 tapper
+                    .withCardOnBattlefield(1, "Debris Field Crusher")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stationAbility = cardRegistry.getCard("Debris Field Crusher")!!
+                    .script.activatedAbilities.first { it.cost is AbilityCost.TapPermanents }
+                val crusherId = game.findPermanent("Debris Field Crusher")!!
+                val wardenId = game.findPermanent("Tapestry Warden")!!
+                val devotedHeroId = game.findPermanent("Devoted Hero")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crusherId,
+                        abilityId = stationAbility.id,
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(devotedHeroId))
+                    )
+                )
+                withClue("Station activation should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                // Remove Tapestry Warden from the battlefield before resolution (e.g., destroyed in
+                // response). The toughness-substitution should no longer apply.
+                game.state = game.state.moveToZone(
+                    wardenId,
+                    ZoneKey(game.player1Id, Zone.BATTLEFIELD),
+                    ZoneKey(game.player1Id, Zone.GRAVEYARD)
+                )
+
+                game.resolveStack()
+
+                val counters = game.state.getEntity(crusherId)?.get<CountersComponent>()
+                withClue("Tapestry Warden gone at resolution; Crusher should get 1 charge counter (power), not 2 (toughness)") {
+                    counters?.getCount(CounterType.CHARGE) shouldBe 1
                 }
             }
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TapestryWardenScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TapestryWardenScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Tapestry Warden (EOE).
+ *
+ * Tapestry Warden: {3}{G} Artifact Creature — Robot Soldier 3/4
+ * Vigilance
+ * Each creature you control with toughness greater than its power assigns combat damage
+ * equal to its toughness rather than its power.
+ * Each creature you control with toughness greater than its power stations permanents
+ * using its toughness rather than its power.
+ */
+class TapestryWardenScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Tapestry Warden — assigns damage as toughness") {
+
+            test("1/2 creature assigns 2 (toughness) damage when Tapestry Warden is in play") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Devoted Hero", summoningSickness = false) // 1/2 (T=2 > P=1)
+                    .withActivePlayer(1)
+                    .withLifeTotal(2, 20)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                // Devoted Hero: 1/2, toughness > power → assigns 2 damage
+                game.declareAttackers(mapOf("Devoted Hero" to 2))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Defending player should have taken 2 (toughness of 1/2 Devoted Hero) damage") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+            }
+
+            test("Tapestry Warden itself (3/4, T > P) assigns 4 (toughness) damage") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .withLifeTotal(2, 20)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Tapestry Warden" to 2))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Tapestry Warden (3/4) should assign 4 (its toughness) damage") {
+                    game.getLifeTotal(2) shouldBe 16
+                }
+            }
+
+            test("creature with power >= toughness is not affected (still uses power)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2 (T=P)
+                    .withActivePlayer(1)
+                    .withLifeTotal(2, 20)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Grizzly Bears (2/2, T == P) should still deal 2 (power) damage") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+            }
+
+            test("ability only applies to controller's creatures, not opponent's") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tapestry Warden", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Devoted Hero", summoningSickness = false) // opponent's 1/2
+                    .withActivePlayer(2)
+                    .withLifeTotal(1, 20)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                // Opponent's 1/2 attacks — Tapestry Warden does NOT apply to opponent's creatures
+                game.declareAttackers(mapOf("Devoted Hero" to 1))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Opponent's 1/2 Devoted Hero should deal 1 (power) damage, not 2 (toughness)") {
+                    game.getLifeTotal(1) shouldBe 19
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/t/tapestry-warden.json
+++ b/manual-scenarios/cards/t/tapestry-warden.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Tapestry Warden", "summoningSickness": false},
+      {"name": "Devoted Hero", "summoningSickness": false},
+      {"name": "Debris Field Crusher", "summoningSickness": false},
+      {"name": "Grizzly Bears", "summoningSickness": false},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -1087,7 +1087,7 @@ Set via `staticAbility { ability = ... }`:
 ### Damage
 
 - `AssignDamageEqualToToughness(filter, onlyWhenToughnessGreaterThanPower)` — assigns combat damage as toughness; use `Scope.Self` for the creature itself, `Scope.AttachedTo` for equipment/aura, `Scope.Battlefield` for global permanents (Tapestry Warden)
-- `StationUsingToughness(filter: GroupFilter)` — creatures matching filter tap for their toughness (rather than power) when stationing, as long as toughness > power (Tapestry Warden)
+- `StationUsingToughness` — marker static ability: while a permanent with this is in play, creatures its controller controls contribute toughness instead of power when tapped to pay a Station cost, as long as toughness > power. Engine pairs it with `DynamicAmount.StationTapPower` in the Station ability's tap-as-cost formula (Tapestry Warden)
 - `DivideCombatDamageFreely(target)` — divide damage freely
 - `AssignCombatDamageAsUnblocked(target)` — may assign combat damage as though unblocked (Thorn Elemental)
 

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -1086,7 +1086,8 @@ Set via `staticAbility { ability = ... }`:
 
 ### Damage
 
-- `AssignDamageEqualToToughness(target, onlyWhenToughnessGreaterThanPower)` — Doran
+- `AssignDamageEqualToToughness(filter, onlyWhenToughnessGreaterThanPower)` — assigns combat damage as toughness; use `Scope.Self` for the creature itself, `Scope.AttachedTo` for equipment/aura, `Scope.Battlefield` for global permanents (Tapestry Warden)
+- `StationUsingToughness(filter: GroupFilter)` — creatures matching filter tap for their toughness (rather than power) when stationing, as long as toughness > power (Tapestry Warden)
 - `DivideCombatDamageFreely(target)` — divide damage freely
 - `AssignCombatDamageAsUnblocked(target)` — may assign combat damage as though unblocked (Thorn Elemental)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -100,24 +100,23 @@ data class AssignDamageEqualToToughness(
 }
 
 /**
- * Creatures matching [filter] that are tapped to activate a Station ability contribute
- * their toughness (rather than their power) as long as their toughness is greater than
- * their power.
+ * Creatures this permanent's controller controls that are tapped to activate a Station
+ * ability contribute their toughness (rather than their power), as long as toughness
+ * is greater than power.
+ *
+ * The engine enforces this via [GrantsStationUsingToughnessComponent]: all permanents
+ * of the same controller are checked — a more restrictive per-creature filter is not
+ * currently supported.
  *
  * Used for Tapestry Warden: "Each creature you control with toughness greater than its
  * power stations permanents using its toughness rather than its power."
  */
 @SerialName("StationUsingToughness")
 @Serializable
-data class StationUsingToughness(
-    val filter: GroupFilter = GroupFilter.AllCreaturesYouControl,
-) : StaticAbility {
+data object StationUsingToughness : StaticAbility {
     override val description: String =
         "Each creature you control with toughness greater than its power stations permanents using its toughness rather than its power"
-    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
-        val newFilter = filter.applyTextReplacement(replacer)
-        return if (newFilter !== filter) copy(filter = newFilter) else this
-    }
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -100,6 +100,27 @@ data class AssignDamageEqualToToughness(
 }
 
 /**
+ * Creatures matching [filter] that are tapped to activate a Station ability contribute
+ * their toughness (rather than their power) as long as their toughness is greater than
+ * their power.
+ *
+ * Used for Tapestry Warden: "Each creature you control with toughness greater than its
+ * power stations permanents using its toughness rather than its power."
+ */
+@SerialName("StationUsingToughness")
+@Serializable
+data class StationUsingToughness(
+    val filter: GroupFilter = GroupFilter.AllCreaturesYouControl,
+) : StaticAbility {
+    override val description: String =
+        "Each creature you control with toughness greater than its power stations permanents using its toughness rather than its power"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * This creature's combat damage may be divided as its controller chooses among
  * the defending player and/or any number of creatures they control.
  * Used for Butcher Orgg.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -652,6 +652,23 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
     }
 
+    /**
+     * The "input value" a creature contributes when tapped to pay a Station ability cost.
+     *
+     * Reads projected power of [entity] (typically [EntityReference.TappedAsCost]) — unless
+     * the entity's controller has a permanent with `StationUsingToughness` and the creature's
+     * toughness exceeds its power, in which case toughness is returned. Keeps the Station-
+     * specific override out of the generic [EntityProperty] evaluator.
+     */
+    @SerialName("StationTapPower")
+    @Serializable
+    data class StationTapPower(
+        val entity: EntityReference = EntityReference.TappedAsCost(0)
+    ) : DynamicAmount {
+        override val description: String = "${entity.description}'s power"
+        override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
+    }
+
     // =========================================================================
     // Division
     // =========================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AdagiaWindsweptBastion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AdagiaWindsweptBastion.kt
@@ -56,10 +56,7 @@ val AdagiaWindsweptBastion = card("Adagia, Windswept Bastion") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = com.wingedsheep.sdk.scripting.targets.EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AtmosphericGreenhouse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AtmosphericGreenhouse.kt
@@ -57,10 +57,7 @@ val AtmosphericGreenhouse = card("Atmospheric Greenhouse") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DawnsireSunstarDreadnought.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DawnsireSunstarDreadnought.kt
@@ -48,10 +48,7 @@ val DawnsireSunstarDreadnought = card("Dawnsire, Sunstar Dreadnought") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DebrisFieldCrusher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DebrisFieldCrusher.kt
@@ -56,10 +56,7 @@ val DebrisFieldCrusher = card("Debris Field Crusher") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/EvendoWakingHaven.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/EvendoWakingHaven.kt
@@ -52,10 +52,7 @@ val EvendoWakingHaven = card("Evendo, Waking Haven") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ExtinguisherBattleship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ExtinguisherBattleship.kt
@@ -67,10 +67,7 @@ val ExtinguisherBattleship = card("Extinguisher Battleship") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FellGravship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FellGravship.kt
@@ -98,10 +98,7 @@ val FellGravship = card("Fell Gravship") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GalvanizingSawship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GalvanizingSawship.kt
@@ -45,10 +45,7 @@ val GalvanizingSawship = card("Galvanizing Sawship") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LumenClassFrigate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LumenClassFrigate.kt
@@ -47,10 +47,7 @@ val LumenClassFrigate = card("Lumen-Class Frigate") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PinnacleKillShip.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PinnacleKillShip.kt
@@ -54,10 +54,7 @@ val PinnacleKillShip = card("Pinnacle Kill-Ship") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SledgeClassSeedship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SledgeClassSeedship.kt
@@ -49,10 +49,7 @@ val SledgeClassSeedship = card("Sledge-Class Seedship") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SpecimenFreighter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SpecimenFreighter.kt
@@ -69,10 +69,7 @@ val SpecimenFreighter = card("Specimen Freighter") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SusurianDirgecraft.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SusurianDirgecraft.kt
@@ -56,10 +56,7 @@ val SusurianDirgecraft = card("Susurian Dirgecraft") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TapestryWarden.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TapestryWarden.kt
@@ -40,9 +40,7 @@ val TapestryWarden = card("Tapestry Warden") {
     }
 
     staticAbility {
-        ability = StationUsingToughness(
-            filter = GroupFilter.AllCreaturesYouControl,
-        )
+        ability = StationUsingToughness
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TapestryWarden.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TapestryWarden.kt
@@ -49,5 +49,17 @@ val TapestryWarden = card("Tapestry Warden") {
         artist = "Andreas Zafiratos"
         flavorText = "Drix never leave their worlds defenseless."
         imageUri = "https://cards.scryfall.io/normal/front/7/c/7cbbab6c-43ae-4e50-97ce-532a3316591a.jpg?1752947411"
+        ruling(
+            "2025-07-25",
+            "Tapestry Warden's second and third abilities don't actually change any creature's power. They change only the amount of combat damage the creature assigns and how many counters are put on a permanent with station when the creature is tapped to pay the cost of a station ability. All other rules and effects that check power or toughness use the real values, even if they cause damage \"equal to a creature's power\" to be dealt."
+        )
+        ruling(
+            "2025-07-25",
+            "If a station ability you control resolves while you control Tapestry Warden, but the creature tapped to pay the cost of that station ability is no longer on the battlefield, check the characteristics of that creature as it last existed on the battlefield. If its toughness was greater than its power, use its toughness to determine how many counters are put on the permanent with station."
+        )
+        ruling(
+            "2025-07-25",
+            "If you activate a station ability while you control Tapestry Warden, but you no longer control Tapestry Warden at the time that ability resolves, use the power of the creature tapped to pay the cost of the station ability to determine how many counters are put on the permanent with station."
+        )
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TapestryWarden.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TapestryWarden.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AssignDamageEqualToToughness
+import com.wingedsheep.sdk.scripting.StationUsingToughness
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tapestry Warden
+ * {3}{G}
+ * Artifact Creature — Robot Soldier
+ * 3/4
+ * Vigilance
+ * Each creature you control with toughness greater than its power assigns combat damage
+ * equal to its toughness rather than its power.
+ * Each creature you control with toughness greater than its power stations permanents
+ * using its toughness rather than its power.
+ */
+val TapestryWarden = card("Tapestry Warden") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact Creature — Robot Soldier"
+    power = 3
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "Each creature you control with toughness greater than its power assigns combat damage " +
+        "equal to its toughness rather than its power.\n" +
+        "Each creature you control with toughness greater than its power stations permanents " +
+        "using its toughness rather than its power."
+
+    keywords(Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = AssignDamageEqualToToughness(
+            filter = GroupFilter.AllCreaturesYouControl,
+            onlyWhenToughnessGreaterThanPower = true,
+        )
+    }
+
+    staticAbility {
+        ability = StationUsingToughness(
+            filter = GroupFilter.AllCreaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "209"
+        artist = "Andreas Zafiratos"
+        flavorText = "Drix never leave their worlds defenseless."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7cbbab6c-43ae-4e50-97ce-532a3316591a.jpg?1752947411"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/UthrosScanship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/UthrosScanship.kt
@@ -53,10 +53,7 @@ val UthrosScanship = card("Uthros Scanship") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/WedgelightRammer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/WedgelightRammer.kt
@@ -62,10 +62,7 @@ val WedgelightRammer = card("Wedgelight Rammer") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/WurmwallSweeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/WurmwallSweeper.kt
@@ -53,10 +53,7 @@ val WurmwallSweeper = card("Wurmwall Sweeper") {
         )
         effect = Effects.AddDynamicCounters(
             counterType = Counters.CHARGE,
-            amount = DynamicAmount.EntityProperty(
-                entity = EntityReference.TappedAsCost(),
-                numericProperty = EntityNumericProperty.Power
-            ),
+            amount = DynamicAmount.StationTapPower(),
             target = EffectTarget.Self
         )
         timing = TimingRule.SorcerySpeed

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -313,6 +313,7 @@ val engineSerializersModule = SerializersModule {
         subclass(GrantsCantLoseGameComponent::class)
         subclass(GrantsControllerHexproofComponent::class)
         subclass(GrantsControllerShroudComponent::class)
+        subclass(GrantsStationUsingToughnessComponent::class)
         subclass(SuppressesHexproofForGroupComponent::class)
         subclass(SuppressesWardForGroupComponent::class)
         subclass(GraveyardEntryTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -169,18 +169,18 @@ class DynamicAmountEvaluator(
                     }
                     return resolveNumericProperty(state, entityId, amount.numericProperty, context, useProjected = false)
                 }
-                // Station mechanic override: when tapping a creature as cost for a Station
-                // ability and the controller has StationUsingToughness in play, use toughness
-                // instead of power if toughness > power.
-                if (amount.entity is EntityReference.TappedAsCost && amount.numericProperty is EntityNumericProperty.Power) {
-                    val power = resolveNumericProperty(state, entityId, EntityNumericProperty.Power, context, useProjected = true, explicitProjected = projectedState)
-                    val toughness = resolveNumericProperty(state, entityId, EntityNumericProperty.Toughness, context, useProjected = true, explicitProjected = projectedState)
-                    if (toughness > power && controllerHasStationUsingToughness(state, entityId)) {
-                        return toughness
-                    }
-                    return power
-                }
                 resolveNumericProperty(state, entityId, amount.numericProperty, context, useProjected = true, explicitProjected = projectedState)
+            }
+
+            // Station mechanic input value: projected power of the referenced entity,
+            // substituting toughness when the entity's controller has StationUsingToughness
+            // in play and toughness > power. Kept off the generic EntityProperty path so the
+            // override never leaks into unrelated "tapped creature's power" reads.
+            is DynamicAmount.StationTapPower -> {
+                val entityId = resolveEntityId(amount.entity, context) ?: return 0
+                val power = resolveNumericProperty(state, entityId, EntityNumericProperty.Power, context, useProjected = true, explicitProjected = projectedState)
+                val toughness = resolveNumericProperty(state, entityId, EntityNumericProperty.Toughness, context, useProjected = true, explicitProjected = projectedState)
+                if (toughness > power && controllerHasStationUsingToughness(state, entityId)) toughness else power
             }
 
             is DynamicAmount.Divide -> {
@@ -640,14 +640,16 @@ class DynamicAmountEvaluator(
     /**
      * Returns true if any permanent controlled by [entityId]'s controller has the
      * [GrantsStationUsingToughnessComponent], enabling the creature to station using
-     * toughness instead of power.
+     * toughness instead of power. Reads projected controllers (Rule 613) so the
+     * effect survives control-changing continuous effects on either permanent.
      */
     private fun controllerHasStationUsingToughness(state: GameState, entityId: EntityId): Boolean {
-        val controller = state.getEntity(entityId)?.get<ControllerComponent>()?.playerId ?: return false
+        val projected = state.projectedState
+        val controller = projected.getController(entityId) ?: return false
         return state.getBattlefield().any { permanentId ->
             val perm = state.getEntity(permanentId) ?: return@any false
             perm.has<GrantsStationUsingToughnessComponent>() &&
-                perm.get<ControllerComponent>()?.playerId == controller
+                projected.getController(permanentId) == controller
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -176,11 +176,22 @@ class DynamicAmountEvaluator(
             // substituting toughness when the entity's controller has StationUsingToughness
             // in play and toughness > power. Kept off the generic EntityProperty path so the
             // override never leaks into unrelated "tapped creature's power" reads.
+            //
+            // If the tapped creature has left the battlefield since the cost was paid (e.g.,
+            // killed in response to the station ability), fall back to the snapshot captured
+            // at activation time — Rule 112.7a "as it last existed on the battlefield"
+            // (Tapestry Warden 2025-07-25 ruling).
             is DynamicAmount.StationTapPower -> {
                 val entityId = resolveEntityId(amount.entity, context) ?: return 0
-                val power = resolveNumericProperty(state, entityId, EntityNumericProperty.Power, context, useProjected = true, explicitProjected = projectedState)
-                val toughness = resolveNumericProperty(state, entityId, EntityNumericProperty.Toughness, context, useProjected = true, explicitProjected = projectedState)
-                if (toughness > power && controllerHasStationUsingToughness(state, entityId)) toughness else power
+                val onBattlefield = state.getBattlefield().contains(entityId)
+                val snapshot = if (!onBattlefield) {
+                    context.tappedPermanentSnapshots.firstOrNull { it.entityId == entityId }
+                } else null
+                val power = snapshot?.power
+                    ?: resolveNumericProperty(state, entityId, EntityNumericProperty.Power, context, useProjected = true, explicitProjected = projectedState)
+                val toughness = snapshot?.toughness
+                    ?: resolveNumericProperty(state, entityId, EntityNumericProperty.Toughness, context, useProjected = true, explicitProjected = projectedState)
+                if (toughness > power && controllerHasStationUsingToughness(state, entityId, snapshot?.controllerId)) toughness else power
             }
 
             is DynamicAmount.Divide -> {
@@ -642,10 +653,18 @@ class DynamicAmountEvaluator(
      * [GrantsStationUsingToughnessComponent], enabling the creature to station using
      * toughness instead of power. Reads projected controllers (Rule 613) so the
      * effect survives control-changing continuous effects on either permanent.
+     *
+     * [fallbackControllerId] is consulted when [entityId] is no longer on the battlefield
+     * (projection has no controller) — typically the snapshot's last-known controller
+     * captured at cost-payment time (Rule 112.7a).
      */
-    private fun controllerHasStationUsingToughness(state: GameState, entityId: EntityId): Boolean {
+    private fun controllerHasStationUsingToughness(
+        state: GameState,
+        entityId: EntityId,
+        fallbackControllerId: EntityId? = null
+    ): Boolean {
         val projected = state.projectedState
-        val controller = projected.getController(entityId) ?: return false
+        val controller = projected.getController(entityId) ?: fallbackControllerId ?: return false
         return state.getBattlefield().any { permanentId ->
             val perm = state.getEntity(permanentId) ?: return@any false
             perm.has<GrantsStationUsingToughnessComponent>() &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsStationUsingToughnessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
@@ -167,6 +168,17 @@ class DynamicAmountEvaluator(
                         else -> { /* fall through */ }
                     }
                     return resolveNumericProperty(state, entityId, amount.numericProperty, context, useProjected = false)
+                }
+                // Station mechanic override: when tapping a creature as cost for a Station
+                // ability and the controller has StationUsingToughness in play, use toughness
+                // instead of power if toughness > power.
+                if (amount.entity is EntityReference.TappedAsCost && amount.numericProperty is EntityNumericProperty.Power) {
+                    val power = resolveNumericProperty(state, entityId, EntityNumericProperty.Power, context, useProjected = true, explicitProjected = projectedState)
+                    val toughness = resolveNumericProperty(state, entityId, EntityNumericProperty.Toughness, context, useProjected = true, explicitProjected = projectedState)
+                    if (toughness > power && controllerHasStationUsingToughness(state, entityId)) {
+                        return toughness
+                    }
+                    return power
                 }
                 resolveNumericProperty(state, entityId, amount.numericProperty, context, useProjected = true, explicitProjected = projectedState)
             }
@@ -620,6 +632,24 @@ class DynamicAmountEvaluator(
             is EntityReference.AffectedEntity -> context.affectedEntityId
             is EntityReference.IterationEntity -> context.pipeline.iterationTarget
         }
+
+    // =========================================================================
+    // Station Toughness Override
+    // =========================================================================
+
+    /**
+     * Returns true if any permanent controlled by [entityId]'s controller has the
+     * [GrantsStationUsingToughnessComponent], enabling the creature to station using
+     * toughness instead of power.
+     */
+    private fun controllerHasStationUsingToughness(state: GameState, entityId: EntityId): Boolean {
+        val controller = state.getEntity(entityId)?.get<ControllerComponent>()?.playerId ?: return false
+        return state.getBattlefield().any { permanentId ->
+            val perm = state.getEntity(permanentId) ?: return@any false
+            perm.has<GrantsStationUsingToughnessComponent>() &&
+                perm.get<ControllerComponent>()?.playerId == controller
+        }
+    }
 
     // =========================================================================
     // Entity Numeric Property Resolution

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -62,6 +62,13 @@ data class EffectContext(
     val additionalCostBlightAmount: Int = 0,
     /** Permanents tapped as part of an activated ability's cost (e.g., Cryptic Gateway) */
     val tappedPermanents: List<EntityId> = emptyList(),
+    /**
+     * Projected P/T/controller snapshots for [tappedPermanents], captured before the
+     * ability went on the stack. Lets evaluators read the tapped creature's
+     * last-known characteristics if it leaves the battlefield before resolution
+     * (Rule 112.7a — e.g., Tapestry Warden's station ruling 2025-07-25).
+     */
+    val tappedPermanentSnapshots: List<PermanentSnapshot> = emptyList(),
     // --- Trigger state ---
     /** Amount of damage from a trigger context (e.g., "Whenever ~ is dealt damage") */
     val triggerDamageAmount: Int? = null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -436,6 +436,13 @@ class ActivateAbilityHandler(
         val sacrificeTargetIds = action.costPayment?.sacrificedPermanents ?: emptyList()
         val sacrificedSnapshots = capturePermanentSnapshots(sacrificeTargetIds, currentState.projectedState)
 
+        // Snapshot tapped-as-cost permanents too — they don't leave the battlefield as part
+        // of the cost, but they might be killed/bounced in response while the ability is on
+        // the stack. Capturing P/T/controller now lets the resolver read last-known
+        // characteristics (Tapestry Warden + station ability case, 2025-07-25 ruling).
+        val tappedTargetIds = action.costPayment?.tappedPermanents ?: emptyList()
+        val tappedSnapshots = capturePermanentSnapshots(tappedTargetIds, currentState.projectedState)
+
         // When using Explicit payment, mana sources were already tapped above —
         // strip the Mana portion so payAbilityCost doesn't try to deduct from the pool.
         // When convoke was applied, replace the mana portion with the reduced cost.
@@ -855,6 +862,7 @@ class ActivateAbilityHandler(
             sacrificedPermanents = sacrificedSnapshots,
             xValue = action.xValue,
             tappedPermanents = action.costPayment?.tappedPermanents ?: emptyList(),
+            tappedPermanentSnapshots = tappedSnapshots,
             descriptionOverride = ability.descriptionOverride
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageUtils.kt
@@ -1,5 +1,7 @@
 package com.wingedsheep.engine.mechanics.combat
 
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
@@ -10,8 +12,6 @@ import com.wingedsheep.sdk.scripting.AssignDamageEqualToToughness
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.StaticAbility
 import com.wingedsheep.sdk.scripting.filters.unified.Scope
-import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
 
 /**
  * Helpers for calculating the amount of combat damage a creature assigns.
@@ -21,6 +21,8 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
  * always or only when toughness exceeds power.
  */
 internal object CombatDamageUtils {
+
+    private val predicateEvaluator = PredicateEvaluator()
 
     /**
      * Returns the combat damage amount that [creatureId] assigns this step.
@@ -39,7 +41,7 @@ internal object CombatDamageUtils {
         if (cardRegistry == null) return power
 
         val toughness = projected.getToughness(creatureId) ?: 0
-        return if (assignsDamageAsToughness(state, creatureId, cardRegistry, power, toughness)) {
+        return if (assignsDamageAsToughness(state, projected, creatureId, cardRegistry, power, toughness)) {
             toughness.coerceAtLeast(0)
         } else {
             power
@@ -48,6 +50,7 @@ internal object CombatDamageUtils {
 
     private fun assignsDamageAsToughness(
         state: GameState,
+        projected: ProjectedState,
         creatureId: EntityId,
         cardRegistry: CardRegistry,
         power: Int,
@@ -70,11 +73,10 @@ internal object CombatDamageUtils {
 
         // Global permanents with Scope.Battlefield (e.g., Tapestry Warden: "creatures you control")
         // The source may equal the creature (e.g., Tapestry Warden applying to itself).
-        val creatureController = state.getEntity(creatureId)?.get<ControllerComponent>()?.playerId
         for (permanentId in state.getBattlefield()) {
             val permCardId = state.getEntity(permanentId)?.get<CardComponent>()?.cardDefinitionId ?: continue
             val abilities = cardRegistry.getCard(permCardId)?.staticAbilities.orEmpty()
-            if (matchesBattlefield(state, permanentId, creatureId, creatureController, abilities, power, toughness)) return true
+            if (matchesBattlefield(state, projected, permanentId, creatureId, abilities, power, toughness)) return true
         }
 
         return false
@@ -82,14 +84,15 @@ internal object CombatDamageUtils {
 
     private fun matchesBattlefield(
         state: GameState,
+        projected: ProjectedState,
         sourceId: EntityId,
         creatureId: EntityId,
-        creatureController: EntityId?,
         abilities: List<StaticAbility>,
         power: Int,
         toughness: Int,
     ): Boolean {
-        val sourceController = state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
+        val sourceController = projected.getController(sourceId) ?: return false
+        val predicateContext = PredicateContext(controllerId = sourceController, sourceId = sourceId)
         for (ability in abilities) {
             val unwrapped = if (ability is ConditionalStaticAbility) ability.ability else ability
             if (unwrapped !is AssignDamageEqualToToughness) continue
@@ -97,16 +100,10 @@ internal object CombatDamageUtils {
             // Honor excludeSelf: skip if this ability excludes the source and creature is the source
             if (unwrapped.filter.excludeSelf && sourceId == creatureId) continue
             if (unwrapped.onlyWhenToughnessGreaterThanPower && toughness <= power) continue
-            // Only the controllerPredicate is evaluated; CardPredicate/StatePredicate
-            // restrictions in baseFilter (e.g. subtype filters) are not checked here.
-            // Tapestry Warden uses AllCreaturesYouControl which has no card predicates,
-            // so this is correct for all current uses.
-            when (unwrapped.filter.baseFilter.controllerPredicate) {
-                ControllerPredicate.ControlledByYou -> if (creatureController != sourceController) continue
-                ControllerPredicate.ControlledByOpponent -> if (creatureController == sourceController) continue
-                null, ControllerPredicate.ControlledByAny -> { /* applies to all */ }
-                else -> continue
-            }
+            // Defer the full filter check (controller, type, subtype, keywords, state) to the
+            // shared PredicateEvaluator so new battlefield-scope uses (e.g. "Each Equipment-
+            // bearing creature you control") are honored without per-call special-casing.
+            if (!predicateEvaluator.matchesWithProjection(state, projected, creatureId, unwrapped.filter.baseFilter, predicateContext)) continue
             return true
         }
         return false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageUtils.kt
@@ -97,7 +97,10 @@ internal object CombatDamageUtils {
             // Honor excludeSelf: skip if this ability excludes the source and creature is the source
             if (unwrapped.filter.excludeSelf && sourceId == creatureId) continue
             if (unwrapped.onlyWhenToughnessGreaterThanPower && toughness <= power) continue
-            // Evaluate controller predicate: "you" = the source permanent's controller
+            // Only the controllerPredicate is evaluated; CardPredicate/StatePredicate
+            // restrictions in baseFilter (e.g. subtype filters) are not checked here.
+            // Tapestry Warden uses AllCreaturesYouControl which has no card predicates,
+            // so this is correct for all current uses.
             when (unwrapped.filter.baseFilter.controllerPredicate) {
                 ControllerPredicate.ControlledByYou -> if (creatureController != sourceController) continue
                 ControllerPredicate.ControlledByOpponent -> if (creatureController == sourceController) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageUtils.kt
@@ -10,6 +10,8 @@ import com.wingedsheep.sdk.scripting.AssignDamageEqualToToughness
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.StaticAbility
 import com.wingedsheep.sdk.scripting.filters.unified.Scope
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 
 /**
  * Helpers for calculating the amount of combat damage a creature assigns.
@@ -66,6 +68,44 @@ internal object CombatDamageUtils {
             if (matches(abilities, Scope.AttachedTo, power, toughness)) return true
         }
 
+        // Global permanents with Scope.Battlefield (e.g., Tapestry Warden: "creatures you control")
+        // The source may equal the creature (e.g., Tapestry Warden applying to itself).
+        val creatureController = state.getEntity(creatureId)?.get<ControllerComponent>()?.playerId
+        for (permanentId in state.getBattlefield()) {
+            val permCardId = state.getEntity(permanentId)?.get<CardComponent>()?.cardDefinitionId ?: continue
+            val abilities = cardRegistry.getCard(permCardId)?.staticAbilities.orEmpty()
+            if (matchesBattlefield(state, permanentId, creatureId, creatureController, abilities, power, toughness)) return true
+        }
+
+        return false
+    }
+
+    private fun matchesBattlefield(
+        state: GameState,
+        sourceId: EntityId,
+        creatureId: EntityId,
+        creatureController: EntityId?,
+        abilities: List<StaticAbility>,
+        power: Int,
+        toughness: Int,
+    ): Boolean {
+        val sourceController = state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
+        for (ability in abilities) {
+            val unwrapped = if (ability is ConditionalStaticAbility) ability.ability else ability
+            if (unwrapped !is AssignDamageEqualToToughness) continue
+            if (unwrapped.filter.scope !is Scope.Battlefield) continue
+            // Honor excludeSelf: skip if this ability excludes the source and creature is the source
+            if (unwrapped.filter.excludeSelf && sourceId == creatureId) continue
+            if (unwrapped.onlyWhenToughnessGreaterThanPower && toughness <= power) continue
+            // Evaluate controller predicate: "you" = the source permanent's controller
+            when (unwrapped.filter.baseFilter.controllerPredicate) {
+                ControllerPredicate.ControlledByYou -> if (creatureController != sourceController) continue
+                ControllerPredicate.ControlledByOpponent -> if (creatureController == sourceController) continue
+                null, ControllerPredicate.ControlledByAny -> { /* applies to all */ }
+                else -> continue
+            }
+            return true
+        }
         return false
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.state.components.battlefield.CantBeTargetedByOppon
 import com.wingedsheep.engine.state.components.battlefield.GrantCantBeBlockedToSmallCreaturesComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerHexproofComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsStationUsingToughnessComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
 import com.wingedsheep.engine.state.components.battlefield.SuppressesHexproofForGroupComponent
@@ -51,6 +52,7 @@ import com.wingedsheep.sdk.scripting.CantBeTargetedByOpponentAbilities
 import com.wingedsheep.sdk.scripting.CantReceiveCounters
 import com.wingedsheep.sdk.scripting.GrantHexproofToController
 import com.wingedsheep.sdk.scripting.GrantShroudToController
+import com.wingedsheep.sdk.scripting.StationUsingToughness
 import com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureHasSubtype
 import com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureIsLegendary
 import com.wingedsheep.sdk.scripting.conditions.Exists
@@ -139,6 +141,11 @@ class StaticAbilityHandler(
         // Add tag component for "you can't lose the game"
         if (allStaticAbilities.any { it is com.wingedsheep.sdk.scripting.GrantCantLoseGame }) {
             result = result.with(GrantsCantLoseGameComponent)
+        }
+
+        // Add tag component for "station using toughness"
+        if (allStaticAbilities.any { it is StationUsingToughness }) {
+            result = result.with(GrantsStationUsingToughnessComponent)
         }
 
         // Add tag component for "can't be the target of abilities your opponents control"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1521,6 +1521,7 @@ class StackResolver(
             sacrificedPermanents = abilityComponent.sacrificedPermanents,
             xValue = abilityComponent.xValue,
             tappedPermanents = abilityComponent.tappedPermanents,
+            tappedPermanentSnapshots = abilityComponent.tappedPermanentSnapshots,
             pipeline = PipelineState(namedTargets = EffectContext.buildNamedTargets(activatedReqs, activatedTargets))
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -381,6 +381,16 @@ data object GrantsControllerHexproofComponent : Component
 data object GrantsCantLoseGameComponent : Component
 
 /**
+ * Marks a permanent as granting the Station-using-toughness effect to creatures its
+ * controller controls. When a creature with this component's controller taps for a
+ * Station ability and its toughness > power, it contributes toughness instead of power.
+ *
+ * Created by [StaticAbilityHandler] from [StationUsingToughness] static abilities.
+ */
+@Serializable
+data object GrantsStationUsingToughnessComponent : Component
+
+/**
  * Marks a permanent as unable to be targeted by abilities opponents control.
  * Unlike hexproof, spells can still target this permanent.
  * Used for Shanna, Sisay's Legacy: "Shanna can't be the target of abilities your opponents control."

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/PermanentSnapshot.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/PermanentSnapshot.kt
@@ -19,6 +19,7 @@ data class PermanentSnapshot(
     val power: Int? = null,
     val toughness: Int? = null,
     val subtypes: Set<String> = emptySet(),
+    val controllerId: EntityId? = null,
 )
 
 /**
@@ -34,6 +35,7 @@ fun capturePermanentSnapshots(
         power = projected.getPower(id),
         toughness = projected.getToughness(id),
         subtypes = projected.getSubtypes(id),
+        controllerId = projected.getController(id),
     )
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -102,6 +102,14 @@ data class ActivatedAbilityOnStackComponent(
     val sacrificedPermanents: List<PermanentSnapshot> = emptyList(),
     val xValue: Int? = null,
     val tappedPermanents: List<EntityId> = emptyList(),
+    /**
+     * Projected P/T/controller snapshots for permanents tapped as part of the cost
+     * (Rule 112.7a — "as it last existed on the battlefield"). Captured before zone
+     * changes so abilities reading the tapped creature's characteristics keep working
+     * if the creature leaves the battlefield before resolution (e.g., Tapestry Warden +
+     * a station ability where the tapper is killed in response).
+     */
+    val tappedPermanentSnapshots: List<PermanentSnapshot> = emptyList(),
     /** Optional human-readable description from `ActivatedAbility.descriptionOverride`,
      *  used when displaying the ability on the stack instead of the auto-generated effect text. */
     val descriptionOverride: String? = null


### PR DESCRIPTION
Introduces two new engine capabilities needed for Tapestry Warden ({3}{G}, 3/4 Vigilance):

1. **Global AssignDamageEqualToToughness (Scope.Battlefield)**: Extends
   CombatDamageUtils to scan the battlefield for permanents with this static
   ability at Scope.Battlefield, evaluating the controller predicate so "you" =
   the ability source's controller. Supports excludeSelf correctly.

2. **StationUsingToughness static ability**: When a creature with toughness >
   power taps for a Station ability and its controller has this ability in play
   (tracked via GrantsStationUsingToughnessComponent), DynamicAmountEvaluator
   substitutes toughness for power in the TappedAsCost entity property lookup.

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>