### PR TITLE
Add Pinnacle Starcage and Pinnacle Emissary; fix predefined token sum…

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 167 / 261
+**Implemented:** 169 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -160,9 +160,9 @@
 - [x] Ouroboroid
 - [ ] Pain for All
 - [ ] Perigee Beckoner
-- [ ] Pinnacle Emissary
+- [x] Pinnacle Emissary
 - [x] Pinnacle Kill-Ship
-- [ ] Pinnacle Starcage
+- [x] Pinnacle Starcage
 - [x] Plasma Bolt
 - [x] Possibility Technician
 - [ ] Pull Through the Weft

--- a/manual-scenarios/cards/p/pinnacle-emissary.json
+++ b/manual-scenarios/cards/p/pinnacle-emissary.json
@@ -1,0 +1,38 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Pinnacle Emissary", "Cryogen Relic", "Melded Moxite"],
+    "battlefield": [
+      {"name": "Pinnacle Emissary"},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Mountain", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/p/pinnacle-starcage.json
+++ b/manual-scenarios/cards/p/pinnacle-starcage.json
@@ -1,0 +1,48 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Pinnacle Starcage"],
+    "battlefield": [
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Hullcarver"},
+      {"name": "Chrome Companion"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Hemosymbic Mite"},
+      {"name": "Gene Pollinator"},
+      {"name": "Atomic Microsizer"},
+      {"name": "All-Fates Stalker"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PinnacleEmissary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PinnacleEmissary.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.SpellCastEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Pinnacle Emissary
+ * {1}{U}{R}
+ * Artifact Creature — Robot, 3/3
+ * Whenever you cast an artifact spell, create a 1/1 colorless Drone artifact creature token with flying
+ * and "This token can block only creatures with flying."
+ * Warp {U/R}
+ */
+val PinnacleEmissary = card("Pinnacle Emissary") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Artifact Creature — Robot"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever you cast an artifact spell, create a 1/1 colorless Drone artifact creature token with flying and \"This token can block only creatures with flying.\"\n" +
+        "Warp {U/R} (You may cast this card from your hand for its warp cost. Exile this creature at the beginning of the next end step, then you may cast it from exile on a later turn.)"
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = SpellCastEvent(spellFilter = GameObjectFilter.Artifact, player = Player.You),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateDroneToken()
+        description = "Whenever you cast an artifact spell, create a 1/1 colorless Drone artifact creature token with flying and \"This token can block only creatures with flying.\""
+    }
+
+    warp = "{U/R}"
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "223"
+        artist = "Alejandro Pacheco"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c922347-f05f-40a4-bbee-6bc02a1e0de5.jpg?1752947469"
+        ruling("2025-07-25", "Pinnacle Emissary's first ability resolves before the spell that caused it to trigger. It resolves even if that spell is countered or otherwise leaves the stack without resolving.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PinnacleStarcage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PinnacleStarcage.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Pinnacle Starcage
+ * {1}{W}{W}
+ * Artifact
+ * When this artifact enters, exile all artifacts and creatures with mana value 2 or less
+ * until this artifact leaves the battlefield.
+ * {6}{W}{W}: Put each card exiled with this artifact into its owner's graveyard, then create
+ * a 2/2 colorless Robot artifact creature token for each card put into a graveyard this way.
+ * Sacrifice this artifact.
+ */
+val PinnacleStarcage = card("Pinnacle Starcage") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, exile all artifacts and creatures with mana value 2 or less until this artifact leaves the battlefield.\n" +
+        "{6}{W}{W}: Put each card exiled with this artifact into its owner's graveyard, then create a 2/2 colorless Robot artifact creature token for each card put into a graveyard this way. Sacrifice this artifact."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        // GameObjectFilter's `or` infix sets matchAll = false, which would make a chained
+        // .manaValueAtMost(2) match any low-MV entity (including lands). Construct manually
+        // so matchAll stays true and the (artifact|creature) and MV<=2 predicates AND.
+        effect = Effects.ExileGroupAndLink(
+            GroupFilter(
+                GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.Or(
+                            listOf(CardPredicate.IsArtifact, CardPredicate.IsCreature)
+                        ),
+                        CardPredicate.ManaValueAtMost(2)
+                    )
+                )
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{6}{W}{W}")
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromLinkedExile(),
+                storeAs = "exiled"
+            ),
+            MoveCollectionEffect(
+                from = "exiled",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                storeMovedAs = "moved"
+            ),
+            CreateTokenEffect(
+                count = DynamicAmount.VariableReference("moved_count"),
+                power = 2,
+                toughness = 2,
+                colors = emptySet(),
+                creatureTypes = setOf("Robot"),
+                artifactToken = true,
+                imageUri = "https://cards.scryfall.io/normal/front/c/4/c46f9a07-005c-44b7-8057-b2f00b274dd6.jpg?1756281130"
+            ),
+            Effects.SacrificeTarget(EffectTarget.Self)
+        )
+        description = "Put each card exiled with this artifact into its owner's graveyard, then create a 2/2 colorless Robot artifact creature token for each card put into a graveyard this way. Sacrifice this artifact."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "27"
+        artist = "Leon Tukker"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1f40c4c-a955-4d9c-8225-251fa4159124.jpg?1752946658"
+        ruling("2025-07-25", "Auras attached to an exiled permanent will be put into their owners' graveyards. Equipment attached to an exiled permanent (if they're not also being exiled) will become unattached and remain on the battlefield. Any counters on the exiled permanents will cease to exist.")
+        ruling("2025-07-25", "If a token is exiled this way, it will cease to exist and won't return to the battlefield.")
+        ruling("2025-07-25", "If an artifact or creature has {X} in its mana cost, X is 0 for the purpose of determining its mana value.")
+        ruling("2025-07-25", "If Pinnacle Starcage leaves the battlefield before its first ability resolves, no artifacts or creatures will be exiled.")
+        ruling("2025-07-25", "Every token has mana value 0 unless it is copying something or was created with a specific mana cost.")
+        ruling("2025-07-25", "In a multiplayer game, if Pinnacle Starcage's owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
@@ -9,6 +9,8 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
@@ -81,7 +83,9 @@ class CreatePredefinedTokenExecutor(
             var container = ComponentContainer.of(
                 tokenComponent,
                 TokenComponent,
-                ControllerComponent(tokenControllerId)
+                ControllerComponent(tokenControllerId),
+                SummoningSicknessComponent,
+                EnteredThisTurnComponent
             )
 
             if (effect.tapped) {


### PR DESCRIPTION
…moning sickness

Pinnacle Starcage: the ETB exiles all artifacts and creatures with mana value 2 or less until the Starcage leaves; the activated ability moves the linked exile into owners' graveyards, creates a 2/2 Robot token for each, and sacrifices the Starcage. Composes ExileGroupAndLink + ReturnLinkedExileUnderOwnersControl + a GatherCards/MoveCollection/CreateToken/SacrificeTarget pipeline — no new SDK or engine primitives. The filter is built manually with matchAll = true so the "(artifact OR creature) AND mana value <= 2" predicates AND correctly; chaining `.manaValueAtMost(2)` after `or` would have matched any low-MV permanent including lands.

Pinnacle Emissary: {1}{U}{R} 3/3 Artifact Creature — Robot with "Whenever you cast an artifact spell, create a 1/1 Drone token" and Warp {U/R}. Composes the existing Effects.CreateDroneToken() facade with an inline TriggerSpec for SpellCastEvent(spellFilter = GameObjectFilter.Artifact, player = Player.You) — same shape as Angry Rabble's "cast a spell with MV ≥ 4" trigger. No SDK changes.

Predefined token summoning sickness: CreatePredefinedTokenExecutor was the only executor under handlers/effects/token/ that did not attach SummoningSicknessComponent / EnteredThisTurnComponent to the new token, so Drone, Mutavault, and transformed Incubator tokens could attack the turn they entered the battlefield. Match the pattern used by every other token executor (CreateTokenExecutor, CreateTokenCopyOfTargetExecutor, etc.): add both components unconditionally at creation time. SummoningSicknessComponent on non-creature tokens (Treasure, Food, Map, Lander) is a no-op because every consumer (AttackRestrictionRules, ManaSolver) gates on isCreature first.