### PR TITLE
Add Loading Zone to Edge of Eternities

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 167 / 261
+**Implemented:** 169 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -127,7 +127,7 @@
 - [x] Lightless Evangel
 - [ ] Lightstall Inquisitor
 - [ ] Lithobraking
-- [ ] Loading Zone
+- [x] Loading Zone
 - [x] Lost in Space
 - [x] Lumen-Class Frigate
 - [ ] Luxknight Breacher

--- a/manual-scenarios/cards/l/loading-zone.json
+++ b/manual-scenarios/cards/l/loading-zone.json
@@ -1,0 +1,44 @@
+{
+  "_description": "Loading Zone counter-doubling sweep. Alice has Loading Zone resolved on the battlefield, plus a Seedship Agrarian (creature with landfall) and a Synthesizer Labship (Spacecraft) to exercise both branches of the recipient filter. Sequence: (1) Play the Forest from hand — Seedship Agrarian's landfall trigger would put one +1/+1 counter on it; Loading Zone doubles → two +1/+1 counters. (2) Activate Station on Synthesizer Labship, tapping Glory Seeker (power 2) — would put 2 CHARGE counters on the Spacecraft; Loading Zone doubles → 4 CHARGE counters. Bonus: cast another Loading Zone from the Warp pile to verify the ruling that two Loading Zones multiply by 4x (1 counter → 4 counters).",
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Forest"],
+    "battlefield": [
+      {"name": "Loading Zone"},
+      {"name": "Seedship Agrarian", "summoningSickness": false},
+      {"name": "Wedgelight Rammer", "summoningSickness": false},
+      {"name": "Glory Seeker", "summoningSickness": false},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Glory Seeker"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Plains",
+      "Plains"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LoadingZone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LoadingZone.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DoubleCounterPlacement
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Loading Zone
+ * {3}{G}
+ * Enchantment
+ *
+ * If one or more counters would be put on a creature, Spacecraft, or Planet you control,
+ * twice that many of each of those kinds of counters are put on it instead.
+ * Warp {G}
+ *
+ * Functions like a Doubling Season restricted to creature/Spacecraft/Planet permanents
+ * you control, for any counter kind. Recipient filter is the "you control" gate, so
+ * placedByYou = false (effect applies regardless of who is placing the counters).
+ */
+val LoadingZone = card("Loading Zone") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "If one or more counters would be put on a creature, Spacecraft, or Planet you control, twice that many of each of those kinds of counters are put on it instead.\n" +
+        "Warp {G} (You may cast this card from your hand for its warp cost. Exile this enchantment at the beginning of the next end step, then you may cast it from exile on a later turn.)"
+
+    replacementEffect(
+        DoubleCounterPlacement(
+            placedByYou = false,
+            appliesTo = GameEvent.CounterPlacementEvent(
+                counterType = CounterTypeFilter.Any,
+                recipient = RecipientFilter.Matching(
+                    GameObjectFilter.Creature.youControl()
+                        .or(GameObjectFilter.Permanent.withSubtype("Spacecraft").youControl())
+                        .or(GameObjectFilter.Permanent.withSubtype("Planet").youControl())
+                )
+            )
+        )
+    )
+
+    warp = "{G}"
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "196"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d2c95bd-79af-4a23-b265-62cc0b164e3e.jpg?1752947354"
+        ruling("2025-07-25", "If a creature, Spacecraft, or Planet you control would enter the battlefield with a number of counters on it, it enters with twice that many instead.")
+        ruling("2025-07-25", "If you control two Loading Zones, the number of counters put on a creature, Spacecraft, or Planet you control is four times the original number. Three Loading Zones multiplies the original number by eight, and so on.")
+        ruling("2025-07-25", "If two or more effects attempt to modify how many counters would be put onto a permanent you control, you choose the order to apply those effects, no matter who controls the sources of those effects.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ReplacementEffectUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ReplacementEffectUtils.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.handlers.effects
 
+import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
@@ -18,6 +19,8 @@ import com.wingedsheep.sdk.scripting.events.RecipientFilter
  * before they produce events (counter placement modifiers, extra turn prevention).
  */
 object ReplacementEffectUtils {
+
+    private val predicateEvaluator = PredicateEvaluator()
 
     /**
      * Check if extra turns are prevented by any PreventExtraTurns replacement effect
@@ -130,6 +133,12 @@ object ReplacementEffectUtils {
             state.getEntity(targetId)?.get<ControllerComponent>()?.playerId == sourceControllerId
         }
         is RecipientFilter.You -> targetId == sourceControllerId
+        is RecipientFilter.Matching -> {
+            val context = PredicateContext(controllerId = sourceControllerId, sourceId = sourceEntityId)
+            predicateEvaluator.matchesWithProjection(
+                state, state.projectedState, targetId, recipient.filter, context
+            )
+        }
         else -> false
     }
 }


### PR DESCRIPTION
Doubling Season-style counter doubler restricted to creature, Spacecraft, and Planet permanents you control, modeled with DoubleCounterPlacement + RecipientFilter.Matching over a composed GameObjectFilter, plus Warp {G}.

Wire RecipientFilter.Matching into ReplacementEffectUtils.matchesRecipientFilter (mirroring DamageUtils): without this case the dispatch fell through to `else -> false`, so any DoubleCounterPlacement / ModifyCounterPlacement effect using a custom GameObjectFilter recipient — including both of Loading Zone's branches — silently did nothing.