### PR TITLE
Update review-changes skill: worktree + main-merge steps

### DIFF
--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -12,15 +12,53 @@ existing primitives instead of growing a card-specific type per Magic card.
 `$ARGUMENTS` may be a PR number/URL, a branch name, or empty (review the working tree's
 diff vs `main`).
 
-## 1. Establish the diff
+## 1. Establish the diff (with `main` merged in)
 
-- **PR** — `gh pr view <n> --json …`, then `git fetch <fork> <head>:pr-<n>-review &&
-  git checkout pr-<n>-review`. Diff vs `main` (or `baseRefName`).
-- **Branch** — `git diff main...<branch>` (three-dot).
-- **Empty** — `git diff main...HEAD` plus `git status`.
+The review must reflect post-merge reality, so `origin/main` is merged into the review
+branch before diffing. Where the work happens depends on what's already checked out:
+
+- **Already on the PR/branch in the current working tree** (`git rev-parse --abbrev-ref
+  HEAD` matches the branch you were asked to review, working tree clean) → review in
+  place. Skip the worktree step.
+- **Anywhere else** (different branch checked out, dirty tree, PR head not fetched yet,
+  user explicitly asks for a worktree) → use a dedicated worktree under
+  `.claude/worktrees/` so the user's primary checkout stays untouched.
+
+Steps:
+
+1. **Resolve the PR / branch.** For a PR URL/number use
+   `gh pr view <n> --json number,title,headRefName,baseRefName,headRepository,headRepositoryOwner,body`
+   to learn the head repo + ref. For a bare branch name, skip to step 3.
+2. **Fetch the head into a local review branch** (skip if already checked out and
+   up-to-date). If the head is on a fork, fetch via HTTPS (this repo's `origin` is SSH
+   and fetches against forks fail):
+   `git fetch https://github.com/<owner>/<repo>.git <headRef>:pr-<n>-review`.
+   Also refresh `origin/main`:
+   `git fetch https://github.com/wingedsheep/argentum-engine.git main:refs/remotes/origin/main`.
+3. **Pick the workspace.** Already on the branch with a clean tree → continue in place.
+   Otherwise: `git worktree add .claude/worktrees/pr-<n>-review pr-<n>-review` (or
+   `.claude/worktrees/<branch>-review` for a branch). Run subsequent commands in
+   whichever workspace applies.
+4. **Merge `origin/main` into the review branch** before reading the diff. This catches
+   conflicts the author hasn't seen yet and ensures the review reflects post-merge
+   reality: `git merge origin/main --no-edit`. If conflicts arise, resolve them (prefer
+   main's structure for backlog/index files, then re-apply the PR's intent — e.g. bump
+   the implemented-cards count, check the new card off the list) and commit. Flag the
+   conflict resolution as a finding in the review so the author knows to either pull
+   main themselves or accept the merge commit.
+5. **Diff against `main`.** PR → `git diff origin/main...HEAD --stat` then full diff for
+   source paths. Branch → `git diff main...<branch>` (three-dot). Empty → `git diff
+   main...HEAD` plus `git status`.
 
 Read every changed file in full, not just the hunk. For large diffs, spawn `Explore` for
 unfamiliar areas.
+
+**Worktree lifecycle (only when a worktree was created).** Leave it in place across
+review rounds. Only remove it (`git worktree remove .claude/worktrees/pr-<n>-review`)
+once the user confirms the PR is merged or the review is abandoned. Mention the worktree
+path in the final review output so the user can hand-off, re-enter, or push fixups to
+it. When the review ran in place, the final output just notes that the branch already
+has `origin/main` merged in (and any merge commit that produced).
 
 ## 2. SDK elegance — the central question
 
@@ -147,4 +185,5 @@ values, layer interactions, "as ~ enters", protection / hexproof / ward).
    test for Z"). If the diff is fine as-is, say so.
 
 This skill writes a review into the conversation. It does not push, post via `gh`, run
-`/ultrareview`, auto-fix, or touch other agents' work.
+`/ultrareview`, auto-fix, or touch other agents' work. The worktree from step 1 stays
+in place after the review so the author (or a follow-up session) can iterate on it.


### PR DESCRIPTION
Codify the workflow used reviewing PR #135: fetch fork via HTTPS (origin is SSH), use a worktree only when in-place review would disturb the checkout, merge origin/main before diffing, and leave the worktree in place until merge.