### PR TITLE
Thread CopyTargetSpell flags through all paths; fix CopyOfComponent C…

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
@@ -419,10 +419,8 @@ data class CopyTargetSpellEffect(
     /**
      * When true, the Legendary supertype is removed from the copy's type line so the resulting
      * token is not legendary (e.g., Jackal, Genius Geneticist's "except the copy isn't legendary").
-     *
-     * Honored only when the targeted spell has no targets and no chosen modes with target
-     * requirements. The modal-with-targets path silently drops it; the targeted permanent-spell
-     * path returns an error (copying a targeted permanent spell is not supported).
+     * Applied to every copy regardless of which path (no-target, modal-with-targets, single-target
+     * permanent or non-permanent) the executor takes.
      */
     val removeLegendary: Boolean = false
 ) : Effect {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -143,24 +143,29 @@ data class CopyTriggeredAbilityTargetContinuation(
  * prompt for the next copy's targets.
  *
  * @property remainingCopies Number of copies still to create (including the one being targeted)
- * @property spellEffect The effect of the original spell to copy
+ * @property spellEffect The effect of the original spell to copy. Null when copying a
+ *   permanent spell (creatures, artifacts, etc.) — those resolve into permanents via
+ *   the spell's CardComponent rather than a stack effect.
  * @property spellTargetRequirements Target requirements for each copy
  * @property spellName Name of the original spell
  * @property controllerId The player who controls the copies
  * @property sourceId The source spell entity ID
+ * @property removeLegendary If true, the Legendary supertype is stripped from each copy's
+ *   CardComponent (CR 707.10f token-copy that "isn't legendary", e.g., Jackal).
  */
 @Serializable
 data class StormCopyTargetContinuation(
     override val decisionId: String,
     val remainingCopies: Int,
-    val spellEffect: Effect,
+    val spellEffect: Effect?,
     val spellTargetRequirements: List<TargetRequirement>,
     val spellName: String,
     val controllerId: EntityId,
     val sourceId: EntityId,
     val totalCopies: Int = remainingCopies,  // Original total copies (defaults to remainingCopies for backward compat)
     /** Keyword enum names (e.g., "WITHER") to grant to each copy while it's on the stack. */
-    val keywordsForCopy: Set<String> = emptySet()
+    val keywordsForCopy: Set<String> = emptySet(),
+    val removeLegendary: Boolean = false
 ) : ContinuationFrame
 
 /**
@@ -196,7 +201,11 @@ data class StormCopyModalTargetContinuation(
     val chosenModes: List<Int>,
     val modeTargetRequirements: Map<Int, List<TargetRequirement>>,
     val accumulatedOrdinalTargets: List<List<ChosenTarget>>,
-    val currentOrdinal: Int
+    val currentOrdinal: Int,
+    /** Keyword enum names (e.g., "WITHER") to grant to each copy while it's on the stack. */
+    val keywordsForCopy: Set<String> = emptySet(),
+    /** If true, strip the Legendary supertype from each resulting copy. */
+    val removeLegendary: Boolean = false
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
@@ -184,26 +184,12 @@ class MiscContinuationResumer(
             controllerId = continuation.controllerId
         )
         if (!stackResult.isSuccess) return stackResult
-        currentState = stackResult.newState
+        currentState = com.wingedsheep.engine.handlers.effects.stack.StormCopyEffectExecutor
+            .applyCopyMutations(
+                stackResult.newState, stackResult.events,
+                continuation.keywordsForCopy, continuation.removeLegendary
+            )
         allEvents.addAll(stackResult.events)
-
-        // Apply any keywords granted to this copy (e.g., wither from Spinerock Tyrant).
-        if (continuation.keywordsForCopy.isNotEmpty()) {
-            val newCopyId = stackResult.events.asReversed()
-                .firstNotNullOfOrNull { e ->
-                    if (e is com.wingedsheep.engine.core.SpellCopiedEvent) e.copyEntityId else null
-                }
-            if (newCopyId != null) {
-                currentState = currentState.updateEntity(newCopyId) { container ->
-                    val existing = container.get<com.wingedsheep.engine.state.components.stack.SpellGrantedKeywordsComponent>()
-                    container.with(
-                        com.wingedsheep.engine.state.components.stack.SpellGrantedKeywordsComponent(
-                            (existing?.keywords ?: emptySet()) + continuation.keywordsForCopy
-                        )
-                    )
-                }
-            }
-        }
 
         val remainingAfterThis = continuation.remainingCopies - 1
         if (remainingAfterThis <= 0) {
@@ -239,24 +225,12 @@ class MiscContinuationResumer(
                     controllerId = continuation.controllerId
                 )
                 if (!res.isSuccess) return res
-                loopState = res.newState
+                loopState = com.wingedsheep.engine.handlers.effects.stack.StormCopyEffectExecutor
+                    .applyCopyMutations(
+                        res.newState, res.events,
+                        continuation.keywordsForCopy, continuation.removeLegendary
+                    )
                 loopEvents.addAll(res.events)
-                if (continuation.keywordsForCopy.isNotEmpty()) {
-                    val newCopyId = res.events.asReversed()
-                        .firstNotNullOfOrNull { e ->
-                            if (e is com.wingedsheep.engine.core.SpellCopiedEvent) e.copyEntityId else null
-                        }
-                    if (newCopyId != null) {
-                        loopState = loopState.updateEntity(newCopyId) { container ->
-                            val existing = container.get<com.wingedsheep.engine.state.components.stack.SpellGrantedKeywordsComponent>()
-                            container.with(
-                                com.wingedsheep.engine.state.components.stack.SpellGrantedKeywordsComponent(
-                                    (existing?.keywords ?: emptySet()) + continuation.keywordsForCopy
-                                )
-                            )
-                        }
-                    }
-                }
                 copiesLeft--
             }
             return checkForMore(loopState, loopEvents)
@@ -271,7 +245,8 @@ class MiscContinuationResumer(
             controllerId = continuation.controllerId,
             sourceId = continuation.sourceId,
             totalCopies = continuation.totalCopies,
-            keywordsForCopy = continuation.keywordsForCopy
+            keywordsForCopy = continuation.keywordsForCopy,
+            removeLegendary = continuation.removeLegendary
         )
         val targetReqInfos = continuation.spellTargetRequirements.mapIndexed { index, req ->
             TargetRequirementInfo(
@@ -334,7 +309,9 @@ class MiscContinuationResumer(
             currentOrdinal = nextOrdinal,
             remainingCopies = continuation.remainingCopies,
             totalCopies = continuation.totalCopies,
-            priorEvents = emptyList()
+            priorEvents = emptyList(),
+            keywordsForCopy = continuation.keywordsForCopy,
+            removeLegendary = continuation.removeLegendary
         )
 
         if (result.isPaused) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellExecutor.kt
@@ -76,7 +76,12 @@ class CopyTargetSpellExecutor(
                     copyTotal = 1,
                     controllerId = context.controllerId
                 )
-                return EffectResult.from(applyKeywordsToCopy(copyResult, effect.keywordsForCopy))
+                if (!copyResult.isSuccess) return EffectResult.from(copyResult)
+                val mutated = StormCopyEffectExecutor.applyCopyMutations(
+                    copyResult.newState, copyResult.events,
+                    effect.keywordsForCopy.toSet(), effect.removeLegendary
+                )
+                return EffectResult.from(ExecutionResult.success(mutated, copyResult.events))
             }
             return EffectResult.from(StormCopyEffectExecutor.driveStormModalCopies(
                 state = state,
@@ -91,7 +96,9 @@ class CopyTargetSpellExecutor(
                 currentOrdinal = 0,
                 remainingCopies = 1,
                 totalCopies = 1,
-                priorEvents = emptyList()
+                priorEvents = emptyList(),
+                keywordsForCopy = effect.keywordsForCopy.toSet(),
+                removeLegendary = effect.removeLegendary
             ))
         }
 
@@ -111,16 +118,11 @@ class CopyTargetSpellExecutor(
                     controllerId = context.controllerId
                 )
                 if (!copyResult.isSuccess) return EffectResult.from(copyResult)
-                val copyId = copyResult.events.filterIsInstance<SpellCopiedEvent>().firstOrNull()?.copyEntityId
-                val stripped = if (effect.removeLegendary && copyId != null) {
-                    copyResult.newState.updateEntity(copyId) { container ->
-                        val card = container.get<CardComponent>() ?: return@updateEntity container
-                        container.with(card.copy(typeLine = card.typeLine.withoutLegendary()))
-                    }
-                } else copyResult.newState
-                return EffectResult.from(applyKeywordsToCopy(
-                    ExecutionResult.success(stripped, copyResult.events), effect.keywordsForCopy
-                ))
+                val mutated = StormCopyEffectExecutor.applyCopyMutations(
+                    copyResult.newState, copyResult.events,
+                    effect.keywordsForCopy.toSet(), effect.removeLegendary
+                )
+                return EffectResult.from(ExecutionResult.success(mutated, copyResult.events))
             }
             val copyAbility = TriggeredAbilityOnStackComponent(
                 sourceId = context.sourceId ?: EntityId.generate(),
@@ -135,15 +137,13 @@ class CopyTargetSpellExecutor(
             ))
         }
 
-        // Spell has targets — prompt for new target selection. Targeted permanent
-        // spells (no spellEffect) are not supported via this path; the caller must
-        // not invoke CopyTargetSpell on a permanent spell with targets.
-        if (spellEffect == null) {
-            return EffectResult.error(state, "Cannot copy target permanent spell with targets")
-        }
+        // Spell has targets — prompt for new target selection. Permanent spells
+        // (spellEffect == null) are supported: the continuation resumes via
+        // putSpellCopy which clones the source's CardComponent, and the
+        // CR 707.10f token tagging happens at resolution in StackResolver.
         return promptForCopyTargets(
             state, context, spellEntityId, spellEffect, targetRequirements, spellName,
-            effect.keywordsForCopy.toSet()
+            effect.keywordsForCopy.toSet(), effect.removeLegendary
         )
     }
 
@@ -174,10 +174,11 @@ class CopyTargetSpellExecutor(
         state: GameState,
         context: EffectContext,
         spellEntityId: EntityId,
-        spellEffect: com.wingedsheep.sdk.scripting.effects.Effect,
+        spellEffect: com.wingedsheep.sdk.scripting.effects.Effect?,
         targetRequirements: List<com.wingedsheep.sdk.scripting.targets.TargetRequirement>,
         spellName: String,
-        keywordsForCopy: Set<String> = emptySet()
+        keywordsForCopy: Set<String> = emptySet(),
+        removeLegendary: Boolean = false
     ): EffectResult {
         val decisionId = "copy-spell-target-${System.nanoTime()}"
 
@@ -208,7 +209,8 @@ class CopyTargetSpellExecutor(
             spellName = spellName,
             controllerId = context.controllerId,
             sourceId = spellEntityId,
-            keywordsForCopy = keywordsForCopy
+            keywordsForCopy = keywordsForCopy,
+            removeLegendary = removeLegendary
         )
         val targetReqInfos = targetRequirements.mapIndexed { index, req ->
             TargetRequirementInfo(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/StormCopyEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/StormCopyEffectExecutor.kt
@@ -225,7 +225,9 @@ class StormCopyEffectExecutor(
             currentOrdinal: Int,
             remainingCopies: Int,
             totalCopies: Int,
-            priorEvents: List<GameEvent>
+            priorEvents: List<GameEvent>,
+            keywordsForCopy: Set<String> = emptySet(),
+            removeLegendary: Boolean = false
         ): ExecutionResult {
             var currentState = state
             val allEvents = priorEvents.toMutableList()
@@ -299,7 +301,9 @@ class StormCopyEffectExecutor(
                         chosenModes = chosenModes,
                         modeTargetRequirements = modeTargetRequirements,
                         accumulatedOrdinalTargets = accumulated,
-                        currentOrdinal = ordinal
+                        currentOrdinal = ordinal,
+                        keywordsForCopy = keywordsForCopy,
+                        removeLegendary = removeLegendary
                     )
 
                     val pausedState = currentState
@@ -320,7 +324,9 @@ class StormCopyEffectExecutor(
                     controllerId = controllerId
                 )
                 if (!copyResult.isSuccess) return copyResult
-                currentState = copyResult.newState
+                currentState = applyCopyMutations(
+                    copyResult.newState, copyResult.events, keywordsForCopy, removeLegendary
+                )
                 allEvents.addAll(copyResult.events)
 
                 copiesLeft--
@@ -329,6 +335,42 @@ class StormCopyEffectExecutor(
             }
 
             return ExecutionResult.success(currentState, allEvents)
+        }
+
+        /**
+         * After a [StackResolver.putSpellCopy] result, patch the new copy entity:
+         * - strip the Legendary supertype if [removeLegendary] (CR 707.10f token-copy clause)
+         * - record granted spell keywords (e.g., wither, lifelink) on the copy
+         */
+        internal fun applyCopyMutations(
+            state: GameState,
+            events: List<GameEvent>,
+            keywordsForCopy: Set<String>,
+            removeLegendary: Boolean
+        ): GameState {
+            if (keywordsForCopy.isEmpty() && !removeLegendary) return state
+            val copyId = events.asReversed()
+                .firstNotNullOfOrNull { e ->
+                    if (e is com.wingedsheep.engine.core.SpellCopiedEvent) e.copyEntityId else null
+                } ?: return state
+            return state.updateEntity(copyId) { container ->
+                var updated = container
+                if (removeLegendary) {
+                    val card = updated.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                    if (card != null) {
+                        updated = updated.with(card.copy(typeLine = card.typeLine.withoutLegendary()))
+                    }
+                }
+                if (keywordsForCopy.isNotEmpty()) {
+                    val existing = updated.get<com.wingedsheep.engine.state.components.stack.SpellGrantedKeywordsComponent>()
+                    updated = updated.with(
+                        com.wingedsheep.engine.state.components.stack.SpellGrantedKeywordsComponent(
+                            (existing?.keywords ?: emptySet()) + keywordsForCopy
+                        )
+                    )
+                }
+                updated
+            }
         }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
@@ -53,8 +53,9 @@ data object TokenComponent : Component
  *
  * [originalCardComponent] is the pre-copy [CardComponent] snapshot. Permanent-level
  * copy effects (Clone, Mockingbird, "X becomes a copy of Y") populate it so the
- * card can revert to its printed identity when it leaves the battlefield
- * (CR 707.2, CR 400.7). Stack-only copies (Storm and friends) leave it null.
+ * card can revert to its printed identity when it leaves the battlefield (CR 400.7
+ * — moving zones makes a new object with no memory of the prior copy). Stack-only
+ * copies (Storm and friends) leave it null.
  */
 @Serializable
 data class CopyOfComponent(


### PR DESCRIPTION
…R cite

- StormCopyTargetContinuation and StormCopyModalTargetContinuation now carry removeLegendary and keywordsForCopy. driveStormModalCopies accepts both, and the post-putSpellCopy mutation is consolidated in a single StormCopyEffectExecutor.applyCopyMutations helper used by every copy path (no-target, no-target-modal, targeted, targeted-modal, no-legal-targets fizzle loop).
- CopyTargetSpellExecutor: drop the "Cannot copy target permanent spell with targets" runtime error. The retarget continuation already routes through putSpellCopy (which copies the source CardComponent), and CR 707.10f token tagging happens in StackResolver.enterPermanentOnBattlefield, so targeted permanent-spell copies work end-to-end. StormCopyTargetContinuation .spellEffect is now nullable since it's only forwarded, never read, for permanent-spell paths.
- CopyOfComponent docstring: drop the spurious CR 707.2 cross-reference (707.2 is about copiable values); the revert-on-leave behaviour is governed by CR 400.7 alone.