### PR TITLE
Add Close Encounter with ChooseCreatureOrWarpedExile cost support

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 176 / 261
+**Implemented:** 177 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -34,7 +34,7 @@
 - [x] Cerebral Download
 - [x] Chorale of the Void
 - [x] Chrome Companion
-- [ ] Close Encounter
+- [x] Close Encounter
 - [x] Cloudsculpt Technician
 - [ ] Codecracker Hound
 - [x] Comet Crawler

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CloseEncounterScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CloseEncounterScenarioTest.kt
@@ -1,0 +1,305 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.WarpExiledComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.permissions.MayPlayPermission
+import com.wingedsheep.engine.state.permissions.addMayPlayPermission
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Close Encounter (Edge of Eternities).
+ *
+ * {1}{G} Instant
+ *   As an additional cost to cast this spell, choose a creature you control or
+ *   a warped creature card you own in exile.
+ *   Close Encounter deals damage equal to the power of the chosen creature or
+ *   card to target creature.
+ *
+ * Exercises the new
+ * [com.wingedsheep.sdk.scripting.AdditionalCost.ChooseCreatureOrWarpedExile]
+ * cost and the [com.wingedsheep.sdk.scripting.values.DynamicAmount.StoredCardPower]
+ * dynamic amount, including the LKI snapshot path documented in the printed
+ * ruling.
+ */
+class CloseEncounterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Choose a creature you control on the battlefield") {
+            test("deals damage equal to chosen creature's power to target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Close Encounter")
+                    .withCardOnBattlefield(1, "Python")            // 3/2, the chosen one
+                    .withCardOnBattlefield(2, "Whiptail Wurm")         // 8/5, the damaged target
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pythonId = game.findPermanent("Python")!!
+                val wurmId = game.findPermanent("Whiptail Wurm")!!
+                val closeEncounterId = game.findCardsInHand(1, "Close Encounter").first()
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = closeEncounterId,
+                        targets = listOf(ChosenTarget.Permanent(wurmId)),
+                        additionalCostPayment = AdditionalCostPayment(
+                            beheldCards = listOf(pythonId)
+                        )
+                    )
+                )
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Whiptail Wurm should have 3 damage marked (Python's power)") {
+                    game.state.getEntity(wurmId)?.get<DamageComponent>()?.amount shouldBe 3
+                }
+
+                withClue("Whiptail Wurm (5 toughness) should still be on the battlefield") {
+                    game.findPermanent("Whiptail Wurm") shouldBe wurmId
+                }
+
+                withClue("Python should still be on the battlefield — choosing doesn't move it") {
+                    game.findPermanent("Python") shouldBe pythonId
+                }
+            }
+
+            test("uses last-known power when chosen creature leaves the battlefield before resolution") {
+                // Ruling: "If that creature is no longer on the battlefield when Close
+                // Encounter resolves, use that creature's power as it last existed on the
+                // battlefield to determine how much damage is dealt." (Capture a snapshot
+                // at cost-pay time and read from it when the live entity is gone.)
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Close Encounter")
+                    .withCardOnBattlefield(1, "Python")           // 3/2 — chosen, then exiled
+                    .withCardOnBattlefield(2, "Whiptail Wurm")        // 8/5 — damaged target
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pythonId = game.findPermanent("Python")!!
+                val wurmId = game.findPermanent("Whiptail Wurm")!!
+                val closeEncounterId = game.findCardsInHand(1, "Close Encounter").first()
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = closeEncounterId,
+                        targets = listOf(ChosenTarget.Permanent(wurmId)),
+                        additionalCostPayment = AdditionalCostPayment(
+                            beheldCards = listOf(pythonId)
+                        )
+                    )
+                )
+                castResult.error shouldBe null
+
+                // Simulate the chosen creature leaving the battlefield between cost-pay and
+                // resolution by moving it directly to the graveyard (an arbitrary response
+                // like Doom Blade resolving in between). Close Encounter is still on the stack.
+                val controllerZone = ZoneKey(game.player1Id, Zone.BATTLEFIELD)
+                val graveyardZone = ZoneKey(game.player1Id, Zone.GRAVEYARD)
+                game.state = game.state
+                    .removeFromZone(controllerZone, pythonId)
+                    .addToZone(graveyardZone, pythonId)
+
+                game.findPermanent("Python") shouldBe null
+
+                game.resolveStack()
+
+                withClue("Damage should reflect Python's LKI power (3), not 0") {
+                    game.state.getEntity(wurmId)?.get<DamageComponent>()?.amount shouldBe 3
+                }
+            }
+        }
+
+        context("Choose a warped creature card you own in exile") {
+            test("deals damage equal to chosen card's printed power to target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Close Encounter")
+                    .withCardInExile(1, "Weftstalker Ardent")          // 2/3, warped in exile
+                    .withCardOnBattlefield(2, "Whiptail Wurm")         // 8/5, damaged target
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Mark the exiled card as a warped exiled card (CR 702.185b). In real play
+                // this happens automatically when the warp end-step trigger exiles a warped
+                // permanent; here we set it up directly.
+                val exiledCardId = game.state.getExile(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Weftstalker Ardent"
+                }
+                game.state = game.state.updateEntity(exiledCardId) { c ->
+                    c.with(WarpExiledComponent(controllerId = game.player1Id))
+                }
+                // The card must also be castable from exile for the warp loop to be
+                // realistic, though Close Encounter doesn't actually require this — it
+                // only inspects the WarpExiledComponent marker.
+                game.state = game.state.addMayPlayPermission(
+                    MayPlayPermission(
+                        id = EntityId.generate(),
+                        cardIds = setOf(exiledCardId),
+                        controllerId = game.player1Id,
+                        sourceId = exiledCardId,
+                        permanent = true,
+                        timestamp = game.state.timestamp,
+                    )
+                )
+
+                val wurmId = game.findPermanent("Whiptail Wurm")!!
+                val closeEncounterId = game.findCardsInHand(1, "Close Encounter").first()
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = closeEncounterId,
+                        targets = listOf(ChosenTarget.Permanent(wurmId)),
+                        additionalCostPayment = AdditionalCostPayment(
+                            beheldCards = listOf(exiledCardId)
+                        )
+                    )
+                )
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Whiptail Wurm should have 2 damage marked (Weftstalker Ardent's printed power)") {
+                    game.state.getEntity(wurmId)?.get<DamageComponent>()?.amount shouldBe 2
+                }
+
+                withClue("Weftstalker Ardent should still be in exile — choosing doesn't move it") {
+                    game.state.getExile(game.player1Id) shouldNotBe emptyList<EntityId>()
+                    game.state.getExile(game.player1Id).contains(exiledCardId) shouldBe true
+                }
+            }
+
+            test("does NOT accept a non-warped exiled creature card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Close Encounter")
+                    .withCardInExile(1, "Weftstalker Ardent")          // exiled but NOT marked as warped
+                    .withCardOnBattlefield(2, "Whiptail Wurm")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val exiledCardId = game.state.getExile(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Weftstalker Ardent"
+                }
+                val wurmId = game.findPermanent("Whiptail Wurm")!!
+                val closeEncounterId = game.findCardsInHand(1, "Close Encounter").first()
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = closeEncounterId,
+                        targets = listOf(ChosenTarget.Permanent(wurmId)),
+                        additionalCostPayment = AdditionalCostPayment(
+                            beheldCards = listOf(exiledCardId)
+                        )
+                    )
+                )
+
+                withClue("Cast must fail — an exiled creature card without WarpExiledComponent is not 'warped'") {
+                    castResult.error shouldNotBe null
+                }
+            }
+        }
+
+        context("Cast validation") {
+            test("must choose an entity — empty beheldCards is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Close Encounter")
+                    .withCardOnBattlefield(1, "Python")
+                    .withCardOnBattlefield(2, "Whiptail Wurm")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurmId = game.findPermanent("Whiptail Wurm")!!
+                val closeEncounterId = game.findCardsInHand(1, "Close Encounter").first()
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = closeEncounterId,
+                        targets = listOf(ChosenTarget.Permanent(wurmId)),
+                        additionalCostPayment = AdditionalCostPayment(beheldCards = emptyList())
+                    )
+                )
+
+                withClue("Cast without choosing must fail") {
+                    castResult.error shouldNotBe null
+                }
+            }
+
+            test("cannot choose a creature controlled by the opponent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Close Encounter")
+                    .withCardOnBattlefield(2, "Python")             // opponent's creature
+                    .withCardOnBattlefield(2, "Whiptail Wurm")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val opponentPythonId = game.findPermanent("Python")!!
+                val wurmId = game.findPermanent("Whiptail Wurm")!!
+                val closeEncounterId = game.findCardsInHand(1, "Close Encounter").first()
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = closeEncounterId,
+                        targets = listOf(ChosenTarget.Permanent(wurmId)),
+                        additionalCostPayment = AdditionalCostPayment(
+                            beheldCards = listOf(opponentPythonId)
+                        )
+                    )
+                )
+
+                withClue("Cast with an opponent's creature as the chosen entity must fail") {
+                    castResult.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/c/close-encounter.json
+++ b/manual-scenarios/cards/c/close-encounter.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Botanist",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Close Encounter", "Germinating Wurm"],
+    "battlefield": [
+      {"name": "Whiptail Wurm"},
+      {"name": "Hill Giant"},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Lyra Dawnbringer"},
+      {"name": "Hill Giant"},
+      {"name": "Grizzly Bears"},
+      {"name": "Forest", "tapped": false},
+      {"name": "Plains", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": []
+}

--- a/mtg-sdk/reference.md
+++ b/mtg-sdk/reference.md
@@ -833,6 +833,7 @@ constructors.
 - `DynamicAmount.CountersOnSelf(counterType)` / `.CountersOnTarget(counterType, targetIndex)` / `.CreaturesSharingTypeWithTriggeringEntity`
 - `DynamicAmount.TargetCount` — number of targets in the current effect context (for "for each target" token creation)
 - `DynamicAmount.VariableReference(variableName)` / `.StoredCardManaValue(collectionName)` / `.AdditionalCostExiledCount`
+- `DynamicAmount.StoredCardPower(collectionName)` — power of the first card stored in a pipeline collection (typically populated by `AdditionalCost.ChooseCreatureOrWarpedExile`). Reads projected power while the entity is on the battlefield, falls back to the LKI snapshot captured at cost-pay time (`EffectContext.chosenEntitySnapshots`), then to the card's printed base power.
 - `DynamicAmount.AttachmentsOnSelf` — count of Auras and Equipment attached to the source entity
 - `DynamicAmount.NumberOfBlockers` / `DynamicAmounts.numberOfBlockers()` — number of creatures blocking the triggering entity
 - `DynamicAmount.DamageDealtToTargetPlayerThisTurn(targetIndex)` — total damage dealt to a target player this turn
@@ -1240,6 +1241,7 @@ Used via `additionalCost(...)` in card DSL for spell additional costs:
 - `AdditionalCost.BlightOrPay(blightAmount, alternativeManaCost)` — Blight N or pay extra mana (Wild Unraveling)
 - `AdditionalCost.BeholdOrPay(filter, alternativeManaCost, storeAs)` — Behold a matching card or pay extra mana; behold reveals but does not exile (Lys Alana Dignitary)
 - `AdditionalCost.RemoveCountersFromYourCreatures(totalCount)` — remove N counters distributed across creatures you control (any counter types qualify); payment supplied via `AdditionalCostPayment.distributedCounterRemovals` (Dawnhand Dissident's linked-exile cost)
+- `AdditionalCost.ChooseCreatureOrWarpedExile(storeAs)` — choose a creature you control or a warped creature card you own in exile (CR 702.185b). The chosen entity id is stored under `storeAs` in pipeline storage; a power/toughness LKI snapshot is captured for battlefield choices. Pair with `DynamicAmount.StoredCardPower(storeAs)` for "damage equal to the power of the chosen creature or card" (Close Encounter, Blade of the Swarm).
 
 CostZone enum: `HAND`, `GRAVEYARD`, `LIBRARY`, `BATTLEFIELD`
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -413,6 +413,31 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
             return if (newFilter !== filter) copy(filter = newFilter) else this
         }
     }
+
+    /**
+     * Choose one entity that is either a creature you control on the battlefield
+     * or a warped creature card you own in exile (CR 702.185b — a "warped" card
+     * is one that was exiled by the warp end-step trigger). The chosen entity ID
+     * is recorded in [AdditionalCostPayment.beheldCards] and surfaced to the
+     * resolution context under [storeAs] via the spell's pipeline storage, so
+     * downstream effects (typically [com.wingedsheep.sdk.scripting.values.DynamicAmount.StoredCardPower])
+     * can read the chosen entity's power.
+     *
+     * Used by Edge of Eternities cards like Close Encounter and Blade of the Swarm.
+     *
+     * Choosing does not change zones — it merely records the chosen entity for the
+     * spell's effect to reference at resolution.
+     */
+    @SerialName("ChooseCreatureOrWarpedExile")
+    @Serializable
+    data class ChooseCreatureOrWarpedExile(
+        val storeAs: String = "chosen"
+    ) : AdditionalCost {
+        override val description: String =
+            "choose a creature you control or a warped creature card you own in exile"
+
+        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost = this
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -265,6 +265,29 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
     }
 
+    /**
+     * Power of the first card stored in a named pipeline collection.
+     *
+     * Resolution order:
+     *  1. If the stored entity is still on the battlefield, use its projected power
+     *     (CR 608.2 "use the values as the spell resolves").
+     *  2. Otherwise, if the spell captured a [com.wingedsheep.engine.state.components.stack.PermanentSnapshot]
+     *     for the entity at cost-pay time, use the snapshot's power
+     *     (CR 112.7a / 608.2h "as it last existed on the battlefield").
+     *  3. Otherwise (e.g. the chosen card was in exile and never on the battlefield
+     *     between cost-pay and resolution), fall back to the card's printed power
+     *     from its base [com.wingedsheep.sdk.model.CardStats].
+     *
+     * Used by Close Encounter: "Close Encounter deals damage equal to the power
+     * of the chosen creature or card to target creature."
+     */
+    @SerialName("StoredCardPower")
+    @Serializable
+    data class StoredCardPower(val collectionName: String) : DynamicAmount {
+        override val description: String = "the power of the chosen creature or card"
+        override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
+    }
+
     // =========================================================================
     // Math Operations - Composable arithmetic on DynamicAmounts
     // =========================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/CloseEncounter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/CloseEncounter.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Close Encounter
+ * {1}{G}
+ * Instant
+ *
+ * As an additional cost to cast this spell, choose a creature you control or
+ * a warped creature card you own in exile.
+ * Close Encounter deals damage equal to the power of the chosen creature or
+ * card to target creature.
+ *
+ * Rulings:
+ *  - If you chose a creature on the battlefield, use that creature's power
+ *    when Close Encounter resolves to determine how much damage is dealt.
+ *    If that creature is no longer on the battlefield when Close Encounter
+ *    resolves, use that creature's power as it last existed on the battlefield
+ *    to determine how much damage is dealt.
+ */
+val CloseEncounter = card("Close Encounter") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, choose a creature you control or a warped creature card you own in exile.\n" +
+        "Close Encounter deals damage equal to the power of the chosen creature or card to target creature."
+
+    additionalCost(AdditionalCost.ChooseCreatureOrWarpedExile(storeAs = "chosen"))
+
+    spell {
+        val damaged = target("creature", Targets.Creature)
+        effect = Effects.DealDamage(DynamicAmount.StoredCardPower("chosen"), damaged)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "176"
+        artist = "Inkognit"
+        flavorText = "Many mistake terrasymbiotic philosophy as pacifism. They are rarely wrong twice."
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8a77351-9115-470f-8141-222c1916b337.jpg?1752947272"
+
+        ruling(
+            "2025-07-25",
+            "If you chose a creature on the battlefield, use that creature's power when Close Encounter resolves to determine how much damage is dealt. If that creature is no longer on the battlefield when Close Encounter resolves, use that creature's power as it last existed on the battlefield to determine how much damage is dealt."
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -732,6 +732,23 @@ class CostHandler(
                 // All steps must be payable
                 cost.steps.all { canPayAdditionalCost(state, it, controllerId) }
             }
+            is AdditionalCost.ChooseCreatureOrWarpedExile -> {
+                // Payable iff the player has at least one valid choice:
+                //   - a creature they control on the battlefield, OR
+                //   - a creature card they own in exile with WarpExiledComponent
+                //     (CR 702.185b — a "warped" exiled card).
+                val projected = state.projectedState
+                val hasOwnCreature = projected.getBattlefieldControlledBy(controllerId).any { id ->
+                    projected.isCreature(id)
+                }
+                if (hasOwnCreature) return true
+                val exileZone = ZoneKey(controllerId, Zone.EXILE)
+                state.getZone(exileZone).any { cardId ->
+                    val container = state.getEntity(cardId) ?: return@any false
+                    if (!container.has<com.wingedsheep.engine.state.components.identity.WarpExiledComponent>()) return@any false
+                    container.get<CardComponent>()?.typeLine?.isCreature == true
+                }
+            }
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.engine.state.components.stack.snapshotFor
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CharacteristicValue
@@ -96,6 +97,24 @@ class DynamicAmountEvaluator(
                 val cards = context.pipeline.storedCollections[amount.collectionName] ?: return 0
                 val cardId = cards.firstOrNull() ?: return 0
                 state.getEntity(cardId)?.get<CardComponent>()?.manaValue ?: 0
+            }
+
+            is DynamicAmount.StoredCardPower -> {
+                val cards = context.pipeline.storedCollections[amount.collectionName] ?: return 0
+                val cardId = cards.firstOrNull() ?: return 0
+                // Prefer the live projected value while the entity is still on the
+                // battlefield (CR 608.2 — resolve using current characteristics).
+                if (cardId in state.getBattlefield()) {
+                    val effectiveProjected = projectedState ?: state.projectedState
+                    effectiveProjected.getPower(cardId)?.let { return it }
+                }
+                // Fall back to the snapshot captured when the chosen entity was on
+                // the battlefield at cost-pay time (CR 112.7a — last known info).
+                context.chosenEntitySnapshots.snapshotFor(cardId)?.power?.let { return it }
+                // Final fallback: the card's printed base power. Used when the chosen
+                // entity was in exile at cost-pay time (warped creature card), or when
+                // no snapshot was captured for some reason.
+                state.getEntity(cardId)?.get<CardComponent>()?.baseStats?.basePower ?: 0
             }
 
             // Math operations

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -64,6 +64,13 @@ data class EffectContext(
     val tappedPermanents: List<EntityId> = emptyList(),
     /** LKI snapshots for [tappedPermanents] (Rule 112.7a). See [PermanentSnapshot]. */
     val tappedPermanentSnapshots: List<PermanentSnapshot> = emptyList(),
+    /**
+     * LKI snapshots (Rule 112.7a) for entities chosen via an additional cost like
+     * [com.wingedsheep.sdk.scripting.AdditionalCost.ChooseCreatureOrWarpedExile].
+     * Indexed by entity id via [com.wingedsheep.engine.state.components.stack.snapshotFor].
+     * Read by [com.wingedsheep.sdk.scripting.values.DynamicAmount.StoredCardPower].
+     */
+    val chosenEntitySnapshots: List<PermanentSnapshot> = emptyList(),
     // --- Trigger state ---
     /** Amount of damage from a trigger context (e.g., "Whenever ~ is dealt damage") */
     val triggerDamageAmount: Int? = null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1146,6 +1146,30 @@ class CastSpellHandler(
                         return "Not enough life to pay ${additionalCost.amount} life"
                     }
                 }
+                is AdditionalCost.ChooseCreatureOrWarpedExile -> {
+                    val chosen = action.additionalCostPayment?.beheldCards ?: emptyList()
+                    if (chosen.isEmpty()) {
+                        return "You must choose a creature you control or a warped creature card you own in exile"
+                    }
+                    if (chosen.size > 1) {
+                        return "You may only choose one creature or warped exiled card"
+                    }
+                    val entityId = chosen.first()
+                    val container = state.getEntity(entityId)
+                        ?: return "Chosen entity not found: $entityId"
+                    val card = container.get<CardComponent>()
+                        ?: return "Chosen entity is not a card: $entityId"
+                    val isOwnCreatureOnBattlefield = entityId in state.getBattlefield() &&
+                        projected.getController(entityId) == action.playerId &&
+                        projected.isCreature(entityId)
+                    val exileZone = ZoneKey(action.playerId, Zone.EXILE)
+                    val isWarpedExiledOwnCard = entityId in state.getZone(exileZone) &&
+                        container.has<com.wingedsheep.engine.state.components.identity.WarpExiledComponent>() &&
+                        card.typeLine.isCreature
+                    if (!isOwnCreatureOnBattlefield && !isWarpedExiledOwnCard) {
+                        return "${card.name} must be a creature you control or a warped creature card you own in exile"
+                    }
+                }
                 else -> {}
             }
         }
@@ -1305,6 +1329,12 @@ class CastSpellHandler(
         val sacrificedSnapshots = mutableListOf<PermanentSnapshot>()
         var exiledCardCount = 0
         val beheldCards = mutableListOf<EntityId>()
+        /**
+         * LKI snapshots for entities chosen via [AdditionalCost.ChooseCreatureOrWarpedExile].
+         * Captured at cost-pay time so [DynamicAmount.StoredCardPower] can read "power as it
+         * last existed on the battlefield" if the chosen creature leaves before resolution.
+         */
+        val chosenEntitySnapshots = mutableListOf<PermanentSnapshot>()
         /** Pipeline storage populated by Behold, consumed by ExileFromStorage */
         val costPipelineCollections = mutableMapOf<String, List<EntityId>>()
 
@@ -1669,6 +1699,25 @@ class CastSpellHandler(
                     is AdditionalCost.PayLife -> {
                         // Handled in the auto-pay pre-pass above (PayLife requires no player choice).
                     }
+                    is AdditionalCost.ChooseCreatureOrWarpedExile -> {
+                        // Choosing does not change zones. Record the chosen entity id under
+                        // [beheldCards] (shared "chosen-as-additional-cost" storage) and in
+                        // the pipeline under [storeAs] so the spell effect can reference it.
+                        // Capture a power/toughness snapshot for battlefield choices so the
+                        // damage effect can fall back to LKI when the creature leaves before
+                        // resolution (CR 112.7a; ruling on Close Encounter).
+                        val chosen = action.additionalCostPayment.beheldCards
+                        if (chosen.isNotEmpty()) {
+                            beheldCards.addAll(chosen)
+                            costPipelineCollections[additionalCost.storeAs] = chosen
+                            val battlefieldChosen = chosen.filter { it in currentState.getBattlefield() }
+                            if (battlefieldChosen.isNotEmpty()) {
+                                chosenEntitySnapshots.addAll(
+                                    capturePermanentSnapshots(battlefieldChosen, currentState.projectedState)
+                                )
+                            }
+                        }
+                    }
                     else -> {}
                 }
             }
@@ -1936,6 +1985,7 @@ class CastSpellHandler(
             modeDamageDistribution = action.modeDamageDistribution,
             totalManaSpent = manaSpentThisCast,
             beheldCards = beheldCards,
+            chosenEntitySnapshots = chosenEntitySnapshots,
             manaSpentWhite = manaSpentEvent?.white ?: 0,
             manaSpentBlue = manaSpentEvent?.blue ?: 0,
             manaSpentBlack = manaSpentEvent?.black ?: 0,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -243,6 +243,26 @@ class CastSpellEnumerator : ActionEnumerator {
                             .filter { context.predicateEvaluator.matches(state, it, cost.filter, predicateContext) }
                         beholdOrPayTargets = battlefieldMatches + handMatches
                     }
+                    is AdditionalCost.ChooseCreatureOrWarpedExile -> {
+                        // Candidates: creatures the caster controls on the battlefield, plus
+                        // warped creature cards they own in exile (CR 702.185b).
+                        val projected = state.projectedState
+                        val battlefieldMatches = projected.getBattlefieldControlledBy(playerId).filter { permId ->
+                            projected.isCreature(permId)
+                        }
+                        val exileZone = ZoneKey(playerId, Zone.EXILE)
+                        val exileMatches = state.getZone(exileZone).filter { cardEntityId ->
+                            val container = state.getEntity(cardEntityId) ?: return@filter false
+                            container.has<com.wingedsheep.engine.state.components.identity.WarpExiledComponent>() &&
+                                container.get<CardComponent>()?.typeLine?.isCreature == true
+                        }
+                        val allTargets = battlefieldMatches + exileMatches
+                        if (allTargets.isEmpty()) {
+                            canPayAdditionalCosts = false
+                        }
+                        beholdTargets = allTargets
+                        beholdCount = 1
+                    }
                     else -> {}
                 }
             }
@@ -1342,9 +1362,10 @@ class CastSpellEnumerator : ActionEnumerator {
         } else if (beholdTargets.isNotEmpty()) {
             val flatCosts = additionalCosts.flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }
             val beholdCost = flatCosts.filterIsInstance<AdditionalCost.Behold>().firstOrNull()
+            val chooseCost = flatCosts.filterIsInstance<AdditionalCost.ChooseCreatureOrWarpedExile>().firstOrNull()
             AdditionalCostData(
-                description = beholdCost?.description ?: "Behold a card",
-                costType = "Behold",
+                description = chooseCost?.description ?: beholdCost?.description ?: "Behold a card",
+                costType = if (chooseCost != null) "ChooseCreatureOrWarpedExile" else "Behold",
                 validBeholdTargets = beholdTargets,
                 beholdCount = beholdCount
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -33,6 +33,7 @@ import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
 import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.engine.state.permissions.removeMayPlayPermissionsForCard
+import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.GrantCantBeCountered
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.core.Color
@@ -115,6 +116,7 @@ class StackResolver(
         modeDamageDistribution: Map<Int, Map<EntityId, Int>> = emptyMap(),
         totalManaSpent: Int = 0,
         beheldCards: List<EntityId> = emptyList(),
+        chosenEntitySnapshots: List<PermanentSnapshot> = emptyList(),
         manaSpentWhite: Int = 0,
         manaSpentBlue: Int = 0,
         manaSpentBlack: Int = 0,
@@ -174,6 +176,7 @@ class StackResolver(
                 wasWarped = wasWarped,
                 wasEvoked = wasEvoked,
                 beheldCards = beheldCards,
+                chosenEntitySnapshots = chosenEntitySnapshots,
                 manaSpentWhite = manaSpentWhite,
                 manaSpentBlue = manaSpentBlue,
                 manaSpentBlack = manaSpentBlack,
@@ -1134,6 +1137,7 @@ class StackResolver(
                 wasKicked = spellComponent.wasKicked,
                 wasBlightPaid = spellComponent.wasBlightPaid,
                 sacrificedPermanents = spellComponent.sacrificedPermanents,
+                chosenEntitySnapshots = spellComponent.chosenEntitySnapshots,
                 damageDistribution = spellComponent.damageDistribution,
                 chosenModes = spellComponent.chosenModes,
                 modeTargetsOrdered = spellComponent.modeTargetsOrdered,
@@ -1144,8 +1148,7 @@ class StackResolver(
                 castFromZone = spellComponent.castFromZone,
                 pipeline = PipelineState(
                     namedTargets = EffectContext.buildNamedTargets(targetRequirements, targets),
-                    storedCollections = if (spellComponent.beheldCards.isNotEmpty())
-                        mapOf("beheld" to spellComponent.beheldCards) else emptyMap()
+                    storedCollections = buildBeheldStoredCollections(spellComponent.beheldCards, resolvedCardDef)
                 )
             )
 
@@ -2244,4 +2247,40 @@ class StackResolver(
         }
     }
 
+}
+
+/**
+ * Build pipeline `storedCollections` for cost-chosen card IDs.
+ *
+ * The chosen IDs (from [AdditionalCost.Behold], [AdditionalCost.BeholdOrPay], or
+ * [AdditionalCost.ChooseCreatureOrWarpedExile]) are stored on the stack object as
+ * [SpellOnStackComponent.beheldCards]. Each of those costs declares its own
+ * `storeAs` key that the card's resolution-time effects reference (e.g.,
+ * `DynamicAmount.StoredCardPower("chosen")`). To keep the effect's reference
+ * stable across cost variants, expose the IDs under every relevant `storeAs`
+ * key plus a default `"beheld"` key for backward compatibility with
+ * pre-existing Behold-using cards.
+ *
+ * Top-level so non-stack consumers (e.g. the client-side preview text builder
+ * in `ClientStateTransformer`) can populate the same pipeline view of the
+ * spell's cost-chosen state without re-implementing the lookup.
+ */
+internal fun buildBeheldStoredCollections(
+    beheldCards: List<EntityId>,
+    cardDef: com.wingedsheep.sdk.model.CardDefinition?
+): Map<String, List<EntityId>> {
+    if (beheldCards.isEmpty()) return emptyMap()
+    val keys = mutableSetOf("beheld")
+    cardDef?.script?.additionalCosts?.forEach { cost ->
+        val flat = if (cost is AdditionalCost.Composite) cost.steps else listOf(cost)
+        for (c in flat) {
+            when (c) {
+                is AdditionalCost.Behold -> keys += c.storeAs
+                is AdditionalCost.BeholdOrPay -> keys += c.storeAs
+                is AdditionalCost.ChooseCreatureOrWarpedExile -> keys += c.storeAs
+                else -> {}
+            }
+        }
+    }
+    return keys.associateWith { beheldCards }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -33,6 +33,15 @@ data class SpellOnStackComponent(
     val wasWarped: Boolean = false,  // For warp - permanent is exiled at end step
     val wasEvoked: Boolean = false,  // For evoke - permanent is sacrificed on ETB
     val beheldCards: List<EntityId> = emptyList(),  // Cards chosen via Behold (stored in pipeline as named collection)
+    /**
+     * Last-known-info snapshots (Rule 112.7a) for entities chosen at cost-pay time
+     * that may later leave the battlefield before the spell resolves. Currently
+     * populated by [com.wingedsheep.sdk.scripting.AdditionalCost.ChooseCreatureOrWarpedExile]
+     * — captures the chosen creature's projected power/toughness/subtypes/controller
+     * so [com.wingedsheep.sdk.scripting.values.DynamicAmount.StoredCardPower] can
+     * read "power as it last existed on the battlefield" at resolution.
+     */
+    val chosenEntitySnapshots: List<PermanentSnapshot> = emptyList(),
     val manaSpentWhite: Int = 0,  // Mana colors spent for mana-spent-gated triggers
     val manaSpentBlue: Int = 0,
     val manaSpentBlack: Int = 0,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1184,9 +1184,15 @@ class ClientStateTransformer(
                 wasKicked = spellOnStack.wasKicked,
                 wasBlightPaid = spellOnStack.wasBlightPaid,
                 sacrificedPermanents = spellOnStack.sacrificedPermanents,
+                chosenEntitySnapshots = spellOnStack.chosenEntitySnapshots,
                 exiledCardCount = spellOnStack.exiledCardCount,
                 additionalCostBlightAmount = spellOnStack.additionalCostBlightAmount,
-                targets = chosenTargets
+                targets = chosenTargets,
+                pipeline = com.wingedsheep.engine.handlers.PipelineState(
+                    storedCollections = com.wingedsheep.engine.mechanics.stack.buildBeheldStoredCollections(
+                        spellOnStack.beheldCards, cardDef
+                    )
+                )
             )
             // Resolve ConditionalEffect at stack-time: opponents see only the branch that
             // will fire (e.g., Cinder Strike shows "deals 4 damage" vs "deals 2 damage"

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -118,6 +118,7 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
       'ExileFromZone',
       'RevealCard',
       'Behold',
+      'ChooseCreatureOrWarpedExile',
       'Blight',
       'Conspire',
     ]
@@ -282,7 +283,7 @@ export function mergeResult(
             ? { discardedCards: selectedTargets }
             : costType === 'ExileFromGraveyard'
               ? { exiledCards: selectedTargets }
-              : costType === 'Behold'
+              : costType === 'Behold' || costType === 'ChooseCreatureOrWarpedExile'
                 ? { beheldCards: selectedTargets }
                 : costType === 'Blight' || costType === 'BlightVariable'
                   ? { blightTargets: selectedTargets }
@@ -543,6 +544,7 @@ export function enterPhase(
           flags.isRevealSelection = true
           break
         case 'Behold':
+        case 'ChooseCreatureOrWarpedExile':
           validTargets = [...(costInfo.validBeholdTargets ?? [])]
           minTargets = costInfo.beholdCount ?? 1
           maxTargets = costInfo.beholdCount ?? 1


### PR DESCRIPTION
Introduces a new AdditionalCost variant for "choose a creature you control or a warped creature card you own in exile" and a paired DynamicAmount.StoredCardPower that reads the chosen entity's power (projected → LKI snapshot → printed base power). Also wires the new cost type through cost enumeration, validation, payment, snapshot capture, stack threading, the runtime stack-text builder, and the client's cost-payment pipeline phases so the behold-style selection UI fires for Close Encounter too.