### PR TITLE
Add Starport Security to Edge of Eternities

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 178 / 261
+**Implemented:** 179 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -207,7 +207,7 @@
 - [x] Starfield Shepherd
 - [x] Starfield Vocalist
 - [x] Starfighter Pilot
-- [ ] Starport Security
+- [x] Starport Security
 - [ ] Starwinder
 - [ ] Station Monitor
 - [x] Steelswarm Operator

--- a/manual-scenarios/cards/s/starport-security.json
+++ b/manual-scenarios/cards/s/starport-security.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Plains"],
+    "battlefield": [
+      {"name": "Starport Security"},
+      {"name": "Sazh's Chocobo"},
+      {"name": "Forest", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Hill Giant"},
+      {"name": "Mountain", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/StarportSecurity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/StarportSecurity.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Starport Security
+ * {W}
+ * Artifact Creature — Robot Soldier
+ * 1/1
+ * {3}{W}, {T}: Tap another target creature. This ability costs {2} less to
+ * activate if you control a creature with a +1/+1 counter on it.
+ */
+val StarportSecurity = card("Starport Security") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Robot Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "{3}{W}, {T}: Tap another target creature. This ability costs {2} less to activate if you control a creature with a +1/+1 counter on it."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{W}"), Costs.Tap)
+        val creature = target(
+            "another target creature",
+            TargetCreature(filter = TargetFilter.OtherCreature)
+        )
+        effect = Effects.Tap(creature)
+        genericCostReduction = DynamicAmount.Conditional(
+            condition = Exists(
+                player = Player.You,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Creature.youControl().withCounter(Counters.PLUS_ONE_PLUS_ONE)
+            ),
+            ifTrue = DynamicAmount.Fixed(2),
+            ifFalse = DynamicAmount.Fixed(0)
+        )
+        description = "{3}{W}, {T}: Tap another target creature. This ability costs {2} less to activate if you control a creature with a +1/+1 counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Lie Setiawan"
+        flavorText = "\"You are a suspect in an ongoing investigation. Do not resist apprehension.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/238cb1db-6c41-4fe1-bc34-340048dfde18.jpg?1752946704"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -135,6 +135,19 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 // creature's power").
                 val effectiveCost = applyAbilityGenericCostReduction(rawCost, ability, state, entityId, playerId)
 
+                // Description shown to the player. When the ability has a generic cost reduction
+                // that's currently active, rebuild the prefix from [effectiveCost] so the menu
+                // reflects what the player will actually pay (e.g., Starport Security drops from
+                // "{3}{W}, {T}: ..." to "{1}{W}, {T}: ..." once a +1/+1-counter creature is in
+                // play). Otherwise fall through to [ability.description], which honours any
+                // descriptionOverride the card defined.
+                val displayDescription =
+                    if (ability.genericCostReduction != null && effectiveCost != rawCost) {
+                        "${effectiveCost.description}: ${ability.effect.description}"
+                    } else {
+                        ability.description
+                    }
+
                 // Ability payment context — lets the solver consider restricted mana that's
                 // only spendable on this kind of activation (e.g., Steelswarm Operator's mana
                 // restricted to abilities of artifact sources).
@@ -435,15 +448,15 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
 
                 // If cost is unaffordable, add as greyed-out option and skip expensive computations
                 if (!costAffordable) {
-                    val abilityManaCostString = when (ability.cost) {
-                        is AbilityCost.Mana -> (ability.cost as AbilityCost.Mana).cost.toString()
-                        is AbilityCost.Composite -> (ability.cost as AbilityCost.Composite).costs
+                    val abilityManaCostString = when (effectiveCost) {
+                        is AbilityCost.Mana -> effectiveCost.cost.toString()
+                        is AbilityCost.Composite -> effectiveCost.costs
                             .filterIsInstance<AbilityCost.Mana>().firstOrNull()?.cost?.toString()
                         else -> null
                     }
                     result.add(LegalAction(
                         actionType = "ActivateAbility",
-                        description = ability.description,
+                        description = displayDescription,
                         action = ActivateAbility(playerId, entityId, ability.id),
                         affordable = false,
                         manaCostString = abilityManaCostString
@@ -493,10 +506,12 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 )
 
                 // Calculate X cost info for activated abilities with X in their mana cost
-                // or X determined by a variable cost (e.g., RemoveXPlusOnePlusOneCounters)
-                val abilityManaCost = when (ability.cost) {
-                    is AbilityCost.Mana -> (ability.cost as AbilityCost.Mana).cost
-                    is AbilityCost.Composite -> (ability.cost as AbilityCost.Composite).costs
+                // or X determined by a variable cost (e.g., RemoveXPlusOnePlusOneCounters).
+                // Use [effectiveCost] so generic-cost reductions (e.g., The Dominion Bracelet,
+                // Starport Security) flow through to the displayed [manaCostString].
+                val abilityManaCost = when (effectiveCost) {
+                    is AbilityCost.Mana -> effectiveCost.cost
+                    is AbilityCost.Composite -> effectiveCost.costs
                         .filterIsInstance<AbilityCost.Mana>().firstOrNull()?.cost
                     else -> null
                 }
@@ -561,7 +576,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         val autoSelectedTarget = ChosenTarget.Player(firstReqInfo.validTargets.first())
                         result.add(LegalAction(
                             actionType = "ActivateAbility",
-                            description = ability.description,
+                            description = displayDescription,
                             action = ActivateAbility(playerId, entityId, ability.id, targets = listOf(autoSelectedTarget)),
                             additionalCostInfo = costInfo,
                             hasXCost = abilityHasXCost,
@@ -576,7 +591,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         val autoSelectedTarget = ChosenTarget.Permanent(entityId)
                         result.add(LegalAction(
                             actionType = "ActivateAbility",
-                            description = ability.description,
+                            description = displayDescription,
                             action = ActivateAbility(playerId, entityId, ability.id, targets = listOf(autoSelectedTarget)),
                             additionalCostInfo = costInfo,
                             hasXCost = abilityHasXCost,
@@ -596,7 +611,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             state.stack.lastOrNull()?.let { it in firstReqInfo.validTargets } == true
                         result.add(LegalAction(
                             actionType = "ActivateAbility",
-                            description = ability.description,
+                            description = displayDescription,
                             action = ActivateAbility(playerId, entityId, ability.id),
                             validTargets = firstReqInfo.validTargets,
                             requiresTargets = true,
@@ -617,7 +632,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 } else {
                     result.add(LegalAction(
                         actionType = "ActivateAbility",
-                        description = ability.description,
+                        description = displayDescription,
                         action = ActivateAbility(playerId, entityId, ability.id),
                         additionalCostInfo = costInfo,
                         hasXCost = abilityHasXCost,


### PR DESCRIPTION
ActivatedAbilityEnumerator was sending the raw cost in both
manaCostString and description, so cards like Starport Security and
The Dominion Bracelet showed "{3}{W}" / "{15}" in the action menu even
when the reduction was active. Build manaCostString from effectiveCost,
and when a reduction is currently shrinking the cost, rebuild the
description prefix from effectiveCost too (descriptionOverride still
wins when no reduction applies, so the full oracle text remains visible
until the condition triggers).