### PR TITLE
Add Unravel to Edge of Eternities

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -245,7 +245,7 @@
 - [ ] Tractor Beam
 - [x] Tragic Trajectory
 - [x] Umbral Collar Zealot
-- [ ] Unravel
+- [x] Unravel
 - [ ] Uthros Psionicist
 - [x] Uthros Scanship
 - [ ] Uthros, Titanic Godcore

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -943,6 +943,12 @@ Numbers computed at resolution time.
 - `TargetPower(target)` — target's current power.
 - `TargetToughness(target)` — target's current toughness.
 - `TargetManaValue(target)` — target's mana value.
+- `DynamicAmounts.targetManaSpent(index)` — sum of all `manaSpent{Color}` buckets on
+  the targeted spell's `SpellOnStackComponent` (i.e. what was actually paid, after
+  cost reductions/increases). Pair with `targetManaValue()` for "if the amount of
+  mana spent to cast that spell was less than its mana value" gates (Unravel).
+  Desugars to `EntityProperty(EntityReference.Target(index), EntityNumericProperty.ManaSpent)`.
+  Returns 0 if the target isn't a spell on the stack.
 - `CardNumericProperty(card, property)` — generic numeric property accessor.
 
 ### Triggering-entity shortcuts (`DynamicAmounts.*` facades)

--- a/manual-scenarios/cards/u/unravel.json
+++ b/manual-scenarios/cards/u/unravel.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Unravel"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Sapling Nursery", "Shock"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": ["PRECOMBAT_MAIN"],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -265,6 +265,9 @@ object DynamicAmounts {
     fun targetManaValue(index: Int = 0): DynamicAmount =
         DynamicAmount.EntityProperty(EntityReference.Target(index), EntityNumericProperty.ManaValue)
 
+    fun targetManaSpent(index: Int = 0): DynamicAmount =
+        DynamicAmount.EntityProperty(EntityReference.Target(index), EntityNumericProperty.ManaSpent)
+
     fun sacrificedPower(index: Int = 0): DynamicAmount =
         DynamicAmount.EntityProperty(EntityReference.Sacrificed(index), EntityNumericProperty.Power)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
@@ -33,6 +33,23 @@ sealed interface EntityNumericProperty {
         override val description: String = "mana value"
     }
 
+    /**
+     * Total mana actually paid from the pool to cast a spell on the stack.
+     * Sums every `manaSpent{Color}` bucket on the spell's `SpellOnStackComponent`.
+     *
+     * Differs from [ManaValue]: ManaValue is the printed cost (unaffected by cost
+     * reductions or increases per CR 202.3; for {X} spells, 202.3e fixes the X
+     * portion to the chosen value once the spell is on the stack). ManaSpent
+     * reflects what was actually paid — so cost-reduced spells (affinity, convoke,
+     * etc.) show less than their mana value here. Returns 0 if the entity is not
+     * a spell on the stack.
+     */
+    @SerialName("ManaSpent")
+    @Serializable
+    data object ManaSpent : EntityNumericProperty {
+        override val description: String = "the amount of mana spent to cast it"
+    }
+
     @SerialName("CounterCount")
     @Serializable
     data class CounterCount(val counterType: CounterTypeFilter) : EntityNumericProperty {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Unravel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Unravel.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Unravel
+ * {1}{U}{U}
+ * Instant
+ * Counter target spell. If the amount of mana spent to cast that spell was less
+ * than its mana value, you draw a card.
+ *
+ * The mana-value-vs-paid comparison only matters when the targeted spell had a
+ * cost reduction (affinity, convoke, delve, etc.); per the Scryfall ruling,
+ * cost reductions/increases don't change mana value (CR 202.3).
+ */
+val Unravel = card("Unravel") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. If the amount of mana spent to cast that spell was less than its mana value, you draw a card."
+
+    spell {
+        target = Targets.Spell
+        effect = ConditionalEffect(
+            condition = Compare(
+                left = DynamicAmounts.targetManaSpent(),
+                operator = ComparisonOperator.LT,
+                right = DynamicAmounts.targetManaValue()
+            ),
+            effect = Effects.CounterSpell().then(Effects.DrawCards(1)),
+            elseEffect = Effects.CounterSpell()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Josh Hass"
+        flavorText = "Drix weftwalking requires neither eternity columns nor Pinnacle codebooks. But the art is ancient, and each passing is a leap of faith."
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e8978214-c853-453d-872d-af56bdaaa3d7.jpg?1752946891"
+        ruling("2025-07-25", "The mana value of a spell isn't changed by alternative costs, cost increases, or cost reductions. For example, if you cast Thrumming Hivepool (an artifact with affinity for Slivers), its mana value is 6 no matter how many Slivers you controlled when you cast it.")
+        ruling("2025-07-25", "For spells with {X} in their mana costs, use the value chosen for X to determine the spell's mana value.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CharacteristicValue
@@ -723,6 +724,12 @@ class DynamicAmountEvaluator(
 
             is EntityNumericProperty.ManaValue ->
                 state.getEntity(entityId)?.get<CardComponent>()?.manaValue ?: 0
+
+            is EntityNumericProperty.ManaSpent -> {
+                val spell = state.getEntity(entityId)?.get<SpellOnStackComponent>() ?: return 0
+                spell.manaSpentWhite + spell.manaSpentBlue + spell.manaSpentBlack +
+                    spell.manaSpentRed + spell.manaSpentGreen + spell.manaSpentColorless
+            }
 
             is EntityNumericProperty.CounterCount -> {
                 val countersComponent = state.getEntity(entityId)?.get<CountersComponent>() ?: return 0

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnravelTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnravelTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.Unravel
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unravel: {1}{U}{U} Instant
+ * "Counter target spell. If the amount of mana spent to cast that spell was
+ *  less than its mana value, you draw a card."
+ *
+ * Verifies the new `EntityNumericProperty.ManaSpent` primitive: the conditional
+ * draw fires iff the targeted spell's recorded `manaSpent{Color}` total is
+ * strictly less than its `CardComponent.manaValue` (Rule 202.3 / oracle ruling:
+ * cost reductions don't change mana value, but they do reduce mana spent).
+ */
+class UnravelTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(Unravel)
+        return driver
+    }
+
+    test("counters target spell but doesn't draw when full cost was paid") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // P2 casts Lightning Bolt at P1 — paid {R} in full so manaSpent == manaValue == 1.
+        val bolt = driver.putCardInHand(p2, "Lightning Bolt")
+        driver.giveMana(p2, Color.RED, 1)
+        driver.passPriority(p1)
+        driver.castSpell(p2, bolt, listOf(p1))
+        val boltOnStack = driver.getTopOfStack()!!
+
+        driver.passPriority(p2)
+
+        // P1 casts Unravel targeting the Bolt.
+        val handBefore = driver.getHand(p1).size
+        val unravel = driver.putCardInHand(p1, "Unravel")
+        driver.giveMana(p1, Color.BLUE, 3)
+        driver.castSpellWithTargets(p1, unravel, listOf(ChosenTarget.Spell(boltOnStack)))
+
+        driver.bothPass()
+
+        // Bolt was countered into P2's graveyard.
+        driver.getGraveyardCardNames(p2) shouldContain "Lightning Bolt"
+        // No bonus draw — mana spent (1) was not less than mana value (1).
+        driver.getHand(p1).size shouldBe handBefore
+    }
+
+    test("draws a card when target spell was cast for less than its mana value") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // P2 casts Lightning Bolt; we then patch the stack object to simulate the
+        // spell having been cast for less than its mana value (the same shape any
+        // cost-reducing keyword like affinity would produce).
+        val bolt = driver.putCardInHand(p2, "Lightning Bolt")
+        driver.giveMana(p2, Color.RED, 1)
+        driver.passPriority(p1)
+        driver.castSpell(p2, bolt, listOf(p1))
+        val boltOnStack = driver.getTopOfStack()!!
+
+        driver.replaceState(
+            driver.state.updateEntity(boltOnStack) { container ->
+                val spell = container.get<SpellOnStackComponent>()!!
+                container.with(spell.copy(manaSpentRed = 0))
+            }
+        )
+
+        driver.passPriority(p2)
+
+        val handBefore = driver.getHand(p1).size
+        val unravel = driver.putCardInHand(p1, "Unravel")
+        driver.giveMana(p1, Color.BLUE, 3)
+        driver.castSpellWithTargets(p1, unravel, listOf(ChosenTarget.Spell(boltOnStack)))
+
+        driver.bothPass()
+
+        driver.getGraveyardCardNames(p2) shouldContain "Lightning Bolt"
+        // Mana spent (0) is less than mana value (1) — Unravel triggers its draw clause.
+        driver.getHand(p1).size shouldBe handBefore + 1
+    }
+})


### PR DESCRIPTION
Adds the EntityNumericProperty.ManaSpent SDK primitive (and DynamicAmounts.targetManaSpent facade) so Unravel can compare the mana actually paid for the targeted spell against its mana value without baking the card into the SDK.