### PR TITLE
Add Entropic Battlecruiser with opponent-discards trigger support

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 195 / 261
+**Implemented:** 196 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -68,7 +68,7 @@
 - [x] Embrace Oblivion
 - [x] Emergency Eject
 - [x] Emissary Escort
-- [ ] Entropic Battlecruiser
+- [x] Entropic Battlecruiser
 - [x] Eumidian Terrabotanist
 - [x] Eusocial Engineering
 - [x] Evendo, Waking Haven

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -735,6 +735,22 @@ in the repo today):
 - `PermanentCardsPutIntoYourGraveyard` — only permanent cards.
 - `CreaturesPutIntoGraveyardFromLibrary` — mill-trigger shape.
 
+### Discard
+
+Fires once per card discarded — a single resolution that discards N cards fires the
+trigger N times (mirrors how `YouDraw` handles multi-card draws). The engine emits
+one aggregate `CardsDiscardedEvent` per resolution and fans it out in the detector.
+`Player.TriggeringPlayer` resolves to the discarding player inside the effect.
+
+- `AnyOpponentDiscards` — whenever an opponent discards a card. (Entropic Battlecruiser.)
+- `YouDiscard` — whenever you discard a card.
+
+**Factory** — `discards(player?, cardFilter?)` — generic shape. `player = Player.Each`
+matches any player; `cardFilter` matches if *any* card in the batch satisfies it.
+The cardFilter is evaluated against the **post-discard zone** (the cards are already
+in the graveyard when the trigger matches) — safe for type/subtype/color predicates,
+but a filter that depends on hand-specific state would read the wrong zone.
+
 ### Spell casting
 
 Named sugar for the common type-primitive cases; reach for `youCastSpell(...)` plus a

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EntropicBattlecruiserScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EntropicBattlecruiserScenarioTest.kt
@@ -1,0 +1,318 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Entropic Battlecruiser.
+ *
+ * Card reference:
+ * - Entropic Battlecruiser ({3}{B}): 3/10 Artifact — Spacecraft
+ *   Station (Tap another creature you control: Put charge counters equal to its power
+ *   on this Spacecraft. Station only as a sorcery. It's an artifact creature at 8+.)
+ *   1+ | Whenever an opponent discards a card, they lose 3 life.
+ *   8+ | Flying, deathtouch
+ *   Whenever this Spacecraft attacks, each opponent discards a card. Each opponent who
+ *   can't loses 3 life.
+ */
+class EntropicBattlecruiserScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("1+ charge counters: opponent-discards trigger") {
+
+            test("does not fire below 1 charge counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Entropic Battlecruiser")
+                    .withCardInHand(1, "Virus Beetle")
+                    .withCardInHand(2, "Mountain")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Battlecruiser stays at 0 charge counters — below the 1+ threshold.
+                val p2LifeBefore = game.getLifeTotal(2)
+
+                val cast = game.castSpell(1, "Virus Beetle")
+                withClue("Virus Beetle should cast: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision() as SelectCardsDecision
+                    game.selectCards(listOf(decision.options.first()))
+                }
+                game.resolveStack()
+
+                withClue("Player 2 should not lose life — Battlecruiser is at 0 charge counters") {
+                    game.getLifeTotal(2) shouldBe p2LifeBefore
+                }
+            }
+
+            test("fires when charge counter ≥ 1: opponent discards → loses 3 life") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Entropic Battlecruiser")
+                    .withCardInHand(1, "Virus Beetle")
+                    .withCardInHand(2, "Mountain")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cruiser = game.findPermanent("Entropic Battlecruiser")!!
+                game.state = game.state.updateEntity(cruiser) {
+                    it.with(CountersComponent().withAdded(CounterType.CHARGE, 1))
+                }
+
+                val p2LifeBefore = game.getLifeTotal(2)
+
+                // Cast Virus Beetle → on ETB it makes the opponent discard their Mountain.
+                val cast = game.castSpell(1, "Virus Beetle")
+                withClue("Virus Beetle should cast: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Opponent picks the only card to discard.
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision() as SelectCardsDecision
+                    game.selectCards(listOf(decision.options.first()))
+                }
+                game.resolveStack()
+
+                withClue("Player 2 should have lost 3 life from Entropic Battlecruiser's 1+ trigger") {
+                    game.getLifeTotal(2) shouldBe p2LifeBefore - 3
+                }
+            }
+
+            test("multi-card discard fans out — opponent discards 2, loses 6 life") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Entropic Battlecruiser")
+                    .withCardInHand(1, "Mind Rot")
+                    .withCardInHand(2, "Mountain")
+                    .withCardInHand(2, "Forest")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cruiser = game.findPermanent("Entropic Battlecruiser")!!
+                game.state = game.state.updateEntity(cruiser) {
+                    it.with(CountersComponent().withAdded(CounterType.CHARGE, 1))
+                }
+
+                val p2LifeBefore = game.getLifeTotal(2)
+
+                // Mind Rot targets opponent and makes them discard two cards in a single
+                // resolution. The engine emits one CardsDiscardedEvent with two cardIds;
+                // the detector fans that out into two separate trigger firings, so the 1+
+                // ability resolves twice for 3 life each.
+                val cast = game.castSpellTargetingPlayer(1, "Mind Rot", 2)
+                withClue("Mind Rot should cast: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision() as SelectCardsDecision
+                    game.selectCards(decision.options.take(2))
+                }
+                game.resolveStack()
+
+                withClue("Two cards discarded in one resolution should fire the 1+ trigger twice → 6 life lost") {
+                    game.getLifeTotal(2) shouldBe p2LifeBefore - 6
+                }
+            }
+
+            test("does not fire when an own discard happens (only opponents)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(2, "Entropic Battlecruiser")
+                    .withCardInHand(1, "Virus Beetle")
+                    .withCardInHand(2, "Mountain")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Player 2 owns the Battlecruiser at 1+ charge. Player 2 (the controller)
+                // should not lose life when Player 2 discards — only when an opponent
+                // (Player 1) discards.
+                val cruiser = game.findPermanent("Entropic Battlecruiser")!!
+                game.state = game.state.updateEntity(cruiser) {
+                    it.with(CountersComponent().withAdded(CounterType.CHARGE, 1))
+                }
+
+                val p1LifeBefore = game.getLifeTotal(1)
+                val p2LifeBefore = game.getLifeTotal(2)
+
+                // Player 1 casts Virus Beetle → Player 1 is the opponent of the
+                // Battlecruiser's controller (Player 2). When Player 2 discards in
+                // response to Virus Beetle, that's the Battlecruiser controller's *own*
+                // discard, which should NOT trigger the 1+ ability.
+                val cast = game.castSpell(1, "Virus Beetle")
+                withClue("Virus Beetle should cast: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision() as SelectCardsDecision
+                    game.selectCards(listOf(decision.options.first()))
+                }
+                game.resolveStack()
+
+                withClue("Player 2 (Battlecruiser controller) should not lose life from own discard") {
+                    game.getLifeTotal(2) shouldBe p2LifeBefore
+                }
+                withClue("Player 1 (the one who cast Virus Beetle) should also be unaffected") {
+                    game.getLifeTotal(1) shouldBe p1LifeBefore
+                }
+            }
+        }
+
+        context("8+ charge counters: becomes a creature with flying and deathtouch") {
+
+            test("is not a creature with 7 or fewer charge counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Entropic Battlecruiser")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cruiser = game.findPermanent("Entropic Battlecruiser")!!
+                game.state = game.state.updateEntity(cruiser) {
+                    it.with(CountersComponent().withAdded(CounterType.CHARGE, 7))
+                }
+
+                val projected = stateProjector.project(game.state)
+                withClue("7 charge counters: not yet a creature") {
+                    projected.isCreature(cruiser) shouldBe false
+                }
+            }
+
+            test("at 8+ charge counters, gains creature type, flying, and deathtouch") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Entropic Battlecruiser")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cruiser = game.findPermanent("Entropic Battlecruiser")!!
+                game.state = game.state.updateEntity(cruiser) {
+                    it.with(CountersComponent().withAdded(CounterType.CHARGE, 8))
+                }
+
+                val projected = stateProjector.project(game.state)
+                withClue("8 charge counters: is a creature") {
+                    projected.isCreature(cruiser) shouldBe true
+                }
+                withClue("flies at 8+ charge counters") {
+                    projected.hasKeyword(cruiser, "FLYING") shouldBe true
+                }
+                withClue("deathtouch at 8+ charge counters") {
+                    projected.hasKeyword(cruiser, "DEATHTOUCH") shouldBe true
+                }
+                withClue("base P/T 3/10 carries over") {
+                    projected.getPower(cruiser) shouldBe 3
+                    projected.getToughness(cruiser) shouldBe 10
+                }
+            }
+        }
+
+        context("Attack trigger: discard or lose 3 life") {
+
+            test("attacking forces each opponent to discard a card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Entropic Battlecruiser")
+                    .withCardInHand(2, "Forest")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cruiser = game.findPermanent("Entropic Battlecruiser")!!
+                // Stamp 8 charge counters so it can attack.
+                game.state = game.state.updateEntity(cruiser) {
+                    it.with(CountersComponent().withAdded(CounterType.CHARGE, 8))
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attackResult = game.declareAttackers(mapOf("Entropic Battlecruiser" to 2))
+                withClue("Attack should declare: ${attackResult.error}") {
+                    attackResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Opponent picks the only card to discard.
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision() as SelectCardsDecision
+                    game.selectCards(listOf(decision.options.first()))
+                }
+                game.resolveStack()
+
+                withClue("Opponent should have discarded their card") {
+                    game.handSize(2) shouldBe 0
+                }
+            }
+
+            test("opponent with empty hand loses 3 life from attack trigger") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Entropic Battlecruiser")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cruiser = game.findPermanent("Entropic Battlecruiser")!!
+                game.state = game.state.updateEntity(cruiser) {
+                    it.with(CountersComponent().withAdded(CounterType.CHARGE, 8))
+                }
+
+                val p2LifeBefore = game.getLifeTotal(2)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attackResult = game.declareAttackers(mapOf("Entropic Battlecruiser" to 2))
+                withClue("Attack should declare: ${attackResult.error}") {
+                    attackResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Opponent with empty hand loses 3 life from attack trigger") {
+                    game.getLifeTotal(2) shouldBe p2LifeBefore - 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -744,6 +744,49 @@ object Triggers {
     )
 
     // =========================================================================
+    // Discard Triggers
+    // =========================================================================
+
+    /**
+     * Whenever an opponent discards a card.
+     */
+    val AnyOpponentDiscards: TriggerSpec = TriggerSpec(
+        event = DiscardEvent(player = Player.Opponent),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
+     * Whenever you discard a card.
+     */
+    val YouDiscard: TriggerSpec = TriggerSpec(
+        event = DiscardEvent(player = Player.You),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
+     * Generic "discards a card" trigger factory. Use [AnyOpponentDiscards] /
+     * [YouDiscard] when their defaults match; reach for this factory for
+     * card-type filters or "any player discards" scopes.
+     *
+     * Examples:
+     * - "Whenever a player discards a card":
+     *   `discards(player = Player.Each)`
+     * - "Whenever an opponent discards a creature card":
+     *   `discards(player = Player.Opponent, cardFilter = GameObjectFilter.Creature)`
+     *
+     * Note: fires once per card discarded — e.g. an opponent discarding 3 cards
+     * in one resolution fires this 3 times. Mirrors how [YouDraw] handles
+     * multi-card draws.
+     */
+    fun discards(
+        player: Player = Player.Each,
+        cardFilter: GameObjectFilter? = null,
+    ): TriggerSpec = TriggerSpec(
+        event = DiscardEvent(player = player, cardFilter = cardFilter),
+        binding = TriggerBinding.ANY,
+    )
+
+    // =========================================================================
     // Stack Triggers
     // =========================================================================
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/EntropicBattlecruiser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/EntropicBattlecruiser.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Entropic Battlecruiser
+ * {3}{B}
+ * Artifact — Spacecraft
+ * Station (Tap another creature you control: Put charge counters equal to its power on this
+ *   Spacecraft. Station only as a sorcery. It's an artifact creature at 8+.)
+ * 1+ | Whenever an opponent discards a card, they lose 3 life.
+ * 8+ | Flying, deathtouch
+ * Whenever this Spacecraft attacks, each opponent discards a card. Each opponent who can't loses 3 life.
+ * 3/10
+ */
+val EntropicBattlecruiser = card("Entropic Battlecruiser") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Spacecraft"
+    power = 3
+    toughness = 10
+    oracleText = "Station (Tap another creature you control: Put charge counters equal to its " +
+        "power on this Spacecraft. Station only as a sorcery. It's an artifact creature at 8+.)\n" +
+        "1+ | Whenever an opponent discards a card, they lose 3 life.\n" +
+        "8+ | Flying, deathtouch\n" +
+        "Whenever this Spacecraft attacks, each opponent discards a card. Each opponent who can't loses 3 life."
+
+    activatedAbility {
+        cost = AbilityCost.TapPermanents(
+            count = 1,
+            filter = GameObjectFilter.Creature,
+            excludeSelf = true
+        )
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.CHARGE,
+            amount = DynamicAmount.EntityProperty(
+                entity = EntityReference.TappedAsCost(),
+                numericProperty = EntityNumericProperty.Power
+            ),
+            target = EffectTarget.Self
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    val chargeCount = DynamicAmount.EntityProperty(
+        entity = EntityReference.Source,
+        numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+    )
+    val atLeast1Charge = Compare(chargeCount, ComparisonOperator.GTE, DynamicAmount.Fixed(1))
+    val atLeast8Charge = Compare(chargeCount, ComparisonOperator.GTE, DynamicAmount.Fixed(8))
+
+    triggeredAbility {
+        trigger = Triggers.AnyOpponentDiscards
+        triggerCondition = atLeast1Charge
+        effect = LoseLifeEffect(3, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = ForEachPlayerEffect(
+            players = Player.EachOpponent,
+            effects = listOf(
+                ConditionalEffect(
+                    condition = Exists(Player.You, Zone.HAND),
+                    effect = EffectPatterns.discardCards(1, EffectTarget.Controller),
+                    elseEffect = LoseLifeEffect(3, EffectTarget.Controller)
+                )
+            )
+        )
+    }
+
+    staticAbility {
+        condition = atLeast8Charge
+        ability = GrantCardType("CREATURE", GroupFilter.source())
+    }
+    staticAbility {
+        condition = atLeast8Charge
+        ability = GrantKeyword(Keyword.FLYING.name, GroupFilter.source())
+    }
+    staticAbility {
+        condition = atLeast8Charge
+        ability = GrantKeyword(Keyword.DEATHTOUCH.name, GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "99"
+        artist = "Josiah \"Jo\" Cameron"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc59796b-9025-44b6-a188-cf6684ebffb9.jpg?1755552755"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.core.BecomesTargetEvent
 import com.wingedsheep.engine.core.BlockersDeclaredEvent
 import com.wingedsheep.engine.core.CardCycledEvent
 import com.wingedsheep.engine.core.CardRevealedFromDrawEvent
+import com.wingedsheep.engine.core.CardsDiscardedEvent
 import com.wingedsheep.engine.core.CardsDrawnEvent
 import com.wingedsheep.engine.core.ControlChangedEvent
 import com.wingedsheep.engine.core.DamageDealtEvent
@@ -92,6 +93,7 @@ data class TriggerContext(
                     modesChosenCount = event.chosenModesCount.takeIf { it > 0 }
                 )
                 is CardsDrawnEvent -> TriggerContext(triggeringPlayerId = event.playerId)
+                is CardsDiscardedEvent -> TriggerContext(triggeringPlayerId = event.playerId)
                 is CardRevealedFromDrawEvent -> TriggerContext(
                     triggeringEntityId = event.cardEntityId,
                     triggeringPlayerId = event.playerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.ClassLevelChangedEvent
 import com.wingedsheep.engine.core.CountersAddedEvent
 import com.wingedsheep.engine.core.AttackersDeclaredEvent
 import com.wingedsheep.engine.core.CardCycledEvent
+import com.wingedsheep.engine.core.CardsDiscardedEvent
 import com.wingedsheep.engine.core.CardsDrawnEvent
 import com.wingedsheep.engine.core.ControlChangedEvent
 import com.wingedsheep.engine.core.DoorUnlockedEvent
@@ -755,6 +756,22 @@ class TriggerDetector(
                     // to `event.count` triggers here.
                     else if (ability.trigger is GameEvent.DrawEvent && event is CardsDrawnEvent) {
                         repeat(event.count) {
+                            triggers.add(
+                                PendingTrigger(
+                                    ability = ability,
+                                    sourceId = entityId,
+                                    sourceName = cardComponent.name,
+                                    controllerId = controllerId,
+                                    triggerContext = TriggerContext.fromEvent(event)
+                                )
+                            )
+                        }
+                    }
+                    // Same shape for "whenever an opponent discards a card" — discarding N cards
+                    // through one effect creates N separate trigger firings.
+                    else if (ability.trigger is GameEvent.DiscardEvent &&
+                        event is CardsDiscardedEvent) {
+                        repeat(event.cardIds.size) {
                             triggers.add(
                                 PendingTrigger(
                                     ability = ability,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.core.AttackersDeclaredEvent
 import com.wingedsheep.engine.core.BecomesTargetEvent
 import com.wingedsheep.engine.core.BlockersDeclaredEvent
 import com.wingedsheep.engine.core.CardCycledEvent
+import com.wingedsheep.engine.core.CardsDiscardedEvent
 import com.wingedsheep.engine.core.GiftGivenEvent
 import com.wingedsheep.engine.core.CardRevealedFromDrawEvent
 import com.wingedsheep.engine.core.CardsDrawnEvent
@@ -66,6 +67,7 @@ enum class TriggerCategory {
     GIFT_GIVEN,
     TRANSFORM,
     COMMIT_CRIME,
+    DISCARD,
 }
 
 /**
@@ -181,6 +183,7 @@ class TriggerIndex(
                 is SdkGameEvent.GiftGivenEvent -> listOf(TriggerCategory.GIFT_GIVEN)
                 is SdkGameEvent.TransformEvent -> listOf(TriggerCategory.TRANSFORM)
                 is SdkGameEvent.CommitCrimeEvent -> listOf(TriggerCategory.COMMIT_CRIME)
+                is SdkGameEvent.DiscardEvent -> listOf(TriggerCategory.DISCARD)
                 // These are handled by specialized detect methods, not the main loop
                 else -> emptyList()
             }
@@ -212,6 +215,7 @@ class TriggerIndex(
             is GiftGivenEvent -> GIFT_GIVEN_LIST
             is com.wingedsheep.engine.core.TransformedEvent -> TRANSFORM_LIST
             is com.wingedsheep.engine.core.CommitCrimeEvent -> COMMIT_CRIME_LIST
+            is CardsDiscardedEvent -> DISCARD_LIST
             else -> emptyList()
         }
 
@@ -235,5 +239,6 @@ class TriggerIndex(
         private val GIFT_GIVEN_LIST = listOf(TriggerCategory.GIFT_GIVEN)
         private val TRANSFORM_LIST = listOf(TriggerCategory.TRANSFORM)
         private val COMMIT_CRIME_LIST = listOf(TriggerCategory.COMMIT_CRIME)
+        private val DISCARD_LIST = listOf(TriggerCategory.DISCARD)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.core.AbilityTriggeredEvent
 import com.wingedsheep.engine.core.AttackersDeclaredEvent
 import com.wingedsheep.engine.core.BlockersDeclaredEvent
 import com.wingedsheep.engine.core.CardCycledEvent
+import com.wingedsheep.engine.core.CardsDiscardedEvent
 import com.wingedsheep.engine.core.GiftGivenEvent
 import com.wingedsheep.engine.core.RoomFullyUnlockedEvent
 import com.wingedsheep.engine.core.CardRevealedFromDrawEvent
@@ -268,7 +269,25 @@ class TriggerMatcher(
                     event.oldLife != event.newLife &&
                     matchesPlayer(trigger.player, event.playerId, controllerId)
             }
-            is GameEvent.DiscardEvent -> false
+            is GameEvent.DiscardEvent -> {
+                if (event !is CardsDiscardedEvent) return false
+                if (!matchesPlayer(trigger.player, event.playerId, controllerId)) return false
+                val filter = trigger.cardFilter
+                if (filter != null) {
+                    // Filter is evaluated against the post-discard state — the cards are
+                    // already in the graveyard when the trigger matches. Safe for type/
+                    // subtype/color predicates (zone-independent on the card definition);
+                    // a filter that depends on hand-specific state would read the wrong zone.
+                    val projected = state.projectedState
+                    val predicateContext = com.wingedsheep.engine.handlers.PredicateContext(
+                        controllerId = controllerId,
+                        sourceId = sourceId
+                    )
+                    event.cardIds.any { cardId ->
+                        predicateEvaluator.matches(state, projected, cardId, filter, predicateContext)
+                    }
+                } else true
+            }
             is GameEvent.SearchLibraryEvent -> false
             // ExtraTurnEvent is only used as a replacement effect filter, not a trigger
             is GameEvent.ExtraTurnEvent -> false


### PR DESCRIPTION
Adds a new trigger shape — Triggers.AnyOpponentDiscards / YouDiscard / discards(player, cardFilter) — wired through TriggerIndex, TriggerMatcher, TriggerContext, and TriggerDetector. The detector expands one CardsDiscarded batch into N trigger firings (one per card), mirroring how YouDraw handles multi-card draws.

Card: Entropic Battlecruiser ({3}{B}, 3/10 Spacecraft) — Station, 1+ trigger that bleeds opponents on every discard, 8+ flying/deathtouch creaturification, and an attack trigger that forces a discard-or-lose-3 across each opponent.