### PR TITLE
Add Divert Disaster to Edge of Eternities

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 195 / 261
+**Implemented:** 196 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -55,7 +55,7 @@
 - [x] Desculpting Blast
 - [ ] Devastating Onslaught
 - [x] Diplomatic Relations
-- [ ] Divert Disaster
+- [x] Divert Disaster
 - [x] Dockworker Drone
 - [x] Drill Too Deep
 - [ ] Drix Fatemaker

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -317,6 +317,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 - `CounterEffect(target, condition?, destination?)` — counter a spell/ability; optionally send elsewhere.
   - `target = CounterTarget.Spell` / `Ability` / `SpellOrAbility` — `SpellOrAbility` dispatches at resolution by inspecting whether the stack entity has a `SpellOnStackComponent`. Used by Teferi's Response.
+  - `condition = CounterCondition.UnlessPaysMana(cost, onPaid?)` / `UnlessPaysDynamic(amount, onPaid?)` — "unless its controller pays …" with an optional `onPaid: Effect` rider that fires **only** when the spell's controller pays (Divert Disaster's "If they do, you create a Lander token"). The rider executes with the counter's controller as `controllerId`, so "you" in the rider resolves to the caster of the counter. The rider does not fire when the spell is countered. Facade: `Effects.CounterUnlessPays(cost, onPaid)` / `Effects.CounterUnlessDynamicPays(amount, exileOnCounter, onPaid)`.
 - `CounterAllOnStackEffect(filter?, destination?)` — counter everything matching.
 - `DestroySourceOfTargetedAbilityEffect` — when the targeted stack object is a permanent's activated/triggered ability, destroy that source permanent. Compose *before* the counter step so the ability component is still readable (Teferi's Response).
 - `CopyTargetSpellEffect(target)` — copy a spell on the stack.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DivertDisasterScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DivertDisasterScenarioTest.kt
@@ -1,11 +1,14 @@
 package com.wingedsheep.gameserver.scenarios
 
+import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -113,6 +116,63 @@ class DivertDisasterScenarioTest : ScenarioTestBase() {
                     game.isOnBattlefield("Lander") shouldBe false
                 }
 
+                game.isInGraveyard(1, "Divert Disaster") shouldBe true
+            }
+
+            test("opponent pays via Springleaf Drum's tap-permanents sub-cost, rider still fires") {
+                // Springleaf Drum ({T}, Tap an untapped creature you control: Add one mana of
+                // any color) is a mana source with a tap-permanents sub-cost. Paying the {2}
+                // through it routes the rider through WardTapPermanentsSubCostContinuation —
+                // the path that previously bailed. The Lander must still be created for the
+                // Divert Disaster caster once payment completes.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Divert Disaster")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 2) // one for Shock's {R}, one for {1} of {2}
+                    .withCardOnBattlefield(2, "Springleaf Drum")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // tapped to satisfy the Drum's sub-cost
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val drumId = game.findPermanent("Springleaf Drum").shouldNotBeNull()
+                val bearsId = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                game.castSpellTargetingPlayer(2, "Shock", targetPlayerNumber = 1)
+                game.passPriority()
+                game.castSpellTargetingStackSpell(1, "Divert Disaster", "Shock")
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(true)
+
+                // Pay {2} by manually picking the Drum plus one land (auto-pay never selects
+                // sub-cost sources). The Drum carries requiresTappingAnotherPermanent.
+                val manaDecision = game.getPendingDecision().shouldBeInstanceOf<SelectManaSourcesDecision>()
+                val drumSource = manaDecision.availableSources.first { it.entityId == drumId }
+                drumSource.requiresTappingAnotherPermanent shouldBe true
+                val landSource = manaDecision.availableSources.first { !it.requiresTappingAnotherPermanent }
+                game.submitManaSourcesDecision(listOf(landSource.entityId, drumSource.entityId), autoPay = false)
+
+                // The Drum's sub-cost prompts for an untapped creature to tap.
+                val tapPrompt = game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+                tapPrompt.options shouldContain bearsId
+                game.selectCards(listOf(bearsId))
+
+                // Shock resolves: Player 1 takes 2 damage.
+                game.resolveStack()
+                game.getLifeTotal(1) shouldBe 18
+
+                // The rider fired despite the payment running through the sub-cost path, and
+                // the Lander is controlled by Player 1 (the counter's caster — "you").
+                val landerId = game.findPermanent("Lander").shouldNotBeNull()
+                game.state.getEntity(landerId)?.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+
+                // Drum and the tapped creature are both tapped; Divert Disaster resolved.
                 game.isInGraveyard(1, "Divert Disaster") shouldBe true
             }
         }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DivertDisasterScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DivertDisasterScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Divert Disaster.
+ *
+ * Divert Disaster: {1}{U}
+ * Instant
+ * Counter target spell unless its controller pays {2}. If they do, you create a Lander token.
+ *
+ * Exercises the new onPaid rider on CounterCondition.UnlessPaysMana: the Lander is created
+ * only on the "they paid" branch.
+ */
+class DivertDisasterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Divert Disaster onPaid rider") {
+
+            test("when opponent pays, spell resolves and caster gets a Lander token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Divert Disaster")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 3) // {R} to cast bolt + {2} to pay
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Player 2 casts Shock targeting Player 1
+                val boltCast = game.castSpellTargetingPlayer(2, "Shock", targetPlayerNumber = 1)
+                withClue("Shock should cast: ${boltCast.error}") {
+                    boltCast.error shouldBe null
+                }
+                game.passPriority() // Player 2 passes; Player 1 can respond
+
+                // Player 1 responds with Divert Disaster targeting Shock
+                val divertCast = game.castSpellTargetingStackSpell(1, "Divert Disaster", "Shock")
+                withClue("Divert Disaster should cast: ${divertCast.error}") {
+                    divertCast.error shouldBe null
+                }
+
+                // Drain stack until Divert Disaster resolves and pauses for Player 2's pay decision
+                game.resolveStack()
+                game.hasPendingDecision() shouldBe true
+                game.getPendingDecision().shouldNotBeNull()
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                (game.getPendingDecision() as YesNoDecision).playerId shouldBe game.player2Id
+
+                // Player 2 chooses to pay {2}
+                game.answerYesNo(true)
+
+                // Mana-source selection appears for Player 2 (the {2} pay)
+                game.hasPendingDecision() shouldBe true
+                game.getPendingDecision().shouldBeInstanceOf<SelectManaSourcesDecision>()
+                game.submitManaSourcesAutoPay()
+
+                // Shock resolves: Player 1 takes 2 damage.
+                game.resolveStack()
+                game.getLifeTotal(1) shouldBe 18
+
+                // The "If they do, you create a Lander token" rider should have fired
+                // for Player 1 (controller of Divert Disaster).
+                withClue("Player 1 should now control a Lander token") {
+                    game.isOnBattlefield("Lander") shouldBe true
+                }
+
+                // Divert Disaster itself is in Player 1's graveyard (it resolved).
+                game.isInGraveyard(1, "Divert Disaster") shouldBe true
+            }
+
+            test("when opponent declines, spell is countered and no Lander is created") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Divert Disaster")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 3) // could pay, but chooses not to
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(2, "Shock", targetPlayerNumber = 1)
+                game.passPriority()
+                game.castSpellTargetingStackSpell(1, "Divert Disaster", "Shock")
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false) // decline payment
+
+                // Continue resolution after the decision.
+                game.resolveStack()
+
+                // Shock is countered → in Player 2's graveyard, no damage taken.
+                game.isInGraveyard(2, "Shock") shouldBe true
+                game.getLifeTotal(1) shouldBe 20
+
+                // Rider must NOT fire on the countered branch.
+                withClue("Lander must not be created when the spell is countered") {
+                    game.isOnBattlefield("Lander") shouldBe false
+                }
+
+                game.isInGraveyard(1, "Divert Disaster") shouldBe true
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1422,17 +1422,27 @@ object Effects {
     /**
      * Counter target spell unless its controller pays a mana cost.
      * "Counter target spell unless its controller pays {cost}."
+     *
+     * [onPaid] is an optional rider that runs **only if** the spell's controller pays
+     * — the "If they do, …" clause on cards like Divert Disaster (controller of the
+     * counter, not of the countered spell, becomes the rider's `controllerId`).
      */
-    fun CounterUnlessPays(cost: String): Effect =
-        CounterEffect(condition = CounterCondition.UnlessPaysMana(ManaCost.parse(cost)))
+    fun CounterUnlessPays(cost: String, onPaid: Effect? = null): Effect =
+        CounterEffect(condition = CounterCondition.UnlessPaysMana(ManaCost.parse(cost), onPaid))
 
     /**
      * Counter target spell unless its controller pays a dynamic generic mana cost.
      * "Counter target spell unless its controller pays {2} for each Wizard on the battlefield."
+     *
+     * [onPaid] mirrors [CounterUnlessPays]'s rider.
      */
-    fun CounterUnlessDynamicPays(amount: DynamicAmount, exileOnCounter: Boolean = false): Effect =
+    fun CounterUnlessDynamicPays(
+        amount: DynamicAmount,
+        exileOnCounter: Boolean = false,
+        onPaid: Effect? = null
+    ): Effect =
         CounterEffect(
-            condition = CounterCondition.UnlessPaysDynamic(amount),
+            condition = CounterCondition.UnlessPaysDynamic(amount, onPaid),
             counterDestination = if (exileOnCounter) CounterDestination.Exile() else CounterDestination.Graveyard
         )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
@@ -87,15 +87,33 @@ sealed interface CounterCondition {
     @Serializable
     data object Always : CounterCondition
 
-    /** Counter unless controller pays a fixed mana cost. */
+    /**
+     * Counter unless controller pays a fixed mana cost.
+     *
+     * @property onPaid Optional effect run **only if** the spell's controller pays the
+     *   cost (the "If they do, …" rider on cards like Divert Disaster). Executed with
+     *   the original spell's caster (of the counter, not of the countered spell) as
+     *   `controllerId`, so "you create a Lander token" targets the counter's caster.
+     *   When the spell is countered instead, the rider does not run.
+     */
     @SerialName("CounterCondition.UnlessPaysMana")
     @Serializable
-    data class UnlessPaysMana(val cost: ManaCost) : CounterCondition
+    data class UnlessPaysMana(
+        val cost: ManaCost,
+        val onPaid: Effect? = null
+    ) : CounterCondition
 
-    /** Counter unless controller pays a dynamic generic mana cost. */
+    /**
+     * Counter unless controller pays a dynamic generic mana cost.
+     *
+     * @property onPaid See [UnlessPaysMana.onPaid].
+     */
     @SerialName("CounterCondition.UnlessPaysDynamic")
     @Serializable
-    data class UnlessPaysDynamic(val amount: DynamicAmount) : CounterCondition
+    data class UnlessPaysDynamic(
+        val amount: DynamicAmount,
+        val onPaid: Effect? = null
+    ) : CounterCondition
 }
 
 /**
@@ -145,9 +163,11 @@ data class CounterEffect(
                     }
                     is CounterCondition.UnlessPaysMana -> {
                         append("Counter target spell unless its controller pays ${condition.cost}")
+                        condition.onPaid?.let { append(". If they do, ${it.description.replaceFirstChar(Char::lowercase)}") }
                     }
                     is CounterCondition.UnlessPaysDynamic -> {
                         append("Counter target spell unless its controller pays ${condition.amount.description}")
+                        condition.onPaid?.let { append(". If they do, ${it.description.replaceFirstChar(Char::lowercase)}") }
                     }
                 }
                 when (val dest = counterDestination) {
@@ -170,9 +190,15 @@ data class CounterEffect(
     override fun applyTextReplacement(replacer: TextReplacer): Effect {
         val newFilter = filter?.applyTextReplacement(replacer)
         val newCondition = when (condition) {
+            is CounterCondition.UnlessPaysMana -> {
+                val newOnPaid = condition.onPaid?.applyTextReplacement(replacer)
+                if (newOnPaid !== condition.onPaid) condition.copy(onPaid = newOnPaid) else condition
+            }
             is CounterCondition.UnlessPaysDynamic -> {
                 val newAmount = condition.amount.applyTextReplacement(replacer)
-                if (newAmount !== condition.amount) CounterCondition.UnlessPaysDynamic(newAmount) else condition
+                val newOnPaid = condition.onPaid?.applyTextReplacement(replacer)
+                if (newAmount !== condition.amount || newOnPaid !== condition.onPaid)
+                    condition.copy(amount = newAmount, onPaid = newOnPaid) else condition
             }
             else -> condition
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DivertDisaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DivertDisaster.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Divert Disaster
+ * {1}{U}
+ * Instant
+ *
+ * Counter target spell unless its controller pays {2}. If they do, you create a Lander token.
+ */
+val DivertDisaster = card("Divert Disaster") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell unless its controller pays {2}. If they do, you create a Lander token. " +
+        "(It's an artifact with \"{2}, {T}, Sacrifice this token: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\")"
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterUnlessPays(
+            cost = "{2}",
+            onPaid = Effects.CreateLander()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "David Álvarez"
+        flavorText = "Illvoi hope for the best outcomes but engineer for the worst."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5f7d2fe-628b-4493-8281-0e5f91ce5d61.jpg?1752946770"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
@@ -274,7 +274,12 @@ data class WardTapPermanentsSubCostContinuation(
     /** Source IDs still to process. Head is the one the current prompt is for. */
     val pendingSubCostSources: List<EntityId>,
     /** Original mana-source menu, kept for source-name lookups when emitting events. */
-    val availableSources: List<ManaSourceOption>
+    val availableSources: List<ManaSourceOption>,
+    /** See [CounterUnlessPaysContinuation.onPaid]. Carried so the rider fires after the
+     *  spell's controller finishes paying through a tap-permanents sub-cost source. */
+    val onPaid: Effect? = null,
+    /** See [CounterUnlessPaysContinuation.sourceId]. Carried for the rider's [EffectContext]. */
+    val sourceId: EntityId? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
@@ -21,6 +21,10 @@ import kotlinx.serialization.Serializable
  * @property manaCost The mana cost to pay
  * @property sourceId The source of the counter-unless-pays effect
  * @property sourceName Name of the source for event messages
+ * @property onPaid Optional rider executed only on the "they paid" branch (e.g. Divert
+ *   Disaster's "If they do, you create a Lander token"). The rider runs with
+ *   [controllerId] as its controller — i.e. the controller of the counter effect, who
+ *   is "you" in the rider text — not the spell's controller who paid.
  */
 @Serializable
 data class CounterUnlessPaysContinuation(
@@ -31,7 +35,8 @@ data class CounterUnlessPaysContinuation(
     val sourceId: EntityId?,
     val sourceName: String?,
     val exileOnCounter: Boolean = false,
-    val controllerId: EntityId? = null
+    val controllerId: EntityId? = null,
+    val onPaid: Effect? = null
 ) : ContinuationFrame
 
 /**
@@ -143,7 +148,11 @@ data class CounterUnlessPaysManaSelectionContinuation(
     val availableSources: List<ManaSourceOption>,
     val autoPaySuggestion: List<EntityId>,
     val exileOnCounter: Boolean = false,
-    val controllerId: EntityId? = null
+    val controllerId: EntityId? = null,
+    /** See [CounterUnlessPaysContinuation.onPaid]. */
+    val onPaid: Effect? = null,
+    /** See [CounterUnlessPaysContinuation.sourceId]. Carried for the rider's [EffectContext]. */
+    val sourceId: EntityId? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -376,15 +376,6 @@ class ManaPaymentContinuationResumer(
                 events.addAll(manual.events)
 
                 if (subCostSources.isNotEmpty()) {
-                    if (continuation.onPaid != null) {
-                        // No card today routes an onPaid rider through a tap-permanents
-                        // sub-cost source. Bail loudly so the next card that hits this
-                        // path is noticed in CI rather than silently dropping the rider.
-                        return ExecutionResult.error(
-                            state,
-                            "onPaid rider through tap-permanents sub-cost is not implemented"
-                        )
-                    }
                     // Persist the pool from the first-phase taps so the sub-cost
                     // continuation reads it off the player's mana pool component on resume.
                     currentState = currentState.updateEntity(playerId) { container ->
@@ -404,7 +395,9 @@ class ManaPaymentContinuationResumer(
                         exileOnCounter = continuation.exileOnCounter,
                         controllerId = continuation.controllerId,
                         pendingSubCostSources = subCostSources,
-                        availableSources = continuation.availableSources
+                        availableSources = continuation.availableSources,
+                        onPaid = continuation.onPaid,
+                        sourceId = continuation.sourceId
                     )
                 }
             }
@@ -1131,7 +1124,9 @@ class ManaPaymentContinuationResumer(
         exileOnCounter: Boolean,
         controllerId: EntityId?,
         pendingSubCostSources: List<EntityId>,
-        availableSources: List<ManaSourceOption>
+        availableSources: List<ManaSourceOption>,
+        onPaid: com.wingedsheep.sdk.scripting.effects.Effect? = null,
+        sourceId: EntityId? = null
     ): ExecutionResult {
         val headSourceId = pendingSubCostSources.first()
         val sourceName = availableSources.firstOrNull { it.entityId == headSourceId }?.name
@@ -1180,7 +1175,9 @@ class ManaPaymentContinuationResumer(
             exileOnCounter = exileOnCounter,
             controllerId = controllerId,
             pendingSubCostSources = pendingSubCostSources,
-            availableSources = availableSources
+            availableSources = availableSources,
+            onPaid = onPaid,
+            sourceId = sourceId
         )
 
         val stateWithDecision = state.withPendingDecision(decision)
@@ -1295,7 +1292,9 @@ class ManaPaymentContinuationResumer(
                 exileOnCounter = continuation.exileOnCounter,
                 controllerId = continuation.controllerId,
                 pendingSubCostSources = remaining,
-                availableSources = continuation.availableSources
+                availableSources = continuation.availableSources,
+                onPaid = continuation.onPaid,
+                sourceId = continuation.sourceId
             )
         }
 
@@ -1322,6 +1321,15 @@ class ManaPaymentContinuationResumer(
                 )
             )
         }
-        return checkForMore(currentState, events)
+        // Payment fully resolved through the sub-cost source — fire the "If they do, …"
+        // rider (no-op when null), with the counter's controller as "you".
+        return runOnPaidThenCheckForMore(
+            currentState,
+            events,
+            continuation.onPaid,
+            continuation.controllerId ?: continuation.payingPlayerId,
+            continuation.sourceId,
+            checkForMore
+        )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -69,7 +69,14 @@ class ManaPaymentContinuationResumer(
                         )
                     )
                 }
-                return checkForMore(currentState, emptyList())
+                return runOnPaidThenCheckForMore(
+                    currentState,
+                    emptyList(),
+                    continuation.onPaid,
+                    continuation.controllerId ?: continuation.payingPlayerId,
+                    continuation.sourceId,
+                    checkForMore
+                )
             }
 
             // Need to tap sources — show mana source selection UI
@@ -112,7 +119,9 @@ class ManaPaymentContinuationResumer(
                 availableSources = sourceOptions,
                 autoPaySuggestion = autoPaySuggestion,
                 exileOnCounter = continuation.exileOnCounter,
-                controllerId = continuation.controllerId
+                controllerId = continuation.controllerId,
+                onPaid = continuation.onPaid,
+                sourceId = continuation.sourceId
             )
 
             val stateWithDecision = state.withPendingDecision(decision)
@@ -367,6 +376,15 @@ class ManaPaymentContinuationResumer(
                 events.addAll(manual.events)
 
                 if (subCostSources.isNotEmpty()) {
+                    if (continuation.onPaid != null) {
+                        // No card today routes an onPaid rider through a tap-permanents
+                        // sub-cost source. Bail loudly so the next card that hits this
+                        // path is noticed in CI rather than silently dropping the rider.
+                        return ExecutionResult.error(
+                            state,
+                            "onPaid rider through tap-permanents sub-cost is not implemented"
+                        )
+                    }
                     // Persist the pool from the first-phase taps so the sub-cost
                     // continuation reads it off the player's mana pool component on resume.
                     currentState = currentState.updateEntity(playerId) { container ->
@@ -416,8 +434,55 @@ class ManaPaymentContinuationResumer(
             )
         }
 
-        // Spell resolves normally — don't counter it
-        return checkForMore(currentState, events)
+        // Spell resolves normally — don't counter it.
+        return runOnPaidThenCheckForMore(
+            currentState,
+            events,
+            continuation.onPaid,
+            continuation.controllerId ?: continuation.payingPlayerId,
+            continuation.sourceId,
+            checkForMore
+        )
+    }
+
+    /**
+     * Run the optional "If they do, …" rider that fires only when the spell's controller
+     * paid the counter-unless cost, then continue the pipeline.
+     *
+     * The rider executes with [riderController] as `controllerId` (the controller of the
+     * counter effect, i.e. "you" in "you create a Lander token"), with the spell's
+     * opponent as `opponentId`. If the rider pauses for a sub-decision we surface that
+     * pause directly; on error we also propagate it. Otherwise events from the prior
+     * payment phase are concatenated with the rider's events.
+     */
+    private fun runOnPaidThenCheckForMore(
+        state: GameState,
+        priorEvents: List<GameEvent>,
+        onPaid: com.wingedsheep.sdk.scripting.effects.Effect?,
+        riderController: EntityId,
+        sourceId: EntityId?,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (onPaid == null) return checkForMore(state, priorEvents)
+
+        val opponentId = state.turnOrder.firstOrNull { it != riderController }
+        val riderContext = com.wingedsheep.engine.handlers.EffectContext(
+            sourceId = sourceId,
+            controllerId = riderController,
+            opponentId = opponentId
+        )
+        val riderResult = services.effectExecutorRegistry
+            .execute(state, onPaid, riderContext)
+            .toExecutionResult()
+        if (riderResult.error != null) return riderResult
+        if (riderResult.isPaused) {
+            return ExecutionResult.paused(
+                riderResult.state,
+                riderResult.pendingDecision!!,
+                priorEvents + riderResult.events
+            )
+        }
+        return checkForMore(riderResult.state, priorEvents + riderResult.events)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CounterEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CounterEffectExecutor.kt
@@ -67,7 +67,8 @@ class CounterEffectExecutor(
         // Step 3: Handle condition (unless pays) or perform counter directly
         return when (val condition = effect.condition) {
             is CounterCondition.Always -> performCounter(state, effect, entityId, context)
-            is CounterCondition.UnlessPaysMana -> handleUnlessPaysMana(state, effect, entityId, condition.cost, context)
+            is CounterCondition.UnlessPaysMana ->
+                handleUnlessPaysMana(state, effect, entityId, condition.cost, condition.onPaid, context)
             is CounterCondition.UnlessPaysDynamic -> handleUnlessPaysDynamic(state, effect, entityId, condition, context)
         }
     }
@@ -118,6 +119,7 @@ class CounterEffectExecutor(
         effect: CounterEffect,
         spellEntityId: EntityId,
         cost: ManaCost,
+        onPaid: com.wingedsheep.sdk.scripting.effects.Effect?,
         context: EffectContext
     ): EffectResult {
         val payingPlayerId = getSpellCasterId(state, spellEntityId)
@@ -128,7 +130,7 @@ class CounterEffectExecutor(
             return performCounter(state, effect, spellEntityId, context)
         }
 
-        return offerPayment(state, effect, spellEntityId, payingPlayerId, cost, context)
+        return offerPayment(state, effect, spellEntityId, payingPlayerId, cost, onPaid, context)
     }
 
     private fun handleUnlessPaysDynamic(
@@ -144,7 +146,8 @@ class CounterEffectExecutor(
         val totalGenericCost = amountEvaluator.evaluate(state, condition.amount, context)
 
         if (totalGenericCost <= 0) {
-            // Cost is 0 or negative — spell is not countered
+            // Cost is 0 or negative — spell is not countered.
+            // The "If they do, …" rider also doesn't fire: nothing was paid.
             return EffectResult.success(state)
         }
 
@@ -155,7 +158,7 @@ class CounterEffectExecutor(
             return performCounter(state, effect, spellEntityId, context)
         }
 
-        return offerPayment(state, effect, spellEntityId, payingPlayerId, manaCost, context)
+        return offerPayment(state, effect, spellEntityId, payingPlayerId, manaCost, condition.onPaid, context)
     }
 
     private fun getSpellCasterId(state: GameState, spellEntityId: EntityId): EntityId? {
@@ -170,6 +173,7 @@ class CounterEffectExecutor(
         spellEntityId: EntityId,
         payingPlayerId: EntityId,
         manaCost: ManaCost,
+        onPaid: com.wingedsheep.sdk.scripting.effects.Effect?,
         context: EffectContext
     ): EffectResult {
         val decisionResult = decisionHandler.createYesNoDecision(
@@ -192,7 +196,8 @@ class CounterEffectExecutor(
             sourceId = context.sourceId,
             sourceName = "Counter unless pays",
             exileOnCounter = exileOnCounter,
-            controllerId = context.controllerId
+            controllerId = context.controllerId,
+            onPaid = onPaid
         )
 
         val stateWithContinuation = decisionResult.state.pushContinuation(continuation)


### PR DESCRIPTION
Extends CounterCondition.UnlessPaysMana / UnlessPaysDynamic with an optional `onPaid: Effect?` rider that runs only when the spell's controller pays the counter cost — Divert Disaster's "If they do, you create a Lander token." The rider is threaded through the CounterUnlessPays continuation chain (yes/no decision → mana-source selection) so it fires once payment fully resolves, with the counter's caster as "you".