### PR TITLE
Add Full Bore to Edge of Eternities with WasCastForWarp predicate

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 195 / 261
+**Implemented:** 196 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -82,7 +82,7 @@
 - [ ] Focus Fire
 - [x] Frenzied Baloth
 - [ ] Frontline War-Rager
-- [ ] Full Bore
+- [x] Full Bore
 - [x] Fungal Colossus
 - [x] Galactic Wayfarer
 - [x] Galvanizing Sawship

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -566,6 +566,12 @@ work for abilities-on-stack (which carry no `CardComponent`).
 - `IsBlocking` — declared as blocker this combat.
 - `IsFaceDown` — currently face-down.
 - `HasCounter(type)` — has at least one counter of `type`.
+- `IsWarpExiled` (filter builder `warpExiled()`) — card in exile via warp's
+  end-of-turn delayed trigger (CR 702.185b).
+- `WasCastForWarp` (filter builder `castForWarp()`) — battlefield permanent that
+  was cast for its warp cost (CR 702.185). Pair with
+  `Conditions.TargetMatchesFilter(GameObjectFilter.Creature.castForWarp(), …)` to
+  branch on whether a target was warp-cast (e.g., Full Bore).
 
 ### `AffectsFilter` — static-ability target shapes
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FullBoreScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FullBoreScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.WarpedComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Full Bore (Edge of Eternities).
+ *
+ * {R} Instant
+ *   Target creature you control gets +3/+2 until end of turn. If that creature
+ *   was cast for its warp cost, it also gains trample and haste until end of turn.
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasCastForWarp]
+ * predicate via `Conditions.TargetMatchesFilter(GameObjectFilter.Creature.castForWarp())`.
+ */
+class FullBoreScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Full Bore — non-warped target") {
+
+            test("pumps target by +3/+2 but does not grant trample or haste") {
+                val game = scenario()
+                    .withPlayers("Active", "Opponent")
+                    .withCardInHand(1, "Full Bore")
+                    .withCardOnBattlefield(1, "Weftstalker Ardent")    // 2/3, not warp-cast
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ardentId = game.findPermanent("Weftstalker Ardent")!!
+
+                val castResult = game.castSpell(1, "Full Bore", targetId = ardentId)
+                withClue("Casting Full Bore for {R} should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+
+                withClue("Ardent should be a 5/5 (2/3 base + 3/+2)") {
+                    projected.getPower(ardentId) shouldBe 5
+                    projected.getToughness(ardentId) shouldBe 5
+                }
+
+                withClue("Non-warped target should NOT gain trample") {
+                    projected.hasKeyword(ardentId, Keyword.TRAMPLE) shouldBe false
+                }
+                withClue("Non-warped target should NOT gain haste") {
+                    projected.hasKeyword(ardentId, Keyword.HASTE) shouldBe false
+                }
+            }
+        }
+
+        context("Full Bore — warp-cast target") {
+
+            test("pumps +3/+2 and grants trample + haste when target was cast for its warp cost") {
+                val game = scenario()
+                    .withPlayers("Active", "Opponent")
+                    .withCardInHand(1, "Full Bore")
+                    .withCardOnBattlefield(1, "Weftstalker Ardent")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ardentId = game.findPermanent("Weftstalker Ardent")!!
+
+                // Mark the creature as having been cast for its warp cost (CR 702.185a).
+                // In real play the StackResolver writes this when a warped spell resolves;
+                // here we set it directly to isolate Full Bore's branch.
+                game.state = game.state.updateEntity(ardentId) { c -> c.with(WarpedComponent) }
+
+                val castResult = game.castSpell(1, "Full Bore", targetId = ardentId)
+                withClue("Casting Full Bore for {R} should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+
+                withClue("Ardent should be a 5/5 (2/3 base + 3/+2)") {
+                    projected.getPower(ardentId) shouldBe 5
+                    projected.getToughness(ardentId) shouldBe 5
+                }
+
+                withClue("Warp-cast target should gain trample") {
+                    projected.hasKeyword(ardentId, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("Warp-cast target should gain haste") {
+                    projected.hasKeyword(ardentId, Keyword.HASTE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -414,6 +414,16 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.IsWarpExiled
     )
 
+    /**
+     * Must be a permanent on the battlefield that was cast for its warp cost
+     * (CR 702.185) — i.e., the engine wrote a `WarpedComponent` when the
+     * warped spell resolved. Use this to gate effects on warp-cast permanents,
+     * e.g. Full Bore's conditional trample + haste branch.
+     */
+    fun castForWarp() = copy(
+        statePredicates = statePredicates + StatePredicate.WasCastForWarp
+    )
+
     // =============================================================================
     // Fluent Builder Methods - Controller Predicates
     // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -201,6 +201,22 @@ sealed interface StatePredicate {
         override val description: String = "warped"
     }
 
+    /**
+     * Permanent on the battlefield that was cast for its warp cost (CR 702.185).
+     * Matches the `WarpedComponent` marker the engine writes when a warped spell
+     * resolves — the permanent-side bookkeeping equivalent of 702.185c's "a spell
+     * was warped this turn."
+     *
+     * Useful for effects that branch on whether a target was cast via warp — e.g.,
+     * Full Bore's "if that creature was cast for its warp cost, it also gains
+     * trample and haste."
+     */
+    @SerialName("WasCastForWarp")
+    @Serializable
+    data object WasCastForWarp : Entity {
+        override val description: String = "cast for its warp cost"
+    }
+
     // =============================================================================
     // Composite / Logical Combinators
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FullBore.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FullBore.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Full Bore
+ * {R}
+ * Instant
+ * Target creature you control gets +3/+2 until end of turn. If that creature was
+ * cast for its warp cost, it also gains trample and haste until end of turn.
+ */
+val FullBore = card("Full Bore") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature you control gets +3/+2 until end of turn. " +
+        "If that creature was cast for its warp cost, it also gains trample and haste until end of turn."
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(3, 2, creature)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.TargetMatchesFilter(
+                        GameObjectFilter.Creature.castForWarp(),
+                        targetIndex = 0
+                    ),
+                    effect = Effects.GrantKeyword(Keyword.TRAMPLE, creature)
+                        .then(Effects.GrantKeyword(Keyword.HASTE, creature))
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "135"
+        artist = "Olivier Bernard"
+        flavorText = "The mining gear that crumbled their planet could also deal terrible damage to flesh."
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cfee64ef-d22d-4024-bc65-59cbd1731d1c.jpg?1752947099"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -340,6 +340,7 @@ class BeginningPhaseManager(
         StatePredicate.HasGreatestPower,
         StatePredicate.IsEquipped,
         StatePredicate.IsModified,
-        StatePredicate.IsWarpExiled -> true
+        StatePredicate.IsWarpExiled,
+        StatePredicate.WasCastForWarp -> true
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -983,6 +983,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsWarpExiled,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasCastForWarp,
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasCounter -> true
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -585,6 +585,10 @@ class PredicateEvaluator {
             StatePredicate.IsWarpExiled ->
                 container.has<com.wingedsheep.engine.state.components.identity.WarpExiledComponent>()
 
+            // Battlefield marker — set when a warped spell resolves (CR 702.185).
+            StatePredicate.WasCastForWarp ->
+                container.has<com.wingedsheep.engine.state.components.battlefield.WarpedComponent>()
+
             // Relative power
             StatePredicate.HasGreatestPower -> {
                 val projected = state.projectedState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -334,6 +334,8 @@ internal class AffectsFilterResolver {
         StatePredicate.IsModified -> com.wingedsheep.engine.handlers.predicates.isModified(state, entityId)
         StatePredicate.IsWarpExiled ->
             container.has<com.wingedsheep.engine.state.components.identity.WarpExiledComponent>()
+        StatePredicate.WasCastForWarp ->
+            container.has<com.wingedsheep.engine.state.components.battlefield.WarpedComponent>()
         StatePredicate.HasGreatestPower -> hasGreatestPowerInProjection(state, entityId, container, projectedValues)
         StatePredicate.HasAnyCounter -> {
             val counters = container.get<CountersComponent>()


### PR DESCRIPTION
Adds the StatePredicate.WasCastForWarp / GameObjectFilter.castForWarp() primitive so card scripts can branch on whether a permanent was cast for its warp cost (CR 702.185a) — mirroring the existing IsWarpExiled predicate that targets the exile-zone marker.

Full Bore ({R} Instant): target creature you control gets +3/+2; if it was warp-cast, it also gains trample and haste.