### PR TITLE
Add Dream Thrush to Invasion

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -246,6 +246,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 - `AddCardType(type, target, duration)` — add a card type (e.g. become an artifact).
 - `AddSubtype(subtype, target, duration)` — add a subtype temporarily.
+- `SetLandType(landType, target, duration, fromChosenValueKey)` — target land *becomes* the basic land type, **replacing** its existing land subtypes (Rule 305.7); pass `fromChosenValueKey` to read the type from a preceding `ChooseOption(OptionType.BASIC_LAND_TYPE)`. One-shot counterpart to the `SetEnchantedLandType` aura static ability. (Dream Thrush)
 - `ChooseColorForTarget(target)` — target picks a color; stored in context.
 - `BecomeChosenManaColor(target)` — adopt the previously chosen color.
 - `ChangeColor(colors, target, duration)` — replace colors with the given set.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DreamThrushScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DreamThrushScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Dream Thrush.
+ *
+ * Card reference:
+ * - Dream Thrush ({1}{U}): Creature — Bird, 1/1, Flying
+ *   "{T}: Target land becomes the basic land type of your choice until end of turn."
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.effects.SetLandTypeEffect] / SetBasicLandTypes
+ * floating modification — "becomes" REPLACES the land's existing land subtypes (Rule 305.7),
+ * unlike the additive AddSubtype.
+ */
+class DreamThrushScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+    private val manaSolver = ManaSolver(cardRegistry)
+
+    /** Activate Dream Thrush's tap ability targeting [landId] and choose [landType]. */
+    private fun ScenarioTestBase.TestGame.changeLandType(landId: com.wingedsheep.sdk.model.EntityId, landType: String) {
+        val thrushId = findPermanent("Dream Thrush")!!
+        val ability = cardRegistry.getCard("Dream Thrush")!!.script.activatedAbilities.first()
+
+        val result = execute(
+            ActivateAbility(
+                playerId = player1Id,
+                sourceId = thrushId,
+                abilityId = ability.id,
+                targets = listOf(ChosenTarget.Permanent(landId))
+            )
+        )
+        withClue("Activation should succeed: ${result.error}") {
+            result.error shouldBe null
+        }
+
+        resolveStack()
+
+        val decision = getPendingDecision()
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val index = decision.options.indexOf(landType)
+        withClue("'$landType' should be among options ${decision.options}") {
+            (index >= 0) shouldBe true
+        }
+        submitDecision(OptionChosenResponse(decision.id, index))
+        resolveStack()
+    }
+
+    init {
+        context("Dream Thrush changes a target land's type") {
+
+            test("opponent's Forest becomes an Island and produces blue mana") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Dream Thrush")
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+                game.changeLandType(forest, "Island")
+
+                val projected = stateProjector.project(game.state)
+                withClue("Land should now be an Island") {
+                    projected.hasSubtype(forest, "Island") shouldBe true
+                }
+                withClue("Land should no longer be a Forest (becomes = replace, Rule 305.7)") {
+                    projected.hasSubtype(forest, "Forest") shouldBe false
+                }
+                withClue("Land should still be a Land") {
+                    projected.hasType(forest, "LAND") shouldBe true
+                }
+                withClue("Opponent should be able to pay {U} from the now-Island land") {
+                    manaSolver.canPay(game.state, game.player2Id, ManaCost.parse("{U}")) shouldBe true
+                }
+                withClue("Opponent should not be able to pay {G} (no longer a Forest)") {
+                    manaSolver.canPay(game.state, game.player2Id, ManaCost.parse("{G}")) shouldBe false
+                }
+            }
+
+            test("the type change wears off at end of turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Dream Thrush")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mountain = game.findPermanent("Mountain")!!
+                game.changeLandType(mountain, "Island")
+
+                withClue("Land should be an Island during the turn") {
+                    stateProjector.project(game.state).hasSubtype(mountain, "Island") shouldBe true
+                }
+
+                // Advance through the cleanup step into the next turn.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val projected = stateProjector.project(game.state)
+                withClue("Land should be a Mountain again after end of turn") {
+                    projected.hasSubtype(mountain, "Mountain") shouldBe true
+                }
+                withClue("Land should no longer be an Island") {
+                    projected.hasSubtype(mountain, "Island") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
 import com.wingedsheep.sdk.scripting.effects.AddDynamicCountersEffect
 import com.wingedsheep.sdk.scripting.effects.MoveAllLastKnownCountersEffect
 import com.wingedsheep.sdk.scripting.effects.AddSubtypeEffect
+import com.wingedsheep.sdk.scripting.effects.SetLandTypeEffect
 import com.wingedsheep.sdk.scripting.effects.AddCountersToCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.AnimateLandEffect
@@ -871,6 +872,18 @@ object Effects {
      */
     fun AddSubtype(subtype: String, target: EffectTarget, duration: Duration = Duration.EndOfTurn): Effect =
         AddSubtypeEffect(subtype, target, duration)
+
+    /**
+     * Set a target land's basic land subtype, replacing all existing land subtypes (Rule 305.7).
+     * "Target land becomes an Island until end of turn." Pass [fromChosenValueKey] to read the
+     * type from a preceding `ChooseOption(OptionType.BASIC_LAND_TYPE)` instead of [landType].
+     */
+    fun SetLandType(
+        landType: String = "",
+        target: EffectTarget = EffectTarget.ContextTarget(0),
+        duration: Duration = Duration.EndOfTurn,
+        fromChosenValueKey: String? = null
+    ): Effect = SetLandTypeEffect(landType, target, duration, fromChosenValueKey)
 
     /** Choose a color and store it on a target permanent. */
     fun ChooseColorForTarget(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TypeAndColorEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TypeAndColorEffects.kt
@@ -186,6 +186,43 @@ data class AddSubtypeEffect(
 }
 
 /**
+ * Set a target land's basic land subtype, replacing all of its existing land
+ * subtypes (Rule 305.7). The one-shot counterpart to the `SetEnchantedLandType`
+ * static ability used by auras like Sea's Claim.
+ *
+ * "Target land becomes the basic land type of your choice until end of turn."
+ *
+ * Unlike [AddSubtypeEffect], this does NOT keep the land's other land types — the
+ * land loses the mana abilities granted by its old types and gains those of the new one.
+ *
+ * @property landType The basic land type to set (static value, e.g. "Island")
+ * @property target Which land to modify
+ * @property duration How long the type change lasts
+ * @property fromChosenValueKey If set, reads the land type from EffectContext.chosenValues
+ *   instead of [landType] (pair with a `ChooseOptionEffect(OptionType.BASIC_LAND_TYPE)`)
+ */
+@SerialName("SetLandType")
+@Serializable
+data class SetLandTypeEffect(
+    val landType: String = "",
+    val target: EffectTarget = EffectTarget.ContextTarget(0),
+    val duration: Duration = Duration.EndOfTurn,
+    val fromChosenValueKey: String? = null
+) : Effect {
+    override val description: String = buildString {
+        append(target.description)
+        if (fromChosenValueKey != null) {
+            append(" becomes the basic land type of your choice")
+        } else {
+            append(" becomes a $landType")
+        }
+        if (duration.description.isNotEmpty()) append(" ${duration.description}")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
+}
+
+/**
  * Add a card type to a target permanent.
  * "That creature becomes an artifact in addition to its other types."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DreamThrush.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DreamThrush.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.OptionType
+
+/**
+ * Dream Thrush
+ * {1}{U}
+ * Creature — Bird
+ * 1/1
+ * Flying
+ * {T}: Target land becomes the basic land type of your choice until end of turn.
+ *
+ * "Becomes" replaces the land's existing land subtypes (Rule 305.7), so the land loses
+ * the mana abilities of its old types and gains those of the chosen type — modeled with
+ * [Effects.SetLandType] rather than the additive [Effects.AddSubtype].
+ */
+val DreamThrush = card("Dream Thrush") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{T}: Target land becomes the basic land type of your choice until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    val chosenKey = "chosenLandType"
+
+    activatedAbility {
+        val land = target("target land", Targets.Land)
+        cost = AbilityCost.Tap
+        effect = Effects.Composite(
+            Effects.ChooseOption(
+                optionType = OptionType.BASIC_LAND_TYPE,
+                storeAs = chosenKey
+            ),
+            Effects.SetLandType(
+                target = land,
+                duration = Duration.EndOfTurn,
+                fromChosenValueKey = chosenKey
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "D. J. Cleland-Hura"
+        flavorText = "Whether for good or ill, their arrival always means change."
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/258217df-ae88-4d93-895a-3fd242baacd1.jpg?1562902554"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -60,6 +60,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.types.ChangeGroupColorE
 import com.wingedsheep.engine.handlers.effects.permanent.types.EachPermanentBecomesCopyOfTargetExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.SetCreatureSubtypesExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.SetGroupCreatureSubtypesExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.types.SetLandTypeExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TransformEffectExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TurnFaceDownExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TurnFaceUpExecutor
@@ -108,6 +109,7 @@ class PermanentExecutors(
         AddCardTypeExecutor(),
         AddCreatureTypeExecutor(),
         AddSubtypeExecutor(),
+        SetLandTypeExecutor(),
         AnimateLandExecutor(),
         BecomeChosenManaColorExecutor(),
         BecomeCreatureExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/SetLandTypeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/SetLandTypeExecutor.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.handlers.effects.permanent.types
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.scripting.effects.SetLandTypeEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [SetLandTypeEffect].
+ * Sets a target land's basic land subtype via a Layer 4 floating effect, replacing
+ * all existing land subtypes (Rule 305.7). Unlike [AddSubtypeExecutor], the land
+ * loses its old land types and the mana abilities they granted.
+ */
+class SetLandTypeExecutor : EffectExecutor<SetLandTypeEffect> {
+
+    override val effectType: KClass<SetLandTypeEffect> = SetLandTypeEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: SetLandTypeEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target)
+            ?: return EffectResult.success(state)
+
+        if (targetId !in state.getBattlefield()) {
+            return EffectResult.success(state)
+        }
+
+        val landType = if (effect.fromChosenValueKey != null) {
+            context.pipeline.chosenValues[effect.fromChosenValueKey]
+                ?: return EffectResult.success(state)
+        } else {
+            effect.landType
+        }
+
+        val newState = state.addFloatingEffect(
+            layer = Layer.TYPE,
+            modification = SerializableModification.SetBasicLandTypes(setOf(landType)),
+            affectedEntities = setOf(targetId),
+            duration = effect.duration,
+            context = context
+        )
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
@@ -248,6 +248,15 @@ sealed interface SerializableModification {
     data class AddSubtype(val subtype: String) : SerializableModification
 
     /**
+     * Set a permanent's basic land subtypes, replacing all existing land subtypes
+     * (Rule 305.7). The one-shot counterpart to the [SetEnchantedLandType] static
+     * ability. Used by "target land becomes the basic land type of your choice"
+     * effects (e.g., Dream Thrush).
+     */
+    @Serializable
+    data class SetBasicLandTypes(val subtypes: Set<String>) : SerializableModification
+
+    /**
      * Add every creature type in addition to existing types, without granting the
      * Changeling keyword. Used by cards like Stalactite Dagger that say "is all
      * creature types" but don't print the Changeling keyword.
@@ -437,6 +446,7 @@ fun SerializableModification.toModification(): Modification = when (this) {
     is SerializableModification.PreventAllCombatDamage -> Modification.NoOp
     is SerializableModification.SetCreatureSubtypes -> Modification.SetCreatureSubtypes(subtypes)
     is SerializableModification.AddSubtype -> Modification.AddSubtype(subtype)
+    is SerializableModification.SetBasicLandTypes -> Modification.SetBasicLandTypes(subtypes)
     is SerializableModification.AddAllCreatureTypes -> Modification.AddAllCreatureTypes
     // SetCantAttack maps to the layer modification for "can't attack" projection
     is SerializableModification.SetCantAttack -> Modification.SetCantAttack


### PR DESCRIPTION
Implements Dream Thrush ({1}{U} 1/1 Bird, flying) with its "{T}: Target land becomes the basic land type of your choice until end of turn" ability.

"Becomes" replaces the land's existing land subtypes (CR 305.7), so a new SetLandTypeEffect (Effects.SetLandType) is added as the one-shot counterpart to the SetEnchantedLandType aura static ability — distinct from the additive AddSubtypeEffect. Backed by a new SerializableModification.SetBasicLandTypes floating modification that maps to the existing Modification.SetBasicLandTypes (Layer 4). Card composes ChooseOption(BASIC_LAND_TYPE) + SetLandType.