### PR TITLE
Add Astelli Reclaimer to Edge of Eternities

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 208 / 261
+**Implemented:** 212 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -13,7 +13,7 @@
 - [x] Annul
 - [x] Anticausal Vestige
 - [x] Archenemy's Charm
-- [ ] Astelli Reclaimer
+- [x] Astelli Reclaimer
 - [x] Atmospheric Greenhouse
 - [x] Atomic Microsizer
 - [x] Auxiliary Boosters
@@ -134,7 +134,7 @@
 - [x] Mechan Assembler
 - [x] Mechan Navigator
 - [x] Mechanozoa
-- [ ] Mechan Shieldmate
+- [x] Mechan Shieldmate
 - [x] Melded Moxite
 - [ ] Meltstrider Eulogist
 - [x] Meltstrider's Gear
@@ -196,7 +196,7 @@
 - [x] Shattered Wings
 - [x] Singularity Rupture
 - [x] Sinister Cryologist
-- [ ] Skystinger
+- [x] Skystinger
 - [x] Slagdrill Scrapper
 - [x] Sledge-Class Seedship
 - [x] Sothera, the Supervoid

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -527,6 +527,14 @@ For modal spells, prefer the explicit `targetPlayerControls(target)` DSL form; p
 - `.withSubtype(s)` / `.withKeyword(k)` — type/ability predicate.
 - `.ofColor(c)` / `.ofColors(set)` — color predicate.
 - `.power(n)` / `.minPower(n)` / `.maxPower(n)` — P/T comparator.
+- `.manaValue(n)` / `.manaValueAtMost(n)` / `.manaValueAtLeast(n)` — mana-value comparator.
+- `.manaValueAtMostX()` — mana value ≤ the X chosen for the source spell/ability.
+- `.manaValueAtMostEntity(ref)` — mana value ≤ a referenced entity's mana value (e.g. Kodama of the East Tree).
+- `.manaValueAtMostEntityManaSpent(ref)` — mana value ≤ the mana **actually spent** to cast a referenced
+  entity. Reads the live `SpellOnStackComponent` buckets while the entity is still a spell, or the
+  `CastRecordComponent` snapshot once it has resolved onto the battlefield (0 if it was never cast).
+  Used by Edge of Eternities warp payoffs like Astelli Reclaimer ("…mana value X or less…, where X is the
+  amount of mana spent to cast this creature") — X is 5 for `{3}{W}{W}`, 3 for warp `{2}{W}`, 0 for free.
 - `.tapped()` / `.untapped()` — tap state.
 - `.nontoken()` / `.token()` — token vs printed.
 - `.faceDown()` — face-down state.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AstelliReclaimerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AstelliReclaimerScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Astelli Reclaimer's enters ability:
+ * "return target noncreature, nonland permanent card with mana value X or less from your
+ * graveyard to the battlefield, where X is the amount of mana spent to cast this creature."
+ *
+ * The interesting seam is that X depends on *how* the creature was cast, not its mana value:
+ *  - cast for {3}{W}{W} → X = 5
+ *  - cast with warp {2}{W} → X = 3
+ *
+ * These exercise the new
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostEntityManaSpent]
+ * target predicate, which reads the source permanent's `CastRecordComponent` snapshot. The
+ * contrast case (test 2) returns the *same* mana-value-4 artifact under a normal cast but
+ * refuses it under a warp cast, proving X tracks mana actually spent.
+ *
+ * Icy Manipulator is a mana-value-4 artifact; All-Fates Scroll is a mana-value-3 artifact.
+ */
+class AstelliReclaimerScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("cast for {3}{W}{W} (X=5): returns a mana value 4 permanent from graveyard") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Astelli Reclaimer")
+                .withCardInGraveyard(1, "Icy Manipulator") // mana value 4 ≤ 5
+                .withLandsOnBattlefield(1, "Plains", 5)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val castResult = game.castSpell(1, "Astelli Reclaimer")
+            withClue("Casting Astelli Reclaimer for its full cost should succeed: ${castResult.error}") {
+                castResult.error shouldBe null
+            }
+            // Resolve the creature spell — it enters, and the enters trigger pauses for a target.
+            game.resolveStack()
+
+            val icyInGraveyard = game.findCardsInGraveyard(1, "Icy Manipulator").firstOrNull()
+                ?: error("Icy Manipulator should still be a legal graveyard target")
+            game.selectTargets(listOf(icyInGraveyard))
+            game.resolveStack()
+
+            withClue("Icy Manipulator (MV 4 ≤ X=5) should be returned to the battlefield") {
+                game.isOnBattlefield("Icy Manipulator") shouldBe true
+            }
+            withClue("Icy Manipulator should no longer be in the graveyard") {
+                game.isInGraveyard(1, "Icy Manipulator") shouldBe false
+            }
+        }
+
+        test("cast with warp {2}{W} (X=3): returns the MV-3 permanent but not the MV-4 one") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Astelli Reclaimer")
+                .withCardInGraveyard(1, "All-Fates Scroll") // mana value 3 ≤ 3 — legal
+                .withCardInGraveyard(1, "Icy Manipulator")  // mana value 4 > 3 — illegal
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val astelliId = game.findCardsInHand(1, "Astelli Reclaimer").firstOrNull()
+                ?: error("Astelli Reclaimer should be in hand")
+            val castResult = game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = astelliId,
+                    useAlternativeCost = true // warp {2}{W} → 3 mana spent
+                )
+            )
+            withClue("Warp cast should succeed: ${castResult.error}") {
+                castResult.error shouldBe null
+            }
+            game.resolveStack()
+
+            // Only All-Fates Scroll (MV 3 ≤ X=3) is a legal target; Icy Manipulator (MV 4) is not.
+            val scrollInGraveyard = game.findCardsInGraveyard(1, "All-Fates Scroll").firstOrNull()
+                ?: error("All-Fates Scroll should be a legal graveyard target")
+            game.selectTargets(listOf(scrollInGraveyard))
+            game.resolveStack()
+
+            withClue("All-Fates Scroll (MV 3 ≤ X=3) should be returned to the battlefield") {
+                game.isOnBattlefield("All-Fates Scroll") shouldBe true
+            }
+            withClue("Icy Manipulator (MV 4 > X=3) was never a legal target and stays in the graveyard") {
+                game.isInGraveyard(1, "Icy Manipulator") shouldBe true
+            }
+            withClue("Icy Manipulator should not have entered the battlefield") {
+                game.isOnBattlefield("Icy Manipulator") shouldBe false
+            }
+        }
+
+        test("cast with warp {2}{W} (X=3): with only a MV-4 permanent, the trigger has no legal target") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Astelli Reclaimer")
+                .withCardInGraveyard(1, "Icy Manipulator") // mana value 4 > 3 — no legal target
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val astelliId = game.findCardsInHand(1, "Astelli Reclaimer").firstOrNull()
+                ?: error("Astelli Reclaimer should be in hand")
+            val castResult = game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = astelliId,
+                    useAlternativeCost = true
+                )
+            )
+            withClue("Warp cast should succeed: ${castResult.error}") {
+                castResult.error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("Astelli Reclaimer should have entered the battlefield (warp cast)") {
+                game.isOnBattlefield("Astelli Reclaimer") shouldBe true
+            }
+            withClue("The enters trigger had no legal target (MV 4 > X=3), so Icy Manipulator stays") {
+                game.isInGraveyard(1, "Icy Manipulator") shouldBe true
+            }
+            withClue("No target decision should be pending — the trigger found no legal target") {
+                game.hasPendingDecision() shouldBe false
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/a/astelli-reclaimer.json
+++ b/manual-scenarios/cards/a/astelli-reclaimer.json
@@ -1,0 +1,31 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Astelli Reclaimer"],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": ["All-Fates Scroll", "Icy Manipulator", "Glory Seeker"],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -222,6 +222,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.ManaValueAtMostEntity(reference)
     )
 
+    /** Mana value at most the mana actually spent to cast a referenced entity (source, etc.) */
+    fun manaValueAtMostEntityManaSpent(reference: EntityReference) = copy(
+        cardPredicates = cardPredicates + CardPredicate.ManaValueAtMostEntityManaSpent(reference)
+    )
+
     /** Power equals */
     fun power(value: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.PowerEquals(value)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -307,6 +307,27 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
     }
 
+    /**
+     * Mana value at most the amount of mana actually spent to cast a referenced entity.
+     *
+     * Resolves the reference (typically [EntityReference.Source]) and reads its mana-spent
+     * record: the live `SpellOnStackComponent` buckets while the source is still a spell, or
+     * the `CastRecordComponent` snapshot once it has resolved into a permanent. Returns no
+     * match when neither is present (e.g., the source was put onto the battlefield without
+     * being cast, so 0 mana was spent — CR-faithful for "X is the amount of mana spent").
+     *
+     * Used by Edge of Eternities warp payoffs like Astelli Reclaimer: "return target ...
+     * card with mana value X or less ..., where X is the amount of mana spent to cast this
+     * creature." X is 5 cast for {3}{W}{W}, 3 cast with warp for {2}{W}, 0 cast for free.
+     */
+    @SerialName("ManaValueAtMostEntityManaSpent")
+    @Serializable
+    data class ManaValueAtMostEntityManaSpent(val reference: EntityReference) : CardPredicate {
+        override val description: String =
+            "with mana value less than or equal to the mana spent to cast ${reference.description}"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
     // =============================================================================
     // Power/Toughness Predicates
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AstelliReclaimer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AstelliReclaimer.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Astelli Reclaimer
+ * {3}{W}{W}
+ * Creature — Angel Warrior
+ * 5/4
+ *
+ * Flying
+ * When this creature enters, return target noncreature, nonland permanent card with mana
+ * value X or less from your graveyard to the battlefield, where X is the amount of mana
+ * spent to cast this creature.
+ * Warp {2}{W}
+ *
+ * X is the mana actually paid to cast this creature: 5 cast for {3}{W}{W}, 3 cast with warp
+ * for {2}{W}, 0 if cast for free or created as a copy on the stack (per Scryfall rulings).
+ * The mana-value-vs-spent comparison is expressed as the
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostEntityManaSpent]
+ * target predicate, which reads the source's `CastRecordComponent` snapshot.
+ */
+val AstelliReclaimer = card("Astelli Reclaimer") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel Warrior"
+    power = 5
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, return target noncreature, nonland permanent card with " +
+        "mana value X or less from your graveyard to the battlefield, where X is the amount " +
+        "of mana spent to cast this creature.\n" +
+        "Warp {2}{W} (You may cast this card from your hand for its warp cost. Exile this " +
+        "creature at the beginning of the next end step, then you may cast it from exile on " +
+        "a later turn.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val card = target(
+            "noncreature, nonland permanent card with mana value X or less in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = (GameObjectFilter.NoncreaturePermanent and GameObjectFilter.Nonland)
+                        .ownedByYou()
+                        .manaValueAtMostEntityManaSpent(EntityReference.Source),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.PutOntoBattlefield(card)
+        description = "When this creature enters, return target noncreature, nonland permanent card " +
+            "with mana value X or less from your graveyard to the battlefield, where X is the amount " +
+            "of mana spent to cast this creature."
+    }
+
+    warp = "{2}{W}"
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "4"
+        artist = "Carly Milligan"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4fb36405-cd28-432f-b0a4-e74ff8be928d.jpg?1752946568"
+        ruling("2025-07-25", "Astelli Reclaimer's enters ability cares about the mana you actually paid to cast Astelli Reclaimer, not its mana cost. If you cast Astelli Reclaimer for {3}{W}{W}, X is 5. If you cast it with warp for {2}{W}, X is 3. Any effects that increase or decrease the cost to cast it will also be taken into account.")
+        ruling("2025-07-25", "If an effect allows you to cast Astelli Reclaimer without paying its mana cost, X will be 0.")
+        ruling("2025-07-25", "If a copy of Astelli Reclaimer is created on the stack, no mana was spent to cast the copy, so X will be 0. The amount of mana spent to cast the original spell is not copied.")
+        ruling("2025-07-25", "If a card in your graveyard has {X} in its mana cost, X is 0 for the purpose of determining its mana value.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -527,6 +527,7 @@ class TriggerMatcher(
             com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostX -> false
             // Entity-relative — TriggerMatcher has no entity context; predicate doesn't apply here.
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostEntity -> false
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostEntityManaSpent -> false
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueEquals -> {
                 val cmc = if (isFaceDown) 0 else cardComponent.manaValue
                 cmc == predicate.value

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.CastRecordComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.sdk.core.CounterType
@@ -264,6 +265,12 @@ class PredicateEvaluator {
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc <= refManaValue
             }
+            is CardPredicate.ManaValueAtMostEntityManaSpent -> {
+                val refEntityId = resolveEntityReference(predicate.reference, context) ?: return false
+                val manaSpent = manaSpentToCast(state, refEntityId)
+                val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
+                cmc <= manaSpent
+            }
 
             // Power/toughness predicates - use projected P/T
             is CardPredicate.PowerEquals -> {
@@ -476,6 +483,26 @@ class PredicateEvaluator {
     /**
      * Resolve an EntityReference to an EntityId using the predicate context.
      */
+    /**
+     * Total mana actually spent to cast an entity. Reads the live [SpellOnStackComponent]
+     * buckets while the entity is still a spell on the stack, otherwise the
+     * [CastRecordComponent] snapshot stamped when it resolved onto the battlefield. Returns 0
+     * when neither is present (entity was put onto the battlefield without being cast, or is
+     * a copy created on the stack — no mana was spent in either case).
+     */
+    private fun manaSpentToCast(state: GameState, entityId: EntityId): Int {
+        val container = state.getEntity(entityId) ?: return 0
+        container.get<SpellOnStackComponent>()?.let { spell ->
+            return spell.manaSpentWhite + spell.manaSpentBlue + spell.manaSpentBlack +
+                spell.manaSpentRed + spell.manaSpentGreen + spell.manaSpentColorless
+        }
+        container.get<CastRecordComponent>()?.let { record ->
+            return record.whiteSpent + record.blueSpent + record.blackSpent +
+                record.redSpent + record.greenSpent + record.colorlessSpent
+        }
+        return 0
+    }
+
     private fun resolveEntityReference(ref: EntityReference, context: PredicateContext?): EntityId? {
         return when (ref) {
             is EntityReference.Source -> context?.sourceId
@@ -681,6 +708,7 @@ class PredicateEvaluator {
             is CardPredicate.ManaValueAtLeast -> record.manaValue >= predicate.min
             // Entity-relative — no entity context for cast records
             is CardPredicate.ManaValueAtMostEntity -> false
+            is CardPredicate.ManaValueAtMostEntityManaSpent -> false
 
             // Power/toughness — not meaningful for cast records
             is CardPredicate.PowerEquals, is CardPredicate.PowerAtMost, is CardPredicate.PowerAtLeast,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -364,7 +364,7 @@ class TargetFinder(
 
             for (cardId in graveyard) {
                 if (filter.excludeSelf && cardId == sourceId) continue
-                val predicateContext = PredicateContext(controllerId = controllerId, ownerId = playerId)
+                val predicateContext = PredicateContext(controllerId = controllerId, ownerId = playerId, sourceId = sourceId)
                 if (predicateEvaluator.matches(state, state.projectedState, cardId, filter.baseFilter, predicateContext)) {
                     targets.add(cardId)
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -441,6 +441,7 @@ internal class AffectsFilterResolver {
         is CardPredicate.ManaValueAtLeast -> card.manaValue >= predicate.min
         // Entity-relative — layer-projection has no trigger/source context for filter purposes here.
         is CardPredicate.ManaValueAtMostEntity -> false
+        is CardPredicate.ManaValueAtMostEntityManaSpent -> false
         is CardPredicate.NameEquals -> card.name == predicate.name
         is CardPredicate.HasBasicLandType -> if (isFaceDown) false else subtypes.any { it.equals(predicate.landType, ignoreCase = true) }
         is CardPredicate.And -> predicate.predicates.all { matchesCardPredicateForProjection(it, card, container, projected, types, subtypes, colors, keywords, isFaceDown) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -828,6 +828,7 @@ class CostCalculator(
             is CardPredicate.ManaValueAtLeast -> cardDef.manaCost.cmc >= predicate.min
             // CostCalculator has no entity context; predicate has no static answer here.
             is CardPredicate.ManaValueAtMostEntity -> false
+            is CardPredicate.ManaValueAtMostEntityManaSpent -> false
 
             is CardPredicate.PowerEquals -> cardDef.creatureStats?.basePower == predicate.value
             is CardPredicate.PowerAtMost -> (cardDef.creatureStats?.basePower ?: 0) <= predicate.max


### PR DESCRIPTION
5/4 Angel Warrior with flying and Warp {2}{W}. Its enters trigger returns a target noncreature, nonland permanent card with mana value X or less from your graveyard to the battlefield, where X is the amount of mana actually spent to cast it (5 for {3}{W}{W}, 3 for warp {2}{W}, 0 if cast for free).

New SDK building block: CardPredicate.ManaValueAtMostEntityManaSpent(reference) plus the GameObjectFilter.manaValueAtMostEntityManaSpent(ref) facade. It reads the referenced entity's mana spent — the live SpellOnStackComponent buckets while it is still a spell, or the CastRecordComponent snapshot once it has resolved into a permanent — so an enters trigger can constrain targets by the mana paid to cast the source. Wired into PredicateEvaluator (with a shared manaSpentToCast helper) and the exhaustive predicate when-blocks in TriggerMatcher, AffectsFilterResolver, and CostCalculator.

TargetFinder.findGraveyardTargets now threads sourceId into the PredicateContext (matching the legal-actions enumerator) so EntityReference.Source resolves during graveyard target selection.

Tests: AstelliReclaimerScenarioTest covers normal cast (X=5 returns a MV-4 permanent), warp cast (X=3 returns a MV-3 permanent but refuses the same MV-4 permanent), and warp with no legal target (trigger fizzles). Docs updated.