### PR TITLE
Add Bringer of the Last Gift to Lost Caverns of Ixalan

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1456,7 +1456,11 @@ Counter effects live in §4 (`AddCounters`, `RemoveCounters`, `Proliferate`, `Mo
 - `GatherCardsEffect(source, filter, into)` — pipeline gather from a zone into a named collection. `CardSource`
   variants include zones (`FromZone`, `FromMultipleZones`), battlefield queries (`BattlefieldMatching`,
   `ControlledPermanents`), linked exile (`FromLinkedExile`), tapped-as-cost (`TappedAsCost`), and the resolved
-  spell/ability targets (`ChosenTargets`).
+  spell/ability targets (`ChosenTargets`). The zone/library sources (`FromZone`, `FromMultipleZones`,
+  `TopOfLibrary`) accept a multi-player `player` reference (`Player.Each`, `Player.ActivePlayerFirst`,
+  `Player.EachOpponent`) and fan out across every relevant player's copy of the zone in a single gather —
+  e.g. "all creature cards in each player's graveyard" (Bringer of the Last Gift). Pair with
+  `MoveCollectionEffect(underOwnersControl = true)` to return each card to its owner.
 - `CaptureControllersEffect(from, storeAs)` — snapshot each entity's current controller into a parallel
   `List<EntityId>` under `storedCollections[storeAs]`. Required when a later step needs "who controlled
   this card before it left the battlefield" — `ControllerComponent` is stripped on move-out.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BringerOfTheLastGiftScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BringerOfTheLastGiftScenarioTest.kt
@@ -1,0 +1,200 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Bringer of the Last Gift.
+ *
+ * Card reference:
+ * - Bringer of the Last Gift ({6}{B}{B}): Creature — Vampire Demon, 6/6
+ *   "Flying"
+ *   "When this creature enters, if you cast it, each player sacrifices all other
+ *    creatures they control. Then each player returns all creature cards from their
+ *    graveyard that weren't put there this way to the battlefield."
+ *
+ * Verifies the snapshot-before-sacrifice composition: pre-existing graveyard creatures
+ * come back (under their owners' control), the creatures sacrificed during resolution do
+ * NOT, and Bringer itself survives (it is excluded from the "all other creatures" sweep).
+ * Also pins the intervening "if you cast it" clause (no trigger when reanimated) and that a
+ * sacrificed token ceases to exist rather than coming back.
+ */
+class BringerOfTheLastGiftScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioBuilder.withLibraryCards(playerNumber: Int, cardName: String, count: Int): ScenarioBuilder {
+        repeat(count) { withCardInLibrary(playerNumber, cardName) }
+        return this
+    }
+
+    private fun TestGame.countControlledTokens(playerNumber: Int): Int {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getBattlefield().count { entityId ->
+            val container = state.getEntity(entityId) ?: return@count false
+            container.has<TokenComponent>() &&
+                container.get<ControllerComponent>()?.playerId == playerId
+        }
+    }
+
+    init {
+        context("Bringer of the Last Gift ETB") {
+
+            test("sacrifices all other creatures, then reanimates each player's pre-existing graveyard creatures") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Bringer of the Last Gift")
+                    // On the battlefield — sacrificed by the trigger ("all other creatures").
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Enormous Baloth")
+                    // Already in the graveyard — returned to the battlefield ("not put there this way").
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(2, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Swamp", 8)
+                    .withLibraryCards(1, "Swamp", 5)
+                    .withLibraryCards(2, "Swamp", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Bringer of the Last Gift")
+                withClue("Casting Bringer of the Last Gift should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Bringer survives — it is excluded from the sacrifice ('all OTHER creatures')") {
+                    game.isOnBattlefield("Bringer of the Last Gift") shouldBe true
+                }
+
+                // Creatures that were on the battlefield are sacrificed and stay in their
+                // owners' graveyards (they were "put there this way").
+                withClue("Grizzly Bears was sacrificed and is not returned") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Enormous Baloth was sacrificed and is not returned") {
+                    game.isOnBattlefield("Enormous Baloth") shouldBe false
+                    game.isInGraveyard(2, "Enormous Baloth") shouldBe true
+                }
+
+                // Pre-existing graveyard creatures return to the battlefield.
+                withClue("Hill Giant (caster's graveyard) returns to the battlefield") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                    game.isInGraveyard(1, "Hill Giant") shouldBe false
+                }
+                withClue("Glory Seeker (opponent's graveyard) returns to the battlefield") {
+                    game.isOnBattlefield("Glory Seeker") shouldBe true
+                    game.isInGraveyard(2, "Glory Seeker") shouldBe false
+                }
+            }
+
+            test("reanimated creatures return under their owners' control") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Bringer of the Last Gift")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(2, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Swamp", 8)
+                    .withLibraryCards(1, "Swamp", 5)
+                    .withLibraryCards(2, "Swamp", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Bringer of the Last Gift").error shouldBe null
+                game.resolveStack()
+
+                val hillGiant = game.findPermanent("Hill Giant")
+                val glorySeeker = game.findPermanent("Glory Seeker")
+
+                withClue("Caster's Hill Giant returns under the caster's control") {
+                    game.state.getEntity(hillGiant!!)?.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+                }
+                withClue("Opponent's Glory Seeker returns under the opponent's control, not the caster's") {
+                    game.state.getEntity(glorySeeker!!)?.get<ControllerComponent>()?.playerId shouldBe game.player2Id
+                }
+            }
+
+            test("entering without being cast (reanimated) does not trigger the sacrifice-and-reanimate ability") {
+                // The ability has an intervening "if you cast it" clause. Per the card's ruling it
+                // does nothing when Bringer is put onto the battlefield without being cast — here via
+                // Breath of Life ("Return target creature card from your graveyard to the battlefield").
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Breath of Life")
+                    // Bringer reaches the battlefield via reanimation, never cast.
+                    .withCardInGraveyard(1, "Bringer of the Last Gift")
+                    // Would be sacrificed if the ability triggered.
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // Would return to the battlefield if the reanimate half triggered.
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withLibraryCards(1, "Plains", 5)
+                    .withLibraryCards(2, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bringerInGraveyard = game.state.getGraveyard(game.player1Id).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Bringer of the Last Gift"
+                }
+                val castResult = game.castSpellTargetingGraveyardCard(1, "Breath of Life", listOf(bringerInGraveyard))
+                withClue("Casting Breath of Life should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Bringer is on the battlefield — reanimated by Breath of Life, not cast") {
+                    game.isOnBattlefield("Bringer of the Last Gift") shouldBe true
+                }
+                withClue("Grizzly Bears survives — the 'if you cast it' ability never triggered") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("Hill Giant stays in the graveyard — the reanimate half never triggered") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                }
+            }
+
+            test("a sacrificed token ceases to exist rather than returning") {
+                // Fungal Infection ({B}) makes a 1/1 Saproling token the caster controls; Grizzly
+                // Bears is just its -1/-1 target. The Bringer sweep then sacrifices the token, which
+                // is put into the graveyard and ceases to exist (CR 111.7) — it is never a creature
+                // *card* in a graveyard, so it cannot be returned.
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Bringer of the Last Gift")
+                    .withCardInHand(1, "Fungal Infection")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 10)
+                    .withLibraryCards(1, "Swamp", 5)
+                    .withLibraryCards(2, "Swamp", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val grizzly = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Fungal Infection", grizzly).error shouldBe null
+                game.resolveStack()
+                withClue("Fungal Infection created a token the caster controls") {
+                    game.countControlledTokens(1) shouldBe 1
+                }
+
+                game.castSpell(1, "Bringer of the Last Gift").error shouldBe null
+                game.resolveStack()
+
+                withClue("The sacrificed token ceased to exist — gone from the battlefield, not reanimated") {
+                    game.countControlledTokens(1) shouldBe 0
+                }
+                withClue("Bringer itself survives the sweep") {
+                    game.isOnBattlefield("Bringer of the Last Gift") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/b/bringer-of-the-last-gift.json
+++ b/manual-scenarios/cards/b/bringer-of-the-last-gift.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Caster",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Bringer of the Last Gift"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": ["Hill Giant"],
+    "library": ["Swamp", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Enormous Baloth"}
+    ],
+    "graveyard": ["Glory Seeker"],
+    "library": ["Swamp", "Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -40,6 +40,11 @@ sealed interface CardSource {
 
     /**
      * Cards from a specific zone matching an optional filter.
+     *
+     * [player] may be a multi-player reference ([Player.Each], [Player.ActivePlayerFirst],
+     * [Player.EachOpponent]) to gather from every relevant player's copy of the zone at once
+     * (e.g. "all creature cards in each player's graveyard"). Single-player references gather
+     * from just that player's zone.
      */
     @SerialName("FromZone")
     @Serializable
@@ -54,6 +59,10 @@ sealed interface CardSource {
     /**
      * Cards from multiple zones matching an optional filter.
      * Used for "search your graveyard, hand, and/or library" effects.
+     *
+     * Like [FromZone], [player] may be a multi-player reference ([Player.Each],
+     * [Player.ActivePlayerFirst], [Player.EachOpponent]) to gather the listed zones across
+     * every relevant player at once.
      */
     @SerialName("FromMultipleZones")
     @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BringerOfTheLastGift.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BringerOfTheLastGift.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Bringer of the Last Gift
+ * {6}{B}{B}
+ * Creature — Vampire Demon
+ * 6/6
+ *
+ * Flying
+ * When this creature enters, if you cast it, each player sacrifices all other creatures
+ * they control. Then each player returns all creature cards from their graveyard that
+ * weren't put there this way to the battlefield.
+ *
+ * Implementation: the "weren't put there this way" clause is handled by snapshotting the
+ * creature cards already in every player's graveyard BEFORE the sacrifice, then returning
+ * only that snapshot. Because [GatherCardsEffect] records entity ids without moving the
+ * cards, the creatures sacrificed during this resolution land in graveyards afterwards and
+ * are therefore absent from the snapshot. The return step uses `underOwnersControl = true`
+ * so each reanimated creature enters under its owner's control, and the sacrifice uses
+ * [MoveType.Sacrifice] so each permanent goes to its owner's graveyard (CR 701.21a). The
+ * first gather spans all graveyards via the multi-player [Player.Each] reference.
+ */
+val BringerOfTheLastGift = card("Bringer of the Last Gift") {
+    manaCost = "{6}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Demon"
+    power = 6
+    toughness = 6
+    oracleText = "Flying\n" +
+        "When this creature enters, if you cast it, each player sacrifices all other creatures they control. Then each player returns all creature cards from their graveyard that weren't put there this way to the battlefield."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        effect = CompositeEffect(
+            listOf(
+                // Snapshot every creature card already in a graveyard, before the sacrifice.
+                // These are the cards "not put there this way" that will be returned.
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.Each,
+                        filter = GameObjectFilter.Creature
+                    ),
+                    storeAs = "graveyardCreaturesBeforeSacrifice"
+                ),
+                // Each player sacrifices all OTHER creatures they control (excludes this creature).
+                GatherCardsEffect(
+                    source = CardSource.BattlefieldMatching(
+                        filter = GameObjectFilter.Creature,
+                        player = Player.Each,
+                        excludeSelf = true
+                    ),
+                    storeAs = "creaturesToSacrifice"
+                ),
+                MoveCollectionEffect(
+                    from = "creaturesToSacrifice",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                    moveType = MoveType.Sacrifice
+                ),
+                // Return the pre-existing graveyard creatures to the battlefield under their
+                // owners' control. The just-sacrificed creatures are not in this snapshot.
+                MoveCollectionEffect(
+                    from = "graveyardCreaturesBeforeSacrifice",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                    underOwnersControl = true
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "94"
+        artist = "Wero Gallo"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19775c18-4cc0-49d3-86e4-0841768cbf4d.jpg?1779253388"
+
+        ruling("2023-11-10", "Bringer of the Last Gift's last ability triggers if you cast it from any zone. It doesn't trigger if you put Bringer of the Last Gift onto the battlefield without casting it.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -46,7 +46,7 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
         val cards = when (val source = effect.source) {
             is CardSource.TopOfLibrary -> {
                 val count = amountEvaluator.evaluate(state, source.count, context)
-                val playerIds = resolvePlayersForLibrary(source.player, context, state)
+                val playerIds = resolvePlayers(source.player, context, state)
                     ?: return EffectResult.error(state, "Could not resolve player for GatherCards")
                 playerIds.flatMap { playerId ->
                     state.getZone(ZoneKey(playerId, Zone.LIBRARY)).take(count)
@@ -54,10 +54,11 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
             }
 
             is CardSource.FromZone -> {
-                val playerId = resolvePlayer(source.player, context, state)
+                val playerIds = resolvePlayers(source.player, context, state)
                     ?: return EffectResult.error(state, "Could not resolve player for GatherCards")
-                val zone = ZoneKey(playerId, source.zone)
-                val allCards = state.getZone(zone)
+                val allCards = playerIds.flatMap { playerId ->
+                    state.getZone(ZoneKey(playerId, source.zone))
+                }
                 if (source.filter != GameObjectFilter.Any) {
                     val predicateContext = PredicateContext.fromEffectContext(context)
                     allCards.filter { cardId ->
@@ -69,10 +70,12 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
             }
 
             is CardSource.FromMultipleZones -> {
-                val playerId = resolvePlayer(source.player, context, state)
+                val playerIds = resolvePlayers(source.player, context, state)
                     ?: return EffectResult.error(state, "Could not resolve player for GatherCards")
-                val allCards = source.zones.flatMap { zone ->
-                    state.getZone(ZoneKey(playerId, zone))
+                val allCards = playerIds.flatMap { playerId ->
+                    source.zones.flatMap { zone ->
+                        state.getZone(ZoneKey(playerId, zone))
+                    }
                 }
                 if (source.filter != GameObjectFilter.Any) {
                     val predicateContext = PredicateContext.fromEffectContext(context)
@@ -251,12 +254,14 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
     }
 
     /**
-     * Resolve a [Player] reference to the list of player ids whose libraries should be
-     * gathered from. Multi-player references like [Player.Each] / [Player.EachOpponent]
-     * fan out (turn-order; opponents in turn-order minus controller); single-player
-     * references collapse to a one-element list.
+     * Resolve a [Player] reference to the list of player ids whose zone should be gathered
+     * from. Multi-player references like [Player.Each] / [Player.ActivePlayerFirst] /
+     * [Player.EachOpponent] fan out (turn-order; opponents in turn-order minus controller),
+     * so a single [CardSource.FromZone] / [CardSource.FromMultipleZones] / [CardSource.TopOfLibrary]
+     * can gather "each player's graveyard/hand/library" at once. Single-player references
+     * collapse to a one-element list.
      */
-    private fun resolvePlayersForLibrary(
+    private fun resolvePlayers(
         player: Player,
         context: EffectContext,
         state: GameState


### PR DESCRIPTION
Implements the {6}{B}{B} 6/6 Vampire Demon: on entering after being cast, each player sacrifices all other creatures, then returns the creature cards that were already in their graveyards.

The "weren't put there this way" clause is handled by gathering the creature cards in every graveyard before the sacrifice, then returning only that snapshot — the just-sacrificed creatures are absent from it.

To support "each player's graveyard" in one step, extend the gather pipeline's FromZone / FromMultipleZones / TopOfLibrary sources to accept multi-player references (Player.Each / ActivePlayerFirst / EachOpponent) and fan out across every relevant player's copy of the zone. Updates the SDK language reference.