### PR TITLE
Add Overlord of the Balemurk to Duskmourn with Impending support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -958,6 +958,9 @@ staticAbility {
   type from the source's `ChosenLandTypeComponent` (paired with
   `EntersWithChoice(ChoiceType.BASIC_LAND_TYPE)`). Chosen-value counterpart to
   `SetEnchantedLandType`, mirroring `GrantChosenColor`/`GrantColor`. (Phantasmal Terrain)
+- `GrantCardType(cardType, filter)` / `RemoveCardType(cardType, filter)` — Layer 4 type-changing statics that add or
+  remove a card type (e.g. `"CREATURE"`). `RemoveCardType` backs Impending's "isn't a creature while it has a time
+  counter" (wrapped in a `ConditionalStaticAbility`); reuse it for any "it's no longer a [type]" effect.
 - `ConditionalStaticAbility` — static gated by a runtime `Condition`.
 - `Effects.CreatePermanentEmblem(...)` — emblem with static abilities (planeswalker ultimates).
 - `AttackTax(amountPerAttacker: DynamicAmount)` — Propaganda / Ghostly Prison / Windborn Muse /
@@ -1026,8 +1029,8 @@ activatedAbility {
 
 Flying, Menace, Intimidate, Fear, Shadow, Horsemanship, all landwalks (Plainswalk … Forestwalk), First Strike, Double
 Strike, Trample, Deathtouch, Lifelink, Vigilance, Reach, Provoke, Flanking, Defender, Indestructible, Hexproof, Shroud, Haste,
-Flash, Prowess, Changeling, Convoke, Delve, Affinity, Storm, Flashback, Evoke, Conspire, Hideaway, Cascade, Plot, Offspring,
-Persist, Ascend, Wither, Toxic, Eerie, Vivid, Fateful Bite, … (display-only — engine effect lives in handlers or
+Flash, Prowess, Changeling, Convoke, Delve, Affinity, Storm, Flashback, Evoke, Impending, Conspire, Hideaway, Cascade, Plot,
+Offspring, Persist, Ascend, Wither, Toxic, Eerie, Vivid, Fateful Bite, … (display-only — engine effect lives in handlers or
 composite abilities).
 
 **Parameterized `KeywordAbility.*`**
@@ -1059,6 +1062,14 @@ composite abilities).
 - `Plot(cost)` — `KeywordAbility.plot(cost)`. Special action available during your main phase while the stack is empty: pay [cost] and exile the card from your hand. It becomes plotted (stamped with a `PlottedComponent`). On a later turn you may cast it from exile without paying its mana cost, as a sorcery (CR 718). Cast permission is granted via the engine's standard `MayPlayPermission` + `PlayWithoutPayingCostComponent`, gated by `Conditions.SourcePlottedOnPriorTurn`. No card-side wiring needed — declare the keyword ability on the card and the engine handles the rest.
 - `Hideaway(n)` — `KeywordAbility.hideaway(n)`; display tag rendered "Hideaway N". Mechanic is composed manually via `MoveCollectionEffect(faceDown = true, linkToSource = true)` + `CardSource.FromLinkedExile()` — the keyword itself carries no engine behavior.
 - `OptionalAdditionalCost(manaCost?, additionalCost?, multi, displayPrefix, branchesEffect, grantsFlashTiming)` — generalised "pay an optional extra cost while casting" primitive. Backs printed Kicker / Multikicker / Offspring **and** the pre-kicker "pay {N} more to cast as though it had flash" pattern (Ghitu Fire). When `branchesEffect = true` (default) paying the cost marks the spell so `WasKicked` fires for the card's own effect/triggers; when `false` the payment is invisible to `WasKicked` (used by `flashKicker`). When `grantsFlashTiming = true` paying the cost unlocks instant-speed casting in addition to whatever else it does. Prefer the factories: `KeywordAbility.kicker(cost)`, `KeywordAbility.kicker(additionalCost)`, `KeywordAbility.multikicker(cost)`, `KeywordAbility.offspring(cost)`, `KeywordAbility.flashKicker(cost)`. Serial name is `Kicker` for wire compatibility.
+- `Impending(time, cost)` — `card { impending(n, cost) }` builder helper (CR 702.176, Duskmourn). A self-alternative
+  cost: pay [cost] instead of the mana cost and the permanent enters with N **time counters**, isn't a creature until
+  the last is removed, and loses one at the beginning of your end step. The helper wires everything from one call — the
+  `KeywordAbility.Impending` alt-cost (display + cast enumeration), a `ConditionalStaticAbility(RemoveCardType("CREATURE"),
+  Conditions.SourceHasCounter(TIME))` "isn't a creature while it has a time counter" static, and a `YourEndStep`
+  triggered ability (gated by the same intervening-if) that removes a time counter. The engine places the N TIME counters
+  when a spell cast for its impending cost resolves; casting for the normal mana cost adds no counters, so neither wiring
+  fires (mirrors `prowess()` / `rampage()`).
 - `Morph(cost)` — cast face-down for `{3}`, flip for cost.
 - `Unmorph(cost, effect)` — turn-face-up cost + bonus effect.
 - `Equip(cost)` — Equipment attach cost.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/OverlordOfTheBalemurkScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/OverlordOfTheBalemurkScenarioTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Overlord of the Balemurk.
+ *
+ * Card reference:
+ * - Overlord of the Balemurk ({3}{B}{B}): Enchantment Creature — Avatar Horror 5/5
+ *   Impending 5—{1}{B}
+ *   Whenever this permanent enters or attacks, mill four cards, then you may return a
+ *   non-Avatar creature card or a planeswalker card from your graveyard to your hand.
+ */
+class OverlordOfTheBalemurkScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private fun ScenarioTestBase.TestGame.timeCounters(perm: com.wingedsheep.sdk.model.EntityId): Int =
+        state.getEntity(perm)?.get<CountersComponent>()?.getCount(CounterType.TIME) ?: 0
+
+    init {
+        context("Overlord of the Balemurk — enters/attacks ability") {
+
+            test("cast for its mana cost: mills four, then may return a non-Avatar creature (Avatars excluded)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Overlord of the Balemurk")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardInGraveyard(1, "Grizzly Bears")  // non-Avatar creature — eligible
+                    .withCardInGraveyard(1, "Heedless One")   // Avatar creature — excluded by filter
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Overlord of the Balemurk")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                // Resolve the spell + its enters trigger; the mill happens, then the optional
+                // return surfaces as a SelectCardsDecision.
+                game.resolveStack()
+
+                withClue("The enters trigger should produce the optional-return decision") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                val optionNames = decision.options.map { game.state.getEntity(it)?.get<CardComponent>()?.name }
+                withClue("Non-Avatar creature is returnable") { optionNames shouldContain "Grizzly Bears" }
+                withClue("Avatar creature is excluded") { optionNames shouldNotContain "Heedless One" }
+
+                val grizzly = decision.options.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                game.selectCards(listOf(grizzly))
+
+                withClue("Returned creature is now in hand") { game.isInHand(1, "Grizzly Bears") shouldBe true }
+                withClue("Avatar stays in the graveyard") { game.isInGraveyard(1, "Heedless One") shouldBe true }
+                withClue("Overlord is on the battlefield") { game.isOnBattlefield("Overlord of the Balemurk") shouldBe true }
+            }
+
+            test("cast for its impending cost: enters with five time counters and isn't a creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Overlord of the Balemurk")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellWithAlternativeCost(1, "Overlord of the Balemurk")
+                withClue("Impending cast should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                game.resolveStack()
+
+                // Even cast for impending it enters and its ability triggers (the optional return).
+                withClue("The enters trigger fires on impending entry too") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(emptyList()) // decline the optional return
+
+                val overlord = game.findPermanent("Overlord of the Balemurk")!!
+                withClue("Enters with five time counters") { game.timeCounters(overlord) shouldBe 5 }
+                withClue("Isn't a creature while it has a time counter") {
+                    projector.project(game.state).isCreature(overlord) shouldBe false
+                }
+                withClue("Still an enchantment while impending") {
+                    projector.project(game.state).hasType(overlord, "ENCHANTMENT") shouldBe true
+                }
+            }
+
+            test("attacking triggers the mill-and-return ability") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Overlord of the Balemurk")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                // It's a creature on the battlefield (no time counters), so it can attack.
+                projector.project(game.state).isCreature(game.findPermanent("Overlord of the Balemurk")!!) shouldBe true
+
+                val attack = game.declareAttackers(mapOf("Overlord of the Balemurk" to 2))
+                withClue("Declaring the attack should succeed: ${attack.error}") { attack.error shouldBe null }
+
+                game.resolveStack()
+
+                withClue("The attacks trigger should produce the optional-return decision") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                val grizzly = decision.options.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                game.selectCards(listOf(grizzly))
+                withClue("Returned creature is now in hand") { game.isInHand(1, "Grizzly Bears") shouldBe true }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/o/overlord-of-the-balemurk-attacks.json
+++ b/manual-scenarios/cards/o/overlord-of-the-balemurk-attacks.json
@@ -1,0 +1,43 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Overlord of the Balemurk"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [
+      "Grizzly Bears",
+      "Karn, Scion of Urza",
+      "Heedless One"
+    ],
+    "library": [
+      "Severed Legion",
+      "Phyrexian Reaper",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "phase": "COMBAT",
+  "step": "DECLARE_ATTACKERS",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/o/overlord-of-the-balemurk-enters.json
+++ b/manual-scenarios/cards/o/overlord-of-the-balemurk-enters.json
@@ -1,0 +1,77 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Overlord of the Balemurk"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [
+      "Grizzly Bears",
+      "Karn, Scion of Urza",
+      "Heedless One"
+    ],
+    "library": [
+      "Severed Legion",
+      "Phyrexian Reaper",
+      "Swamp",
+      "Grizzly Bears",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -35,7 +35,8 @@ enum class CounterType {
     CHORUS,
     DREAM,
     QUEST,
-    GROWTH
+    GROWTH,
+    TIME
 }
 
 /**
@@ -72,4 +73,5 @@ object Counters {
     const val DREAM = "dream"
     const val QUEST = "quest"
     const val GROWTH = "growth"
+    const val TIME = "time"
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -82,6 +82,21 @@ enum class Keyword(val displayName: String) {
     STORM("Storm"),
     FLASHBACK("Flashback"),
     EVOKE("Evoke"),
+
+    /**
+     * Impending N—[cost] (CR 702.176, Duskmourn: House of Horror).
+     * "If you cast this spell for its impending cost, it enters with N time counters
+     * and isn't a creature until the last is removed. At the beginning of your end step,
+     * remove a time counter from it."
+     *
+     * Modelled as a self-alternative cost ([KeywordAbility.Impending]). The
+     * `impending(n, cost)` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder] wires the
+     * full behavior: the alternative cost, the conditional "isn't a creature while it
+     * has a time counter" type-removing static ability, and the "remove a time counter
+     * at the beginning of your end step" triggered ability. The engine adds the N TIME
+     * counters when a spell cast for its impending cost resolves.
+     */
+    IMPENDING("Impending"),
     CONSPIRE("Conspire"),
     HIDEAWAY("Hideaway"),
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -411,6 +411,55 @@ class CardBuilder(private val name: String) {
     }
 
     /**
+     * Add Impending N—[cost] (CR 702.176, Duskmourn: House of Horror).
+     *
+     * "If you cast this spell for its impending cost, it enters with N time counters and
+     * isn't a creature until the last is removed. At the beginning of your end step, remove
+     * a time counter from it."
+     *
+     * Wires the full keyword from one call:
+     *  - the [KeywordAbility.Impending] alternative cost (display text + cast enumeration),
+     *  - a conditional "isn't a creature while it has a time counter" type-removing static
+     *    ability ([RemoveCardType] gated by [Conditions.SourceHasCounter]), and
+     *  - a "remove a time counter at the beginning of your end step" triggered ability,
+     *    gated by the same intervening-if so it stops once the counters are gone.
+     *
+     * CR 702.176a gates the not-a-creature static and the end-step trigger on "impending
+     * cost was paid AND it has a time counter"; we gate only on the time counter, since the
+     * engine adds time counters solely when a spell resolves having been cast for its
+     * impending cost (the battlefield never tracks "was cast for impending"). The two are
+     * equivalent unless an external effect stamps a time counter onto a permanent not cast
+     * for impending — a case no current card produces.
+     *
+     * The engine places [time] TIME counters on the permanent when a spell cast for its
+     * impending cost resolves (see the cast/resolve path); these wirings then count it down
+     * and keep it a non-creature enchantment until the last counter is removed. Casting the
+     * card for its normal mana cost adds no time counters, so neither wiring ever fires and
+     * it behaves as an ordinary enchantment creature.
+     */
+    fun impending(time: Int, cost: String) {
+        keywordAbilityList.add(KeywordAbility.Impending(time, ManaCost.parse(cost)))
+        val hasTimeCounter = Conditions.SourceHasCounter(
+            com.wingedsheep.sdk.scripting.events.CounterTypeFilter.Named(Counters.TIME)
+        )
+        staticAbilities.add(
+            ConditionalStaticAbility(
+                ability = RemoveCardType("CREATURE", GroupFilter.source()),
+                condition = hasTimeCounter
+            )
+        )
+        triggeredAbilities.add(
+            TriggeredAbility.create(
+                trigger = Triggers.YourEndStep.event,
+                binding = Triggers.YourEndStep.binding,
+                effect = Effects.RemoveCounters(Counters.TIME, 1, EffectTarget.Self),
+                triggerCondition = hasTimeCounter,
+                descriptionOverride = "At the beginning of your end step, remove a time counter from this permanent."
+            )
+        )
+    }
+
+    /**
      * Add a parameterized keyword ability.
      * Examples: ward {2}, protection from blue, annihilator 2
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -444,6 +444,33 @@ sealed interface KeywordAbility {
     }
 
     // =========================================================================
+    // Impending
+    // =========================================================================
+
+    /**
+     * Impending N—[cost] (CR 702.176, Duskmourn: House of Horror).
+     * "If you cast this spell for its impending cost, it enters with N time counters
+     * and isn't a creature until the last is removed. At the beginning of your end step,
+     * remove a time counter from it."
+     *
+     * Impending is a self-alternative cost: you may pay [cost] rather than the spell's
+     * mana cost. When a spell cast for its impending cost resolves, the engine places
+     * [time] time counters on the permanent. While it has a time counter it isn't a
+     * creature, and at the beginning of the controller's end step a time counter is
+     * removed; the permanent becomes a creature once the last is gone.
+     *
+     * The full behavior is wired by the `impending(n, cost)` DSL helper on
+     * [com.wingedsheep.sdk.dsl.CardBuilder], which attaches this keyword ability plus the
+     * conditional type-removing static ability and the end-step counter-removal trigger.
+     */
+    @SerialName("Impending")
+    @Serializable
+    data class Impending(val time: Int, val cost: ManaCost) : KeywordAbility {
+        override val keyword: Keyword = Keyword.IMPENDING
+        override val description: String = "Impending $time—$cost"
+    }
+
+    // =========================================================================
     // Devour
     // =========================================================================
 
@@ -653,6 +680,13 @@ sealed interface KeywordAbility {
          * Create Evoke with mana cost from string.
          */
         fun evoke(cost: String): KeywordAbility = Evoke(ManaCost.parse(cost))
+
+        /**
+         * Create Impending with a time-counter count and an impending mana cost.
+         * Prefer the `impending(n, cost)` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder],
+         * which also wires the associated static ability and end-step trigger.
+         */
+        fun impending(time: Int, cost: String): KeywordAbility = Impending(time, ManaCost.parse(cost))
 
         /**
          * Create Conspire keyword ability.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
@@ -69,6 +69,29 @@ data class GrantCardType(
 }
 
 /**
+ * Removes a card type (e.g., "CREATURE") from the target permanent.
+ * The mirror of [GrantCardType] — a Layer 4 (type-changing) continuous effect.
+ *
+ * Used by Impending ("isn't a creature until the last time counter is removed"), gated
+ * behind a [ConditionalStaticAbility]. General-purpose: any "it's no longer a [type]"
+ * effect can reuse it.
+ *
+ * @property cardType The card type to remove (e.g., "CREATURE", "ARTIFACT")
+ * @property filter What this ability applies to
+ */
+@SerialName("RemoveCardType")
+@Serializable
+data class RemoveCardType(
+    val cardType: String,
+    val filter: GroupFilter = GroupFilter.source()
+) : StaticAbility {
+    override val description: String = "isn't ${
+        if (cardType.first().lowercaseChar() in "aeiou") "an" else "a"
+    } ${cardType.lowercase()}"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}
+
+/**
  * Grants a supertype (e.g., Legendary) to the target permanent.
  * Used for On Serra's Wings: "Enchanted creature is legendary."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/OverlordOfTheBalemurk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/OverlordOfTheBalemurk.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Overlord of the Balemurk
+ * {3}{B}{B}
+ * Enchantment Creature — Avatar Horror
+ * 5/5
+ *
+ * Impending 5—{1}{B} (If you cast this spell for its impending cost, it enters with five
+ * time counters and isn't a creature until the last is removed. At the beginning of your
+ * end step, remove a time counter from it.)
+ *
+ * Whenever this permanent enters or attacks, mill four cards, then you may return a
+ * non-Avatar creature card or a planeswalker card from your graveyard to your hand.
+ *
+ * Impending is wired by the `impending(n, cost)` DSL helper: the alternative cost, the
+ * "isn't a creature while it has a time counter" type-removing static ability, and the
+ * "remove a time counter at the beginning of your end step" trigger. The engine places
+ * the five time counters when the spell is cast for its impending cost.
+ *
+ * The "enters or attacks" ability is one effect referenced by two triggered abilities
+ * (an enters-the-battlefield trigger and an attacks trigger). Per the Scryfall ruling,
+ * the returned card may be any eligible card in your graveyard — not only one milled by
+ * this resolution — so the optional return gathers the whole graveyard.
+ */
+val OverlordOfTheBalemurk = card("Overlord of the Balemurk") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment Creature — Avatar Horror"
+    oracleText = "Impending 5—{1}{B} (If you cast this spell for its impending cost, it enters with five time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\n" +
+        "Whenever this permanent enters or attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand."
+    power = 5
+    toughness = 5
+
+    impending(5, "{1}{B}")
+
+    // "Mill four cards, then you may return a non-Avatar creature card or a planeswalker
+    // card from your graveyard to your hand." Shared by the enters and attacks triggers.
+    val returnableFilter = GameObjectFilter.Creature.notSubtype(Subtype.AVATAR) or GameObjectFilter.Planeswalker
+    val millAndReturn: Effect = CompositeEffect(
+        listOf(
+            // Mill four cards.
+            EffectPatterns.mill(4),
+            // ...then you may return a non-Avatar creature or planeswalker card from your
+            // graveyard to your hand (any eligible card, not just the milled ones).
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.GRAVEYARD, Player.You, returnableFilter),
+                storeAs = "balemurkReturnable"
+            ),
+            SelectFromCollectionEffect(
+                from = "balemurkReturnable",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "balemurkToReturn",
+                showAllCards = true,
+                prompt = "You may return a non-Avatar creature or planeswalker card to your hand",
+                selectedLabel = "Return to hand",
+                remainderLabel = "Leave in graveyard"
+            ),
+            MoveCollectionEffect(
+                from = "balemurkToReturn",
+                destination = CardDestination.ToZone(Zone.HAND)
+            )
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = millAndReturn
+        description = "Whenever this permanent enters, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = millAndReturn
+        description = "Whenever this permanent attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "113"
+        artist = "Babs Webb"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b911653-7b96-4cf3-a907-13c5c53a14f7.jpg?1726286269"
+        ruling("2024-09-20", "You may return any non-Avatar creature card or any planeswalker card from your graveyard to your hand with the last ability, not just one you milled while resolving that ability.")
+        ruling("2024-09-20", "If you choose to pay the impending cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to, countered, and so on.")
+        ruling("2024-09-20", "If an object enters as a copy of a permanent that was cast with its impending cost, it won't enter with time counters, and it will be a creature.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -329,16 +329,22 @@ class CastSpellHandler(
                     if (evokeAbility != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, evokeAbility.cost, action.playerId)
                     } else {
-                        // Check self-alternative cost (e.g., Zahid's {3}{U} + tap artifact)
-                        val selfAltCost = cardDef.script.selfAlternativeCost
-                        if (selfAltCost != null) {
-                            val altMana = ManaCost.parse(selfAltCost.manaCost)
-                            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altMana, action.playerId)
+                        // Check impending cost
+                        val impendingAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Impending>().firstOrNull()
+                        if (impendingAbility != null) {
+                            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, impendingAbility.cost, action.playerId)
                         } else {
-                            // Fall back to battlefield-granted alternative cost (e.g., Jodah's {W}{U}{B}{R}{G})
-                            val altCosts = costCalculator.findAlternativeCastingCosts(state, action.playerId)
-                            if (altCosts.isEmpty()) return "No alternative casting cost available"
-                            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altCosts.first())
+                            // Check self-alternative cost (e.g., Zahid's {3}{U} + tap artifact)
+                            val selfAltCost = cardDef.script.selfAlternativeCost
+                            if (selfAltCost != null) {
+                                val altMana = ManaCost.parse(selfAltCost.manaCost)
+                                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altMana, action.playerId)
+                            } else {
+                                // Fall back to battlefield-granted alternative cost (e.g., Jodah's {W}{U}{B}{R}{G})
+                                val altCosts = costCalculator.findAlternativeCastingCosts(state, action.playerId)
+                                if (altCosts.isEmpty()) return "No alternative casting cost available"
+                                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altCosts.first())
+                            }
                         }
                     }
                 }
@@ -1244,16 +1250,22 @@ class CastSpellHandler(
                     if (evokeAbility != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, evokeAbility.cost, action.playerId)
                     } else {
-                        val selfAltCost = cardDef.script.selfAlternativeCost
-                        if (selfAltCost != null) {
-                            val altMana = ManaCost.parse(selfAltCost.manaCost)
-                            costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, altMana, action.playerId)
+                        // Check impending cost
+                        val impendingAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Impending>().firstOrNull()
+                        if (impendingAbility != null) {
+                            costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, impendingAbility.cost, action.playerId)
                         } else {
-                            val altCosts = costCalculator.findAlternativeCastingCosts(currentState, action.playerId)
-                            if (altCosts.isNotEmpty()) {
-                                costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, altCosts.first())
+                            val selfAltCost = cardDef.script.selfAlternativeCost
+                            if (selfAltCost != null) {
+                                val altMana = ManaCost.parse(selfAltCost.manaCost)
+                                costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, altMana, action.playerId)
                             } else {
-                                cardComponent.manaCost
+                                val altCosts = costCalculator.findAlternativeCastingCosts(currentState, action.playerId)
+                                if (altCosts.isNotEmpty()) {
+                                    costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, altCosts.first())
+                                } else {
+                                    cardComponent.manaCost
+                                }
                             }
                         }
                     }
@@ -1938,6 +1950,10 @@ class CastSpellHandler(
         val wasEvoked = action.useAlternativeCost && cardDef != null &&
             cardDef.keywordAbilities.any { it is KeywordAbility.Evoke }
 
+        // Determine if this spell is being cast using impending
+        val wasImpending = action.useAlternativeCost && cardDef != null &&
+            cardDef.keywordAbilities.any { it is KeywordAbility.Impending }
+
         // Extract per-color mana spent from payment events (for mana-spent-gated triggers)
         val manaSpentEvent = paymentResult.events.filterIsInstance<ManaSpentEvent>().firstOrNull()
 
@@ -2005,6 +2021,7 @@ class CastSpellHandler(
             wasBlightPaid = (action.additionalCostPayment?.blightTargets?.isNotEmpty() == true),
             wasWarped = wasWarped,
             wasEvoked = wasEvoked,
+            wasImpending = wasImpending,
             chosenModes = action.chosenModes,
             modeTargetsOrdered = effectiveModeTargetsOrdered,
             modeTargetRequirements = perModeTargetRequirements,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -370,6 +370,13 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, evokeMana, precomputedSources = cachedSources)
             } else false
 
+            // Check impending cost (alternative cost from Impending keyword)
+            val impendingAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Impending>().firstOrNull()
+            val canAffordImpending = if (impendingAbility != null) {
+                val impendingMana = context.costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, impendingAbility.cost, playerId)
+                context.manaSolver.canPay(state, playerId, impendingMana, precomputedSources = cachedSources)
+            } else false
+
             // Check blight path affordability (base cost without the extra mana, but needs a creature)
             val canAffordBlightPath = if (blightOrPayCost != null && blightCreatures.isNotEmpty()) {
                 context.manaSolver.canPay(state, playerId, blightBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
@@ -380,7 +387,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, beholdBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
-            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordBlightPath && !canAffordBeholdPath) continue
+            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordBlightPath && !canAffordBeholdPath) continue
 
             val targetReqs = buildList {
                 addAll(cardDef.script.targetRequirements)
@@ -516,6 +523,20 @@ class CastSpellEnumerator : ActionEnumerator {
                 SelfAltCostResult(
                     manaCostString = evokeMana.toString(),
                     autoTapPreview = evokePreview,
+                    additionalCostInfo = null
+                )
+            } else null
+
+            // Compute impending cost info
+            val impendingCostResult = if (canAffordImpending && impendingAbility != null) {
+                val impendingMana = context.costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, impendingAbility.cost, playerId)
+                val impendingPreview = if (context.skipAutoTapPreview) null else {
+                    context.manaSolver.solve(state, playerId, impendingMana, precomputedSources = cachedSources)
+                        ?.sources?.map { it.entityId }
+                }
+                SelfAltCostResult(
+                    manaCostString = impendingMana.toString(),
+                    autoTapPreview = impendingPreview,
                     additionalCostInfo = null
                 )
             } else null
@@ -798,6 +819,15 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = evokeCostResult.autoTapPreview
                             ))
                         }
+                        if (impendingCostResult != null) {
+                            result.add(LegalAction(
+                                actionType = "CastWithAlternativeCost",
+                                description = "Impending ${cardComponent.name} (${impendingCostResult.manaCostString})",
+                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true),
+                                manaCostString = impendingCostResult.manaCostString,
+                                autoTapPreview = impendingCostResult.autoTapPreview
+                            ))
+                        }
                         if (blightPathInfo != null) {
                             result.add(LegalAction(
                                 actionType = "CastSpell",
@@ -911,6 +941,23 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = evokeCostResult.autoTapPreview
                             ))
                         }
+                        if (impendingCostResult != null) {
+                            result.add(LegalAction(
+                                actionType = "CastWithAlternativeCost",
+                                description = "Impending ${cardComponent.name} (${impendingCostResult.manaCostString})",
+                                action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                                validTargets = firstReqInfo.validTargets,
+                                requiresTargets = true,
+                                targetCount = firstReq.count,
+                                minTargets = firstReq.effectiveMinCount,
+                                targetDescription = firstReq.description,
+                                targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
+                                xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
+                                xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
+                                manaCostString = impendingCostResult.manaCostString,
+                                autoTapPreview = impendingCostResult.autoTapPreview
+                            ))
+                        }
                         if (blightPathInfo != null) {
                             result.add(LegalAction(
                                 actionType = "CastSpell",
@@ -1000,6 +1047,15 @@ class CastSpellEnumerator : ActionEnumerator {
                         action = CastSpell(playerId, cardId, useAlternativeCost = true),
                         manaCostString = evokeCostResult.manaCostString,
                         autoTapPreview = evokeCostResult.autoTapPreview
+                    ))
+                }
+                if (impendingCostResult != null) {
+                    result.add(LegalAction(
+                        actionType = "CastWithAlternativeCost",
+                        description = "Impending ${cardComponent.name} (${impendingCostResult.manaCostString})",
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        manaCostString = impendingCostResult.manaCostString,
+                        autoTapPreview = impendingCostResult.autoTapPreview
                     ))
                 }
                 if (blightPathInfo != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -38,6 +38,7 @@ import com.wingedsheep.sdk.scripting.GrantProtection
 import com.wingedsheep.sdk.scripting.GrantSubtype
 import com.wingedsheep.sdk.scripting.IsAllCreatureTypes
 import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.RemoveCardType
 import com.wingedsheep.sdk.scripting.GrantSupertype
 import com.wingedsheep.sdk.scripting.GrantProtectionFromChosenColorToGroup
 import com.wingedsheep.sdk.scripting.GrantHexproofFromOwnColorsToGroup
@@ -461,6 +462,12 @@ class StaticAbilityHandler(
             is GrantCardType -> {
                 ContinuousEffectData(
                     modification = Modification.AddType(ability.cardType.uppercase()),
+                    affectsFilter = convertGroupFilter(ability.filter)
+                )
+            }
+            is RemoveCardType -> {
+                ContinuousEffectData(
+                    modification = Modification.RemoveType(ability.cardType.uppercase()),
                     affectsFilter = convertGroupFilter(ability.filter)
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -110,6 +110,7 @@ class StackResolver(
         wasBlightPaid: Boolean = false,
         wasWarped: Boolean = false,
         wasEvoked: Boolean = false,
+        wasImpending: Boolean = false,
         chosenModes: List<Int> = emptyList(),
         modeTargetsOrdered: List<List<ChosenTarget>> = emptyList(),
         modeTargetRequirements: Map<Int, List<TargetRequirement>> = emptyMap(),
@@ -175,6 +176,7 @@ class StackResolver(
                 castFromZone = castFromZone,
                 wasWarped = wasWarped,
                 wasEvoked = wasEvoked,
+                wasImpending = wasImpending,
                 beheldCards = beheldCards,
                 chosenEntitySnapshots = chosenEntitySnapshots,
                 manaSpentWhite = manaSpentWhite,
@@ -974,6 +976,20 @@ class StackResolver(
             // Track if this permanent was cast for its evoke cost
             if (spellComponent.wasEvoked) {
                 updated = updated.with(com.wingedsheep.engine.state.components.battlefield.EvokedComponent)
+            }
+
+            // Impending (CR 702.176a): a permanent cast for its impending cost enters with
+            // N time counters. While it has a time counter it isn't a creature and a counter
+            // is removed at the beginning of its controller's end step — both wired by the
+            // impending keyword's static ability and triggered ability on the card script.
+            if (spellComponent.wasImpending) {
+                val impendingTime = cardDef?.keywordAbilities
+                    ?.filterIsInstance<KeywordAbility.Impending>()
+                    ?.firstOrNull()?.time ?: 0
+                if (impendingTime > 0) {
+                    val existingCounters = updated.get<CountersComponent>() ?: CountersComponent()
+                    updated = updated.with(existingCounters.withAdded(CounterType.TIME, impendingTime))
+                }
             }
 
             // For split-layout cards (CR 709), attach a RoomComponent recording every face's

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -32,6 +32,7 @@ data class SpellOnStackComponent(
     val castFromZone: Zone? = null,  // Zone the spell was cast from (e.g., HAND for normal casting)
     val wasWarped: Boolean = false,  // For warp - permanent is exiled at end step
     val wasEvoked: Boolean = false,  // For evoke - permanent is sacrificed on ETB
+    val wasImpending: Boolean = false,  // For impending - permanent enters with time counters and isn't a creature until they're gone
     val beheldCards: List<EntityId> = emptyList(),  // Cards chosen via Behold (stored in pipeline as named collection)
     /**
      * Last-known-info snapshots (Rule 112.7a) for entities chosen at cost-pay time

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ImpendingMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ImpendingMechanicTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Mechanic-level tests for Impending (CR 702.176), wired by the `impending(n, cost)` DSL helper.
+ *
+ * A permanent cast for its impending cost enters with N time counters, isn't a creature while it
+ * has one, and loses a time counter at the beginning of its controller's end step — becoming a
+ * creature once the last is removed. Cast for its normal mana cost, it adds no time counters and
+ * behaves as an ordinary enchantment creature.
+ */
+class ImpendingMechanicTest : FunSpec({
+
+    // One time counter — its full lifecycle (enter → first end step → creature) fits in one turn.
+    val impendingOne = card("Impending One") {
+        manaCost = "{3}{B}{B}"
+        typeLine = "Enchantment Creature — Horror"
+        power = 5
+        toughness = 5
+        impending(1, "{1}{B}")
+    }
+
+    // Five time counters — mirrors Overlord of the Balemurk's "enters with five time counters".
+    val impendingFive = card("Impending Five") {
+        manaCost = "{3}{B}{B}"
+        typeLine = "Enchantment Creature — Horror"
+        power = 5
+        toughness = 5
+        impending(5, "{1}{B}")
+    }
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(impendingOne, impendingFive))
+        return driver
+    }
+
+    fun timeCounters(driver: GameTestDriver, perm: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getEntity(perm)?.get<CountersComponent>()?.getCount(CounterType.TIME) ?: 0
+
+    test("a creature can be cast for its impending cost") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val cardId = driver.putCardInHand(player, "Impending Five")
+        driver.giveMana(player, Color.BLACK, 2)
+
+        val result = driver.submit(
+            CastSpell(player, cardId, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+        driver.stackSize shouldBe 1
+    }
+
+    test("cast for impending, it enters with N time counters and isn't a creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val cardId = driver.putCardInHand(player, "Impending Five")
+        driver.giveMana(player, Color.BLACK, 2)
+        driver.submit(
+            CastSpell(player, cardId, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+
+        val perm = driver.findPermanent(player, "Impending Five")
+        perm shouldNotBe null
+        timeCounters(driver, perm!!) shouldBe 5
+        projector.project(driver.state).isCreature(perm) shouldBe false
+        // It's still an enchantment while impending.
+        projector.project(driver.state).hasType(perm, "ENCHANTMENT") shouldBe true
+    }
+
+    test("a time counter is removed at the controller's end step; it becomes a creature when the last is gone") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val cardId = driver.putCardInHand(player, "Impending One")
+        driver.giveMana(player, Color.BLACK, 2)
+        driver.submit(
+            CastSpell(player, cardId, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+
+        val perm = driver.findPermanent(player, "Impending One")!!
+        timeCounters(driver, perm) shouldBe 1
+        projector.project(driver.state).isCreature(perm) shouldBe false
+
+        // Advance to the controller's end step; the remove-a-time-counter trigger goes on the stack.
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass() // resolve the impending end-step trigger
+
+        timeCounters(driver, perm) shouldBe 0
+        projector.project(driver.state).isCreature(perm) shouldBe true
+    }
+
+    test("cast for its normal mana cost, it enters as a creature with no time counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val cardId = driver.putCardInHand(player, "Impending Five")
+        driver.giveMana(player, Color.BLACK, 5)
+        driver.submit(
+            CastSpell(player, cardId, useAlternativeCost = false, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+
+        val perm = driver.findPermanent(player, "Impending Five")!!
+        timeCounters(driver, perm) shouldBe 0
+        projector.project(driver.state).isCreature(perm) shouldBe true
+    }
+})

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -91,4 +91,5 @@ export const counterManaClass: Record<string, string> = {
   DREAM: 'counter-charge',
   QUEST: 'counter-lore',
   GROWTH: 'counter-charge',
+  TIME: 'counter-time',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -423,6 +423,15 @@ export function getGrowthCounters(card: ClientCard): number {
 }
 
 /**
+ * Get the number of time counters on a card. Time counters appear on permanents
+ * cast for their Impending cost (and Suspend/Vanishing-style mechanics); the
+ * permanent isn't a creature until the last one is removed.
+ */
+export function getTimeCounters(card: ClientCard): number {
+  return card.counters[CounterType.TIME] ?? 0
+}
+
+/**
  * Get an emoji or icon for an effect based on its icon identifier.
  */
 export function getEffectIcon(icon: string): string {

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1173,6 +1173,22 @@ export const styles: Record<string, React.CSSProperties> = {
     zIndex: 5,
     textShadow: '0 0 4px rgba(120, 220, 180, 0.8)',
   } as React.CSSProperties,
+  // Time counter badge (Impending — counts down to becoming a creature)
+  timeCounterBadge: {
+    position: 'absolute',
+    top: 4,
+    right: 4,
+    backgroundColor: 'rgba(40, 30, 70, 0.95)',
+    borderRadius: 4,
+    border: '1px solid rgba(170, 140, 230, 0.7)',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 2,
+    color: '#cbb6f0',
+    fontWeight: 700,
+    zIndex: 5,
+    textShadow: '0 0 4px rgba(170, 140, 230, 0.8)',
+  } as React.CSSProperties,
   // Quest counter badge (for Beastmaster Ascension etc.)
   questCounterBadge: {
     position: 'absolute',

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -39,6 +39,7 @@ import {
   getDreamCounters,
   getQuestCounters,
   getGrowthCounters,
+  getTimeCounters,
 } from '../board/shared'
 import { styles, bandColorFor } from '../board/styles'
 import {
@@ -1521,6 +1522,20 @@ export function GameCard({
           <i className={`ms ms-${counterManaClass.GROWTH}`} style={{ fontSize: responsive.badges.counterIconFontSize }} />
           <span style={{ fontWeight: 700 }}>
             {getGrowthCounters(card)}
+          </span>
+        </div>
+      )}
+
+      {/* Time counter badge (Impending — counts down to becoming a creature) */}
+      {battlefield && getTimeCounters(card) > 0 && (
+        <div style={{
+          ...styles.timeCounterBadge,
+          fontSize: responsive.badges.counterTextFontSize,
+          padding: responsive.badges.badgePadding,
+        }}>
+          <i className={`ms ms-${counterManaClass.TIME}`} style={{ fontSize: responsive.badges.counterIconFontSize }} />
+          <span style={{ fontWeight: 700 }}>
+            {getTimeCounters(card)}
           </span>
         </div>
       )}

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -186,6 +186,7 @@ export enum Keyword {
   STORM = 'STORM',
   FLASHBACK = 'FLASHBACK',
   EVOKE = 'EVOKE',
+  IMPENDING = 'IMPENDING',
   CONSPIRE = 'CONSPIRE',
   HIDEAWAY = 'HIDEAWAY',
   CASCADE = 'CASCADE',
@@ -242,6 +243,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.STORM]: 'Storm',
   [Keyword.FLASHBACK]: 'Flashback',
   [Keyword.EVOKE]: 'Evoke',
+  [Keyword.IMPENDING]: 'Impending',
   [Keyword.CONSPIRE]: 'Conspire',
   [Keyword.HIDEAWAY]: 'Hideaway',
   [Keyword.CASCADE]: 'Cascade',
@@ -330,6 +332,7 @@ export enum CounterType {
   DREAM = 'DREAM',
   QUEST = 'QUEST',
   GROWTH = 'GROWTH',
+  TIME = 'TIME',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -360,6 +363,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.DREAM]: 'Dream',
   [CounterType.QUEST]: 'Quest',
   [CounterType.GROWTH]: 'Growth',
+  [CounterType.TIME]: 'Time',
 }
 
 /**


### PR DESCRIPTION
Implements the Impending keyword (CR 702.175) as a reusable mechanic and Overlord of the Balemurk, the first card to use it.

Impending is wired by a new `impending(n, cost)` DSL helper on CardBuilder (mirrors prowess()/rampage()): it adds the KeywordAbility.Impending self-alternative cost, a ConditionalStaticAbility(RemoveCardType("CREATURE"), SourceHasCounter(TIME)) so the permanent isn't a creature while it has a time counter, and a YourEndStep trigger that removes one time counter (gated by the same intervening-if). The engine places N TIME counters when a spell cast for its impending cost resolves.

SDK: IMPENDING keyword, TIME counter type, KeywordAbility.Impending, RemoveCardType static ability, impending() builder helper. Engine: wasImpending threaded through cast → stack → resolve; impending alt-cost enumerated/charged alongside warp/evoke; StaticAbilityHandler maps RemoveCardType → Modification.RemoveType.
Frontend: IMPENDING keyword + TIME counter enums/display, time counter badge.

Overlord's "whenever this permanent enters or attacks" is one effect shared by an enters and an attacks trigger: mill four, then optionally return a non-Avatar creature or planeswalker card from your graveyard to your hand (whole graveyard, per ruling).

Tests: ImpendingMechanicTest (rules-engine) covers cast-for-impending counters
+ not-a-creature + end-step countdown + normal cast; OverlordOfTheBalemurk ScenarioTest (game-server) covers mill+return, Avatar exclusion, impending entry, and the attacks trigger. Updated card-sdk-language-reference.md.