### PR TITLE
Add Haliya, Ascendant Cadet to Edge of Eternities

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -95,7 +95,7 @@
 - [x] Gravblade Heavy
 - [x] Gravkill
 - [x] Gravpack Monoist
-- [ ] Haliya, Ascendant Cadet
+- [x] Haliya, Ascendant Cadet
 - [x] Haliya, Guided by Light
 - [x] Hardlight Containment
 - [x] Harmonious Grovestrider

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HaliyaAscendantCadetScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HaliyaAscendantCadetScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import io.kotest.matchers.shouldBe
+
+/**
+ * Haliya, Ascendant Cadet:
+ *  - Whenever Haliya enters or attacks, put a +1/+1 counter on target creature you control.
+ *  - Whenever one or more creatures you control with +1/+1 counters on them deal combat damage
+ *    to a player, draw a card.
+ *
+ * The second ability relies on the combat-damage batch trigger honoring a state predicate
+ * (the +1/+1 counter filter), so the negative test below guards that the engine does not fire
+ * the draw for a counter-less creature.
+ */
+class HaliyaAscendantCadetScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("Haliya's enter trigger puts a +1/+1 counter on a target creature you control") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Haliya, Ascendant Cadet")
+                .withCardOnBattlefield(1, "Forest")
+                .withCardOnBattlefield(1, "Plains")
+                .withCardOnBattlefield(1, "Plains")
+                .withCardOnBattlefield(1, "Plains")
+                .withCardOnBattlefield(1, "Plains")
+                .withCardInLibrary(1, "Plains")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Haliya, Ascendant Cadet")
+            // Resolve the creature spell; the enter trigger then asks for a target.
+            game.resolveStack()
+
+            val haliyaId = game.findPermanent("Haliya, Ascendant Cadet")!!
+            // Only Haliya is on the battlefield, so it targets itself.
+            game.selectTargets(listOf(haliyaId))
+            game.resolveStack()
+
+            val counters = game.state.getEntity(haliyaId)?.get<CountersComponent>()
+            counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+
+            val projected = game.state.projectedState
+            projected.getPower(haliyaId) shouldBe 4
+            projected.getToughness(haliyaId) shouldBe 4
+        }
+
+        test("attack trigger counters a creature, then that creature's combat damage draws a card") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Haliya, Ascendant Cadet")
+                .withCardOnBattlefield(1, "Hill Giant")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Mountain")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handSizeBefore = game.handSize(1)
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(
+                mapOf(
+                    "Haliya, Ascendant Cadet" to 2,
+                    "Hill Giant" to 2
+                )
+            )
+
+            // Haliya's attack trigger puts a +1/+1 counter on the Hill Giant.
+            val hillGiantId = game.findPermanent("Hill Giant")!!
+            game.selectTargets(listOf(hillGiantId))
+            game.resolveStack()
+
+            val giantCounters = game.state.getEntity(hillGiantId)?.get<CountersComponent>()
+            giantCounters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareNoBlockers()
+            game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+            // The Hill Giant had a +1/+1 counter when it connected, so the draw trigger fires once.
+            game.handSize(1) shouldBe handSizeBefore + 1
+        }
+
+        test("a creature without a +1/+1 counter dealing combat damage does not draw a card") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Haliya, Ascendant Cadet")
+                .withCardOnBattlefield(1, "Hill Giant")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Mountain")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handSizeBefore = game.handSize(1)
+
+            // Attack only with the counter-less Hill Giant; Haliya stays back so no counter is placed.
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Hill Giant" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareNoBlockers()
+            game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+            // No creature with a +1/+1 counter dealt combat damage, so Haliya's draw does not fire.
+            game.handSize(1) shouldBe handSizeBefore
+        }
+    }
+}

--- a/manual-scenarios/cards/h/haliya-ascendant-cadet.json
+++ b/manual-scenarios/cards/h/haliya-ascendant-cadet.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Haliya",
+  "player2Name": "Defender",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Haliya, Ascendant Cadet"],
+    "battlefield": [
+      {"name": "Haliya, Ascendant Cadet"},
+      {"name": "Hill Giant", "counters": {"PLUS_ONE_PLUS_ONE": 1}},
+      {"name": "Glory Seeker"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Storm Crow", "Plains", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Glory Seeker"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Storm Crow"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/HaliyaAscendantCadet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/HaliyaAscendantCadet.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.OneOrMoreDealCombatDamageToPlayerEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+
+/**
+ * Haliya, Ascendant Cadet
+ * {2}{G}{W}{W}
+ * Legendary Creature — Human Soldier
+ * 3/3
+ *
+ * Whenever Haliya enters or attacks, put a +1/+1 counter on target creature you control.
+ * Whenever one or more creatures you control with +1/+1 counters on them deal combat damage
+ * to a player, draw a card.
+ */
+val HaliyaAscendantCadet = card("Haliya, Ascendant Cadet") {
+    manaCost = "{2}{G}{W}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever Haliya enters or attacks, put a +1/+1 counter on target creature you control.\n" +
+        "Whenever one or more creatures you control with +1/+1 counters on them deal combat damage to a player, draw a card."
+
+    // Whenever Haliya enters or attacks, put a +1/+1 counter on target creature you control.
+    // No combined "enters or attacks" trigger exists, so model it as two abilities sharing the effect.
+    val counterDescription = "put a +1/+1 counter on target creature you control"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+        description = counterDescription
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+        description = counterDescription
+    }
+
+    // Whenever one or more creatures you control with +1/+1 counters on them deal combat damage
+    // to a player, draw a card. Batching trigger — fires at most once per combat damage event.
+    // The +1/+1 counter must be present at the time damage is dealt (see ruling).
+    triggeredAbility {
+        trigger = TriggerSpec(
+            OneOrMoreDealCombatDamageToPlayerEvent(
+                sourceFilter = GameObjectFilter.Creature.youControl()
+                    .withCounter(Counters.PLUS_ONE_PLUS_ONE)
+            ),
+            TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+        description = "Whenever one or more creatures you control with +1/+1 counters on them " +
+            "deal combat damage to a player, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "218"
+        artist = "Justyna Dura"
+        flavorText = "\"By the eternal and everflowing light, I swear myself to this cause.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/683d6eba-7f98-4105-b318-7f2290012f32.jpg?1752947448"
+
+        ruling(
+            "2025-07-25",
+            "A creature that deals combat damage to a player must have a +1/+1 counter on it at " +
+                "the time damage is dealt in order for Haliya, Ascendant Cadet's last ability to trigger."
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1364,24 +1364,24 @@ class TriggerDetector(
                 val controllerId = entry.controllerId
                 val damageEvents = combatDamageByController[controllerId] ?: continue
 
-                // Check if any damage source matches the sourceFilter (using projected state for subtypes)
+                // Check if any damage source matches the sourceFilter. Damage events are already
+                // grouped by source controller and matched to observers with the same controller,
+                // so "you control" is satisfied; we still run the full filter via the canonical
+                // evaluator so state predicates (e.g. +1/+1 counters) and any other card/controller
+                // predicates are honored — not just the handful of card predicates handled inline.
                 val firstMatchingInfo = damageEvents.firstOrNull { info ->
                     val sourceContainer = state.getEntity(info.sourceId) ?: return@firstOrNull false
                     sourceContainer.get<CardComponent>() ?: return@firstOrNull false
                     if (!projected.isCreature(info.sourceId)) return@firstOrNull false
                     if (sourceContainer.has<FaceDownComponent>()) return@firstOrNull false
 
-                    // Check card predicates from the sourceFilter
-                    trigger.sourceFilter.cardPredicates.all { predicate ->
-                        when (predicate) {
-                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature -> true
-                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
-                                projected.hasSubtype(info.sourceId, predicate.subtype.value)
-                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNontoken ->
-                                !sourceContainer.has<TokenComponent>()
-                            else -> true
-                        }
-                    }
+                    predicateEvaluator.matches(
+                        state,
+                        projected,
+                        info.sourceId,
+                        trigger.sourceFilter,
+                        PredicateContext(controllerId = controllerId, sourceId = entry.entityId)
+                    )
                 }
 
                 if (firstMatchingInfo != null) {


### PR DESCRIPTION
Implements the {2}{G}{W}{W} legendary 3/3 with two abilities:
- "enters or attacks" → put a +1/+1 counter on target creature you control (two triggered abilities sharing the effect).
- "one or more creatures you control with +1/+1 counters on them deal combat damage to a player" → draw a card (batching trigger).

The second ability needs the combat-damage batch trigger to honor a state predicate (the +1/+1 counter filter). detectCombatDamageBatchTriggers previously matched only a hardcoded subset of card predicates and ignored state/controller predicates, so it now evaluates the full sourceFilter via PredicateEvaluator.matches. This is a general fix benefiting any filtered "one or more creatures you control deal combat damage" trigger.