### PR TITLE
Add Ardyn, the Usurper to Final Fantasy

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -272,7 +272,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CreateToken(name, p, t, colors?, subtypes?, keywords?, count?, tapped?)` — make N tokens.
 - `CreateDynamicToken(...)` — tokens whose P/T is computed.
 - `CreateTokenCopyOfSelf(count?, tapped?)` — token copies of source.
-- `CreateTokenCopyOfTarget(target, count?, tapped?)` — token copy of another permanent.
+- `CreateTokenCopyOfTarget(target, count?, overridePower?, overrideToughness?, tapped?, attacking?, triggeredAbilities?, addedKeywords?, addedSupertypes?, removedSupertypes?, overrideColors?, overrideSubtypes?)` —
+  token copy of another permanent (or a card in any zone — the executor copies the target's `CardComponent`,
+  so a graveyard/exile card works). `overrideColors`/`overrideSubtypes` replace the copy's colors/subtypes
+  outright for "a token that's a copy … except it's a 5/5 black Demon" wording (Ardyn, the Usurper).
 - `CreateTokenCopyOfEquippedCreature(count?, tapped?)` — equipment-specific copy.
 - `CreateTreasure(count?, tapped?)` — Treasure tokens.
 - `CreateFood(count?, controller?)` — Food tokens.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ArdynTheUsurperScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ArdynTheUsurperScenarioTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Ardyn, the Usurper.
+ *
+ * - "Demons you control have menace, lifelink, and haste." (static keyword grant)
+ * - Starscourge — At the beginning of combat on your turn, exile up to one target creature
+ *   card from a graveyard. If you exiled a card this way, create a token that's a copy of
+ *   that card, except it's a 5/5 black Demon. (exercises the new overrideColors /
+ *   overrideSubtypes fields on CreateTokenCopyOfTargetEffect)
+ */
+class ArdynTheUsurperScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private fun ScenarioTestBase.TestGame.findToken(name: String): EntityId? =
+        state.getBattlefield().find { entityId ->
+            val container = state.getEntity(entityId) ?: return@find false
+            container.has<TokenComponent>() &&
+                container.get<CardComponent>()?.name == name
+        }
+
+    init {
+        context("Ardyn, the Usurper") {
+
+            test("Demons you control have menace, lifelink, and haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ardyn, the Usurper")
+                    .withCardOnBattlefield(1, "Grinning Demon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val demonId = game.findPermanent("Grinning Demon")!!
+                val ardynId = game.findPermanent("Ardyn, the Usurper")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Your Demon should have menace") {
+                    projected.hasKeyword(demonId, Keyword.MENACE) shouldBe true
+                }
+                withClue("Your Demon should have lifelink") {
+                    projected.hasKeyword(demonId, Keyword.LIFELINK) shouldBe true
+                }
+                withClue("Your Demon should have haste") {
+                    projected.hasKeyword(demonId, Keyword.HASTE) shouldBe true
+                }
+                withClue("Ardyn itself is not a Demon, so it should not gain menace") {
+                    projected.hasKeyword(ardynId, Keyword.MENACE) shouldBe false
+                }
+            }
+
+            test("Starscourge exiles a graveyard creature and makes a 5/5 black Demon copy") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ardyn, the Usurper")
+                    // Grizzly Bears (2/2 green Bear) sits in the opponent's graveyard.
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearsId = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+
+                // Advance into combat — Starscourge fires and asks for a target.
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                withClue("Starscourge should ask for a graveyard target at beginning of combat") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(bearsId))
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be exiled from the graveyard") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                    game.state.getExile(game.player2Id).contains(bearsId) shouldBe true
+                }
+
+                val tokenId = game.findToken("Grizzly Bears")
+                withClue("A token copy of Grizzly Bears should be on the battlefield") {
+                    (tokenId != null) shouldBe true
+                }
+                val tokenCard = game.state.getEntity(tokenId!!)!!.get<CardComponent>()!!
+                withClue("Token is 5/5") { tokenCard.baseStats shouldBe CreatureStats(5, 5) }
+                withClue("Token is black") { tokenCard.colors shouldBe setOf(Color.BLACK) }
+                withClue("Token is a Demon") { tokenCard.typeLine.subtypes shouldBe setOf(Subtype.DEMON) }
+                withClue("Token is still a creature") { tokenCard.typeLine.isCreature shouldBe true }
+
+                // The token is a Demon you control, so Ardyn's static buffs it.
+                val projected = stateProjector.project(game.state)
+                withClue("Demon token gains menace from Ardyn") {
+                    projected.hasKeyword(tokenId, Keyword.MENACE) shouldBe true
+                }
+                withClue("Demon token gains lifelink from Ardyn") {
+                    projected.hasKeyword(tokenId, Keyword.LIFELINK) shouldBe true
+                }
+                withClue("Demon token gains haste from Ardyn") {
+                    projected.hasKeyword(tokenId, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("Starscourge may exile zero cards — no token created") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ardyn, the Usurper")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                withClue("Starscourge should still offer the optional target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.skipTargets()
+                game.resolveStack()
+
+                withClue("Declining the target leaves the card in the graveyard") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("No Demon token is created when no card is exiled") {
+                    game.findToken("Grizzly Bears") shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/a/ardyn-the-usurper.json
+++ b/manual-scenarios/cards/a/ardyn-the-usurper.json
@@ -1,0 +1,45 @@
+{
+  "player1Name": "Ardyn Pilot",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Ardyn, the Usurper"},
+      {"name": "Grinning Demon"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [
+      "Glory Seeker"
+    ],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [
+      "Grizzly Bears",
+      "Grinning Demon"
+    ],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["BEGIN_COMBAT"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1143,7 +1143,9 @@ object Effects {
         triggeredAbilities: List<TriggeredAbility> = emptyList(),
         addedKeywords: Set<com.wingedsheep.sdk.core.Keyword> = emptySet(),
         addedSupertypes: Set<com.wingedsheep.sdk.core.Supertype> = emptySet(),
-        removedSupertypes: Set<com.wingedsheep.sdk.core.Supertype> = emptySet()
+        removedSupertypes: Set<com.wingedsheep.sdk.core.Supertype> = emptySet(),
+        overrideColors: Set<com.wingedsheep.sdk.core.Color>? = null,
+        overrideSubtypes: Set<com.wingedsheep.sdk.core.Subtype>? = null
     ): Effect = CreateTokenCopyOfTargetEffect(
         target = target,
         count = DynamicAmount.Fixed(count),
@@ -1154,7 +1156,9 @@ object Effects {
         triggeredAbilities = triggeredAbilities,
         addedKeywords = addedKeywords,
         addedSupertypes = addedSupertypes,
-        removedSupertypes = removedSupertypes
+        removedSupertypes = removedSupertypes,
+        overrideColors = overrideColors,
+        overrideSubtypes = overrideSubtypes
     )
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
@@ -363,15 +363,19 @@ data class CreateTokenCopyOfTargetEffect(
 ) : Effect {
     override val description: String = buildString {
         append("Create ${count.description} token copies of target permanent")
-        if (overridePower != null && overrideToughness != null) {
-            append(", except they're $overridePower/$overrideToughness")
-        }
-        if (overrideColors != null || overrideSubtypes != null) {
-            val color = overrideColors?.joinToString(" ") { it.displayName.lowercase() }
-            val type = overrideSubtypes?.joinToString(" ") { it.value }
-            append(", except ${if (count == DynamicAmount.Fixed(1)) "it's" else "they're"} ${
-                listOfNotNull(color, type).joinToString(" ")
-            }")
+        // Merge any copiable-value overrides into one clause, e.g. "except it's a 5/5 black Demon".
+        val pt = if (overridePower != null && overrideToughness != null) "$overridePower/$overrideToughness" else null
+        val color = overrideColors?.joinToString(" ") { it.displayName.lowercase() }
+        val type = overrideSubtypes?.joinToString(" ") { it.value }
+        val descriptor = listOfNotNull(pt, color, type).joinToString(" ")
+        if (descriptor.isNotEmpty()) {
+            val pronoun = if (count == DynamicAmount.Fixed(1)) "it's" else "they're"
+            // Article only when the descriptor ends in a type noun ("a Demon"); a bare P/T or
+            // color reads fine without one ("it's 5/5", "it's black").
+            val article = if (type != null) {
+                if (descriptor.first().lowercaseChar() in "aeiou") "an " else "a "
+            } else ""
+            append(", except $pronoun $article$descriptor")
         }
         if (tapped) append(" tapped")
         if (attacking) append(" and attacking")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.sdk.scripting.effects
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Supertype
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.StaticAbility
@@ -348,12 +349,29 @@ data class CreateTokenCopyOfTargetEffect(
     /** Supertypes added to the token copy's type line (e.g., LEGENDARY for Adagia, Windswept Bastion). */
     val addedSupertypes: Set<Supertype> = emptySet(),
     /** Supertypes stripped from the token copy's type line (e.g., LEGENDARY for Impostor Syndrome). */
-    val removedSupertypes: Set<Supertype> = emptySet()
+    val removedSupertypes: Set<Supertype> = emptySet(),
+    /**
+     * Replaces the token copy's colors outright (e.g., black for Ardyn, the Usurper's
+     * "a 5/5 black Demon"). Null leaves the copied card's colors untouched.
+     */
+    val overrideColors: Set<Color>? = null,
+    /**
+     * Replaces the token copy's subtypes outright (e.g., Demon for Ardyn, the Usurper).
+     * Null leaves the copied card's subtypes untouched.
+     */
+    val overrideSubtypes: Set<Subtype>? = null
 ) : Effect {
     override val description: String = buildString {
         append("Create ${count.description} token copies of target permanent")
         if (overridePower != null && overrideToughness != null) {
             append(", except they're $overridePower/$overrideToughness")
+        }
+        if (overrideColors != null || overrideSubtypes != null) {
+            val color = overrideColors?.joinToString(" ") { it.displayName.lowercase() }
+            val type = overrideSubtypes?.joinToString(" ") { it.value }
+            append(", except ${if (count == DynamicAmount.Fixed(1)) "it's" else "they're"} ${
+                listOfNotNull(color, type).joinToString(" ")
+            }")
         }
         if (tapped) append(" tapped")
         if (attacking) append(" and attacking")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ArdynTheUsurper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ArdynTheUsurper.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ardyn, the Usurper
+ * {5}{B}{B}{B}
+ * Legendary Creature — Elder Human Noble
+ * 4/4
+ *
+ * Demons you control have menace, lifelink, and haste.
+ * Starscourge — At the beginning of combat on your turn, exile up to one target creature
+ * card from a graveyard. If you exiled a card this way, create a token that's a copy of
+ * that card, except it's a 5/5 black Demon.
+ *
+ * "Starscourge" is an ability word with no rules meaning.
+ */
+val ArdynTheUsurper = card("Ardyn, the Usurper") {
+    manaCost = "{5}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Elder Human Noble"
+    power = 4
+    toughness = 4
+    oracleText = "Demons you control have menace, lifelink, and haste.\n" +
+        "Starscourge — At the beginning of combat on your turn, exile up to one target creature " +
+        "card from a graveyard. If you exiled a card this way, create a token that's a copy of " +
+        "that card, except it's a 5/5 black Demon."
+
+    // Demons you control have menace, lifelink, and haste.
+    val demons = GroupFilter.AllCreaturesYouControl.withSubtype("Demon")
+    staticAbility { ability = GrantKeyword(Keyword.MENACE, demons) }
+    staticAbility { ability = GrantKeyword(Keyword.LIFELINK, demons) }
+    staticAbility { ability = GrantKeyword(Keyword.HASTE, demons) }
+
+    // Starscourge — At the beginning of combat on your turn, exile up to one target creature
+    // card from a graveyard, then create a 5/5 black Demon token copy of it.
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        // "Up to one target" — exile and copy both no-op if no target is chosen, which
+        // naturally satisfies the oracle's "if you exiled a card this way" guard.
+        val graveyardCard = target(
+            "creature card from a graveyard",
+            TargetObject(optional = true, filter = TargetFilter.CreatureInGraveyard)
+        )
+        effect = CompositeEffect(listOf(
+            Effects.Exile(graveyardCard),
+            Effects.CreateTokenCopyOfTarget(
+                graveyardCard,
+                overridePower = 5,
+                overrideToughness = 5,
+                overrideColors = setOf(Color.BLACK),
+                overrideSubtypes = setOf(Subtype.DEMON)
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "89"
+        artist = "Russell Lu"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/4627072e-9c72-4084-8021-690777342548.jpg?1748706094"
+
+        ruling("2025-06-06", "Except for the listed exceptions, the token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into a graveyard.")
+        ruling("2025-06-06", "If a card copied by the token had any \"when [this permanent] enters\" abilities, the token also has those abilities, and they'll trigger when it's created. Similarly, any \"as [this permanent] enters\" or \"[this permanent] enters with\" abilities that the token has copied will also work.")
+        ruling("2025-06-06", "If the copied card has {X} in its mana cost, X is 0.")
+        ruling("2025-06-06", "The token is a Demon creature instead of its other types and is black instead of its other colors. Its base power and toughness are 5/5. These are copiable values of the token that other effects may copy.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -77,18 +77,16 @@ class CreateTokenCopyOfTargetExecutor(
             val overrideStats = if (op != null && ot != null) {
                 CreatureStats(op, ot)
             } else null
-            val tokenTypeLine = if (effect.addedSupertypes.isEmpty() && effect.removedSupertypes.isEmpty()) {
-                targetCard.typeLine
-            } else {
-                targetCard.typeLine.copy(
-                    supertypes = targetCard.typeLine.supertypes + effect.addedSupertypes - effect.removedSupertypes
-                )
-            }
+            val tokenTypeLine = targetCard.typeLine.copy(
+                supertypes = targetCard.typeLine.supertypes + effect.addedSupertypes - effect.removedSupertypes,
+                subtypes = effect.overrideSubtypes ?: targetCard.typeLine.subtypes
+            )
             val tokenCard = targetCard.copy(
                 ownerId = controllerId,
                 typeLine = tokenTypeLine,
                 baseStats = overrideStats ?: targetCard.baseStats,
-                baseKeywords = targetCard.baseKeywords + effect.addedKeywords
+                baseKeywords = targetCard.baseKeywords + effect.addedKeywords,
+                colors = effect.overrideColors ?: targetCard.colors
             )
 
             val components = mutableListOf<Component>(


### PR DESCRIPTION
Static grant of menace/lifelink/haste to Demons you control, plus the Starscourge begin-combat trigger that exiles up to one target creature card from a graveyard and makes a 5/5 black Demon token copy of it.

Adds overrideColors/overrideSubtypes to CreateTokenCopyOfTargetEffect so a token copy can take a fixed color and creature type ("except it's a 5/5 black Demon").