### PR TITLE
Add Superior Spider-Man to Marvel's Spider-Man

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 27 / 189
+**Implemented:** 28 / 189
 - [x] Agent Venom
 - [x] Angry Rabble
 - [x] Amazing Acrobatics
@@ -159,7 +159,7 @@
 - [ ] Sudden Strike
 - [ ] Sun-Spider, Nimble Webber
 - [ ] Superior Foes of Spider-Man
-- [ ] Superior Spider-Man
+- [x] Superior Spider-Man
 - [ ] Supportive Parents
 - [ ] Swarm, Being of Bees
 - [ ] Symbiote Spider-Man

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1459,6 +1459,17 @@ replacementEffect {
   "Devour land N" wording. **Scope today:** only the stack-spell entry path is wired; reanimation and
   token entries skip Devour (which is fine for printed cards — Devour creatures all cost real mana to
   cast).
+- `EntersAsCopy(optional, copyFilter, copyFromZone, filterByTotalManaSpent, additionalSubtypes, additionalKeywords, nameOverride, powerOverride, toughnessOverride, exileCopiedCard)` —
+  "enter as a copy of …". As the permanent resolves, the controller picks an object matching
+  `copyFilter` and the permanent enters as a copy (Rule 707 copiable values), with any overrides
+  applied. `copyFromZone` selects the candidate pool: `Zone.BATTLEFIELD` (default — Clone, Clever
+  Impersonator, Mockingbird) copies a permanent in play; `Zone.GRAVEYARD` copies a creature *card*
+  from any graveyard (Superior Spider-Man) via the modal card-list overlay. `additionalSubtypes` /
+  `additionalKeywords` are added "in addition to its other types"; `nameOverride` keeps a fixed name;
+  `powerOverride` / `toughnessOverride` force base P/T; `exileCopiedCard` exiles the copied card after
+  the copy ("When you do, exile that card"). `filterByTotalManaSpent` restricts copy targets to mana
+  value ≤ total mana spent (Mockingbird). The copy snapshots a `CopyOfComponent` so it reverts to its
+  printed identity when it leaves the battlefield (CR 400.7 / 707.2).
 - Custom — implement the `ReplacementEffect` interface directly.
 
 Amount-modifying replacements expose **both** `multiplier` (×) and `modifier` (±) on the same type — do not split into

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SuperiorSpiderManScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SuperiorSpiderManScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Superior Spider-Man.
+ *
+ * Superior Spider-Man {2}{U}{B}
+ * Legendary Creature — Spider Human Hero
+ * 4/4
+ * Mind Swap — You may have Superior Spider-Man enter as a copy of any creature card in a graveyard,
+ * except his name is Superior Spider-Man and he's a 4/4 Spider Human Hero in addition to his other
+ * types. When you do, exile that card.
+ *
+ * Exercises the graveyard-sourced [com.wingedsheep.sdk.scripting.EntersAsCopy] path: name override,
+ * 4/4 P/T override, added Spider/Human/Hero types, and exiling the copied card.
+ */
+class SuperiorSpiderManScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Superior Spider-Man — graveyard clone with overrides") {
+
+            test("enters as a copy of a creature card in a graveyard, keeping name + 4/4 and exiling the card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Superior Spider-Man")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInGraveyard(2, "Glory Seeker") // 2/2 Human Soldier
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Superior Spider-Man")
+                withClue("Should cast Superior Spider-Man: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Should have pending graveyard copy selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                val glorySeekerInGrave = game.state.getGraveyard(game.player2Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Glory Seeker"
+                }
+                game.selectCards(listOf(glorySeekerInGrave))
+
+                // The permanent keeps Superior Spider-Man's name (name override).
+                val copy = game.findPermanent("Superior Spider-Man")
+                withClue("Player should control a permanent named Superior Spider-Man") {
+                    copy shouldNotBe null
+                }
+                val copyCard = game.state.getEntity(copy!!)?.get<CardComponent>()!!
+
+                withClue("Copy should be forced to 4/4") {
+                    copyCard.baseStats?.basePower shouldBe 4
+                    copyCard.baseStats?.baseToughness shouldBe 4
+                }
+                withClue("Copy should gain Spider/Human/Hero on top of Glory Seeker's Human Soldier types") {
+                    copyCard.typeLine.subtypes.map { it.value } shouldContainAll
+                        listOf("Spider", "Human", "Hero", "Soldier")
+                }
+
+                // "When you do, exile that card."
+                withClue("Copied card should have been exiled, not left in graveyard") {
+                    game.state.getGraveyard(game.player2Id).contains(glorySeekerInGrave) shouldBe false
+                    game.state.getExile(game.player2Id).contains(glorySeekerInGrave) shouldBe true
+                }
+            }
+
+            test("optional — declining leaves Superior Spider-Man as his printed 4/4 self, graveyard card untouched") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Superior Spider-Man")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInGraveyard(2, "Glory Seeker")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Superior Spider-Man")
+                game.resolveStack()
+                game.skipSelection()
+
+                val spidey = game.findPermanent("Superior Spider-Man")
+                withClue("Superior Spider-Man should enter as himself") {
+                    spidey shouldNotBe null
+                }
+                val card = game.state.getEntity(spidey!!)?.get<CardComponent>()!!
+                withClue("He is printed as a 4/4") {
+                    card.baseStats?.basePower shouldBe 4
+                    card.baseStats?.baseToughness shouldBe 4
+                }
+                withClue("No copy was made, so the graveyard card should be untouched") {
+                    val gloryStillInGrave = game.state.getGraveyard(game.player2Id).any { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Glory Seeker"
+                    }
+                    gloryStillInGrave shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/s/superior-spider-man.json
+++ b/manual-scenarios/cards/s/superior-spider-man.json
@@ -1,0 +1,30 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Superior Spider-Man"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": ["Skyward Spider", "Agent Venom"],
+    "library": ["Island", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": ["Rhino, Barreling Brute", "Kraven the Hunter"],
+    "library": ["Island", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -675,29 +675,46 @@ data class ModifyLifeLoss(
 // =============================================================================
 
 /**
- * Enter the battlefield as a copy of a permanent.
+ * Enter the battlefield as a copy of a card or permanent.
  * Example: Clone ("You may have this creature enter as a copy of any creature on the battlefield")
  * Example: Clever Impersonator ("You may have this creature enter as a copy of any nonland permanent on the battlefield")
+ * Example: Superior Spider-Man ("You may have this creature enter as a copy of any creature card in a
+ *          graveyard, except his name is Superior Spider-Man and he's a 4/4 Spider Human Hero ... When
+ *          you do, exile that card.")
  *
- * When this permanent would enter the battlefield, the controller may choose a permanent
- * on the battlefield matching [copyFilter]. If they do, the permanent enters as a copy of that permanent.
- * If they don't (or can't), the permanent enters as itself (typically 0/0 and dies).
+ * When this permanent would enter the battlefield, the controller may choose an object in [copyFromZone]
+ * matching [copyFilter]. If they do, the permanent enters as a copy of that object (with the overrides
+ * below applied). If they don't (or can't), the permanent enters as itself (typically 0/0 and dies).
  *
  * @param copyFilter Filter for what can be copied. Defaults to creatures only (Clone).
  *                   Use [GameObjectFilter.Companion.NonlandPermanent] for Clever Impersonator.
+ * @param copyFromZone Where to look for copy candidates. [Zone.BATTLEFIELD] (default) copies a permanent;
+ *                   [Zone.GRAVEYARD] copies a creature *card* from any graveyard (Superior Spider-Man).
  * @param filterByTotalManaSpent When true, only creatures with mana value ≤ total mana spent
  *                                to cast this spell are valid copy targets. Used for Mockingbird.
- * @param additionalSubtypes Subtypes to add to the copy (e.g., "Bird" for Mockingbird).
+ * @param additionalSubtypes Subtypes to add to the copy (e.g., "Bird" for Mockingbird; "Spider", "Human",
+ *                   "Hero" for Superior Spider-Man — added "in addition to its other types").
  * @param additionalKeywords Keywords to grant to the copy (e.g., FLYING for Mockingbird).
+ * @param nameOverride When non-null, the copy keeps this name instead of the copied object's name
+ *                   ("except his name is Superior Spider-Man").
+ * @param powerOverride When non-null, the copy's base power is set to this value ("he's a 4/4 ...").
+ * @param toughnessOverride When non-null, the copy's base toughness is set to this value.
+ * @param exileCopiedCard When true, the copied card is exiled after the copy is applied
+ *                   ("When you do, exile that card"). Only meaningful with [copyFromZone] = graveyard.
  */
 @SerialName("EntersAsCopy")
 @Serializable
 data class EntersAsCopy(
     val optional: Boolean = true,
     val copyFilter: GameObjectFilter = GameObjectFilter.Creature,
+    val copyFromZone: Zone = Zone.BATTLEFIELD,
     val filterByTotalManaSpent: Boolean = false,
     val additionalSubtypes: List<String> = emptyList(),
     val additionalKeywords: List<Keyword> = emptyList(),
+    val nameOverride: String? = null,
+    val powerOverride: Int? = null,
+    val toughnessOverride: Int? = null,
+    val exileCopiedCard: Boolean = false,
     override val appliesTo: GameEvent = GameEvent.ZoneChangeEvent(
         filter = GameObjectFilter.Any,
         to = Zone.BATTLEFIELD
@@ -705,10 +722,28 @@ data class EntersAsCopy(
 ) : ReplacementEffect {
     override val description: String = run {
         val filterDesc = copyFilter.description
-        if (optional) {
-            "You may have this creature enter as a copy of any $filterDesc on the battlefield"
+        val where = if (copyFromZone == Zone.GRAVEYARD) "$filterDesc card in a graveyard" else "$filterDesc on the battlefield"
+        val lead = if (optional) {
+            "You may have this creature enter as a copy of any $where"
         } else {
-            "This creature enters as a copy of any $filterDesc on the battlefield"
+            "This creature enters as a copy of any $where"
+        }
+        buildString {
+            append(lead)
+            val exceptions = buildList {
+                if (nameOverride != null) add("its name is $nameOverride")
+                if (powerOverride != null && toughnessOverride != null) {
+                    add("it's $powerOverride/$toughnessOverride")
+                }
+                if (additionalSubtypes.isNotEmpty()) {
+                    add("a ${additionalSubtypes.joinToString(" ")} in addition to its other types")
+                }
+                if (additionalKeywords.isNotEmpty()) {
+                    add("it has ${additionalKeywords.joinToString(", ") { it.name.lowercase() }}")
+                }
+            }
+            if (exceptions.isNotEmpty()) append(", except ${exceptions.joinToString(" and ")}")
+            if (exileCopiedCard) append(". When you do, exile that card")
         }
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SuperiorSpiderMan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SuperiorSpiderMan.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersAsCopy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Superior Spider-Man
+ * {2}{U}{B}
+ * Legendary Creature — Spider Human Hero
+ * 4/4
+ * Mind Swap — You may have Superior Spider-Man enter as a copy of any creature card in a graveyard,
+ * except his name is Superior Spider-Man and he's a 4/4 Spider Human Hero in addition to his other
+ * types. When you do, exile that card.
+ *
+ * "Mind Swap" is an ability word (flavor only). The mechanical behavior is a graveyard-sourced
+ * [EntersAsCopy]: the copy keeps Superior Spider-Man's name, is forced to 4/4, gains the Spider/
+ * Human/Hero creature types on top of the copied card's types, and the copied card is exiled.
+ */
+val SuperiorSpiderMan = card("Superior Spider-Man") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Spider Human Hero"
+    power = 4
+    toughness = 4
+    oracleText = "Mind Swap — You may have Superior Spider-Man enter as a copy of any creature card " +
+        "in a graveyard, except his name is Superior Spider-Man and he's a 4/4 Spider Human Hero in " +
+        "addition to his other types. When you do, exile that card."
+
+    replacementEffect(
+        EntersAsCopy(
+            optional = true,
+            copyFilter = GameObjectFilter.Creature,
+            copyFromZone = Zone.GRAVEYARD,
+            additionalSubtypes = listOf("Spider", "Human", "Hero"),
+            nameOverride = "Superior Spider-Man",
+            powerOverride = 4,
+            toughnessOverride = 4,
+            exileCopiedCard = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "155"
+        artist = "Carlos Dattoli"
+        flavorText = "\"I will be Spider-Man. With my unparalleled genius, I shall become the *Superior* Spider-Man.\"\n—Otto Octavius"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad4adc3e-ec41-4406-8ff2-59ba8067cf4e.jpg?1758203859"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -149,6 +149,12 @@ data class ModalTargetContinuation(
  * @property optional Whether the copy is optional (Clone is optional)
  * @property additionalSubtypes Subtypes to add to the copy (e.g., "Bird" for Mockingbird)
  * @property additionalKeywords Keywords to grant to the copy (e.g., FLYING for Mockingbird)
+ * @property nameOverride When non-null, the copy keeps this name instead of the copied object's
+ *   name (Superior Spider-Man: "except his name is Superior Spider-Man")
+ * @property powerOverride When non-null, overrides the copy's base power (Superior Spider-Man: 4)
+ * @property toughnessOverride When non-null, overrides the copy's base toughness (Superior Spider-Man: 4)
+ * @property exileCopiedCard When true, exile the copied card after copying it (Superior Spider-Man:
+ *   "When you do, exile that card"). Used for graveyard copies.
  */
 @Serializable
 data class CloneEntersContinuation(
@@ -158,7 +164,11 @@ data class CloneEntersContinuation(
     val ownerId: EntityId,
     val castFaceDown: Boolean,
     val additionalSubtypes: List<String> = emptyList(),
-    val additionalKeywords: List<Keyword> = emptyList()
+    val additionalKeywords: List<Keyword> = emptyList(),
+    val nameOverride: String? = null,
+    val powerOverride: Int? = null,
+    val toughnessOverride: Int? = null,
+    val exileCopiedCard: Boolean = false
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -401,12 +401,14 @@ class ModalAndCloneContinuationResumer(
         // If a creature was selected, copy its CardComponent
         val selectedCreatureId = response.selectedCards.firstOrNull()
         val copiedCardDef: com.wingedsheep.sdk.model.CardDefinition?
+        var copyApplied = false
 
         if (selectedCreatureId != null) {
             val targetContainer = newState.getEntity(selectedCreatureId)
             val targetCardComponent = targetContainer?.get<CardComponent>()
 
             if (targetCardComponent != null) {
+                copyApplied = true
                 // Create a copy of the target's CardComponent, keeping Clone's ownerId
                 // Apply additional subtypes and keywords if specified (e.g., Mockingbird adds Bird + flying)
                 var copiedCardComponent = targetCardComponent.copy(
@@ -422,6 +424,20 @@ class ModalAndCloneContinuationResumer(
                 if (continuation.additionalKeywords.isNotEmpty()) {
                     copiedCardComponent = copiedCardComponent.copy(
                         baseKeywords = copiedCardComponent.baseKeywords + continuation.additionalKeywords
+                    )
+                }
+                // Name override (e.g., Superior Spider-Man keeps his own name)
+                if (continuation.nameOverride != null) {
+                    copiedCardComponent = copiedCardComponent.copy(name = continuation.nameOverride)
+                }
+                // Power/toughness override (e.g., Superior Spider-Man is always 4/4)
+                if (continuation.powerOverride != null || continuation.toughnessOverride != null) {
+                    val basePower = continuation.powerOverride
+                        ?: copiedCardComponent.baseStats?.basePower ?: 0
+                    val baseToughness = continuation.toughnessOverride
+                        ?: copiedCardComponent.baseStats?.baseToughness ?: 0
+                    copiedCardComponent = copiedCardComponent.copy(
+                        baseStats = com.wingedsheep.sdk.model.CreatureStats(basePower, baseToughness)
                     )
                 }
 
@@ -474,6 +490,15 @@ class ModalAndCloneContinuationResumer(
                 copyOfOriginalName = copyOfOriginalName
             )
         )
+
+        // "When you do, exile that card." (Superior Spider-Man) — exile the copied
+        // graveyard card after the copy has been applied and the permanent has entered.
+        if (continuation.exileCopiedCard && copyApplied && selectedCreatureId != null) {
+            val exileResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+                .moveToZone(newState, selectedCreatureId, Zone.EXILE)
+            newState = exileResult.state
+            events.addAll(exileResult.events)
+        }
 
         return checkForMore(newState, events)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -683,9 +683,16 @@ class StackResolver(
         if (cardDef != null && !spellComponent.castFaceDown) {
             val entersAsCopy = cardDef.script.replacementEffects.filterIsInstance<EntersAsCopy>().firstOrNull()
             if (entersAsCopy != null) {
-                // Find all permanents on the battlefield matching the copy filter
+                // Find candidates to copy. Battlefield copies (Clone) read permanents in play;
+                // graveyard copies (Superior Spider-Man) read creature cards across every graveyard.
                 val copyFilter = entersAsCopy.copyFilter
-                var candidates = state.getBattlefield().filter { entityId ->
+                val copyFromGraveyard = entersAsCopy.copyFromZone == Zone.GRAVEYARD
+                val candidatePool = if (copyFromGraveyard) {
+                    state.turnOrder.flatMap { state.getGraveyard(it) }
+                } else {
+                    state.getBattlefield()
+                }
+                var candidates = candidatePool.filter { entityId ->
                     predicateEvaluator.matches(
                         state, state.projectedState, entityId, copyFilter,
                         PredicateContext(controllerId = controllerId)
@@ -709,14 +716,15 @@ class StackResolver(
                 if (candidates.isNotEmpty()) {
                     // Present the selection decision
                     val filterDesc = copyFilter.description
+                    val whereDesc = if (copyFromGraveyard) "$filterDesc card in a graveyard" else "$filterDesc"
                     val decisionId = "clone-enters-${spellId.value}"
                     val decision = SelectCardsDecision(
                         id = decisionId,
                         playerId = controllerId,
                         prompt = if (entersAsCopy.optional) {
-                            "You may choose a $filterDesc to copy"
+                            "You may choose a $whereDesc to copy"
                         } else {
-                            "Choose a $filterDesc to copy"
+                            "Choose a $whereDesc to copy"
                         },
                         context = DecisionContext(
                             sourceId = spellId,
@@ -726,7 +734,9 @@ class StackResolver(
                         options = candidates,
                         minSelections = if (entersAsCopy.optional) 0 else 1,
                         maxSelections = 1,
-                        useTargetingUI = true
+                        // Battlefield copies click permanents in-place; graveyard copies use the
+                        // modal card-list overlay (graveyards aren't on the battlefield).
+                        useTargetingUI = !copyFromGraveyard
                     )
 
                     // Push continuation
@@ -737,7 +747,11 @@ class StackResolver(
                         ownerId = ownerId,
                         castFaceDown = spellComponent.castFaceDown,
                         additionalSubtypes = entersAsCopy.additionalSubtypes,
-                        additionalKeywords = entersAsCopy.additionalKeywords
+                        additionalKeywords = entersAsCopy.additionalKeywords,
+                        nameOverride = entersAsCopy.nameOverride,
+                        powerOverride = entersAsCopy.powerOverride,
+                        toughnessOverride = entersAsCopy.toughnessOverride,
+                        exileCopiedCard = entersAsCopy.exileCopiedCard
                     )
 
                     val pausedState = state


### PR DESCRIPTION
Extends EntersAsCopy with a graveyard copy source plus name, P/T, and exile-the-copied-card overrides so Superior Spider-Man can enter as a 4/4 Spider Human Hero copy of any creature card in a graveyard, then exile it.