### PR TITLE
LTR: Amass Orcs mechanic (CR 701.47) + 13 Amass cards

### DIFF
--- a/backlog/sets/lord-of-the-rings/TODO.md
+++ b/backlog/sets/lord-of-the-rings/TODO.md
@@ -24,7 +24,9 @@ Verify status anytime with: `scripts/card-status --set LTR` (and `--list --set L
   unlocks ~50 missing cards (the largest bucket; Amass is the next at ~24). Building the
   substrate first (one commit), then one card per commit. See
   [`MagicCompRules_20260417.pdf`] rule 701.52 for the four cumulative emblem abilities.
-- ⬜ **Amass Orcs** — next mechanic (~24 cards).
+- 🚧 **Amass Orcs** — substrate done on branch `ltr-amass` (CR 701.47: `Effects.Amass`,
+  `AmassExecutor` + `AmassContinuation`, composing `CreateToken`/`AddCounters`/`AddSubtype`).
+  First card attached: **Dunland Crebain**. ~23 Amass cards remain to attach.
 
 ## Data sources — do NOT hit the network
 

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 156 / 291
+**Implemented:** 157 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -124,7 +124,7 @@ starter-deck/special cards and basic lands.
 - [x] Isildur's Fateful Strike
 - [x] Lash of the Balrog
 - [ ] Lobelia Sackville-Baggins
-- [ ] March from the Black Gate
+- [x] March from the Black Gate
 - [x] Mirkwood Bats
 - [x] Mordor Muster
 - [x] Mordor Trebuchet

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 159 / 291
+**Implemented:** 160 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -149,7 +149,7 @@ starter-deck/special cards and basic lands.
 ### Red
 
 - [ ] Battle-Scarred Goblin
-- [ ] Book of Mazarbul
+- [x] Book of Mazarbul
 - [ ] Breaking of the Fellowship
 - [x] Cast into the Fire
 - [ ] Display of Power

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 162 / 291
+**Implemented:** 163 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -101,7 +101,7 @@ starter-deck/special cards and basic lands.
 - [x] Stern Scolding
 - [x] Storm of Saruman
 - [ ] Surrounded by Orcs
-- [ ] Treason of Isengard
+- [x] Treason of Isengard
 - [x] The Watcher in the Water
 - [x] Willow-Wind
 

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 154 / 291
+**Implemented:** 155 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -113,7 +113,7 @@ starter-deck/special cards and basic lands.
 - [x] Cirith Ungol Patrol
 - [x] Claim the Precious
 - [x] Dunland Crebain
-- [ ] Easterling Vanguard
+- [x] Easterling Vanguard
 - [ ] Gollum, Patient Plotter
 - [ ] Gollum's Bite
 - [x] Gorbag of Minas Morgul

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 153 / 291
+**Implemented:** 154 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -95,7 +95,7 @@ starter-deck/special cards and basic lands.
 - [ ] Press the Enemy
 - [ ] Rangers of Ithilien
 - [ ] Saruman the White
-- [ ] Saruman's Trickery
+- [x] Saruman's Trickery
 - [ ] Scroll of Isildur
 - [ ] Soothing of Sméagol
 - [x] Stern Scolding

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 160 / 291
+**Implemented:** 161 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -140,7 +140,7 @@ starter-deck/special cards and basic lands.
 - [x] Shadow of the Enemy
 - [x] Shelob's Ambush
 - [x] Snarling Warg
-- [ ] The Torment of Gollum
+- [x] The Torment of Gollum
 - [ ] Troll of Khazad-dûm
 - [x] Uruk-hai Berserker
 - [ ] Voracious Fell Beast

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 152 / 291
+**Implemented:** 153 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -74,7 +74,7 @@ starter-deck/special cards and basic lands.
 - [ ] Borne Upon a Wind
 - [x] Captain of Umbar
 - [ ] Council's Deliberation
-- [ ] Deceive the Messenger
+- [x] Deceive the Messenger
 - [ ] Dreadful as the Storm
 - [ ] Elrond, Lord of Rivendell
 - [ ] Gandalf, Friend of the Shire

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 151 / 291
+**Implemented:** 152 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -126,7 +126,7 @@ starter-deck/special cards and basic lands.
 - [ ] Lobelia Sackville-Baggins
 - [ ] March from the Black Gate
 - [x] Mirkwood Bats
-- [ ] Mordor Muster
+- [x] Mordor Muster
 - [x] Mordor Trebuchet
 - [x] Morgul-Knife Wound
 - [ ] Nasty End

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 157 / 291
+**Implemented:** 158 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -185,7 +185,7 @@ starter-deck/special cards and basic lands.
 - [x] Spiteful Banditry
 - [x] Swarming of Moria
 - [ ] There and Back Again
-- [ ] Warbeast of Gorgoroth
+- [x] Warbeast of Gorgoroth
 
 ### Green
 

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 150 / 291
+**Implemented:** 151 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -112,7 +112,7 @@ starter-deck/special cards and basic lands.
 - [ ] Call of the Ring
 - [x] Cirith Ungol Patrol
 - [x] Claim the Precious
-- [ ] Dunland Crebain
+- [x] Dunland Crebain
 - [ ] Easterling Vanguard
 - [ ] Gollum, Patient Plotter
 - [ ] Gollum's Bite

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 161 / 291
+**Implemented:** 162 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -117,7 +117,7 @@ starter-deck/special cards and basic lands.
 - [ ] Gollum, Patient Plotter
 - [ ] Gollum's Bite
 - [x] Gorbag of Minas Morgul
-- [ ] Gothmog, Morgul Lieutenant
+- [x] Gothmog, Morgul Lieutenant
 - [ ] Gríma Wormtongue
 - [ ] Grond, the Gatebreaker
 - [x] Haunt of the Dead Marshes

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 158 / 291
+**Implemented:** 159 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -134,7 +134,7 @@ starter-deck/special cards and basic lands.
 - [x] Oath of the Grey Host
 - [ ] One Ring to Rule Them All
 - [ ] Orcish Bowmasters
-- [ ] Orcish Medicine
+- [x] Orcish Medicine
 - [x] Sam's Desperate Rescue
 - [ ] Sauron, the Necromancer
 - [x] Shadow of the Enemy

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 155 / 291
+**Implemented:** 156 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -183,7 +183,7 @@ starter-deck/special cards and basic lands.
 - [x] Rush the Room
 - [x] Smite the Deathless
 - [x] Spiteful Banditry
-- [ ] Swarming of Moria
+- [x] Swarming of Moria
 - [ ] There and Back Again
 - [ ] Warbeast of Gorgoroth
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1644,8 +1644,12 @@ Card authors rarely reference these directly; they are created/updated by the ma
   `RingBearerCantBeBlockedByGreaterPowerRule`; the ≥2/≥3/≥4 triggered abilities are appended to the bearer by
   `TriggerAbilityResolver` (see `TheRingAbilities`). For card triggers/checks use `Triggers.RingTemptsYou`
   ("Whenever the Ring tempts you") and `Conditions.SourceIsRingBearer` ("if this is your Ring-bearer").
-
----
+- **Amass [subtype] N (CR 701.47)** — `Effects.Amass(count, subtype = "Orc")` (fixed) or
+  `Effects.Amass(amount, subtype)` (a `DynamicAmount`, for "amass Orcs X"). If the controller controls no Army
+  creature, a 0/0 black `[subtype]` Army token is created first (composing `CreateTokenEffect`); then they put N
+  +1/+1 counters on an Army they control (a `SelectCardsDecision` resolved by `AmassContinuation` picks which one
+  when they control several) and that Army becomes the subtype if it isn't already. The counter/subtype back half
+  lives in `AmassResolution`; counters route through `AddCountersEffect`, so placement replacements still apply.
 
 ## 20. Miscellaneous author-facing knobs
 

--- a/manual-scenarios/cards/m/mordor-muster.json
+++ b/manual-scenarios/cards/m/mordor-muster.json
@@ -1,0 +1,30 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Mordor Muster", "Mordor Muster"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -520,6 +520,18 @@ object Effects {
         com.wingedsheep.sdk.scripting.effects.TheRingTemptsYouEffect(target)
 
     /**
+     * "Amass [subtype] N" (CR 701.47). The controller puts N +1/+1 counters on an Army they
+     * control, creating a 0/0 black [subtype] Army token first if they control no Army, and the
+     * chosen Army becomes that subtype in addition to its other types.
+     */
+    fun Amass(count: Int, subtype: String = "Orc"): Effect =
+        com.wingedsheep.sdk.scripting.effects.AmassEffect(DynamicAmount.Fixed(count), subtype)
+
+    /** "Amass [subtype] X" with a dynamic amount (e.g. Fall of Cair Andros, The Mouth of Sauron). */
+    fun Amass(amount: DynamicAmount, subtype: String = "Orc"): Effect =
+        com.wingedsheep.sdk.scripting.effects.AmassEffect(amount, subtype)
+
+    /**
      * Return to hand.
      */
     fun ReturnToHand(target: EffectTarget): Effect =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/AmassEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/AmassEffect.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.sdk.scripting.effects
+
+import com.wingedsheep.sdk.scripting.text.TextReplacer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * "Amass [subtype] N" (CR 701.47).
+ *
+ * To amass Orcs N: if the controller doesn't control an Army creature, first create a 0/0 black
+ * [subtype] Army creature token. Then they choose an Army they control, put N +1/+1 counters on it,
+ * and — if it isn't already that subtype — it becomes that subtype in addition to its other types.
+ *
+ * The amount is a [DynamicAmount] so the keyword supports both the fixed printings ("amass Orcs 2")
+ * and the variable ones ("amass Orcs X", e.g. Fall of Cair Andros, The Mouth of Sauron, Shagrat).
+ */
+@SerialName("Amass")
+@Serializable
+data class AmassEffect(
+    val amount: DynamicAmount = DynamicAmount.Fixed(1),
+    val subtype: String = "Orc"
+) : Effect {
+    override val description: String = "amass ${subtype}s ${amount.description}"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect =
+        copy(amount = amount.applyTextReplacement(replacer))
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BookOfMazarbul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BookOfMazarbul.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Book of Mazarbul
+ * {2}{R}
+ * Enchantment — Saga
+ *
+ * I — Amass Orcs 1.
+ * II — Amass Orcs 2.
+ * III — Creatures you control get +1/+0 and gain menace until end of turn.
+ */
+val BookOfMazarbul = card("Book of Mazarbul") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Amass Orcs 1. (Put a +1/+1 counter on an Army you control. It's also an Orc. If you don't " +
+        "control an Army, create a 0/0 black Orc Army creature token first.)\n" +
+        "II — Amass Orcs 2.\n" +
+        "III — Creatures you control get +1/+0 and gain menace until end of turn."
+
+    sagaChapter(1) {
+        effect = Effects.Amass(1)
+    }
+    sagaChapter(2) {
+        effect = Effects.Amass(2)
+    }
+    sagaChapter(3) {
+        effect = EffectPatterns.modifyStatsForAll(1, 0, GroupFilter.AllCreaturesYouControl)
+            .then(EffectPatterns.grantKeywordToAll(Keyword.MENACE, GroupFilter.AllCreaturesYouControl))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "116"
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04dcef75-6f98-4233-ae32-6fe41724c8e0.jpg?1688569131"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DeceiveTheMessenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DeceiveTheMessenger.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deceive the Messenger
+ * {U}
+ * Instant
+ *
+ * Target creature gets -3/-0 until end of turn.
+ * Amass Orcs 1.
+ */
+val DeceiveTheMessenger = card("Deceive the Messenger") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -3/-0 until end of turn.\n" +
+        "Amass Orcs 1. (Put a +1/+1 counter on an Army you control. It's also an Orc. If you don't " +
+        "control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-3, 0, creature)
+            .then(Effects.Amass(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Tomas Duchek"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2984bc6-7c12-46e4-8dd3-b23e29a7a7ec.jpg?1686968062"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunlandCrebain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunlandCrebain.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dunland Crebain
+ * {2}{B}
+ * Creature — Bird Horror
+ * 1/1
+ *
+ * Flying
+ * When this creature enters, amass Orcs 2. (Put two +1/+1 counters on an Army you control. It's
+ * also an Orc. If you don't control an Army, create a 0/0 black Orc Army creature token first.)
+ */
+val DunlandCrebain = card("Dunland Crebain") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bird Horror"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature enters, amass Orcs 2. (Put two +1/+1 counters on an Army you control. " +
+        "It's also an Orc. If you don't control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Amass(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Alexander Ostrowski"
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/695c05ab-e46e-46c7-bd2e-ef0b2307e449.jpg?1686968429"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/EasterlingVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/EasterlingVanguard.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Easterling Vanguard
+ * {1}{B}
+ * Creature — Human Warrior
+ * 2/1
+ *
+ * When this creature dies, amass Orcs 1.
+ */
+val EasterlingVanguard = card("Easterling Vanguard") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature dies, amass Orcs 1. (Put a +1/+1 counter on an Army you control. " +
+        "It's also an Orc. If you don't control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Amass(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "83"
+        artist = "Javier Charro"
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e860dd40-07c5-47c3-92a8-1ee95a953c2f.jpg?1686968439"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GothmogMorgulLieutenant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GothmogMorgulLieutenant.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gothmog, Morgul Lieutenant
+ * {3}{B}
+ * Legendary Creature — Human Soldier
+ * 3/3
+ *
+ * When Gothmog enters, amass Orcs 1.
+ * Creature tokens you control have deathtouch.
+ */
+val GothmogMorgulLieutenant = card("Gothmog, Morgul Lieutenant") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "When Gothmog enters, amass Orcs 1. (Put a +1/+1 counter on an Army you control. " +
+        "It's also an Orc. If you don't control an Army, create a 0/0 black Orc Army creature token first.)\n" +
+        "Creature tokens you control have deathtouch."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Amass(1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.DEATHTOUCH,
+            filter = GroupFilter((GameObjectFilter.Creature and GameObjectFilter.Token).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Ilker Yildiz"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1c10e93-88eb-46b9-8adc-583661807990.jpg?1686968484"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MarchFromTheBlackGate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MarchFromTheBlackGate.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * March from the Black Gate
+ * {1}{B}
+ * Enchantment
+ *
+ * When this enchantment enters and whenever an Army you control attacks, amass Orcs 1.
+ */
+val MarchFromTheBlackGate = card("March from the Black Gate") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters and whenever an Army you control attacks, amass Orcs 1. " +
+        "(Put a +1/+1 counter on an Army you control. It's also an Orc. If you don't control an Army, " +
+        "create a 0/0 black Orc Army creature token first.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Amass(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouAttackWithFilter(
+            GameObjectFilter.Creature.withSubtype("Army").youControl()
+        )
+        effect = Effects.Amass(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "94"
+        artist = "Victor Harmatiuk"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e57815d4-b21f-4ceb-a3f1-73cff5f0e612.jpg?1686968563"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MordorMuster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MordorMuster.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mordor Muster
+ * {1}{B}
+ * Sorcery
+ *
+ * You draw a card and you lose 1 life.
+ * Amass Orcs 1. (Put a +1/+1 counter on an Army you control. It's also an Orc. If you don't
+ * control an Army, create a 0/0 black Orc Army creature token first.)
+ */
+val MordorMuster = card("Mordor Muster") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "You draw a card and you lose 1 life.\n" +
+        "Amass Orcs 1. (Put a +1/+1 counter on an Army you control. It's also an Orc. If you don't " +
+        "control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    spell {
+        effect = Effects.DrawCards(1)
+            .then(Effects.LoseLife(1, EffectTarget.Controller))
+            .then(Effects.Amass(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "96"
+        artist = "Pavel Kolomeyets"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aae2f15a-0629-453e-992c-a199af194a3c.jpg?1686968586"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/OrcishMedicine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/OrcishMedicine.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Orcish Medicine
+ * {1}{B}
+ * Instant
+ *
+ * Target creature gains your choice of lifelink or indestructible until end of turn.
+ * Amass Orcs 1.
+ *
+ * Modeled as a choose-one between the two keyword grants; the amass rider rides along on the chosen
+ * mode so the whole spell (including the amass) is countered if the single target becomes illegal.
+ */
+val OrcishMedicine = card("Orcish Medicine") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gains your choice of lifelink or indestructible until end of turn.\n" +
+        "Amass Orcs 1. (Put a +1/+1 counter on an Army you control. It's also an Orc. If you don't " +
+        "control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Target creature gains lifelink until end of turn") {
+                val creature = target("target creature", Targets.Creature)
+                effect = Effects.GrantKeyword(Keyword.LIFELINK, creature)
+                    .then(Effects.Amass(1))
+            }
+            mode("Target creature gains indestructible until end of turn") {
+                val creature = target("target creature", Targets.Creature)
+                effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature)
+                    .then(Effects.Amass(1))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "104"
+        artist = "Irvin Rodriguez"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66fae9ab-2302-4dea-a4e8-701938a0ef09.jpg?1686968679"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumansTrickery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumansTrickery.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Saruman's Trickery
+ * {1}{U}{U}
+ * Instant
+ *
+ * Counter target spell.
+ * Amass Orcs 1.
+ */
+val SarumansTrickery = card("Saruman's Trickery") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell.\n" +
+        "Amass Orcs 1. (Put a +1/+1 counter on an Army you control. It's also an Orc. If you don't " +
+        "control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    spell {
+        target("target spell", Targets.Spell)
+        effect = Effects.CounterSpell()
+            .then(Effects.Amass(1))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "68"
+        artist = "Yongjae Choi"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8eb6c23b-e52e-4533-9625-884eb0a4d866.jpg?1686968278"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SwarmingOfMoria.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SwarmingOfMoria.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swarming of Moria
+ * {2}{R}
+ * Sorcery
+ *
+ * Create a Treasure token.
+ * Amass Orcs 2.
+ */
+val SwarmingOfMoria = card("Swarming of Moria") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\n" +
+        "Amass Orcs 2. (Put two +1/+1 counters on an Army you control. It's also an Orc. If you don't " +
+        "control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    spell {
+        effect = Effects.CreateTreasure()
+            .then(Effects.Amass(2))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Pavel Kolomeyets"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a1bd073-4351-4c56-9b07-4430d0d83084.jpg?1686969195"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheTormentOfGollum.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheTormentOfGollum.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Torment of Gollum
+ * {3}{B}
+ * Sorcery
+ *
+ * Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.
+ * Amass Orcs 2.
+ */
+val TheTormentOfGollum = card("The Torment of Gollum") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You choose a nonland card from it. That player " +
+        "discards that card.\n" +
+        "Amass Orcs 2. (Put two +1/+1 counters on an Army you control. It's also an Orc. If you don't " +
+        "control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    spell {
+        val opponent = target("target opponent", TargetOpponent())
+        effect = CompositeEffect(
+            listOf(
+                RevealHandEffect(opponent),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "hand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    filter = GameObjectFilter.Nonland,
+                    storeSelected = "toDiscard",
+                    prompt = "Choose a nonland card to discard"
+                ),
+                MoveCollectionEffect(
+                    from = "toDiscard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    moveType = MoveType.Discard
+                ),
+                Effects.Amass(2)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "110"
+        artist = "Nino Is"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba2c8c25-1fa9-4cc4-a378-5eccc25bacf0.jpg?1686968743"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TreasonOfIsengard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TreasonOfIsengard.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Treason of Isengard
+ * {2}{U}
+ * Sorcery
+ *
+ * Put up to one target instant or sorcery card from your graveyard on top of your library.
+ * Amass Orcs 2.
+ */
+val TreasonOfIsengard = card("Treason of Isengard") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Put up to one target instant or sorcery card from your graveyard on top of your library.\n" +
+        "Amass Orcs 2. (Put two +1/+1 counters on an Army you control. It's also an Orc. If you don't " +
+        "control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    spell {
+        val card = target(
+            "up to one target instant or sorcery card from your graveyard",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.InstantOrSorcery.ownedByYou(), zone = Zone.GRAVEYARD),
+                optional = true
+            )
+        )
+        effect = Effects.PutOnTopOfLibrary(card)
+            .then(Effects.Amass(2))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Pavel Kolomeyets"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71f97505-c961-4890-acd0-32a63919ac2a.jpg?1686968343"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WarbeastOfGorgoroth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WarbeastOfGorgoroth.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Warbeast of Gorgoroth
+ * {4}{R}
+ * Creature — Beast
+ * 5/4
+ *
+ * Whenever this creature or another creature you control with power 4 or greater dies, amass Orcs 2.
+ */
+val WarbeastOfGorgoroth = card("Warbeast of Gorgoroth") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 4
+    oracleText = "Whenever this creature or another creature you control with power 4 or greater dies, " +
+        "amass Orcs 2. (Put two +1/+1 counters on an Army you control. It's also an Orc. If you don't " +
+        "control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().powerAtLeast(4),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Amass(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Oleg Shekhovtsov"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5eeecb9e-fbde-429b-b3da-18a4dbadf6de.jpg?1686969217"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -137,6 +137,29 @@ data class RingTemptContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume "amass [subtype] N" after the controller chooses which Army to put the counters on
+ * (CR 701.47a). Only reached when the controller has more than one Army; the chosen Army receives
+ * [amount] +1/+1 counters and becomes [subtype] if it isn't already.
+ *
+ * @property controllerId The player amassing (also the chooser).
+ * @property opponentId That player's opponent (for the resolution context).
+ * @property subtype The Army subtype being amassed (e.g., "Orc").
+ * @property amount Number of +1/+1 counters to place.
+ * @property sourceId The amassing source (for context/display).
+ * @property candidates The Armies offered at decision time, used to validate the response.
+ */
+@Serializable
+data class AmassContinuation(
+    override val decisionId: String,
+    val controllerId: EntityId,
+    val opponentId: EntityId?,
+    val subtype: String,
+    val amount: Int,
+    val sourceId: EntityId?,
+    val candidates: List<EntityId>
+) : ContinuationFrame
+
+/**
  * Resume creating a copy of a triggered ability after the player selects new targets.
  *
  * Used by Kirol-style effects ("Copy target triggered ability you control. You may choose

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -235,6 +235,7 @@ val engineSerializersModule = SerializersModule {
         subclass(RemoveAnyNumberOfCountersContinuation::class)
         subclass(ProliferateContinuation::class)
         subclass(RingTemptContinuation::class)
+        subclass(AmassContinuation::class)
         subclass(StormCopyTargetContinuation::class)
         subclass(StormCopyModalTargetContinuation::class)
         subclass(CopyTriggeredAbilityTargetContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
@@ -46,6 +46,7 @@ class ContinuationHandler(
         registerModule(CastModalContinuationResumer(services))
         registerModule(TokenContinuationResumer(services))
         registerModule(RingTemptContinuationResumer(services))
+        registerModule(AmassContinuationResumer(services))
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/AmassContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/AmassContinuationResumer.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.handlers.continuations
+
+import com.wingedsheep.engine.core.AmassContinuation
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.handlers.effects.player.AmassResolution
+import com.wingedsheep.engine.state.GameState
+
+/**
+ * Resumes "amass [subtype] N" after the controller picks which Army to amass (CR 701.47a).
+ *
+ * Reached only when the controller has more than one Army. The chosen Army gets the +1/+1 counters
+ * and becomes the subtype if it isn't already, via the shared [AmassResolution].
+ */
+class AmassContinuationResumer(
+    private val services: EngineServices
+) : ContinuationResumerModule {
+
+    override fun resumers(): List<ContinuationResumer<*>> = listOf(
+        resumer(AmassContinuation::class, ::resumeAmass)
+    )
+
+    private fun resumeAmass(
+        state: GameState,
+        continuation: AmassContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(state, "Expected an Army selection for amass")
+        }
+
+        val chosen = response.selectedCards.firstOrNull { it in continuation.candidates }
+            ?: continuation.candidates.first()
+
+        val result = AmassResolution.applyToArmy(
+            state = state,
+            armyId = chosen,
+            controllerId = continuation.controllerId,
+            opponentId = continuation.opponentId,
+            subtype = continuation.subtype,
+            amount = continuation.amount,
+            sourceId = continuation.sourceId,
+            executeEffect = services.effectExecutorRegistry::execute
+        )
+
+        return checkForMore(result.state, result.events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassExecutor.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.AmassContinuation
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.DecisionRequestedEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.AmassEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import java.util.UUID
+import kotlin.reflect.KClass
+
+/**
+ * Resolves [AmassEffect] — "amass [subtype] N" (CR 701.47).
+ *
+ * 1. If the controller controls no Army creature, create a 0/0 black [subtype] Army token first.
+ * 2. The controller chooses an Army they control (no prompt when they have exactly one — including
+ *    the token just created); [AmassContinuation] handles the choice when several Armies exist.
+ * 3. Put N +1/+1 counters on the chosen Army and make it the subtype if it isn't already.
+ *
+ * Token creation and counter placement compose the existing [CreateTokenEffect] / AddCounters
+ * executors via the injected [executeEffect]; the counter/subtype back half lives in
+ * [AmassResolution] so the single-army path and the continuation share it.
+ */
+class AmassExecutor(
+    private val executeEffect: (GameState, Effect, EffectContext) -> EffectResult,
+    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
+) : EffectExecutor<AmassEffect> {
+
+    override val effectType: KClass<AmassEffect> = AmassEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: AmassEffect,
+        context: EffectContext
+    ): EffectResult {
+        val controllerId = context.controllerId
+        val opponentId = context.opponentId
+        val subtype = effect.subtype
+        val amount = amountEvaluator.evaluate(state, effect.amount, context)
+
+        val armies = controlledArmies(state, controllerId)
+
+        // No Army → create a 0/0 black [subtype] Army token, then amass onto it (now the sole Army).
+        if (armies.isEmpty()) {
+            val createResult = executeEffect(
+                state,
+                CreateTokenEffect(
+                    power = 0,
+                    toughness = 0,
+                    colors = setOf(Color.BLACK),
+                    creatureTypes = setOf(subtype, ARMY),
+                    name = "$subtype Army"
+                ),
+                context
+            )
+            if (createResult.error != null) return createResult
+
+            val tokenId = controlledArmies(createResult.state, controllerId).firstOrNull()
+                ?: return EffectResult.success(createResult.state, createResult.events)
+
+            val applied = AmassResolution.applyToArmy(
+                createResult.state, tokenId, controllerId, opponentId, subtype, amount, context.sourceId, executeEffect
+            )
+            return EffectResult.success(applied.state, createResult.events + applied.events)
+        }
+
+        // Exactly one Army → no choice to make.
+        if (armies.size == 1) {
+            return AmassResolution.applyToArmy(
+                state, armies.single(), controllerId, opponentId, subtype, amount, context.sourceId, executeEffect
+            )
+        }
+
+        // Multiple Armies → the controller chooses which one is amassed (CR 701.47a).
+        val sourceName = context.sourceId
+            ?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+            ?: "Amass"
+        val decisionId = UUID.randomUUID().toString()
+        val decision = SelectCardsDecision(
+            id = decisionId,
+            playerId = controllerId,
+            prompt = "Amass ${subtype}s — choose an Army you control to put the counters on",
+            context = DecisionContext(
+                sourceId = context.sourceId,
+                sourceName = sourceName,
+                phase = DecisionPhase.RESOLUTION
+            ),
+            options = armies,
+            minSelections = 1,
+            maxSelections = 1,
+            useTargetingUI = true
+        )
+        val continuation = AmassContinuation(
+            decisionId = decisionId,
+            controllerId = controllerId,
+            opponentId = opponentId,
+            subtype = subtype,
+            amount = amount,
+            sourceId = context.sourceId,
+            candidates = armies
+        )
+        val newState = state.withPendingDecision(decision).pushContinuation(continuation)
+        return EffectResult.paused(
+            newState,
+            decision,
+            listOf(
+                DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = controllerId,
+                    decisionType = "SELECT_CARDS",
+                    prompt = decision.prompt
+                )
+            )
+        )
+    }
+
+    private fun controlledArmies(state: GameState, controllerId: EntityId): List<EntityId> {
+        val projected = state.projectedState
+        return projected.getBattlefieldControlledBy(controllerId)
+            .filter { projected.isCreature(it) && projected.hasSubtype(it, ARMY) }
+    }
+
+    private companion object {
+        const val ARMY = "Army"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassResolution.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassResolution.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shared resolution for the back half of "amass [subtype] N" (CR 701.47a), after the Army has been
+ * chosen (or created): put N +1/+1 counters on it, and — if it isn't already that subtype — make it
+ * that subtype in addition to its other types.
+ *
+ * Both [AmassExecutor] (the 0-army and single-army cases) and the multi-army continuation resumer
+ * route through here so the counter-placement and type-changing behaviour stay identical.
+ */
+object AmassResolution {
+
+    fun applyToArmy(
+        state: GameState,
+        armyId: EntityId,
+        controllerId: EntityId,
+        opponentId: EntityId?,
+        subtype: String,
+        amount: Int,
+        sourceId: EntityId?,
+        executeEffect: (GameState, Effect, EffectContext) -> EffectResult
+    ): EffectResult {
+        val context = EffectContext(sourceId = sourceId, controllerId = controllerId, opponentId = opponentId)
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+
+        // Put N +1/+1 counters on the Army. Routing through AddCountersEffect keeps counter-placement
+        // replacements (Hardened Scales, Doubling Season, …) applying to amassed counters.
+        if (amount > 0) {
+            val counterResult = executeEffect(
+                newState,
+                AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, amount, EffectTarget.SpecificEntity(armyId)),
+                context
+            )
+            newState = counterResult.state
+            events += counterResult.events
+        }
+
+        // "If it isn't a [subtype], it becomes a [subtype] in addition to its other types."
+        if (!newState.projectedState.hasSubtype(armyId, subtype)) {
+            newState = newState.addFloatingEffect(
+                layer = Layer.TYPE,
+                modification = SerializableModification.AddSubtype(subtype),
+                affectedEntities = setOf(armyId),
+                duration = Duration.Permanent,
+                context = context
+            )
+        }
+
+        return EffectResult.success(newState, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -34,6 +34,7 @@ class PlayerExecutors(
     }
 
     override fun executors(): List<EffectExecutor<*>> = listOf(
+        AmassExecutor(effectExecutor),
         AddCombatPhaseExecutor(),
         AnyPlayerMayPayExecutor(),
         CantCastSpellsExecutor(),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmassScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmassScenarioTest.kt
@@ -10,11 +10,15 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -67,9 +71,54 @@ class AmassScenarioTest : FunSpec({
         }
     }
 
+    // Warbeast of Gorgoroth's dies trigger: "Whenever this creature or another creature you control
+    // with power 4 or greater dies, amass Orcs 2." The filter has to read last-known power, since the
+    // creature is already in the graveyard when the leaves-the-battlefield trigger is evaluated.
+    val Warbeast = card("Warbeast of Gorgoroth") {
+        manaCost = "{4}{R}"
+        typeLine = "Creature — Beast"
+        power = 5; toughness = 4
+        triggeredAbility {
+            trigger = Triggers.leavesBattlefield(
+                filter = GameObjectFilter.Creature.youControl().powerAtLeast(4),
+                to = Zone.GRAVEYARD,
+                binding = TriggerBinding.ANY
+            )
+            effect = Effects.Amass(2)
+        }
+    }
+
+    // Vanilla bodies to die on cue: one at the power-4 boundary, one just below it.
+    val BigBeast = card("Cave Troll") {
+        manaCost = "{0}"
+        typeLine = "Creature — Troll"
+        power = 4; toughness = 4
+    }
+    val SmallBeast = card("Goblin Footman") {
+        manaCost = "{0}"
+        typeLine = "Creature — Goblin"
+        power = 3; toughness = 3
+    }
+
+    // {0} sorcery that destroys a target creature, to send a chosen body to the graveyard on demand.
+    val Slay = card("Slay") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Destroy target creature."
+        spell {
+            val creature = target("target creature", Targets.Creature)
+            effect = Effects.Destroy(creature)
+        }
+    }
+
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(AmassTwo, AmassOne, ZombieArmyA, ZombieArmyB, DunlandCrebain))
+        driver.registerCards(
+            TestCards.all + listOf(
+                AmassTwo, AmassOne, ZombieArmyA, ZombieArmyB, DunlandCrebain,
+                Warbeast, BigBeast, SmallBeast, Slay
+            )
+        )
         return driver
     }
 
@@ -169,5 +218,64 @@ class AmassScenarioTest : FunSpec({
         val army = driver.armiesControlledBy(active).single()
         projector.project(driver.state).getPower(army) shouldBe 2
         driver.plusOneCounters(army) shouldBe 2
+    }
+
+    // Cast {0} "Slay" on a target creature and resolve it (the creature dies).
+    fun GameTestDriver.slay(player: EntityId, victim: EntityId) {
+        val slayId = putCardInHand(player, "Slay")
+        castSpell(player, slayId, listOf(victim))
+        bothPass()
+    }
+
+    test("Warbeast dies and triggers off its own last-known power 5 (amass Orcs 2)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val warbeast = driver.putCreatureOnBattlefield(active, "Warbeast of Gorgoroth")
+        driver.armiesControlledBy(active).size shouldBe 0
+
+        driver.slay(active, warbeast)   // Slay resolves → Warbeast dies → its leaves trigger goes on the stack
+        driver.bothPass()               // resolve "amass Orcs 2"
+
+        // The dies trigger fired even though Warbeast is in the graveyard: a 2/2 Orc Army now exists.
+        val army = driver.armiesControlledBy(active).single()
+        projector.project(driver.state).getPower(army) shouldBe 2
+        driver.plusOneCounters(army) shouldBe 2
+    }
+
+    test("another power-4 creature dying triggers Warbeast via last-known power (amass Orcs 2)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(active, "Warbeast of Gorgoroth")
+        val troll = driver.putCreatureOnBattlefield(active, "Cave Troll")
+        driver.armiesControlledBy(active).size shouldBe 0
+
+        driver.slay(active, troll)      // the 4/4 dies; Warbeast's trigger must read its last-known power 4
+        driver.bothPass()               // resolve "amass Orcs 2"
+
+        val army = driver.armiesControlledBy(active).single()
+        projector.project(driver.state).getPower(army) shouldBe 2
+        driver.plusOneCounters(army) shouldBe 2
+    }
+
+    test("a power-3 creature dying does not trigger Warbeast (no amass)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(active, "Warbeast of Gorgoroth")
+        val footman = driver.putCreatureOnBattlefield(active, "Goblin Footman")
+
+        driver.slay(active, footman)    // 3/3 is below the power-4 threshold
+        driver.bothPass()
+
+        // No trigger, so no Army token was created.
+        driver.armiesControlledBy(active).size shouldBe 0
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmassScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmassScenarioTest.kt
@@ -1,0 +1,173 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Substrate tests for the Amass mechanic (CR 701.47): "amass [subtype] N" creates a 0/0 black Army
+ * token when you control none, then puts N +1/+1 counters on an Army you control and makes it the
+ * subtype. Covers token creation, counter stacking onto the same Army, the multi-Army choice, and
+ * the printed "When this creature enters, amass Orcs 2" shape (Dunland Crebain).
+ */
+class AmassScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // {0} sorceries that just amass, so the substrate can be exercised deterministically.
+    val AmassTwo = card("Amass Two") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Amass Orcs 2."
+        spell { effect = Effects.Amass(2) }
+    }
+    val AmassOne = card("Amass One") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Amass Orcs 1."
+        spell { effect = Effects.Amass(1) }
+    }
+
+    // Pre-existing Armies for the multi-Army choice. Base 2/2 so they survive state-based actions.
+    val ZombieArmyA = card("Zombie Army Alpha") {
+        manaCost = "{0}"
+        typeLine = "Creature — Zombie Army"
+        power = 2; toughness = 2
+    }
+    val ZombieArmyB = card("Zombie Army Beta") {
+        manaCost = "{0}"
+        typeLine = "Creature — Zombie Army"
+        power = 2; toughness = 2
+    }
+
+    // The printed card: {2}{B} 1/1 Bird Horror with flying and "When this creature enters, amass Orcs 2."
+    val DunlandCrebain = card("Dunland Crebain") {
+        manaCost = "{2}{B}"
+        typeLine = "Creature — Bird Horror"
+        power = 1; toughness = 1
+        keywords(Keyword.FLYING)
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.Amass(2)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AmassTwo, AmassOne, ZombieArmyA, ZombieArmyB, DunlandCrebain))
+        return driver
+    }
+
+    fun GameTestDriver.armiesControlledBy(player: EntityId): List<EntityId> {
+        val projected = projector.project(state)
+        return projected.getBattlefieldControlledBy(player)
+            .filter { projected.isCreature(it) && projected.hasSubtype(it, "Army") }
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // Cast a {0} amass sorcery and resolve it (no pending decision when you control 0 or 1 Army).
+    fun GameTestDriver.amass(player: EntityId, cardName: String) {
+        val cardId = putCardInHand(player, cardName)
+        castSpell(player, cardId)
+        bothPass()
+    }
+
+    test("amass with no Army creates a 0/0 black Orc Army token and puts the counters on it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.armiesControlledBy(active).size shouldBe 0
+
+        driver.amass(active, "Amass Two")
+
+        val armies = driver.armiesControlledBy(active)
+        armies.size shouldBe 1
+        val army = armies.single()
+
+        val projected = projector.project(driver.state)
+        projected.hasSubtype(army, "Orc") shouldBe true
+        projected.hasSubtype(army, "Army") shouldBe true
+        projected.getPower(army) shouldBe 2
+        projected.getToughness(army) shouldBe 2
+        driver.plusOneCounters(army) shouldBe 2
+    }
+
+    test("amassing again grows the same Army and creates no second Army") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.amass(active, "Amass Two")
+        val army = driver.armiesControlledBy(active).single()
+
+        driver.amass(active, "Amass One")
+
+        driver.armiesControlledBy(active) shouldBe listOf(army)
+        driver.plusOneCounters(army) shouldBe 3
+        projector.project(driver.state).getPower(army) shouldBe 3
+    }
+
+    test("with multiple Armies, the controller chooses which one is amassed (CR 701.47a)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val alpha = driver.putCreatureOnBattlefield(active, "Zombie Army Alpha")
+        val beta = driver.putCreatureOnBattlefield(active, "Zombie Army Beta")
+
+        val cardId = driver.putCardInHand(active, "Amass Two")
+        driver.castSpell(active, cardId)
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        decision as SelectCardsDecision
+        decision.options.toSet() shouldBe setOf(alpha, beta)
+        driver.submitDecision(active, CardsSelectedResponse(decision.id, listOf(alpha)))
+
+        // Alpha received the counters and became an Orc; Beta is untouched.
+        driver.plusOneCounters(alpha) shouldBe 2
+        projector.project(driver.state).hasSubtype(alpha, "Orc") shouldBe true
+        driver.plusOneCounters(beta) shouldBe 0
+        projector.project(driver.state).hasSubtype(beta, "Orc") shouldBe false
+    }
+
+    test("Dunland Crebain's enter trigger amasses Orcs 2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.giveMana(active, Color.BLACK, 3)
+        val crebain = driver.putCardInHand(active, "Dunland Crebain")
+        driver.castSpell(active, crebain)
+        driver.bothPass() // resolve the creature spell — it enters and its ETB trigger goes on the stack
+        driver.bothPass() // resolve the "amass Orcs 2" triggered ability
+
+        driver.findPermanent(active, "Dunland Crebain") shouldNotBe null
+        val army = driver.armiesControlledBy(active).single()
+        projector.project(driver.state).getPower(army) shouldBe 2
+        driver.plusOneCounters(army) shouldBe 2
+    }
+})


### PR DESCRIPTION
## Summary

Implements the **Amass Orcs** keyword action (CR 701.47) — the LTR set's
second headline mechanic after the Ring — plus the 13 Amass cards that
compose from it and existing SDK primitives. One engine commit for the
substrate, then one commit per card.

Draft progress for LTR: **137 → 150 / 261**.

### Engine: the Amass mechanic (commit `Add Amass Orcs mechanic…`)
- `AmassEffect` + `Effects.Amass(n)` / `Effects.Amass(amount)` (fixed N or a
  `DynamicAmount` for "amass Orcs X").
- `AmassExecutor` resolves CR 701.47 by **composing existing executors**
  (`CreateToken` → `AddCounters` → `AddSubtype`): if you control no Army it
  creates a 0/0 black Orc Army token, then puts N +1/+1 counters on an Army you
  control and makes it an Orc. Counters route through `AddCountersEffect`, so
  placement replacements (Hardened Scales, Doubling Season) keep applying.
- `AmassContinuation` + `AmassContinuationResumer` handle the "choose which
  Army" step when you control more than one (reusing `SelectCardsDecision`, so
  no new event/decision type and no client changes). The counter+subtype back
  half lives in `AmassResolution`, shared by the single-Army and multi-Army
  paths.
- Modeled on the existing "the Ring tempts you" pattern; `docs/card-sdk-language-reference.md`
  updated.

### Cards (one commit each)
- **Dunland Crebain** — Flying; ETB amass Orcs 2
- **Mordor Muster** — draw, lose 1 life, amass Orcs 1
- **Deceive the Messenger** — −3/−0, amass Orcs 1
- **Saruman's Trickery** — counter target spell, amass Orcs 1
- **Easterling Vanguard** — dies → amass Orcs 1
- **Swarming of Moria** — Treasure, amass Orcs 2
- **March from the Black Gate** — amass Orcs 1 on enter and whenever an Army you control attacks
- **Warbeast of Gorgoroth** — power-4+ creature dies → amass Orcs 2
- **Orcish Medicine** — lifelink/indestructible choice, amass Orcs 1
- **Book of Mazarbul** — Saga: amass 1 / amass 2 / team +1/0 + menace
- **The Torment of Gollum** — targeted discard, amass Orcs 2
- **Gothmog, Morgul Lieutenant** — ETB amass Orcs 1; your creature tokens have deathtouch
- **Treason of Isengard** — return an instant/sorcery from your graveyard to top, amass Orcs 2

### Not included (need new engine work)
Surfaced for follow-up PRs, grouped by the feature each needs:
- **Reflexive "when you do" / amassed-Army-power reference**: Surrounded by Orcs, Foray of Orcs, Grishnákh.
- **New triggers**: Saruman the White (2nd spell each turn), Orcish Bowmasters (opponent draws), Fall of Cair Andros (excess noncombat damage), Sauron, the Dark Lord.
- **Other**: Gríma Wormtongue (can't-gain-life + sacrificed-legendary), The Mouth of Sauron (Amass X = I/S in milled player's graveyard), Shagrat (attach Equipment + Amass X).
- **Barad-dûr** (deferred) — land needs an activated-ability activation restriction ("only if a creature died this turn") and an `{X}{X}` cost.

## Test plan
- [x] `AmassScenarioTest` (rules-engine): 0-Army token creation (→ 2/2 Orc Army), counter stacking onto the same Army, the multi-Army choice (CR 701.47a), and Dunland Crebain's
ETB trigger.
- [x] Full `:rules-engine:test` green (no regressions from the continuation/serialization/executor wiring).
- [x] `:mtg-sets:compileKotlin` green; `scripts/card-status --set LTR` loads all 13 card definitions.
- [ ] Manual: `manual-scenarios/cards/m/mordor-muster.json` (cast twice to see both Amass paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
