### PR TITLE
Implement Invasion gap #7: conditional/amount-relational damage repla…

### DIFF
--- a/backlog/invasion-engine-gaps.md
+++ b/backlog/invasion-engine-gaps.md
@@ -303,7 +303,29 @@ already existed (Gigapede precedent), so no engine work was required.
 
 ---
 
-### #7 — Conditional / amount-relational damage replacements · 6 cards
+### #7 — Conditional / amount-relational damage replacements · 6 cards ✅ MOSTLY DONE
+
+> **Implemented (5 of 6 cards; Protective Sphere deferred to #8).** New SDK vocabulary, no per-card
+> executors: `AmountFilter` (`Any`/`AtMost`/`AtLeast`/`Exactly`) on `GameEvent.DamageEvent`; `CapDamage`
+> replacement; `PreventDamage.restrictions: List<Condition>` (condition-gated prevention, mirrors
+> `ModifyLifeLoss.restrictions`); relational `CardPredicate.SharesColorWithRecipient` +
+> `GameObjectFilter.sharingColorWithRecipient()`; `CardPredicate.SharesChosenColorWithSource` +
+> `sharingChosenColorWithSource()`; `EffectTarget.ControllerOfDamageSource`. Engine: `AmountFilter`,
+> the relational source predicate, and `restrictions` are honored in `DamageUtils.applyStaticDamageReduction`;
+> `CapDamage` in `applyStaticDamageAmplification`; the previously-dead `RedirectDamage` replacement is now
+> applied as a continuous static via a new `findStaticDamageRedirect` scan in `dealDamageToTarget`
+> (each source applies once per event, loop-guarded by `appliedRedirects`). All paths shared by combat
+> and noncombat damage. Cards authored in `definitions/inv/cards/`: **Callous Giant** (AmountFilter),
+> **Divine Presence** (CapDamage), **Well-Laid Plans** (SharesColorWithRecipient), **Spirit of
+> Resistance** (#2 five-color condition + restrictions), **Harsh Judgment** (RedirectDamage +
+> ControllerOfDamageSource + chosen-color predicate). Covered by per-card scenario tests
+> (`CallousGiantTest`, `DivinePresenceTest`, `WellLaidPlansTest`, `SpiritOfResistanceTest`,
+> `HarshJudgmentTest`).
+>
+> **Protective Sphere remains blocked on #8** — it prevents damage from a source sharing a color with
+> *the mana spent on the activation cost*, which needs per-color mana-spent tracking (gap #8). The
+> reusable hook is ready: store the spent color as the prevention's chosen color and reuse the
+> chosen-color source predicate.
 
 This is the largest gap and the place where it's most tempting to write six bespoke executors. The
 elegant path is to **enrich the existing `appliesTo` filter vocabulary** so the existing
@@ -590,8 +612,9 @@ filter.
 3. **`SharesColorWith` filter** (#5) — one predicate, reusable family.
 4. **Per-color mana tracking + X restriction** (#8) — unlocks Soul Burn / Atalya and feeds #7's
    Protective Sphere.
-5. **Damage-replacement vocabulary** (#7) — `AmountFilter`, relational/chosen-color `SourceFilter`s,
-   `CapDamage`, `ControllerOfDamageSource`; unlocks 6 cards and enriches the shared event system.
+5. **Damage-replacement vocabulary** (#7) ✅ — `AmountFilter`, relational/chosen-color predicates,
+   `CapDamage`, `PreventDamage.restrictions`, `RedirectDamage` (now wired), `ControllerOfDamageSource`;
+   unlocked 5 cards and enriched the shared event system. Protective Sphere still waits on #8.
 6. **Tapped-for-mana event + rider + replacement** (#3) — 3 cards, reusable mana hooks.
 7. **Name-a-card choice + filter** (#10) — 2 cards, large external family.
 8. **Pile-separation trio** (#21) — 5 cards from three composable additions.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1538,7 +1538,24 @@ replacementEffect {
 }
 ```
 
-- `ReplacementEffect.PreventDamage(amount?, direction?, scope?, source?, recipient?)` — prevent damage of a given shape.
+- `ReplacementEffect.PreventDamage(amount?, restrictions?, appliesTo)` — prevent damage matching the
+  `GameEvent.DamageEvent` shape. `amount = null` prevents all; a number prevents up to that much.
+  `restrictions: List<Condition>` (default empty) gates the prevention on extra conditions evaluated
+  against the source's controller — the same pattern as `ModifyLifeLoss.restrictions`. Use it for
+  "as long as …, prevent …" statics (Spirit of Resistance: a five-distinct-colors `Compare` gate).
+- `CapDamage(maxAmount, appliesTo)` — clamp matching damage to `maxAmount` (a *replacement* distinct
+  from prevent/modify; applied after all amplification). Divine Presence: `CapDamage(3, DamageEvent(recipient = Any))`.
+- `RedirectDamage(redirectTo, appliesTo)` — redirect matching damage to another recipient. Now wired
+  as a continuous static replacement (each source applies at most once per damage event). `redirectTo`
+  supports `EffectTarget.ControllerOfDamageSource` (the controller of the damaging source),
+  `Controller`/`Self` (the replacement's owner/controller), and `TargetController`. Harsh Judgment:
+  redirect chosen-color instant/sorcery damage dealt to you back to the spell's controller.
+- **DamageEvent filters (gap #7):** `GameEvent.DamageEvent(recipient, source, damageType, amount)`.
+  `amount: AmountFilter` (`Any` / `AtMost(n)` / `AtLeast(n)` / `Exactly(n)`) gates on the would-be
+  amount (Callous Giant: `AtMost(3)`). `source = SourceFilter.Matching(filter)` can carry relational
+  predicates: `GameObjectFilter.sharingColorWithRecipient()` (`CardPredicate.SharesColorWithRecipient`,
+  Well-Laid Plans — "another creature that shares a color") and `sharingChosenColorWithSource()`
+  (`CardPredicate.SharesChosenColorWithSource`, reads the replacement source's `ChosenColorComponent`).
 - `ReplacementEffect.EntersBattlefieldTappedUnless(condition)` — ETB tapped unless condition met.
 - `ReplacementEffect.IfYouDoBranchEffect(...)` — branch on "if you do" replacement.
 - `OnEnterRunEffect(effect)` — generic "as ~ enters the battlefield, run [effect]". The wrapped effect

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.sdk.scripting
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.events.AmountFilter
 import com.wingedsheep.sdk.scripting.events.ControllerFilter
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.events.DamageType
@@ -58,9 +59,14 @@ sealed interface GameEvent : TextReplaceable<GameEvent> {
     data class DamageEvent(
         val recipient: RecipientFilter = RecipientFilter.Any,
         val source: SourceFilter = SourceFilter.Any,
-        val damageType: DamageType = DamageType.Any
+        val damageType: DamageType = DamageType.Any,
+        val amount: AmountFilter = AmountFilter.Any
     ) : GameEvent {
         override val description: String = buildString {
+            if (amount != AmountFilter.Any) {
+                append(amount.description)
+                append(" ")
+            }
             if (damageType != DamageType.Any) {
                 append(damageType.description)
                 append(" ")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -381,15 +381,32 @@ data class PersistEffect(
 /**
  * Prevent damage.
  * Example: Fog effects, protection, damage shields
+ *
+ * The optional [restrictions] list lets a card gate the prevention on arbitrary
+ * additional conditions (mirroring [ModifyLifeLoss.restrictions]). Each entry is a
+ * [Condition] evaluated against the source permanent's controller; the prevention
+ * only applies when *all* restrictions hold. This is how "as long as …, prevent …"
+ * statics are expressed without a dedicated conditional-replacement wrapper — e.g.
+ * Spirit of Resistance ("As long as you control a permanent of each color, prevent
+ * all damage that would be dealt to you").
  */
 @SerialName("PreventDamage")
 @Serializable
 data class PreventDamage(
     val amount: Int? = null,  // null = prevent all
+    val restrictions: List<Condition> = emptyList(),
     override val appliesTo: GameEvent
 ) : ReplacementEffect {
     override val description: String = buildString {
-        append("If ${appliesTo.description}, prevent ")
+        val restrictionDesc = restrictions.joinToString(" and ") { it.description.removePrefix("if ") }
+        if (restrictionDesc.isNotEmpty()) {
+            append(restrictionDesc.replaceFirstChar { it.uppercase() })
+            append(", if ")
+        } else {
+            append("If ")
+        }
+        append(appliesTo.description)
+        append(", prevent ")
         if (amount == null) {
             append("that damage")
         } else {
@@ -399,7 +416,10 @@ data class PreventDamage(
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
         val newAppliesTo = appliesTo.applyTextReplacement(replacer)
-        return if (newAppliesTo !== appliesTo) copy(appliesTo = newAppliesTo) else this
+        val newRestrictions = restrictions.map { it.applyTextReplacement(replacer) }
+        val anyChanged = newAppliesTo !== appliesTo ||
+            newRestrictions.zip(restrictions).any { (n, o) -> n !== o }
+        return if (anyChanged) copy(appliesTo = newAppliesTo, restrictions = newRestrictions) else this
     }
 }
 
@@ -454,6 +474,31 @@ data class ModifyDamageAmount(
     override val description: String = buildString {
         append("If ${appliesTo.description}, it deals that much damage plus $modifier instead")
     }
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        return if (newAppliesTo !== appliesTo) copy(appliesTo = newAppliesTo) else this
+    }
+}
+
+/**
+ * Cap damage at a maximum amount. If a matching source would deal more than
+ * [maxAmount] damage, it deals exactly [maxAmount] instead (smaller amounts are
+ * unchanged). Distinct from [PreventDamage] (which subtracts) and [ModifyDamageAmount]
+ * (which adds): capping clamps to an upper bound.
+ *
+ * Example: Divine Presence ("If a source would deal 4 or more damage to a permanent
+ * or player, that source deals 3 damage to that permanent or player instead.") →
+ * `CapDamage(maxAmount = 3, appliesTo = DamageEvent(recipient = AnyPermanentOrPlayer))`.
+ */
+@SerialName("CapDamage")
+@Serializable
+data class CapDamage(
+    val maxAmount: Int,
+    override val appliesTo: GameEvent
+) : ReplacementEffect {
+    override val description: String =
+        "If ${appliesTo.description}, it deals $maxAmount damage instead"
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
         val newAppliesTo = appliesTo.applyTextReplacement(replacer)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -206,6 +206,56 @@ sealed interface DamageType {
 }
 
 // =============================================================================
+// Amount Filters - Threshold on the amount of a quantitative event (e.g. damage)
+// =============================================================================
+
+/**
+ * Filter on the *amount* of a quantitative game event — currently the amount of
+ * damage a [GameEvent.DamageEvent] would deal. Lets a replacement effect apply only
+ * when the would-be amount crosses a threshold, without baking the threshold into the
+ * replacement type itself.
+ *
+ * Used by Callous Giant ("If a source would deal 3 or less damage to this creature,
+ * prevent that damage") via [AtMost]. Reusable by any future amount-gated prevention
+ * or modification (e.g. "if it would deal 5 or more damage").
+ */
+@Serializable
+sealed interface AmountFilter {
+    val description: String
+
+    /** Returns true when [amount] satisfies this filter. */
+    fun matches(amount: Int): Boolean
+
+    @SerialName("AmountAny")
+    @Serializable
+    data object Any : AmountFilter {
+        override val description = ""
+        override fun matches(amount: Int) = true
+    }
+
+    @SerialName("AmountAtMost")
+    @Serializable
+    data class AtMost(val value: Int) : AmountFilter {
+        override val description = "$value or less"
+        override fun matches(amount: Int) = amount <= value
+    }
+
+    @SerialName("AmountAtLeast")
+    @Serializable
+    data class AtLeast(val value: Int) : AmountFilter {
+        override val description = "$value or more"
+        override fun matches(amount: Int) = amount >= value
+    }
+
+    @SerialName("AmountExactly")
+    @Serializable
+    data class Exactly(val value: Int) : AmountFilter {
+        override val description = "exactly $value"
+        override fun matches(amount: Int) = amount == value
+    }
+}
+
+// =============================================================================
 // Counter Type Filters
 // =============================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -332,6 +332,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.HasChosenSubtype
     )
 
+    /** Must include the color chosen on the source permanent (ChosenColorComponent) */
+    fun sharingChosenColorWithSource() = copy(
+        cardPredicates = cardPredicates + CardPredicate.SharesChosenColorWithSource
+    )
+
     /** Must share a creature type with the referenced entity */
     fun sharingCreatureTypeWith(entity: EntityReference) = copy(
         cardPredicates = cardPredicates + CardPredicate.SharesCreatureTypeWith(entity)
@@ -340,6 +345,15 @@ data class GameObjectFilter(
     /** Must share a color with the referenced entity */
     fun sharingColorWith(entity: EntityReference) = copy(
         cardPredicates = cardPredicates + CardPredicate.SharesColorWith(entity)
+    )
+
+    /**
+     * Must share a color with the recipient of the in-flight damage (and not be that
+     * recipient). Only meaningful in a damage replacement's source filter. Used by
+     * Well-Laid Plans.
+     */
+    fun sharingColorWithRecipient() = copy(
+        cardPredicates = cardPredicates + CardPredicate.SharesColorWithRecipient
     )
 
     // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -492,6 +492,20 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
     }
 
+    /**
+     * Matches objects whose color set includes the color chosen on the source
+     * permanent (read from its ChosenColorComponent). Composable color analogue of
+     * [HasChosenSubtype] — combine with a type predicate to express e.g. "an instant
+     * or sorcery spell of the chosen color" (Harsh Judgment). Colorless objects never
+     * match; if the source has no chosen color, nothing matches.
+     */
+    @SerialName("SharesChosenColorWithSource")
+    @Serializable
+    data object SharesChosenColorWithSource : CardPredicate {
+        override val description: String = "of the chosen color"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
     /** Matches creatures that share a creature subtype with the referenced entity */
     @SerialName("SharesCreatureTypeWith")
     @Serializable
@@ -513,6 +527,20 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
             is EntityReference.Triggering -> "that shares a color with it"
             else -> "that shares a color with ${entity.description}"
         }
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
+    /**
+     * Matches objects that share a color with the recipient of the in-flight damage,
+     * and are not that recipient. Only meaningful inside a damage replacement's source
+     * filter, where the engine supplies the recipient. Combine with a type predicate to
+     * express "another creature that shares a color" — Well-Laid Plans uses
+     * `GameObjectFilter.Creature` + this predicate. Colorless on either side never matches.
+     */
+    @SerialName("SharesColorWithRecipient")
+    @Serializable
+    data object SharesColorWithRecipient : CardPredicate {
+        override val description: String = "that shares a color with it"
         override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
     }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
@@ -211,4 +211,19 @@ sealed interface EffectTarget {
     data object ControllerOfTriggeringEntity : EffectTarget {
         override val description: String = "that spell's controller"
     }
+
+    /**
+     * CONTROLLER OF DAMAGE SOURCE: the controller of the source dealing the damage
+     * currently being processed. Only meaningful inside a damage replacement
+     * (e.g. [com.wingedsheep.sdk.scripting.RedirectDamage]); resolved by the damage
+     * pipeline from the source of the in-flight damage.
+     *
+     * Used by Harsh Judgment ("If an instant or sorcery spell of the chosen color
+     * would deal damage to you, it deals that damage to its controller instead").
+     */
+    @SerialName("ControllerOfDamageSource")
+    @Serializable
+    data object ControllerOfDamageSource : EffectTarget {
+        override val description: String = "its controller"
+    }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CallousGiant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CallousGiant.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.events.AmountFilter
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Callous Giant
+ * {4}{R}{R}
+ * Creature — Giant
+ * 4/4
+ * If a source would deal 3 or less damage to this creature, prevent that damage.
+ *
+ * Invasion engine gap #7: the all-or-nothing damage threshold is expressed with the new
+ * [AmountFilter] on [GameEvent.DamageEvent] — the prevention only fires when the would-be
+ * amount is 3 or less, otherwise the full amount lands.
+ */
+val CallousGiant = card("Callous Giant") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    power = 4
+    toughness = 4
+    oracleText = "If a source would deal 3 or less damage to this creature, prevent that damage."
+
+    replacementEffect(
+        PreventDamage(
+            appliesTo = GameEvent.DamageEvent(
+                recipient = RecipientFilter.Self,
+                amount = AmountFilter.AtMost(3)
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "139"
+        artist = "Mark Brill"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/330028c4-8e91-4fe3-a87d-1660dfd2507e.jpg?1562905295"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DivinePresence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DivinePresence.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CapDamage
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Divine Presence
+ * {2}{W}
+ * Enchantment
+ * If a source would deal 4 or more damage to a permanent or player, that source deals 3
+ * damage to that permanent or player instead.
+ *
+ * Invasion engine gap #7: capping (clamp to a maximum) is neither prevention (subtract) nor
+ * modification (add), so it uses the new [CapDamage] replacement. `maxAmount = 3` reproduces
+ * "4 or more → 3" exactly — amounts of 3 or less are already below the cap and unchanged.
+ */
+val DivinePresence = card("Divine Presence") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "If a source would deal 4 or more damage to a permanent or player, that source deals 3 damage to that permanent or player instead."
+
+    replacementEffect(
+        CapDamage(
+            maxAmount = 3,
+            appliesTo = GameEvent.DamageEvent(recipient = RecipientFilter.Any)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "15"
+        artist = "Ron Spears"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28cb898d-d6ce-410a-83bf-37962cca2735.jpg?1562903314"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HarshJudgment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HarshJudgment.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.RedirectDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Harsh Judgment
+ * {2}{W}{W}
+ * Enchantment
+ * As this enchantment enters, choose a color.
+ * If an instant or sorcery spell of the chosen color would deal damage to you, it deals that
+ * damage to its controller instead.
+ *
+ * Invasion engine gap #7: this is the first card to use the [RedirectDamage] static
+ * replacement (previously defined but unwired). The chosen color is stored at ETB via
+ * [EntersWithChoice] (ChoiceType.COLOR → ChosenColorComponent); the source filter combines
+ * `InstantOrSorcery` with [CardPredicate.SharesChosenColorWithSource]; and the redirect
+ * destination uses the new [EffectTarget.ControllerOfDamageSource].
+ */
+val HarshJudgment = card("Harsh Judgment") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "As this enchantment enters, choose a color.\n" +
+        "If an instant or sorcery spell of the chosen color would deal damage to you, it deals that damage to its controller instead."
+
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+
+    replacementEffect(
+        RedirectDamage(
+            redirectTo = EffectTarget.ControllerOfDamageSource,
+            appliesTo = GameEvent.DamageEvent(
+                recipient = RecipientFilter.You,
+                source = SourceFilter.Matching(
+                    GameObjectFilter.InstantOrSorcery.sharingChosenColorWithSource()
+                )
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "19"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/34c78dee-ab45-4638-b89a-10686145b19a.jpg?1562905655"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SpiritOfResistance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SpiritOfResistance.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Spirit of Resistance
+ * {2}{W}
+ * Enchantment
+ * As long as you control a permanent of each color, prevent all damage that would be dealt to you.
+ *
+ * Invasion engine gap #7 / #2: the "as long as …" gate uses the new [PreventDamage.restrictions]
+ * list (mirroring `ModifyLifeLoss.restrictions`) rather than a bespoke conditional-replacement
+ * wrapper. The five-color condition is a distinct-colors aggregation capped at 5 (a single
+ * five-color permanent satisfies it), evaluated against the source's controller each time damage
+ * would be dealt.
+ */
+val SpiritOfResistance = card("Spirit of Resistance") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "As long as you control a permanent of each color, prevent all damage that would be dealt to you."
+
+    replacementEffect(
+        PreventDamage(
+            restrictions = listOf(
+                Compare(
+                    DynamicAmounts.colorsAmongPermanents(Player.You),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(5)
+                )
+            ),
+            appliesTo = GameEvent.DamageEvent(recipient = RecipientFilter.You)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "38"
+        artist = "John Avon"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fb66439-df73-4a01-a8d4-6f2334297fdf.jpg?1562914374"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WellLaidPlans.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WellLaidPlans.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * Well-Laid Plans
+ * {2}{U}
+ * Enchantment
+ * Prevent all damage that would be dealt to a creature by another creature if they share a color.
+ *
+ * Invasion engine gap #7: "by another creature ... if they share a color" composes the
+ * existing `Creature` filter with the new relational [CardPredicate.SharesColorWithRecipient]
+ * predicate (via [GameObjectFilter.sharingColorWithRecipient]). The predicate compares the
+ * damage source's colors against the recipient's and excludes self-damage, so the prevention
+ * only triggers between two distinct, color-sharing creatures.
+ */
+val WellLaidPlans = card("Well-Laid Plans") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Prevent all damage that would be dealt to a creature by another creature if they share a color."
+
+    replacementEffect(
+        PreventDamage(
+            appliesTo = GameEvent.DamageEvent(
+                recipient = RecipientFilter.AnyCreature,
+                source = SourceFilter.Matching(
+                    GameObjectFilter.Creature.sharingColorWithRecipient()
+                )
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "88"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c55eb8f-925a-42c1-9e48-d7f99cab3b01.jpg?1562900616"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -390,6 +390,25 @@ class PredicateEvaluator {
                 colors.any { it in referenceColors }
             }
 
+            CardPredicate.SharesChosenColorWithSource -> {
+                val sourceId = context?.sourceId ?: return false
+                val chosenColor = state.getEntity(sourceId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.ChosenColorComponent>()?.color
+                    ?: return false
+                chosenColor.name in colors
+            }
+
+            CardPredicate.SharesColorWithRecipient -> {
+                val recipientId = context?.recipientId ?: return false
+                if (recipientId == entityId) return false
+                val recipientColors = projected.getColors(recipientId).ifEmpty {
+                    state.getEntity(recipientId)?.get<CardComponent>()?.colors?.map { it.name }?.toSet()
+                        ?: emptySet()
+                }
+                if (recipientColors.isEmpty() || colors.isEmpty()) return false
+                colors.any { it in recipientColors }
+            }
+
             // Context-relative predicates (pipeline variable references)
             is CardPredicate.HasSubtypeFromVariable -> {
                 val chosenType = context?.chosenValues?.get(predicate.variableName) ?: return false
@@ -755,7 +774,8 @@ class PredicateEvaluator {
             // Source-relative and context predicates — not applicable
             CardPredicate.NotOfSourceChosenType, CardPredicate.SharesCreatureTypeWithSource,
             CardPredicate.SharesCreatureTypeWithTriggeringEntity, CardPredicate.HasChosenSubtype,
-            CardPredicate.HasChosenColor,
+            CardPredicate.HasChosenColor, CardPredicate.SharesChosenColorWithSource,
+            CardPredicate.SharesColorWithRecipient,
             is CardPredicate.SharesCreatureTypeWith,
             is CardPredicate.SharesColorWith -> false
             is CardPredicate.HasSubtypeFromVariable, is CardPredicate.HasSubtypeInStoredList,
@@ -814,7 +834,13 @@ data class PredicateContext(
      * The color chosen during the current effect's resolution (e.g. via `ChooseColorThen`).
      * Read by [CardPredicate.HasChosenColor] so filters can match "permanents of that color".
      */
-    val chosenColor: Color? = null
+    val chosenColor: Color? = null,
+    /**
+     * The recipient of the in-flight damage, when evaluating a damage replacement's source
+     * filter. Read by [CardPredicate.SharesColorWithRecipient] so a source filter can be
+     * relative to what's being damaged (Well-Laid Plans).
+     */
+    val recipientId: EntityId? = null
 ) {
     /**
      * Resolve an [EffectTarget] reference to a concrete player [EntityId].

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -37,17 +37,20 @@ import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CapDamage
 import com.wingedsheep.sdk.scripting.DamageCantBePrevented
 import com.wingedsheep.sdk.scripting.DoubleDamage
 import com.wingedsheep.sdk.scripting.ModifyDamageAmount
 import com.wingedsheep.sdk.scripting.ModifyLifeLoss
 import com.wingedsheep.sdk.scripting.PreventDamage
 import com.wingedsheep.sdk.scripting.PreventLifeGain
+import com.wingedsheep.sdk.scripting.RedirectDamage
 import com.wingedsheep.sdk.scripting.ReplaceDamageWithCounters
 import com.wingedsheep.sdk.scripting.events.DamageType
 import com.wingedsheep.sdk.scripting.events.RecipientFilter
 import com.wingedsheep.sdk.scripting.events.SourceFilter
 import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
  * Utility functions for dealing damage, applying damage prevention/amplification/redirection,
@@ -74,7 +77,9 @@ object DamageUtils {
         targetId: EntityId,
         amount: Int,
         sourceId: EntityId?,
-        cantBePrevented: Boolean = false
+        cantBePrevented: Boolean = false,
+        isCombatDamage: Boolean = false,
+        appliedRedirects: Set<EntityId> = emptySet()
     ): EffectResult {
         if (amount <= 0) return EffectResult.success(state)
 
@@ -85,15 +90,29 @@ object DamageUtils {
         // Check for damage redirection (Glarecaster, Zealous Inquisitor)
         val (redirectState, redirectTargetId, redirectAmount) = checkDamageRedirection(state, targetId, amount)
         if (redirectTargetId != null) {
-            val redirectResult = dealDamageToTarget(redirectState, redirectTargetId, redirectAmount, sourceId, cantBePrevented)
+            val redirectResult = dealDamageToTarget(redirectState, redirectTargetId, redirectAmount, sourceId, cantBePrevented, isCombatDamage, appliedRedirects)
             val remainingDamage = amount - redirectAmount
             return if (remainingDamage > 0) {
                 // Partial redirection — deal remaining damage to original target
                 val afterRedirect = redirectResult.state
-                val remainingResult = dealDamageToTarget(afterRedirect, targetId, remainingDamage, sourceId, cantBePrevented)
+                val remainingResult = dealDamageToTarget(afterRedirect, targetId, remainingDamage, sourceId, cantBePrevented, isCombatDamage, appliedRedirects)
                 EffectResult.success(remainingResult.state, redirectResult.events + remainingResult.events)
             } else {
                 redirectResult
+            }
+        }
+
+        // Check for static damage-redirection replacement effects (Harsh Judgment). Unlike the
+        // floating shields above these are continuous statics; each source applies at most once
+        // per damage event (CR 616.1), tracked via [appliedRedirects] to avoid redirect loops.
+        if (!cantBePrevented && sourceId != null) {
+            val (staticRedirectTo, staticRedirectSource) =
+                findStaticDamageRedirect(state, targetId, amount, sourceId, isCombatDamage, appliedRedirects)
+            if (staticRedirectTo != null && staticRedirectSource != null) {
+                return dealDamageToTarget(
+                    state, staticRedirectTo, amount, sourceId, cantBePrevented, isCombatDamage,
+                    appliedRedirects + staticRedirectSource
+                )
             }
         }
 
@@ -552,6 +571,104 @@ object DamageUtils {
     }
 
     /**
+     * Find a static [RedirectDamage] replacement effect that applies to the in-flight
+     * damage (Harsh Judgment). Scans battlefield permanents with a
+     * [ReplacementEffectSourceComponent]; the first matching effect whose source hasn't
+     * already applied this event ([appliedRedirects]) wins.
+     *
+     * Returns (redirectTargetId, redirectSourceEntityId) — the entity to redirect the
+     * full amount to, plus the replacement source's id (so the caller can mark it applied
+     * and prevent redirect loops). Returns (null, null) when nothing applies.
+     */
+    private fun findStaticDamageRedirect(
+        state: GameState,
+        targetId: EntityId,
+        amount: Int,
+        sourceId: EntityId,
+        isCombatDamage: Boolean,
+        appliedRedirects: Set<EntityId>
+    ): Pair<EntityId?, EntityId?> {
+        val projected = state.projectedState
+
+        for (entityId in state.getBattlefield()) {
+            if (entityId in appliedRedirects) continue
+            val container = state.getEntity(entityId) ?: continue
+            val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+
+            for (effect in replacementComponent.replacementEffects) {
+                if (effect !is RedirectDamage) continue
+
+                val damageEvent = effect.appliesTo
+                if (damageEvent !is com.wingedsheep.sdk.scripting.GameEvent.DamageEvent) continue
+
+                val damageTypeMatches = when (damageEvent.damageType) {
+                    is DamageType.Any -> true
+                    is DamageType.Combat -> isCombatDamage
+                    is DamageType.NonCombat -> !isCombatDamage
+                }
+                if (!damageTypeMatches) continue
+                if (!damageEvent.amount.matches(amount)) continue
+
+                val sourceMatches = when (val source = damageEvent.source) {
+                    is SourceFilter.Any -> true
+                    is SourceFilter.Matching -> {
+                        val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId, recipientId = targetId)
+                        predicateEvaluator.matches(state, projected, sourceId, source.filter, context)
+                    }
+                    else -> false
+                }
+                if (!sourceMatches) continue
+
+                val recipientMatches = when (val recipient = damageEvent.recipient) {
+                    is RecipientFilter.Any -> true
+                    is RecipientFilter.You -> targetId == sourceControllerId
+                    is RecipientFilter.Self -> targetId == entityId
+                    is RecipientFilter.Matching -> {
+                        val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId)
+                        predicateEvaluator.matches(state, projected, targetId, recipient.filter, context)
+                    }
+                    is RecipientFilter.CreatureYouControl -> {
+                        projected.isCreature(targetId) && projected.getController(targetId) == sourceControllerId
+                    }
+                    else -> false
+                }
+                if (!recipientMatches) continue
+
+                val redirectTo = resolveRedirectTarget(state, effect.redirectTo, sourceId, entityId, targetId)
+                if (redirectTo != null && redirectTo != targetId) {
+                    return redirectTo to entityId
+                }
+            }
+        }
+        return null to null
+    }
+
+    /**
+     * Resolve the [EffectTarget] of a static [RedirectDamage] to a concrete entity id.
+     * [damageSourceId] is the source dealing the in-flight damage, [replacementOwnerId]
+     * the permanent carrying the replacement, [originalTargetId] the original recipient.
+     */
+    private fun resolveRedirectTarget(
+        state: GameState,
+        target: EffectTarget,
+        damageSourceId: EntityId,
+        replacementOwnerId: EntityId,
+        originalTargetId: EntityId
+    ): EntityId? = when (target) {
+        is EffectTarget.ControllerOfDamageSource ->
+            state.getEntity(damageSourceId)?.get<ControllerComponent>()?.playerId
+                ?: state.getEntity(damageSourceId)?.get<CardComponent>()?.ownerId
+        is EffectTarget.Controller ->
+            state.getEntity(replacementOwnerId)?.get<ControllerComponent>()?.playerId
+        is EffectTarget.TargetController ->
+            state.projectedState.getController(originalTargetId)
+                ?: state.getEntity(originalTargetId)?.get<ControllerComponent>()?.playerId
+        is EffectTarget.Self -> replacementOwnerId
+        else -> null
+    }
+
+    /**
      * Check for deflect damage shields (Deflecting Palm).
      *
      * Scans floating effects for DeflectNextDamageFromSource matching the damage source.
@@ -699,6 +816,21 @@ object DamageUtils {
                 }
                 if (!damageTypeMatches) continue
 
+                // Amount threshold (Callous Giant: "3 or less"). Checked against the full
+                // incoming would-be amount, not the partially-prevented remainder.
+                if (!damageEvent.amount.matches(amount)) continue
+
+                // Additional gating conditions evaluated against the source's controller
+                // (Spirit of Resistance: "as long as you control a permanent of each color").
+                if (effect.restrictions.isNotEmpty()) {
+                    val context = EffectContext(
+                        sourceId = entityId,
+                        controllerId = sourceControllerId,
+                        opponentId = state.turnOrder.firstOrNull { it != sourceControllerId },
+                    )
+                    if (effect.restrictions.any { !conditionEvaluator.evaluate(state, it, context) }) continue
+                }
+
                 // Check if the damage source matches the source filter
                 val sourceMatches = when (val source = damageEvent.source) {
                     is SourceFilter.Any -> true
@@ -709,7 +841,7 @@ object DamageUtils {
                     is SourceFilter.Matching -> {
                         if (sourceId == null) false
                         else {
-                            val context = PredicateContext(controllerId = sourceControllerId)
+                            val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId, recipientId = targetId)
                             predicateEvaluator.matches(state, projected, sourceId, source.filter, context)
                         }
                     }
@@ -720,6 +852,7 @@ object DamageUtils {
                 // Check if the target matches the recipient filter
                 val recipientMatches = when (val recipient = damageEvent.recipient) {
                     is RecipientFilter.Self -> targetId == entityId
+                    is RecipientFilter.You -> targetId == sourceControllerId
                     is RecipientFilter.EnchantedCreature, is RecipientFilter.EquippedCreature -> {
                         val attachedTo = container.get<AttachedToComponent>()?.targetId
                         targetId == attachedTo
@@ -736,6 +869,9 @@ object DamageUtils {
                         val isControlled = projected.getController(targetId) == sourceControllerId
                         isCreature && isControlled
                     }
+                    is RecipientFilter.AnyCreature -> projected.isCreature(targetId)
+                    is RecipientFilter.AnyPlayer -> targetId in state.turnOrder
+                    is RecipientFilter.AnyPermanent -> targetId in state.getBattlefield()
                     is RecipientFilter.Any -> true
                     else -> false
                 }
@@ -921,6 +1057,60 @@ object DamageUtils {
                         }
                     }
                 }
+            }
+        }
+
+        // Cap damage replacements (Divine Presence): clamp the would-be amount to a maximum.
+        // Applied last so it caps the fully-amplified amount. Capping is a replacement, so
+        // prevention shields still apply afterward to the capped amount.
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+
+            for (effect in replacementComponent.replacementEffects) {
+                if (effect !is CapDamage) continue
+                if (amplifiedAmount <= effect.maxAmount) continue
+
+                val damageEvent = effect.appliesTo
+                if (damageEvent !is com.wingedsheep.sdk.scripting.GameEvent.DamageEvent) continue
+
+                val damageTypeMatches = when (damageEvent.damageType) {
+                    is DamageType.Any -> true
+                    is DamageType.Combat -> isCombatDamage
+                    is DamageType.NonCombat -> !isCombatDamage
+                }
+                if (!damageTypeMatches) continue
+                if (!damageEvent.amount.matches(amplifiedAmount)) continue
+
+                val sourceMatches = when (val source = damageEvent.source) {
+                    is SourceFilter.Any -> true
+                    is SourceFilter.Matching -> {
+                        if (sourceId == null) false
+                        else {
+                            val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId, recipientId = targetId)
+                            predicateEvaluator.matches(state, projected, sourceId, source.filter, context)
+                        }
+                    }
+                    else -> false
+                }
+                if (!sourceMatches) continue
+
+                val recipientMatches = when (val recipient = damageEvent.recipient) {
+                    is RecipientFilter.Any -> true
+                    is RecipientFilter.Self -> targetId == entityId
+                    is RecipientFilter.Matching -> {
+                        val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId)
+                        predicateEvaluator.matches(state, projected, targetId, recipient.filter, context)
+                    }
+                    is RecipientFilter.CreatureYouControl -> {
+                        projected.isCreature(targetId) && projected.getController(targetId) == sourceControllerId
+                    }
+                    else -> false
+                }
+                if (!recipientMatches) continue
+
+                amplifiedAmount = effect.maxAmount
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -466,6 +466,8 @@ internal class AffectsFilterResolver {
         CardPredicate.SharesCreatureTypeWithSource,
         CardPredicate.SharesCreatureTypeWithTriggeringEntity,
         CardPredicate.HasChosenSubtype,
+        CardPredicate.SharesChosenColorWithSource,
+        CardPredicate.SharesColorWithRecipient,
         is CardPredicate.SharesCreatureTypeWith,
         is CardPredicate.SharesColorWith,
         is CardPredicate.HasSubtypeFromVariable,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -581,6 +581,7 @@ class StaticAbilityHandler(
 
     private fun isRuntimeReplacementEffect(it: com.wingedsheep.sdk.scripting.ReplacementEffect): Boolean =
         it is PreventDamage || it is DoubleDamage || it is ModifyDamageAmount || it is PreventLifeGain ||
+        it is com.wingedsheep.sdk.scripting.CapDamage || it is com.wingedsheep.sdk.scripting.RedirectDamage ||
         it is com.wingedsheep.sdk.scripting.ModifyLifeLoss ||
         it is com.wingedsheep.sdk.scripting.PreventDraw ||
         it is com.wingedsheep.sdk.scripting.DamageCantBePrevented || it is ReplaceDamageWithCounters ||

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -885,6 +885,15 @@ class CostCalculator(
             }
             is CardPredicate.SharesCreatureTypeWith -> true
             is CardPredicate.SharesColorWith -> true
+            CardPredicate.SharesColorWithRecipient -> false
+            CardPredicate.SharesChosenColorWithSource -> {
+                if (sourceEntityId == null || state == null) return false
+                val chosenColor = state.getEntity(sourceEntityId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.ChosenColorComponent>()
+                    ?.color
+                    ?: return false
+                cardDef.colors.contains(chosenColor)
+            }
 
             is CardPredicate.HasSubtypeFromVariable -> true
             is CardPredicate.HasSubtypeInStoredList -> true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CallousGiantTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CallousGiantTest.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.CallousGiant
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Callous Giant (INV #139) — Invasion engine gap #7, [AmountFilter] threshold.
+ *
+ * "If a source would deal 3 or less damage to this creature, prevent that damage."
+ */
+class CallousGiantTest : FunSpec({
+
+    fun newGame(): Pair<GameTestDriver, com.wingedsheep.sdk.model.EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CallousGiant))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    test("prevents 3 damage (at the threshold)") {
+        val (driver, you) = newGame()
+        val giant = driver.putCreatureOnBattlefield(you, "Callous Giant")
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Permanent(giant)))
+        driver.bothPass()
+
+        // 3 damage is fully prevented.
+        (driver.state.getEntity(giant)?.get<DamageComponent>()?.amount ?: 0) shouldBe 0
+    }
+
+    test("does not prevent 4 damage (above the threshold)") {
+        val (driver, you) = newGame()
+        val giant = driver.putCreatureOnBattlefield(you, "Callous Giant")
+
+        driver.giveMana(you, Color.RED, 4)
+        val stoke = driver.putCardInHand(you, "Stoke the Flames")
+        driver.castSpellWithTargets(you, stoke, listOf(ChosenTarget.Permanent(giant)))
+        driver.bothPass()
+
+        // 4 damage is not prevented — the 4/4 dies.
+        driver.getGraveyardCardNames(you).contains("Callous Giant") shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DivinePresenceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DivinePresenceTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.DivinePresence
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Divine Presence (INV #15) — Invasion engine gap #7, the [CapDamage] replacement.
+ *
+ * "If a source would deal 4 or more damage to a permanent or player, that source deals 3
+ * damage to that permanent or player instead."
+ */
+class DivinePresenceTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, com.wingedsheep.sdk.model.EntityId, com.wingedsheep.sdk.model.EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DivinePresence))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        return Triple(driver, you, driver.getOpponent(you))
+    }
+
+    fun GameTestDriver.lifeOf(playerId: com.wingedsheep.sdk.model.EntityId): Int =
+        state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+
+    test("caps 4 damage to 3") {
+        val (driver, you, opponent) = newGame()
+        driver.putPermanentOnBattlefield(you, "Divine Presence")
+
+        driver.giveMana(you, Color.RED, 4)
+        val stoke = driver.putCardInHand(you, "Stoke the Flames")
+        driver.castSpellWithTargets(you, stoke, listOf(ChosenTarget.Player(opponent)))
+        driver.bothPass()
+
+        // 4 damage capped to 3 → opponent loses 3, not 4.
+        driver.lifeOf(opponent) shouldBe 17
+    }
+
+    test("leaves 3-or-less damage unchanged") {
+        val (driver, you, opponent) = newGame()
+        driver.putPermanentOnBattlefield(you, "Divine Presence")
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent)))
+        driver.bothPass()
+
+        // 3 is below the cap — full 3 damage.
+        driver.lifeOf(opponent) shouldBe 17
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarshJudgmentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarshJudgmentTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.ChosenColorComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.HarshJudgment
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Harsh Judgment (INV #19) — Invasion engine gap #7, first user of the [RedirectDamage]
+ * static replacement + [EffectTarget.ControllerOfDamageSource].
+ *
+ * "If an instant or sorcery spell of the chosen color would deal damage to you, it deals that
+ * damage to its controller instead."
+ *
+ * The Harsh Judgment controller is the *non-active* player so the active player's spell has a
+ * distinct controller to redirect to. The chosen color is injected directly (the
+ * EntersWithChoice(COLOR) → ChosenColorComponent path is covered elsewhere).
+ */
+class HarshJudgmentTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(HarshJudgment))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+        return Triple(driver, active, driver.getOpponent(active))
+    }
+
+    fun GameTestDriver.lifeOf(playerId: EntityId): Int =
+        state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+
+    test("redirects chosen-color instant damage to the spell's controller") {
+        val (driver, active, defender) = newGame()
+        // Defender controls Harsh Judgment with red chosen.
+        val judgment = driver.putPermanentOnBattlefield(defender, "Harsh Judgment")
+        driver.addComponent(judgment, ChosenColorComponent(Color.RED))
+
+        // Active player casts a red instant (Lightning Bolt) at the defender.
+        driver.giveMana(active, Color.RED, 1)
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.castSpellWithTargets(active, bolt, listOf(ChosenTarget.Player(defender)))
+        driver.bothPass()
+
+        // Damage is redirected to the bolt's controller (the active player).
+        driver.lifeOf(defender) shouldBe 20
+        driver.lifeOf(active) shouldBe 17
+    }
+
+    test("does not redirect a spell of a different color") {
+        val (driver, active, defender) = newGame()
+        val judgment = driver.putPermanentOnBattlefield(defender, "Harsh Judgment")
+        driver.addComponent(judgment, ChosenColorComponent(Color.BLUE))
+
+        driver.giveMana(active, Color.RED, 1)
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.castSpellWithTargets(active, bolt, listOf(ChosenTarget.Player(defender)))
+        driver.bothPass()
+
+        // Red bolt is not the chosen color (blue) — normal damage to the defender.
+        driver.lifeOf(defender) shouldBe 17
+        driver.lifeOf(active) shouldBe 20
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiritOfResistanceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiritOfResistanceTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.SpiritOfResistance
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Spirit of Resistance (INV #38) — Invasion engine gaps #2 + #7.
+ *
+ * "As long as you control a permanent of each color, prevent all damage that would be dealt to you."
+ * Built as a [com.wingedsheep.sdk.scripting.PreventDamage] gated by a five-distinct-colors
+ * restriction.
+ */
+class SpiritOfResistanceTest : FunSpec({
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SpiritOfResistance))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun GameTestDriver.lifeOf(playerId: EntityId): Int =
+        state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+
+    // One creature of each of the five colors.
+    val fiveColorBoard = listOf(
+        "Savannah Lions",   // W
+        "Phantom Warrior",  // U
+        "Black Creature",   // B
+        "Goblin Guide",     // R
+        "Llanowar Elves",   // G
+    )
+
+    test("prevents all damage to you while you control a permanent of each color") {
+        val (driver, you) = newGame()
+        driver.putPermanentOnBattlefield(you, "Spirit of Resistance")
+        fiveColorBoard.forEach { driver.putCreatureOnBattlefield(you, it) }
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(you)))
+        driver.bothPass()
+
+        driver.lifeOf(you) shouldBe 20
+    }
+
+    test("does not prevent damage when a color is missing") {
+        val (driver, you) = newGame()
+        driver.putPermanentOnBattlefield(you, "Spirit of Resistance")
+        // Only four colors — no green permanent.
+        fiveColorBoard.dropLast(1).forEach { driver.putCreatureOnBattlefield(you, it) }
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(you)))
+        driver.bothPass()
+
+        driver.lifeOf(you) shouldBe 17
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WellLaidPlansTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WellLaidPlansTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.WellLaidPlans
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Well-Laid Plans (INV #88) — Invasion engine gap #7, the relational
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.SharesColorWithRecipient] source predicate.
+ *
+ * "Prevent all damage that would be dealt to a creature by another creature if they share a color."
+ */
+class WellLaidPlansTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(WellLaidPlans))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        return Triple(driver, you, driver.getOpponent(you))
+    }
+
+    test("prevents combat damage between two creatures sharing a color") {
+        val (driver, you, opponent) = newGame()
+        driver.putPermanentOnBattlefield(you, "Well-Laid Plans")
+
+        // Two red creatures: Goblin Guide (attacker) vs Goblin Guide (blocker).
+        val attacker = driver.putCreatureOnBattlefield(you, "Goblin Guide")
+        driver.removeSummoningSickness(attacker)
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Goblin Guide")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(attacker), opponent)
+        driver.bothPass()
+        driver.declareBlockers(opponent, mapOf(blocker to listOf(attacker)))
+        driver.bothPass()
+        driver.bothPass() // first strike step
+        driver.bothPass() // combat damage
+
+        // Both red → all combat damage between them prevented; both survive unscathed.
+        (driver.state.getEntity(attacker)?.get<DamageComponent>()?.amount ?: 0) shouldBe 0
+        (driver.state.getEntity(blocker)?.get<DamageComponent>()?.amount ?: 0) shouldBe 0
+        driver.getGraveyardCardNames(opponent).contains("Goblin Guide") shouldBe false
+    }
+
+    test("does not prevent damage between creatures of different colors") {
+        val (driver, you, opponent) = newGame()
+        driver.putPermanentOnBattlefield(you, "Well-Laid Plans")
+
+        // Red attacker vs white blocker — no shared color.
+        val attacker = driver.putCreatureOnBattlefield(you, "Goblin Guide")   // R 2/1
+        driver.removeSummoningSickness(attacker)
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Savannah Lions") // W 1/1
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(attacker), opponent)
+        driver.bothPass()
+        driver.declareBlockers(opponent, mapOf(blocker to listOf(attacker)))
+        driver.bothPass()
+        driver.bothPass() // first strike step
+        driver.bothPass() // combat damage
+
+        // 2 damage to the 1/1 Lions is not prevented — it dies.
+        driver.getGraveyardCardNames(opponent).contains("Savannah Lions") shouldBe true
+    }
+})

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -1310,4 +1310,13 @@ class GameTestDriver {
     fun getHandSize(playerId: EntityId): Int {
         return getHand(playerId).size
     }
+
+    /**
+     * Attach (or replace) a component on an entity (test helper). Useful for setting up
+     * state that would normally be produced by an entry choice, e.g. a
+     * [com.wingedsheep.engine.state.components.identity.ChosenColorComponent].
+     */
+    fun addComponent(entityId: EntityId, component: com.wingedsheep.engine.state.Component) {
+        _state = _state.updateEntity(entityId) { it.withComponent(component) }
+    }
 }


### PR DESCRIPTION
…cements

Enriches the composable damage-replacement vocabulary (no per-card executors) to cover 5 of the 6 gap-#7 cards; Protective Sphere stays deferred to gap #8 (per-color mana-spent tracking).

SDK:
- AmountFilter (Any/AtMost/AtLeast/Exactly) + DamageEvent.amount
- CapDamage replacement (clamp to a maximum)
- PreventDamage.restrictions: List<Condition> (condition-gated prevention)
- CardPredicate.SharesColorWithRecipient + sharingColorWithRecipient()
- CardPredicate.SharesChosenColorWithSource + sharingChosenColorWithSource()
- EffectTarget.ControllerOfDamageSource

Engine (shared combat + noncombat paths in DamageUtils):
- AmountFilter, relational source predicate (via PredicateContext.recipientId), and restrictions honored in applyStaticDamageReduction
- CapDamage applied in applyStaticDamageAmplification
- RedirectDamage (previously defined but never applied) now wired as a continuous static via findStaticDamageRedirect, loop-guarded per CR 616.1
- added missing You/AnyCreature/AnyPlayer/AnyPermanent recipient branches

Cards (definitions/inv/cards): Callous Giant, Divine Presence, Well-Laid Plans, Spirit of Resistance (also closes the #2 five-color half), Harsh Judgment.

Tests: 5 scenario tests (10 cases). Full mtg-sdk/rules-engine/mtg-sets/ game-server suites pass. Adds a GameTestDriver.addComponent test helper.