### PR TITLE
Invasion gap #8: color-restricted X spend + per-color X tracking

### DIFF
--- a/backlog/invasion-engine-gaps.md
+++ b/backlog/invasion-engine-gaps.md
@@ -375,7 +375,20 @@ prevention.
 
 ---
 
-### #8 — Color-restricted X-spend + per-color mana tracking · Soul Burn, Atalya
+### #8 — Color-restricted X-spend + per-color mana tracking · Soul Burn, Atalya ✅ DONE
+
+> **Implemented (primitive + both cards).** `xManaRestriction: Set<Color>` on `CardScript` (spell) and
+> `ActivatedAbility`, surfaced through the `spell { }` / `activatedAbility { }` DSL. The mana solver
+> grew an `xManaRestriction` parameter + dedicated restricted-X pass (`ManaSolution.xRestrictedManaSpent`
+> reports the per-color X allocation); `CastPaymentProcessor` and `ActivateAbilityHandler` restrict the
+> floating-mana X loops to the allowed colors (colorless disallowed) and `canPay` only counts allowed-color
+> pool mana toward X. Per-color mana spent on X is stored on `SpellOnStackComponent.manaSpentOnXByColor`,
+> plumbed into `EffectContext`, and read by the new `DynamicAmount.ManaSpentOnX(color)`. **Soul Burn**
+> ({X}{2}{B}, `xManaRestriction = {BLACK, RED}`, life = `Effects.GainLife(DynamicAmount.ManaSpentOnX(BLACK))`)
+> and **Atalya, Samite Master** (modal `{X},{T}` ability, `xManaRestriction = {WHITE}`) authored in
+> `definitions/inv/cards/`. Covered by `SoulBurnAndAtalyaXManaTest`. **Scoping note:** Soul Burn implements
+> the original Invasion life-gain wording (life = black spent on X); the modern Oracle's secondary caps
+> (damage dealt / target's life / loyalty / toughness) are omitted as edge-case-only refinements.
 
 **What exists.** Per-color spent buckets (`manaSpentWhite…`) live on `SpellOnStackComponent`
 (`StackComponents.kt:47-52`) but are **not** exposed to `EffectContext` (only the

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -110,6 +110,12 @@ the `CardDefinition`.
 - `warp` — cast from anywhere; exiled at end of turn.
 - `conditionalFlash` — flash while condition holds.
 - `cantBeCountered` — spell is uncounterable.
+- `xManaRestriction = setOf(Color.BLACK, Color.RED)` — "spend only [colors] on X." Restricts which
+  mana may pay the `{X}` portion of the cost (the fixed colored/generic portion is unaffected).
+  Available in both `spell { }` and `activatedAbility { }` blocks; honored by the mana solver and the
+  payment path. Per-color amount spent on X is then readable via `DynamicAmount.ManaSpentOnX(color)`.
+  Soul Burn (`spell { xManaRestriction = setOf(Color.BLACK, Color.RED) }`) and Atalya, Samite Master
+  (`activatedAbility { xManaRestriction = setOf(Color.WHITE) }`) are the first users.
 
 **`AdditionalCost`** — extra costs paid alongside the mana cost.
 
@@ -1302,6 +1308,12 @@ Numbers computed at resolution time.
 
 - `Fixed(n)` — literal constant.
 - `XValue` — the X chosen for the spell/ability.
+- `TotalManaSpent` — total mana paid from the pool to cast the current spell (sum of every per-color
+  bucket; for X spells the X portion is included). E.g. Memory Deluge "where X is the mana spent."
+- `ManaSpentOnX(color)` — the amount of `{color}` mana spent on the `{X}` portion specifically, broken
+  down by color. Used by payoffs that scale with how much of a color went into X — Soul Burn ("you gain
+  life equal to the amount of black mana spent on X"). Pair with `xManaRestriction` (see below) so the X
+  can only be paid with the relevant colors.
 - `Add(a, b)` — `a + b`.
 - `Subtract(a, b)` — `a − b`.
 - `Multiply(a, b)` — `a × b`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -748,7 +748,8 @@ class CardBuilder(private val name: String) {
             classLevels = classLevelsList.toList(),
             sagaChapters = sagaChaptersList.toList(),
             selfExileOnResolve = spellBuilder?.exilesOnResolve ?: false,
-            selfAlternativeCost = selfAlternativeCost
+            selfAlternativeCost = selfAlternativeCost,
+            xManaRestriction = spellBuilder?.xManaRestriction ?: emptySet()
         )
 
         // Build metadata
@@ -827,6 +828,8 @@ class SpellBuilder {
     var effect: Effect? = null
     var target: TargetRequirement? = null
     var condition: Condition? = null
+    /** Colors that may be spent on the `{X}` portion of this spell's cost (empty = any). */
+    var xManaRestriction: Set<Color> = emptySet()
     private var selfExileOnResolve: Boolean = false
 
     /**
@@ -1122,6 +1125,8 @@ class ActivatedAbilityBuilder {
     var hasConvoke: Boolean = false
     var holdPriority: Boolean = false
     var genericCostReduction: DynamicAmount? = null
+    /** Colors that may be spent on the `{X}` portion of this ability's cost (empty = any). */
+    var xManaRestriction: Set<Color> = emptySet()
 
     // Named target bindings (for multi-target abilities)
     private val namedTargets: MutableList<Pair<String, TargetRequirement>> = mutableListOf()
@@ -1161,7 +1166,8 @@ class ActivatedAbilityBuilder {
             descriptionOverride = description,
             hasConvoke = hasConvoke,
             holdPriority = holdPriority,
-            genericCostReduction = genericCostReduction
+            genericCostReduction = genericCostReduction,
+            xManaRestriction = xManaRestriction
         )
     }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.sdk.model
 
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.scripting.ClassLevelAbility
 import com.wingedsheep.sdk.scripting.SagaChapterAbility
 import com.wingedsheep.sdk.scripting.*
@@ -213,7 +214,19 @@ data class CardScript(
      * option alongside the normal cast option, provided the player can afford
      * the alternative mana cost and pay any required additional costs.
      */
-    val selfAlternativeCost: SelfAlternativeCost? = null
+    val selfAlternativeCost: SelfAlternativeCost? = null,
+
+    /**
+     * Colors that may be spent on the `{X}` portion of this spell's mana cost.
+     * Empty means no restriction (X can be paid with any mana, the default).
+     *
+     * Used for cards like Soul Burn ("Spend only black and/or red mana on X"). The
+     * restriction applies only to the variable `{X}` symbols — the fixed colored/generic
+     * portion of the cost is unaffected. Honored by the mana solver and cast payment path,
+     * and the per-color amount actually spent on X is exposed via
+     * [com.wingedsheep.sdk.scripting.values.DynamicAmount.ManaSpentOnX].
+     */
+    val xManaRestriction: Set<Color> = emptySet()
 ) {
     /**
      * Whether this card has any scripted behavior.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.sdk.scripting
 
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.effects.Effect
@@ -36,7 +37,14 @@ data class ActivatedAbility(
      *  amount returned for the source. Used by cards like The Dominion Bracelet whose
      *  granted activated ability "costs {X} less to activate, where X is this creature's power."
      *  Per Scryfall ruling, the reduced cost is locked in before costs are paid. */
-    val genericCostReduction: DynamicAmount? = null
+    val genericCostReduction: DynamicAmount? = null,
+    /**
+     * Colors that may be spent on the `{X}` portion of this ability's cost.
+     * Empty means no restriction (the default). Used for abilities like Atalya, Samite
+     * Master ("Spend only white mana on X"). Honored by the mana solver and the
+     * activated-ability payment path.
+     */
+    val xManaRestriction: Set<Color> = emptySet()
 ) : TextReplaceable<ActivatedAbility> {
     /** Backward-compatible secondary constructor for single-target abilities. */
     constructor(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.sdk.scripting.values
 
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.GameObjectFilter
@@ -245,6 +246,24 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     @Serializable
     data object TotalManaSpent : DynamicAmount {
         override val description: String = "the total mana spent to cast this spell"
+        override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
+    }
+
+    /**
+     * The amount of mana of a specific [color] that was spent on the `{X}` portion of the
+     * current spell or activated ability.
+     *
+     * Distinct from [TotalManaSpent] (which sums every color across the whole cost): this
+     * counts only mana paid toward the variable `{X}` symbols, broken down by color. Used
+     * by cards whose payoff scales with how much of a color was spent on X — e.g. Soul Burn
+     * ("You gain life equal to the amount of {B} spent on X"). Typically paired with an
+     * `xManaRestriction` on the spell/ability so the X portion can only be paid with the
+     * relevant colors.
+     */
+    @SerialName("ManaSpentOnX")
+    @Serializable
+    data class ManaSpentOnX(val color: Color) : DynamicAmount {
+        override val description: String = "the amount of {${color.symbol}} spent on X"
         override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AtalyaSamiteMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AtalyaSamiteMaster.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Atalya, Samite Master
+ * {3}{W}{W}
+ * Legendary Creature — Human Cleric
+ * 2/3
+ * {X}, {T}: Choose one —
+ * • Prevent the next X damage that would be dealt to target creature this turn. Spend only
+ *   white mana on X.
+ * • You gain X life. Spend only white mana on X.
+ *
+ * The `xManaRestriction = {WHITE}` on the activated ability forces the `{X}` to be paid with
+ * white mana only (honored by the mana solver and the activated-ability payment path).
+ */
+val AtalyaSamiteMaster = card("Atalya, Samite Master") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 2
+    toughness = 3
+    oracleText = "{X}, {T}: Choose one —\n" +
+        "• Prevent the next X damage that would be dealt to target creature this turn. " +
+        "Spend only white mana on X.\n" +
+        "• You gain X life. Spend only white mana on X."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}"), Costs.Tap)
+        xManaRestriction = setOf(Color.WHITE)
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                Effects.PreventNextDamage(DynamicAmount.XValue, EffectTarget.ContextTarget(0)),
+                Targets.Creature,
+                "Prevent the next X damage that would be dealt to target creature this turn"
+            ),
+            Mode.noTarget(
+                Effects.GainLife(DynamicAmount.XValue),
+                "You gain X life"
+            )
+        )
+        description = "{X}, {T}: Choose one — Prevent the next X damage that would be dealt to " +
+            "target creature this turn; or you gain X life. Spend only white mana on X."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "4"
+        artist = "Rebecca Guay"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90500e7a-f76d-453a-bda0-d56d3f7c7534.jpg?1562924117"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SoulBurn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SoulBurn.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Soul Burn
+ * {X}{2}{B}
+ * Sorcery
+ * Spend only black and/or red mana on X.
+ * Soul Burn deals X damage to any target. You gain life equal to the amount of black
+ * mana spent this way.
+ *
+ * The `xManaRestriction` limits the `{X}` portion to black/red mana, and
+ * [DynamicAmount.ManaSpentOnX] reads how much of that was black to size the life gain.
+ *
+ * Note: this implements the original Invasion wording (life gained = black mana spent on
+ * X). The current Oracle text additionally caps the life gain at the actual damage dealt /
+ * the target's life total / loyalty / toughness; those secondary caps are omitted as they
+ * only differ in edge cases where the target survives with fewer hit points than X.
+ */
+val SoulBurn = card("Soul Burn") {
+    manaCost = "{X}{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Spend only black and/or red mana on X.\n" +
+        "Soul Burn deals X damage to any target. You gain life equal to the amount of " +
+        "black mana spent this way."
+
+    spell {
+        xManaRestriction = setOf(Color.BLACK, Color.RED)
+        target = Targets.Any
+        effect = Effects.Composite(
+            Effects.DealXDamage(EffectTarget.ContextTarget(0)),
+            Effects.GainLife(DynamicAmount.ManaSpentOnX(Color.BLACK))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "124"
+        artist = "Andrew Goldhawk"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70515cd2-97d5-4491-a758-bc7188fdc6dc.jpg?1562917470"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -79,6 +79,8 @@ class DynamicAmountEvaluator(
 
             is DynamicAmount.TotalManaSpent -> context.totalManaSpent
 
+            is DynamicAmount.ManaSpentOnX -> context.manaSpentOnXByColor[amount.color] ?: 0
+
             is DynamicAmount.YourLifeTotal -> {
                 state.getEntity(context.controllerId)?.get<LifeTotalComponent>()?.life ?: 0
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -34,6 +34,12 @@ data class EffectContext(
      * not the same as [xValue]. Used by `DynamicAmount.TotalManaSpent`.
      */
     val totalManaSpent: Int = 0,
+    /**
+     * Per-color mana spent on the `{X}` portion of the spell or activated ability, for a
+     * color-restricted X (e.g. Soul Burn's "spend only black and/or red mana on X").
+     * Read by `DynamicAmount.ManaSpentOnX`. Empty when X was unrestricted.
+     */
+    val manaSpentOnXByColor: Map<Color, Int> = emptyMap(),
     val wasKicked: Boolean = false,
     /** True if the spell's optional Blight additional cost was paid (BlightOrPay path chosen). */
     val wasBlightPaid: Boolean = false,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -412,7 +412,7 @@ class ActivateAbilityHandler(
                         .filter { it !in chosen }
                         .toSet() + selfExcludedSources
                     val solution = manaSolver.solve(
-                        currentState, action.playerId, manaCost, manaXValue, excludeSources = excluded
+                        currentState, action.playerId, manaCost, manaXValue, excludeSources = excluded, xManaRestriction = ability.xManaRestriction
                     ) ?: return ExecutionResult.error(state, "Selected mana sources cannot pay this ability's cost")
                     for (source in solution.sources) {
                         val sourceName = currentState.getEntity(source.entityId)
@@ -424,7 +424,7 @@ class ActivateAbilityHandler(
                     }
                 }
                 else -> {
-                    val autoTapResult = autoTapForManaCost(currentState, action.playerId, manaPool, manaCost, cardComponent.name, manaXValue, selfExcludedSources, executeAbilityContext)
+                    val autoTapResult = autoTapForManaCost(currentState, action.playerId, manaPool, manaCost, cardComponent.name, manaXValue, selfExcludedSources, executeAbilityContext, ability.xManaRestriction)
                         ?: return ExecutionResult.error(state, "Not enough mana to activate this ability")
                     currentState = autoTapResult.newState
                     manaPool = autoTapResult.newPool
@@ -502,15 +502,21 @@ class ActivateAbilityHandler(
         if (action.paymentStrategy !is PaymentStrategy.Explicit && manaCost != null && manaCost.hasX && xValue > 0) {
             val xSymbolCount = manaCost.xCount.coerceAtLeast(1)
             var xRemainingToPay = xValue * xSymbolCount
+            val xManaRestriction = ability.xManaRestriction
+            val xColorsAllowed: Set<Color> =
+                if (xManaRestriction.isEmpty()) Color.entries.toSet() else xManaRestriction
 
-            // Spend colorless first for X
-            while (xRemainingToPay > 0 && manaPool.colorless > 0) {
-                manaPool = manaPool.spendColorless()!!
-                xRemainingToPay--
+            // Spend colorless first for X — never allowed when X is color-restricted ("spend only [colors] on X").
+            if (xManaRestriction.isEmpty()) {
+                while (xRemainingToPay > 0 && manaPool.colorless > 0) {
+                    manaPool = manaPool.spendColorless()!!
+                    xRemainingToPay--
+                }
             }
 
-            // Spend colored mana for remaining X
+            // Spend colored mana for remaining X (restricted to allowed colors).
             for (color in Color.entries) {
+                if (color !in xColorsAllowed) continue
                 while (xRemainingToPay > 0 && manaPool.get(color) > 0) {
                     manaPool = manaPool.spend(color)!!
                     xRemainingToPay--
@@ -1048,6 +1054,7 @@ class ActivateAbilityHandler(
         xValue: Int = 0,
         excludeSources: Set<com.wingedsheep.sdk.model.EntityId> = emptySet(),
         abilityContext: SpellPaymentContext? = null,
+        xManaRestriction: Set<Color> = emptySet(),
     ): AutoTapResult? {
         // Determine what the floating pool can cover (with the ability context so restricted
         // mana eligible for this activation counts toward coverage)
@@ -1060,8 +1067,9 @@ class ActivateAbilityHandler(
             return AutoTapResult(state, pool, emptyList())
         }
 
-        // Tap sources for the remaining cost (xValue is treated as additional generic mana)
-        val solution = manaSolver.solve(state, playerId, remainingCost, xValue, excludeSources = excludeSources, spellContext = abilityContext)
+        // Tap sources for the remaining cost (xValue is treated as additional generic mana,
+        // or restricted to xManaRestriction colors for "spend only [colors] on X" abilities)
+        val solution = manaSolver.solve(state, playerId, remainingCost, xValue, excludeSources = excludeSources, spellContext = abilityContext, xManaRestriction = xManaRestriction)
             ?: return null
 
         var currentState = state

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
@@ -38,7 +38,14 @@ data class PaymentResult(
      * onto the engine [com.wingedsheep.engine.core.SpellCastEvent] so triggers
      * filtering on "paid with Treasure mana" can fire.
      */
-    val paidWithTreasureMana: Boolean = false
+    val paidWithTreasureMana: Boolean = false,
+    /**
+     * For a color-restricted `{X}` cost ("spend only [colors] on X"), the per-color
+     * breakdown of mana spent on the X portion. The cast handler stores this on the spell's
+     * stack object so it can be read at resolution via `DynamicAmount.ManaSpentOnX`
+     * (e.g. Soul Burn's "gain life equal to the {B} spent on X"). Empty when X is unrestricted.
+     */
+    val xManaSpentByColor: Map<Color, Int> = emptyMap()
 )
 
 /**
@@ -78,11 +85,12 @@ class CastPaymentProcessor(
         effectiveCost: ManaCost,
         cardName: String,
         xValue: Int,
-        spellContext: SpellPaymentContext? = null
+        spellContext: SpellPaymentContext? = null,
+        xManaRestriction: Set<Color> = emptySet()
     ): PaymentResult {
         return when (action.paymentStrategy) {
-            is PaymentStrategy.FromPool -> payFromPool(state, action.playerId, effectiveCost, cardName, xValue, spellContext)
-            is PaymentStrategy.AutoPay -> autoPay(state, action.playerId, effectiveCost, cardName, xValue, spellContext)
+            is PaymentStrategy.FromPool -> payFromPool(state, action.playerId, effectiveCost, cardName, xValue, spellContext, xManaRestriction)
+            is PaymentStrategy.AutoPay -> autoPay(state, action.playerId, effectiveCost, cardName, xValue, spellContext, xManaRestriction = xManaRestriction)
             is PaymentStrategy.Explicit -> explicitPay(
                 state,
                 action.playerId,
@@ -90,7 +98,8 @@ class CastPaymentProcessor(
                 effectiveCost,
                 cardName,
                 xValue,
-                spellContext
+                spellContext,
+                xManaRestriction
             )
         }
     }
@@ -101,7 +110,8 @@ class CastPaymentProcessor(
         cost: ManaCost,
         cardName: String,
         xValue: Int,
-        spellContext: SpellPaymentContext? = null
+        spellContext: SpellPaymentContext? = null,
+        xManaRestriction: Set<Color> = emptySet()
     ): PaymentResult {
         val poolComponent = state.getEntity(playerId)?.get<ManaPoolComponent>()
             ?: ManaPoolComponent()
@@ -135,11 +145,19 @@ class CastPaymentProcessor(
         // Pay for X from remaining pool (multiply by X symbol count for XX costs)
         val xSymbolCount = cost.xCount.coerceAtLeast(1)
         var xRemainingToPay = xValue * xSymbolCount
+        // Per-color mana spent on the X portion (for DynamicAmount.ManaSpentOnX).
+        val xSpentByColor = mutableMapOf<Color, Int>()
+        // When X is color-restricted, only these colors may pay it (and colorless can't).
+        val xColorsAllowed: Set<Color> =
+            if (xManaRestriction.isEmpty()) Color.entries.toSet() else xManaRestriction
 
         // Spend eligible restricted mana for X first
         if (spellContext != null) {
             for (entry in poolAfterPayment.restrictedMana.toList()) {
                 if (xRemainingToPay <= 0) break
+                // A color-restricted X can't be paid with off-color or colorless restricted mana.
+                if (entry.color != null && entry.color !in xColorsAllowed) continue
+                if (entry.color == null && xManaRestriction.isNotEmpty()) continue
                 if (entry.restriction.isSatisfiedBy(spellContext)) {
                     val spent = poolAfterPayment.spendRestricted(entry.color, spellContext)
                     if (spent != null) {
@@ -152,6 +170,7 @@ class CastPaymentProcessor(
                                 Color.RED -> redSpent++
                                 Color.GREEN -> greenSpent++
                             }
+                            xSpentByColor[entry.color] = (xSpentByColor[entry.color] ?: 0) + 1
                         } else colorlessSpent++
                         xRemainingToPay--
                     }
@@ -159,15 +178,18 @@ class CastPaymentProcessor(
             }
         }
 
-        // Spend colorless first for X
-        while (xRemainingToPay > 0 && poolAfterPayment.colorless > 0) {
-            poolAfterPayment = poolAfterPayment.spendColorless()!!
-            colorlessSpent++
-            xRemainingToPay--
+        // Spend colorless first for X — never allowed when X is color-restricted.
+        if (xManaRestriction.isEmpty()) {
+            while (xRemainingToPay > 0 && poolAfterPayment.colorless > 0) {
+                poolAfterPayment = poolAfterPayment.spendColorless()!!
+                colorlessSpent++
+                xRemainingToPay--
+            }
         }
 
-        // Spend colored mana for remaining X
+        // Spend colored mana for remaining X (restricted to allowed colors).
         for (color in Color.entries) {
+            if (color !in xColorsAllowed) continue
             while (xRemainingToPay > 0 && poolAfterPayment.get(color) > 0) {
                 poolAfterPayment = poolAfterPayment.spend(color)!!
                 when (color) {
@@ -177,6 +199,7 @@ class CastPaymentProcessor(
                     Color.RED -> redSpent++
                     Color.GREEN -> greenSpent++
                 }
+                xSpentByColor[color] = (xSpentByColor[color] ?: 0) + 1
                 xRemainingToPay--
             }
         }
@@ -209,7 +232,14 @@ class CastPaymentProcessor(
         )
 
         val consumedRiders = ridersConsumedDuringPayment(poolComponent.restrictedMana, poolAfterPayment.restrictedMana)
-        return PaymentResult(newState, listOf(event), null, consumedRiders, paidWithTreasureMana = treasureConsumed > 0)
+        return PaymentResult(
+            newState,
+            listOf(event),
+            null,
+            consumedRiders,
+            paidWithTreasureMana = treasureConsumed > 0,
+            xManaSpentByColor = xSpentByColor
+        )
     }
 
     private fun autoPay(
@@ -219,7 +249,8 @@ class CastPaymentProcessor(
         cardName: String,
         xValue: Int,
         spellContext: SpellPaymentContext? = null,
-        excludeSources: Set<EntityId> = emptySet()
+        excludeSources: Set<EntityId> = emptySet(),
+        xManaRestriction: Set<Color> = emptySet()
     ): PaymentResult {
         var currentState = state
         val events = mutableListOf<GameEvent>()
@@ -244,11 +275,19 @@ class CastPaymentProcessor(
         // Use remaining floating mana for X cost (multiply by X symbol count for XX costs)
         val xSymbolCount = cost.xCount.coerceAtLeast(1)
         var xRemainingToPay = xValue * xSymbolCount
+        // Per-color mana spent on the X portion (for DynamicAmount.ManaSpentOnX).
+        val xSpentByColor = mutableMapOf<Color, Int>()
+        // When X is color-restricted, only these colors may pay it (and colorless can't).
+        val xColorsAllowed: Set<Color> =
+            if (xManaRestriction.isEmpty()) Color.entries.toSet() else xManaRestriction
 
         // Spend eligible restricted mana for X first
         if (spellContext != null) {
             for (entry in poolAfterPayment.restrictedMana.toList()) {
                 if (xRemainingToPay <= 0) break
+                // A color-restricted X can't be paid with off-color or colorless restricted mana.
+                if (entry.color != null && entry.color !in xColorsAllowed) continue
+                if (entry.color == null && xManaRestriction.isNotEmpty()) continue
                 if (entry.restriction.isSatisfiedBy(spellContext)) {
                     val spent = poolAfterPayment.spendRestricted(entry.color, spellContext)
                     if (spent != null) {
@@ -261,6 +300,7 @@ class CastPaymentProcessor(
                                 Color.RED -> redSpent++
                                 Color.GREEN -> greenSpent++
                             }
+                            xSpentByColor[entry.color] = (xSpentByColor[entry.color] ?: 0) + 1
                         } else colorlessSpent++
                         xRemainingToPay--
                     }
@@ -268,15 +308,18 @@ class CastPaymentProcessor(
             }
         }
 
-        // Spend colorless first for X
-        while (xRemainingToPay > 0 && poolAfterPayment.colorless > 0) {
-            poolAfterPayment = poolAfterPayment.spendColorless()!!
-            colorlessSpent++
-            xRemainingToPay--
+        // Spend colorless first for X — never allowed when X is color-restricted.
+        if (xManaRestriction.isEmpty()) {
+            while (xRemainingToPay > 0 && poolAfterPayment.colorless > 0) {
+                poolAfterPayment = poolAfterPayment.spendColorless()!!
+                colorlessSpent++
+                xRemainingToPay--
+            }
         }
 
-        // Spend colored mana for remaining X
+        // Spend colored mana for remaining X (restricted to allowed colors).
         for (color in Color.entries) {
+            if (color !in xColorsAllowed) continue
             while (xRemainingToPay > 0 && poolAfterPayment.get(color) > 0) {
                 poolAfterPayment = poolAfterPayment.spend(color)!!
                 when (color) {
@@ -286,6 +329,7 @@ class CastPaymentProcessor(
                     Color.RED -> redSpent++
                     Color.GREEN -> greenSpent++
                 }
+                xSpentByColor[color] = (xSpentByColor[color] ?: 0) + 1
                 xRemainingToPay--
             }
         }
@@ -314,9 +358,13 @@ class CastPaymentProcessor(
         // Tap lands for remaining cost (using xRemainingToPay instead of full xValue)
         var solutionConsumedRiders: Set<ManaSpellRider> = emptySet()
         if (!remainingCost.isEmpty() || xRemainingToPay > 0) {
-            val solution = manaSolver.solve(currentState, playerId, remainingCost, xRemainingToPay, excludeSources = excludeSources, spellContext = spellContext)
+            val solution = manaSolver.solve(currentState, playerId, remainingCost, xRemainingToPay, excludeSources = excludeSources, spellContext = spellContext, xManaRestriction = xManaRestriction)
                 ?: return PaymentResult(currentState, events, "Not enough mana to auto-pay")
             solutionConsumedRiders = solution.consumedRiders
+            // Fold the X portion the solver tapped (allowed colors only) into the X-by-color tally.
+            for ((color, amount) in solution.xRestrictedManaSpent) {
+                xSpentByColor[color] = (xSpentByColor[color] ?: 0) + amount
+            }
 
             // Tap each source AND run any non-mana side effects of the matching
             // activated mana ability (e.g. Adarkar Wastes' "this land deals 1
@@ -376,7 +424,8 @@ class CastPaymentProcessor(
             events,
             null,
             consumedRiders,
-            paidWithTreasureMana = treasureConsumedFromPool > 0
+            paidWithTreasureMana = treasureConsumedFromPool > 0,
+            xManaSpentByColor = xSpentByColor
         )
     }
 
@@ -401,14 +450,15 @@ class CastPaymentProcessor(
         cost: ManaCost,
         cardName: String,
         xValue: Int,
-        spellContext: SpellPaymentContext? = null
+        spellContext: SpellPaymentContext? = null,
+        xManaRestriction: Set<Color> = emptySet()
     ): PaymentResult {
         val chosenSet = strategy.manaAbilitiesToActivate.toSet()
         val excluded = manaSolver.findAvailableManaSources(state, playerId)
             .map { it.entityId }
             .filter { it !in chosenSet }
             .toSet()
-        return autoPay(state, playerId, cost, cardName, xValue, spellContext, excluded)
+        return autoPay(state, playerId, cost, cardName, xValue, spellContext, excluded, xManaRestriction)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -571,9 +571,14 @@ class CastSpellHandler(
         // permission carries that flag (e.g. Taster of Wares, Cruelclaw's Heist).
         val effectiveCost = if (isCastWithAnyManaType(state, action)) cost.relaxColors() else cost
 
+        // "Spend only [colors] on X" restriction (Soul Burn) — limits which mana can pay X.
+        val cardDef = cardComponent?.let { cardRegistry.getCard(it.cardDefinitionId) }
+        val xManaRestriction = (action.faceIndex?.let { cardDef?.cardFaces?.getOrNull(it)?.script }
+            ?: cardDef?.script)?.xManaRestriction ?: emptySet()
+
         return when (action.paymentStrategy) {
             is PaymentStrategy.AutoPay -> {
-                if (!manaSolver.canPay(state, action.playerId, effectiveCost, xValue, spellContext = spellCtx)) {
+                if (!manaSolver.canPay(state, action.playerId, effectiveCost, xValue, spellContext = spellCtx, xManaRestriction = xManaRestriction)) {
                     "Not enough mana to cast this spell"
                 } else null
             }
@@ -1817,8 +1822,13 @@ class CastSpellHandler(
             effectiveCost = effectiveCost.relaxColors()
         }
 
+        // "Spend only [colors] on X" restriction (Soul Burn). Use the cast face's script for
+        // split/adventure cards, otherwise the card's own script.
+        val xManaRestriction = (action.faceIndex?.let { cardDef?.cardFaces?.getOrNull(it)?.script }
+            ?: cardDef?.script)?.xManaRestriction ?: emptySet()
+
         // Handle mana payment via dedicated processor
-        val paymentResult = paymentProcessor.processPayment(currentState, action, effectiveCost, cardComponent.name, xValue, spellContext)
+        val paymentResult = paymentProcessor.processPayment(currentState, action, effectiveCost, cardComponent.name, xValue, spellContext, xManaRestriction)
         if (paymentResult.error != null) {
             return ExecutionResult.error(currentState, paymentResult.error)
         }
@@ -2044,6 +2054,7 @@ class CastSpellHandler(
             manaSpentRed = manaSpentEvent?.red ?: 0,
             manaSpentGreen = manaSpentEvent?.green ?: 0,
             manaSpentColorless = manaSpentEvent?.colorless ?: 0,
+            manaSpentOnXByColor = paymentResult.xManaSpentByColor,
             faceIndex = action.faceIndex,
             paidWithTreasureMana = paymentResult.paidWithTreasureMana
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -176,7 +176,14 @@ data class ManaSolution(
      * ability contributes [ManaSpellRider.MakesSpellUncounterable] when tapped for
      * a color, but its colorless `{T}: Add {C}` ability does not).
      */
-    val consumedRiders: Set<ManaSpellRider> = emptySet()
+    val consumedRiders: Set<ManaSpellRider> = emptySet(),
+    /**
+     * For a color-restricted `{X}` cost ("spend only [colors] on X"), the per-color
+     * breakdown of mana this solution allocated to the X portion specifically. Empty
+     * when the cost has no X restriction. The cast/ability payment path adds this to the
+     * mana-spent-on-X accumulator that backs `DynamicAmount.ManaSpentOnX`.
+     */
+    val xRestrictedManaSpent: Map<Color, Int> = emptyMap()
 )
 
 /**
@@ -242,7 +249,14 @@ class ManaSolver(
         xValue: Int = 0,
         excludeSources: Set<EntityId> = emptySet(),
         spellContext: SpellPaymentContext? = null,
-        precomputedSources: List<ManaSource>? = null
+        precomputedSources: List<ManaSource>? = null,
+        /**
+         * Colors that may be spent on the `{X}` portion of [cost] ("spend only [colors] on X").
+         * Empty (default) means X behaves like ordinary generic. When non-empty, the X mana is
+         * paid by a dedicated pass that only taps sources able to produce one of these colors,
+         * and the per-color amount is reported in [ManaSolution.xRestrictedManaSpent].
+         */
+        xManaRestriction: Set<Color> = emptySet()
     ): ManaSolution? {
         // Get all untapped mana sources controlled by the player.
         //
@@ -458,9 +472,48 @@ class ManaSolver(
             activationCostRemaining--
         }
 
-        // 2. Pay generic costs (and X), using bonus mana first
-        // xValue here is the total extra generic mana needed for X (callers handle XX multiplication)
-        var genericRemaining = cost.genericAmount + xValue
+        // 1c. Pay the color-restricted X portion ("spend only [colors] on X"), if any.
+        //     Runs before the generic pass so unrestricted generic mana isn't consumed by a
+        //     source that could have paid the restricted X. Only sources able to produce one
+        //     of the allowed colors are eligible; the per-color amount is reported back so the
+        //     payment path can expose it via DynamicAmount.ManaSpentOnX.
+        val xRestrictedSpent = mutableMapOf<Color, Int>()
+        if (xManaRestriction.isNotEmpty() && xValue > 0) {
+            // Spend bonus mana of an allowed color (or an any-color bonus) toward X.
+            fun spendBonusManaOnX(): Color? {
+                val idx = bonusManaPool.indexOfFirst {
+                    it.amount > 0 && (it.color in xManaRestriction || it.anyColor)
+                }
+                if (idx < 0) return null
+                val entry = bonusManaPool[idx]
+                val color = if (entry.color in xManaRestriction) entry.color else xManaRestriction.first()
+                bonusManaPool[idx] = entry.copy(amount = entry.amount - 1)
+                return color
+            }
+            var xRemaining = xValue
+            while (xRemaining > 0) {
+                val bonusColor = spendBonusManaOnX()
+                if (bonusColor != null) {
+                    xRestrictedSpent[bonusColor] = (xRestrictedSpent[bonusColor] ?: 0) + 1
+                    xRemaining--
+                    continue
+                }
+                val source = remainingSources
+                    .filter { src -> src.availableColorsFor(spellContext).any { it in xManaRestriction } }
+                    .minByOrNull { calculateTapPriority(it, handRequirements, availableSourcesByColor) }
+                    ?: return null // Can't pay X with the allowed colors
+                val colorToUse = source.availableColorsFor(spellContext).first { it in xManaRestriction }
+                manaProduced[source.entityId] = ManaProduction(color = colorToUse, amount = source.manaAmount)
+                useSource(source, colorToUse)
+                xRestrictedSpent[colorToUse] = (xRestrictedSpent[colorToUse] ?: 0) + 1
+                xRemaining--
+            }
+        }
+
+        // 2. Pay generic costs (and unrestricted X), using bonus mana first.
+        // xValue here is the total extra generic mana needed for X (callers handle XX multiplication).
+        // When X is color-restricted it was already paid by pass 1c above, so it's excluded here.
+        var genericRemaining = cost.genericAmount + (if (xManaRestriction.isEmpty()) xValue else 0)
 
         while (genericRemaining > 0) {
             // Try to spend bonus mana first
@@ -506,7 +559,13 @@ class ManaSolver(
             val color = manaProduced[source.entityId]?.color ?: return@flatMapTo emptySet()
             source.colorRiders[color] ?: emptySet()
         }
-        return ManaSolution(usedSources, manaProduced, bonusManaPool.filter { it.amount > 0 }, consumedRiders)
+        return ManaSolution(
+            usedSources,
+            manaProduced,
+            bonusManaPool.filter { it.amount > 0 },
+            consumedRiders,
+            xRestrictedManaSpent = xRestrictedSpent
+        )
     }
 
     /**
@@ -1441,7 +1500,9 @@ class ManaSolver(
         xValue: Int = 0,
         excludeSources: Set<EntityId> = emptySet(),
         spellContext: SpellPaymentContext? = null,
-        precomputedSources: List<ManaSource>? = null
+        precomputedSources: List<ManaSource>? = null,
+        /** Colors that may pay the `{X}` portion ("spend only [colors] on X"); empty = any. */
+        xManaRestriction: Set<Color> = emptySet()
     ): Boolean {
         // Get the player's floating mana pool
         val poolComponent = state.getEntity(playerId)?.get<ManaPoolComponent>()
@@ -1467,7 +1528,12 @@ class ManaSolver(
         // Calculate how much X mana is needed (multiply by X symbol count for XX costs)
         val xSymbolCount = cost.xCount.coerceAtLeast(1)
         val totalXMana = xValue * xSymbolCount
-        val xPaidFromPool = poolAfterPartial.total.coerceAtMost(totalXMana)
+        // Only allowed-color pool mana counts toward a color-restricted X.
+        val xPaidFromPool = if (xManaRestriction.isEmpty()) {
+            poolAfterPartial.total.coerceAtMost(totalXMana)
+        } else {
+            xManaRestriction.sumOf { poolAfterPartial.get(it) }.coerceAtMost(totalXMana)
+        }
         val xRemainingToPay = totalXMana - xPaidFromPool
 
         // If nothing remains after using pool (including X), we can pay
@@ -1476,7 +1542,7 @@ class ManaSolver(
         }
 
         // Check if we can tap sources for the remaining cost (including remaining X)
-        if (solve(state, playerId, remainingCost, xRemainingToPay, excludeSources, spellContext, precomputedSources) != null) return true
+        if (solve(state, playerId, remainingCost, xRemainingToPay, excludeSources, spellContext, precomputedSources, xManaRestriction) != null) return true
 
         // Fallback: check if "extras" — mana abilities the auto-tap solver doesn't pick — can
         // cover the remaining cost. Two flavors:

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -124,6 +124,7 @@ class StackResolver(
         manaSpentRed: Int = 0,
         manaSpentGreen: Int = 0,
         manaSpentColorless: Int = 0,
+        manaSpentOnXByColor: Map<Color, Int> = emptyMap(),
         faceIndex: Int? = null,
         paidWithTreasureMana: Boolean = false
     ): ExecutionResult {
@@ -185,6 +186,7 @@ class StackResolver(
                 manaSpentRed = manaSpentRed,
                 manaSpentGreen = manaSpentGreen,
                 manaSpentColorless = manaSpentColorless,
+                manaSpentOnXByColor = manaSpentOnXByColor,
                 faceIndex = faceIndex
             ))
             if (effectiveTargets.isNotEmpty()) {
@@ -1246,6 +1248,7 @@ class StackResolver(
                 totalManaSpent = spellComponent.manaSpentWhite + spellComponent.manaSpentBlue +
                     spellComponent.manaSpentBlack + spellComponent.manaSpentRed +
                     spellComponent.manaSpentGreen + spellComponent.manaSpentColorless,
+                manaSpentOnXByColor = spellComponent.manaSpentOnXByColor,
                 wasKicked = spellComponent.wasKicked,
                 wasBlightPaid = spellComponent.wasBlightPaid,
                 sacrificedPermanents = spellComponent.sacrificedPermanents,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.state.components.stack
 
 import com.wingedsheep.engine.state.Component
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityId
@@ -50,6 +51,12 @@ data class SpellOnStackComponent(
     val manaSpentRed: Int = 0,
     val manaSpentGreen: Int = 0,
     val manaSpentColorless: Int = 0,
+    /**
+     * Per-color mana spent on the `{X}` portion of this spell, for a color-restricted X
+     * (e.g. Soul Burn's "spend only black and/or red mana on X"). Read at resolution via
+     * `DynamicAmount.ManaSpentOnX`. Empty when X was unrestricted or the spell has no X.
+     */
+    val manaSpentOnXByColor: Map<Color, Int> = emptyMap(),
     /**
      * For split-layout cards (CR 709), the index of the face that was cast into
      * [com.wingedsheep.sdk.model.CardDefinition.cardFaces]. Threaded from

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulBurnAndAtalyaXManaTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulBurnAndAtalyaXManaTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.AtalyaSamiteMaster
+import com.wingedsheep.mtg.sets.definitions.inv.cards.SoulBurn
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Invasion engine gap #8 — color-restricted `{X}` spend + per-color mana-spent-on-X tracking.
+ *
+ *  - **Soul Burn** ({X}{2}{B}, "spend only black and/or red mana on X"): exercises both the
+ *    `xManaRestriction` (X payable only with black/red) and `DynamicAmount.ManaSpentOnX`
+ *    (life gained = black mana spent on X).
+ *  - **Atalya, Samite Master** ({X},{T}, "spend only white mana on X"): exercises the same
+ *    restriction on the activated-ability payment path.
+ */
+class SoulBurnAndAtalyaXManaTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(SoulBurn, AtalyaSamiteMaster))
+        return d
+    }
+
+    fun solver(): ManaSolver {
+        val registry = CardRegistry()
+        registry.register(TestCards.all + listOf(SoulBurn, AtalyaSamiteMaster))
+        return ManaSolver(registry)
+    }
+
+    test("Soul Burn: life gained equals the black mana spent on X") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val soulBurn = d.putCardInHand(me, "Soul Burn")
+        // {X}{2}{B} with X=3 paid entirely with black: base {2}{B} = 3 black, X = 3 black.
+        d.giveMana(me, Color.BLACK, 6)
+        d.castXSpell(me, soulBurn, xValue = 3, targets = listOf(opp))
+        d.bothPass()
+
+        // 3 damage to the opponent; 3 life gained (3 black mana spent on X).
+        d.getLifeTotal(opp) shouldBe 17
+        d.getLifeTotal(me) shouldBe 23
+    }
+
+    test("Soul Burn: X can be paid only with black or red mana") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 10, "Forest" to 10), startingLife = 20)
+        val me = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // 2 black sources + 4 green sources. Base {2}{B} consumes the one mandatory black plus
+        // two generic; at most one black source can be left for X, so X=2 can't be covered by the
+        // black/red restriction even though the board has plenty of (green) mana for it.
+        repeat(2) { d.putLandOnBattlefield(me, "Swamp") }
+        repeat(4) { d.putLandOnBattlefield(me, "Forest") }
+
+        val solver = solver()
+        val cost = ManaCost.parse("{X}{2}{B}")
+        val brOnly = setOf(Color.BLACK, Color.RED)
+
+        // Without the restriction, X=2 is easily affordable from the green mana.
+        solver.canPay(d.state, me, cost, xValue = 2).shouldBeTrue()
+        // With "spend only black/red on X", the green mana can't pay X → not affordable.
+        solver.canPay(d.state, me, cost, xValue = 2, xManaRestriction = brOnly).shouldBeFalse()
+    }
+
+    test("Atalya: X can be paid only with white mana") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 10, "Forest" to 10), startingLife = 20)
+        val me = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // One white source, three green. Atalya's {X} portion must be white only.
+        d.putLandOnBattlefield(me, "Plains")
+        repeat(3) { d.putLandOnBattlefield(me, "Forest") }
+
+        val solver = solver()
+        val xCost = ManaCost.parse("{X}")
+        val whiteOnly = setOf(Color.WHITE)
+
+        // X=1 is payable with the single white source.
+        solver.canPay(d.state, me, xCost, xValue = 1, xManaRestriction = whiteOnly).shouldBeTrue()
+        // X=2 needs a second white source — the green mana can't pay it.
+        solver.canPay(d.state, me, xCost, xValue = 2, xManaRestriction = whiteOnly).shouldBeFalse()
+        // Without the restriction, X=2 is affordable from any two lands.
+        solver.canPay(d.state, me, xCost, xValue = 2).shouldBeTrue()
+    }
+})


### PR DESCRIPTION
Implements [Invasion engine gap #8](backlog/invasion-engine-gaps.md) — color-restricted `{X}` spend + per-color mana-spent-on-X tracking — and the two cards that need it.

## New composable vocabulary
- **`DynamicAmount.ManaSpentOnX(color)`** — how much of a color was spent on the `{X}` portion of a cost (sibling of `TotalManaSpent`).
- **`xManaRestriction: Set<Color>`** — "spend only [colors] on X", declarable in both `spell { }` and `activatedAbility { }`. Empty = unrestricted (the default), so no existing card changes behavior.

## Engine wiring
All new params default to empty, threaded through both payment paths:
- `ManaSolver.solve(…, xManaRestriction)` — dedicated restricted-X pass paying X from allowed-color sources only (colorless disallowed), running before the generic pass; `ManaSolution.xRestrictedManaSpent` reports the per-color X allocation. `canPay` only counts allowed-color pool mana toward X.
- `CastPaymentProcessor` (spells) and `ActivateAbilityHandler` (abilities) restrict their floating-mana X loops and accumulate per-color X spend; processor returns `PaymentResult.xManaSpentByColor`.
- Stored on `SpellOnStackComponent.manaSpentOnXByColor` → `EffectContext` → read by `DynamicAmount.ManaSpentOnX`. `CastSpellHandler` reads the restriction (cast-face aware) and feeds both `processPayment` and the `validatePayment` gate.

## Cards (`definitions/inv/cards/`, auto-discovered)
- **Soul Burn** `{X}{2}{B}` — X restricted to B/R; gain life = black mana spent on X.
- **Atalya, Samite Master** `{X},{T}` modal — white-only X; prevent-X-damage / gain-X-life.

## Tests
`SoulBurnAndAtalyaXManaTest` — Soul Burn lifegain = black-on-X (full cast integration) + solver-level restriction checks for B/R (Soul Burn) and white (Atalya). Mana/cast/ability regression suites pass; `mtg-sdk`, `rules-engine`, `mtg-sets`, `game-server` all compile.

## Scoping note
Soul Burn implements the **original Invasion** life-gain wording (= black spent on X), matching the gap doc's intent. The modern Oracle's secondary caps (damage dealt / target's life / loyalty / toughness) are omitted as edge-case-only refinements — documented in the card, the backlog, and the SDK reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)