### PR TITLE
Searchable incomplete-set picker, Invasion sealed support, backfill incomplete flags

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/BrothersWarSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/BrothersWarSet.kt
@@ -16,6 +16,7 @@ object BrothersWarSet : MtgSet {
     override val code = "BRO"
     override val displayName = "The Brothers' War"
     override val releaseDate = "2022-11-18"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/AetherdriftSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/AetherdriftSet.kt
@@ -16,6 +16,7 @@ object AetherdriftSet : MtgSet {
     override val code = "DFT"
     override val displayName = "Aetherdrift"
     override val releaseDate = "2025-02-14"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/DominariaUnitedSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/DominariaUnitedSet.kt
@@ -16,6 +16,7 @@ object DominariaUnitedSet : MtgSet {
     override val code = "DMU"
     override val displayName = "Dominaria United"
     override val releaseDate = "2022-09-09"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/DuskmournSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/DuskmournSet.kt
@@ -16,6 +16,7 @@ object DuskmournSet : MtgSet {
     override val code = "DSK"
     override val displayName = "Duskmourn: House of Horror"
     override val releaseDate = "2024-09-27"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
@@ -20,6 +20,7 @@ object FoundationsSet : MtgSet {
     override val code = "FDN"
     override val displayName = "Foundations"
     override val releaseDate = "2024-11-15"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/FinalFantasySet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/FinalFantasySet.kt
@@ -16,6 +16,7 @@ object FinalFantasySet : MtgSet {
     override val code = "FIN"
     override val displayName = "Final Fantasy"
     override val releaseDate = "2025-06-13"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/FateReforgedSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/FateReforgedSet.kt
@@ -20,6 +20,7 @@ object FateReforgedSet : MtgSet {
     override val code = "FRF"
     override val displayName = "Fate Reforged"
     override val releaseDate = "2015-01-23"
+    override val incomplete = true
     override val sealedSupported = false
 
     override val cards: List<CardDefinition> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/InnistradRemasteredSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/InnistradRemasteredSet.kt
@@ -15,6 +15,7 @@ object InnistradRemasteredSet : MtgSet {
     override val code = "INR"
     override val displayName = "Innistrad Remastered"
     override val releaseDate = "2025-01-24"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/InvasionSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/InvasionSet.kt
@@ -21,6 +21,7 @@ object InvasionSet : MtgSet {
     override val releaseDate = "2000-10-02"
     override val block = "Invasion"
     override val incomplete = true
+    override val sealedSupported = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/LostCavernsOfIxalanSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/LostCavernsOfIxalanSet.kt
@@ -15,6 +15,7 @@ object LostCavernsOfIxalanSet : MtgSet {
     override val code = "LCI"
     override val displayName = "The Lost Caverns of Ixalan"
     override val releaseDate = "2023-11-17"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/InnistradMidnightHuntSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/InnistradMidnightHuntSet.kt
@@ -16,6 +16,7 @@ object InnistradMidnightHuntSet : MtgSet {
     override val code = "MID"
     override val displayName = "Innistrad: Midnight Hunt"
     override val releaseDate = "2021-09-24"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/MurdersAtKarlovManorSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/MurdersAtKarlovManorSet.kt
@@ -16,6 +16,7 @@ object MurdersAtKarlovManorSet : MtgSet {
     override val code = "MKM"
     override val displayName = "Murders at Karlov Manor"
     override val releaseDate = "2024-02-09"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/MarchOfTheMachineSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/MarchOfTheMachineSet.kt
@@ -16,6 +16,7 @@ object MarchOfTheMachineSet : MtgSet {
     override val code = "MOM"
     override val displayName = "March of the Machine"
     override val releaseDate = "2023-04-21"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/PhyrexiaAllWillBeOneSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/PhyrexiaAllWillBeOneSet.kt
@@ -15,6 +15,7 @@ object PhyrexiaAllWillBeOneSet : MtgSet {
     override val code = "ONE"
     override val displayName = "Phyrexia: All Will Be One"
     override val releaseDate = "2023-02-10"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/OutlawsOfThunderJunctionSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/OutlawsOfThunderJunctionSet.kt
@@ -16,6 +16,7 @@ object OutlawsOfThunderJunctionSet : MtgSet {
     override val code = "OTJ"
     override val displayName = "Outlaws of Thunder Junction"
     override val releaseDate = "2024-04-19"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/RivalsOfIxalanSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/RivalsOfIxalanSet.kt
@@ -16,6 +16,7 @@ object RivalsOfIxalanSet : MtgSet {
     override val code = "RIX"
     override val displayName = "Rivals of Ixalan"
     override val releaseDate = "2018-01-19"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/SpiderManSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/SpiderManSet.kt
@@ -16,6 +16,7 @@ object SpiderManSet : MtgSet {
     override val code = "SPM"
     override val displayName = "Marvel's Spider-Man"
     override val releaseDate = "2025-09-26"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/TarkirDragonstormSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/TarkirDragonstormSet.kt
@@ -16,6 +16,7 @@ object TarkirDragonstormSet : MtgSet {
     override val code = "TDM"
     override val displayName = "Tarkir: Dragonstorm"
     override val releaseDate = "2025-04-11"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/AvatarTheLastAirbenderSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/AvatarTheLastAirbenderSet.kt
@@ -15,6 +15,7 @@ object AvatarTheLastAirbenderSet : MtgSet {
     override val code = "TLA"
     override val displayName = "Avatar: The Last Airbender"
     override val releaseDate = "2025-11-21"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/InnistradCrimsonVowSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/InnistradCrimsonVowSet.kt
@@ -16,6 +16,7 @@ object InnistradCrimsonVowSet : MtgSet {
     override val code = "VOW"
     override val displayName = "Innistrad: Crimson Vow"
     override val releaseDate = "2021-11-19"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/WildsOfEldrainSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/WildsOfEldrainSet.kt
@@ -16,6 +16,7 @@ object WildsOfEldrainSet : MtgSet {
     override val code = "WOE"
     override val displayName = "Wilds of Eldraine"
     override val releaseDate = "2023-09-08"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/WorldwakeSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/WorldwakeSet.kt
@@ -19,6 +19,7 @@ object WorldwakeSet : MtgSet {
     override val code = "WWK"
     override val displayName = "Worldwake"
     override val releaseDate = "2010-02-05"
+    override val incomplete = true
     override val sealedSupported = false
 
     override val cards: List<CardDefinition> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/IxalanSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/IxalanSet.kt
@@ -16,6 +16,7 @@ object IxalanSet : MtgSet {
     override val code = "XLN"
     override val displayName = "Ixalan"
     override val releaseDate = "2017-09-29"
+    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1324,6 +1324,55 @@
   margin: 0 0 var(--space-3);
 }
 
+.incompleteSetsSearch {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: var(--space-2);
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--font-sm);
+  outline: none;
+}
+
+.incompleteSetsSearch:focus {
+  border-color: var(--color-accent-dark);
+}
+
+.incompleteSetsSearch::placeholder {
+  color: var(--text-disabled);
+}
+
+.incompleteSetsList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  max-height: 48vh;
+  overflow-y: auto;
+}
+
+.incompleteSetRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  width: 100%;
+  text-align: left;
+}
+
+.incompleteSetRow .setButtonCardCount {
+  flex-shrink: 0;
+}
+
+.incompleteSetsEmpty {
+  font-size: var(--font-sm);
+  color: var(--text-disabled);
+  text-align: center;
+  padding: var(--space-4) 0;
+}
+
 
 /* =========================================================================
  * Player List

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -698,6 +698,7 @@ function LobbyOverlay({
   const tournamentState = useGameStore((state) => state.tournamentState)
   const [copied, setCopied] = useState(false)
   const [showIncompleteSets, setShowIncompleteSets] = useState(false)
+  const [incompleteSearch, setIncompleteSearch] = useState('')
 
   // Show tournament standings when tournament is active
   if (tournamentState) {
@@ -751,6 +752,20 @@ function LobbyOverlay({
   const completeSets = lobbyState.settings.availableSets.filter((s) => !s.incomplete)
   const incompleteSets = lobbyState.settings.availableSets.filter((s) => s.incomplete)
   const selectedIncompleteCount = incompleteSets.filter((s) => lobbyState.settings.setCodes.includes(s.code)).length
+  // Searchable multi-select inside the modal — match on set name or code, like the deckbuilder picker.
+  const incompleteSearchNeedle = incompleteSearch.trim().toLowerCase()
+  const filteredIncompleteSets = incompleteSearchNeedle
+    ? incompleteSets.filter(
+        (s) =>
+          s.name.toLowerCase().includes(incompleteSearchNeedle) ||
+          s.code.toLowerCase().includes(incompleteSearchNeedle),
+      )
+    : incompleteSets
+
+  const closeIncompleteSets = () => {
+    setShowIncompleteSets(false)
+    setIncompleteSearch('')
+  }
 
   const toggleSet = (code: string) => {
     const isSelected = lobbyState.settings.setCodes.includes(code)
@@ -767,6 +782,24 @@ function LobbyOverlay({
         key={set.code}
         onClick={() => toggleSet(set.code)}
         className={`${styles.settingsButton} ${isSelected ? (isAnyDraft ? `${styles.settingsButtonActive} ${styles.settingsButtonDraft}` : styles.settingsButtonActive) : ''}`}
+      >
+        <span>{set.name}</span>
+        {set.implementedCount != null && (
+          <span className={styles.setButtonCardCount}>{set.implementedCount} cards</span>
+        )}
+      </button>
+    )
+  }
+
+  // Full-width toggle row used inside the searchable incomplete-sets multi-select.
+  const renderIncompleteSetRow = (set: AvailableSet) => {
+    const isSelected = lobbyState.settings.setCodes.includes(set.code)
+    return (
+      <button
+        key={set.code}
+        type="button"
+        onClick={() => toggleSet(set.code)}
+        className={`${styles.settingsButton} ${styles.incompleteSetRow} ${isSelected ? styles.settingsButtonActive : ''}`}
       >
         <span>{set.name}</span>
         {set.implementedCount != null && (
@@ -1384,19 +1417,35 @@ function LobbyOverlay({
       </div>
 
       {showIncompleteSets && (
-        <div className={styles.deckViewerBackdrop} onClick={() => setShowIncompleteSets(false)}>
+        <div className={styles.deckViewerBackdrop} onClick={closeIncompleteSets}>
           <div className={styles.deckViewerPanel} style={{ maxWidth: 560 }} onClick={(e) => e.stopPropagation()}>
             <div className={styles.deckViewerHeader}>
               <h3 className={styles.deckViewerTitle}>Incomplete sets</h3>
-              <button className={styles.deckViewerClose} onClick={() => setShowIncompleteSets(false)}>×</button>
+              <button className={styles.deckViewerClose} onClick={closeIncompleteSets}>×</button>
             </div>
             <div className={styles.deckViewerBody}>
               <p className={styles.incompleteSetsNote}>
                 These sets aren't fully implemented yet — some cards are missing, so boosters draw from a
-                combined pool of the cards that exist. Selecting one mixes it into your pool.
+                combined pool of the cards that exist. Pick any number to mix into your pool.
               </p>
-              <div className={styles.setSelectionGrid} style={{ justifyContent: 'flex-start' }}>
-                {renderGroupedSets(incompleteSets)}
+              <input
+                type="text"
+                className={styles.incompleteSetsSearch}
+                placeholder="Search sets by name or code…"
+                value={incompleteSearch}
+                spellCheck={false}
+                autoComplete="off"
+                autoFocus
+                onChange={(e) => setIncompleteSearch(e.target.value)}
+              />
+              <div className={styles.incompleteSetsList}>
+                {filteredIncompleteSets.length > 0 ? (
+                  filteredIncompleteSets.map(renderIncompleteSetRow)
+                ) : (
+                  <div className={styles.incompleteSetsEmpty}>
+                    {incompleteSearchNeedle ? 'No sets match your search.' : 'No incomplete sets available.'}
+                  </div>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Three related tournament/set-selection changes:

- **Searchable incomplete-set picker.** The tournament lobby's "Incomplete sets…" modal is now a searchable multi-select — filter by set name or code (mirroring the deckbuilder's `SetCombobox`), with each row showing the implemented card count and an empty state. Availability is gated **solely** by the `sealedSupported` flag; the earlier `>= 25 cards` floor was removed as redundant.
- **Invasion gets sealed support.** `InvasionSet` now sets `sealedSupported = true` (78 cards, still `incomplete`). It appears in the incomplete modal and routes through the `BoosterGenerator` combined-pool path that already fires for any incomplete set — same as ARN / EOE / LTR, so no booster-strategy override is needed.
- **Backfill `incomplete = true` on 22 stub sets.** A batch of scaffolded sets were defaulting to "complete" despite having only a handful of native cards. Flagged: WWK, FRF, SPM, RIX, ONE, FDN, XLN, DMU, WOE, MID, OTJ, TDM, VOW, BRO, DFT, DSK, MKM, MOM, TLA, INR, LCI, FIN.

## Notes
- The backfill is functionally inert today (none of those sets is `sealedSupported`), but prevents them from masquerading as complete in the main grid if they ever get sealed support.
- Deliberately untouched: the 8 genuinely-complete sets (SCG, LGN, POR, DOM, KTK, BLB, ECL, ONS) and the 6 Commander/special products (BLC, C15, C17, CMD, NCC, PZ2 — card-status reports 0/0, so completeness can't be assessed).

## Testing
- `web-client` `npm run typecheck` — clean
- `./gradlew :mtg-sets:compileKotlin` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)