### PR TITLE
Invasion gap #9: discard (incl. at random) as an activation cost

### DIFF
--- a/backlog/invasion-engine-gaps.md
+++ b/backlog/invasion-engine-gaps.md
@@ -244,7 +244,15 @@ Card-by-card:
 
 ---
 
-### #4 — Opponent / any-player cast-trigger sugar · Rewards of Diversity, Pure Reflection
+### #4 — Opponent / any-player cast-trigger sugar · Rewards of Diversity, Pure Reflection ✅ DONE
+
+> **Implemented (facade + both cards).** `Triggers.AnyPlayerCastsSpell`, `Triggers.OpponentCastsSpell`,
+> `Triggers.anyPlayerCasts(spellFilter)`, `Triggers.opponentCasts(spellFilter)` added to `Triggers.kt`.
+> **Rewards of Diversity** (`opponentCasts(Multicolored)`) and **Pure Reflection**
+> (`anyPlayerCasts(Creature)` → destroy existing Reflections, create X/X token under the caster's
+> control) authored in `definitions/inv/cards/` and auto-registered. Covered by
+> `RewardsOfDiversityScenarioTest` (incl. the `Player.Opponent`-scoping negative case) and
+> `PureReflectionScenarioTest`.
 
 **What exists.** Already wired at runtime (`TriggerMatcher.matchesPlayer`). Only the `Triggers` facade
 lacks constants; cards can construct `SpellCastEvent(player = …)` directly today.
@@ -621,7 +629,7 @@ filter.
    card authoring plus ≤2 trivial surfacing tweaks (graveyard `activeZone` setter, public
    `RevealTopOfLibrary`, opponent-cast facade constants).
 1. **`ColorIsMostCommon` self-condition** (#1) — 5 djinns from one condition.
-2. **Opponent/any-player cast facade** (#4) — already runtime-wired; sugar only, broadly reusable.
+2. **Opponent/any-player cast facade** (#4) ✅ — runtime-wired; facade added, Rewards of Diversity + Pure Reflection done.
 3. **`SharesColorWith` filter** (#5) — one predicate, reusable family.
 4. **Per-color mana tracking + X restriction** (#8) — unlocks Soul Burn / Atalya and feeds #7's
    Protective Sphere.

--- a/backlog/invasion-engine-gaps.md
+++ b/backlog/invasion-engine-gaps.md
@@ -417,16 +417,28 @@ covers the small family of "spend only [color] on X" spells.
 
 ---
 
-### #9 — Discard (incl. at random) as a cost · Meteor Storm
+### #9 — Discard (incl. at random) as a cost · Meteor Storm ✅ DONE
 
-**What exists.** `AbilityCost.Discard(filter)` (single, chosen) and `AdditionalCost.DiscardCards(count,
-filter)`. No "at random" and `AbilityCost.Discard` has no count.
+> **Implemented (primitive + card).** `AbilityCost.Discard` grew `count: Int = 1` and
+> `atRandom: Boolean = false`; facades `Costs.Discard(filter, count, atRandom)` and
+> `Costs.DiscardAtRandom(count, filter)`. When `atRandom`, `CostHandler.payAbilityCost` picks the
+> discarded cards itself (`eligible.shuffled().take(count)`, the same unseeded pattern as
+> `PayOrSufferExecutor.executeRandomDiscard`) — no player selection; otherwise the player's
+> `discardChoices` (first `count`) are discarded via `ZoneTransitionService.discardCards`. Both the
+> standalone and composite `AbilityCost.Discard` arms of `ActivatedAbilityEnumerator` now gate on
+> `targets.size >= count` and skip the discard-selection `AdditionalCostData` when `atRandom` (it
+> surfaces `discardCount = cost.count` otherwise). The payability check widened from `isNotEmpty()` to
+> `size >= count`. **Meteor Storm** authored in `definitions/inv/cards/MeteorStorm.kt` ({R}{G}
+> Enchantment; `Costs.Composite(Mana("{2}{R}{G}"), DiscardAtRandom(2))` → `DealDamage(4, any target)`).
+> Covered by `MeteorStormDiscardCostTest`.
+>
+> **Scoping note:** the `AdditionalCost.DiscardCards` "for symmetry" `atRandom` tweak was intentionally
+> skipped — no card in the set needs random discard as a *spell* additional cost, and adding an
+> unhonored field would mislead. Revisit when such a card appears.
 
-**Plan.** Add `count: Int = 1` and `atRandom: Boolean = false` to `AbilityCost.Discard` (and `atRandom`
-to `AdditionalCost.DiscardCards` for symmetry). The `CostHandler` selects randomly when `atRandom`.
-Cost is a distinct family from Effects, so widening it (rather than composing) is the right call here.
-- **Meteor Storm** = activated ability, cost `Composite(Mana("{R}"), Discard(count = 2, atRandom =
-  true))`, effect `DealDamage(3, AnyTarget)`.
+**What existed.** `AbilityCost.Discard(filter)` (single, chosen) and `AdditionalCost.DiscardCards(count,
+filter)`. No "at random" and `AbilityCost.Discard` had no count. Cost is a distinct family from Effects,
+so widening it (rather than composing) was the right call here.
 
 **Leverage.** Random discard recurs (Browbeat-likes, Wheel-of-Fortune riders). Small, contained.
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -100,6 +100,14 @@ the `CardDefinition`.
 - `Costs.PayLife(amount)` — pay N life.
 - `Costs.Sacrifice(filter)` — sacrifice a permanent matching the filter (may include self).
 - `Costs.SacrificeAnother(filter)` — sacrifice a *different* permanent matching the filter.
+- `Costs.DiscardCard` — discard a card you choose (any card).
+- `Costs.Discard(filter, count = 1, atRandom = false)` — discard `count` cards matching the filter.
+  When `atRandom` is true the engine picks the cards (no player selection); otherwise the player
+  chooses which cards to discard.
+- `Costs.DiscardAtRandom(count, filter)` — discard `count` cards chosen at random (Meteor Storm:
+  "Discard two cards at random").
+- `Costs.DiscardHand` — discard your entire hand.
+- `Costs.DiscardSelf` — discard this card (cycling-style).
 - `Costs.Composite(c1, c2, ...)` — multiple costs paid together.
 
 **Spell-level alternatives**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -94,10 +94,22 @@ object Costs {
     val DiscardCard: AbilityCost = AbilityCost.Discard()
 
     /**
-     * Discard a card matching the filter.
+     * Discard one or more cards matching the filter.
+     *
+     * @param count how many cards to discard
+     * @param atRandom when true, the engine picks the discarded cards at random (no player choice)
      */
-    fun Discard(filter: GameObjectFilter = GameObjectFilter.Any): AbilityCost =
-        AbilityCost.Discard(filter)
+    fun Discard(
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        count: Int = 1,
+        atRandom: Boolean = false
+    ): AbilityCost = AbilityCost.Discard(filter, count, atRandom)
+
+    /**
+     * Discard [count] cards chosen at random (e.g. Meteor Storm's "Discard two cards at random").
+     */
+    fun DiscardAtRandom(count: Int, filter: GameObjectFilter = GameObjectFilter.Any): AbilityCost =
+        AbilityCost.Discard(filter, count, atRandom = true)
 
     /**
      * Discard your entire hand.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -171,16 +171,27 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
     }
 
     /**
-     * Discard a card
+     * Discard one or more cards.
      *
      * @property filter Which cards can be discarded
+     * @property count How many cards to discard
+     * @property atRandom When true, the engine chooses the discarded cards at random
+     *   (no player selection); otherwise the player picks which cards to discard.
      */
     @SerialName("CostDiscard")
     @Serializable
     data class Discard(
-        val filter: GameObjectFilter = GameObjectFilter.Any
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val count: Int = 1,
+        val atRandom: Boolean = false
     ) : AbilityCost {
-        override val description: String = "Discard a ${filter.description}"
+        override val description: String = buildString {
+            append("Discard ")
+            if (count == 1) append("a ") else append("$count ")
+            append(filter.description)
+            if (count != 1) append("s")
+            if (atRandom) append(" at random")
+        }
 
         override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {
             val newFilter = filter.applyTextReplacement(replacer)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MeteorStorm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MeteorStorm.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteor Storm
+ * {R}{G}
+ * Enchantment
+ * {2}{R}{G}, Discard two cards at random: This enchantment deals 4 damage to any target.
+ *
+ * The "discard two cards at random" portion of the activation cost is paid automatically by the
+ * engine (no player selection) via `Costs.DiscardAtRandom(2)`.
+ */
+val MeteorStorm = card("Meteor Storm") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Enchantment"
+    oracleText = "{2}{R}{G}, Discard two cards at random: This enchantment deals 4 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}{G}"), Costs.DiscardAtRandom(2))
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(4, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "256"
+        artist = "John Avon"
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36489b24-f8a8-46b6-b879-0a5ce400a6dc.jpg?1562905963"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -99,7 +99,7 @@ class CostHandler(
             }
             is AbilityCost.Discard -> {
                 val handZone = ZoneKey(controllerId, Zone.HAND)
-                findMatchingCardsUnified(state, state.getZone(handZone), cost.filter, controllerId).isNotEmpty()
+                findMatchingCardsUnified(state, state.getZone(handZone), cost.filter, controllerId).size >= cost.count
             }
             is AbilityCost.DiscardHand -> {
                 // You can always discard your hand, even if it's empty
@@ -324,16 +324,24 @@ class CostHandler(
                 CostPaymentResult.success(newState, manaPool, events)
             }
             is AbilityCost.Discard -> {
-                val toDiscard = choices.discardChoices.firstOrNull()
-                    ?: return CostPaymentResult.failure("No discard target chosen")
-
-                val discardContainer = state.getEntity(toDiscard)
-                    ?: return CostPaymentResult.failure("Card to discard not found")
-                val discardOwner = discardContainer.get<ControllerComponent>()?.playerId
-                    ?: return CostPaymentResult.failure("Card to discard has no owner")
+                val toDiscard: List<EntityId> = if (cost.atRandom) {
+                    // Engine chooses the discarded cards at random — no player selection.
+                    val eligible = findMatchingCardsUnified(
+                        state, state.getZone(ZoneKey(controllerId, Zone.HAND)), cost.filter, controllerId
+                    )
+                    if (eligible.size < cost.count) {
+                        return CostPaymentResult.failure("Not enough cards to discard at random")
+                    }
+                    eligible.shuffled().take(cost.count)
+                } else {
+                    if (choices.discardChoices.size < cost.count) {
+                        return CostPaymentResult.failure("Must choose ${cost.count} card(s) to discard")
+                    }
+                    choices.discardChoices.take(cost.count)
+                }
 
                 val result = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
-                    .discardCard(state, discardOwner, toDiscard)
+                    .discardCards(state, controllerId, toDiscard)
                 CostPaymentResult.success(result.state, manaPool, result.events)
             }
             is AbilityCost.DiscardHand -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -244,9 +244,13 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         if (blightCreatures.isEmpty()) continue
                     }
                     is AbilityCost.Discard -> {
-                        discardCost = effectiveCost
-                        discardTargets = context.costUtils.findDiscardTargets(state, playerId, effectiveCost.filter)
-                        if (discardTargets.isEmpty()) continue
+                        val targets = context.costUtils.findDiscardTargets(state, playerId, effectiveCost.filter)
+                        if (targets.size < effectiveCost.count) continue
+                        // Random discard is paid automatically at cost time — no player selection.
+                        if (!effectiveCost.atRandom) {
+                            discardCost = effectiveCost
+                            discardTargets = targets
+                        }
                     }
                     is AbilityCost.RemoveCounterFromSelf -> {
                         val counters = container.get<CountersComponent>()
@@ -391,11 +395,15 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     }
                                 }
                                 is AbilityCost.Discard -> {
-                                    discardCost = subCost
-                                    discardTargets = context.costUtils.findDiscardTargets(state, playerId, subCost.filter)
-                                    if (discardTargets.isEmpty()) {
+                                    val targets = context.costUtils.findDiscardTargets(state, playerId, subCost.filter)
+                                    if (targets.size < subCost.count) {
                                         costCanBePaid = false
                                         break
+                                    }
+                                    // Random discard is paid automatically at cost time — no player selection.
+                                    if (!subCost.atRandom) {
+                                        discardCost = subCost
+                                        discardTargets = targets
                                     }
                                 }
                                 is AbilityCost.ExileXFromGraveyard -> {
@@ -833,7 +841,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 description = discardCost.description,
                 costType = "DiscardCard",
                 validDiscardTargets = discardTargets,
-                discardCount = 1,
+                discardCount = discardCost.count,
                 counterRemovalCreatures = counterRemovalCreatures
             )
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MeteorStormDiscardCostTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MeteorStormDiscardCostTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.MeteorStorm
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Invasion engine gap #9 — discard (at random) as an activation cost.
+ *
+ * Meteor Storm: "{2}{R}{G}, Discard two cards at random: This enchantment deals 4 damage to any
+ * target." The "discard two cards at random" portion is paid automatically by the engine (no
+ * player selection), via `Costs.DiscardAtRandom(2)`.
+ */
+class MeteorStormDiscardCostTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(MeteorStorm))
+        return d
+    }
+
+    test("activating Meteor Storm discards two cards at random and deals 4 damage") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Forest" to 20), startingLife = 20)
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val storm = d.putPermanentOnBattlefield(me, "Meteor Storm")
+        val abilityId = MeteorStorm.activatedAbilities.first().id
+
+        // Two cards to feed the random discard cost.
+        d.putCardInHand(me, "Centaur Courser")
+        d.putCardInHand(me, "Savannah Lions")
+        val handBefore = d.getHandSize(me)
+        val graveBefore = d.getGraveyard(me).size
+
+        // {2}{R}{G}: pay from a pool of two red + two green.
+        d.giveMana(me, Color.RED, 2)
+        d.giveMana(me, Color.GREEN, 2)
+
+        val result = d.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = storm,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opp))
+            )
+        )
+        result.isSuccess shouldBe true
+        d.bothPass()
+
+        // Exactly two cards discarded at random; they land in the graveyard.
+        d.getHandSize(me) shouldBe handBefore - 2
+        d.getGraveyard(me).size shouldBe graveBefore + 2
+
+        // 4 damage to the opponent.
+        d.getLifeTotal(opp) shouldBe 16
+    }
+
+    test("Meteor Storm cannot be activated without two cards to discard") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Forest" to 20), startingLife = 20)
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val storm = d.putPermanentOnBattlefield(me, "Meteor Storm")
+        val abilityId = MeteorStorm.activatedAbilities.first().id
+
+        // Empty the hand — not enough cards for "discard two at random".
+        var s = d.state
+        d.getHand(me).forEach { s = s.removeFromZone(ZoneKey(me, Zone.HAND), it) }
+        d.replaceState(s)
+        d.giveMana(me, Color.RED, 2)
+        d.giveMana(me, Color.GREEN, 2)
+
+        d.submitExpectFailure(
+            ActivateAbility(
+                playerId = me,
+                sourceId = storm,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opp))
+            )
+        )
+    }
+})


### PR DESCRIPTION
Implements **gap #9** from `backlog/invasion-engine-gaps.md` — discard (including *at random*) as an activation cost — unlocking **Meteor Storm**.

## SDK
- `AbilityCost.Discard` gains `count: Int = 1` and `atRandom: Boolean = false` (description renders e.g. "Discard 2 cards at random"). Existing single-discard callers are unaffected — both fields default.
- `Costs.Discard(filter, count, atRandom)` widened; new `Costs.DiscardAtRandom(count, filter)` facade.

## Engine
- `CostHandler`: payability widened from `isNotEmpty()` to `size >= count`. Payment discards `count` cards via `ZoneTransitionService.discardCards` — for `atRandom` the engine picks them itself (`eligible.shuffled().take(count)`, the same unseeded pattern as `PayOrSufferExecutor.executeRandomDiscard`); otherwise it uses the player's first `count` `discardChoices`.
- `ActivatedAbilityEnumerator`: both the standalone and composite `AbilityCost.Discard` arms gate on `targets.size >= count` and **skip the discard-selection prompt entirely when `atRandom`** (no UI needed); surfaced `discardCount` now reflects `cost.count` instead of a hardcoded `1`.

## Card
- `MeteorStorm.kt` (INV): `{R}{G}` Enchantment, `{2}{R}{G}, Discard two cards at random: deals 4 damage to any target` (verified against Scryfall).

## Docs / backlog
- Added the discard-cost facades to `card-sdk-language-reference.md`; marked gap #9 done.

## Scoping note
The backlog suggested adding `atRandom` to `AdditionalCost.DiscardCards` "for symmetry." Intentionally **skipped** — no card needs random discard as a *spell* additional cost, and an unhonored field would mislead. Documented as revisit-when-needed.

Behavioral note: the random discard uses an unseeded `.shuffled()` — like all randomness in this engine (coin flips, library shuffles, `executeRandomDiscard`) it is not replay-deterministic. Pre-existing engine-wide limitation, not introduced here.

## Tests
- `MeteorStormDiscardCostTest` (new): activation discards exactly 2 random cards (hand −2, graveyard +2) and deals 4; rejected when the hand has fewer than 2 cards. Both pass.
- Regression run of `*Discard*`, `*Cycling*`, `UndeadGladiator`, `*ActivatedAbility*`, plus `:mtg-sdk:test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)