### PR TITLE
Invasion gap #10: "name a card" choice + name-matching filter

### DIFF
--- a/backlog/invasion-engine-gaps.md
+++ b/backlog/invasion-engine-gaps.md
@@ -432,25 +432,31 @@ Cost is a distinct family from Effects, so widening it (rather than composing) i
 
 ---
 
-### #10 — "Name a card" choice + name-matching filter · Desperate Research, Lobotomy
+### #10 — "Name a card" choice + name-matching filter · Desperate Research, Lobotomy ✅ DONE
 
-**What exists.** Only `CardPredicate.NameEquals(static)`. No `CARD_NAME` option type, no choose-a-name
+> **Implemented (primitives + both cards).** Two halves of the "name a card" family, no per-card
+> executors. **Naming half:** `OptionType.CARD_NAME` (options = `CardRegistry.allCardNames()` sorted —
+> the existing `ChooseOptionDecision` renders it as a searchable list, so no client change and no
+> free-text entry) surfaced via `Effects.ChooseCardName(storeAs, prompt?, excludeBasicLandNames?)`;
+> `ChooseOptionPipelineExecutor` now takes the registry. **Capture half:** `Effects.StoreCardName(from,
+> storeAs)` + `StoreCardNameExecutor` record the name of a chosen card into `chosenValues` — threaded
+> through a new `EffectResult.updatedChosenValues` channel merged by `CompositeEffectExecutor` and
+> `EffectContinuationRunner`. **Matching:** `CardPredicate.NameEqualsChosen(variableName)` +
+> `GameObjectFilter.namedFromVariable(variableName)` (case-insensitive; fails closed in
+> static/projection — wired into `PredicateEvaluator`, `AffectsFilterResolver`, `CostCalculator`).
+> Cards authored in `definitions/inv/cards/`: **Desperate Research** (`ChooseCardName` → reveal top 7 →
+> `SelectFromCollection(All, namedFromVariable)` matches to hand, rest exiled) and **Lobotomy**
+> (`RevealHand` → choose a non-basic-land card → `StoreCardName` → gather all same-named across
+> graveyard/hand/library → exile → shuffle). Covered by `DesperateResearchTest` + `LobotomyTest`.
+> **Scoping note:** Lobotomy's oracle wording is "choose a card from the revealed hand" (capture-name
+> half), not a typed name; the doc's original framing of both as free naming was corrected.
+
+**What existed.** Only `CardPredicate.NameEquals(static)`. No `CARD_NAME` option type, no choose-a-name
 effect.
 
-**Plan.**
-1. Add `OptionType.CARD_NAME` + `ChooseCardNameEffect(storeAs)` storing the chosen name in
-   `EffectContext` (`chosenCardName: String?` plus a named pipeline variable). The client gets a
-   name-entry/autocomplete decision.
-2. Add `CardPredicate.NameEqualsChosen` matching the stored chosen name.
-
-**Composition** (both reuse the existing gather/search/move pipeline):
-- **Lobotomy** = `ChooseCardName` → search target player's hand+graveyard+library with
-  `NameEqualsChosen` → exile all matches.
-- **Desperate Research** = `ChooseCardName` → gather library → partition by `NameEqualsChosen` →
-  matches to hand, remainder to graveyard.
-
 **Leverage.** Unlocks the whole "name a card" family (Pithing Needle is a different axis, but Cranial
-Extraction, Memoricide, Sadistic Sacrament all follow this exact shape).
+Extraction, Memoricide, Sadistic Sacrament all follow this exact shape); `StoreCardName` /
+`NameEqualsChosen` also serve any "choose a card, then act on cards with that name" effect.
 
 ---
 
@@ -637,7 +643,8 @@ filter.
    `CapDamage`, `PreventDamage.restrictions`, `RedirectDamage` (now wired), `ControllerOfDamageSource`;
    unlocked 5 cards and enriched the shared event system. Protective Sphere still waits on #8.
 6. **Tapped-for-mana event + rider + replacement** (#3) — 3 cards, reusable mana hooks.
-7. **Name-a-card choice + filter** (#10) — 2 cards, large external family.
+7. **Name-a-card choice + filter** (#10) ✅ — `OptionType.CARD_NAME` / `Effects.ChooseCardName` +
+   `StoreCardName` (capture-from-chosen-card) + `NameEqualsChosen` filter; Desperate Research + Lobotomy done.
 8. **Pile-separation trio** (#21) — 5 cards from three composable additions.
 9. Scope additions: protection supertype (#13), dynamic-color protection (#15), chosen-type landwalk
    (#14), discard-at-random cost (#9) — small, independent.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -577,6 +577,11 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   Colorless entities share no color (never match). Used by Spreading Plague ("destroy all other creatures
   that share a color with it") — pair with `Effects.DestroyAll(filter, excludeTriggering = true)` so the
   triggering creature itself is spared.
+- `.named(name)` — `CardPredicate.NameEquals`: matches a fixed card name.
+- `.namedFromVariable(variableName)` — `CardPredicate.NameEqualsChosen`: matches the card name stored in
+  `chosenValues[variableName]` (case-insensitive). Set the name with `Effects.ChooseCardName` (player names it)
+  or `Effects.StoreCardName` (captured from a chosen card). Fails closed in static/projection contexts. Used by
+  the "name a card … cards with that name" family (Desperate Research, Lobotomy).
 - `.power(n)` / `.minPower(n)` / `.maxPower(n)` — P/T comparator.
 - `.manaValue(n)` / `.manaValueAtMost(n)` / `.manaValueAtLeast(n)` — mana-value comparator.
 - `.manaValueAtMostX()` — mana value ≤ the X chosen for the source spell/ability.
@@ -1537,6 +1542,8 @@ staticAbility { ability = SetEnchantedLandTypeFromChosen }
 - `ChooseColorAndGrantProtectionTo{Target,Group}Effect` — color → protection from that color.
 - `GrantHexproofFromChosenColorEffect(target)` — same shape, hexproof.
 - `ChooseCreatureTypeEffect(...)` — pause for creature-type selection.
+- `Effects.ChooseCardName(storeAs, prompt?, excludeBasicLandNames?)` — name a card (`ChooseOptionEffect(OptionType.CARD_NAME)`); the chosen name is stored in `chosenValues[storeAs]`. Options are every registry card name (searchable list, not free text); `excludeBasicLandNames` drops the five basics. Match cards by it with `GameObjectFilter.namedFromVariable(storeAs)`. (Desperate Research)
+- `Effects.StoreCardName(from, storeAs)` — capture the name of the first card in collection `from` into `chosenValues[storeAs]`. The "choose a card, then act on cards of that name" counterpart to `ChooseCardName`. (Lobotomy)
 - `SelectTargetEffect(...)` — pick from a valid target set.
 - `SeparatePermanentsIntoPilesEffect(filter, piles)` — divvy permanents into piles (Fact-or-Fiction shape).
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2094,6 +2094,36 @@ object Effects {
         excludedOptions: List<String> = emptyList()
     ): Effect = ChooseOptionEffect(optionType, storeAs, prompt, excludedOptions)
 
+    /** The five basic land card names, excluded by "name a card other than a basic land card name" effects. */
+    private val BASIC_LAND_CARD_NAMES = listOf("Plains", "Island", "Swamp", "Mountain", "Forest")
+
+    /**
+     * Name a card. The chosen name is stored in `chosenValues[storeAs]`; match cards
+     * against it later with [com.wingedsheep.sdk.scripting.filters.unified.GameObjectFilter.namedFromVariable].
+     * Used by "name a card …" effects (Desperate Research).
+     *
+     * @param excludeBasicLandNames When true, the five basic land card names are not
+     *   offered ("other than a basic land card name").
+     */
+    fun ChooseCardName(
+        storeAs: String = "chosenCardName",
+        prompt: String? = null,
+        excludeBasicLandNames: Boolean = false
+    ): Effect = ChooseOptionEffect(
+        optionType = OptionType.CARD_NAME,
+        storeAs = storeAs,
+        prompt = prompt,
+        excludedOptions = if (excludeBasicLandNames) BASIC_LAND_CARD_NAMES else emptyList()
+    )
+
+    /**
+     * Capture the name of the first card in stored collection [from] into
+     * `chosenValues[storeAs]`. The "choose a card, then act on cards with that name"
+     * counterpart to [ChooseCardName] (Lobotomy).
+     */
+    fun StoreCardName(from: String, storeAs: String = "chosenCardName"): Effect =
+        com.wingedsheep.sdk.scripting.effects.StoreCardNameEffect(from, storeAs)
+
     /**
      * Choose a creature type. Creatures of the chosen type get +X/+Y until end of turn,
      * optionally gaining a keyword.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -805,7 +805,14 @@ enum class OptionType {
     /** Choose from the five Magic colors */
     COLOR,
     /** Choose from the five basic land types (Plains, Island, Swamp, Mountain, Forest) */
-    BASIC_LAND_TYPE
+    BASIC_LAND_TYPE,
+    /**
+     * Name a card. Options are every card name the engine knows about (the registry),
+     * sorted alphabetically, so the player searches/filters a list rather than typing
+     * free text. Pair the stored name with [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameEqualsChosen]
+     * to match cards by it. Used by "name a card" effects (Desperate Research, etc.).
+     */
+    CARD_NAME
 }
 
 /**
@@ -834,6 +841,7 @@ data class ChooseOptionEffect(
             OptionType.CREATURE_TYPE -> "a creature type"
             OptionType.COLOR -> "a color"
             OptionType.BASIC_LAND_TYPE -> "a basic land type"
+            OptionType.CARD_NAME -> "a card name"
         })
     }
 
@@ -1196,4 +1204,28 @@ data class StoreNumberEffect(
         val newAmount = amount.applyTextReplacement(replacer)
         return if (newAmount !== amount) copy(amount = newAmount) else this
     }
+}
+
+/**
+ * Read the name of the first card in a stored collection and store it under [storeAs] in
+ * pipeline `chosenValues`. Subsequent effects can match cards against it via
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameEqualsChosen] (e.g.
+ * `GameObjectFilter.namedFromVariable(storeAs)`).
+ *
+ * This is the "capture a card's name" counterpart to [ChooseOptionEffect] with
+ * [OptionType.CARD_NAME]: instead of the player naming a card, the name is taken from a
+ * card they selected. Used by Lobotomy ("you choose a card … search for all cards with
+ * the same name"). A no-op when [from] is empty or missing.
+ *
+ * @property from Stored collection whose first card's name to capture.
+ * @property storeAs Key under which the captured name is stored in `chosenValues`.
+ */
+@SerialName("StoreCardName")
+@Serializable
+data class StoreCardNameEffect(
+    val from: String,
+    val storeAs: String = "chosenCardName"
+) : Effect {
+    override val description: String = "Note the name of the $from card"
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -203,6 +203,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.NameEquals(name)
     )
 
+    /** Match cards whose name equals the card name stored in chosenValues[variableName] */
+    fun namedFromVariable(variableName: String) = copy(
+        cardPredicates = cardPredicates + CardPredicate.NameEqualsChosen(variableName)
+    )
+
     /** Mana value equals */
     fun manaValue(value: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.ManaValueEquals(value)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -250,6 +250,21 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
     }
 
+    /**
+     * Matches cards whose name equals the value stored in `chosenValues[variableName]` —
+     * a card name chosen earlier in the pipeline (via [com.wingedsheep.sdk.scripting.effects.OptionType.CARD_NAME]
+     * or [com.wingedsheep.sdk.scripting.effects.StoreCardNameEffect]). Matching is
+     * case-insensitive. Fails closed (no match) when nothing has been stored yet, or in
+     * static/projection contexts that have no pipeline. Used by "name a card … cards with
+     * that name" effects (Desperate Research, Lobotomy).
+     */
+    @SerialName("NameEqualsChosen")
+    @Serializable
+    data class NameEqualsChosen(val variableName: String) : CardPredicate {
+        override val description: String = "with the chosen name"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
     // =============================================================================
     // Keyword Predicates
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DesperateResearch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DesperateResearch.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Desperate Research
+ * {1}{B}
+ * Sorcery
+ *
+ * Choose a card name other than a basic land card name. Reveal the top seven cards of
+ * your library and put all of them with that name into your hand. Exile the rest.
+ *
+ * Invasion engine gap #10 — the "name a card" half of the family. [Effects.ChooseCardName]
+ * stores the chosen name in `chosenValues`; the reveal partitions the top seven by it via
+ * [GameObjectFilter.namedFromVariable] (matches to hand, the rest exiled).
+ */
+val DesperateResearch = card("Desperate Research") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Choose a card name other than a basic land card name. Reveal the top seven cards of " +
+        "your library and put all of them with that name into your hand. Exile the rest."
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                // 1. Name a card (no basic land card names).
+                Effects.ChooseCardName(
+                    storeAs = "chosenName",
+                    prompt = "Choose a card name other than a basic land card name",
+                    excludeBasicLandNames = true
+                ),
+                // 2. Reveal the top seven cards of your library.
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(7), Player.You),
+                    storeAs = "revealed",
+                    revealed = true
+                ),
+                // 3. Partition: cards with the chosen name vs. the rest.
+                SelectFromCollectionEffect(
+                    from = "revealed",
+                    selection = SelectionMode.All,
+                    filter = GameObjectFilter.Any.namedFromVariable("chosenName"),
+                    storeSelected = "matches",
+                    storeRemainder = "rest"
+                ),
+                // 4. Put all matches into your hand.
+                MoveCollectionEffect(
+                    from = "matches",
+                    destination = CardDestination.ToZone(Zone.HAND, Player.You)
+                ),
+                // 5. Exile the rest.
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.You)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "100"
+        artist = "Ron Spencer"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a42ac7e-4a27-488c-a2e7-338b18103b02.jpg?1562916353"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Lobotomy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Lobotomy.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lobotomy
+ * {2}{U}{B}
+ * Sorcery
+ *
+ * Target player reveals their hand, then you choose a card other than a basic land card
+ * from it. Search that player's graveyard, hand, and library for all cards with the same
+ * name as the chosen card and exile them. Then that player shuffles.
+ *
+ * Invasion engine gap #10 — the "capture a card's name" half of the "name a card" family.
+ * Instead of typing a name, the controller picks a card and [Effects.StoreCardName] records
+ * its name into `chosenValues`; the search then matches every card of that name via
+ * [GameObjectFilter.namedFromVariable] ([CardPredicate.NameEqualsChosen]).
+ */
+val Lobotomy = card("Lobotomy") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Sorcery"
+    oracleText = "Target player reveals their hand, then you choose a card other than a basic land card from it. " +
+        "Search that player's graveyard, hand, and library for all cards with the same name as the chosen card " +
+        "and exile them. Then that player shuffles."
+
+    spell {
+        val player = target("player", TargetPlayer())
+        effect = CompositeEffect(
+            listOf(
+                // 1. Target player reveals their hand.
+                RevealHandEffect(player),
+                // 2. Gather their hand so the controller can choose a card.
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "hand"
+                ),
+                // 3. You choose a card other than a basic land card.
+                SelectFromCollectionEffect(
+                    from = "hand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    filter = GameObjectFilter(cardPredicates = listOf(CardPredicate.Not(CardPredicate.IsBasicLand))),
+                    storeSelected = "chosen",
+                    prompt = "Choose a card other than a basic land card",
+                    alwaysPrompt = true,
+                    showAllCards = true
+                ),
+                // 4. Record the chosen card's name.
+                Effects.StoreCardName(from = "chosen", storeAs = "chosenName"),
+                // 5. Find every card of that name across their graveyard, hand, and library.
+                GatherCardsEffect(
+                    source = CardSource.FromMultipleZones(
+                        zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+                        player = Player.ContextPlayer(0),
+                        filter = GameObjectFilter.Any.namedFromVariable("chosenName")
+                    ),
+                    storeAs = "toExile"
+                ),
+                // 6. Exile them.
+                MoveCollectionEffect(
+                    from = "toExile",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0))
+                ),
+                // 7. That player shuffles.
+                ShuffleLibraryEffect(target = EffectTarget.ContextTarget(0))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "255"
+        artist = "D. Alexander Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff307dbb-4ab6-457b-be56-47106864bf61.jpg?1562946537"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EffectResult.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EffectResult.kt
@@ -21,7 +21,9 @@ data class EffectResult(
     /** Subtype-group lists produced by pipeline effects (GatherSubtypes, etc.) */
     val updatedSubtypeGroups: Map<String, List<Set<String>>> = emptyMap(),
     /** Named numeric values produced by pipeline effects (StoreNumber, etc.). */
-    val updatedStoredNumbers: Map<String, Int> = emptyMap()
+    val updatedStoredNumbers: Map<String, Int> = emptyMap(),
+    /** Named string values produced by pipeline effects (StoreCardName, etc.). */
+    val updatedChosenValues: Map<String, String> = emptyMap()
 ) {
     val isSuccess: Boolean get() = error == null && pendingDecision == null
     val isPaused: Boolean get() = pendingDecision != null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -410,6 +410,11 @@ class PredicateEvaluator {
             }
 
             // Context-relative predicates (pipeline variable references)
+            is CardPredicate.NameEqualsChosen -> {
+                val chosenName = context?.chosenValues?.get(predicate.variableName) ?: return false
+                card.name.equals(chosenName, ignoreCase = true)
+            }
+
             is CardPredicate.HasSubtypeFromVariable -> {
                 val chosenType = context?.chosenValues?.get(predicate.variableName) ?: return false
                 val entitySubtypes = projectedValues?.subtypes ?: card.typeLine.subtypes.map { it.value }.toSet()
@@ -767,6 +772,7 @@ class PredicateEvaluator {
 
             // Name predicates — not stored in record
             is CardPredicate.NameEquals -> false
+            is CardPredicate.NameEqualsChosen -> false
 
             // Keyword predicates — not stored in record
             is CardPredicate.HasKeyword, is CardPredicate.NotKeyword -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectContinuationRunner.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectContinuationRunner.kt
@@ -69,24 +69,30 @@ class EffectContinuationRunner(
             }
             allEvents.addAll(result.events)
 
-            if (result.updatedCollections.isNotEmpty() || result.updatedSubtypeGroups.isNotEmpty()) {
+            if (result.updatedCollections.isNotEmpty() ||
+                result.updatedSubtypeGroups.isNotEmpty() ||
+                result.updatedChosenValues.isNotEmpty()
+            ) {
                 currentContext = currentContext.copy(
                     pipeline = currentContext.pipeline.copy(
                         storedCollections = currentContext.pipeline.storedCollections + result.updatedCollections,
-                        storedSubtypeGroups = currentContext.pipeline.storedSubtypeGroups + result.updatedSubtypeGroups
+                        storedSubtypeGroups = currentContext.pipeline.storedSubtypeGroups + result.updatedSubtypeGroups,
+                        chosenValues = currentContext.pipeline.chosenValues + result.updatedChosenValues
                     )
                 )
             }
         }
 
-        // Return accumulated collections / subtype groups so callers can propagate them
+        // Return accumulated collections / subtype groups / chosen values so callers can propagate them
         val accumulatedCollections = currentContext.pipeline.storedCollections - initialContext.pipeline.storedCollections.keys
         val accumulatedSubtypeGroups = currentContext.pipeline.storedSubtypeGroups - initialContext.pipeline.storedSubtypeGroups.keys
+        val accumulatedChosenValues = currentContext.pipeline.chosenValues - initialContext.pipeline.chosenValues.keys
         return EffectResult(
             currentState,
             allEvents,
             updatedCollections = accumulatedCollections,
-            updatedSubtypeGroups = accumulatedSubtypeGroups
+            updatedSubtypeGroups = accumulatedSubtypeGroups,
+            updatedChosenValues = accumulatedChosenValues
         )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeEffectExecutor.kt
@@ -103,31 +103,35 @@ class CompositeEffectExecutor(
             }
             allEvents.addAll(result.events)
 
-            // Merge any updated collections / subtype groups / stored numbers from the sub-effect into the context
+            // Merge any updated collections / subtype groups / stored numbers / chosen values from the sub-effect into the context
             if (result.updatedCollections.isNotEmpty() ||
                 result.updatedSubtypeGroups.isNotEmpty() ||
-                result.updatedStoredNumbers.isNotEmpty()
+                result.updatedStoredNumbers.isNotEmpty() ||
+                result.updatedChosenValues.isNotEmpty()
             ) {
                 currentContext = currentContext.copy(
                     pipeline = currentContext.pipeline.copy(
                         storedCollections = currentContext.pipeline.storedCollections + result.updatedCollections,
                         storedSubtypeGroups = currentContext.pipeline.storedSubtypeGroups + result.updatedSubtypeGroups,
-                        storedNumbers = currentContext.pipeline.storedNumbers + result.updatedStoredNumbers
+                        storedNumbers = currentContext.pipeline.storedNumbers + result.updatedStoredNumbers,
+                        chosenValues = currentContext.pipeline.chosenValues + result.updatedChosenValues
                     )
                 )
             }
         }
 
-        // Return accumulated collections / subtype groups / stored numbers so parent composites can see them
+        // Return accumulated collections / subtype groups / stored numbers / chosen values so parent composites can see them
         val accumulatedCollections = currentContext.pipeline.storedCollections - context.pipeline.storedCollections.keys
         val accumulatedSubtypeGroups = currentContext.pipeline.storedSubtypeGroups - context.pipeline.storedSubtypeGroups.keys
         val accumulatedStoredNumbers = currentContext.pipeline.storedNumbers - context.pipeline.storedNumbers.keys
+        val accumulatedChosenValues = currentContext.pipeline.chosenValues - context.pipeline.chosenValues.keys
         return EffectResult(
             currentState,
             allEvents,
             updatedCollections = accumulatedCollections,
             updatedSubtypeGroups = accumulatedSubtypeGroups,
-            updatedStoredNumbers = accumulatedStoredNumbers
+            updatedStoredNumbers = accumulatedStoredNumbers,
+            updatedChosenValues = accumulatedChosenValues
         )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChooseOptionPipelineExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChooseOptionPipelineExecutor.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.handlers.effects.library
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Subtype
@@ -18,8 +19,15 @@ import kotlin.reflect.KClass
  * When the player responds, the chosen value is stored in the pipeline's
  * EffectContext.chosenValues (via ChooseOptionPipelineContinuation) for
  * subsequent effects.
+ *
+ * For [OptionType.CARD_NAME] ("name a card") the option list is every card name the
+ * [cardRegistry] knows about, sorted alphabetically — the client renders a searchable
+ * list, so there is no free-text entry. Names that no card uses can't be matched by
+ * anything in a zone anyway, so restricting to the registry loses nothing in practice.
  */
-class ChooseOptionPipelineExecutor : EffectExecutor<ChooseOptionEffect> {
+class ChooseOptionPipelineExecutor(
+    private val cardRegistry: CardRegistry
+) : EffectExecutor<ChooseOptionEffect> {
 
     override val effectType: KClass<ChooseOptionEffect> = ChooseOptionEffect::class
 
@@ -35,6 +43,7 @@ class ChooseOptionPipelineExecutor : EffectExecutor<ChooseOptionEffect> {
             OptionType.CREATURE_TYPE -> Subtype.ALL_CREATURE_TYPES
             OptionType.COLOR -> listOf("White", "Blue", "Black", "Red", "Green")
             OptionType.BASIC_LAND_TYPE -> Subtype.ALL_BASIC_LAND_TYPES.toList()
+            OptionType.CARD_NAME -> cardRegistry.allCardNames().sorted()
         }
 
         val excludedLower = effect.excludedOptions.map { it.lowercase() }.toSet()
@@ -44,6 +53,7 @@ class ChooseOptionPipelineExecutor : EffectExecutor<ChooseOptionEffect> {
             OptionType.CREATURE_TYPE -> "Choose a creature type"
             OptionType.COLOR -> "Choose a color"
             OptionType.BASIC_LAND_TYPE -> "Choose a basic land type"
+            OptionType.CARD_NAME -> "Name a card"
         }
 
         val decisionId = UUID.randomUUID().toString()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -51,7 +51,7 @@ class LibraryExecutors(
         GatherSubtypesExecutor(),
         CaptureControllersExecutor(),
         ChooseCreatureTypePipelineExecutor(),
-        ChooseOptionPipelineExecutor(),
+        ChooseOptionPipelineExecutor(cardRegistry = cardRegistry),
         GatherCardsExecutor(),
         SelectFromCollectionExecutor(),
         ChoosePileExecutor(),
@@ -59,6 +59,7 @@ class LibraryExecutors(
         MoveCollectionExecutor(cardRegistry = cardRegistry, targetFinder = targetFinder),
         FilterCollectionExecutor(),
         PutOnTopOrBottomOfLibraryExecutor(),
-        StoreNumberExecutor()
+        StoreNumberExecutor(),
+        StoreCardNameExecutor()
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/StoreCardNameExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/StoreCardNameExecutor.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.StoreCardNameEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [StoreCardNameEffect].
+ *
+ * Reads the name of the first card in the [StoreCardNameEffect.from] collection and emits
+ * it via [EffectResult.updatedChosenValues]. The surrounding
+ * [com.wingedsheep.engine.handlers.effects.composite.CompositeEffectExecutor] /
+ * [com.wingedsheep.engine.handlers.continuations.EffectContinuationRunner] merges the
+ * value into the pipeline context so later sub-effects can match it via
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameEqualsChosen].
+ *
+ * No-op (success, nothing stored) when the collection is empty or missing — e.g. the
+ * player had nothing to choose, mirroring "do as much as possible" resolution.
+ */
+class StoreCardNameExecutor : EffectExecutor<StoreCardNameEffect> {
+
+    override val effectType: KClass<StoreCardNameEffect> = StoreCardNameEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: StoreCardNameEffect,
+        context: EffectContext
+    ): EffectResult {
+        val cardId = context.pipeline.storedCollections[effect.from]?.firstOrNull()
+            ?: return EffectResult.success(state)
+        val name = state.getEntity(cardId)?.get<CardComponent>()?.name
+            ?: return EffectResult.success(state)
+        return EffectResult(state = state, updatedChosenValues = mapOf(effect.storeAs to name))
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -472,6 +472,7 @@ internal class AffectsFilterResolver {
         is CardPredicate.SharesColorWith,
         is CardPredicate.HasSubtypeFromVariable,
         is CardPredicate.HasSubtypeInStoredList,
+        is CardPredicate.NameEqualsChosen,
         is CardPredicate.HasSubtypeInEachStoredGroup -> false
         // Stack-only predicates — never match a battlefield entity being projected.
         CardPredicate.IsActivatedOrTriggeredAbility,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -898,6 +898,7 @@ class CostCalculator(
             is CardPredicate.HasSubtypeFromVariable -> true
             is CardPredicate.HasSubtypeInStoredList -> true
             is CardPredicate.HasSubtypeInEachStoredGroup -> true
+            is CardPredicate.NameEqualsChosen -> true
 
             is CardPredicate.And -> predicate.predicates.all { matchesCardPredicate(cardDef, it, sourceEntityId, state, projectedState) }
             is CardPredicate.Or -> predicate.predicates.any { matchesCardPredicate(cardDef, it, sourceEntityId, state, projectedState) }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesperateResearchTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesperateResearchTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.DesperateResearch
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Desperate Research (INV #100) — Invasion engine gap #10, the "name a card" half.
+ *
+ * "Choose a card name other than a basic land card name. Reveal the top seven cards of
+ * your library and put all of them with that name into your hand. Exile the rest."
+ */
+class DesperateResearchTest : FunSpec({
+
+    test("named cards go to hand, the rest are exiled") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DesperateResearch))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        // Seed the top seven: three Lightning Bolts (named) + four Stoke the Flames (the rest).
+        repeat(4) { driver.putCardOnTopOfLibrary(you, "Stoke the Flames") }
+        repeat(3) { driver.putCardOnTopOfLibrary(you, "Lightning Bolt") }
+
+        val dr = driver.putCardInHand(you, "Desperate Research")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.castSpell(you, dr)
+        driver.bothPass()
+
+        // Resolving the spell pauses to name a card.
+        val decision = driver.pendingDecision
+        decision.shouldNotBe(null)
+        decision as ChooseOptionDecision
+        // Basic land card names are excluded from the choices.
+        decision.options shouldNotContain "Plains"
+        val boltIndex = decision.options.indexOf("Lightning Bolt")
+        boltIndex shouldNotBe -1
+        driver.submitDecision(you, OptionChosenResponse(decision.id, boltIndex))
+
+        driver.isPaused shouldBe false
+        // The three Lightning Bolts are now in hand; the four Stoke the Flames are exiled.
+        driver.findCardsInHand(you, "Lightning Bolt").size shouldBe 3
+        driver.getExileCardNames(you).count { it == "Stoke the Flames" } shouldBe 4
+        driver.getExileCardNames(you) shouldNotContain "Lightning Bolt"
+    }
+
+    test("naming a card absent from the top seven exiles all of them") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DesperateResearch))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        repeat(7) { driver.putCardOnTopOfLibrary(you, "Stoke the Flames") }
+
+        val dr = driver.putCardInHand(you, "Desperate Research")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.castSpell(you, dr)
+        driver.bothPass()
+
+        val decision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(you, OptionChosenResponse(decision.id, decision.options.indexOf("Lightning Bolt")))
+
+        driver.isPaused shouldBe false
+        driver.findCardsInHand(you, "Lightning Bolt").size shouldBe 0
+        driver.getExileCardNames(you).count { it == "Stoke the Flames" } shouldBe 7
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LobotomyTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LobotomyTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.Lobotomy
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Lobotomy (INV #255) — Invasion engine gap #10, the "capture a card's name" half.
+ *
+ * "Target player reveals their hand, then you choose a card other than a basic land card
+ * from it. Search that player's graveyard, hand, and library for all cards with the same
+ * name as the chosen card and exile them. Then that player shuffles."
+ */
+class LobotomyTest : FunSpec({
+
+    test("exiles every card sharing the chosen card's name across all three zones") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Lobotomy))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opp = driver.getOpponent(you)
+
+        // Opponent has Lightning Bolt copies in hand, graveyard, and library, plus
+        // unrelated cards (and a basic land that must not be selectable).
+        val boltInHand = driver.putCardInHand(opp, "Lightning Bolt")
+        driver.putCardInHand(opp, "Stoke the Flames")
+        driver.putCardInHand(opp, "Plains")
+        driver.putCardInGraveyard(opp, "Lightning Bolt")
+        driver.putCardInGraveyard(opp, "Stoke the Flames")
+        driver.putCardOnTopOfLibrary(opp, "Lightning Bolt")
+        driver.putCardOnTopOfLibrary(opp, "Stoke the Flames")
+
+        val lobotomy = driver.putCardInHand(you, "Lobotomy")
+        driver.giveMana(you, Color.BLUE, 1)
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveMana(you, Color.WHITE, 2)
+        driver.castSpell(you, lobotomy, targets = listOf(opp))
+        driver.bothPass()
+
+        // Resolving pauses for the controller to choose a card from the revealed hand.
+        driver.submitCardSelection(you, listOf(boltInHand))
+
+        driver.isPaused shouldBe false
+        // All three Lightning Bolts are exiled; nothing named otherwise is touched.
+        driver.getExileCardNames(opp).count { it == "Lightning Bolt" } shouldBe 3
+        driver.getExileCardNames(opp) shouldNotContain "Stoke the Flames"
+        driver.findCardsInHand(opp, "Lightning Bolt").size shouldBe 0
+        driver.getGraveyardCardNames(opp) shouldContain "Stoke the Flames"
+        driver.getGraveyardCardNames(opp) shouldNotContain "Lightning Bolt"
+        // The basic land was never eligible and stays in hand.
+        (driver.findCardInHand(opp, "Plains") != null) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements Invasion engine gap #10 — the "name a card" choice + name-matching filter family — and the two cards it unlocks (**Desperate Research**, **Lobotomy**). No per-card executors; everything composes existing pipeline primitives.

## Correction to the gap doc
The doc framed both cards as free naming. Lobotomy's actual oracle text has you *choose a card from a revealed hand* and match by *that card's name* — not a typed name. So this builds two complementary halves of one family.

## What's added
**Naming half** (Desperate Research)
- `OptionType.CARD_NAME` + `Effects.ChooseCardName(storeAs, prompt?, excludeBasicLandNames?)`. Options come from `CardRegistry.allCardNames()` (sorted) and render via the existing searchable `ChooseOptionDecision` — **no web-client change**, no free-text plumbing. `ChooseOptionPipelineExecutor` now takes the registry.

**Capture half** (Lobotomy)
- `Effects.StoreCardName(from, storeAs)` + `StoreCardNameExecutor` record a chosen card's name into `chosenValues`, threaded through a new `EffectResult.updatedChosenValues` channel merged by `CompositeEffectExecutor` and `EffectContinuationRunner`.

**Matching**
- `CardPredicate.NameEqualsChosen(variableName)` + `GameObjectFilter.namedFromVariable(...)` (case-insensitive; fails closed in static/projection — wired into `PredicateEvaluator`, `AffectsFilterResolver`, `CostCalculator`).

## Cards
- **Desperate Research** ({1}{B}): name a card → reveal top 7 → matches to hand, rest exiled.
- **Lobotomy** ({2}{U}{B}): target reveals hand → choose a non-basic-land card → capture its name → exile all same-named across graveyard/hand/library → shuffle.

## Verification
- New `DesperateResearchTest` (incl. no-match case) + `LobotomyTest` (matches across all three zones, basic-land exclusion) — all pass.
- Full `rules-engine` `*Test` suite, `:mtg-sdk:test`, `:mtg-sets:test` green; `game-server` compiles.
- Updated `docs/card-sdk-language-reference.md` and marked gap #10 ✅ in `backlog/invasion-engine-gaps.md`.

## Note
For `OptionType.CARD_NAME` the decision ships the full registry name list to the client (the existing UI filters it client-side) — simplest correct approach matching the doc's "searchable list" intent; server-side autocomplete could replace it later if the registry grows large.

🤖 Generated with [Claude Code](https://claude.com/claude-code)