### PR TITLE
﻿﻿Add Uthros Psionicist; generalize cost gating to NthOfTypePerTurn

### DIFF
--- a/backlog/sdk-reusability-consolidation.md
+++ b/backlog/sdk-reusability-consolidation.md
@@ -79,12 +79,12 @@ one `ModifySpellCost(target, modification, gating)`:
   `ReduceGenericBy(CostReductionSource)` / `ReduceColored(symbols)` /
   `ReduceColoredPerUnit(symbols, countSource)` / `IncreaseGeneric(amount)` /
   `IncreaseGenericPerOtherSpellThisTurn(amountPerSpell)`.
-- `gating: CostGating` — `None` / `FirstOfTypePerTurn` (Eluge).
+- `gating: CostGating` — `None` / `NthOfTypePerTurn(n)` (Eluge uses `n = 1`; Uthros Psionicist `n = 2`).
 
 `CostCalculator` rewritten around the new shape: a single
 `scanBattlefieldModifySpellCost` walks every battlefield permanent once,
 `targetMatchesSpell` filters by target/scope (using *projected* controller, not
-base), `gatingApplies` checks first-of-type-per-turn, and `applyToSpellCast`
+base), `gatingApplies` checks nth-of-type-per-turn, and `applyToSpellCast`
 dispatches by modification kind. Face-down (`calculateFaceDownCost`) and morph
 (`calculateMorphCostIncrease`) walk the same scan with target-typed filters.
 `ReduceFaceDownCastingCost` was unused dead code and dropped entirely.

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 213 / 261
+**Implemented:** 214 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -246,7 +246,7 @@
 - [x] Tragic Trajectory
 - [x] Umbral Collar Zealot
 - [x] Unravel
-- [ ] Uthros Psionicist
+- [x] Uthros Psionicist
 - [x] Uthros Scanship
 - [x] Uthros, Titanic Godcore
 - [x] Vaultguard Trooper

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 214 / 261
+**Implemented:** 215 / 261
 ---
 
 - [x] Adagia, Windswept Bastion

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1026,6 +1026,38 @@ staticAbility {
 - `CantBeAttackedWithout(keyword)` — Form of the Dragon-style "Creatures without flying can't
   attack you." defender-side restriction.
 
+**Spell cost statics — `ModifySpellCost`**
+
+Replaces the per-shape cost classes. Use directly as the `ability` of a `staticAbility { }` block.
+
+```kotlin
+staticAbility {
+    ability = ModifySpellCost(
+        target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+        modification = CostModification.ReduceGeneric(2),
+        gating = CostGating.NthOfTypePerTurn(2),
+    )
+}
+```
+
+- `target: SpellCostTarget` — `SelfCast`, `YouCast(filter)`, `AnyCaster(filter)`,
+  `OpponentsCastTargeting(GroupFilter)`, `FaceDownYouCast`, `MorphActivation`.
+- `modification: CostModification` — `ReduceGeneric(amount)`, `ReduceGenericBy(source)`,
+  `ReduceColored(symbols)`, `ReduceColoredPerUnit(symbols, source)`, `IncreaseGeneric(amount)`,
+  `IncreaseGenericPerOtherSpellThisTurn(amountPerSpell)`, `IncreaseLife(amount)`.
+  Reduction `source: CostReductionSource` covers fixed amounts, counts of permanents/cards in
+  zones, target/condition gates, and a few mechanic-specific shapes — see
+  `CostStaticAbilities.kt` for the full list.
+- `gating: CostGating` — restricts how often the modifier fires:
+  - `None` (default) — applies to every matching cast.
+  - `FirstOfTypePerTurn` — only the first matching spell each turn (Eluge).
+  - `NthOfTypePerTurn(n)` — only when this is the Nth matching spell (1-indexed; counts the spell
+    currently being cast). For Uthros Psionicist's "the second spell you cast each turn costs {2}
+    less" use `NthOfTypePerTurn(2)` with `target = YouCast(GameObjectFilter.Any)`.
+
+`NthOfTypePerTurn` and `FirstOfTypePerTurn` require a filter-bearing target
+(`YouCast` / `AnyCaster`) — they need a notion of "type" to count.
+
 **Global denial statics** (no `filter`/`duration` block — they're singleton-style)
 
 - `PreventCycling` — "Players can't cycle cards." (Stabilizer)

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1050,13 +1050,13 @@ staticAbility {
   `CostStaticAbilities.kt` for the full list.
 - `gating: CostGating` — restricts how often the modifier fires:
   - `None` (default) — applies to every matching cast.
-  - `FirstOfTypePerTurn` — only the first matching spell each turn (Eluge).
-  - `NthOfTypePerTurn(n)` — only when this is the Nth matching spell (1-indexed; counts the spell
-    currently being cast). For Uthros Psionicist's "the second spell you cast each turn costs {2}
-    less" use `NthOfTypePerTurn(2)` with `target = YouCast(GameObjectFilter.Any)`.
+  - `NthOfTypePerTurn(n)` — only when this is the Nth matching spell each turn (1-indexed; counts the
+    spell currently being cast). Use `n = 1` for "the first ... each turn" (Eluge); use
+    `NthOfTypePerTurn(2)` with `target = YouCast(GameObjectFilter.Any)` for Uthros Psionicist's "the
+    second spell you cast each turn costs {2} less".
 
-`NthOfTypePerTurn` and `FirstOfTypePerTurn` require a filter-bearing target
-(`YouCast` / `AnyCaster`) — they need a notion of "type" to count.
+`NthOfTypePerTurn` requires a filter-bearing target (`YouCast` / `AnyCaster`) — it needs a notion
+of "type" to count.
 
 **Global denial statics** (no `filter`/`duration` block — they're singleton-style)
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/UthrosPsionicistScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/UthrosPsionicistScenarioTest.kt
@@ -135,6 +135,44 @@ class UthrosPsionicistScenarioTest : ScenarioTestBase() {
                     effective.cmc shouldBe 1
                 }
             }
+
+            test("cost increase applies before the reduction, flooring the generic at {0} (CR 601.2f)") {
+                // Glowrider taxes noncreature spells +{1}; Uthros reduces the second spell by {2}.
+                // Per CR 601.2f the total cost is the base cost plus increases minus reductions, and the
+                // generic component can't drop below {0}. Opt is {U} (0 generic): 0 + 1 − 2 floors to {0},
+                // leaving {U} (CMC 1). Applying the reduction before the increase would instead floor 0 − 2
+                // to {0} and then add {1}, giving {1}{U} (CMC 2) — so CMC 1 confirms the correct ordering.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Uthros Psionicist")
+                    .withCardOnBattlefield(1, "Glowrider") // Noncreature spells cost {1} more
+                    .withCardInHand(1, "Shock")
+                    .withCardInHand(1, "Opt") // {U}
+                    .withLandsOnBattlefield(1, "Mountain", 2) // Shock is taxed to {1}{R}
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // First spell of the turn (Shock — itself taxed to {1}{R} by Glowrider).
+                val shockResult = game.castSpellTargetingPlayer(1, "Shock", 2)
+                withClue("Shock should cast: ${shockResult.error}") {
+                    shockResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Opt is now the second spell: {U} +{1} (Glowrider) −{2} (Uthros), floored → {U}.
+                val opt = cardRegistry.getCard("Opt")!!
+                val costCalc = CostCalculator(cardRegistry)
+                val effective = costCalc.calculateEffectiveCost(game.state, opt, game.player1Id)
+
+                withClue("Second spell Opt: {U} +{1} −{2} floored at {0} → {U} (CMC 1)") {
+                    effective.cmc shouldBe 1
+                }
+            }
         }
     }
 }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/UthrosPsionicistScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/UthrosPsionicistScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Uthros Psionicist.
+ *
+ * Uthros Psionicist: {2}{U} Creature — Jellyfish Scientist 2/4
+ * "The second spell you cast each turn costs {2} less to cast."
+ *
+ * Per Scryfall ruling (2025-07-25), Uthros Psionicist itself counts toward the per-turn
+ * spell tally. If it's the first spell you cast this turn, your next spell is the second.
+ */
+class UthrosPsionicistScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Uthros Psionicist — second-spell cost reduction") {
+
+            test("first spell of the turn is not reduced") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Uthros Psionicist")
+                    .withCardInHand(1, "Divination") // {2}{U}
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val divination = cardRegistry.getCard("Divination")!!
+                val costCalc = CostCalculator(cardRegistry)
+                val effective = costCalc.calculateEffectiveCost(game.state, divination, game.player1Id)
+
+                withClue("First spell of the turn: Divination ({2}{U}) should cost its full CMC 3") {
+                    effective.cmc shouldBe 3
+                }
+            }
+
+            test("second spell of the turn costs {2} less") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Uthros Psionicist")
+                    .withCardInHand(1, "Shock")
+                    .withCardInHand(1, "Divination") // {2}{U}
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast the first spell of the turn (Shock) targeting Player2
+                val shockResult = game.castSpellTargetingPlayer(1, "Shock", 2)
+                withClue("Shock should cast normally: ${shockResult.error}") {
+                    shockResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Divination is now the second spell — reduced by {2}, so {U} instead of {2}{U}
+                val divination = cardRegistry.getCard("Divination")!!
+                val costCalc = CostCalculator(cardRegistry)
+                val effective = costCalc.calculateEffectiveCost(game.state, divination, game.player1Id)
+
+                withClue("Second spell: Divination ({2}{U}) should be reduced by {2} → CMC 1") {
+                    effective.cmc shouldBe 1
+                }
+            }
+
+            test("third spell of the turn is not reduced") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Uthros Psionicist")
+                    .withCardInHand(1, "Shock")
+                    .withCardInHand(1, "Opt") // {U}
+                    .withCardInHand(1, "Divination") // {2}{U}
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast two spells first so Divination becomes the third.
+                game.castSpellTargetingPlayer(1, "Shock", 2)
+                game.resolveStack()
+                game.castSpell(1, "Opt")
+                game.resolveStack()
+
+                val divination = cardRegistry.getCard("Divination")!!
+                val costCalc = CostCalculator(cardRegistry)
+                val effective = costCalc.calculateEffectiveCost(game.state, divination, game.player1Id)
+
+                withClue("Third spell: Divination ({2}{U}) should cost its full CMC 3") {
+                    effective.cmc shouldBe 3
+                }
+            }
+
+            test("Uthros Psionicist itself counts as a cast spell") {
+                // Uthros is the first spell of the turn — its own static ability is active
+                // once it's on the battlefield, so the next spell qualifies as the "second".
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Uthros Psionicist") // {2}{U}
+                    .withCardInHand(1, "Divination")        // {2}{U}
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val uthrosResult = game.castSpell(1, "Uthros Psionicist")
+                withClue("Uthros should cast: ${uthrosResult.error}") {
+                    uthrosResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Uthros is on the battlefield and was the first cast spell. Divination is the second.
+                val divination = cardRegistry.getCard("Divination")!!
+                val costCalc = CostCalculator(cardRegistry)
+                val effective = costCalc.calculateEffectiveCost(game.state, divination, game.player1Id)
+
+                withClue("Second spell after casting Uthros: Divination reduced to {U} → CMC 1") {
+                    effective.cmc shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/u/uthros-psionicist.json
+++ b/manual-scenarios/cards/u/uthros-psionicist.json
@@ -1,0 +1,33 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Divination", "Divination", "Opt"],
+    "battlefield": [
+      {"name": "Uthros Psionicist"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island", "Island", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -35,12 +35,11 @@ data class ModifySpellCost(
             CostGating.None -> ""
         }
         // A gated description ("The Nth ...") refers to a single spell, so phrase it in the singular.
+        val noun = if (gated) "spell" else "spells"
         val subject = when (target) {
             SpellCostTarget.SelfCast -> "This spell"
-            is SpellCostTarget.YouCast ->
-                "${target.filter.description} ${if (gated) "spell" else "spells"} you cast"
-            is SpellCostTarget.AnyCaster ->
-                "${target.filter.description} ${if (gated) "spell" else "spells"}"
+            is SpellCostTarget.YouCast -> "${filterAdjective(target.filter)}$noun you cast"
+            is SpellCostTarget.AnyCaster -> "${filterAdjective(target.filter)}$noun"
             is SpellCostTarget.OpponentsCastTargeting ->
                 "Spells your opponents cast that target ${target.targetFilter.description}"
             SpellCostTarget.FaceDownYouCast -> "Face-down creature spells you cast"
@@ -65,6 +64,14 @@ data class ModifySpellCost(
         val agreedVerb = if (gated) verb.replaceFirst("cost ", "costs ") else verb
         val prefix = if (gate.isNotEmpty()) gate + subject.replaceFirstChar { it.lowercase() } else subject
         return "$prefix $agreedVerb$perTurn"
+    }
+
+    // A filter that narrows nothing (e.g. GameObjectFilter.Any) describes itself as "card", which
+    // reads wrong as an adjective ("the second card spell you cast"). Emit no adjective in that case
+    // so the unconstrained form is just "spell(s)".
+    private fun filterAdjective(filter: GameObjectFilter): String {
+        val desc = filter.description
+        return if (desc.isBlank() || desc == "card") "" else "$desc "
     }
 
     private fun ordinal(n: Int): String = when (n) {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -29,7 +29,11 @@ data class ModifySpellCost(
     override val description: String = buildDescription()
 
     private fun buildDescription(): String {
-        val gate = if (gating == CostGating.FirstOfTypePerTurn) "The first " else ""
+        val gate = when (gating) {
+            CostGating.FirstOfTypePerTurn -> "The first "
+            is CostGating.NthOfTypePerTurn -> "The ${ordinal(gating.n)} "
+            CostGating.None -> ""
+        }
         val subject = when (target) {
             SpellCostTarget.SelfCast -> "This spell"
             is SpellCostTarget.YouCast -> "${target.filter.description} spells you cast"
@@ -50,9 +54,30 @@ data class ModifySpellCost(
                 "cost {${modification.amountPerSpell}} more to cast for each other spell that player has cast this turn"
             is CostModification.IncreaseLife -> "cost an additional ${modification.amount} life to cast"
         }
-        val firstOfType = if (gating == CostGating.FirstOfTypePerTurn) " each turn" else ""
+        val perTurn = when (gating) {
+            CostGating.FirstOfTypePerTurn, is CostGating.NthOfTypePerTurn -> " each turn"
+            CostGating.None -> ""
+        }
         val prefix = if (gate.isNotEmpty()) gate + subject.replaceFirstChar { it.lowercase() } else subject
-        return "$prefix $verb$firstOfType"
+        return "$prefix $verb$perTurn"
+    }
+
+    private fun ordinal(n: Int): String = when (n) {
+        1 -> "first"
+        2 -> "second"
+        3 -> "third"
+        4 -> "fourth"
+        5 -> "fifth"
+        else -> {
+            val suffix = when {
+                n % 100 in 11..13 -> "th"
+                n % 10 == 1 -> "st"
+                n % 10 == 2 -> "nd"
+                n % 10 == 3 -> "rd"
+                else -> "th"
+            }
+            "$n$suffix"
+        }
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
@@ -215,6 +240,16 @@ sealed interface CostGating {
     @SerialName("FirstOfTypePerTurn")
     @Serializable
     data object FirstOfTypePerTurn : CostGating
+
+    /**
+     * Modifier applies only when the matching spell being cast is the Nth such spell the casting
+     * player has cast this turn (1-indexed; counts itself). For Uthros Psionicist's
+     * "The second spell you cast each turn costs {2} less to cast", use [NthOfTypePerTurn] with
+     * `n = 2`.
+     */
+    @SerialName("NthOfTypePerTurn")
+    @Serializable
+    data class NthOfTypePerTurn(val n: Int) : CostGating
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -29,15 +29,18 @@ data class ModifySpellCost(
     override val description: String = buildDescription()
 
     private fun buildDescription(): String {
+        val gated = gating != CostGating.None
         val gate = when (gating) {
-            CostGating.FirstOfTypePerTurn -> "The first "
             is CostGating.NthOfTypePerTurn -> "The ${ordinal(gating.n)} "
             CostGating.None -> ""
         }
+        // A gated description ("The Nth ...") refers to a single spell, so phrase it in the singular.
         val subject = when (target) {
             SpellCostTarget.SelfCast -> "This spell"
-            is SpellCostTarget.YouCast -> "${target.filter.description} spells you cast"
-            is SpellCostTarget.AnyCaster -> "${target.filter.description} spells"
+            is SpellCostTarget.YouCast ->
+                "${target.filter.description} ${if (gated) "spell" else "spells"} you cast"
+            is SpellCostTarget.AnyCaster ->
+                "${target.filter.description} ${if (gated) "spell" else "spells"}"
             is SpellCostTarget.OpponentsCastTargeting ->
                 "Spells your opponents cast that target ${target.targetFilter.description}"
             SpellCostTarget.FaceDownYouCast -> "Face-down creature spells you cast"
@@ -55,11 +58,13 @@ data class ModifySpellCost(
             is CostModification.IncreaseLife -> "cost an additional ${modification.amount} life to cast"
         }
         val perTurn = when (gating) {
-            CostGating.FirstOfTypePerTurn, is CostGating.NthOfTypePerTurn -> " each turn"
+            is CostGating.NthOfTypePerTurn -> " each turn"
             CostGating.None -> ""
         }
+        // The gated subject is singular, so make the verb agree ("cost" -> "costs").
+        val agreedVerb = if (gated) verb.replaceFirst("cost ", "costs ") else verb
         val prefix = if (gate.isNotEmpty()) gate + subject.replaceFirstChar { it.lowercase() } else subject
-        return "$prefix $verb$perTurn"
+        return "$prefix $agreedVerb$perTurn"
     }
 
     private fun ordinal(n: Int): String = when (n) {
@@ -234,18 +239,10 @@ sealed interface CostGating {
     data object None : CostGating
 
     /**
-     * Modifier applies only to the first matching spell the casting player casts each turn
-     * (e.g. Eluge's "the first instant or sorcery spell you cast each turn").
-     */
-    @SerialName("FirstOfTypePerTurn")
-    @Serializable
-    data object FirstOfTypePerTurn : CostGating
-
-    /**
      * Modifier applies only when the matching spell being cast is the Nth such spell the casting
-     * player has cast this turn (1-indexed; counts itself). For Uthros Psionicist's
-     * "The second spell you cast each turn costs {2} less to cast", use [NthOfTypePerTurn] with
-     * `n = 2`.
+     * player has cast this turn (1-indexed; counts itself). Use `n = 1` for "the first ... each
+     * turn" (e.g. Eluge) and `n = 2` for Uthros Psionicist's "the second spell you cast each turn
+     * costs {2} less to cast".
      */
     @SerialName("NthOfTypePerTurn")
     @Serializable

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/ModifySpellCostDescriptionTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/ModifySpellCostDescriptionTest.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.sdk.scripting
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class ModifySpellCostDescriptionTest : DescribeSpec({
+
+    describe("ModifySpellCost.description with NthOfTypePerTurn gating") {
+
+        it("renders the unconstrained Any filter without a leaked 'card' adjective (Uthros Psionicist)") {
+            val ability = ModifySpellCost(
+                target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+                modification = CostModification.ReduceGeneric(2),
+                gating = CostGating.NthOfTypePerTurn(2),
+            )
+            ability.description shouldBe "The second spell you cast costs {2} less to cast each turn"
+        }
+
+        it("keeps the filter adjective for a typed filter (Eluge, the Shoreless Sea)") {
+            val ability = ModifySpellCost(
+                target = SpellCostTarget.YouCast(GameObjectFilter.InstantOrSorcery),
+                modification = CostModification.ReduceColored("{U}"),
+                gating = CostGating.NthOfTypePerTurn(1),
+            )
+            ability.description shouldBe
+                "The first instant or sorcery spell you cast costs {U} less to cast each turn"
+        }
+
+        it("keeps the plural form when ungated") {
+            val ability = ModifySpellCost(
+                target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+                modification = CostModification.ReduceGeneric(1),
+            )
+            ability.description shouldBe "spells you cast cost {1} less to cast"
+        }
+    }
+})

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ElugeTheShoreslessSea.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ElugeTheShoreslessSea.kt
@@ -74,7 +74,7 @@ val ElugeTheShoreslessSea = card("Eluge, the Shoreless Sea") {
                     counterType = Counters.FLOOD,
                 ),
             ),
-            gating = CostGating.FirstOfTypePerTurn,
+            gating = CostGating.NthOfTypePerTurn(1),
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/UthrosPsionicist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/UthrosPsionicist.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Uthros Psionicist
+ * {2}{U}
+ * Creature — Jellyfish Scientist
+ * 2/4
+ *
+ * The second spell you cast each turn costs {2} less to cast.
+ *
+ * Rulings (Scryfall, 2025-07-25):
+ * - Cost reduction is applied after cost increases (CR 601.2f).
+ * - Uthros Psionicist itself counts toward the per-turn spell tally. If it was the first spell
+ *   you cast this turn, the next spell you cast is your second.
+ */
+val UthrosPsionicist = card("Uthros Psionicist") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Jellyfish Scientist"
+    oracleText = "The second spell you cast each turn costs {2} less to cast."
+    power = 2
+    toughness = 4
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.NthOfTypePerTurn(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Inkognit"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e23cc5fd-afe4-480c-8858-ed80a082584e.jpg?1752946892"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -248,19 +248,26 @@ class CostCalculator(
         cardDef: CardDefinition,
         ability: ModifySpellCost,
     ): Boolean {
-        return when (ability.gating) {
+        return when (val gating = ability.gating) {
             CostGating.None -> true
             CostGating.FirstOfTypePerTurn -> {
-                val target = ability.target
-                val filter = when (target) {
-                    is SpellCostTarget.YouCast -> target.filter
-                    is SpellCostTarget.AnyCaster -> target.filter
-                    else -> return false  // Gating requires a filter to know what "of type" means.
-                }
+                val filter = filterForGating(ability.target) ?: return false
                 val records = state.spellsCastThisTurnByPlayer[casterId] ?: emptyList()
                 records.none { predicateEvaluator.matchesFilter(it, filter) }
             }
+            is CostGating.NthOfTypePerTurn -> {
+                val filter = filterForGating(ability.target) ?: return false
+                val records = state.spellsCastThisTurnByPlayer[casterId] ?: emptyList()
+                val priorMatching = records.count { predicateEvaluator.matchesFilter(it, filter) }
+                priorMatching == gating.n - 1
+            }
         }
+    }
+
+    private fun filterForGating(target: SpellCostTarget) = when (target) {
+        is SpellCostTarget.YouCast -> target.filter
+        is SpellCostTarget.AnyCaster -> target.filter
+        else -> null  // Gating requires a filter to know what "of type" means.
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -111,15 +111,18 @@ class CostCalculator(
         // Commander tax (CR 903.8).
         totalIncrease += calculateCommanderTax(state, cardDef, casterId, fromZone)
 
-        // Apply: generic reduction → colored reduction (no overflow) → colored reduction (with overflow) → generic increase.
-        var effectiveCost = reduceGenericCost(cardDef.manaCost, totalReduction)
+        // CR 601.2f: the total cost is the base cost plus all cost increases, then minus all cost
+        // reductions; the mana component is floored at {0} (it can't be reduced below {0}). Apply
+        // increases first so a reduction that overshoots {0} doesn't leave a stale increase behind
+        // (e.g. {U} +{1} −{2} → {U}, not {1}{U}).
+        var effectiveCost = increaseGenericCost(cardDef.manaCost, totalIncrease)
+        effectiveCost = reduceGenericCost(effectiveCost, totalReduction)
         if (coloredReductionSymbols.isNotEmpty()) {
             effectiveCost = reduceColoredCost(effectiveCost, coloredReductionSymbols)
         }
         if (coloredReductionWithOverflow.isNotEmpty()) {
             effectiveCost = reduceColoredCostWithOverflow(effectiveCost, coloredReductionWithOverflow)
         }
-        effectiveCost = increaseGenericCost(effectiveCost, totalIncrease)
         return effectiveCost
     }
 
@@ -250,11 +253,6 @@ class CostCalculator(
     ): Boolean {
         return when (val gating = ability.gating) {
             CostGating.None -> true
-            CostGating.FirstOfTypePerTurn -> {
-                val filter = filterForGating(ability.target) ?: return false
-                val records = state.spellsCastThisTurnByPlayer[casterId] ?: emptyList()
-                records.none { predicateEvaluator.matchesFilter(it, filter) }
-            }
             is CostGating.NthOfTypePerTurn -> {
                 val filter = filterForGating(ability.target) ?: return false
                 val records = state.spellsCastThisTurnByPlayer[casterId] ?: emptyList()


### PR DESCRIPTION

## Summary

Implements **Uthros Psionicist** (EOE) — `{2}{U}` 2/4 Jellyfish Scientist whose
static ability reads "The second spell you cast each turn costs {2} less to cast."

Supporting this card required generalizing the existing cost-gating primitive and
correcting cost-calculation ordering:

- **`CostGating.FirstOfTypePerTurn` → `CostGating.NthOfTypePerTurn(n)`.** The old
  boolean "first spell" gate becomes a 1-indexed Nth-spell gate. Eluge, the
  Shoreless Sea migrates to `NthOfTypePerTurn(1)` (no behavior change); Uthros uses
  `NthOfTypePerTurn(2)`. `gatingApplies` now counts prior matching spells this turn
  and fires when the count equals `n - 1`.
- **Cost ordering fixed per CR 601.2f.** `calculateEffectiveCost` now applies cost
  *increases* before *reductions*, with the generic component floored at `{0}`.
  Previously reductions ran first, which could leave a stale increase behind
  (`{U}` +{1} −{2} incorrectly yielded `{1}{U}` instead of `{U}`).
- **Description generation** handles the Nth-ordinal phrasing and singular/verb
  agreement ("The second ... spell you cast ... costs ... each turn").

Uthros itself counts toward the per-turn tally (per Scryfall ruling 2025-07-25):
if it's the first spell cast this turn, the next spell is the "second".

## Changes

- New card: `eoe/cards/UthrosPsionicist.kt` (+ manual scenario JSON)
- `CostStaticAbilities.kt` — `NthOfTypePerTurn(n)`, ordinal/agreement in descriptions
- `CostCalculator.kt` — CR 601.2f ordering, `filterForGating` helper
- `ElugeTheShoreslessSea.kt` — migrated to `NthOfTypePerTurn(1)`
- Docs: `card-sdk-language-reference.md` `ModifySpellCost` section
- Backlog: EOE marked 215/261
