### PR TITLE
Edge of Eternities: add 20 booster cards, document remaining blockers

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 234 / 261
+**Implemented:** 235 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -111,7 +111,7 @@
 - [x] Illvoi Infiltrator
 - [x] Illvoi Light Jammer
 - [x] Illvoi Operative
-- [ ] Infinite Guideline Station
+- [x] Infinite Guideline Station
 - [x] Insatiable Skittermaw
 - [x] Interceptor Mechan
 - [x] Intrepid Tenderfoot

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 218 / 261
+**Implemented:** 219 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -117,7 +117,7 @@
 - [x] Intrepid Tenderfoot
 - [x] Invasive Maneuvers
 - [x] Kavaron Harrier
-- [ ] Kavaron, Memorial World
+- [x] Kavaron, Memorial World
 - [x] Kavaron Skywarden
 - [x] Kavaron Turbodrone
 - [ ] Kav Landseeker

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -126,7 +126,7 @@
 - [x] Lashwhip Predator
 - [x] Lightless Evangel
 - [ ] Lightstall Inquisitor
-- [ ] Lithobraking
+- [x] Lithobraking
 - [x] Loading Zone
 - [x] Lost in Space
 - [x] Lumen-Class Frigate

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 225 / 261
+**Implemented:** 226 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -175,7 +175,7 @@
 - [x] Remnant Elemental
 - [x] Requiem Monolith
 - [x] Reroute Systems
-- [ ] Rescue Skiff
+- [x] Rescue Skiff
 - [x] Rig for War
 - [ ] Roving Actuator
 - [x] Ruinous Rampage

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 228 / 261
+**Implemented:** 229 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -136,7 +136,7 @@
 - [x] Mechanozoa
 - [x] Mechan Shieldmate
 - [x] Melded Moxite
-- [ ] Meltstrider Eulogist
+- [x] Meltstrider Eulogist
 - [x] Meltstrider's Gear
 - [x] Meltstrider's Resolve
 - [x] Memorial Team Leader

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 215 / 261
+**Implemented:** 218 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -79,7 +79,7 @@
 - [x] Famished Worldsire
 - [x] Fell Gravship
 - [x] Flight-Deck Coordinator
-- [ ] Focus Fire
+- [x] Focus Fire
 - [x] Frenzied Baloth
 - [ ] Frontline War-Rager
 - [x] Full Bore

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 223 / 261
+**Implemented:** 224 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -208,7 +208,7 @@
 - [x] Starfield Vocalist
 - [x] Starfighter Pilot
 - [x] Starport Security
-- [ ] Starwinder
+- [x] Starwinder
 - [ ] Station Monitor
 - [x] Steelswarm Operator
 - [x] Stomping Ground

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 229 / 261
+**Implemented:** 230 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -182,7 +182,7 @@
 - [x] Rust Harvester
 - [x] Sacred Foundry
 - [x] Sami's Curiosity
-- [ ] Sami, Ship's Engineer
+- [x] Sami, Ship's Engineer
 - [ ] Sami, Wildcat Captain
 - [x] Scour for Scrap
 - [x] Scout for Survivors

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 221 / 261
+**Implemented:** 222 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -213,7 +213,7 @@
 - [x] Steelswarm Operator
 - [x] Stomping Ground
 - [x] Sunset Saboteur
-- [ ] Sunstar Chaplain
+- [x] Sunstar Chaplain
 - [x] Sunstar Expansionist
 - [x] Sunstar Lightsmith
 - [x] Survey Mechan

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 219 / 261
+**Implemented:** 220 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -81,7 +81,7 @@
 - [x] Flight-Deck Coordinator
 - [x] Focus Fire
 - [x] Frenzied Baloth
-- [ ] Frontline War-Rager
+- [x] Frontline War-Rager
 - [x] Full Bore
 - [x] Fungal Colossus
 - [x] Galactic Wayfarer

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 226 / 261
+**Implemented:** 227 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -242,7 +242,7 @@
 - [x] The Seriema
 - [ ] Thrumming Hivepool
 - [x] Timeline Culler
-- [ ] Tractor Beam
+- [x] Tractor Beam
 - [x] Tragic Trajectory
 - [x] Umbral Collar Zealot
 - [x] Unravel

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 220 / 261
+**Implemented:** 221 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -48,7 +48,7 @@
 - [x] Dark Endurance
 - [x] Dauntless Scrapbot
 - [x] Dawnsire, Sunstar Dreadnought
-- [ ] Dawnstrike Vanguard
+- [x] Dawnstrike Vanguard
 - [x] Debris Field Crusher
 - [x] Decode Transmissions
 - [x] Depressurize

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 231 / 261
+**Implemented:** 232 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -209,7 +209,7 @@
 - [x] Starfighter Pilot
 - [x] Starport Security
 - [x] Starwinder
-- [ ] Station Monitor
+- [x] Station Monitor
 - [x] Steelswarm Operator
 - [x] Stomping Ground
 - [x] Sunset Saboteur

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 233 / 261
+**Implemented:** 234 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -122,7 +122,7 @@
 - [x] Kavaron Turbodrone
 - [ ] Kav Landseeker
 - [x] Knight Luminary
-- [ ] Larval Scoutlander
+- [x] Larval Scoutlander
 - [x] Lashwhip Predator
 - [x] Lightless Evangel
 - [ ] Lightstall Inquisitor

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 224 / 261
+**Implemented:** 225 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -254,7 +254,7 @@
 - [x] Virus Beetle
 - [x] Voidforged Titan
 - [x] Vote Out
-- [ ] Warmaker Gunship
+- [x] Warmaker Gunship
 - [x] Watery Grave
 - [ ] Weapons Manufacturing
 - [x] Wedgelight Rammer

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 222 / 261
+**Implemented:** 223 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -130,7 +130,7 @@
 - [x] Loading Zone
 - [x] Lost in Space
 - [x] Lumen-Class Frigate
-- [ ] Luxknight Breacher
+- [x] Luxknight Breacher
 - [x] Mechan Assembler
 - [x] Mechan Navigator
 - [x] Mechanozoa

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -219,7 +219,7 @@
 - [x] Survey Mechan
 - [x] Susurian Dirgecraft
 - [x] Susurian Voidborn
-- [ ] Susur Secundi, Void Altar
+- [x] Susur Secundi, Void Altar
 - [x] Swarm Culler
 - [x] Synthesizer Labship
 - [x] Syr Vondam, Sunstar Exemplar

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 232 / 261
+**Implemented:** 233 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -86,7 +86,7 @@
 - [x] Fungal Colossus
 - [x] Galactic Wayfarer
 - [x] Galvanizing Sawship
-- [ ] Genemorph Imago
+- [x] Genemorph Imago
 - [x] Gene Pollinator
 - [x] Germinating Wurm
 - [x] Gigastorm Titan

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 227 / 261
+**Implemented:** 228 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -39,7 +39,7 @@
 - [x] Codecracker Hound
 - [x] Comet Crawler
 - [ ] Command Bridge
-- [ ] Consult the Star Charts
+- [x] Consult the Star Charts
 - [ ] Cosmogoyf
 - [x] Cosmogrand Zenith
 - [x] Cryogen Relic

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 230 / 261
+**Implemented:** 231 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -58,7 +58,7 @@
 - [x] Divert Disaster
 - [x] Dockworker Drone
 - [x] Drill Too Deep
-- [ ] Drix Fatemaker
+- [x] Drix Fatemaker
 - [x] Dual-Sun Adepts
 - [x] Dual-Sun Technique
 - [x] Dubious Delicacy

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -1,93 +1,348 @@
 # Edge of Eternities (EOE) - Missing Effects & Implementation Plan
 
-This document lists engine features required to implement EOE cards that do not yet exist in the
-Argentum Engine, ordered by priority (number of cards unblocked).
+Engine features required to implement the remaining EOE cards. Each section lists the cards it
+unblocks, the exact oracle clause that can't be expressed with current primitives, and a sketch of
+the engine/SDK work needed.
+
+As of the latest pass, **235 / 261** booster cards are implemented. The 26 cards below remain
+blocked on the engine features listed here. Cards whose every clause maps to an existing primitive
+have already been implemented and are not listed.
 
 ---
 
-## 5. Poison Counters
+## 1. Conditional draw-replacement static
 
-**Cards affected:** 1 (Virulent Silencer), but also Thrumming Hivepool (Slivers) could enable
-future poison cards.
+**Cards:** Quantum Riddler.
 
-**Rules:** "That player gets two poison counters. A player with ten or more poison counters loses
-the game."
+**Clause:** "As long as you have one or fewer cards in hand, if you would draw one or more cards,
+you draw that many cards plus one instead."
 
-**Implementation plan:**
-
-1. **rules-engine:** Add `PoisonCounterComponent` to player entities tracking poison count.
-2. **rules-engine:** Add `AddPoisonCountersEffect` and corresponding executor.
-3. **rules-engine:** Add state-based action: "A player with 10+ poison counters loses the game."
-4. **game-server:** Expose poison counter count in `MaskedGameState` / client DTOs.
-5. **web-client:** Display poison counter count in player info panel.
-
-**Dependencies:** None.
+**Plan:** Add a continuous draw-replacement static ability that intercepts draw events for its
+controller, adds a fixed amount, and is gated by a `Condition` (hand-size). The flying body, the
+ETB "draw a card", and `Warp {1}{U}` are all already expressible — only the replacement static is
+missing.
 
 ---
 
-## 7. Token Doubling (Replacement Effect)
+## 2. "Was dealt damage this turn" tracking
 
-**Cards affected:** 1 (Exalted Sunborn).
+**Cards:** Faller's Faithful.
 
-**Rules:** "If one or more tokens would be created under your control, twice that many of those
-tokens are created instead."
+**Clause:** "If that creature wasn't dealt damage this turn, its controller draws two cards."
 
-**Implementation plan:**
-
-1. **rules-engine:** Add a replacement effect that intercepts `CreateTokenEffect` execution.
-   When the controller has a token-doubling continuous effect, double the token count.
-2. **mtg-sdk:** Add a static ability type: `DoubleTokenCreation`.
-
-**Dependencies:** None, but replacement effect infrastructure for token creation may need work.
+**Plan:** Track per-permanent "damaged this turn" state (cleared at cleanup) and expose it as a
+`Condition` usable on a context target. The ETB "destroy up to one target creature" is already
+expressible; only the damage-history conditional is missing.
 
 ---
 
-## 8. Devour (Land Variant)
+## 3. Excess-damage detection
 
-**Cards affected:** 1 (Famished Worldsire).
+**Cards:** Orbital Plunge.
 
-**Rules:** "Devour land 3 — As this enters, you may sacrifice any number of lands. It enters with
-three times that many +1/+1 counters."
+**Clause:** "If excess damage was dealt this way, create a Lander token."
 
-**Implementation plan:**
-
-1. **mtg-sdk:** Extend existing `Devour` keyword (if creature-only) to support a filter parameter
-   (lands vs creatures).
-2. **rules-engine:** Modify devour handler to accept a `GameObjectFilter` for what can be
-   sacrificed, rather than hardcoding creatures.
-
-**Dependencies:** Check if standard Devour (creatures) is already implemented.
+**Plan:** Add a way for a damage effect to report whether it dealt damage in excess of lethal
+(toughness minus marked damage), surfaced as a condition or follow-up trigger. The base "deals 6
+damage to target creature" and `Effects.CreateLander()` already exist.
 
 ---
 
-## 12. "Mana Spent to Cast" Tracking
+## 4. Targeting cards in the warp-exile zone
 
-**Cards affected:** 2+ (Dyadrine enters with counters equal to mana spent; Astelli Reclaimer uses
-X = mana spent).
+**Cards:** Blade of the Swarm.
 
-**Rules:** Track the total mana spent to cast a spell (not just X value).
+**Clause:** "Put target exiled card with warp on the bottom of its owner's library."
 
-**Implementation plan:**
-
-1. **rules-engine:** Store `manaSpentToCast` on spells/permanents when cast. This may already be
-   partially tracked for X spells.
-2. **mtg-sdk:** Add `DynamicAmount.ManaSpentToCast` for use in ETB effects.
-
-**Dependencies:** None.
+**Plan:** Make cards exiled with warp targetable: a `TargetFilter` for "exiled card with warp" plus
+a move-to-library-bottom effect for an exile-zone target. The modal "two +1/+1 counters" branch is
+already expressible.
 
 ---
 
-## Implementation Order (Recommended)
+## 5. Continuous "your creatures enter with extra counters" + lands-entered-this-turn tracker
 
-| Phase | Feature                    | Cards Unblocked | Effort |
-|-------|----------------------------|-----------------|--------|
-| 7     | Mana spent tracking        | ~2              | Small  |
-| 8     | Poison counters            | ~1              | Medium |
-| 9     | Stun counters              | ~1              | Small  |
-| 10    | Token doubling             | ~1              | Medium |
-| 11    | Devour (land variant)      | ~1              | Small  |
-| 12    | Mindslaver                 | ~1              | Huge   |
+**Cards:** Bioengineered Future.
 
-After phases 1-5, the majority of EOE cards become implementable using existing engine effects
-(ETB triggers, +1/+1 counters, destroy, exile, draw, mill, surveil, kicker, convoke, equip,
-landfall, combat damage triggers, etc.).
+**Clause:** "Each creature you control enters with an additional +1/+1 counter on it for each land
+that entered the battlefield under your control this turn."
+
+**Plan:** (a) Add a `TurnTracker`/`DynamicAmount` for "lands that entered under your control this
+turn". (b) Add a continuous static replacement that adds ETB +1/+1 counters to *other* creatures
+you control (not just self), with a dynamic count. The "create a Lander" ETB is already
+expressible.
+
+---
+
+## 6. `DynamicAmount` = mana spent to cast (usable in ETB replacement)
+
+**Cards:** Dyadrine, Synthesis Amalgam.
+
+**Clause:** "Dyadrine enters with a number of +1/+1 counters on it equal to the amount of mana spent
+to cast it."
+
+**Plan:** Persist `manaSpentToCast` on the permanent and expose a `DynamicAmount` that
+`EntersWithDynamicCounters` can read (today `TotalManaSpent` is only meaningful during cast
+resolution). The attack ability ("remove a +1/+1 counter from each of two creatures you control;
+if you do, draw a card and create a Robot token") is close to expressible but depends on a
+"remove a counter from each of N chosen creatures" cost/effect — verify before implementing.
+
+---
+
+## 7. Characteristic-defining P/T from cards in exile
+
+**Cards:** Cosmogoyf.
+
+**Clause:** "Cosmogoyf's power is equal to the number of cards you own in exile and its toughness is
+equal to that number plus 1."
+
+**Plan:** Add a `DynamicAmount` that counts cards a player owns across all exile sub-zones, then use
+it as a characteristic-defining P/T (Layer 7b set-base from a dynamic value, applied in all zones).
+
+---
+
+## 7b. Land: "sacrifice unless you tap an untapped permanent"
+
+**Cards:** Command Bridge.
+
+**Clause:** "When this land enters, sacrifice it unless you tap an untapped permanent you control."
+
+**Plan:** Add an ETB "sacrifice this unless you pay <cost>" intervening-choice effect where the
+alternative cost is tapping an untapped permanent you control. The "enters tapped" and the
+any-color mana ability are already expressible.
+
+---
+
+## 8. Delayed trigger that always fires on the controller's *next* turn's end step
+
+**Cards:** Kav Landseeker.
+
+**Clause:** "At the beginning of the end step on your next turn, sacrifice that token."
+
+**Plan:** `CreateDelayedTriggerEffect.onControllerNextTurn` fires at the *next upcoming* end step on
+the controller's turn — i.e. it fires *this* turn if the current-turn end step hasn't started. Add a
+flag/variant that unconditionally skips the current turn and fires on the controller's following
+turn's end step. The Menace body and the ETB "create a Lander" are already expressible.
+
+---
+
+## 9. Impulse "exile from top until a nonland card, you may cast it this turn"
+
+**Cards:** Territorial Bruntar.
+
+**Clause:** "Whenever a land you control enters, exile cards from the top of your library until you
+exile a nonland card. You may cast that card this turn."
+
+**Plan:** Add an effect/pattern that exiles from the top until a nonland card is hit and grants
+may-play-this-turn on it (`GrantMayPlayFromExileEffect`). `ExileFromTopRepeatingEffect` puts the
+card into hand and doesn't grant impulse, so it can't be reused. Reach and the landfall trigger are
+already expressible.
+
+---
+
+## 10. Dynamic-toughness mass destroy + reanimate-from-batch
+
+**Cards:** Zero Point Ballad.
+
+**Clause:** "Destroy all creatures with toughness X or less. ... If X is 6 or more, return a creature
+card put into a graveyard this way to the battlefield under your control."
+
+**Plan:** (a) `GameObjectFilter.toughnessAtMost` only accepts a fixed `Int`; add a dynamic-threshold
+variant (`toughnessAtMost(DynamicAmount)`) so the destroy filter can read X. (b) Track which
+creatures were put into a graveyard by this destruction and allow selecting one to return when
+X ≥ 6. "Lose X life" is already expressible.
+
+---
+
+## 11. Noncreature artifact tokens with custom names + embedded triggered abilities
+
+**Cards:** Weapons Manufacturing.
+
+**Clause:** "create a colorless artifact token named Munitions with 'When this token leaves the
+battlefield, it deals 2 damage to any target.'"
+
+**Plan:** `CreateTokenExecutor` hardcodes "Creature" into every token's type line, so it can only make
+creature tokens. Either (a) add a predefined "Munitions" token CardDefinition (noncreature artifact
+with the leaves-battlefield damage trigger) to `PredefinedTokens.kt` and create it via
+`CreatePredefinedTokenEffect`, or (b) generalize token creation to allow a noncreature type line +
+embedded triggered abilities. The "whenever a nontoken artifact you control enters" trigger is
+already expressible.
+
+---
+
+## 12. Opponent exiles from hand and may play it (with cost/tapped modifiers)
+
+**Cards:** Lightstall Inquisitor.
+
+**Clause:** "each opponent exiles a card from their hand and may play that card for as long as it
+remains exiled. Each spell cast this way costs {1} more to cast. Each land played this way enters
+tapped."
+
+**Plan:** Add an opponent-targeted "exile a card from hand, grant the *owner* may-play from exile"
+effect, plus a cost increase on those specific cards and a lands-enter-tapped modifier scoped to
+them. Vigilance is already expressible.
+
+---
+
+## 13. Token-creation replacement: copies of a chosen permanent (once per turn)
+
+**Cards:** Moonlit Meditation.
+
+**Clause:** "The first time you would create one or more tokens each turn, you may instead create
+that many tokens that are copies of enchanted permanent."
+
+**Plan:** Add a replacement effect on `CreateTokenEffect` that, once per turn, optionally swaps the
+created tokens for copies of the enchanted permanent. Requires once-per-turn gating and an
+aura-attached "copy of enchanted permanent" token source.
+
+---
+
+## 14. Affinity granted to the spells you cast / affinity for a subtype
+
+**Cards:** Sami, Wildcat Captain (affinity for artifacts on all your spells);
+Thrumming Hivepool (affinity for Slivers on itself).
+
+**Clause:** "Spells you cast have affinity for artifacts." / "Affinity for Slivers."
+
+**Plan:** Affinity for artifacts exists as a per-card keyword, but (a) granting it to *all spells a
+player casts* via a static, and (b) an affinity-for-`<subtype>` variant, are both missing. Sami's
+double strike + vigilance and Hivepool's Sliver anthem / upkeep Sliver tokens are already
+expressible.
+
+---
+
+## 15. Grant the Warp alternative-cast cost to cards in hand
+
+**Cards:** Tannuk, Steadfast Second.
+
+**Clause:** "Artifact cards and red creature cards in your hand have warp {2}{R}."
+
+**Plan:** Add a static that grants the Warp keyword (with a specified cost) to cards in hand matching
+a filter. "Other creatures you control have haste" is already expressible.
+
+---
+
+## 16. Put a permanent from hand, then grant it arbitrary abilities
+
+**Cards:** Terminal Velocity.
+
+**Clause:** "You may put an artifact or creature card from your hand onto the battlefield. That
+permanent gains haste, 'When this permanent leaves the battlefield, it deals damage equal to its
+mana value to each creature,' and 'At the beginning of your end step, sacrifice this permanent.'"
+
+**Plan:** Add a way to grant a bundle of abilities (a triggered LTB ability + a self-sac end-step
+trigger + haste) to a specific permanent put onto the battlefield. Put-from-hand exists; granting a
+*new triggered ability* to a target permanent does not.
+
+---
+
+## 17. Once-per-turn gating for triggered abilities (counters-placed → draw)
+
+**Cards:** Terrasymbiosis.
+
+**Clause:** "Whenever you put one or more +1/+1 counters on a creature you control, you may draw that
+many cards. Do this only once each turn."
+
+**Plan:** The trigger and "draw that many"
+(`ContextPropertyKey.TRIGGER_COUNTERS_PLACED_AMOUNT`) likely exist; the gap is a generic
+"do this only once each turn" limiter on a triggered ability.
+
+---
+
+## 18. Copy a card from a zone and cast the copy for free
+
+**Cards:** Roving Actuator.
+
+**Clause:** "exile up to one target instant or sorcery card with mana value 2 or less from your
+graveyard. Copy it. You may cast the copy without paying its mana cost."
+
+**Plan:** Add an effect that creates a copy of a *card* (not a spell on the stack) and offers to cast
+the copy without paying its cost. The Void trigger gate is already expressible.
+
+---
+
+## 19. Cast spells from the top of your library (type-filtered) + restricted mana
+
+**Cards:** Mm'menon, the Right Hand.
+
+**Clause:** "You may cast artifact spells from the top of your library." + "Artifacts you control
+have '{T}: Add {U}. Spend this mana only to cast a spell from anywhere other than your hand.'"
+
+**Plan:** Add (a) a static "may cast cards of type X from the top of your library", (b) restricted
+mana that can only pay for spells cast from non-hand zones, and (c) "look at the top card any time".
+Flying is already expressible.
+
+---
+
+## 20. "First spell each turn may be cast without paying its mana cost"
+
+**Cards:** Weftwalking.
+
+**Clause:** "The first spell each player casts during each of their turns may be cast without paying
+its mana cost."
+
+**Plan:** Add a static that grants free-cast permission to the first spell each player casts on each
+of their own turns (per-player, per-turn gate). The ETB "shuffle hand and graveyard into library,
+then draw seven" is already expressible.
+
+---
+
+## 21. Reanimate as a typed, ability-stripped permanent
+
+**Cards:** Xu-Ifit, Osteoharmonist.
+
+**Clause:** "Return target creature card from your graveyard to the battlefield. It's a Skeleton in
+addition to its other types and has no abilities."
+
+**Plan:** Add a continuous effect, tied to the reanimated permanent, that adds the Skeleton subtype
+(layer 4) and removes all abilities (layer 6). Plain reanimation already exists.
+
+---
+
+## 22. Odd/even mass destroy + mass temporary control of all creatures
+
+**Cards:** Mutinous Massacre.
+
+**Clause:** "Choose odd or even. Destroy each creature with mana value of the chosen quality. Then
+gain control of all creatures until end of turn. Untap them. They gain haste until end of turn."
+
+**Plan:** Add (a) an odd/even mana-value filter (parity predicate) for the destroy, and (b) mass
+"gain control of all creatures until end of turn" (today `Effects.GainControl` targets a single
+permanent). Untap-all + grant-haste-all are expressible.
+
+---
+
+## 23. Multi-group graveyard return with split destinations
+
+**Cards:** Pull Through the Weft.
+
+**Clause:** "Return up to two target nonland permanent cards from your graveyard to your hand, then
+return up to two target land cards from your graveyard to the battlefield tapped."
+
+**Plan:** A single spell with two independent "up to two target" graveyard selections that route to
+*different* zones (hand vs. battlefield-tapped). Single-group graveyard return to one zone exists
+(e.g. Scout for Survivors); the dual-group/dual-destination shape needs verification or a new
+multi-target pattern.
+
+---
+
+## 24. Planeswalker emblem + "becomes a 0/0 Robot artifact creature"
+
+**Cards:** Tezzeret, Cruel Captain.
+
+**Clause:** "−7: You get an emblem with 'At the beginning of combat on your turn, put three +1/+1
+counters on target artifact you control. If it's not a creature, it becomes a 0/0 Robot artifact
+creature.'"
+
+**Plan:** Planeswalkers and loyalty abilities are supported. The gaps are (a) emblem creation with a
+recurring combat-trigger ability, and (b) a "becomes a 0/0 Robot artifact creature" type-set on a
+noncreature artifact. The passive ("whenever an artifact you control enters, add a loyalty
+counter"), the 0 untap, and the −3 tutor are expressible.
+
+---
+
+## Already covered elsewhere
+
+Poison counters (Virulent Silencer), token doubling (Exalted Sunborn), devour-land (Famished
+Worldsire), and "mana spent" for X-counters (Astelli Reclaimer) were previously listed here and are
+now implemented; their entries have been removed.

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,6 +3,46 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
+## Status: cards still blocked on engine work (26)
+
+The booster set is at **235 / 261**. The cards below are the only unimplemented ones; each is blocked
+on a missing engine/SDK feature. The blocking clause and the engine change needed are summarized
+here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in parentheses).
+
+Everything else in this file that is still listed under a category but checked `[x]` has been
+implemented; unchecked `[ ]` entries below the categories are the remaining blockers.
+
+| Card | Blocking clause | Engine change needed (missing-effects §) |
+|------|-----------------|-------------------------------------------|
+| Quantum Riddler | "if you would draw one or more cards, you draw that many plus one instead" while hand ≤ 1 | Conditional draw-replacement static (§1) |
+| Faller's Faithful | "if that creature wasn't dealt damage this turn, ... draws two cards" | "Was dealt damage this turn" tracking (§2) |
+| Orbital Plunge | "If excess damage was dealt this way, create a Lander token" | Excess-damage detection (§3) |
+| Blade of the Swarm | "Put target exiled card with warp on the bottom of its owner's library" | Targeting warp-exiled cards (§4) |
+| Bioengineered Future | "Each creature you control enters with an additional +1/+1 counter ... for each land that entered ... this turn" | Continuous extra-ETB-counters + lands-entered-this-turn tracker (§5) |
+| Dyadrine, Synthesis Amalgam | "enters with ... +1/+1 counters ... equal to the amount of mana spent to cast it" | Mana-spent `DynamicAmount` in ETB replacement (§6) |
+| Cosmogoyf | power/toughness = "number of cards you own in exile" (+1) | CDA P/T from cards-in-exile count (§7) |
+| Command Bridge | "sacrifice it unless you tap an untapped permanent you control" | ETB sacrifice-unless-pay-cost (§7b) |
+| Kav Landseeker | "At the beginning of the end step on your next turn, sacrifice that token" | Delayed trigger that always fires next turn's end step (§8) |
+| Territorial Bruntar | "exile cards from the top ... until you exile a nonland card. You may cast that card this turn" | Impulse-until-nonland effect (§9) |
+| Zero Point Ballad | "Destroy all creatures with toughness X or less" + reanimate one destroyed this way | Dynamic-toughness mass destroy + reanimate-from-batch (§10) |
+| Weapons Manufacturing | create the noncreature "Munitions" artifact token with a leaves-battlefield damage trigger | Noncreature tokens with embedded triggers (§11) |
+| Lightstall Inquisitor | "each opponent exiles a card from their hand and may play that card ..." (+cost/tapped) | Opponent exile-from-hand-may-play with modifiers (§12) |
+| Moonlit Meditation | "instead create that many tokens that are copies of enchanted permanent" (once/turn) | Token-creation replacement → copies (§13) |
+| Sami, Wildcat Captain | "Spells you cast have affinity for artifacts" | Affinity granted to your spells (§14) |
+| Thrumming Hivepool | "Affinity for Slivers" | Affinity for a subtype (§14) |
+| Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Grant Warp to hand cards (§15) |
+| Terminal Velocity | put a permanent from hand and grant it haste + an LTB trigger + an end-step self-sac | Grant arbitrary abilities to a put-in permanent (§16) |
+| Terrasymbiosis | "Whenever you put ... +1/+1 counters on a creature ... draw that many. Do this only once each turn." | Once-per-turn gating for triggered abilities (§17) |
+| Roving Actuator | "exile ... an instant or sorcery ... Copy it. You may cast the copy without paying its mana cost." | Copy a card and cast the copy (§18) |
+| Mm'menon, the Right Hand | "cast artifact spells from the top of your library" + restricted mana | Play-from-top static + restricted mana (§19) |
+| Weftwalking | "The first spell each player casts ... may be cast without paying its mana cost" | First-spell-free static (§20) |
+| Xu-Ifit, Osteoharmonist | reanimate "It's a Skeleton ... and has no abilities" | Reanimate as typed, ability-stripped permanent (§21) |
+| Mutinous Massacre | "Choose odd or even. Destroy each creature with mana value of the chosen quality. Then gain control of all creatures ..." | Odd/even MV filter + mass temporary control (§22) |
+| Pull Through the Weft | return up to two nonland permanents to hand **and** up to two lands to the battlefield tapped | Dual-group graveyard return with split destinations (§23) |
+| Tezzeret, Cruel Captain | −7 emblem; "it becomes a 0/0 Robot artifact creature" | Emblem creation + becomes-Robot type-set (§24) |
+
+---
+
 ## Warp, and related
 
 - [x] Bygone Colossus
@@ -14,14 +54,14 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Codecracker Hound
 - [ ] Quantum Riddler
 - [ ] Starfield Vocalist
-- [ ] Starwinder
+- [x] Starwinder
 - [ ] Perigee Beckoner
 - [ ] Full Bore
 - [ ] Possibility Technician
 - [ ] Tannuk, Steadfast Second
 - [ ] Broodguard Elite
 - [ ] Close Encounter
-- [ ] Drix Fatemaker
+- [x] Drix Fatemaker
 - [ ] Loading Zone
 - [ ] Susurian Voidborn
 - [ ] Timeline Culler
@@ -45,11 +85,11 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 ## Drone token:
 - [x] Desculpting Blast
-- [ ] Station Monitor
+- [x] Station Monitor
 - [ ] Pinnacle Emissary
 
 ## Complex:
-- [ ] Consult the Star Charts
+- [x] Consult the Star Charts
 - [ ] Dyadrine, Synthesis Amalgam
 - [ ] Pull Through the Weft
 - [ ] Requiem Monolith
@@ -71,10 +111,10 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Kav Landseeker
 
 ## May sacrifice, if you do
-- [ ] Larval Scoutlander
+- [x] Larval Scoutlander
 
 ## Enters with counters, not trigger new counters, (Enters with dynamic counters)
-- [ ] Luxknight Breacher
+- [x] Luxknight Breacher
 
 ## You may cast artifact spells from the top of your library.
 - [ ] Mm'menon, the Right Hand
@@ -107,11 +147,11 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Bioengineered Future
 
 # if you control two or more tapped creatures
-- [ ] Dawnstrike Vanguard
+- [x] Dawnstrike Vanguard
 - [ ] Flight-Deck Coordinator
-- [ ] Frontline War-Rager
-- [ ] Sami, Ship's Engineer
-- [ ] Sunstar Chaplain
+- [x] Frontline War-Rager
+- [x] Sami, Ship's Engineer
+- [x] Sunstar Chaplain
 - [ ] Vaultguard Trooper
 
 ## Create X tokens that are copies of target artifact or creature you control. Those tokens gain haste until end of turn. Sacrifice them at the beginning of the next end step.
@@ -136,7 +176,7 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Focus Fire
 
 ## target creature has base power and toughness 3/3 until end of turn. If you control six or more lands, that creature has base power and toughness 6/6 until end of turn instead
-- [ ] Genemorph Imago
+- [x] Genemorph Imago
 
 ## This spell costs {3} less to cast if you’ve cast another spell this turn.
 - [ ] Gigastorm Titan
@@ -145,7 +185,7 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Haliya, Ascendant Cadet
 
 ## create a tapped 2/2 colorless Robot artifact creature token for each multicolored permanent you control.
-- [ ] Infinite Guideline Station
+- [x] Infinite Guideline Station
 
 ## Conditional activated ability:
 - [ ] Kavaron, Memorial World
@@ -164,7 +204,7 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Mechan Shieldmate
 
 ## Whenever a creature you control with a +1/+1 counter on it dies, draw a card.
-- [ ] Meltstrider Eulogist
+- [x] Meltstrider Eulogist
 
 ## Exile the top X cards of your library, where X is one plus the mana value of the sacrificed artifact. You may play those cards this turn.
 - [ ] Memorial Vault
@@ -188,7 +228,7 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Pinnacle Starcage
 
 ## return target creature or enchantment card from your graveyard to the battlefield
-- [ ] Rescue Skiff
+- [x] Rescue Skiff
 
 ## Return up to three target creature cards with total mana value 3 or less from your graveyard to the battlefield. Put a +1/+1 counter on each of them
 - [ ] Scout for Survivors
@@ -233,7 +273,7 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] The Seriema
 
 ## You control enchanted permanent
-- [ ] Tractor Beam
+- [x] Tractor Beam
 
 ## The second spell you cast each turn costs {2} less to cast.
 - [ ] Uthros Psionicist
@@ -245,7 +285,7 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 - [ ] Virulent Silencer
 
 ## When this Spacecraft enters, it deals damage equal to the number of artifacts you control to target creature an opponent controls.
-- [ ] Warmaker Gunship
+- [x] Warmaker Gunship
 
 ## create a colorless artifact token named Munitions with “When this token leaves the battlefield, it deals 2 damage to any target.”
 - [ ] Weapons Manufacturing

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ConsultTheStarCharts.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ConsultTheStarCharts.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Consult the Star Charts
+ * {1}{U}
+ * Instant
+ *
+ * Kicker {1}{U}
+ * Look at the top X cards of your library, where X is the number of lands you control.
+ * Put one of those cards into your hand. If this spell was kicked, put two of those cards
+ * into your hand instead. Put the rest on the bottom of your library in a random order.
+ */
+val ConsultTheStarCharts = card("Consult the Star Charts") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\n" +
+        "Look at the top X cards of your library, where X is the number of lands you control. " +
+        "Put one of those cards into your hand. If this spell was kicked, put two of those cards " +
+        "into your hand instead. Put the rest on the bottom of your library in a random order."
+
+    keywordAbility(KeywordAbility.kicker("{1}{U}"))
+
+    spell {
+        // Unkicked: look at top X (X = lands you control), keep one, rest on bottom in random order.
+        effect = EffectPatterns.lookAtTopAndKeep(
+            count = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land),
+            keepCount = DynamicAmount.Fixed(1),
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.Random
+        )
+
+        // Kicked: keep two instead.
+        kickerEffect = EffectPatterns.lookAtTopAndKeep(
+            count = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land),
+            keepCount = DynamicAmount.Fixed(2),
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.Random
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "51"
+        artist = "Antonio José Manzanedo"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a16a6555-2e3a-4587-aacd-0307d696b26c.jpg?1752946753"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DawnstrikeVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DawnstrikeVanguard.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dawnstrike Vanguard
+ * {5}{W}
+ * Creature — Human Knight
+ * 4/5
+ *
+ * Lifelink
+ * At the beginning of your end step, if you control two or more tapped creatures,
+ * put a +1/+1 counter on each creature you control other than this creature.
+ */
+val DawnstrikeVanguard = card("Dawnstrike Vanguard") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 4
+    toughness = 5
+    oracleText = "Lifelink\n" +
+        "At the beginning of your end step, if you control two or more tapped creatures, " +
+        "put a +1/+1 counter on each creature you control other than this creature."
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature.tapped()),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2)
+        )
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter.OtherCreaturesYouControl,
+            effect = AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "10"
+        artist = "Arif Wijaya"
+        flavorText = "\"Arrive as the dawn, and banish night through your brilliance!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a041722-9483-469f-9c17-7f0253b0db50.jpg?1752946591"
+
+        ruling(
+            "2025-07-25",
+            "Dawnstrike Vanguard's last ability will check as your end step starts to see if you " +
+                "control two or more tapped creatures. If you don't, the ability won't trigger at all. " +
+                "You won't be able to tap anything during your end step in time to have the ability " +
+                "trigger. If you don't control two or more tapped creatures when the ability resolves, " +
+                "the ability won't do anything."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DrixFatemaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DrixFatemaker.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Drix Fatemaker
+ * {3}{G}
+ * Creature — Drix Wizard
+ * 3/2
+ *
+ * When this creature enters, put a +1/+1 counter on target creature.
+ * Each creature you control with a +1/+1 counter on it has trample.
+ * Warp {1}{G}
+ */
+val DrixFatemaker = card("Drix Fatemaker") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Drix Wizard"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, put a +1/+1 counter on target creature.\n" +
+        "Each creature you control with a +1/+1 counter on it has trample.\n" +
+        "Warp {1}{G} (You may cast this card from your hand for its warp cost. Exile this creature at " +
+        "the beginning of the next end step, then you may cast it from exile on a later turn.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+        description = "When this creature enters, put a +1/+1 counter on target creature."
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.TRAMPLE,
+            GroupFilter(GameObjectFilter.Creature.youControl().withCounter(Counters.PLUS_ONE_PLUS_ONE))
+        )
+    }
+
+    warp = "{1}{G}"
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Anna Pavleeva"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1beb7566-305e-4091-bdc4-cf4c789ac05a.jpg?1752947281"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FocusFire.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FocusFire.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Focus Fire
+ * {W}
+ * Instant
+ *
+ * Focus Fire deals X damage to target attacking or blocking creature, where X is
+ * 2 plus the number of creatures and/or Spacecraft you control.
+ *
+ * A Spacecraft you control that's also a creature counts only once toward X — a
+ * single count over the "creature OR Spacecraft" filter matches each permanent at
+ * most once. X is evaluated only as Focus Fire resolves (standard for DynamicAmount).
+ */
+val FocusFire = card("Focus Fire") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Focus Fire deals X damage to target attacking or blocking creature, where X is 2 plus the number of creatures and/or Spacecraft you control."
+
+    spell {
+        val t = target("target", TargetPermanent(filter = TargetFilter.AttackingOrBlockingCreature))
+        effect = Effects.DealDamage(
+            DynamicAmount.Add(
+                DynamicAmount.Fixed(2),
+                DynamicAmounts.battlefield(
+                    Player.You,
+                    GameObjectFilter.Creature or GameObjectFilter.Permanent.withSubtype("Spacecraft")
+                ).count()
+            ),
+            t
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Borja Pindado"
+        flavorText = "\"We are the arrows of Sunsolde's Quiver.\"\n—*Declaration of Fleet Purpose*, Axiom 2"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9ddfcbc-0f84-4315-aaa3-ca54ff64d7de.jpg?1752946622"
+        ruling("2025-07-25", "The value of X is calculated only once, as Focus Fire resolves.")
+        ruling("2025-07-25", "A Spacecraft you control that's also a creature counts only once toward the value of X.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FrontlineWarRager.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FrontlineWarRager.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Frontline War-Rager
+ * {2}{R}
+ * Creature — Kavu Soldier
+ * 2/3
+ *
+ * At the beginning of your end step, if you control two or more tapped creatures,
+ * put a +1/+1 counter on this creature.
+ */
+val FrontlineWarRager = card("Frontline War-Rager") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "At the beginning of your end step, if you control two or more tapped creatures, " +
+        "put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature.tapped()),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Jason Rainville"
+        flavorText = "The Kav have more than ideology or profit on the line. They fight for a home."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa232943-818b-4944-be60-2d80c806bf62.jpg?1752947094"
+
+        ruling(
+            "2025-07-25",
+            "Frontline War-Rager's ability will check as your end step starts to see if you control " +
+                "two or more tapped creatures. If you don't, the ability won't trigger at all. You won't " +
+                "be able to tap anything during your end step in time to have the ability trigger. If you " +
+                "don't control two or more tapped creatures when the ability resolves, the ability won't " +
+                "do anything."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GenemorphImago.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GenemorphImago.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.SetBasePowerToughnessEffect
+
+/**
+ * Genemorph Imago
+ * {G}{U}
+ * Creature — Insect Druid
+ * 1/3
+ *
+ * Flying
+ * Landfall — Whenever a land you control enters, target creature has base power and toughness 3/3
+ * until end of turn. If you control six or more lands, that creature has base power and toughness
+ * 6/6 until end of turn instead.
+ */
+val GenemorphImago = card("Genemorph Imago") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Insect Druid"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Landfall — Whenever a land you control enters, target creature has base power and toughness " +
+        "3/3 until end of turn. If you control six or more lands, that creature has base power and " +
+        "toughness 6/6 until end of turn instead."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        val t = target("target creature", Targets.Creature)
+        effect = ConditionalEffect(
+            condition = Conditions.ControlLandsAtLeast(6),
+            effect = SetBasePowerToughnessEffect(t, 6, 6, Duration.EndOfTurn),
+            elseEffect = SetBasePowerToughnessEffect(t, 3, 3, Duration.EndOfTurn)
+        )
+        description = "Landfall — Whenever a land you control enters, target creature has base power " +
+            "and toughness 3/3 until end of turn. If you control six or more lands, that creature has " +
+            "base power and toughness 6/6 until end of turn instead."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "217"
+        artist = "Brian Valeza"
+        flavorText = "\"We can all be more than we are. Let me help.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40f0ecf7-f49e-46ff-aa5b-9ff5361b72c5.jpg?1752947444"
+
+        ruling(
+            "2025-07-25",
+            "The effect of Genemorph Imago's landfall ability will overwrite any previous effects that " +
+                "set the creature's power and toughness to specific values. Effects that otherwise modify " +
+                "the target creature's power and toughness will still apply no matter when they took " +
+                "effect. The same is true for +1/+1 counters."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/InfiniteGuidelineStation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/InfiniteGuidelineStation.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Infinite Guideline Station
+ * {W}{U}{B}{R}{G}
+ * Legendary Artifact — Spacecraft
+ * 7/15
+ *
+ * When Infinite Guideline Station enters, create a tapped 2/2 colorless Robot artifact creature
+ * token for each multicolored permanent you control.
+ * Station (Tap another creature you control: Put charge counters equal to its power on this
+ * Spacecraft. Station only as a sorcery. It's an artifact creature at 12+.)
+ * 12+ | Flying
+ * Whenever Infinite Guideline Station attacks, draw a card for each multicolored permanent you control.
+ */
+val InfiniteGuidelineStation = card("Infinite Guideline Station") {
+    manaCost = "{W}{U}{B}{R}{G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Legendary Artifact — Spacecraft"
+    power = 7
+    toughness = 15
+    oracleText = "When Infinite Guideline Station enters, create a tapped 2/2 colorless Robot artifact " +
+        "creature token for each multicolored permanent you control.\n" +
+        "Station (Tap another creature you control: Put charge counters equal to its power on this " +
+        "Spacecraft. Station only as a sorcery. It's an artifact creature at 12+.)\n12+ | Flying\n" +
+        "Whenever Infinite Guideline Station attacks, draw a card for each multicolored permanent you control."
+
+    // ETB: create a tapped 2/2 colorless Robot artifact creature token for each multicolored permanent.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            count = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Multicolored),
+            name = "Robot",
+            power = 2,
+            toughness = 2,
+            colors = emptySet(),
+            creatureTypes = setOf("Robot"),
+            artifactToken = true,
+            tapped = true,
+            imageUri = "https://cards.scryfall.io/normal/front/c/4/c46f9a07-005c-44b7-8057-b2f00b274dd6.jpg?1756281130"
+        )
+        description = "create a tapped 2/2 colorless Robot artifact creature token for each multicolored permanent you control"
+    }
+
+    // Station activated ability: tap another creature → add charge counters equal to its power
+    activatedAbility {
+        cost = AbilityCost.TapPermanents(
+            count = 1,
+            filter = GameObjectFilter.Creature,
+            excludeSelf = true
+        )
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.CHARGE,
+            amount = DynamicAmount.EntityProperty(
+                entity = EntityReference.TappedAsCost(),
+                numericProperty = EntityNumericProperty.Power
+            ),
+            target = EffectTarget.Self
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    // Conditional type change: artifact creature at 12+ charge counters
+    staticAbility {
+        condition = Compare(
+            left = DynamicAmount.EntityProperty(
+                entity = EntityReference.Source,
+                numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(12)
+        )
+        ability = GrantCardType("CREATURE", GroupFilter.source())
+    }
+
+    // Conditional keyword: flying at 12+ charge counters
+    staticAbility {
+        condition = Compare(
+            left = DynamicAmount.EntityProperty(
+                entity = EntityReference.Source,
+                numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(12)
+        )
+        ability = GrantKeyword(Keyword.FLYING.name, GroupFilter.source())
+    }
+
+    // Whenever this attacks, draw a card for each multicolored permanent you control.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.DrawCards(DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Multicolored))
+        description = "Whenever Infinite Guideline Station attacks, draw a card for each multicolored permanent you control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "219"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/5688894a-bbec-476b-ae2e-94000be258d0.jpg?1755341280"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavaronMemorialWorld.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavaronMemorialWorld.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.StaticTarget
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Kavaron, Memorial World
+ * Land — Planet
+ * This land enters tapped.
+ * {T}: Add {R}.
+ * Station (Tap another creature you control: Put charge counters equal to its power on this Planet. Station only as a sorcery.)
+ * 12+ | {1}{R}, {T}, Sacrifice a land: Create a 2/2 colorless Robot artifact creature token, then creatures you control get +1/+0 and gain haste until end of turn.
+ */
+val KavaronMemorialWorld = card("Kavaron, Memorial World") {
+    typeLine = "Land — Planet"
+    oracleText = "This land enters tapped.\n{T}: Add {R}.\nStation (Tap another creature you control: Put charge counters equal to its power on this Planet. Station only as a sorcery.)\n12+ | {1}{R}, {T}, Sacrifice a land: Create a 2/2 colorless Robot artifact creature token, then creatures you control get +1/+0 and gain haste until end of turn."
+
+    // This land enters tapped
+    replacementEffect(EntersTapped())
+
+    // Basic mana ability: {T}: Add {R}
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+    }
+
+    // Station activated ability: tap another creature → add charge counters equal to its power
+    activatedAbility {
+        cost = AbilityCost.TapPermanents(
+            count = 1,
+            filter = GameObjectFilter.Creature,
+            excludeSelf = true
+        )
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.CHARGE,
+            amount = DynamicAmount.EntityProperty(
+                entity = EntityReference.TappedAsCost(),
+                numericProperty = EntityNumericProperty.Power
+            ),
+            target = EffectTarget.Self
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    val charge12 = Compare(
+        left = DynamicAmount.EntityProperty(
+            entity = EntityReference.Source,
+            numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+        ),
+        operator = ComparisonOperator.GTE,
+        right = DynamicAmount.Fixed(12)
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{R}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Land)
+        )
+        effect = ConditionalEffect(
+            condition = charge12,
+            effect = Effects.Composite(
+                listOf(
+                    // Create a 2/2 colorless Robot artifact creature token
+                    CreateTokenEffect(
+                        power = 2,
+                        toughness = 2,
+                        colors = setOf(), // colorless
+                        creatureTypes = setOf("Robot"),
+                        artifactToken = true,
+                        imageUri = "https://cards.scryfall.io/normal/front/c/4/c46f9a07-005c-44b7-8057-b2f00b274dd6.jpg?1756281130"
+                    ),
+                    // Creatures you control get +1/+0 and gain haste until end of turn
+                    ForEachInGroupEffect(
+                        GroupFilter.AllCreaturesYouControl,
+                        com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect(
+                            powerModifier = DynamicAmount.Fixed(1),
+                            toughnessModifier = DynamicAmount.Fixed(0),
+                            target = EffectTarget.Self,
+                            duration = com.wingedsheep.sdk.scripting.Duration.EndOfTurn
+                        )
+                    ),
+                    ForEachInGroupEffect(
+                        GroupFilter.AllCreaturesYouControl,
+                        com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect(
+                            keyword = Keyword.HASTE,
+                            target = EffectTarget.Self,
+                            duration = com.wingedsheep.sdk.scripting.Duration.EndOfTurn
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "255"
+        artist = "Adam Paquette"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60f3ca25-9dcc-4781-bf7b-ab6736d8db29.jpg?1755341338"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavaronMemorialWorld.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavaronMemorialWorld.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantKeyword
-import com.wingedsheep.sdk.scripting.StaticTarget
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.conditions.Compare
 import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LarvalScoutlander.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LarvalScoutlander.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Larval Scoutlander
+ * {2}{G}
+ * Artifact — Spacecraft
+ * 3/3
+ *
+ * When this Spacecraft enters, you may sacrifice a land or Lander. If you do, search your library
+ * for up to two basic land cards, put them onto the battlefield tapped, then shuffle.
+ * Station (Tap another creature you control: Put charge counters equal to its power on this
+ * Spacecraft. Station only as a sorcery. It's an artifact creature at 7+.)
+ * 7+ | Flying
+ */
+val LarvalScoutlander = card("Larval Scoutlander") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Spacecraft"
+    power = 3
+    toughness = 3
+    oracleText = "When this Spacecraft enters, you may sacrifice a land or Lander. If you do, search " +
+        "your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.\n" +
+        "Station (Tap another creature you control: Put charge counters equal to its power on this " +
+        "Spacecraft. Station only as a sorcery. It's an artifact creature at 7+.)\n7+ | Flying"
+
+    // When this Spacecraft enters, you may sacrifice a land or Lander. If you do, search your
+    // library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Effects.Sacrifice(
+                GameObjectFilter.Land.or(GameObjectFilter.Permanent.withSubtype("Lander")),
+                count = 1,
+                target = EffectTarget.Controller
+            ).then(
+                EffectPatterns.searchLibrary(
+                    filter = GameObjectFilter.BasicLand,
+                    count = 2,
+                    destination = SearchDestination.BATTLEFIELD,
+                    entersTapped = true,
+                    shuffleAfter = true
+                )
+            )
+        )
+        description = "When this Spacecraft enters, you may sacrifice a land or Lander. If you do, " +
+            "search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle."
+    }
+
+    // Station activated ability: tap another creature → add charge counters equal to its power
+    activatedAbility {
+        cost = AbilityCost.TapPermanents(
+            count = 1,
+            filter = GameObjectFilter.Creature,
+            excludeSelf = true
+        )
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.CHARGE,
+            amount = DynamicAmount.EntityProperty(
+                entity = EntityReference.TappedAsCost(),
+                numericProperty = EntityNumericProperty.Power
+            ),
+            target = EffectTarget.Self
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    // Conditional type change: artifact creature at 7+ charge counters
+    staticAbility {
+        condition = Compare(
+            left = DynamicAmount.EntityProperty(
+                entity = EntityReference.Source,
+                numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(7)
+        )
+        ability = GrantCardType("CREATURE", GroupFilter.source())
+    }
+
+    // Conditional keyword: flying at 7+ charge counters
+    staticAbility {
+        condition = Compare(
+            left = DynamicAmount.EntityProperty(
+                entity = EntityReference.Source,
+                numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(7)
+        )
+        ability = GrantKeyword(Keyword.FLYING.name, GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "194"
+        artist = "Javier Charro"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6083f43-58dc-46fc-aeff-347b1080417b.jpg?1755341414"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Lithobraking.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Lithobraking.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lithobraking
+ * {2}{R}
+ * Instant
+ * Create a Lander token. Then you may sacrifice an artifact. When you do,
+ * Lithobraking deals 2 damage to each creature.
+ */
+val Lithobraking = card("Lithobraking") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Create a Lander token. Then you may sacrifice an artifact. When you do, " +
+        "Lithobraking deals 2 damage to each creature. " +
+        "(A Lander token is an artifact with \"{2}, {T}, Sacrifice this token: Search your library " +
+        "for a basic land card, put it onto the battlefield tapped, then shuffle.\")"
+
+    spell {
+        effect = Effects.CreateLander().then(
+            ReflexiveTriggerEffect(
+                action = SacrificeEffect(GameObjectFilter.Artifact),
+                optional = true,
+                reflexiveEffect = ForEachInGroupEffect(
+                    GroupFilter.AllCreatures,
+                    DealDamageEffect(2, EffectTarget.Self)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "Andrew Mar"
+        flavorText = "A Kav landing\n—Sotheran expression meaning \"a bad time\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a22024c-2c0f-4487-98d1-ee89cf3dba89.jpg?1752947127"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LuxknightBreacher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LuxknightBreacher.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Luxknight Breacher
+ * {3}{W}
+ * Creature — Human Knight
+ * 2/2
+ *
+ * This creature enters with a +1/+1 counter on it for each other creature and/or artifact you control.
+ */
+val LuxknightBreacher = card("Luxknight Breacher") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 2
+    oracleText = "This creature enters with a +1/+1 counter on it for each other creature and/or artifact you control."
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.CreatureOrArtifact,
+                excludeSelf = true
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "Cristi Balanescu"
+        flavorText = "\"Only when a vessel is emptied of shallow ego may the depths of light flow in to fill it.\"\n" +
+            "—Seraphus Chek, Sunstar poet"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1236731-0d33-4705-8077-3cf58acf9a39.jpg?1752946655"
+
+        ruling(
+            "2025-07-25",
+            "In the rare case where Luxknight Breacher enters at the same time as one or more other " +
+                "creatures and/or artifacts you control, it doesn't count those other creatures and/or " +
+                "artifacts. It counts only creatures and/or artifacts that are already on the battlefield " +
+                "under your control."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MeltstriderEulogist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MeltstriderEulogist.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Meltstrider Eulogist
+ * {2}{G}
+ * Creature — Insect Soldier
+ * 3/3
+ *
+ * Whenever a creature you control with a +1/+1 counter on it dies, draw a card.
+ */
+val MeltstriderEulogist = card("Meltstrider Eulogist") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever a creature you control with a +1/+1 counter on it dies, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().withCounter(Counters.PLUS_ONE_PLUS_ONE),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.DrawCards(1)
+        description = "Whenever a creature you control with a +1/+1 counter on it dies, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "197"
+        artist = "Jason A. Engle"
+        flavorText = "There are no failures in terrasymbiosis, only lessons learned."
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df61aa0c-effc-4d57-be19-876a82c41d33.jpg?1752947359"
+
+        ruling(
+            "2025-07-25",
+            "If Meltstrider Eulogist dies at the same time as one or more creatures you control with " +
+                "+1/+1 counters on them, its ability will trigger for each of those creatures. This " +
+                "includes Meltstrider Eulogist itself if it had a +1/+1 counter on it when it died."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/RescueSkiff.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/RescueSkiff.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Rescue Skiff
+ * {5}{W}
+ * Artifact — Spacecraft
+ * 5/6
+ *
+ * When this Spacecraft enters, return target creature or enchantment card from your graveyard
+ * to the battlefield.
+ * Station (Tap another creature you control: Put charge counters equal to its power on this
+ * Spacecraft. Station only as a sorcery. It's an artifact creature at 10+.)
+ * 10+ | Flying
+ */
+val RescueSkiff = card("Rescue Skiff") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Spacecraft"
+    power = 5
+    toughness = 6
+    oracleText = "When this Spacecraft enters, return target creature or enchantment card from your " +
+        "graveyard to the battlefield.\n" +
+        "Station (Tap another creature you control: Put charge counters equal to its power on this " +
+        "Spacecraft. Station only as a sorcery. It's an artifact creature at 10+.)\n10+ | Flying"
+
+    // When this Spacecraft enters, return target creature or enchantment card from your graveyard
+    // to the battlefield.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target creature or enchantment card from your graveyard",
+            TargetObject(filter = TargetFilter(GameObjectFilter.CreatureOrEnchantment.ownedByYou(), zone = Zone.GRAVEYARD))
+        )
+        effect = MoveToZoneEffect(target = t, destination = Zone.BATTLEFIELD)
+        description = "return target creature or enchantment card from your graveyard to the battlefield"
+    }
+
+    // Station activated ability: tap another creature → add charge counters equal to its power
+    activatedAbility {
+        cost = AbilityCost.TapPermanents(
+            count = 1,
+            filter = GameObjectFilter.Creature,
+            excludeSelf = true
+        )
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.CHARGE,
+            amount = DynamicAmount.EntityProperty(
+                entity = EntityReference.TappedAsCost(),
+                numericProperty = EntityNumericProperty.Power
+            ),
+            target = EffectTarget.Self
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    // Conditional type change: artifact creature at 10+ charge counters
+    staticAbility {
+        condition = Compare(
+            left = DynamicAmount.EntityProperty(
+                entity = EntityReference.Source,
+                numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(10)
+        )
+        ability = GrantCardType("CREATURE", GroupFilter.source())
+    }
+
+    // Conditional keyword: flying at 10+ charge counters
+    staticAbility {
+        condition = Compare(
+            left = DynamicAmount.EntityProperty(
+                entity = EntityReference.Source,
+                numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(10)
+        )
+        ability = GrantKeyword(Keyword.FLYING.name, GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "32"
+        artist = "Viko Menezes"
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6fe86bfb-c67d-4df9-88c9-f083091f4cda.jpg?1755341383"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SamiShipsEngineer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SamiShipsEngineer.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sami, Ship's Engineer
+ * {2}{R}{W}
+ * Legendary Creature — Human Artificer
+ * 2/4
+ *
+ * At the beginning of your end step, if you control two or more tapped creatures,
+ * create a tapped 2/2 colorless Robot artifact creature token.
+ */
+val SamiShipsEngineer = card("Sami, Ship's Engineer") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Human Artificer"
+    power = 2
+    toughness = 4
+    oracleText = "At the beginning of your end step, if you control two or more tapped creatures, " +
+        "create a tapped 2/2 colorless Robot artifact creature token."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature.tapped()),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2)
+        )
+        effect = CreateTokenEffect(
+            name = "Robot",
+            power = 2,
+            toughness = 2,
+            colors = emptySet(),
+            creatureTypes = setOf("Robot"),
+            artifactToken = true,
+            tapped = true,
+            imageUri = "https://cards.scryfall.io/normal/front/c/4/c46f9a07-005c-44b7-8057-b2f00b274dd6.jpg?1756281130"
+        )
+        description = "create a tapped 2/2 colorless Robot artifact creature token"
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "225"
+        artist = "Zara Alfonso"
+        flavorText = "Whenever Sami was down on their luck, they returned to an old comfort: the clinks " +
+            "and clanks of tinkering."
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75c38cc9-07de-46d4-8195-f04b2b7e0fee.jpg?1752947477"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Starwinder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Starwinder.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Starwinder
+ * {5}{U}{U}
+ * Creature — Leviathan
+ * 7/7
+ *
+ * Whenever a creature you control deals combat damage to a player, you may draw that many cards.
+ * Warp {2}{U}{U}
+ */
+val Starwinder = card("Starwinder") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Leviathan"
+    power = 7
+    toughness = 7
+    oracleText = "Whenever a creature you control deals combat damage to a player, you may draw that many cards.\n" +
+        "Warp {2}{U}{U} (You may cast this card from your hand for its warp cost. Exile this creature at " +
+        "the beginning of the next end step, then you may cast it from exile on a later turn.)"
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = MayEffect(
+            Effects.DrawCards(DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT))
+        )
+        description = "Whenever a creature you control deals combat damage to a player, you may draw that many cards."
+    }
+
+    warp = "{2}{U}{U}"
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "79"
+        artist = "Devin Elle Kurtz"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27d1a010-5790-4b35-9fdc-0e366eed021d.jpg?1752946871"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/StationMonitor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/StationMonitor.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Station Monitor
+ * {W}{U}
+ * Creature — Lizard Artificer
+ * 2/2
+ *
+ * Whenever you cast your second spell each turn, create a 1/1 colorless Drone artifact creature
+ * token with flying and "This token can block only creatures with flying."
+ */
+val StationMonitor = card("Station Monitor") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Lizard Artificer"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you cast your second spell each turn, create a 1/1 colorless Drone artifact " +
+        "creature token with flying and \"This token can block only creatures with flying.\""
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        effect = Effects.CreateDroneToken()
+        description = "create a 1/1 colorless Drone artifact creature token with flying and " +
+            "\"This token can block only creatures with flying.\""
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "230"
+        artist = "Camille Alquier"
+        flavorText = "\"Keeping tabs on a whole station is too much for just one.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba9f6d16-ee3e-4fbb-b78a-6292188eb61f.jpg?1752947501"
+
+        ruling(
+            "2025-07-25",
+            "Station Monitor's ability will count any spells you've cast this turn, which may include " +
+                "Station Monitor itself. It doesn't matter if the other spells resolved, didn't resolve, " +
+                "were countered, or are still on the stack. If Station Monitor was the first spell you " +
+                "cast this turn, the next spell you cast this turn is your second spell."
+        )
+        ruling(
+            "2025-07-25",
+            "Station Monitor's ability resolves before the spell that caused it to trigger. It resolves " +
+                "even if that spell is countered or otherwise leaves the stack without resolving."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SunstarChaplain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SunstarChaplain.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sunstar Chaplain
+ * {1}{W}
+ * Creature — Human Cleric
+ * 3/2
+ *
+ * At the beginning of your end step, if you control two or more tapped creatures,
+ * put a +1/+1 counter on target creature you control.
+ * {2}, Remove a +1/+1 counter from a creature you control: Tap target artifact or creature.
+ */
+val SunstarChaplain = card("Sunstar Chaplain") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 3
+    toughness = 2
+    oracleText = "At the beginning of your end step, if you control two or more tapped creatures, " +
+        "put a +1/+1 counter on target creature you control.\n" +
+        "{2}, Remove a +1/+1 counter from a creature you control: Tap target artifact or creature."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature.tapped()),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2)
+        )
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+        description = "put a +1/+1 counter on target creature you control"
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.RemovePlusOnePlusOneCounters(GameObjectFilter.Creature.youControl(), 1)
+        )
+        val t = target(
+            "target artifact or creature",
+            TargetObject(filter = TargetFilter(GameObjectFilter.CreatureOrArtifact))
+        )
+        effect = Effects.Tap(t)
+        description = "Tap target artifact or creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "40"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83719626-3ff8-4566-9911-88212e753c69.jpg?1752946709"
+
+        ruling(
+            "2025-07-25",
+            "Sunstar Chaplain's first ability will check as your end step starts to see if you " +
+                "control two or more tapped creatures. If you don't, the ability won't trigger at all. " +
+                "You won't be able to tap anything during your end step in time to have the ability " +
+                "trigger. If you don't control two or more tapped creatures when the ability resolves, " +
+                "the ability won't do anything."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SusurSecundiVoidAltar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SusurSecundiVoidAltar.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Susur Secundi, Void Altar
+ * Land — Planet
+ * This land enters tapped.
+ * {T}: Add {B}.
+ * Station (Tap another creature you control: Put charge counters equal to its power on this Planet. Station only as a sorcery.)
+ * 12+ | {1}{B}, {T}, Pay 2 life, Sacrifice a creature: Draw cards equal to the sacrificed creature's power. Activate only as a sorcery.
+ */
+val SusurSecundiVoidAltar = card("Susur Secundi, Void Altar") {
+    typeLine = "Land — Planet"
+    colorIdentity = "B"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {B}.\n" +
+        "Station (Tap another creature you control: Put charge counters equal to its power on this Planet. Station only as a sorcery.)\n" +
+        "12+ | {1}{B}, {T}, Pay 2 life, Sacrifice a creature: Draw cards equal to the sacrificed creature's power. Activate only as a sorcery."
+
+    // This land enters tapped
+    replacementEffect(EntersTapped())
+
+    // Basic mana ability: {T}: Add {B}
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    // Station: tap another creature → add charge counters equal to its power
+    activatedAbility {
+        cost = AbilityCost.TapPermanents(
+            count = 1,
+            filter = GameObjectFilter.Creature,
+            excludeSelf = true
+        )
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.CHARGE,
+            amount = DynamicAmount.EntityProperty(
+                entity = EntityReference.TappedAsCost(),
+                numericProperty = EntityNumericProperty.Power
+            ),
+            target = com.wingedsheep.sdk.scripting.targets.EffectTarget.Self
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    // 12+ charge counters: {1}{B}, {T}, Pay 2 life, Sacrifice a creature:
+    // Draw cards equal to the sacrificed creature's power
+    val charge12 = Compare(
+        left = DynamicAmount.EntityProperty(
+            entity = EntityReference.Source,
+            numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+        ),
+        operator = ComparisonOperator.GTE,
+        right = DynamicAmount.Fixed(12)
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}"),
+            Costs.Tap,
+            Costs.PayLife(2),
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        effect = Effects.DrawCards(DynamicAmounts.sacrificedPower())
+        timing = TimingRule.SorcerySpeed
+        restrictions = listOf(ActivationRestriction.OnlyIfCondition(charge12))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "259"
+        artist = "Adam Paquette"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aefb8c0d-2bc6-4bec-851e-0137b4abfb22.jpg?1755341450"
+        ruling("2025-07-25", "A station card is a card with the station keyword ability. The station keyword means \"Tap another untapped creature you control: Put a number of charge counters on this permanent equal to the tapped creature's power. Activate only as a sorcery.\"")
+        ruling("2025-07-25", "Each station symbol represents an ability. A station symbol means \"As long as this permanent has N or more charge counters on it, it has [abilities]\".")
+        ruling("2025-07-25", "Planet is a land subtype with no special meaning. It doesn't grant the land any intrinsic abilities.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TractorBeam.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TractorBeam.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ControlEnchantedPermanent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Tractor Beam
+ * {2}{U}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature or Spacecraft
+ * When this Aura enters, tap enchanted permanent.
+ * You control enchanted permanent.
+ * Enchanted permanent doesn't untap during its controller's untap step.
+ */
+val TractorBeam = card("Tractor Beam") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature or Spacecraft\n" +
+        "When this Aura enters, tap enchanted permanent.\n" +
+        "You control enchanted permanent.\n" +
+        "Enchanted permanent doesn't untap during its controller's untap step."
+
+    auraTarget = TargetPermanent(
+        filter = TargetFilter(
+            GameObjectFilter.Creature.or(GameObjectFilter.Permanent.withSubtype("Spacecraft"))
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Tap(EffectTarget.EnchantedPermanent)
+    }
+
+    staticAbility {
+        ability = ControlEnchantedPermanent
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "82"
+        artist = "Sergey Glushakov"
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efc96d54-d6e1-49b6-b4c2-70b997776548.jpg?1752946884"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/WarmakerGunship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/WarmakerGunship.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Warmaker Gunship
+ * {2}{R}
+ * Artifact — Spacecraft
+ * 4/3
+ *
+ * When this Spacecraft enters, it deals damage equal to the number of artifacts you control
+ * to target creature an opponent controls.
+ * Station (Tap another creature you control: Put charge counters equal to its power on this
+ * Spacecraft. Station only as a sorcery. It's an artifact creature at 6+.)
+ * 6+ | Flying
+ */
+val WarmakerGunship = card("Warmaker Gunship") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Spacecraft"
+    power = 4
+    toughness = 3
+    oracleText = "When this Spacecraft enters, it deals damage equal to the number of artifacts you " +
+        "control to target creature an opponent controls.\n" +
+        "Station (Tap another creature you control: Put charge counters equal to its power on this " +
+        "Spacecraft. Station only as a sorcery. It's an artifact creature at 6+.)\n6+ | Flying"
+
+    // When this Spacecraft enters, it deals damage equal to the number of artifacts you control
+    // to target creature an opponent controls.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.DealDamage(
+            amount = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Artifact),
+            target = t,
+            damageSource = EffectTarget.Self
+        )
+        description = "When this Spacecraft enters, it deals damage equal to the number of artifacts " +
+            "you control to target creature an opponent controls."
+    }
+
+    // Station activated ability: tap another creature → add charge counters equal to its power
+    activatedAbility {
+        cost = AbilityCost.TapPermanents(
+            count = 1,
+            filter = GameObjectFilter.Creature,
+            excludeSelf = true
+        )
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.CHARGE,
+            amount = DynamicAmount.EntityProperty(
+                entity = EntityReference.TappedAsCost(),
+                numericProperty = EntityNumericProperty.Power
+            ),
+            target = EffectTarget.Self
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    // Conditional type change: artifact creature at 6+ charge counters
+    staticAbility {
+        condition = Compare(
+            left = DynamicAmount.EntityProperty(
+                entity = EntityReference.Source,
+                numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(6)
+        )
+        ability = GrantCardType("CREATURE", GroupFilter.source())
+    }
+
+    // Conditional keyword: flying at 6+ charge counters
+    staticAbility {
+        condition = Compare(
+            left = DynamicAmount.EntityProperty(
+                entity = EntityReference.Source,
+                numericProperty = EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(6)
+        )
+        ability = GrantKeyword(Keyword.FLYING.name, GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "167"
+        artist = "Julian Kok Joon Wen"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e5957f4-1cae-4989-8b40-27fc6e2fcf5e.jpg?1755341273"
+    }
+}


### PR DESCRIPTION
## Summary

Implements 20 Edge of Eternities booster cards (215 → 235 / 261) using existing
SDK primitives only — no engine changes. Also catalogs every remaining
unimplemented card with the exact clause that blocks it and the engine work needed.

All cards are data-driven `cardDef { }` definitions composed from existing effects,
triggers, conditions, filters, and keywords; each was added in its own commit.

### Cards added

**"Two-or-more-tapped-creatures" end-step cycle**
- Frontline War-Rager, Dawnstrike Vanguard, Sunstar Chaplain, Sami, Ship's Engineer

**+1/+1 counter payoffs**
- Luxknight Breacher (enters-with dynamic counters), Drix Fatemaker (group trample grant + Warp),
  Meltstrider Eulogist (counter-creature-dies draw)

**Station Spacecraft (ETB + charge-counter threshold)**
- Warmaker Gunship, Rescue Skiff, Larval Scoutlander, Infinite Guideline Station

**Other**
- Starwinder (Warp + "draw that many" combat-damage trigger)
- Tractor Beam (control aura), Consult the Star Charts (kicker), Genemorph Imago (landfall set-base-P/T),
  Station Monitor (Drone token), Focus Fire, Lithobraking, Susur Secundi · Void Altar, Kavaron · Memorial World

### Backlog docs
- `problem-cards.md`: new status table mapping each of the 26 still-blocked cards →
  blocking oracle clause → engine change required.
- `missing-effects.md`: rewritten into 24 numbered engine-feature sections (e.g. conditional
  draw-replacement statics, cast-from-non-hand-zone permissions, dynamic-toughness mass removal,
  noncreature tokens with embedded triggers, granted-affinity statics).

  ## Test plan
- [x] `just build` / `:mtg-sets:compileKotlin` — all cards compile
- [x] `:mtg-sets:test` + build — catalog registration & card-definition serialization pass (all 20 load)
- [x] Each card verified clause-by-clause against authoritative oracle text (eoe.json / Scryfall)
- [ ] (Optional) Spot-check a few cards in-app — no new effects/UI were introduced, so no new scenario/E2E tests were required