### PR TITLE
Mana Maze + color-relational cast restriction — Invasion gap #18

### DIFF
--- a/backlog/invasion-engine-gaps.md
+++ b/backlog/invasion-engine-gaps.md
@@ -670,22 +670,24 @@ was the precedent for a projection-time, board-derived keyword grant.
 
 ---
 
-### #18 — Color-relational cast restriction · Mana Maze
+### #18 — Color-relational cast restriction · Mana Maze ✅ DONE
 
-**What exists.** `CastRestriction` is timing/phase only and is *per-spell-definition*;
-`spellsCastThisTurnByPlayer` records casts but there's no "most recently cast spell" color check, and
-Mana Maze restricts **all** spells globally.
-
-**Plan.**
-1. Track the most recent cast: add `lastCastSpellColors: Set<Color>?` to `GameState`, updated on every
-   `SpellCastEvent`.
-2. Model Mana Maze as a `StaticAbility.CantCastSpellsSharingColorWithLastCast` consulted by
-   `CastPermissionUtils.canCastSpell()` — reject a candidate that shares a color with
-   `lastCastSpellColors`. This is a global continuous restriction (correct for Mana Maze), not a
-   per-card cast restriction.
-
-**Leverage.** Narrow (one card), but `lastCastSpellColors` tracking is cheap and the static-restriction
-hook is reusable for other "players can't cast…" effects. Medium effort.
+> **Implemented (primitive + card).** New SDK `data object CantCastSpellsSharingColorWithLastCast`
+> (global static ability) backed by `GameState.lastCastSpellColors: Set<Color>?` — the colors of the
+> spell most recently cast this turn, written in `CastSpellHandler` alongside the existing
+> `spellsCastThisTurnByPlayer` record and cleared each turn in `TurnManager.startTurn()`. The check
+> lives in `CastPermissionUtils.sharesColorWithMostRecentCast(state, spellCardId)` (true only when some
+> battlefield permanent has the static, a colored spell was cast earlier this turn, and the candidate's
+> colors overlap that set) and is enforced both authoritatively in `CastSpellHandler.validate` and in
+> the hand-cast `CastSpellEnumerator` so legal actions stay correct. Never blocks the first spell of the
+> turn; a colorless spell shares no color (always castable) and casting one lifts the restriction. **Mana
+> Maze** (`{1}{U}` Enchantment) authored in `definitions/inv/cards/ManaMaze.kt`; covered by
+> `ManaMazeScenarioTest` (first-spell, same-color block, differently-colored allow, colorless lift).
+>
+> **Scoping note:** the restriction reads the candidate's base `CardComponent.colors` (matching how
+> `lastCastSpellColors` is recorded). Color-changing a card in hand is not a real concern; a recolored
+> *spell on the stack* still records its base colors as "most recently cast", which is the practical
+> universe.
 
 ---
 
@@ -760,4 +762,4 @@ filter.
 9. Scope additions: protection supertype (#13 ✅), dynamic-color protection (#15 ✅), chosen-type
    landwalk (#14 ✅), discard-at-random cost (#9 ✅) — small, independent.
 10. Bespoke / heavier: stack color-change (#11 ✅), life auction (#16 ✅), text-changing (#17 ✅),
-    Mana Maze restriction (#18), reveal-and-compare (#19).
+    Mana Maze restriction (#18 ✅), reveal-and-compare (#19).

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1108,6 +1108,11 @@ of "type" to count.
 - `RestrictSpellsCastPerTurn(maxPerTurn)` — the controller can't cast more than `maxPerTurn`
   spell(s) each turn. Per-controller; the most restrictive applies when several are in play.
   Already-cast spells count, even those cast before this permanent entered. (Yawgmoth's Agenda)
+- `CantCastSpellsSharingColorWithLastCast` — *global* (all players): can't cast a spell that shares a
+  color with the spell most recently cast this turn. Backed by `GameState.lastCastSpellColors` (the
+  colors of the last spell cast, cleared each turn). Never blocks the first spell of the turn; a
+  colorless spell shares no color, so it is always castable and casting one lifts the restriction
+  until the next colored spell. (Mana Maze)
 
 **Tapped-for-mana mana statics** (extra mana / replaced mana when a land is tapped for mana — resolve
 inline as triggered mana abilities, off the stack per CR 605). These fire on the *manual* mana-ability

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ManaMazeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ManaMazeScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Mana Maze (Invasion gap #18).
+ *
+ * Card reference:
+ * - Mana Maze ({1}{U}): Enchantment
+ *   Players can't cast spells that share a color with the spell most recently cast this turn.
+ *
+ * Exercises the `CantCastSpellsSharingColorWithLastCast` global cast restriction backed by
+ * `GameState.lastCastSpellColors`: the restriction never blocks the first spell of the turn,
+ * blocks a spell sharing a color with the most recently cast one, lets a differently-colored
+ * spell through, and is lifted by casting a colorless spell.
+ */
+class ManaMazeScenarioTest : ScenarioTestBase() {
+
+    private val blueBearA = CardDefinition.creature(
+        name = "MM Blue Bear A",
+        manaCost = ManaCost.parse("{1}{U}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    private val blueBearB = CardDefinition.creature(
+        name = "MM Blue Bear B",
+        manaCost = ManaCost.parse("{1}{U}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    private val redBear = CardDefinition.creature(
+        name = "MM Red Bear",
+        manaCost = ManaCost.parse("{1}{R}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    private val colorlessGolem = CardDefinition.creature(
+        name = "MM Colorless Golem",
+        manaCost = ManaCost.parse("{2}"),
+        subtypes = setOf(Subtype("Golem")),
+        power = 2,
+        toughness = 2
+    )
+
+    init {
+        cardRegistry.register(blueBearA)
+        cardRegistry.register(blueBearB)
+        cardRegistry.register(redBear)
+        cardRegistry.register(colorlessGolem)
+
+        fun newGame(): TestGame {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(1, "Mana Maze")
+                .withCardInHand(1, "MM Blue Bear A")
+                .withCardInHand(1, "MM Blue Bear B")
+                .withCardInHand(1, "MM Red Bear")
+                .withCardInHand(1, "MM Colorless Golem")
+                .withActivePlayer(1)
+                .withPriorityPlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+            // Plenty of mana of every color so payment never gates the test.
+            game.state = game.state.updateEntity(game.player1Id) {
+                it.with(ManaPoolComponent(white = 5, blue = 5, black = 5, red = 5, green = 5, colorless = 5))
+            }
+            return game
+        }
+
+        context("Mana Maze") {
+            test("does not block the first spell of the turn") {
+                val game = newGame()
+                withClue("No spell cast yet this turn — nothing to share a color with") {
+                    game.castSpell(1, "MM Blue Bear A").error shouldBe null
+                }
+            }
+
+            test("blocks a second spell sharing a color with the most recently cast spell") {
+                val game = newGame()
+                game.castSpell(1, "MM Blue Bear A").error shouldBe null
+                game.resolveStack()
+
+                withClue("Second blue spell shares blue with the most recently cast spell") {
+                    game.castSpell(1, "MM Blue Bear B").error.shouldNotBeNull()
+                }
+            }
+
+            test("allows a spell that shares no color with the most recently cast spell") {
+                val game = newGame()
+                game.castSpell(1, "MM Blue Bear A").error shouldBe null
+                game.resolveStack()
+
+                withClue("Red shares no color with the blue spell just cast") {
+                    game.castSpell(1, "MM Red Bear").error shouldBe null
+                }
+            }
+
+            test("a colorless spell is always castable and lifts the restriction") {
+                val game = newGame()
+                game.castSpell(1, "MM Blue Bear A").error shouldBe null
+                game.resolveStack()
+
+                // Colorless shares no color, so it is castable even after a colored spell.
+                game.castSpell(1, "MM Colorless Golem").error shouldBe null
+                game.resolveStack()
+
+                withClue("After a colorless spell, the most-recent colors are empty, so blue is free again") {
+                    game.castSpell(1, "MM Blue Bear B").error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/m/mana-maze.json
+++ b/manual-scenarios/cards/m/mana-maze.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Maze Caster",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Dream Thrush", "Opt", "Scorching Lava"],
+    "battlefield": [
+      {"name": "Mana Maze"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Mountain", "Opt"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Horned Cheetah"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -237,3 +237,22 @@ data class RestrictSpellsCastPerTurn(
         "You can't cast more than $maxPerTurn spell${if (maxPerTurn == 1) "" else "s"} each turn"
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
 }
+
+/**
+ * Players can't cast a spell that shares a color with the spell most recently cast this turn.
+ * Used by Mana Maze (Invasion).
+ *
+ * This is a global continuous restriction — it applies to every player, not just the source's
+ * controller. The engine tracks the colors of the most recently cast spell on
+ * [com.wingedsheep.engine.state.GameState.lastCastSpellColors] (cleared at the start of each turn)
+ * and, while any permanent on the battlefield has this static ability, refuses to cast a spell
+ * whose colors overlap that set. A colorless spell shares no color, so it is always castable and
+ * casting one (an empty color set) lifts the restriction until the next colored spell is cast.
+ */
+@SerialName("CantCastSpellsSharingColorWithLastCast")
+@Serializable
+data object CantCastSpellsSharingColorWithLastCast : StaticAbility {
+    override val description: String =
+        "Players can't cast a spell that shares a color with the spell most recently cast this turn"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ManaMaze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ManaMaze.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantCastSpellsSharingColorWithLastCast
+
+/**
+ * Mana Maze
+ * {1}{U}
+ * Enchantment
+ * Players can't cast spells that share a color with the spell most recently cast this turn.
+ */
+val ManaMaze = card("Mana Maze") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Players can't cast spells that share a color with the spell most recently cast this turn."
+
+    staticAbility {
+        ability = CantCastSpellsSharingColorWithLastCast
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "59"
+        artist = "Rebecca Guay"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d62cc17-8fa3-495c-a098-ffbbec89fa53.jpg?1562897736"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -99,7 +99,8 @@ class TurnManager(
             spellsCastThisTurnByPlayer = emptyMap(),
             pendingSpellCopies = emptyList(),
             spellWarpedThisTurn = false,
-            nonlandPermanentLeftBattlefieldThisTurn = false
+            nonlandPermanentLeftBattlefieldThisTurn = false,
+            lastCastSpellColors = null
         )
 
         // Reset cards-drawn-this-turn count for ALL players (not just active player)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -170,6 +170,11 @@ class CastSpellHandler(
             return "You can't cast another spell this turn"
         }
 
+        // Mana Maze: can't cast a spell sharing a color with the spell most recently cast this turn.
+        if (castPermissionUtils.sharesColorWithMostRecentCast(state, action.cardId)) {
+            return "You can't cast a spell that shares a color with the spell most recently cast this turn"
+        }
+
         if (hasForageFromGraveyard) {
             if (!costHandler.canPayAdditionalCost(state, AdditionalCost.Forage, action.playerId)) {
                 return "Cannot forage: need 3 other cards in graveyard or a Food"
@@ -2000,7 +2005,9 @@ class CastSpellHandler(
             val existing = currentState.spellsCastThisTurnByPlayer[action.playerId] ?: emptyList()
             currentState = currentState.copy(
                 spellsCastThisTurnByPlayer = currentState.spellsCastThisTurnByPlayer +
-                    (action.playerId to existing + record)
+                    (action.playerId to existing + record),
+                // "the spell most recently cast this turn" — read by Mana Maze's cast restriction.
+                lastCastSpellColors = record.colors
             )
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -50,6 +50,9 @@ class CastSpellEnumerator : ActionEnumerator {
             // Skip all spells if player can't cast spells this turn
             if (context.cantCastSpells) continue
 
+            // Mana Maze: can't cast a spell sharing a color with the most recently cast spell this turn
+            if (context.castPermissionUtils.sharesColorWithMostRecentCast(state, cardId)) continue
+
             // Look up card definition for target requirements and cast restrictions
             val cardDef = context.cardRegistry.getCard(cardComponent.name) ?: continue
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -14,6 +14,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.CantCastSpellsSharingColorWithLastCast
 import com.wingedsheep.sdk.scripting.CastRestriction
 import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.ExtraLoyaltyActivation
@@ -132,6 +133,30 @@ class CastPermissionUtils(
         if (limit == null) return false
         val castThisTurn = state.playerSpellsCastThisTurn[playerId] ?: 0
         return castThisTurn >= limit
+    }
+
+    /**
+     * Mana Maze (CR via [CantCastSpellsSharingColorWithLastCast]): true when a spell can't be cast
+     * because its colors overlap those of the spell most recently cast this turn.
+     *
+     * Returns false unless (a) some permanent on the battlefield has the restriction static ability,
+     * (b) a colored spell was cast earlier this turn ([GameState.lastCastSpellColors] is non-null and
+     * non-empty), and (c) the candidate spell shares at least one of those colors. A colorless spell
+     * never shares a color, so it is always castable.
+     */
+    fun sharesColorWithMostRecentCast(state: GameState, spellCardId: EntityId): Boolean {
+        val lastColors = state.lastCastSpellColors
+        if (lastColors.isNullOrEmpty()) return false
+
+        val restrictionActive = state.getBattlefield().any { permanentId ->
+            val card = state.getEntity(permanentId)?.get<CardComponent>()
+            val cardDef = card?.let { cardRegistry.getCard(it.cardDefinitionId) }
+            cardDef?.script?.staticAbilities?.any { it is CantCastSpellsSharingColorWithLastCast } == true
+        }
+        if (!restrictionActive) return false
+
+        val spellColors = state.getEntity(spellCardId)?.get<CardComponent>()?.colors ?: return false
+        return spellColors.any { it in lastColors }
     }
 
     fun hasPlayFromTopOfLibrary(state: GameState, playerId: EntityId): Boolean {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -107,6 +107,13 @@ data class GameState(
     val nonlandPermanentLeftBattlefieldThisTurn: Boolean = false,
 
     /**
+     * Colors of the spell most recently cast this turn (by any player), or null if no spell has
+     * been cast yet this turn. Used by Mana Maze's "can't cast a spell that shares a color with
+     * the spell most recently cast this turn" restriction. Cleared at the start of each turn.
+     */
+    val lastCastSpellColors: Set<Color>? = null,
+
+    /**
      * Game-mode configuration the engine reads for format-dependent behaviour (commander damage
      * threshold, command-zone redirect, etc.). Defaults to [Format.Standard] so existing
      * persisted states / tests need no migration.


### PR DESCRIPTION
Implements **Mana Maze** `{1}{U}` Enchantment (Invasion gap #18):

> Players can't cast spells that share a color with the spell most recently cast this turn.

Built as a reusable global cast-restriction primitive, not a card-specific executor.

## SDK (`mtg-sdk`)
- `data object CantCastSpellsSharingColorWithLastCast : StaticAbility` — a global "players can't cast…" restriction.

## Engine (`rules-engine`)
- `GameState.lastCastSpellColors: Set<Color>?` — colors of the spell most recently cast this turn.
- `CastSpellHandler` writes it alongside the existing `spellsCastThisTurnByPlayer` record; `TurnManager.startTurn()` clears it each turn.
- `CastPermissionUtils.sharesColorWithMostRecentCast(...)` — gate logic (only fires when the static is on the battlefield, a colored spell was cast earlier this turn, and colors overlap).
- Enforced **authoritatively** in `CastSpellHandler.validate` and mirrored in the hand-cast `CastSpellEnumerator` so legal actions stay correct.
- First spell of the turn is never blocked; a colorless spell shares no color (always castable) and casting one lifts the restriction.

## Content / tests / docs
- `definitions/inv/cards/ManaMaze.kt`
- `ManaMazeScenarioTest` — first-spell-free, same-color block, differently-colored allow, colorless lift (all pass).
- `manual-scenarios/cards/m/mana-maze.json` — interactive demo board.
- Updated `card-sdk-language-reference.md`; marked gap #18 ✅ DONE in `backlog/invasion-engine-gaps.md`.

Card-status: INV 91 → 92 implemented. Remaining open Invasion gaps are #19 (Psychic Battle) and #21 (the five pile-separation cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)