### PR TITLE
LTR: 13 composable cards (Ring/Amass) + engine-gap map for the rest

### DIFF
--- a/backlog/sets/lord-of-the-rings/TODO.md
+++ b/backlog/sets/lord-of-the-rings/TODO.md
@@ -27,6 +27,18 @@ Verify status anytime with: `scripts/card-status --set LTR` (and `--list --set L
 - 🚧 **Amass Orcs** — substrate done on branch `ltr-amass` (CR 701.47: `Effects.Amass`,
   `AmassExecutor` + `AmassContinuation`, composing `CreateToken`/`AddCounters`/`AddSubtype`).
   First card attached: **Dunland Crebain**. ~23 Amass cards remain to attach.
+- ✅ **The Ring & Amass substrate are now on `main`** (`Effects.TheRingTemptsYou`,
+  `Triggers.RingTemptsYou`, `Conditions.SourceIsRingBearer`, `Effects.Amass`). With them
+  present, a further batch of cards that compose from existing primitives was added directly
+  on `main`, one commit per card (2026-05-29):
+  Fiery Inscription, Grey Havens Navigator, Soothing of Sméagol, Bombadil's Song,
+  Now for Wrath Now for Ruin!, The Black Breath, Nazgûl, Saruman the White,
+  Bilbo Retired Burglar, War of the Last Alliance, Horses of the Bruinen, Warg Rider,
+  Assault on Osgiliath. Draft now 161/261.
+- ⏳ **Everything still missing needs new engine work** — see the
+  "Engine gaps blocking the remaining cards" section below. Each card is listed under the
+  primitive it is waiting on, with the exact blocking clause. Stop and open a dedicated PR
+  per gap rather than approximating.
 
 ## Data sources — do NOT hit the network
 
@@ -133,3 +145,321 @@ Group by the shared feature so one PR can clear several cards:
 - Battlefield filtering must use projected state (`matchesWithProjection`).
 - Basic lands (Plains/Island/Swamp/Mountain/Forest) are covered by `basicLandsFallback`;
   add LTR-art basic-land variants only if you want the distinct printings.
+
+---
+
+## Engine gaps blocking the remaining cards
+
+Every card still unchecked in `cards.md` (excluding the five basic lands, which the fallback
+covers) needs at least one new engine primitive. They are grouped below by the gap they wait
+on; each bullet quotes the **specific clause** that cannot be composed today. A card with more
+than one gap is listed under its dominant gap with the secondary one noted inline. Clear a gap
+in its own PR, then attach all of its cards.
+
+Verified present today and used by the composed batch: `Effects.TheRingTemptsYou`,
+`Triggers.RingTemptsYou`, `Conditions.SourceIsRingBearer`, `Conditions.CreatureDiedThisTurn`,
+`Effects.Amass` (incl. `DynamicAmount.XValue`), `EffectPatterns.scry`/`mill`/`searchLibrary`,
+`ForEachInGroupEffect` + `GroupFilter`, `GrantKeyword` static, `Targets.UpToCreatures` +
+`ForEachTargetEffect`.
+
+### Gap 1 — "Whenever you scry" trigger
+**Engine change:** emit a `ScriedEvent` carrying the number of cards looked at, add a
+`Triggers.WheneverYouScry`, and a `DynamicAmount` for "cards looked at while scrying this way".
+- **Arwen Undómiel** — "Whenever you scry, put a +1/+1 counter on target creature."
+- **Celeborn the Wise** — "Whenever you scry, Celeborn gets +1/+1 … for each card looked at."
+- **Chance-Met Elves** — "Whenever you scry, put a +1/+1 counter on this creature." (once/turn)
+- **Council's Deliberation** — "Whenever you scry, … exile this card from your graveyard …"
+- **Elrond, Lord of Rivendell** — scry on each creature ETB; needs "second time this ability
+  resolved this turn" counter as well.
+- **Elrond, Master of Healing** — "Whenever you scry, put a +1/+1 counter on each of up to X
+  target creatures, where X is the number of cards looked at."
+- **Galadriel of Lothlórien** — "Whenever you scry, you may reveal the top card …" (also Gap 3).
+- **Glorfindel, Dauntless Rescuer** — "Whenever you scry, choose one and Glorfindel gets +1/+1."
+- **Legolas, Counter of Kills** — "Whenever you scry, if Legolas is tapped, you may untap it."
+- **Nimrodel Watcher** — "Whenever you scry, this creature gets +1/+0 and can't be blocked."
+- **Lost Isle Calling** — "Whenever you scry, put a verse counter on this." (also Gap 6 counter)
+- **Elvish Mariner** (Extra) — "Whenever you scry, tap up to X target nonland permanents …"
+
+### Gap 2 — "draw your second card each turn" trigger
+**Engine change:** an Nth-card-drawn-per-turn trigger (per player), the draw analogue of
+`Triggers.NthSpellCast`.
+- **Knights of Dol Amroth** — "Whenever you draw your second card each turn, put a +1/+1 counter."
+- **Prince Imrahil the Fair** — "Whenever you draw your second card each turn, create a token."
+- **Stalwarts of Osgiliath** — same trigger (ETB Ring tempts half is already composable).
+
+### Gap 3 — "the Ring tempted you and you chose a creature other than this" condition
+**Engine change:** a condition usable with `Triggers.RingTemptsYou` meaning "you chose a
+creature other than {source} as your Ring-bearer" (CR 701.52d).
+- **Aragorn, Company Leader** — "…if you chose a creature other than Aragorn as your
+  Ring-bearer…" (also Gap 7 keyword counters).
+- **Faramir, Field Commander** — "…if you chose a creature other than Faramir…, create a token."
+- **Gandalf, Friend of the Shire** — "…if you chose a creature other than Gandalf…, draw a card."
+  (also Gap 4 cast-as-flash).
+- **Galadriel of Lothlórien** — chapter-one half (also Gap 1).
+
+### Gap 4 — "cast [filter] spells as though they had flash" permission
+**Engine change:** a static/one-shot permission granting flash-timing to a filtered set of
+spells.
+- **Borne Upon a Wind** — "You may cast spells this turn as though they had flash."
+- **Gandalf, Friend of the Shire** — "You may cast sorcery spells as though they had flash."
+- **Gandalf the White** — "You may cast legendary spells and artifact spells as though they
+  had flash." (also needs the extra-trigger replacement below).
+
+### Gap 5 — Goad
+**Engine change:** Goad effect + goaded combat-forcing state (CR 701.41).
+- **Glóin, Dwarf Emissary** — "{T}, Sacrifice a Treasure: Goad target creature."
+
+### Gap 6 — new counter types (each spans the 5 counter layers)
+**Engine change:** add the counter type across `CounterType`, `StateProjector`, and the three
+web-client files; some also need "enters with N counters where N = …".
+- **Dawn of a New Age** — hope counter; "enters with a hope counter for each creature you control."
+- **Lost Isle Calling** — verse counter (also Gap 1).
+- **Palantír of Orthanc** — influence counter (also Gap 1 scry + complex opponent choice).
+- **The One Ring** — burden counter (also Gap 9 protection-from-everything).
+- **Scroll of Isildur** — stun counter (also Saga gain-control-for-duration).
+
+### Gap 7 — keyword counters + "choose a kind of counter"
+**Engine change:** first-strike/vigilance/deathtouch/lifelink counters wired through the
+keyword-counter map, plus a "choose one of these counter kinds" effect.
+- **Aragorn, Company Leader** — "…put your choice of a counter from among first strike,
+  vigilance, deathtouch, and lifelink…; …put one of each of those kinds on another creature."
+
+### Gap 8 — protection from a chosen / total quality
+**Engine change:** protection-from-everything (CR 702.16e), protection-from-chosen-colors, and
+protection-from-chosen-card-type.
+- **The One Ring** — "you gain protection from everything until your next turn."
+- **Éowyn, Fearless Knight** — "Legendary creatures you control gain protection from each of
+  that creature's colors…" (also exile-creature-with-greater-power).
+- **Pippin, Guard of the Citadel** — "…gains protection from the card type of your choice…"
+
+### Gap 9 — copy a spell on the stack
+**Engine change:** "copy target instant/sorcery spell(s), you may choose new targets."
+- **Display of Power** — "Copy any number of target instant and/or sorcery spells."
+- **Gandalf the Grey** — "Copy target instant or sorcery spell you control." (also a
+  modal-with-memory "choose one that hasn't been chosen").
+
+### Gap 10 — cast a spell without paying its mana cost from hand / return a spell from the stack
+**Engine change:** "you may cast a spell from your hand with mana value ≤ X without paying its
+mana cost"; and bouncing a spell off the stack.
+- **Press the Enemy** — "Return target spell or nonland permanent…; You may cast an instant or
+  sorcery spell with equal or lesser mana value from your hand without paying its mana cost."
+- **Glamdring** — "…you may cast an instant or sorcery spell from your hand with mana value ≤
+  that damage without paying its mana cost." (also dynamic +1/+0 per I/S in graveyard).
+- **Flame of Anor** — modal with a conditional extra mode ("if you control a Wizard … choose two").
+
+### Gap 11 — activated abilities that function from the graveyard
+**Engine change:** activated abilities usable while the card is in the graveyard, with
+"Exile this card from your graveyard" as a cost, sorcery-speed gating.
+- **Gollum's Bite** — "{3}{B}, Exile this card from your graveyard: The Ring tempts you."
+- **Gollum, Patient Plotter** — "{B}, Sacrifice a creature: Return this card from your
+  graveyard to your hand." (LTB Ring tempts half is composable).
+
+### Gap 12 — reflexive reference to "the amassed Army"
+**Engine change:** expose the just-amassed Army to a reflexive "when you do" effect (its power),
+and an excess-damage trigger.
+- **Foray of Orcs** — "…deals X damage…, where X is the amassed Army's power."
+- **Grishnákh, Brash Instigator** — "…gain control of target … creature … with power ≤ the
+  amassed Army's power."
+- **Shagrat, Loot Bearer** — "…amass Orcs X, where X is the number of Equipment attached…"
+  (also attach-equipment-on-attack).
+- **Fall of Cair Andros** — "Whenever a creature an opponent controls is dealt excess noncombat
+  damage, amass Orcs X…" (excess-damage trigger).
+- **Surrounded by Orcs** — "…target player mills X cards, where X is the amassed Army's power."
+- **The Mouth of Sauron** — "amass Orcs X, where X is the number of instant and sorcery cards in
+  **that player's** graveyard" (dynamic count keyed to a targeted player's graveyard).
+
+### Gap 13 — set base power AND toughness
+**Engine change:** `SetBaseToughness` / `SetBasePowerAndToughness` (only `SetBasePower` exists).
+- **Dreadful as the Storm** — "Target creature has base power and toughness 5/5…" (Ring tempts
+  half composable).
+- **Frodo, Sauron's Bane** — "…becomes a Halfling Scout with base power and toughness 2/3…"
+  (also activated type/ability morphing + a Ring-tempt-count win condition).
+
+### Gap 14 — flicker (exile and return under your control)
+**Engine change:** a blink effect that exiles then returns a permanent under your control.
+- **Slip On the Ring** — "Exile target creature you own, then return it to the battlefield under
+  your control." (Ring tempts half composable).
+
+### Gap 15 — "deal damage to each blocker" / one-sided creature-deals-damage
+**Engine change:** "{source} deals N damage to each creature blocking it"; "target creature
+deals damage equal to its power to another target creature."
+- **Battle-Scarred Goblin** — "…it deals 1 damage to each creature blocking it."
+- **Breaking of the Fellowship** — "Target creature an opponent controls deals damage equal to
+  its power to another target creature that player controls."
+- **Legolas, Master Archer** — "Legolas deals damage equal to its power to up to one target
+  creature." (also a "cast a spell that targets X" trigger).
+
+### Gap 16 — count of permanents sacrificed by an effect
+**Engine change:** a dynamic amount for "permanents sacrificed this way."
+- **Voracious Fell Beast** — "Create a Food token for each creature sacrificed this way."
+
+### Gap 17 — condition keyed to a creature sacrificed as a cost
+**Engine change:** a condition on the creature paid as an additional/activation sacrifice cost
+(e.g. "was legendary").
+- **Nasty End** — "…If the sacrificed creature was legendary, draw three cards instead."
+- **Gríma Wormtongue** — "If the sacrificed creature was legendary, amass Orcs 2." (also
+  "your opponents can't gain life" static).
+- **Rise of the Witch-king** — "If you sacrificed a creature this way, you may return another
+  permanent card from your graveyard to the battlefield." (each-player edict + reanimate).
+
+### Gap 18 — Ring-bearer player-state conditions and statics
+**Engine change:** a player-level "you control a Ring-bearer" condition and a "must be blocked
+if able" static gated on a condition.
+- **Dúnedain Rangers** — "…if you don't control a Ring-bearer, the Ring tempts you."
+- **Frodo Baggins** — "As long as Frodo Baggins is your Ring-bearer, it must be blocked if able."
+
+### Gap 19 — "permanent you controlled left the battlefield this turn" condition
+**Engine change:** a this-turn condition broader than `CreatureDiedThisTurn`.
+- **Shortcut to Mushrooms** — "…if a permanent you controlled left the battlefield this turn…"
+  (ETB Ring tempts half composable).
+
+### Gap 20 — "a card put into a graveyard from the battlefield this turn" filter
+**Engine change:** a zone filter that matches cards that entered a graveyard from the
+battlefield during the current turn.
+- **Samwise the Stouthearted** — "…target permanent card in your graveyard that was put there
+  from the battlefield this turn."
+- **Lobelia Sackville-Baggins** — "…creature card from an opponent's graveyard that was put
+  there from the battlefield this turn…" (then Treasures = exiled card's power).
+
+### Gap 21 — graveyard-functional triggered ability
+**Engine change:** a triggered ability that works while the card is in the graveyard.
+- **Ringwraiths** (Extra) — "When the Ring tempts you, return this card from your graveyard to
+  your hand." (also ETB -3/-3 with conditional 3 life loss if the target was legendary).
+
+### Gap 22 — restricted / graveyard-derived mana
+**Engine change:** mana abilities whose mana is spendable only on a card class, plus a
+"can't be countered" rider, and mana of colors derived from graveyard contents.
+- **Delighted Halfling** — "Spend this mana only to cast a legendary spell, and that spell
+  can't be countered."
+- **Great Hall of the Citadel** — "Spend this mana only to cast legendary spells."
+- **The Grey Havens** — "Add one mana of any color among legendary creature cards in your
+  graveyard." (ETB scry half composable).
+
+### Gap 23 — cycling variants (land/type/basic-land cycling)
+**Engine change:** Landcycling / Typecycling / Swampcycling keywords.
+- **Troll of Khazad-dûm** — "Swampcycling {1}" (also "can't be blocked except by three or more").
+
+### Gap 24 — nonbasic landwalk keyword
+**Engine change:** a `NONBASIC_LANDWALK` keyword + evasion check.
+- **Trailblazer's Boots** (Extra) — "Equipped creature has nonbasic landwalk."
+
+### Gap 25 — "X in an activated-ability cost" amass / doubled-X
+**Engine change:** support `DynamicAmount.XValue` inside activated-ability costs (and `{X}{X}`).
+- **Barad-dûr** — "{X}{X}{B}, {T}: Amass Orcs X. Activate only if a creature died this turn."
+  (`CreatureDiedThisTurn` exists; conditional ETB-tapped is the other half).
+
+### Gap 26 — "lose all abilities until end of turn"
+**Engine change:** an effect that strips all abilities from a creature for a duration.
+- **Barrow-Blade** — "…that creature loses all abilities until end of turn." (plus the
+  blocks/blocked trigger targeting the *other* creature).
+
+### Gap 27 — assign combat damage by toughness
+**Engine change:** a continuous effect making a creature assign combat damage equal to its
+toughness rather than its power.
+- **Bill the Pony** — "…target creature you control assigns combat damage equal to its
+  toughness rather than its power." (Food half composable).
+
+### Gap 28 — equip-ability timing / cost modification
+**Engine change:** "activate equip abilities at instant speed," equip-cost reduction, and a
+"first equip each turn costs {0}" replacement.
+- **Forge Anew** — instant-speed equip + free first equip (return-Equipment-from-GY half
+  composable).
+- **Éowyn, Lady of Rohan** — "Equip abilities you activate cost {1} less to activate." (plus a
+  begin-combat modal first strike/vigilance with an equipped-creature branch).
+
+### Gap 29 — conditional keyword from combat opponent's subtype
+**Engine change:** a static granting a keyword conditioned on what is blocking/blocked-by.
+- **Sting, the Glinting Dagger** — "Equipped creature has first strike as long as it's blocking
+  or blocked by a Goblin or Orc." (begin-of-combat untap is composable).
+
+### Gap 30 — cost reduction conditioned on game history
+**Engine change:** cost reductions that read per-turn state (cards drawn, permanents sacrificed).
+- **Gwaihir the Windlord** — "costs {2} less … as long as you've drawn two or more cards this
+  turn." ("Other Birds you control have vigilance" is composable today).
+- **The Balrog, Durin's Bane** — "costs {1} less to cast for each permanent sacrificed this
+  turn." (plus "can't be blocked except by legendary" + a death trigger).
+
+### Gap 31 — Vehicles / Crew
+**Engine change:** the Vehicle card type, crewing, and conditional artifact-creature state.
+- **Grond, the Gatebreaker** — "Crew 3" + "As long as it's your turn and you control an Army,
+  Grond is an artifact creature."
+
+### Gap 32 — phasing
+**Engine change:** phase out/in (CR 702.26) and a phase-in trigger.
+- **King of the Oathbreakers** — "…it phases out." / "Whenever … phases in, create a token."
+
+### Gap 33 — token that is a copy of a creature with overrides
+**Engine change:** create-token-copy of a card in the graveyard / dying creature with type and
+P/T overrides and added abilities, plus delayed conditional exile.
+- **Sauron, the Necromancer** — "Create a tapped and attacking token that's a copy of that card,
+  except it's a 3/3 black Wraith with menace … exile that token unless Sauron is your Ring-bearer."
+- **Shelob, Child of Ungoliant** — "…create a token that's a copy of that creature, except it's
+  a Food artifact … and it loses all other card types." (Spider death-tracking; the Spider
+  anthem statics are composable).
+
+### Gap 34 — excess damage redirected to controller
+**Engine change:** "excess damage is dealt to that creature's controller instead."
+- **Gandalf's Sanction** — dynamic X = I/S cards in your graveyard; "Excess damage is dealt to
+  that creature's controller instead."
+
+### Gap 35 — "damage can't be prevented" + same-controller spread
+**Engine change:** a turn-long prevention shutoff and "N damage to each other creature with the
+same controller as the target."
+- **Fear, Fire, Foes!** — "Damage can't be prevented this turn. … X damage to target creature
+  and 1 damage to each other creature with the same controller."
+
+### Gap 36 — combat-history target filters
+**Engine change:** filters/edicts keyed to "blocked or was blocked by a legendary creature this
+turn," "dealt combat damage to you this turn," and "least power."
+- **You Cannot Pass!** — "Destroy target creature that blocked or was blocked by a legendary
+  creature this turn."
+- **Witch-king of Angmar** — "…each opponent sacrifices a creature … that dealt combat damage to
+  you this turn." (plus discard→indestructible and Ring tempts).
+- **Witch-king, Bringer of Ruin** (Extra) — "…defending player sacrifices a creature with the
+  least power among creatures they control."
+
+### Gap 37 — gain control for a "for as long as you control this" duration
+**Engine change:** a control-change duration tied to continued control of the source.
+- **Rangers of Ithilien** — "gain control of up to one target creature with lesser power for as
+  long as you control this creature." (Ring tempts half composable).
+- **Scroll of Isildur** — "Gain control of up to one target artifact for as long as you control
+  this Saga." (also stun counter, Gap 6).
+
+### Gap 38 — one-off complex cards (each its own PR)
+**Engine change:** bespoke — these don't share a clean reusable gap with others.
+- **Goldberry, River-Daughter** — move counters of each kind between target permanents.
+- **Bewitching Leechcraft** — grant the enchanted creature a custom untap-replacement ability.
+- **Radagast the Brown** — look at top X (= creature's mana value), reveal a creature not
+  sharing a type with one you control.
+- **Long List of the Ents** — Saga that *notes creature types* and buffs the next cast of that
+  type.
+- **Peregrin Took** — token-creation replacement ("those tokens plus an additional Food").
+- **Phial of Galadriel** — draw-replacement (draw two if hand empty) + life-gain doubling.
+- **Tom Bombadil** — "4+ lore counters among Sagas → hexproof and indestructible" + a
+  "final chapter ability resolves" trigger.
+- **Sharkey, Tyrant of the Shire** — copy/lock opponents' land activated abilities.
+- **Saruman of Many Colors** — Ward—discard; second-spell mill/exile/copy/cast chain.
+- **Sauron, the Dark Lord** — Ward—sac; "Army deals combat damage → the Ring tempts you" + more.
+- **Ent-Draught Basin** — "{X}, {T}: +1/+1 counter on target creature with power X."
+- **Mount Doom** — "Choose up to two creatures, then destroy the rest."
+- **Faramir, Prince of Ithilien** — delayed end-step "choose an opponent" + did-they-attack-you.
+- **Boromir, Warden of the Tower** — "if no mana was spent to cast it, counter that spell."
+- **Call of the Ring** — "Whenever you choose a creature as your Ring-bearer …" trigger.
+- **Glorious Gale** — counter creature spell + "if it was a legendary spell" conditional.
+- **There and Back Again** — Saga producing **Smaug**, a named token with its own death trigger.
+- **Hew the Entwood** — sacrifice any number of lands, reveal X, put artifact/land cards in play.
+- **Ringsight** — tutor for a card that "shares a color with a legendary creature you control."
+- **One Ring to Rule Them All** — Saga; mill = your Ring-bearer's power (Gap 12-style dynamic).
+- **The Ring Goes South** — reveal until X lands, X = legendary creatures you control.
+- **Orcish Bowmasters** — "whenever an opponent draws a card except the first … in their draw
+  step" trigger.
+- **Sauron's Ransom** — opponent separates your top four into hidden face-down/face-up piles.
+- **Flame of Anor** — see Gap 9/10 (conditional modal count).
+- **Sméagol, Helpful Guide** — reveal-until-land put under your control (the end-step Ring-tempt
+  half uses `CreatureDiedThisTurn`, already present).
+- **Riders of the Mark** (Extra) — Affinity for Humans (composable) + end-step "if it attacked,
+  return it to hand and create tokens equal to its toughness."
+- **Fires of Mount Doom** (Extra) — impulse-exile-and-play + destroy attached Equipment + damage.
+- **Frodo, Determined Hero** (Extra) — attach Equipment of MV 2–3 on enter/attack + "prevent all
+  damage to Frodo during your turn."
+- **Gollum, Scheming Guide** (Extra) — opponent guesses whether your top card is land/nonland.

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -108,7 +108,7 @@ starter-deck/special cards and basic lands.
 ### Black
 
 - [x] Bitter Downfall
-- [ ] The Black Breath
+- [x] The Black Breath
 - [ ] Call of the Ring
 - [x] Cirith Ungol Patrol
 - [x] Claim the Precious

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 163 / 291
+**Implemented:** 176 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -159,7 +159,7 @@ starter-deck/special cards and basic lands.
 - [x] Erkenbrand, Lord of Westfold
 - [ ] Fall of Cair Andros
 - [ ] Fear, Fire, Foes!
-- [ ] Fiery Inscription
+- [x] Fiery Inscription
 - [x] Fire of Orthanc
 - [ ] Foray of Orcs
 - [x] Gimli, Counter of Kills

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -130,7 +130,7 @@ starter-deck/special cards and basic lands.
 - [x] Mordor Trebuchet
 - [x] Morgul-Knife Wound
 - [ ] Nasty End
-- [ ] Nazgûl
+- [x] Nazgûl
 - [x] Oath of the Grey Host
 - [ ] One Ring to Rule Them All
 - [ ] Orcish Bowmasters

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -60,7 +60,7 @@ starter-deck/special cards and basic lands.
 - [ ] Stalwarts of Osgiliath
 - [x] Tale of Tinúviel
 - [x] Took Reaper
-- [ ] War of the Last Alliance
+- [x] War of the Last Alliance
 - [x] Westfold Rider
 - [ ] You Cannot Pass!
 

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -235,7 +235,7 @@ starter-deck/special cards and basic lands.
 - [x] Arwen, Mortal Queen
 - [ ] Arwen Undómiel
 - [ ] The Balrog, Durin's Bane
-- [ ] Bilbo, Retired Burglar
+- [x] Bilbo, Retired Burglar
 - [x] Butterbur, Bree Innkeeper
 - [x] Denethor, Ruling Steward
 - [x] Doors of Durin

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -80,7 +80,7 @@ starter-deck/special cards and basic lands.
 - [ ] Gandalf, Friend of the Shire
 - [ ] Glorious Gale
 - [ ] Goldberry, River-Daughter
-- [ ] Grey Havens Navigator
+- [x] Grey Havens Navigator
 - [x] Hithlain Knots
 - [ ] Horses of the Bruinen
 - [x] Ioreth of the Healing House

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -48,7 +48,7 @@ starter-deck/special cards and basic lands.
 - [x] Landroval, Horizon Witness
 - [x] Lost to Legend
 - [x] Nimble Hobbit
-- [ ] Now for Wrath, Now for Ruin!
+- [x] Now for Wrath, Now for Ruin!
 - [x] Protector of Gondor
 - [x] Reprieve
 - [x] Rosie Cotton of South Lane

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -97,7 +97,7 @@ starter-deck/special cards and basic lands.
 - [ ] Saruman the White
 - [x] Saruman's Trickery
 - [ ] Scroll of Isildur
-- [ ] Soothing of Sméagol
+- [x] Soothing of Sméagol
 - [x] Stern Scolding
 - [x] Storm of Saruman
 - [ ] Surrounded by Orcs

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -190,7 +190,7 @@ starter-deck/special cards and basic lands.
 ### Green
 
 - [x] Bag End Porter
-- [ ] Bombadil's Song
+- [x] Bombadil's Song
 - [x] Brandywine Farmer
 - [ ] Celeborn the Wise
 - [ ] Chance-Met Elves

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -334,7 +334,7 @@ starter-deck/special cards and basic lands.
 
 ### Red
 
-- [ ] Assault on Osgiliath
+- [x] Assault on Osgiliath
 
 ### Green
 

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -392,7 +392,7 @@ starter-deck/special cards and basic lands.
 
 ### Black
 
-- [ ] Warg Rider
+- [x] Warg Rider
 
 ### Red
 

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -82,7 +82,7 @@ starter-deck/special cards and basic lands.
 - [ ] Goldberry, River-Daughter
 - [x] Grey Havens Navigator
 - [x] Hithlain Knots
-- [ ] Horses of the Bruinen
+- [x] Horses of the Bruinen
 - [x] Ioreth of the Healing House
 - [x] Isolation at Orthanc
 - [x] Ithilien Kingfisher

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -94,7 +94,7 @@ starter-deck/special cards and basic lands.
 - [x] Pelargir Survivor
 - [ ] Press the Enemy
 - [ ] Rangers of Ithilien
-- [ ] Saruman the White
+- [x] Saruman the White
 - [x] Saruman's Trickery
 - [ ] Scroll of Isildur
 - [x] Soothing of Sméagol

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AssaultOnOsgiliath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AssaultOnOsgiliath.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Assault on Osgiliath
+ * {X}{R}{R}{R}
+ * Sorcery
+ *
+ * Amass Orcs X, then Goblins and Orcs you control gain double strike and haste until end of turn.
+ */
+val AssaultOnOsgiliath = card("Assault on Osgiliath") {
+    manaCost = "{X}{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Amass Orcs X, then Goblins and Orcs you control gain double strike and haste until end of turn. " +
+        "(To amass Orcs X, put X +1/+1 counters on an Army you control. It's also an Orc. If you don't control " +
+        "an Army, create a 0/0 black Orc Army creature token first.)"
+
+    spell {
+        effect = Effects.Amass(DynamicAmount.XValue)
+            .then(
+                ForEachInGroupEffect(
+                    filter = GroupFilter(
+                        com.wingedsheep.sdk.scripting.GameObjectFilter.Creature
+                            .withAnySubtype("Goblin", "Orc").youControl()
+                    ),
+                    effect = GrantKeywordEffect(Keyword.DOUBLE_STRIKE.name, EffectTarget.Self, Duration.EndOfTurn)
+                        .then(GrantKeywordEffect(Keyword.HASTE.name, EffectTarget.Self, Duration.EndOfTurn))
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "285"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/2549b70a-6bd0-4c9b-96b7-4ab775a30cd3.jpg?1719684269"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BilboRetiredBurglar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BilboRetiredBurglar.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bilbo, Retired Burglar
+ * {1}{U}{R}
+ * Legendary Creature — Halfling Rogue
+ * 1/3
+ *
+ * When Bilbo enters or leaves the battlefield, the Ring tempts you.
+ * Whenever Bilbo deals combat damage to a player, create a Treasure token.
+ */
+val BilboRetiredBurglar = card("Bilbo, Retired Burglar") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Halfling Rogue"
+    power = 1
+    toughness = 3
+    oracleText = "When Bilbo enters or leaves the battlefield, the Ring tempts you.\n" +
+        "Whenever Bilbo deals combat damage to a player, create a Treasure token."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.TheRingTemptsYou()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.TheRingTemptsYou()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.CreateTreasure()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "196"
+        artist = "Anna Pavleeva"
+        flavorText = "\"I don't know half of you half as well as I should like; and I like less than half of you half as well as you deserve.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/527df93e-cc2b-4216-909a-4ada1abcbfd3.jpg?1687694657"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BombadilsSong.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BombadilsSong.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+
+/**
+ * Bombadil's Song
+ * {1}{G}
+ * Instant
+ *
+ * Target creature you control gets +1/+1 and gains hexproof until end of turn. The Ring tempts you.
+ */
+val BombadilsSong = card("Bombadil's Song") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature you control gets +1/+1 and gains hexproof until end of turn. The Ring tempts you. " +
+        "(A creature with hexproof can't be the target of spells or abilities your opponents control.)"
+
+    spell {
+        val creature = target("creature you control", Targets.CreatureYouControl)
+        effect = ModifyStatsEffect(
+            powerModifier = 1,
+            toughnessModifier = 1,
+            target = creature,
+            duration = Duration.EndOfTurn
+        )
+            .then(Effects.GrantKeyword(Keyword.HEXPROOF, creature, Duration.EndOfTurn))
+            .then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Marie Magny"
+        flavorText = "\"Hey dol! merry dol! ring a dong dillo!\n" +
+            "Ring a dong! hop along! fal lal the willow!\n" +
+            "Tom Bom, jolly Tom, Tom Bombadillo!\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/6391699e-987a-499f-9fec-96f2362760b9.jpg?1687694677"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FieryInscription.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FieryInscription.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fiery Inscription
+ * {2}{R}
+ * Enchantment
+ *
+ * When this enchantment enters, the Ring tempts you.
+ * Whenever you cast an instant or sorcery spell, this enchantment deals 2 damage to each opponent.
+ */
+val FieryInscription = card("Fiery Inscription") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, the Ring tempts you.\n" +
+        "Whenever you cast an instant or sorcery spell, this enchantment deals 2 damage to each opponent."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.TheRingTemptsYou()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.DealDamage(2, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "126"
+        artist = "John Di Giovanni"
+        flavorText = "Ash nazg durbatulûk, ash nazg gimbatul, ash nazg thrakatulûk agh burzum-ishi krimpatul."
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c321159-43e5-40fc-9f0c-4ecc4f6cfd20.jpg?1686968925"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GreyHavensNavigator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GreyHavensNavigator.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grey Havens Navigator
+ * {2}{U}
+ * Creature — Elf Pilot
+ * 3/2
+ *
+ * Flash
+ * When this creature enters, scry 1.
+ */
+val GreyHavensNavigator = card("Grey Havens Navigator") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elf Pilot"
+    power = 3
+    toughness = 2
+    oracleText = "Flash\nWhen this creature enters, scry 1."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Henry Peters"
+        flavorText = "It was an old tradition that beyond the Shire stood the Grey Havens, from which at times elven-ships set sail, never to return."
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4dd89994-bdff-47ca-a65d-10afcc7e773e.jpg?1686968120"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/HorsesOfTheBruinen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/HorsesOfTheBruinen.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Horses of the Bruinen
+ * {3}{U}{U}
+ * Sorcery
+ *
+ * Return up to two target creatures to their owners' hands. Scry 1. The Ring tempts you.
+ */
+val HorsesOfTheBruinen = card("Horses of the Bruinen") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return up to two target creatures to their owners' hands. Scry 1. The Ring tempts you."
+
+    spell {
+        target("up to two target creatures", Targets.UpToCreatures(2))
+        effect = ForEachTargetEffect(
+            listOf(Effects.ReturnToHand(EffectTarget.ContextTarget(0)))
+        )
+            .then(EffectPatterns.scry(1))
+            .then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "55"
+        artist = "Kasia 'Kafis' Zielińska"
+        flavorText = "The black horses were filled with madness, and leaping forward in terror they bore their riders into the rushing flood."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7725dc2-2654-4ffb-b6b3-510ae64ec6af.jpg?1686968142"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/Nazgul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/Nazgul.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Nazgûl
+ * {2}{B}
+ * Creature — Wraith Knight
+ * 1/2
+ *
+ * Deathtouch
+ * When this creature enters, the Ring tempts you.
+ * Whenever the Ring tempts you, put a +1/+1 counter on each Wraith you control.
+ * A deck can have up to nine cards named Nazgûl.
+ */
+val Nazgul = card("Nazgûl") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Wraith Knight"
+    power = 1
+    toughness = 2
+    oracleText = "Deathtouch\n" +
+        "When this creature enters, the Ring tempts you.\n" +
+        "Whenever the Ring tempts you, put a +1/+1 counter on each Wraith you control.\n" +
+        "A deck can have up to nine cards named Nazgûl."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.TheRingTemptsYou()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.RingTemptsYou
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter.allCreaturesWithSubtype("Wraith").youControl(),
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "100"
+        artist = "Igor Krstic"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/833936c6-9381-4c0b-a81c-4a938be95040.jpg?1739485417"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/NowForWrathNowForRuin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/NowForWrathNowForRuin.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Now for Wrath, Now for Ruin!
+ * {3}{W}
+ * Sorcery
+ *
+ * Put a +1/+1 counter on each creature you control. They gain vigilance until end of turn.
+ * The Ring tempts you.
+ */
+val NowForWrathNowForRuin = card("Now for Wrath, Now for Ruin!") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Put a +1/+1 counter on each creature you control. They gain vigilance until end of turn. The Ring tempts you."
+
+    spell {
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter.AllCreaturesYouControl,
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+                .then(GrantKeywordEffect(Keyword.VIGILANCE.name, EffectTarget.Self, Duration.EndOfTurn))
+        ).then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Valera Lutfullina"
+        flavorText = "The Captains of the West came at last to challenge the Black Gate and the might of Mordor."
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2e2c80d-7581-46ba-8237-7886b91c19b3.jpg?1687694562"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumanTheWhite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumanTheWhite.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Saruman the White
+ * {4}{U}
+ * Legendary Creature — Avatar Wizard
+ * 4/4
+ *
+ * Ward {2}
+ * Whenever you cast your second spell each turn, amass Orcs 2.
+ */
+val SarumanTheWhite = card("Saruman the White") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 4
+    toughness = 4
+    oracleText = "Ward {2}\n" +
+        "Whenever you cast your second spell each turn, amass Orcs 2. (Put two +1/+1 counters on an Army " +
+        "you control. It's also an Orc. If you don't control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        effect = Effects.Amass(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "67"
+        artist = "Matt Stewart"
+        flavorText = "\"Sauron's victory is at hand; and there will be rich reward for those who aided it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1bfccbab-29fa-4e92-8919-6cd4815fb655.jpg?1686968266"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SoothingOfSmeagol.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SoothingOfSmeagol.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Soothing of Sméagol
+ * {1}{U}
+ * Instant
+ *
+ * Return target nontoken creature to its owner's hand. The Ring tempts you.
+ */
+val SoothingOfSmeagol = card("Soothing of Sméagol") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target nontoken creature to its owner's hand. The Ring tempts you."
+
+    spell {
+        val creature = target(
+            "nontoken creature",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.nontoken()))
+        )
+        effect = Effects.ReturnToHand(creature)
+            .then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Lixin Yin"
+        flavorText = "Frodo's heart sank. This was too much like trickery, and certainly what he did would seem a treachery to the poor treacherous creature."
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be6400e8-7f99-4005-9a92-ffbc359d3871.jpg?1686968300"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheBlackBreath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheBlackBreath.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Black Breath
+ * {2}{B}
+ * Sorcery
+ *
+ * Creatures your opponents control get -1/-1 until end of turn. The Ring tempts you.
+ */
+val TheBlackBreath = card("The Black Breath") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Creatures your opponents control get -1/-1 until end of turn. The Ring tempts you."
+
+    spell {
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter.AllCreaturesOpponentsControl,
+            effect = ModifyStatsEffect(
+                powerModifier = -1,
+                toughnessModifier = -1,
+                target = EffectTarget.Self,
+                duration = Duration.EndOfTurn
+            )
+        ).then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Chris Cold"
+        flavorText = "\"When the black breath blows, death's shadow grows.\"\n—A rhyme of old days"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e63983d-c36b-4440-b9e1-baaa6c7c0ba9.jpg?1686968386"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WarOfTheLastAlliance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WarOfTheLastAlliance.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * War of the Last Alliance
+ * {3}{W}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I, II — Search your library for a legendary creature card, reveal it, put it into your hand, then shuffle.
+ * III — Creatures you control gain double strike until end of turn. The Ring tempts you.
+ */
+val WarOfTheLastAlliance = card("War of the Last Alliance") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I, II — Search your library for a legendary creature card, reveal it, put it into your hand, then shuffle.\n" +
+        "III — Creatures you control gain double strike until end of turn. The Ring tempts you."
+
+    sagaChapter(1) {
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.Creature.legendary(),
+            count = 1,
+            reveal = true
+        )
+    }
+
+    sagaChapter(2) {
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.Creature.legendary(),
+            count = 1,
+            reveal = true
+        )
+    }
+
+    sagaChapter(3) {
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter.AllCreaturesYouControl,
+            effect = GrantKeywordEffect(Keyword.DOUBLE_STRIKE.name, EffectTarget.Self, Duration.EndOfTurn)
+        ).then(Effects.TheRingTemptsYou())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "36"
+        artist = "Alexander Forssberg"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60ddf2cd-5b33-4c8a-a610-8e6a15404dde.jpg?1686967971"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WargRider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WargRider.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Warg Rider
+ * {4}{B}
+ * Creature — Orc Warrior
+ * 4/3
+ *
+ * Menace
+ * Other Orcs and Goblins you control have menace.
+ * At the beginning of combat on your turn, amass Orcs 2.
+ */
+val WargRider = card("Warg Rider") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Orc Warrior"
+    power = 4
+    toughness = 3
+    oracleText = "Menace\n" +
+        "Other Orcs and Goblins you control have menace.\n" +
+        "At the beginning of combat on your turn, amass Orcs 2. (Put two +1/+1 counters on an Army you " +
+        "control. It's also an Orc. If you don't control an Army, create a 0/0 black Orc Army creature token first.)"
+
+    keywords(Keyword.MENACE)
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.MENACE,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withAnySubtype("Orc", "Goblin").youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = Effects.Amass(2)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "826"
+        artist = "Pascal Quidault"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18cc2bc6-12bb-4795-b2b2-9d414823b773.jpg?1719684212"
+    }
+}


### PR DESCRIPTION
## Summary

Adds the next batch of **The Lord of the Rings: Tales of Middle-earth** cards that
compose from primitives already on `main` — now that the Ring and Amass substrate
(`Effects.TheRingTemptsYou`, `Triggers.RingTemptsYou`, `Conditions.SourceIsRingBearer`,
`Effects.Amass` incl. `DynamicAmount.XValue`) is merged. One commit per card, no engine
changes. The remaining unimplemented cards are triaged and documented under the exact
engine gap each one waits on.

LTR draft **150 → 161 / 261**, Extra **13 → 15 / 28** (total 176/291).

## Cards added (one commit each)

- **White:** Now for Wrath, Now for Ruin!, War of the Last Alliance
- **Blue:** Grey Havens Navigator, Soothing of Sméagol, Saruman the White, Horses of the Bruinen
- **Black:** The Black Breath, Nazgûl, Warg Rider *(Extra)*
- **Red:** Fiery Inscription, Assault on Osgiliath *(Extra)*
- **Green:** Bombadil's Song
- **Multicolor:** Bilbo, Retired Burglar

Each composes from existing facades only — Ring tempts / Amass (incl. `XValue`),
`EffectPatterns.scry`/`searchLibrary`, `ForEachInGroupEffect` + `GroupFilter`,
`Targets.UpToCreatures` + `ForEachTargetEffect`, `GrantKeyword` static, `NthSpellCast`,
Saga chapters, Treasure tokens, ward.

## Docs

`backlog/sets/lord-of-the-rings/TODO.md` gains an **"Engine gaps blocking the remaining
cards"** section: every still-missing non-basic card is listed under the primitive it needs
(38 gaps, e.g. a "Whenever you scry" trigger, an Nth-card-drawn trigger, Goad, phasing, new
counter types, protection-from-everything, copy-spell, free-cast-from-hand, set-base-toughness,
flicker, cycling variants, nonbasic landwalk, Vehicles/Crew) with the exact blocking clause —
so each gap can be cleared in its own dedicated PR.

## Test plan

- [x] `./gradlew :mtg-sets:compileKotlin` — all 13 cards compile
- [x] `MtgSetCatalogTest` + `CardDiscoveryTest` — cards load via discovery, catalog valid
- [x] `scripts/card-status --set LTR` — reflects 161/261 draft, 15/28 extra
- [ ] (no engine changes; no new scenario/E2E tests required for this batch)
