### PR TITLE
Fix Artificial Evolution scenario tests for ChooseReplacementDecision

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CabalSlaverScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CabalSlaverScenarioTest.kt
@@ -1,8 +1,8 @@
 package com.wingedsheep.gameserver.scenarios
 
-import com.wingedsheep.engine.core.ChooseOptionDecision
-import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ChooseReplacementDecision
 import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.ReplacementChosenResponse
 import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
@@ -20,16 +20,18 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  */
 class CabalSlaverScenarioTest : ScenarioTestBase() {
 
-    private fun ScenarioTestBase.TestGame.chooseCreatureType(typeName: String) {
+    /** Perform an Artificial Evolution text-change via the single [ChooseReplacementDecision]. */
+    private fun ScenarioTestBase.TestGame.chooseReplacement(from: String, to: String) {
         val decision = getPendingDecision()
         decision.shouldNotBeNull()
-        decision.shouldBeInstanceOf<ChooseOptionDecision>()
-        val options = decision.options
-        val index = options.indexOf(typeName)
-        withClue("Creature type '$typeName' should be in options $options") {
-            (index >= 0) shouldBe true
+        decision.shouldBeInstanceOf<ChooseReplacementDecision>()
+        val fromIndex = decision.fromOptions.indexOf(from)
+        val toIndex = decision.toOptions.indexOf(to)
+        withClue("'$from' should be in fromOptions and '$to' in toOptions") {
+            (fromIndex >= 0) shouldBe true
+            (toIndex >= 0) shouldBe true
         }
-        submitDecision(OptionChosenResponse(decision.id, index))
+        submitDecision(ReplacementChosenResponse(decision.id, fromIndex, toIndex))
     }
 
     init {
@@ -192,8 +194,7 @@ class CabalSlaverScenarioTest : ScenarioTestBase() {
                 game.resolveStack()
 
                 // Choose FROM: Goblin → TO: Elf
-                game.chooseCreatureType("Goblin")
-                game.chooseCreatureType("Elf")
+                game.chooseReplacement("Goblin", "Elf")
 
                 // Now attack with Elvish Warrior - should trigger discard
                 game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
@@ -228,8 +229,7 @@ class CabalSlaverScenarioTest : ScenarioTestBase() {
                 game.castSpell(1, "Artificial Evolution", cabalSlaver)
                 game.resolveStack()
 
-                game.chooseCreatureType("Goblin")
-                game.chooseCreatureType("Elf")
+                game.chooseReplacement("Goblin", "Elf")
 
                 // Attack with Goblin Sledder - should NOT trigger (now watches for Elves)
                 game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FlamestickCourierTextChangeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FlamestickCourierTextChangeScenarioTest.kt
@@ -1,8 +1,8 @@
 package com.wingedsheep.gameserver.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
-import com.wingedsheep.engine.core.ChooseOptionDecision
-import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ChooseReplacementDecision
+import com.wingedsheep.engine.core.ReplacementChosenResponse
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
@@ -11,7 +11,7 @@ import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.assertions.withClue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
@@ -23,16 +23,18 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  */
 class FlamestickCourierTextChangeScenarioTest : ScenarioTestBase() {
 
-    private fun ScenarioTestBase.TestGame.chooseCreatureType(typeName: String) {
+    /** Perform an Artificial Evolution text-change via the single [ChooseReplacementDecision]. */
+    private fun ScenarioTestBase.TestGame.chooseReplacement(from: String, to: String) {
         val decision = getPendingDecision()
         decision.shouldNotBeNull()
-        decision.shouldBeInstanceOf<ChooseOptionDecision>()
-        val options = decision.options
-        val index = options.indexOf(typeName)
-        withClue("Creature type '$typeName' should be in options $options") {
-            (index >= 0) shouldNotBe false
+        decision.shouldBeInstanceOf<ChooseReplacementDecision>()
+        val fromIndex = decision.fromOptions.indexOf(from)
+        val toIndex = decision.toOptions.indexOf(to)
+        withClue("'$from' should be in fromOptions and '$to' in toOptions") {
+            (fromIndex >= 0) shouldBe true
+            (toIndex >= 0) shouldBe true
         }
-        submitDecision(OptionChosenResponse(decision.id, index))
+        submitDecision(ReplacementChosenResponse(decision.id, fromIndex, toIndex))
     }
 
     init {
@@ -54,8 +56,7 @@ class FlamestickCourierTextChangeScenarioTest : ScenarioTestBase() {
                 val courier = game.findPermanent("Flamestick Courier")!!
                 game.castSpell(1, "Artificial Evolution", courier)
                 game.resolveStack()
-                game.chooseCreatureType("Goblin")
-                game.chooseCreatureType("Bird")
+                game.chooseReplacement("Goblin", "Bird")
 
                 // Now activate Flamestick Courier's ability targeting Sage Aven (a Bird)
                 val cardDef = cardRegistry.getCard("Flamestick Courier")!!
@@ -92,8 +93,7 @@ class FlamestickCourierTextChangeScenarioTest : ScenarioTestBase() {
                 val courier = game.findPermanent("Flamestick Courier")!!
                 game.castSpell(1, "Artificial Evolution", courier)
                 game.resolveStack()
-                game.chooseCreatureType("Goblin")
-                game.chooseCreatureType("Bird")
+                game.chooseReplacement("Goblin", "Bird")
 
                 // Try to activate Flamestick Courier's ability targeting Raging Goblin
                 val cardDef = cardRegistry.getCard("Flamestick Courier")!!
@@ -133,8 +133,7 @@ class FlamestickCourierTextChangeScenarioTest : ScenarioTestBase() {
                 val sledder = game.findPermanent("Goblin Sledder")!!
                 game.castSpell(1, "Artificial Evolution", sledder)
                 game.resolveStack()
-                game.chooseCreatureType("Goblin")
-                game.chooseCreatureType("Bird")
+                game.chooseReplacement("Goblin", "Bird")
 
                 // Activate Goblin Sledder's ability: sacrifice Sage Aven (a Bird), target Storm Crow
                 val cardDef = cardRegistry.getCard("Goblin Sledder")!!
@@ -176,8 +175,7 @@ class FlamestickCourierTextChangeScenarioTest : ScenarioTestBase() {
                 val sledder = game.findPermanent("Goblin Sledder")!!
                 game.castSpell(1, "Artificial Evolution", sledder)
                 game.resolveStack()
-                game.chooseCreatureType("Goblin")
-                game.chooseCreatureType("Bird")
+                game.chooseReplacement("Goblin", "Bird")
 
                 // Try to activate Goblin Sledder's ability: sacrifice Raging Goblin
                 // The cost now requires sacrificing a Bird, but Raging Goblin is a Goblin

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HeedlessOneScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HeedlessOneScenarioTest.kt
@@ -1,8 +1,8 @@
 package com.wingedsheep.gameserver.scenarios
 
 import com.wingedsheep.engine.core.CastSpell
-import com.wingedsheep.engine.core.ChooseOptionDecision
-import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ChooseReplacementDecision
+import com.wingedsheep.engine.core.ReplacementChosenResponse
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
@@ -26,16 +26,18 @@ class HeedlessOneScenarioTest : ScenarioTestBase() {
 
     private val stateProjector = StateProjector()
 
-    private fun ScenarioTestBase.TestGame.chooseCreatureType(typeName: String) {
+    /** Perform an Artificial Evolution text-change via the single [ChooseReplacementDecision]. */
+    private fun ScenarioTestBase.TestGame.chooseReplacement(from: String, to: String) {
         val decision = getPendingDecision()
         decision.shouldNotBeNull()
-        decision.shouldBeInstanceOf<ChooseOptionDecision>()
-        val options = decision.options
-        val index = options.indexOf(typeName)
-        withClue("Creature type '$typeName' should be in options $options") {
-            (index >= 0) shouldBe true
+        decision.shouldBeInstanceOf<ChooseReplacementDecision>()
+        val fromIndex = decision.fromOptions.indexOf(from)
+        val toIndex = decision.toOptions.indexOf(to)
+        withClue("'$from' should be in fromOptions and '$to' in toOptions") {
+            (fromIndex >= 0) shouldBe true
+            (toIndex >= 0) shouldBe true
         }
-        submitDecision(OptionChosenResponse(decision.id, index))
+        submitDecision(ReplacementChosenResponse(decision.id, fromIndex, toIndex))
     }
 
     init {
@@ -114,8 +116,7 @@ class HeedlessOneScenarioTest : ScenarioTestBase() {
                 // Cast Artificial Evolution targeting Heedless One, change Elf → Crocodile
                 game.castSpell(2, "Artificial Evolution", heedlessOne)
                 game.resolveStack()
-                game.chooseCreatureType("Elf")
-                game.chooseCreatureType("Crocodile")
+                game.chooseReplacement("Elf", "Crocodile")
 
                 // Heedless One now counts Crocodiles instead of Elves.
                 // Text replacement also changes its type line from "Elf Avatar" to "Crocodile Avatar",

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ProtectionFromSubtypeTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ProtectionFromSubtypeTest.kt
@@ -1,8 +1,8 @@
 package com.wingedsheep.gameserver.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
-import com.wingedsheep.engine.core.ChooseOptionDecision
-import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ChooseReplacementDecision
+import com.wingedsheep.engine.core.ReplacementChosenResponse
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
@@ -29,16 +29,18 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  */
 class ProtectionFromSubtypeTest : ScenarioTestBase() {
 
-    private fun ScenarioTestBase.TestGame.chooseCreatureType(typeName: String) {
+    /** Perform an Artificial Evolution text-change via the single [ChooseReplacementDecision]. */
+    private fun ScenarioTestBase.TestGame.chooseReplacement(from: String, to: String) {
         val decision = getPendingDecision()
         decision.shouldNotBeNull()
-        decision.shouldBeInstanceOf<ChooseOptionDecision>()
-        val options = decision.options
-        val index = options.indexOf(typeName)
-        withClue("Creature type '$typeName' should be in options") {
-            (index >= 0) shouldBe true
+        decision.shouldBeInstanceOf<ChooseReplacementDecision>()
+        val fromIndex = decision.fromOptions.indexOf(from)
+        val toIndex = decision.toOptions.indexOf(to)
+        withClue("'$from' should be in fromOptions and '$to' in toOptions") {
+            (fromIndex >= 0) shouldBe true
+            (toIndex >= 0) shouldBe true
         }
-        submitDecision(OptionChosenResponse(decision.id, index))
+        submitDecision(ReplacementChosenResponse(decision.id, fromIndex, toIndex))
     }
 
     init {
@@ -203,8 +205,7 @@ class ProtectionFromSubtypeTest : ScenarioTestBase() {
                 val guideId = game.findPermanent("Foothill Guide")!!
                 game.castSpell(1, "Artificial Evolution", guideId)
                 game.resolveStack()
-                game.chooseCreatureType("Goblin")
-                game.chooseCreatureType("Elf")
+                game.chooseReplacement("Goblin", "Elf")
 
                 // Now attack with Goblin Sledder
                 game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
@@ -243,8 +244,7 @@ class ProtectionFromSubtypeTest : ScenarioTestBase() {
                 val guideId = game.findPermanent("Foothill Guide")!!
                 game.castSpell(1, "Artificial Evolution", guideId)
                 game.resolveStack()
-                game.chooseCreatureType("Goblin")
-                game.chooseCreatureType("Elf")
+                game.chooseReplacement("Goblin", "Elf")
 
                 // Attack with Foothill Guide — Wellwisher (Elf) should not be able to block
                 game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ThoughtboundPrimocScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ThoughtboundPrimocScenarioTest.kt
@@ -1,8 +1,8 @@
 package com.wingedsheep.gameserver.scenarios
 
-import com.wingedsheep.engine.core.ChooseOptionDecision
-import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ChooseReplacementDecision
 import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.ReplacementChosenResponse
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
@@ -28,16 +28,18 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  */
 class ThoughtboundPrimocScenarioTest : ScenarioTestBase() {
 
-    private fun ScenarioTestBase.TestGame.chooseCreatureType(typeName: String) {
+    /** Perform an Artificial Evolution text-change via the single [ChooseReplacementDecision]. */
+    private fun ScenarioTestBase.TestGame.chooseReplacement(from: String, to: String) {
         val decision = getPendingDecision()
         decision.shouldNotBeNull()
-        decision.shouldBeInstanceOf<ChooseOptionDecision>()
-        val options = decision.options
-        val index = options.indexOf(typeName)
-        withClue("Creature type '$typeName' should be in options $options") {
-            (index >= 0) shouldBe true
+        decision.shouldBeInstanceOf<ChooseReplacementDecision>()
+        val fromIndex = decision.fromOptions.indexOf(from)
+        val toIndex = decision.toOptions.indexOf(to)
+        withClue("'$from' should be in fromOptions and '$to' in toOptions") {
+            (fromIndex >= 0) shouldBe true
+            (toIndex >= 0) shouldBe true
         }
-        submitDecision(OptionChosenResponse(decision.id, index))
+        submitDecision(ReplacementChosenResponse(decision.id, fromIndex, toIndex))
     }
 
     init {
@@ -195,8 +197,7 @@ class ThoughtboundPrimocScenarioTest : ScenarioTestBase() {
                 val primoc = game.findPermanent("Thoughtbound Primoc")!!
                 game.castSpell(1, "Artificial Evolution", primoc)
                 game.resolveStack()
-                game.chooseCreatureType("Wizard")
-                game.chooseCreatureType("Cleric")
+                game.chooseReplacement("Wizard", "Cleric")
 
                 // Advance to next upkeep (P2's turn → P1's turn → upkeep)
                 game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)


### PR DESCRIPTION
## Summary

The Crystal Spray change (#226) migrated Artificial Evolution's creature-type text change from **two sequential `ChooseOptionDecision`s** (pick FROM, then pick TO) to **a single `ChooseReplacementDecision`** (FROM + TO chosen together, via `ReplacementChosenResponse`). That PR updated `ArtificialEvolutionScenarioTest` but missed five other test files that also cast Artificial Evolution — their local `chooseCreatureType` helpers still asserted `ChooseOptionDecision` and failed with `AssertionFailedError`.

This migrates each to the canonical `chooseReplacement(from, to)` helper already used in `ArtificialEvolutionScenarioTest`:

- `CabalSlaverScenarioTest`
- `FlamestickCourierTextChangeScenarioTest`
- `HeedlessOneScenarioTest`
- `ProtectionFromSubtypeTest`
- `ThoughtboundPrimocScenarioTest`

Per file: swapped imports (`ChooseOptionDecision`/`OptionChosenResponse` → `ChooseReplacementDecision`/`ReplacementChosenResponse`), replaced the `chooseCreatureType` helper, and collapsed each consecutive FROM/TO call pair into one `chooseReplacement` call.

Test-only fix — the engine behavior was already correct; the tests had simply not been migrated to the new decision shape.

## Test plan

All 18 tests across the five classes pass:

```
./gradlew :game-server:test \
  --tests "*.CabalSlaverScenarioTest" \
  --tests "*.FlamestickCourierTextChangeScenarioTest" \
  --tests "*.HeedlessOneScenarioTest" \
  --tests "*.ProtectionFromSubtypeTest" \
  --tests "*.ThoughtboundPrimocScenarioTest"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)