### PR TITLE
Add Goblin Spy (Invasion) — public top-of-library reveal (gap #20)

### DIFF
--- a/backlog/invasion-engine-gaps.md
+++ b/backlog/invasion-engine-gaps.md
@@ -140,7 +140,7 @@ cards, not one.
 |---|---------|----------------------|
 | #6 | **Pyre Zombie** | ✅ **Implemented** (`inv/cards/PyreZombie.kt`). Graveyard-functional upkeep trigger via `triggerZone = Zone.GRAVEYARD` + `MayPayManaEffect({1}{B}{B}, ReturnToHand(Self))` (same shape as Onslaught's Gigapede); sac ability = `Costs.Composite(Mana({1}{R}{R}), SacrificeSelf)` → `DealDamage(2, Targets.Any)`. The `triggeredAbility { }` builder already surfaces `triggerZone`; `TriggerDetector` scans graveyard cards (`TriggerDetector.kt:359-405`). No engine work. |
 | #12 | **Backlash**, **Agonizing Demise** (kicked) | `EffectTarget.TargetController` already exists (`EffectTarget.kt:57-62`), plus `ControllerOfTriggeringEntity`. Backlash = `DealDamage(amount = DynamicAmounts.targetPower(0), target = EffectTarget.TargetController)`; Agonizing Demise riders on `Conditions.WasKicked`. |
-| #20 | **Goblin Spy** | `MiscStaticAbilities.LookAtTopOfLibrary` / `PlayFromTopOfLibrary` exist (`MiscStaticAbilities.kt:162-201`). One nuance: Goblin Spy reveals to **all** players (public), `LookAtTopOfLibrary` is private. Add a sibling `RevealTopOfLibrary` data object (public reveal, no play permission) mirroring the existing ones — ~5 lines, not a new system. |
+| #20 | **Goblin Spy** | ✅ **Implemented** (`inv/cards/GoblinSpy.kt`). Added sibling `RevealTopOfLibrary` data object (public reveal, no play permission) and united the `ClientStateTransformer` public-reveal path so it fires for `PlayFromTopOfLibrary` **or** `RevealTopOfLibrary`; cast/play-from-top permission stays keyed on `PlayFromTopOfLibrary`. See gap #20 below. |
 | #2 (half) | **Coalition Victory** | ✅ **Implemented** (`inv/cards/CoalitionVictory.kt`). "A creature of each color" = `Compare(DynamicAmounts.colorsAmongPermanents(Player.You, GameObjectFilter.Creature), GTE, Fixed(5))` (a single 5-color creature satisfies it — matches the official ruling, and `Aggregation.DISTINCT_COLORS` caps at 5). "A land of each basic land type" = `Conditions.BasicLandTypesAtLeast(5)`. Combined with `Conditions.All(...)` inside a `ConditionalEffect` → `Effects.WinGame()`. No new primitive. |
 | #4 (runtime) | **Rewards of Diversity**, **Pure Reflection** (trigger half) | `SpellCastEvent(player = Player.Opponent / Player.Each)` is already matched at runtime (`TriggerMatcher.matchesPlayer`, lines 668-675). Rewards of Diversity = trigger on `Player.Opponent` + multicolored filter, payoff to `Player.TriggeringPlayer`. Only ergonomic gap: facade constants (see #4 below). |
 
@@ -741,10 +741,17 @@ pieces — the trigger, the collection filter, and the retarget effect — are r
 
 ---
 
-### #20 — Play with top card revealed · Goblin Spy
+### #20 — Play with top card revealed · Goblin Spy ✅ DONE
 
-**Already buildable** modulo a public-reveal variant — see the table. Add `RevealTopOfLibrary` data
-object (public) beside the existing private `LookAtTopOfLibrary`. ~5 lines.
+> **Implemented (primitive + card).** New SDK `data object RevealTopOfLibrary` — the public-reveal-only
+> sibling of `PlayFromTopOfLibrary` (reveals the controller's top card to all players, grants no play
+> permission). The two abilities were *united* on the visibility path: `ClientStateTransformer`'s public
+> top-card reveal now fires for a player controlling **either** `PlayFromTopOfLibrary` **or**
+> `RevealTopOfLibrary` (one shared `revealsTopOfLibraryPublicly` predicate), while the cast/play-from-top
+> permission paths stay keyed on `PlayFromTopOfLibrary` alone. **Goblin Spy** ({R} 1/1 Goblin Rogue)
+> authored in `definitions/inv/cards/GoblinSpy.kt` as a single `staticAbility { ability = RevealTopOfLibrary }`.
+> Covered by `GoblinSpyTest` (opponent sees the top card; no reveal source → hidden; reveal grants no
+> cast-from-top permission). Documented in the SDK reference's new "Top-of-library reveal & play" subsection.
 
 ---
 
@@ -781,8 +788,8 @@ filter.
 
 ## Suggested build order (highest leverage first)
 
-0. **Close the already-buildable cards** (#6, #12, #20, Coalition Victory, Rewards of Diversity) — pure
-   card authoring plus ≤2 trivial surfacing tweaks (graveyard `activeZone` setter, public
+0. **Close the already-buildable cards** (#6 ✅, #12, #20 ✅, Coalition Victory ✅, Rewards of Diversity ✅) —
+   pure card authoring plus ≤2 trivial surfacing tweaks (graveyard `activeZone` setter, public
    `RevealTopOfLibrary`, opponent-cast facade constants).
 1. **`ColorIsMostCommon` self-condition** (#1) — 5 djinns from one condition.
 2. **Opponent/any-player cast facade** (#4) ✅ — runtime-wired; facade added, Rewards of Diversity + Pure Reflection done.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1150,6 +1150,23 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   Festival of Embers. Pair with `MayPlayLandsFromGraveyard` for "play lands and cast spells from
   your graveyard". Lands are *played*, not cast, so they need the lands permission separately.
 
+**Top-of-library reveal & play** (reveal the top card of a library, optionally with permission to
+play it from there). Visibility (public reveal to all players) and play permission are separate
+concerns — the `ClientStateTransformer` reveals the top card for `PlayFromTopOfLibrary` *or*
+`RevealTopOfLibrary`, while the cast/play-from-top paths key only on the play-granting variants.
+
+- `RevealTopOfLibrary` — *public reveal only*, no play permission: the controller's top card is
+  shown to all players, but can only be played once drawn. (**Goblin Spy**)
+- `PlayFromTopOfLibrary` — public reveal **and** "play lands and cast spells from the top of your
+  library" (all card types). (Future Sight)
+- `PlayLandsAndCastFilteredFromTopOfLibrary(spellFilter)` — like `PlayFromTopOfLibrary` but only
+  spells matching `spellFilter` are castable (lands always playable). (Glarb, Calamity's Augur =
+  `GameObjectFilter.Any.manaValueAtLeast(4)`)
+- `CastSpellTypesFromTopOfLibrary(filter)` — cast only matching spell types from the top; no land
+  play, no full public reveal. (Precognition Field = instants/sorceries)
+- `LookAtTopOfLibrary` — *private*: the controller may look at their own top card any time (revealed
+  only to them, not opponents). (Lens of Clarity, Vizier of the Menagerie)
+
 > Multiple lord effects on one card → multiple `staticAbility { }` blocks.
 
 ---

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -255,6 +255,24 @@ data object LookAtTopOfLibrary : StaticAbility {
 }
 
 /**
+ * Play with the top card of your library revealed (to all players), without granting any
+ * permission to play it from there. Used for Goblin Spy.
+ *
+ * This is the public-reveal half of [PlayFromTopOfLibrary] with the play permission removed:
+ * the controller's top card is shown to everyone, but it can only be played once it's drawn.
+ * The engine treats it identically to [PlayFromTopOfLibrary] for *visibility* (the
+ * ClientStateTransformer reveals the top card to all players), but unlike that ability it does
+ * not appear in any cast/play-from-top permission path.
+ */
+@SerialName("RevealTopOfLibrary")
+@Serializable
+data object RevealTopOfLibrary : StaticAbility {
+    override val description: String =
+        "Play with the top card of your library revealed."
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}
+
+/**
  * You may play lands and cast spells matching a filter from the top of your library.
  * Unlike PlayFromTopOfLibrary, this restricts which spells can be cast (but always allows lands).
  * Used for Glarb, Calamity's Augur (mana value 4 or greater).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/GoblinSpy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/GoblinSpy.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
+
+/**
+ * Goblin Spy
+ * {R}
+ * Creature — Goblin Rogue
+ * 1/1
+ * Play with the top card of your library revealed.
+ *
+ * Unlike Future Sight, Goblin Spy grants no permission to play the revealed card — it only
+ * makes the top card public. Modeled with [RevealTopOfLibrary] (the public-reveal-only sibling
+ * of [com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary]).
+ */
+val GoblinSpy = card("Goblin Spy") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Play with the top card of your library revealed."
+
+    staticAbility {
+        ability = RevealTopOfLibrary
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Scott M. Fischer"
+        flavorText = "\"Isn't he on our side?\"\n\"Yep.\"\n\"Why's he spyin' on us?\"\n\"Don't ask.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a89a099-8805-4b26-babd-5d9f48ee406a.jpg?1595438179"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -38,6 +38,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.LookAtFaceDownCreatures
 import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
 import com.wingedsheep.sdk.scripting.conditions.AllConditions
 import com.wingedsheep.sdk.scripting.conditions.AnyCondition
 import com.wingedsheep.sdk.scripting.conditions.Compare
@@ -172,10 +173,12 @@ class ClientStateTransformer(
         }
         // --- FIX END ---
 
-        // Reveal top library card for players with PlayFromTopOfLibrary (e.g., Future Sight)
-        // The top card is revealed to ALL players per the card's oracle text.
+        // Reveal top library card for players who "play with the top card revealed"
+        // (PlayFromTopOfLibrary, e.g. Future Sight; or RevealTopOfLibrary, e.g. Goblin Spy).
+        // The top card is revealed to ALL players per the card's oracle text. The two abilities
+        // differ only in play permission (handled elsewhere); the public reveal is identical.
         for (ownerId in state.turnOrder) {
-            if (hasPlayFromTopOfLibrary(state, ownerId)) {
+            if (revealsTopOfLibraryPublicly(state, ownerId)) {
                 val library = state.getLibrary(ownerId)
                 if (library.isNotEmpty()) {
                     val topCardId = library.first()
@@ -353,13 +356,16 @@ class ClientStateTransformer(
     }
 
     /**
-     * Check if a player controls a permanent with PlayFromTopOfLibrary.
+     * Check if a player controls a permanent that reveals the top card of their library to all
+     * players — either [PlayFromTopOfLibrary] (Future Sight) or [RevealTopOfLibrary] (Goblin Spy).
+     * The two abilities share the public-reveal visibility; they diverge only in play permission,
+     * which is handled by the cast/play-from-top paths (keyed on [PlayFromTopOfLibrary] alone).
      */
-    private fun hasPlayFromTopOfLibrary(state: GameState, playerId: EntityId): Boolean {
+    private fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean {
         for (entityId in state.getBattlefield(playerId)) {
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            if (cardDef.script.staticAbilities.any { it is PlayFromTopOfLibrary }) {
+            if (cardDef.script.staticAbilities.any { it is PlayFromTopOfLibrary || it is RevealTopOfLibrary }) {
                 return true
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinSpyTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinSpyTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Goblin Spy.
+ *
+ * Goblin Spy: {R}
+ * Creature — Goblin Rogue
+ * 1/1
+ * Play with the top card of your library revealed.
+ *
+ * Goblin Spy reveals the top card of its controller's library to ALL players (public), but —
+ * unlike Future Sight — grants no permission to play it from there. The public reveal shares the
+ * [com.wingedsheep.engine.view.ClientStateTransformer] path with Future Sight's
+ * `PlayFromTopOfLibrary`; this test pins both the shared visibility and the *absence* of play
+ * permission.
+ */
+class GoblinSpyTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun transformer(d: GameTestDriver): ClientStateTransformer =
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+
+    test("top card is revealed to the opponent while Goblin Spy is on the battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Plains" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(activePlayer, "Goblin Spy")
+        val topCard = driver.putCardOnTopOfLibrary(activePlayer, "Lightning Bolt")
+
+        // From the opponent's viewpoint, the controller's top library card must be public:
+        // it is transformed into the shared `cards` map and listed in the library zone.
+        val view = transformer(driver).transform(driver.state, viewingPlayerId = opponent)
+
+        view.cards.keys shouldContain topCard
+        val libraryZone = view.zones.first {
+            it.zoneId.ownerId == activePlayer && it.zoneId.zoneType == Zone.LIBRARY
+        }
+        libraryZone.cardIds shouldContain topCard
+    }
+
+    test("top card is NOT revealed when no reveal source is present") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Plains" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val topCard = driver.putCardOnTopOfLibrary(activePlayer, "Lightning Bolt")
+
+        val view = transformer(driver).transform(driver.state, viewingPlayerId = opponent)
+
+        // With no reveal source, the opponent must not see the controller's top card.
+        view.cards.keys shouldNotContain topCard
+    }
+
+    test("Goblin Spy does NOT grant permission to cast from the top of the library") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Plains" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(activePlayer, "Goblin Spy")
+        val boltOnTop = driver.putCardOnTopOfLibrary(activePlayer, "Lightning Bolt")
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val creature = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        // Unlike Future Sight, the revealed top card cannot be cast from the library.
+        val castResult = driver.castSpell(activePlayer, boltOnTop, listOf(creature))
+        castResult.isSuccess shouldBe false
+    }
+})


### PR DESCRIPTION
Implements gap #20 from `backlog/invasion-engine-gaps.md`.

## Card

**Goblin Spy** — `{R}` Creature — Goblin Rogue, 1/1
> Play with the top card of your library revealed.

The public-reveal-only cousin of Future Sight: it makes the controller's top card public, but grants **no** permission to play it from there.

## Approach — unite, don't duplicate

The engine already had two near-identical top-of-library primitives:

- `PlayFromTopOfLibrary` — public reveal **+** play permission (Future Sight)
- `LookAtTopOfLibrary` — *private* reveal, no play (Lens of Clarity)

Goblin Spy is the third corner (public reveal, no play). Rather than add a third bespoke reveal block, the change separates the two concerns:

1. New SDK `data object RevealTopOfLibrary` — public reveal only.
2. `ClientStateTransformer`'s public top-card reveal now fires for a player controlling **`PlayFromTopOfLibrary` OR `RevealTopOfLibrary`** via one shared `revealsTopOfLibraryPublicly` predicate (renamed from `hasPlayFromTopOfLibrary`).
3. Cast/play-from-top **permission** paths stay keyed on `PlayFromTopOfLibrary` alone — so Goblin Spy reveals without granting play.

`GoblinSpy.kt` is a single `staticAbility { ability = RevealTopOfLibrary }`, auto-discovered into Invasion. No new event, continuation, decision, or frontend work — the reveal flows through the same view-layer path Future Sight already uses.

## Tests

`GoblinSpyTest` (rules-engine):
- opponent sees the controller's top card while Goblin Spy is in play
- no reveal source → top card stays hidden
- reveal grants **no** cast-from-top permission

`FutureSightTest` + `GlarbCalamitysAugurTest` remain green (shared path intact). Full `just build` passes (`StaticAbility` is sealed, so any exhaustive `when` would have broken — none did).

## Docs / bookkeeping

- New "Top-of-library reveal & play" subsection in `docs/card-sdk-language-reference.md` documenting the full family.
- Gap #20 marked ✅ in `backlog/invasion-engine-gaps.md`.
- `just check-card-printing "Goblin Spy"` ✓ (INV is the sole/canonical printing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)