### PR TITLE
Add Mutinous Massacre to Edge of Eternities with mana-value parity su…

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 235 / 261
+**Implemented:** 236 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -150,7 +150,7 @@
 - [x] Monoist Sentry
 - [ ] Moonlit Meditation
 - [x] Mouth of the Storm
-- [ ] Mutinous Massacre
+- [x] Mutinous Massacre
 - [x] Nanoform Sentinel
 - [x] Nebula Dragon
 - [x] Nova Hellkite

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -616,6 +616,8 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   `CastRecordComponent` snapshot once it has resolved onto the battlefield (0 if it was never cast).
   Used by Edge of Eternities warp payoffs like Astelli Reclaimer ("…mana value X or less…, where X is the
   amount of mana spent to cast this creature") — X is 5 for `{3}{W}{W}`, 3 for warp `{2}{W}`, 0 for free.
+- `.manaValueIsOdd()` / `.manaValueIsEven()` — mana-value parity (zero is even). Pair with modal
+  spells whose modes ask the caster to choose a parity (e.g. *Mutinous Massacre*).
 - `.tapped()` / `.untapped()` — tap state.
 - `.nontoken()` / `.token()` — token vs printed.
 - `.faceDown()` — face-down state.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MutinousMassacreScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MutinousMassacreScenarioTest.kt
@@ -6,8 +6,11 @@ import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
 import io.kotest.assertions.withClue
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -27,10 +30,22 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  * - Grizzly Bears  : {1}{G} = MV 2 (even)
  * - Raging Cougar  : {2}{R} = MV 3 (odd)
  * - Hill Giant     : {3}{R} = MV 4 (even)
+ *
+ * The "(Zero is even.)" clause and the {X}->0 ruling are exercised by an {X}-cost creature
+ * (mana value 0), which must be treated as even.
  */
 class MutinousMassacreScenarioTest : ScenarioTestBase() {
 
     private val stateProjector = StateProjector()
+
+    // An {X}-cost creature: X is 0 off the stack, so mana value is 0 — even (CR ruling).
+    private val xCostBeast = CardDefinition.creature(
+        name = "MM X Beast",
+        manaCost = ManaCost.parse("{X}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 2,
+        toughness = 2
+    )
 
     private fun TestGame.chooseMode(descriptionContains: String) {
         val decision = getPendingDecision()
@@ -44,6 +59,8 @@ class MutinousMassacreScenarioTest : ScenarioTestBase() {
     }
 
     init {
+        cardRegistry.register(xCostBeast)
+
         context("Mutinous Massacre — Odd mode") {
             test("destroys odd-MV creatures, steals/untaps/hastes the rest") {
                 val game = scenario()
@@ -184,6 +201,66 @@ class MutinousMassacreScenarioTest : ScenarioTestBase() {
                 val afterEot = stateProjector.project(game.state)
                 withClue("Hill Giant should return to Player 2's control at end of turn") {
                     afterEot.getController(stolenGiant) shouldBe game.player2Id
+                }
+            }
+        }
+
+        context("Mutinous Massacre — zero is even") {
+            test("an {X}-cost creature (MV 0) is destroyed by Even, spared by Odd") {
+                // Even mode: MV-0 beast dies, odd Llanowar Elves (MV 1) survives.
+                run {
+                    val game = scenario()
+                        .withPlayers("Player", "Opponent")
+                        .withCardInHand(1, "Mutinous Massacre")
+                        .withLandsOnBattlefield(1, "Swamp", 4)
+                        .withLandsOnBattlefield(1, "Mountain", 3)
+                        .withCardOnBattlefield(2, "MM X Beast")      // MV 0 — even
+                        .withCardOnBattlefield(2, "Llanowar Elves")  // MV 1 — odd
+                        .withActivePlayer(1)
+                        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                        .build()
+
+                    game.castSpell(1, "Mutinous Massacre")
+                    game.chooseMode("Even")
+                    game.resolveStack()
+
+                    withClue("MM X Beast (MV 0) should be destroyed by Even — zero is even") {
+                        game.isInGraveyard(2, "MM X Beast") shouldBe true
+                    }
+                    withClue("Llanowar Elves (MV 1, odd) should survive Even mode") {
+                        game.isOnBattlefield("Llanowar Elves") shouldBe true
+                    }
+                }
+
+                // Odd mode: MV-0 beast survives (and is stolen), odd Llanowar Elves dies.
+                run {
+                    val game = scenario()
+                        .withPlayers("Player", "Opponent")
+                        .withCardInHand(1, "Mutinous Massacre")
+                        .withLandsOnBattlefield(1, "Swamp", 4)
+                        .withLandsOnBattlefield(1, "Mountain", 3)
+                        .withCardOnBattlefield(2, "MM X Beast")      // MV 0 — even
+                        .withCardOnBattlefield(2, "Llanowar Elves")  // MV 1 — odd
+                        .withActivePlayer(1)
+                        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                        .build()
+
+                    val stolenBeast = game.findPermanent("MM X Beast")!!
+
+                    game.castSpell(1, "Mutinous Massacre")
+                    game.chooseMode("Odd")
+                    game.resolveStack()
+
+                    withClue("MM X Beast (MV 0, even) should survive Odd mode") {
+                        game.isOnBattlefield("MM X Beast") shouldBe true
+                    }
+                    withClue("Llanowar Elves (MV 1, odd) should be destroyed by Odd mode") {
+                        game.isInGraveyard(2, "Llanowar Elves") shouldBe true
+                    }
+                    val projected = stateProjector.project(game.state)
+                    withClue("Surviving MV-0 beast should be stolen by Player 1") {
+                        projected.getController(stolenBeast) shouldBe game.player1Id
+                    }
                 }
             }
         }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MutinousMassacreScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MutinousMassacreScenarioTest.kt
@@ -1,0 +1,191 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Mutinous Massacre.
+ *
+ * Card reference:
+ * - Mutinous Massacre ({3}{B}{B}{R}{R}): Sorcery
+ *   "Choose odd or even. Destroy each creature with mana value of the chosen quality.
+ *   Then gain control of all creatures until end of turn. Untap them.
+ *   They gain haste until end of turn. (Zero is even.)"
+ *
+ * Setup uses creatures with known mana values:
+ * - Llanowar Elves : {G}    = MV 1 (odd)
+ * - Grizzly Bears  : {1}{G} = MV 2 (even)
+ * - Raging Cougar  : {2}{R} = MV 3 (odd)
+ * - Hill Giant     : {3}{R} = MV 4 (even)
+ */
+class MutinousMassacreScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private fun TestGame.chooseMode(descriptionContains: String) {
+        val decision = getPendingDecision()
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val idx = decision.options.indexOfFirst { it.contains(descriptionContains, ignoreCase = true) }
+        check(idx >= 0) {
+            "No mode matched '$descriptionContains' in ${decision.options}"
+        }
+        submitDecision(OptionChosenResponse(decision.id, idx))
+    }
+
+    init {
+        context("Mutinous Massacre — Odd mode") {
+            test("destroys odd-MV creatures, steals/untaps/hastes the rest") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Mutinous Massacre")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    // Player 1's board: one of each parity
+                    .withCardOnBattlefield(1, "Llanowar Elves")     // MV 1 — odd, dies
+                    .withCardOnBattlefield(1, "Grizzly Bears")      // MV 2 — even, survives
+                    // Player 2's board: one of each parity, both tapped
+                    .withCardOnBattlefield(2, "Raging Cougar", tapped = true) // MV 3 — odd, dies
+                    .withCardOnBattlefield(2, "Hill Giant", tapped = true)    // MV 4 — even, survives
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ownBears = game.findPermanent("Grizzly Bears")!!
+                val stolenGiant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Mutinous Massacre")
+                game.chooseMode("Odd")
+                game.resolveStack()
+
+                withClue("Llanowar Elves (MV 1, odd) should be destroyed") {
+                    game.isInGraveyard(1, "Llanowar Elves") shouldBe true
+                }
+                withClue("Raging Cougar (MV 3, odd) should be destroyed") {
+                    game.isInGraveyard(2, "Raging Cougar") shouldBe true
+                }
+                withClue("Grizzly Bears (MV 2, even) should survive") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("Hill Giant (MV 4, even) should survive") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+
+                val projected = stateProjector.project(game.state)
+                withClue("Player 1 should control their own Grizzly Bears") {
+                    projected.getController(ownBears) shouldBe game.player1Id
+                }
+                withClue("Player 1 should have stolen Hill Giant") {
+                    projected.getController(stolenGiant) shouldBe game.player1Id
+                }
+                withClue("Stolen Hill Giant should be untapped") {
+                    game.state.getEntity(stolenGiant)?.has<TappedComponent>() shouldBe false
+                }
+                withClue("Stolen Hill Giant should have haste") {
+                    projected.hasKeyword(stolenGiant, Keyword.HASTE) shouldBe true
+                }
+                withClue("Player 1's own Bears should also have haste") {
+                    projected.hasKeyword(ownBears, Keyword.HASTE) shouldBe true
+                }
+            }
+        }
+
+        context("Mutinous Massacre — Even mode") {
+            test("destroys even-MV creatures, steals/untaps/hastes the rest") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Mutinous Massacre")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(1, "Llanowar Elves") // MV 1, odd, survives
+                    .withCardOnBattlefield(1, "Grizzly Bears")  // MV 2, even, dies
+                    .withCardOnBattlefield(2, "Raging Cougar", tapped = true) // MV 3, odd, survives
+                    .withCardOnBattlefield(2, "Hill Giant", tapped = true)    // MV 4, even, dies
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ownElves = game.findPermanent("Llanowar Elves")!!
+                val stolenCougar = game.findPermanent("Raging Cougar")!!
+
+                game.castSpell(1, "Mutinous Massacre")
+                game.chooseMode("Even")
+                game.resolveStack()
+
+                withClue("Grizzly Bears (MV 2, even) should be destroyed") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Hill Giant (MV 4, even) should be destroyed") {
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+                withClue("Llanowar Elves (MV 1, odd) should survive") {
+                    game.isOnBattlefield("Llanowar Elves") shouldBe true
+                }
+                withClue("Raging Cougar (MV 3, odd) should survive") {
+                    game.isOnBattlefield("Raging Cougar") shouldBe true
+                }
+
+                val projected = stateProjector.project(game.state)
+                withClue("Player 1 should now control the stolen Raging Cougar") {
+                    projected.getController(stolenCougar) shouldBe game.player1Id
+                }
+                withClue("Stolen Raging Cougar should be untapped") {
+                    game.state.getEntity(stolenCougar)?.has<TappedComponent>() shouldBe false
+                }
+                withClue("Stolen Raging Cougar should have haste") {
+                    projected.hasKeyword(stolenCougar, Keyword.HASTE) shouldBe true
+                }
+                withClue("Player 1's own Elves should have haste too") {
+                    projected.hasKeyword(ownElves, Keyword.HASTE) shouldBe true
+                }
+            }
+        }
+
+        context("Mutinous Massacre — control reverts at end of turn") {
+            test("stolen creature returns to original controller at cleanup") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Mutinous Massacre")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Hill Giant") // MV 4, survives Odd mode
+                    // Library padding so neither player decks out during cleanup turns.
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stolenGiant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Mutinous Massacre")
+                game.chooseMode("Odd")
+                game.resolveStack()
+
+                val midTurn = stateProjector.project(game.state)
+                withClue("Player 1 should control Hill Giant after resolution") {
+                    midTurn.getController(stolenGiant) shouldBe game.player1Id
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.CLEANUP)
+
+                val afterEot = stateProjector.project(game.state)
+                withClue("Hill Giant should return to Player 2's control at end of turn") {
+                    afterEot.getController(stolenGiant) shouldBe game.player2Id
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/m/mutinous-massacre.json
+++ b/manual-scenarios/cards/m/mutinous-massacre.json
@@ -1,0 +1,42 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Mutinous Massacre"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Cloud Pirates"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Mountain", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Devoted Hero"},
+      {"name": "Armored Pegasus"},
+      {"name": "Charging Paladin"},
+      {"name": "Anaconda", "tapped": true},
+      {"name": "Ardent Militia"},
+      {"name": "Alabaster Dragon", "tapped": true}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -238,6 +238,16 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.ManaValueAtMostEntityManaSpent(reference)
     )
 
+    /** Mana value is even (zero is even). */
+    fun manaValueIsEven() = copy(
+        cardPredicates = cardPredicates + CardPredicate.ManaValueIsEven
+    )
+
+    /** Mana value is odd. */
+    fun manaValueIsOdd() = copy(
+        cardPredicates = cardPredicates + CardPredicate.ManaValueIsOdd
+    )
+
     /** Power equals */
     fun power(value: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.PowerEquals(value)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -362,6 +362,20 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
     }
 
+    @SerialName("ManaValueIsEven")
+    @Serializable
+    data object ManaValueIsEven : CardPredicate {
+        override val description: String = "with even mana value"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
+    @SerialName("ManaValueIsOdd")
+    @Serializable
+    data object ManaValueIsOdd : CardPredicate {
+        override val description: String = "with odd mana value"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
     // =============================================================================
     // Power/Toughness Predicates
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MutinousMassacre.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MutinousMassacre.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GainControlEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mutinous Massacre
+ * {3}{B}{B}{R}{R}
+ * Sorcery
+ * Choose odd or even. Destroy each creature with mana value of the chosen quality.
+ * Then gain control of all creatures until end of turn. Untap them.
+ * They gain haste until end of turn. (Zero is even.)
+ *
+ * Modeled as a 2-mode modal spell: the player chooses Odd or Even, the chosen mode wipes
+ * creatures with the matching parity, then takes the Insurrection-style swing on the
+ * survivors.
+ */
+val MutinousMassacre = card("Mutinous Massacre") {
+    manaCost = "{3}{B}{B}{R}{R}"
+    colorIdentity = "BR"
+    typeLine = "Sorcery"
+    oracleText = "Choose odd or even. Destroy each creature with mana value of the chosen quality. " +
+        "Then gain control of all creatures until end of turn. Untap them. " +
+        "They gain haste until end of turn. (Zero is even.)"
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Odd") {
+                effect = Effects.Composite(
+                    Effects.DestroyAll(GameObjectFilter.Creature.manaValueIsOdd()),
+                    ForEachInGroupEffect(GroupFilter.AllCreatures, GainControlEffect(EffectTarget.Self, Duration.EndOfTurn)),
+                    ForEachInGroupEffect(GroupFilter.AllCreatures, TapUntapEffect(EffectTarget.Self, tap = false)),
+                    ForEachInGroupEffect(GroupFilter.AllCreatures, GrantKeywordEffect(Keyword.HASTE, EffectTarget.Self, Duration.EndOfTurn))
+                )
+            }
+            mode("Even") {
+                effect = Effects.Composite(
+                    Effects.DestroyAll(GameObjectFilter.Creature.manaValueIsEven()),
+                    ForEachInGroupEffect(GroupFilter.AllCreatures, GainControlEffect(EffectTarget.Self, Duration.EndOfTurn)),
+                    ForEachInGroupEffect(GroupFilter.AllCreatures, TapUntapEffect(EffectTarget.Self, tap = false)),
+                    ForEachInGroupEffect(GroupFilter.AllCreatures, GrantKeywordEffect(Keyword.HASTE, EffectTarget.Self, Duration.EndOfTurn))
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "222"
+        artist = "Quintin Gleim"
+        flavorText = "Kavaron's degradation poisoned many hearts, which the Monoists were happy to exploit."
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42d5034f-18f0-4d57-9840-6be52c286247.jpg?1752947466"
+
+        ruling("2025-07-25", "If a creature has {X} in its mana cost, X is 0 for the purpose of determining its mana value.")
+        ruling("2025-07-25", "You'll untap all creatures, including those you already control. They'll also gain haste even if they were already untapped.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -567,6 +567,14 @@ class TriggerMatcher(
                 val cmc = if (isFaceDown) 0 else cardComponent.manaValue
                 cmc == predicate.value
             }
+            com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueIsEven -> {
+                val cmc = if (isFaceDown) 0 else cardComponent.manaValue
+                cmc % 2 == 0
+            }
+            com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueIsOdd -> {
+                val cmc = if (isFaceDown) 0 else cardComponent.manaValue
+                cmc % 2 != 0
+            }
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.PowerAtLeast -> {
                 val power = if (isFaceDown) 2
                     else lastKnownPower ?: projected.getPower(entityId) ?: cardComponent.baseStats?.basePower ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -273,6 +273,14 @@ class PredicateEvaluator {
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc <= manaSpent
             }
+            CardPredicate.ManaValueIsEven -> {
+                val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
+                cmc % 2 == 0
+            }
+            CardPredicate.ManaValueIsOdd -> {
+                val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
+                cmc % 2 != 0
+            }
 
             // Power/toughness predicates - use projected P/T
             is CardPredicate.PowerEquals -> {
@@ -762,6 +770,8 @@ class PredicateEvaluator {
             // Entity-relative — no entity context for cast records
             is CardPredicate.ManaValueAtMostEntity -> false
             is CardPredicate.ManaValueAtMostEntityManaSpent -> false
+            CardPredicate.ManaValueIsEven -> record.manaValue % 2 == 0
+            CardPredicate.ManaValueIsOdd -> record.manaValue % 2 != 0
 
             // Power/toughness — not meaningful for cast records
             is CardPredicate.PowerEquals, is CardPredicate.PowerAtMost, is CardPredicate.PowerAtLeast,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -448,6 +448,8 @@ internal class AffectsFilterResolver {
         // Entity-relative — layer-projection has no trigger/source context for filter purposes here.
         is CardPredicate.ManaValueAtMostEntity -> false
         is CardPredicate.ManaValueAtMostEntityManaSpent -> false
+        CardPredicate.ManaValueIsEven -> card.manaValue % 2 == 0
+        CardPredicate.ManaValueIsOdd -> card.manaValue % 2 != 0
         is CardPredicate.NameEquals -> card.name == predicate.name
         is CardPredicate.HasBasicLandType -> if (isFaceDown) false else subtypes.any { it.equals(predicate.landType, ignoreCase = true) }
         is CardPredicate.And -> predicate.predicates.all { matchesCardPredicateForProjection(it, card, container, projected, types, subtypes, colors, keywords, isFaceDown) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -836,6 +836,8 @@ class CostCalculator(
             // CostCalculator has no entity context; predicate has no static answer here.
             is CardPredicate.ManaValueAtMostEntity -> false
             is CardPredicate.ManaValueAtMostEntityManaSpent -> false
+            CardPredicate.ManaValueIsEven -> cardDef.manaCost.cmc % 2 == 0
+            CardPredicate.ManaValueIsOdd -> cardDef.manaCost.cmc % 2 != 0
 
             is CardPredicate.PowerEquals -> cardDef.creatureStats?.basePower == predicate.value
             is CardPredicate.PowerAtMost -> (cardDef.creatureStats?.basePower ?: 0) <= predicate.max


### PR DESCRIPTION
…pport

Modeled as a 2-mode modal spell. Adds new CardPredicate.ManaValueIsOdd / ManaValueIsEven (face-down treated as CMC 0, i.e. even) wired through PredicateEvaluator, AffectsFilterResolver, CostCalculator, and TriggerMatcher, plus manaValueIsOdd() / manaValueIsEven() chain builders on GameObjectFilter.