### PR TITLE
Invasion gap #21: pile-separation cycle (5 cards)

### DIFF
--- a/backlog/invasion-engine-gaps.md
+++ b/backlog/invasion-engine-gaps.md
@@ -755,7 +755,46 @@ pieces — the trigger, the collection filter, and the retarget effect — are r
 
 ---
 
-### #21 — "Each player separates; an opponent chooses a pile" + chosen-pile restriction · 5 cards
+### #21 — "Each player separates; an opponent chooses a pile" + chosen-pile restriction · 5 cards ✅ DONE
+
+> **Implemented (all 5 cards).** The verification corrected the gap's premise: two of the three proposed
+> "additions" already existed. **`CardSource.ControlledPermanents(player, filter)`** gathers a player's
+> permanents (proposed addition #1 — already present), and a full **`ForEachPlayerEffect`** combinator
+> (executor + `ForEachPlayerContinuation` + auto-resumer) already iterates players running a pausing
+> sub-pipeline (proposed addition #2 — already present). The only fix it needed: `ForEachPlayerExecutor`
+> now recomputes `opponentId` for each per-player context, so `Chooser.Opponent` / `Player.Opponent`
+> inside the loop resolve to the *iterated* player's opponent (Bend or Break: an opponent of each
+> separating player chooses that player's pile).
+>
+> Proposed addition #3 (a chosen-pile restriction) was built as **one generic, broadly-reusable atom**
+> instead of a `GroupFilter.InStoredCollection` variant (which can't work — a `dynamicGroupFilter` is
+> re-evaluated at projection with no pipeline access, so the chosen pile would be lost): new
+> **`ForEachInCollectionEffect(collection, effect)`** runs a sub-effect once per entity in a stored
+> collection with `iterationTarget` set — the collection-based sibling of `ForEachInGroupEffect`. The
+> "only the chosen pile can attack/block" payoff then *composes* from existing atoms:
+> `ForEachInCollection(nonChosenPile, Effects.CantAttack(EffectTarget.Self))` snapshots a per-creature
+> can't-attack/can't-block floating effect (creatures entering after the split are unaffected). For
+> Global Ruin a new **`SelectionRestriction.OnePerBasicLandType`** (cap + resumer trim + decision flag)
+> keeps one land per basic type and rejects typeless lands.
+>
+> Cards authored in `definitions/inv/cards/`, each composed from the pile primitives (Gather → Select →
+> ChoosePile → Move/Tap/restrict), covered by per-card scenario tests in `game-server`
+> (`DeathOrGloryScenarioTest`, `BendOrBreakScenarioTest`, `GlobalRuinScenarioTest`,
+> `FightOrFlightScenarioTest`, `StandOrFallScenarioTest`):
+> - **Death or Glory** — pure pile composition over the graveyard (opponent picks the exiled pile; the
+>   other returns to the battlefield). No engine change.
+> - **Bend or Break** — `ForEachPlayer(Each)`: each player separates their nontoken lands, an opponent
+>   destroys one pile (`MoveCollection(Destroy)`), the other is tapped (`TapUntapCollection`).
+> - **Global Ruin** — `ForEachPlayer(Each)` + `SelectFromCollection(OnePerBasicLandType)` →
+>   `MoveCollection(Sacrifice)` of the remainder.
+> - **Fight or Flight** — `Triggers.phase(BEGIN_COMBAT, EachOpponent)`; you split the active player's
+>   creatures, they pick the attacking pile, the rest get `CantAttack` via `ForEachInCollection`.
+> - **Stand or Fall** — `Triggers.BeginCombat` + `ForEachPlayer(EachOpponent)`; you (the source's
+>   controller, via `Chooser.SourceController`) split each defender's creatures, they pick the blocking
+>   pile, the rest get `CantBlock`.
+>
+> **Scoping note:** per-player iteration runs separate → choose → resolve in turn order (the engine is
+> two-player in practice, where the printed simultaneity of the destroys is moot).
 
 **What exists.** `ChoosePileEffect` (binary chooser, `Chooser.Opponent` supported) +
 `SelectFromCollectionEffect` partition + the `factOrFiction` pattern. `CantAttackGroupEffect` /
@@ -802,7 +841,8 @@ filter.
 6. **Tapped-for-mana event + rider + replacement** (#3) — 3 cards, reusable mana hooks.
 7. **Name-a-card choice + filter** (#10) ✅ — `OptionType.CARD_NAME` / `Effects.ChooseCardName` +
    `StoreCardName` (capture-from-chosen-card) + `NameEqualsChosen` filter; Desperate Research + Lobotomy done.
-8. **Pile-separation trio** (#21) — 5 cards from three composable additions.
+8. **Pile-separation trio** (#21) ✅ — 5 cards; the gather + per-player primitives already existed, so it
+   reduced to one `opponentId` fix, a generic `ForEachInCollection` atom, and `OnePerBasicLandType`.
 9. Scope additions: protection supertype (#13 ✅), dynamic-color protection (#15 ✅), chosen-type
    landwalk (#14 ✅), discard-at-random cost (#9 ✅) — small, independent.
 10. Bespoke / heavier: stack color-change (#11 ✅), life auction (#16 ✅), text-changing (#17 ✅),

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1754,8 +1754,21 @@ Counter effects live in §4 (`AddCounters`, `RemoveCounters`, `Proliferate`, `Mo
   `ForEachPlayerEffect`). Used by Builder's Bane via the
   `GatherCards(ChosenTargets) → CaptureControllers → MoveCollection(Destroy, storeMovedAs) → ForEachCapturedController`
   shape.
-- `SelectFromCollectionEffect(from, into, selectCount?, allowZero?, alwaysPrompt?)` — let a player pick from a
-  collection.
+- `ForEachInCollectionEffect(collection, effect)` — run `effect` once per entity in a named pipeline collection
+  (snapshotted at resolution), with `pipeline.iterationTarget` set to that entity. Collection-based sibling of
+  `ForEachInGroupEffect` (which iterates a battlefield filter): use it to apply a per-entity effect to a *chosen*
+  set rather than a re-evaluated filter. Pair with a single-target effect on `EffectTarget.Self` — e.g.
+  `ForEachInCollection(nonChosenPile, Effects.CantAttack(EffectTarget.Self))` gives each creature in a chosen pile
+  its own snapshot can't-attack floating effect (Fight or Flight / Stand or Fall; creatures entering after the
+  split are unaffected).
+- `SelectFromCollectionEffect(from, into, selectCount?, allowZero?, alwaysPrompt?, restrictions?)` — let a player pick
+  from a collection. `restrictions` (`List<SelectionRestriction>`) cap and trim the picks server-side: `OnePerCardType`,
+  `OnePerColor(matchControllerPermanentColors?)`, `OnePerCardName`, `TotalManaValueAtMost(max)`, and
+  `OnePerBasicLandType`. `OnePerBasicLandType` keeps at most one land of each basic land type (a kept land claims
+  *every* basic type it has) and — unlike `OnePerColor`, where a colourless card is unconstrained — a land with no
+  basic land type can't be kept at all (Global Ruin: "chooses a land of each basic land type, then sacrifices the
+  rest"). Each restriction also exposes a boolean flag on `SelectCardsDecision` (`onePerBasicLandType`, …) so the UI
+  can disable redundant picks.
 
 **Linked exile**
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BendOrBreakScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BendOrBreakScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Bend or Break — a per-player "divvy" (CR 700.3) over lands.
+ *
+ *   {3}{R} Sorcery
+ *   "Each player separates all nontoken lands they control into two piles. For each
+ *    player, one of their piles is chosen by one of their opponents of their choice.
+ *    Destroy all lands in the chosen piles. Tap all lands in the other piles."
+ *
+ * Each player partitions their own lands; an opponent of that player chooses which
+ * pile dies (the other is tapped). Drives both players' iterations to also exercise
+ * the per-iteration `Chooser.Opponent` resolution inside ForEachPlayerEffect.
+ */
+class BendOrBreakScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bend or Break") {
+
+            test("each player splits their lands; their opponent destroys one pile, the rest are tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Bend or Break")
+                    // P1's four Mountains double as the casting mana and the pile fodder.
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    // P2's lands (distinct names so the piles are identifiable).
+                    .withCardOnBattlefield(2, "Plains")
+                    .withCardOnBattlefield(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Bend or Break").error shouldBe null
+                game.resolveStack()
+
+                // Iteration 1: P1 separates their four Mountains.
+                val p1Split = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("The separating player (P1) makes their own partition") {
+                    p1Split.playerId shouldBe game.player1Id
+                    p1Split.options.size shouldBe 4
+                }
+                // Pile 1 = two Mountains; Pile 2 = the other two.
+                game.selectCards(p1Split.options.take(2))
+
+                // P2 (P1's opponent) chooses which of P1's piles is destroyed.
+                val p1Choose = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<ChooseOptionDecision>()
+                withClue("An opponent of the separating player chooses the doomed pile") {
+                    p1Choose.playerId shouldBe game.player2Id
+                }
+                game.submitDecision(OptionChosenResponse(p1Choose.id, 0)) // destroy Pile 1 (2 Mountains)
+
+                // Iteration 2: P2 separates their two lands.
+                val p2Split = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("P2 separates their own lands") {
+                    p2Split.playerId shouldBe game.player2Id
+                    p2Split.options.size shouldBe 2
+                }
+                val plainsId = p2Split.options.first { nameOf(game, it) == "Plains" }
+                game.selectCards(listOf(plainsId)) // Pile 1 = Plains; Pile 2 = Island
+
+                // P1 (P2's opponent) chooses which of P2's piles is destroyed.
+                val p2Choose = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<ChooseOptionDecision>()
+                withClue("P1 chooses for P2's piles — opponentId is recomputed per iteration") {
+                    p2Choose.playerId shouldBe game.player1Id
+                }
+                game.submitDecision(OptionChosenResponse(p2Choose.id, 0)) // destroy Pile 1 (Plains)
+                game.resolveStack()
+
+                withClue("P1: two Mountains destroyed, two remain (tapped)") {
+                    game.findPermanents("Mountain").size shouldBe 2
+                    game.graveyardSize(1) shouldBe 3 // 2 Mountains + Bend or Break
+                    game.findPermanents("Mountain").forEach { id ->
+                        game.state.getEntity(id)?.has<TappedComponent>() shouldBe true
+                    }
+                }
+                withClue("P2: Plains destroyed, Island remains and is tapped") {
+                    game.isOnBattlefield("Plains") shouldBe false
+                    game.isInGraveyard(2, "Plains") shouldBe true
+                    game.isOnBattlefield("Island") shouldBe true
+                    val islandId = game.findPermanent("Island").shouldNotBeNull()
+                    game.state.getEntity(islandId)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+
+    private fun nameOf(game: TestGame, id: EntityId): String? =
+        game.state.getEntity(id)?.get<CardComponent>()?.name
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DeathOrGloryScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DeathOrGloryScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Death or Glory — a graveyard "divvy" (CR 700.3).
+ *
+ *   {4}{W} Sorcery
+ *   "Separate all creature cards in your graveyard into two piles. Exile the pile
+ *    of an opponent's choice and return the other to the battlefield."
+ *
+ * You partition your graveyard creature cards; an opponent picks which pile is
+ * exiled, and the other pile returns to the battlefield under your control.
+ */
+class DeathOrGloryScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Death or Glory") {
+
+            test("you split; opponent exiles one pile, the other returns to the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Death or Glory")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    // Graveyard: two creature cards + a noncreature (must be ignored).
+                    .withCardInGraveyard(1, "Glory Seeker")   // 2/2 creature
+                    .withCardInGraveyard(1, "Festering Goblin") // 1/1 creature
+                    .withCardInGraveyard(1, "Mountain")        // land — not a creature card
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Death or Glory").error shouldBe null
+                game.resolveStack()
+
+                // Step 1 — caster separates their creature cards.
+                val partition = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("The caster makes the partition") {
+                    partition.playerId shouldBe game.player1Id
+                }
+                withClue("Only the two creature cards are options — the Mountain is excluded") {
+                    partition.options.size shouldBe 2
+                    partition.options.mapNotNull { nameOf(game, it) }.toSet() shouldBe
+                        setOf("Glory Seeker", "Festering Goblin")
+                }
+
+                // Pile 1 = Glory Seeker; Pile 2 = Festering Goblin.
+                val pileGlory = partition.options.filter { nameOf(game, it) == "Glory Seeker" }
+                game.selectCards(pileGlory)
+
+                // Step 2 — opponent picks which pile is exiled.
+                val pickPile = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<ChooseOptionDecision>()
+                withClue("The opponent — not the caster — chooses the exiled pile") {
+                    pickPile.playerId shouldBe game.player2Id
+                }
+                // Opponent exiles Pile 1 (Glory Seeker); Festering Goblin returns.
+                game.submitDecision(OptionChosenResponse(pickPile.id, 0))
+                game.resolveStack()
+
+                val exile = game.state.getZone(ZoneKey(game.player1Id, Zone.EXILE))
+                    .mapNotNull { nameOf(game, it) }
+                withClue("Chosen pile (Glory Seeker) is exiled") {
+                    exile shouldBe listOf("Glory Seeker")
+                }
+                withClue("Other pile (Festering Goblin) returns to the battlefield under your control") {
+                    game.isOnBattlefield("Festering Goblin") shouldBe true
+                    val gobId = game.findPermanent("Festering Goblin").shouldNotBeNull()
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.BATTLEFIELD)) shouldContainId gobId
+                }
+                withClue("The noncreature card stays in the graveyard, alongside the spent spell") {
+                    game.isInGraveyard(1, "Mountain") shouldBe true
+                    game.isInGraveyard(1, "Death or Glory") shouldBe true
+                }
+            }
+        }
+    }
+
+    private infix fun List<EntityId>.shouldContainId(id: EntityId) {
+        (id in this) shouldBe true
+    }
+
+    private fun nameOf(game: TestGame, id: EntityId): String? =
+        game.state.getEntity(id)?.get<CardComponent>()?.name
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FightOrFlightScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FightOrFlightScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Fight or Flight.
+ *
+ *   {3}{W} Enchantment
+ *   "At the beginning of combat on each opponent's turn, separate all creatures that
+ *    player controls into two piles. Only creatures in the pile of their choice can
+ *    attack this turn."
+ *
+ * You (the enchantment's controller) partition the active opponent's creatures; that
+ * player chooses which pile can attack, and the other pile can't attack this turn.
+ */
+class FightOrFlightScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Fight or Flight") {
+
+            test("on the opponent's combat, you split their creatures; the unchosen pile can't attack") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Fight or Flight")
+                    .withCardOnBattlefield(2, "Glory Seeker")     // P2's 2/2
+                    .withCardOnBattlefield(2, "Festering Goblin") // P2's 1/1
+                    .withActivePlayer(2) // opponent's turn
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gloryId = game.findPermanent("Glory Seeker").shouldNotBeNull()
+                val goblinId = game.findPermanent("Festering Goblin").shouldNotBeNull()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                // Step 1 — you (the enchantment's controller) separate the active player's creatures.
+                val split = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("The enchantment's controller separates the active opponent's creatures") {
+                    split.playerId shouldBe game.player1Id
+                    split.options.toSet() shouldBe setOf(gloryId, goblinId)
+                }
+                // Pile 1 = Glory Seeker; Pile 2 = Festering Goblin.
+                game.selectCards(listOf(gloryId))
+
+                // Step 2 — the active player chooses which pile can attack.
+                val choose = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<ChooseOptionDecision>()
+                withClue("The active player — not you — chooses which pile can attack") {
+                    choose.playerId shouldBe game.player2Id
+                }
+                // Choose Pile 2 (Festering Goblin) as the attackers; Glory Seeker is then restricted.
+                game.submitDecision(OptionChosenResponse(choose.id, 1))
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+                withClue("Glory Seeker (unchosen pile) can't attack this turn") {
+                    projected.cantAttack(gloryId) shouldBe true
+                }
+                withClue("Festering Goblin (chosen pile) can still attack") {
+                    projected.cantAttack(goblinId) shouldBe false
+                }
+            }
+        }
+    }
+
+    @Suppress("unused")
+    private fun nameOf(game: TestGame, id: EntityId): String? =
+        game.state.getEntity(id)?.get<CardComponent>()?.name
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/GlobalRuinScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/GlobalRuinScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Global Ruin.
+ *
+ *   {4}{W} Sorcery
+ *   "Each player chooses from the lands they control a land of each basic land type,
+ *    then sacrifices the rest."
+ *
+ * Each player keeps at most one land of each basic land type (a kept land claims all
+ * its basic types) and sacrifices the remainder; a land with no basic land type can't
+ * be kept. Exercises the new SelectionRestriction.OnePerBasicLandType inside
+ * ForEachPlayerEffect — both the per-type cap and the resumer's rejection of a
+ * duplicate type and of a typeless land.
+ */
+class GlobalRuinScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Global Ruin") {
+
+            test("each player keeps one land per basic type; duplicates and typeless lands are sacrificed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Global Ruin")
+                    // P1's five lands double as casting mana: 2 Plains, 1 Island, 1 Forest, 1 Mountain.
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    // P2: a basic land plus a typeless land that can't be kept.
+                    .withCardOnBattlefield(2, "Mountain")
+                    .withCardOnBattlefield(2, "Coastal Tower") // "Land" — no basic land type
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Global Ruin").error shouldBe null
+                game.resolveStack()
+
+                // Iteration 1: P1 chooses lands to keep.
+                val p1Choice = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("Each player chooses their own lands to keep") {
+                    p1Choice.playerId shouldBe game.player1Id
+                }
+                withClue("The UI is told this is a one-per-basic-land-type selection") {
+                    p1Choice.onePerBasicLandType shouldBe true
+                }
+                withClue("At most one land per distinct basic type (Plains/Island/Forest/Mountain = 4)") {
+                    p1Choice.maxSelections shouldBe 4
+                }
+                // Try to keep both Plains plus Island + Forest (within the cap of 4). The second
+                // Plains is rejected as a duplicate type; the Mountain isn't chosen.
+                val plains = p1Choice.options.filter { nameOf(game, it) == "Plains" }
+                val island = p1Choice.options.first { nameOf(game, it) == "Island" }
+                val forest = p1Choice.options.first { nameOf(game, it) == "Forest" }
+                game.selectCards(listOf(plains[0], plains[1], island, forest))
+
+                // Iteration 2: P2 chooses — and greedily picks the typeless land.
+                val p2Choice = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                p2Choice.playerId shouldBe game.player2Id
+                val coastalTower = p2Choice.options.first { nameOf(game, it) == "Coastal Tower" }
+                game.selectCards(listOf(coastalTower))
+                game.resolveStack()
+
+                withClue("P1 keeps one Plains, the Island and the Forest; the extra Plains and the unchosen Mountain are sacrificed") {
+                    game.findPermanents("Plains").size shouldBe 1
+                    game.findPermanents("Island").size shouldBe 1
+                    game.findPermanents("Forest").size shouldBe 1
+                    game.findPermanents("Mountain").any {
+                        game.state.getZone(com.wingedsheep.engine.state.ZoneKey(game.player1Id, com.wingedsheep.sdk.core.Zone.BATTLEFIELD)).contains(it)
+                    } shouldBe false
+                    game.graveyardSize(1) shouldBe 3 // extra Plains + Mountain + Global Ruin
+                }
+                withClue("P2 can't keep the typeless Coastal Tower even though they chose it; both their lands are sacrificed") {
+                    game.isInGraveyard(2, "Coastal Tower") shouldBe true
+                    game.isInGraveyard(2, "Mountain") shouldBe true
+                    game.graveyardSize(2) shouldBe 2
+                }
+            }
+        }
+    }
+
+    private fun nameOf(game: TestGame, id: EntityId): String? =
+        game.state.getEntity(id)?.get<CardComponent>()?.name
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StandOrFallScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StandOrFallScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Stand or Fall.
+ *
+ *   {3}{R} Enchantment
+ *   "At the beginning of combat on your turn, for each defending player, separate all
+ *    creatures that player controls into two piles and that player chooses one. Only
+ *    creatures in the chosen piles can block this turn."
+ *
+ * On your combat, for each opponent you (the source's controller) partition their
+ * creatures; that player chooses which pile can block, and the other pile can't block
+ * this turn.
+ */
+class StandOrFallScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Stand or Fall") {
+
+            test("on your combat, you split the defender's creatures; the unchosen pile can't block") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Stand or Fall")
+                    .withCardOnBattlefield(2, "Glory Seeker")     // defender's 2/2
+                    .withCardOnBattlefield(2, "Festering Goblin") // defender's 1/1
+                    .withActivePlayer(1) // your turn
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gloryId = game.findPermanent("Glory Seeker").shouldNotBeNull()
+                val goblinId = game.findPermanent("Festering Goblin").shouldNotBeNull()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                // Step 1 — you (the source's controller) separate the defending player's creatures.
+                val split = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("The enchantment's controller separates the defender's creatures") {
+                    split.playerId shouldBe game.player1Id
+                    split.options.toSet() shouldBe setOf(gloryId, goblinId)
+                }
+                // Pile 1 = Glory Seeker; Pile 2 = Festering Goblin.
+                game.selectCards(listOf(gloryId))
+
+                // Step 2 — the defending player chooses which pile can block.
+                val choose = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<ChooseOptionDecision>()
+                withClue("The defending player chooses which of their piles can block") {
+                    choose.playerId shouldBe game.player2Id
+                }
+                // Choose Pile 2 (Festering Goblin) as the blockers; Glory Seeker is then restricted.
+                game.submitDecision(OptionChosenResponse(choose.id, 1))
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+                withClue("Glory Seeker (unchosen pile) can't block this turn") {
+                    projected.cantBlock(gloryId) shouldBe true
+                }
+                withClue("Festering Goblin (chosen pile) can still block") {
+                    projected.cantBlock(goblinId) shouldBe false
+                }
+            }
+        }
+    }
+
+    @Suppress("unused")
+    private fun nameOf(game: TestGame, id: EntityId): String? =
+        game.state.getEntity(id)?.get<CardComponent>()?.name
+}

--- a/manual-scenarios/cards/b/bend-or-break-pile-separation.json
+++ b/manual-scenarios/cards/b/bend-or-break-pile-separation.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Bend or Break"],
+    "battlefield": [
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Plains", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Swamp", "tapped": false},
+      {"name": "Forest", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -807,6 +807,41 @@ data class ForEachPlayerEffect(
 }
 
 /**
+ * Run a sub-effect once for each permanent/card in a named pipeline collection.
+ *
+ * For each entity in `storedCollections[collection]` (snapshotted at resolution), the
+ * sub-effect runs with `pipeline.iterationTarget` set to that entity — so a single-target
+ * effect referencing [com.wingedsheep.sdk.scripting.targets.EffectTarget.Self] applies to
+ * the current entity. This is the collection-based sibling of [ForEachInGroupEffect]
+ * (which iterates a battlefield filter): use it to apply a per-entity effect to a *chosen*
+ * set of permanents rather than a re-evaluated filter.
+ *
+ * Example — "only creatures in the chosen pile can attack" (Fight or Flight): after a
+ * Gather → Select → ChoosePile pipeline, run `ForEachInCollection(nonChosenPile,
+ * CantAttack(Self))` so each creature in the restricted pile gets its own snapshot
+ * can't-attack floating effect (creatures entering later are unaffected).
+ *
+ * @property collection Name of the pipeline collection to iterate
+ * @property effect The effect to run for each entity (typically targeting `EffectTarget.Self`)
+ */
+@SerialName("ForEachInCollection")
+@Serializable
+data class ForEachInCollectionEffect(
+    val collection: String,
+    val effect: Effect
+) : Effect {
+    override val description: String = buildString {
+        append("For each permanent in $collection, ")
+        append(effect.description.replaceFirstChar { it.lowercase() })
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect {
+        val newEffect = effect.applyTextReplacement(replacer)
+        return if (newEffect !== effect) copy(effect = newEffect) else this
+    }
+}
+
+/**
  * Flip a coin. Execute one effect if you win, another if you lose.
  * "Flip a coin. If you win the flip, [wonEffect]. If you lose the flip, [lostEffect]."
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -347,6 +347,26 @@ sealed interface SelectionRestriction {
     data class TotalManaValueAtMost(val max: Int) : SelectionRestriction {
         override val description: String = "with total mana value $max or less"
     }
+
+    /**
+     * At most one land of each basic land type (Plains/Island/Swamp/Mountain/Forest)
+     * may be selected. A selected land claims *every* basic land type it has, so a dual
+     * land that is both a Plains and an Island consumes both slots (Global Ruin ruling).
+     *
+     * Unlike [OnePerColor] — where a colourless card is unconstrained and always
+     * selectable — a land with **no** basic land type can't be kept at all: "chooses
+     * ... a land of each basic land type" only lets you keep typed lands, so a typeless
+     * land falls into the remainder. The executor enforces this server-side: a selection
+     * naming a typeless land, or a second land sharing an already-claimed basic type, is
+     * rejected (in response order) and falls through to the remainder collection.
+     *
+     * Used for Global Ruin.
+     */
+    @SerialName("OnePerBasicLandType")
+    @Serializable
+    data object OnePerBasicLandType : SelectionRestriction {
+        override val description: String = "at most one land of each basic land type"
+    }
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BendOrBreak.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BendOrBreak.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.TapUntapCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Bend or Break
+ * {3}{R}
+ * Sorcery
+ * Each player separates all nontoken lands they control into two piles. For each
+ * player, one of their piles is chosen by one of their opponents of their choice.
+ * Destroy all lands in the chosen piles. Tap all lands in the other piles.
+ *
+ * A per-player "divvy" (CR 700.3): each player partitions their own lands, then an
+ * opponent of that player chooses which pile dies. Composed from the pile primitives
+ * inside [ForEachPlayerEffect] — within the loop the iterated player is the controller
+ * (so they separate and `Chooser.Opponent` resolves to *their* opponent). Each player's
+ * separate → choose → destroy/tap runs in turn order (the engine is two-player in
+ * practice, where simultaneity is moot).
+ */
+val BendOrBreak = card("Bend or Break") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Each player separates all nontoken lands they control into two piles. For each player, one of their piles is chosen by one of their opponents of their choice. Destroy all lands in the chosen piles. Tap all lands in the other piles."
+
+    spell {
+        effect = ForEachPlayerEffect(
+            players = Player.Each,
+            effects = listOf(
+                // 1. Gather the nontoken lands this player controls.
+                GatherCardsEffect(
+                    source = CardSource.ControlledPermanents(
+                        player = Player.You,
+                        filter = GameObjectFilter.Land.nontoken()
+                    ),
+                    storeAs = "lands"
+                ),
+                // 2. This player separates their lands into two piles.
+                SelectFromCollectionEffect(
+                    from = "lands",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    chooser = Chooser.Controller,
+                    storeSelected = "pileA",
+                    storeRemainder = "pileB",
+                    selectedLabel = "Pile 1",
+                    remainderLabel = "Pile 2",
+                    prompt = "Separate your lands into two piles. The lands you select form Pile 1; the rest form Pile 2.",
+                    useTargetingUI = true,
+                    alwaysPrompt = true
+                ),
+                // 3. An opponent chooses one of this player's piles to be destroyed.
+                ChoosePileEffect(
+                    pileA = "pileA",
+                    pileB = "pileB",
+                    pileALabel = "Pile 1",
+                    pileBLabel = "Pile 2",
+                    chooser = Chooser.Opponent,
+                    storeChosenAs = "destroyed",
+                    storeOtherAs = "tapped",
+                    prompt = "Choose which of the player's land piles is destroyed; the other pile is tapped."
+                ),
+                // 4. Destroy the chosen pile.
+                MoveCollectionEffect(
+                    from = "destroyed",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                    moveType = MoveType.Destroy
+                ),
+                // 5. Tap the other pile.
+                TapUntapCollectionEffect(collectionName = "tapped", tap = true)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "137"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b76b6660-d4b2-44de-a1a7-8d00811f90f6.jpg?1562931926"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DeathOrGlory.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DeathOrGlory.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Death or Glory
+ * {4}{W}
+ * Sorcery
+ * Separate all creature cards in your graveyard into two piles. Exile the pile
+ * of an opponent's choice and return the other to the battlefield.
+ *
+ * A "divvy" (CR 700.3) over the graveyard: you partition your creature cards,
+ * an opponent chooses one pile to be exiled, and the rest return. Composed from
+ * the same pile primitives as Do or Die / Fact or Fiction — Gather (graveyard) →
+ * SelectFromCollection (you split) → ChoosePile (opponent picks the exiled pile) →
+ * MoveCollection (exile chosen, battlefield other).
+ */
+val DeathOrGlory = card("Death or Glory") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Separate all creature cards in your graveyard into two piles. Exile the pile of an opponent's choice and return the other to the battlefield."
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                // 1. Gather every creature card in your graveyard.
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature
+                    ),
+                    storeAs = "creatures"
+                ),
+                // 2. You separate them into two piles.
+                SelectFromCollectionEffect(
+                    from = "creatures",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    chooser = Chooser.Controller,
+                    storeSelected = "pileA",
+                    storeRemainder = "pileB",
+                    selectedLabel = "Pile 1",
+                    remainderLabel = "Pile 2",
+                    prompt = "Separate your creature cards into two piles. The cards you select form Pile 1; the rest form Pile 2.",
+                    alwaysPrompt = true
+                ),
+                // 3. An opponent chooses which pile is exiled.
+                ChoosePileEffect(
+                    pileA = "pileA",
+                    pileB = "pileB",
+                    pileALabel = "Pile 1",
+                    pileBLabel = "Pile 2",
+                    chooser = Chooser.Opponent,
+                    storeChosenAs = "exiled",
+                    storeOtherAs = "returned",
+                    prompt = "Choose which pile of creature cards is exiled; the other returns to the battlefield."
+                ),
+                // 4. Exile the chosen pile.
+                MoveCollectionEffect(
+                    from = "exiled",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                ),
+                // 5. Return the other pile to the battlefield under your control.
+                MoveCollectionEffect(
+                    from = "returned",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "13"
+        artist = "Jeff Easley"
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/81f967c9-b38d-489d-96cc-44a6b1804e10.jpg?1562921230"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FightOrFlight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FightOrFlight.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fight or Flight
+ * {3}{W}
+ * Enchantment
+ * At the beginning of combat on each opponent's turn, separate all creatures
+ * that player controls into two piles. Only creatures in the pile of their
+ * choice can attack this turn.
+ *
+ * A "divvy" (CR 700.3) restriction: you (the ability's controller) partition the
+ * active opponent's creatures, that player chooses which pile can attack, and the
+ * other pile can't attack this turn. Composed from the pile primitives plus a
+ * resolution-time snapshot restriction — ForEachInCollection over the non-chosen
+ * pile applies a single-target [Effects.CantAttack] to each creature, so creatures
+ * entering after the split are unaffected.
+ */
+val FightOrFlight = card("Fight or Flight") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of combat on each opponent's turn, separate all creatures that player controls into two piles. Only creatures in the pile of their choice can attack this turn."
+
+    triggeredAbility {
+        trigger = Triggers.phase(Step.BEGIN_COMBAT, Player.EachOpponent)
+        effect = CompositeEffect(
+            listOf(
+                // 1. Gather the creatures the active opponent controls.
+                GatherCardsEffect(
+                    source = CardSource.ControlledPermanents(
+                        player = Player.Opponent,
+                        filter = GameObjectFilter.Creature
+                    ),
+                    storeAs = "creatures"
+                ),
+                // 2. You separate that player's creatures into two piles.
+                SelectFromCollectionEffect(
+                    from = "creatures",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    chooser = Chooser.Controller,
+                    storeSelected = "pileA",
+                    storeRemainder = "pileB",
+                    selectedLabel = "Pile 1",
+                    remainderLabel = "Pile 2",
+                    prompt = "Separate the active player's creatures into two piles. The creatures you select form Pile 1; the rest form Pile 2.",
+                    useTargetingUI = true,
+                    alwaysPrompt = true
+                ),
+                // 3. That player chooses which pile may attack.
+                ChoosePileEffect(
+                    pileA = "pileA",
+                    pileB = "pileB",
+                    pileALabel = "Pile 1",
+                    pileBLabel = "Pile 2",
+                    chooser = Chooser.Opponent,
+                    storeChosenAs = "canAttack",
+                    storeOtherAs = "cantAttack",
+                    prompt = "Choose which pile of your creatures can attack this turn."
+                ),
+                // 4. Only the chosen pile can attack — the other pile can't attack this turn.
+                ForEachInCollectionEffect(
+                    collection = "cantAttack",
+                    effect = Effects.CantAttack(EffectTarget.Self)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "16"
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46bde162-3737-4b93-a27a-63b909a4183d.jpg?1562909374"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/GlobalRuin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/GlobalRuin.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SelectionRestriction
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Global Ruin
+ * {4}{W}
+ * Sorcery
+ * Each player chooses from the lands they control a land of each basic land type,
+ * then sacrifices the rest.
+ *
+ * Not a pile card — each player keeps at most one land of each basic land type and
+ * sacrifices the remainder. Composed inside [ForEachPlayerEffect]: each player gathers
+ * their lands and selects them under the [SelectionRestriction.OnePerBasicLandType]
+ * cap (a kept land claims every basic land type it has; a typeless land can't be kept),
+ * then the unselected remainder is sacrificed.
+ */
+val GlobalRuin = card("Global Ruin") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Each player chooses from the lands they control a land of each basic land type, then sacrifices the rest."
+
+    spell {
+        effect = ForEachPlayerEffect(
+            players = Player.Each,
+            effects = listOf(
+                // 1. Gather the lands this player controls.
+                GatherCardsEffect(
+                    source = CardSource.ControlledPermanents(
+                        player = Player.You,
+                        filter = GameObjectFilter.Land
+                    ),
+                    storeAs = "lands"
+                ),
+                // 2. This player keeps one land of each basic land type; the rest are the remainder.
+                SelectFromCollectionEffect(
+                    from = "lands",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    chooser = Chooser.Controller,
+                    restrictions = listOf(SelectionRestriction.OnePerBasicLandType),
+                    storeSelected = "kept",
+                    storeRemainder = "sacrificed",
+                    selectedLabel = "Keep",
+                    remainderLabel = "Sacrifice",
+                    prompt = "Choose a land of each basic land type to keep; the rest are sacrificed.",
+                    useTargetingUI = true,
+                    alwaysPrompt = true
+                ),
+                // 3. Sacrifice the rest.
+                MoveCollectionEffect(
+                    from = "sacrificed",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                    moveType = MoveType.Sacrifice
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "18"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/336474b4-2cf5-44c0-b72c-f75f1a7ed928.jpg?1562905357"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StandOrFall.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StandOrFall.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stand or Fall
+ * {3}{R}
+ * Enchantment
+ * At the beginning of combat on your turn, for each defending player, separate
+ * all creatures that player controls into two piles and that player chooses one.
+ * Only creatures in the chosen piles can block this turn.
+ *
+ * A per-defender "divvy" (CR 700.3) restriction: for each opponent you partition
+ * their creatures (as the source's controller), they choose which pile can block,
+ * and the other pile can't block this turn. Composed inside [ForEachPlayerEffect]
+ * over the defending players — within the loop the iterated player is the controller,
+ * so `Player.You`/`Chooser.Controller` is that defender while `Chooser.SourceController`
+ * stays the enchantment's controller (who separates). The non-chosen pile gets a
+ * snapshot can't-block restriction via ForEachInCollection + single-target
+ * [Effects.CantBlock].
+ */
+val StandOrFall = card("Stand or Fall") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of combat on your turn, for each defending player, separate all creatures that player controls into two piles and that player chooses one. Only creatures in the chosen piles can block this turn."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = ForEachPlayerEffect(
+            players = Player.EachOpponent,
+            effects = listOf(
+                // 1. Gather the creatures this defending player controls.
+                GatherCardsEffect(
+                    source = CardSource.ControlledPermanents(
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature
+                    ),
+                    storeAs = "creatures"
+                ),
+                // 2. You (the enchantment's controller) separate that player's creatures into two piles.
+                SelectFromCollectionEffect(
+                    from = "creatures",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    chooser = Chooser.SourceController,
+                    storeSelected = "pileA",
+                    storeRemainder = "pileB",
+                    selectedLabel = "Pile 1",
+                    remainderLabel = "Pile 2",
+                    prompt = "Separate this player's creatures into two piles. The creatures you select form Pile 1; the rest form Pile 2.",
+                    useTargetingUI = true,
+                    alwaysPrompt = true
+                ),
+                // 3. That player chooses which pile may block.
+                ChoosePileEffect(
+                    pileA = "pileA",
+                    pileB = "pileB",
+                    pileALabel = "Pile 1",
+                    pileBLabel = "Pile 2",
+                    chooser = Chooser.Controller,
+                    storeChosenAs = "canBlock",
+                    storeOtherAs = "cantBlock",
+                    prompt = "Choose which pile of your creatures can block this turn."
+                ),
+                // 4. Only the chosen pile can block — the other pile can't block this turn.
+                ForEachInCollectionEffect(
+                    collection = "cantBlock",
+                    effect = Effects.CantBlock(EffectTarget.Self)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "171"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60c34970-a106-490c-ac37-6156eb7f34ce.jpg?1562914611"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -151,6 +151,13 @@ data class SelectCardsDecision(
     /** When true, at most one card of each name may be selected */
     val onePerCardName: Boolean = false,
     /**
+     * When true, at most one land of each basic land type may be selected; a selected
+     * land claims every basic land type it has, and a land with no basic land type can't
+     * be selected at all (Global Ruin). The server enforces this; the UI should disable
+     * lands sharing an already-claimed basic land type.
+     */
+    val onePerBasicLandType: Boolean = false,
+    /**
      * Maximum sum of mana values across selected cards (Scout for Survivors). null
      * means no cap. {X} contributes 0 (CR 202.3e for cards not on the stack). The
      * UI is expected to disable cards whose mana value would push the running total

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -380,7 +380,15 @@ class LibraryAndZoneContinuationResumer(
             val claimedTypes = mutableSetOf<com.wingedsheep.sdk.core.CardType>()
             val claimedColors = mutableSetOf<com.wingedsheep.sdk.core.Color>()
             val claimedNames = mutableSetOf<String>()
+            val claimedLandTypes = mutableSetOf<com.wingedsheep.sdk.core.Subtype>()
             var runningManaValue = 0
+            // Basic land subtypes a card has (Plains/Island/Swamp/Mountain/Forest), for OnePerBasicLandType.
+            fun basicLandTypesOf(cardId: EntityId): Set<com.wingedsheep.sdk.core.Subtype> =
+                state.getEntity(cardId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                    ?.typeLine?.subtypes
+                    ?.filter { it.value in com.wingedsheep.sdk.core.Subtype.ALL_BASIC_LAND_TYPES }
+                    ?.toSet() ?: emptySet()
             for (cardId in response.selectedCards) {
                 val acceptsAllRestrictions = continuation.restrictions.all { restriction ->
                     when (restriction) {
@@ -409,6 +417,11 @@ class LibraryAndZoneContinuationResumer(
                                 ?.manaValue ?: 0
                             runningManaValue + mv <= restriction.max
                         }
+                        is SelectionRestriction.OnePerBasicLandType -> {
+                            val types = basicLandTypesOf(cardId)
+                            // A typeless land can't be kept; a typed land needs all its types free.
+                            types.isNotEmpty() && types.none { it in claimedLandTypes }
+                        }
                     }
                 }
                 if (acceptsAllRestrictions) {
@@ -436,6 +449,9 @@ class LibraryAndZoneContinuationResumer(
                                 runningManaValue += state.getEntity(cardId)
                                     ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
                                     ?.manaValue ?: 0
+                            }
+                            is SelectionRestriction.OnePerBasicLandType -> {
+                                claimedLandTypes += basicLandTypesOf(cardId)
                             }
                         }
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
@@ -41,6 +41,7 @@ class CompositeExecutors(
     private val reflexiveTriggerEffectExecutor by lazy { ReflexiveTriggerEffectExecutor(effectExecutor, targetFinder, decisionHandler) }
     private val flipCoinExecutor by lazy { FlipCoinExecutor(effectExecutor) }
     private val forEachInGroupExecutor by lazy { ForEachInGroupExecutor(effectExecutor) }
+    private val forEachInCollectionExecutor by lazy { ForEachInCollectionExecutor(effectExecutor) }
     private val repeatWhileExecutor by lazy { RepeatWhileExecutor(effectExecutor) }
     private val conditionalOnCollectionExecutor by lazy { ConditionalOnCollectionExecutor(effectExecutor) }
     private val flipTwoCoinsExecutor by lazy { FlipTwoCoinsExecutor(effectExecutor) }
@@ -65,6 +66,7 @@ class CompositeExecutors(
         forEachPlayerExecutor,
         forEachCapturedControllerExecutor,
         forEachInGroupExecutor,
+        forEachInCollectionExecutor,
         ifYouDoEffectExecutor,
         mayEffectExecutor,
         mayRevealCardFromHandEffectExecutor,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachInCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachInCollectionExecutor.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.handlers.effects.composite
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for ForEachInCollectionEffect.
+ *
+ * Iterates the entities in a named pipeline collection (snapshotted at resolution) and
+ * runs the sub-effect once per entity with `pipeline.iterationTarget` set to it, so a
+ * single-target sub-effect referencing `EffectTarget.Self` applies to the current entity.
+ *
+ * Collection-based sibling of [ForEachInGroupExecutor]; mirrors its per-iteration
+ * iterationTarget swap and pause propagation.
+ */
+class ForEachInCollectionExecutor(
+    private val effectExecutor: (GameState, Effect, EffectContext) -> EffectResult
+) : EffectExecutor<ForEachInCollectionEffect> {
+
+    override val effectType: KClass<ForEachInCollectionEffect> = ForEachInCollectionEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ForEachInCollectionEffect,
+        context: EffectContext
+    ): EffectResult {
+        val entities = context.pipeline.storedCollections[effect.collection].orEmpty()
+        if (entities.isEmpty()) {
+            return EffectResult.success(state)
+        }
+
+        var currentState = state
+        val allEvents = mutableListOf<GameEvent>()
+
+        for (entityId in entities) {
+            val innerContext = context.copy(
+                pipeline = context.pipeline.copy(iterationTarget = entityId)
+            )
+            val result = effectExecutor(currentState, effect.effect, innerContext)
+
+            if (result.isPaused) {
+                return EffectResult.paused(
+                    result.state,
+                    result.pendingDecision!!,
+                    allEvents + result.events
+                )
+            }
+
+            currentState = result.newState
+            allEvents.addAll(result.events)
+        }
+
+        return EffectResult.success(currentState, allEvents)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachPlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachPlayerExecutor.kt
@@ -56,9 +56,13 @@ class ForEachPlayerExecutor(
             val remainingPlayers = players.drop(index + 1)
 
             // Create a per-player context with controllerId set to the current player
-            // and fresh storedCollections
+            // and fresh storedCollections. Recompute opponentId relative to the iterated
+            // player so Chooser.Opponent / Player.Opponent inside the loop resolve to *this*
+            // player's opponent (e.g. Bend or Break: an opponent of each separating player
+            // chooses that player's pile), not the original caster's opponent.
             val perPlayerContext = outerContext.copy(
                 controllerId = playerId,
+                opponentId = state.turnOrder.firstOrNull { it != playerId } ?: outerContext.opponentId,
                 pipeline = outerContext.pipeline.copy(storedCollections = emptyMap())
             )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -275,6 +275,15 @@ class SelectFromCollectionExecutor : EffectExecutor<SelectFromCollectionEffect> 
                     }
                     picked
                 }
+                is SelectionRestriction.OnePerBasicLandType -> {
+                    // One slot per distinct basic land type present among eligible lands.
+                    // Typeless lands contribute nothing (they can't be kept).
+                    eligibleCards.flatMap { cardId ->
+                        state.getEntity(cardId)?.get<CardComponent>()?.typeLine?.subtypes
+                            ?.filter { it.value in com.wingedsheep.sdk.core.Subtype.ALL_BASIC_LAND_TYPES }
+                            ?: emptySet()
+                    }.toSet().size
+                }
             }
             if (limit < ceiling) ceiling = limit
         }
@@ -347,6 +356,7 @@ class SelectFromCollectionExecutor : EffectExecutor<SelectFromCollectionEffect> 
             onePerColor = effect.restrictions.any { it is SelectionRestriction.OnePerColor },
             availableColors = controllerPermanentColors?.map { it.name },
             onePerCardName = effect.restrictions.any { it is SelectionRestriction.OnePerCardName },
+            onePerBasicLandType = effect.restrictions.any { it is SelectionRestriction.OnePerBasicLandType },
             maxTotalManaValue = effect.restrictions
                 .filterIsInstance<SelectionRestriction.TotalManaValueAtMost>()
                 .also {

--- a/web-client/src/components/decisions/CardSelectionDecisionUI.tsx
+++ b/web-client/src/components/decisions/CardSelectionDecisionUI.tsx
@@ -18,6 +18,15 @@ function extractCardTypes(typeLine: string): string[] {
   return mainTypes.trim().split(/\s+/).filter((w) => CARD_TYPES.has(w))
 }
 
+/** The five basic land types, used for the OnePerBasicLandType restriction. */
+const BASIC_LAND_TYPES = new Set(['Plains', 'Island', 'Swamp', 'Mountain', 'Forest'])
+
+/** Extract basic land subtypes from a type-line (e.g. "Land — Plains Island" → ["Plains", "Island"]). */
+function extractBasicLandTypes(typeLine: string): string[] {
+  const subtypes = typeLine.split(/[—–-]/)[1] ?? ''
+  return subtypes.trim().split(/\s+/).filter((w) => BASIC_LAND_TYPES.has(w))
+}
+
 /** Map colour name → display symbol + CSS colour for the indicator pip. */
 const COLOR_PIPS: Record<string, { symbol: string; bg: string; fg: string }> = {
   WHITE: { symbol: 'W', bg: '#f8f6e8', fg: '#3a3320' },
@@ -130,6 +139,17 @@ export function CardSelectionDecision({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [decision.onePerColor, decision.cardInfo, selectedCards, gameState?.cards])
 
+  // OnePerBasicLandType: compute which basic land types are already claimed by selected cards.
+  const claimedLandTypes = useMemo(() => {
+    if (!decision.onePerBasicLandType) return new Set<string>()
+    const types = new Set<string>()
+    for (const id of selectedCards) {
+      const typeLine = decision.cardInfo?.[id]?.typeLine ?? gameState?.cards[id]?.typeLine ?? ''
+      for (const t of extractBasicLandTypes(typeLine)) types.add(t)
+    }
+    return types
+  }, [decision.onePerBasicLandType, decision.cardInfo, selectedCards, gameState?.cards])
+
   /** Read a card's mana value: prefer gameState (server-computed), fall back to parsing the cost string. */
   const manaValueForCard = (cardId: EntityId): number => {
     const fromState = gameState?.cards[cardId]?.manaValue
@@ -160,6 +180,12 @@ export function CardSelectionDecision({
     }
     if (decision.maxTotalManaValue != null) {
       if (totalManaValueSelected + manaValueForCard(cardId) > decision.maxTotalManaValue) return true
+    }
+    if (decision.onePerBasicLandType) {
+      const typeLine = decision.cardInfo?.[cardId]?.typeLine ?? gameState?.cards[cardId]?.typeLine ?? ''
+      const landTypes = extractBasicLandTypes(typeLine)
+      // A land with no basic land type can't be kept; one sharing a claimed type is blocked.
+      if (landTypes.length === 0 || landTypes.some((t) => claimedLandTypes.has(t))) return true
     }
     return false
   }

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -296,6 +296,11 @@ export interface SelectCardsDecision extends PendingDecisionBase {
   /** When true, at most one card of each colour may be selected (colourless unconstrained) */
   readonly onePerColor?: boolean
   /**
+   * When true, at most one land of each basic land type may be selected (a kept land claims
+   * every basic type it has); a land with no basic land type can't be selected (Global Ruin).
+   */
+  readonly onePerBasicLandType?: boolean
+  /**
    * The colour budget for [onePerColor] when restricted to the chooser's permanent colours
    * (e.g., Sanar's Vivid trigger). One pip per colour name (e.g., ["WHITE","BLUE"]). When
    * undefined or empty, the UI shows the generic five-colour list.


### PR DESCRIPTION
Implements [gap #21](backlog/invasion-engine-gaps.md) from the Invasion engine-gap analysis — the "each player separates into two piles, an opponent chooses a pile" cycle.

## Cards (5)
| Card | Shape |
|------|-------|
| **Death or Glory** | Pure pile composition over the graveyard — you split, opponent exiles a pile, the other returns. **No engine change.** |
| **Bend or Break** | `ForEachPlayer(Each)` → destroy chosen pile, tap the other (`TapUntapCollection`). |
| **Global Ruin** | `ForEachPlayer(Each)` + `OnePerBasicLandType` → sacrifice the remainder. |
| **Fight or Flight** | Begin-combat-each-opponent trigger → unchosen pile gets `CantAttack`. |
| **Stand or Fall** | Your-combat trigger + `ForEachPlayer(EachOpponent)` (separator = `Chooser.SourceController`) → unchosen pile gets `CantBlock`. |

## Engine changes
Verification showed the gap doc over-scoped this: **`CardSource.ControlledPermanents`** and a full **`ForEachPlayerEffect`** combinator already existed. So the new work is small and composable:

- **`ForEachPlayerExecutor`** now recomputes `opponentId` per iterated player, so `Chooser.Opponent` / `Player.Opponent` inside the loop resolve to *that* player's opponent (Bend or Break).
- **`ForEachInCollectionEffect`** — one generic "run a sub-effect per entity in a stored collection" iterator (collection-based sibling of `ForEachInGroupEffect`). The "only the chosen pile can attack/block" payoff *composes* from the existing single-target `Effects.CantAttack(Self)` / `CantBlock(Self)` rather than adding combat-specific effects. A `GroupFilter.InStoredCollection` variant wouldn't have worked — a `dynamicGroupFilter` is re-evaluated at projection with no pipeline access, so the chosen pile would be lost; the restriction must snapshot at resolution, which the single-target effects already do.
- **`SelectionRestriction.OnePerBasicLandType`** (cap + resumer trim + `SelectCardsDecision` flag) — keep one land per basic land type (a kept land claims all its basic types); a typeless land can't be kept (Global Ruin).

Web client mirrors the existing `onePerColor` gray-out for `OnePerBasicLandType`.

## Tests
- Per-card scenario tests in `game-server` (`DeathOrGlory`, `BendOrBreak`, `GlobalRuin`, `FightOrFlight`, `StandOrFall`).
- Full **rules-engine suite: 2056 tests, 0 failures** (the shared `opponentId` change has no regressions).
- mtg-sdk / rules-engine / mtg-sets / game-server tests compile; web-client typechecks.

INV card count: 91 → 99 / 335. SDK reference and gap doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)