### PR TITLE
Add Invasion mana cameos (Bloodstone, Drake-Skull, Seashell, Tigereye)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BloodstoneCameo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BloodstoneCameo.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Bloodstone Cameo
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {B} or {R}.
+ */
+val BloodstoneCameo = card("Bloodstone Cameo") {
+    manaCost = "{3}"
+    colorIdentity = "BR"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {B} or {R}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "298"
+        artist = "Tony Szczudlo"
+        flavorText = "\"The stone whispers to me of dragon's fire and darkness. I wish I'd never pried it from the figurehead of that sunken Keldon longship.\"\n—Isel, master carver"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9db32fa-64b2-4ef6-88f2-28e758d420bb.jpg?1562945391"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DrakeSkullCameo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DrakeSkullCameo.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Drake-Skull Cameo
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {U} or {B}.
+ */
+val DrakeSkullCameo = card("Drake-Skull Cameo") {
+    manaCost = "{3}"
+    colorIdentity = "UB"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {U} or {B}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "302"
+        artist = "Dan Frazier"
+        flavorText = "\"A strange skull was turned up by an Ephran farmer's plow. I traded a copper ring for the 'ox skull.' It resonates of the sea and danger.\"\n—Isel, master carver"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a3ce135-9c2f-45bd-b2db-c0e00c50c964.jpg?1562909996"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SeashellCameo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SeashellCameo.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Seashell Cameo
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {W} or {U}.
+ */
+val SeashellCameo = card("Seashell Cameo") {
+    manaCost = "{3}"
+    colorIdentity = "WU"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {W} or {U}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "311"
+        artist = "Tony Szczudlo"
+        flavorText = "\"Today a seashell fell from the empty sky here in Kinymu, a hundred leagues from the sea. I'm torn—shall I carve a woman or a bird?\"\n—Isel, master carver"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9efdbcad-e2e4-4f54-ade5-920b1853109e.jpg?1562927074"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TigereyeCameo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TigereyeCameo.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Tigereye Cameo
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {G} or {W}.
+ */
+val TigereyeCameo = card("Tigereye Cameo") {
+    manaCost = "{3}"
+    colorIdentity = "GW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {G} or {W}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "314"
+        artist = "Donato Giancola"
+        flavorText = "\"An elvish adventurer unearthed this stone in Jolrael's jungle. Now it's truly fit for display in one of her palaces.\"\n—Isel, master carver"
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/25976da8-338d-4f46-b8ea-78a0aa3daa35.jpg?1562902582"
+    }
+}


### PR DESCRIPTION
Implements 4 Invasion mana-cameo artifacts, each a `{3}` artifact with two single-color mana abilities (mirrors the existing `TrollHornCameo.kt`).

- **Bloodstone Cameo** — `{T}: Add {B} or {R}`
- **Drake-Skull Cameo** — `{T}: Add {U} or {B}`
- **Seashell Cameo** — `{T}: Add {W} or {U}`
- **Tigereye Cameo** — `{T}: Add {G} or {W}`

**Note:** current Scryfall oracle errata removed the original "creature spell" mana rider; all four are plain dual mana rocks. Composed entirely from existing `Effects.AddMana` — no new engine primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)