### PR TITLE
Add Invasion dual taplands (Elfhame Palace, Salt Marsh, Shivan Oasis, Urborg Volcano)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ElfhamePalace.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ElfhamePalace.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Elfhame Palace
+ * Land
+ * This land enters tapped.
+ * {T}: Add {G} or {W}.
+ */
+val ElfhamePalace = card("Elfhame Palace") {
+    typeLine = "Land"
+    colorIdentity = "GW"
+    oracleText = "This land enters tapped.\n{T}: Add {G} or {W}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "322"
+        artist = "Jerry Tiritilli"
+        flavorText = "Llanowar has seven elfhames, or kingdoms, each with its own ruler. Their palaces are objects of awe, wonder, and envy."
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/65986555-a5d7-497e-876f-b8d967d6aa5b.jpg?1562915620"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SaltMarsh.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SaltMarsh.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Salt Marsh
+ * Land
+ * This land enters tapped.
+ * {T}: Add {U} or {B}.
+ */
+val SaltMarsh = card("Salt Marsh") {
+    typeLine = "Land"
+    colorIdentity = "UB"
+    oracleText = "This land enters tapped.\n{T}: Add {U} or {B}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "326"
+        artist = "Jerry Tiritilli"
+        flavorText = "Only death breeds in stagnant water.\n—Urborg saying"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed64934b-0e64-4b2f-97aa-c3fb7e6ce0b0.jpg?1562942685"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShivanOasis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShivanOasis.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Shivan Oasis
+ * Land
+ * This land enters tapped.
+ * {T}: Add {R} or {G}.
+ */
+val ShivanOasis = card("Shivan Oasis") {
+    typeLine = "Land"
+    colorIdentity = "RG"
+    oracleText = "This land enters tapped.\n{T}: Add {R} or {G}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "327"
+        artist = "Rob Alexander"
+        flavorText = "Only the hardiest explorers survive to eat the fruit."
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/9841f7e8-162c-44a3-96f3-af944fce15d1.jpg?1562925740"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrborgVolcano.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrborgVolcano.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Urborg Volcano
+ * Land
+ * This land enters tapped.
+ * {T}: Add {B} or {R}.
+ */
+val UrborgVolcano = card("Urborg Volcano") {
+    typeLine = "Land"
+    colorIdentity = "BR"
+    oracleText = "This land enters tapped.\n{T}: Add {B} or {R}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "330"
+        artist = "Tony Szczudlo"
+        flavorText = "Deep in the heart of Urborg lie massive volcanoes whose thick black smoke covers the land with perpetual darkness."
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c76f346c-ae34-4f5f-8e3b-6c77b0c4d530.jpg?1562935023"
+    }
+}


### PR DESCRIPTION
Implements 4 Invasion dual taplands — each enters tapped and taps for one of two colors (mirrors `CoastalTower.kt`: `replacementEffect(EntersTapped())` + two `{T}` mana abilities).

- **Elfhame Palace** — GW
- **Salt Marsh** — UB
- **Shivan Oasis** — RG
- **Urborg Volcano** — BR

No new engine primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)