### PR TITLE
Add Invasion sac/filter lands (Geothermal Crevice, Ancient Spring, Irrigation Ditch, Tinder Farm)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AncientSpring.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AncientSpring.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Ancient Spring
+ * Land
+ * This land enters tapped.
+ * {T}: Add {U}.
+ * {T}, Sacrifice this land: Add {W}{B}.
+ */
+val AncientSpring = card("Ancient Spring") {
+    typeLine = "Land"
+    colorIdentity = "WUB"
+    oracleText = "This land enters tapped.\n{T}: Add {U}.\n{T}, Sacrifice this land: Add {W}{B}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.WHITE),
+            Effects.AddMana(Color.BLACK),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "319"
+        artist = "Don Hazeltine"
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/004eefa4-947b-45fc-b45c-5263bfd763bc.jpg?1562895051"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/GeothermalCrevice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/GeothermalCrevice.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Geothermal Crevice
+ * Land
+ * This land enters tapped.
+ * {T}: Add {R}.
+ * {T}, Sacrifice this land: Add {B}{G}.
+ */
+val GeothermalCrevice = card("Geothermal Crevice") {
+    typeLine = "Land"
+    colorIdentity = "BGR"
+    oracleText = "This land enters tapped.\n{T}: Add {R}.\n{T}, Sacrifice this land: Add {B}{G}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.BLACK),
+            Effects.AddMana(Color.GREEN),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "323"
+        artist = "John Avon"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e744b593-13fe-4967-b492-ac02f5815e57.jpg?1562941417"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/IrrigationDitch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/IrrigationDitch.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Irrigation Ditch
+ * Land
+ * This land enters tapped.
+ * {T}: Add {W}.
+ * {T}, Sacrifice this land: Add {G}{U}.
+ */
+val IrrigationDitch = card("Irrigation Ditch") {
+    typeLine = "Land"
+    colorIdentity = "GWU"
+    oracleText = "This land enters tapped.\n{T}: Add {W}.\n{T}, Sacrifice this land: Add {G}{U}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.GREEN),
+            Effects.AddMana(Color.BLUE),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "324"
+        artist = "Rob Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/977f1b44-166c-4faf-8a7b-d431707e90ce.jpg?1562925548"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TinderFarm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TinderFarm.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Tinder Farm
+ * Land
+ * This land enters tapped.
+ * {T}: Add {G}.
+ * {T}, Sacrifice this land: Add {R}{W}.
+ */
+val TinderFarm = card("Tinder Farm") {
+    typeLine = "Land"
+    colorIdentity = "GRW"
+    oracleText = "This land enters tapped.\n{T}: Add {G}.\n{T}, Sacrifice this land: Add {R}{W}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.RED),
+            Effects.AddMana(Color.WHITE),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "329"
+        artist = "Rob Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/989b5901-aeb0-4a48-8c53-3b0ec0e0deba.jpg?1562925784"
+    }
+}


### PR DESCRIPTION
Implements 4 lands of the Invasion sacrifice/filter cycle (mirrors the existing `SulfurVent.kt`): enters tapped, single-color tap ability, plus `{T}, Sacrifice` for two colored mana.

- **Geothermal Crevice** — BGR
- **Ancient Spring** — WUB
- **Irrigation Ditch** — GWU
- **Tinder Farm** — GRW

**Note:** "Tainted Well" was intentionally skipped — it is a *Mirage* aura, not part of this cycle. The 5th cycle land is **Sulfur Vent (UBR)**, already implemented. No new engine primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)