### PR TITLE
Add Invasion green creatures (Charging Troll, Yavimaya Barbarian, Llanowar Cavalry, Pincer Spider)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ChargingTroll.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ChargingTroll.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Charging Troll
+ * {2}{G}{W}
+ * Creature — Troll
+ * 3/3
+ * Vigilance
+ * {G}: Regenerate this creature.
+ */
+val ChargingTroll = card("Charging Troll") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Troll"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance\n{G}: Regenerate this creature."
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "239"
+        artist = "Dave Dorman"
+        flavorText = "They stop for nothing, not even the end of a battle."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58956099-6b97-4c7b-ab23-9f9b4d50ef95.jpg?1562913006"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LlanowarCavalry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LlanowarCavalry.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Llanowar Cavalry
+ * {2}{G}
+ * Creature — Human Soldier
+ * 1/4
+ * {W}: This creature gains vigilance until end of turn.
+ */
+val LlanowarCavalry = card("Llanowar Cavalry") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 4
+    oracleText = "{W}: This creature gains vigilance until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{W}")
+        effect = Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Eric Peterson"
+        flavorText = "For the first time, elves welcomed Benalish soldiers into the forest with something other than arrows."
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21d92191-a743-4916-bbe4-5e207e964d9b.jpg?1562901760"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PincerSpider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PincerSpider.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pincer Spider
+ * {2}{G}
+ * Creature — Spider
+ * 2/3
+ * Kicker {3}
+ * Reach
+ * If this creature was kicked, it enters with a +1/+1 counter on it.
+ */
+val PincerSpider = card("Pincer Spider") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    power = 2
+    toughness = 3
+    oracleText = "Kicker {3} (You may pay an additional {3} as you cast this spell.)\n" +
+        "Reach (This creature can block creatures with flying.)\n" +
+        "If this creature was kicked, it enters with a +1/+1 counter on it."
+
+    keywords(Keyword.REACH)
+    keywordAbility(KeywordAbility.kicker("{3}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "201"
+        artist = "Dan Frazier"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/23271658-19ae-420d-beeb-4bed4fdbb891.jpg?1562902046"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/YavimayaBarbarian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/YavimayaBarbarian.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Yavimaya Barbarian
+ * {R}{G}
+ * Creature — Elf Barbarian
+ * 2/2
+ * Protection from blue
+ */
+val YavimayaBarbarian = card("Yavimaya Barbarian") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Elf Barbarian"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from blue"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLUE)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "290"
+        artist = "Don Hazeltine"
+        flavorText = "Not all elves embrace the pastoral life. Some still roam the forest's edge, forever making war against their hated enemies."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e17377d-4dad-4144-b0ce-c849636096a2.jpg?1562923706"
+    }
+}


### PR DESCRIPTION
Implements 4 green Invasion creatures, all composed from existing primitives.

- **Charging Troll** `{2}{G}{W}` 3/3 — vigilance + `{G}: regenerate`
- **Yavimaya Barbarian** `{R}{G}` 2/2 — protection from blue
- **Llanowar Cavalry** `{2}{G}` 1/4 — `{W}: gains vigilance until end of turn`
- **Pincer Spider** `{2}{G}` 2/3 — reach + kicker `{3}` (enters with a +1/+1 counter if kicked)

No new engine primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)