### PR TITLE
Add Invasion black creatures (Shivan Zombie, Vodalian Zombie, Urborg Phantom)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShivanZombie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShivanZombie.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Shivan Zombie
+ * {B}{R}
+ * Creature — Phyrexian Barbarian Zombie
+ * 2/2
+ * Protection from white
+ */
+val ShivanZombie = card("Shivan Zombie") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Phyrexian Barbarian Zombie"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from white"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.WHITE)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "271"
+        artist = "Tony Szczudlo"
+        flavorText = "Barbarians long for a glorious death in battle. Phyrexia was eager to grant that wish."
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4c99269-f730-4d33-bbce-9e855e9ad0fc.jpg?1562944260"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrborgPhantom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrborgPhantom.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Urborg Phantom
+ * {2}{B}
+ * Creature — Spirit Minion
+ * 3/1
+ * This creature can't block.
+ * {U}: Prevent all combat damage that would be dealt to and dealt by this creature this turn.
+ */
+val UrborgPhantom = card("Urborg Phantom") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit Minion"
+    power = 3
+    toughness = 1
+    oracleText = "This creature can't block.\n{U}: Prevent all combat damage that would be dealt to and dealt by this creature this turn."
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.PreventCombatDamageToAndBy(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Daren Bader"
+        flavorText = "A chilling fog with teeth of ice."
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/397355b9-5b67-4973-972e-3505c500d116.jpg?1562906570"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianZombie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianZombie.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Vodalian Zombie
+ * {U}{B}
+ * Creature — Merfolk Zombie
+ * 2/2
+ * Protection from green
+ */
+val VodalianZombie = card("Vodalian Zombie") {
+    manaCost = "{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Merfolk Zombie"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from green"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.GREEN)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "286"
+        artist = "Greg Hildebrandt & Tim Hildebrandt"
+        flavorText = "\"Every last one of you will become my servant. It's a shame you won't live to see the irony.\"\n—Tsabo Tavoc, Phyrexian general"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f30a5a06-32ce-4d71-b71f-e3e1d8d4511a.jpg?1562943854"
+    }
+}


### PR DESCRIPTION
Implements 3 black Invasion creatures, composed from existing primitives.

- **Shivan Zombie** `{B}{R}` 2/2 — protection from white
- **Vodalian Zombie** `{U}{B}` 2/2 — protection from green
- **Urborg Phantom** `{2}{B}` 3/1 — can't block + `{U}: prevent all combat damage to/by it this turn`

**Skipped: Phyrexian Battleflies** — its `{B}: +1/+0; activate no more than twice each turn` needs a new `ActivationRestriction.MaxPerTurn(n)` primitive + per-ability activation counter (the SDK only has `OncePerTurn`). Flagged rather than built, per the composability constraint. (Side note: `docs/card-sdk-language-reference.md` references a `MaxPerTurn(n)` that doesn't exist in the SDK — the doc is out of date.)

No new engine primitives in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)