### PR TITLE
Add Invasion domain spells (Tribal Flames, Wandering Stream, Worldly Counsel, Ordered Migration)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/OrderedMigration.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/OrderedMigration.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ordered Migration
+ * {3}{W}{U}
+ * Sorcery
+ * Domain — Create a 1/1 blue Bird creature token with flying for each basic land type
+ * among lands you control.
+ */
+val OrderedMigration = card("Ordered Migration") {
+    manaCost = "{3}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Sorcery"
+    oracleText = "Domain — Create a 1/1 blue Bird creature token with flying for each basic land type among lands you control."
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmounts.domain(),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Bird"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/0/0/000d9280-a79a-4f9f-822c-7aaecbff3337.jpg?1712316187"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "258"
+        artist = "Heather Hudson"
+        flavorText = "\"Birds reach all parts of the world,\" said Barrin. \"They will make excellent scouts.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04d83a07-6054-45f1-bdf9-07f2006238d2.jpg?1562895903"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TribalFlames.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TribalFlames.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tribal Flames
+ * {1}{R}
+ * Sorcery
+ * Domain — Tribal Flames deals X damage to any target, where X is the number of
+ * basic land types among lands you control.
+ */
+val TribalFlames = card("Tribal Flames") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Domain — Tribal Flames deals X damage to any target, where X is the number of basic land types among lands you control."
+
+    spell {
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(DynamicAmounts.domain(), t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "176"
+        artist = "Tony Szczudlo"
+        flavorText = "\"Fire is the universal language.\"\n—Jhoira, master artificer"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b32531e-c759-4603-abd0-1724e8df70db.jpg?1562926326"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WanderingStream.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WanderingStream.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Wandering Stream
+ * {2}{G}
+ * Sorcery
+ * Domain — You gain 2 life for each basic land type among lands you control.
+ */
+val WanderingStream = card("Wandering Stream") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Domain — You gain 2 life for each basic land type among lands you control."
+
+    spell {
+        // 2 life per basic land type = domain × 2.
+        effect = Effects.GainLife(DynamicAmount.Multiply(DynamicAmounts.domain(), 2))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "224"
+        artist = "Quinton Hoover"
+        flavorText = "\"Dominaria touches us all.\"\n—Molimo, maro-sorcerer"
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6da5cb6c-253b-44f0-98f9-d75f42c6e14b.jpg?1562916978"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WorldlyCounsel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WorldlyCounsel.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Worldly Counsel
+ * {1}{U}
+ * Instant
+ * Domain — Look at the top X cards of your library, where X is the number of basic
+ * land types among lands you control. Put one of those cards into your hand and the
+ * rest on the bottom of your library in any order.
+ */
+val WorldlyCounsel = card("Worldly Counsel") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Domain — Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put one of those cards into your hand and the rest on the bottom of your library in any order."
+
+    spell {
+        // Look at domain cards, keep one in hand, rest to bottom of library in chosen order.
+        effect = EffectPatterns.lookAtTopAndKeep(
+            count = DynamicAmounts.domain(),
+            keepCount = DynamicAmount.Fixed(1),
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.ControllerChooses
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Gary Ruddell"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8fc66fbf-f411-4607-aece-7c35d9a07c80.jpg?1562924010"
+    }
+}


### PR DESCRIPTION
Implements 4 Invasion domain spells using the existing `DynamicAmounts.domain()`.

- **Tribal Flames** — deal damage = domain to any target
- **Wandering Stream** — gain 2 life per basic land type
- **Worldly Counsel** — look at top (domain) cards, keep 1, rest to bottom
- **Ordered Migration** — create (domain) 1/1 blue flying Bird tokens

No new engine primitives. (Bird token art uses the most recent 1/1 blue Bird printing, as no INV-specific token exists.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)