### PR TITLE
Add Invasion utility spells (Heroes' Reunion, Tranquility, Cremate, Repulse)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Cremate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Cremate.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+
+/**
+ * Cremate
+ * {B}
+ * Instant
+ * Exile target card from a graveyard.
+ * Draw a card.
+ */
+val Cremate = card("Cremate") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target card from a graveyard.\nDraw a card."
+
+    spell {
+        val t = target("target", Targets.CardInGraveyard)
+        effect = MoveToZoneEffect(t, Zone.EXILE)
+            .then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "96"
+        artist = "Andrew Goldhawk"
+        flavorText = "Death's embrace need not be cold."
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/1095cdfe-8060-4a73-bacf-9f983152b486.jpg?1562898378"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HeroesReunion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HeroesReunion.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Heroes' Reunion
+ * {G}{W}
+ * Instant
+ * Target player gains 7 life.
+ */
+val HeroesReunion = card("Heroes' Reunion") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Instant"
+    oracleText = "Target player gains 7 life."
+
+    spell {
+        val t = target("target player", TargetPlayer())
+        effect = Effects.GainLife(7, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "250"
+        artist = "Terese Nielsen"
+        flavorText = "\"You helped save my people from a Phyrexian fate. Did you think I wouldn't return the favor?\"\n—Eladamri, to Gerrard"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/135d6043-5ec1-4ad4-8296-41fe23f11cb9.jpg?1562898871"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Repulse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Repulse.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Repulse
+ * {2}{U}
+ * Instant
+ * Return target creature to its owner's hand.
+ * Draw a card.
+ */
+val Repulse = card("Repulse") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target creature to its owner's hand.\nDraw a card."
+
+    spell {
+        target = TargetCreature()
+        effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0))
+            .then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Aaron Boyd"
+        flavorText = "\"You aren't invited.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a04e9be-48be-440e-9825-cfffd4c2b1a4.jpg?1562926068"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Tranquility.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Tranquility.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Tranquility
+ * {2}{G}
+ * Sorcery
+ * Destroy all enchantments.
+ */
+val Tranquility = card("Tranquility") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all enchantments."
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Enchantment)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "217"
+        artist = "Rob Alexander"
+        flavorText = "The plagues robbed Dominaria of all but its dreams. Eladamri hoped dreams were enough."
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/97019ba5-ce2a-460c-8a4e-2b22053ced65.jpg?1562925426"
+    }
+}


### PR DESCRIPTION
Implements 4 Invasion instants/sorceries, composed from existing primitives.

- **Heroes' Reunion** `{G}{W}` — target player gains 7 life
- **Tranquility** `{2}{G}` — destroy all enchantments
- **Cremate** `{B}` — exile target card from a graveyard, draw a card
- **Repulse** `{2}{U}` — return target creature to hand, draw a card

No new engine primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)