### PR TITLE
Add Llanowar Vanguard, Kavu Aggressor, Loafing Giant, and Wayfaring Giant to Invasion

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/LoafingGiantScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/LoafingGiantScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Loafing Giant.
+ *
+ * Card reference:
+ * - Loafing Giant ({4}{R}): Creature — Giant 4/6
+ *   Whenever this creature attacks or blocks, mill a card. If a land card was milled this
+ *   way, prevent all combat damage this creature would deal this turn.
+ *
+ * Verifies the milled-card-type branch: a land milled prevents Loafing Giant's combat
+ * damage, while a nonland milled lets the damage through.
+ */
+class LoafingGiantScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Loafing Giant attack trigger") {
+
+            test("milling a land prevents Loafing Giant's combat damage") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Loafing Giant", tapped = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Loafing Giant" to 2))
+                // Resolve the "attacks" trigger: mills the Forest, then prevents damage.
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Forest should have been milled to the graveyard") {
+                    game.findCardsInGraveyard(1, "Forest").size shouldBe 1
+                }
+                withClue("Combat damage should be prevented when a land is milled") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+
+            test("milling a nonland deals combat damage normally") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Loafing Giant", tapped = false)
+                    .withCardInLibrary(1, "Kavu Aggressor")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Loafing Giant" to 2))
+                // Resolve the "attacks" trigger: mills a nonland, no prevention.
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Kavu Aggressor should have been milled to the graveyard") {
+                    game.findCardsInGraveyard(1, "Kavu Aggressor").size shouldBe 1
+                }
+                withClue("Loafing Giant (4 power) should deal combat damage when a nonland is milled") {
+                    game.getLifeTotal(2) shouldBe 16
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuAggressor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuAggressor.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kavu Aggressor
+ * {2}{R}
+ * Creature — Kavu
+ * 3/2
+ * Kicker {4}
+ * This creature can't block.
+ * If this creature was kicked, it enters with a +1/+1 counter on it.
+ */
+val KavuAggressor = card("Kavu Aggressor") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu"
+    power = 3
+    toughness = 2
+    oracleText = "Kicker {4} (You may pay an additional {4} as you cast this spell.)\n" +
+        "This creature can't block.\n" +
+        "If this creature was kicked, it enters with a +1/+1 counter on it."
+
+    keywordAbility(KeywordAbility.kicker("{4}"))
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Christopher Moeller"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2832ad3-ce7f-44d2-beb2-c95d982905a6.jpg?1562927844"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LlanowarVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LlanowarVanguard.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Llanowar Vanguard
+ * {2}{G}
+ * Creature — Dryad
+ * 1/1
+ * {T}: This creature gets +0/+4 until end of turn.
+ */
+val LlanowarVanguard = card("Llanowar Vanguard") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: This creature gets +0/+4 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = ModifyStatsEffect(0, 4, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Greg Hildebrandt & Tim Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72e6ed79-bdfd-49f9-bfa4-be4196880487.jpg?1562917999"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LoafingGiant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LoafingGiant.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Loafing Giant
+ * {4}{R}
+ * Creature — Giant
+ * 4/6
+ * Whenever this creature attacks or blocks, mill a card. If a land card was milled this
+ * way, prevent all combat damage this creature would deal this turn.
+ *
+ * Composed from the standard mill pipeline (GatherCards → MoveCollection to graveyard)
+ * gated by [Conditions.CollectionContainsMatch] on the milled card, mirroring Cache Grab.
+ * "Attacks or blocks" is two SELF triggers sharing the same effect.
+ */
+val LoafingGiant = card("Loafing Giant") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    power = 4
+    toughness = 6
+    oracleText = "Whenever this creature attacks or blocks, mill a card. If a land card was milled this way, prevent all combat damage this creature would deal this turn."
+
+    val millAndMaybePrevent = CompositeEffect(
+        listOf(
+            // Mill a card: gather top card, move it to the graveyard.
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                storeAs = "milled"
+            ),
+            MoveCollectionEffect(
+                from = "milled",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD)
+            ),
+            // If a land card was milled this way, prevent all combat damage this creature
+            // would deal this turn.
+            ConditionalEffect(
+                condition = Conditions.CollectionContainsMatch("milled", GameObjectFilter.Land),
+                effect = Effects.PreventCombatDamageFrom(GroupFilter.source())
+            )
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = millAndMaybePrevent
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = millAndMaybePrevent
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "153"
+        artist = "Greg Hildebrandt & Tim Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fab5f738-04d0-44c9-88ec-28469b668040.jpg?1562945565"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WayfaringGiant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WayfaringGiant.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Wayfaring Giant
+ * {5}{W}
+ * Creature — Giant
+ * 1/3
+ * Domain — This creature gets +1/+1 for each basic land type among lands you control.
+ */
+val WayfaringGiant = card("Wayfaring Giant") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Giant"
+    power = 1
+    toughness = 3
+    oracleText = "Domain — This creature gets +1/+1 for each basic land type among lands you control."
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmounts.domain(),
+            toughnessBonus = DynamicAmounts.domain()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "44"
+        artist = "Christopher Moeller"
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57e45de5-0e8b-41d3-979b-ec5a29cac682.jpg?1562912879"
+    }
+}


### PR DESCRIPTION
Adds four Invasion (INV) cards. All are first printed in INV, so each is canonical in the INV package. No engine/SDK changes — every card composes existing primitives.

## Cards

- **Llanowar Vanguard** ({2}{G}, 1/1 Dryad) — `{T}`: this creature gets +0/+4 until end of turn. (`Costs.Tap` + `ModifyStatsEffect(0, 4, Self)`)
- **Kavu Aggressor** ({2}{R}, 3/2 Kavu) — Kicker {4}; can't block; enters with a +1/+1 counter if kicked. (`KeywordAbility.kicker` + `CantBlock()` + `EntersBattlefield`/`WasKicked` -> `AddCounters`)
- **Loafing Giant** ({4}{R}, 4/6 Giant) — Whenever it attacks or blocks, mill a card; if a land was milled this way, prevent all combat damage it would deal this turn. Composed from the standard mill pipeline (`GatherCards` -> `MoveCollection` to graveyard) gated by `Conditions.CollectionContainsMatch("milled", Land)` (mirrors Cache Grab), with `Effects.PreventCombatDamageFrom(GroupFilter.source())`. "Attacks or blocks" is two SELF triggers sharing one effect.
- **Wayfaring Giant** ({5}{W}, 1/3 Giant) — Domain — gets +1/+1 for each basic land type among lands you control. (`GrantDynamicStatsEffect` with `DynamicAmounts.domain()`)

## Testing

- `:mtg-sets:compileKotlin` clean.
- Added `LoafingGiantScenarioTest` covering both branches of the milled-card check: a land milled prevents Loafing Giant's combat damage (opponent stays at 20), a nonland milled lets 4 damage through (opponent to 16). Both pass.
- The other three cards use only existing, already-tested effects, so no new scenario tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)