### PR TITLE
Add four Invasion cards: Blurred Mongoose, Prison Barricade, Faerie Squadron, Vodalian Serpent

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BlurredMongooseScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BlurredMongooseScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Blurred Mongoose.
+ *
+ * Card reference:
+ * - Blurred Mongoose ({1}{G}): Creature — Mongoose 2/1
+ *   This spell can't be countered.
+ *   Shroud (This creature can't be the target of spells or abilities.)
+ */
+class BlurredMongooseScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Blurred Mongoose") {
+
+            test("definition marks the spell as uncounterable") {
+                val def = cardRegistry.getCard("Blurred Mongoose")!!
+                withClue("Blurred Mongoose's spell can't be countered") {
+                    def.script.cantBeCountered shouldBe true
+                }
+            }
+
+            test("resolves to a 2/1 with shroud on the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Blurred Mongoose")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Blurred Mongoose")
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val mongooseId = game.findPermanent("Blurred Mongoose")!!
+                val clientState = game.getClientState(1)
+                val mongoose = clientState.cards[mongooseId]!!
+
+                withClue("Blurred Mongoose should have shroud") {
+                    mongoose.keywords.contains(Keyword.SHROUD) shouldBe true
+                }
+                withClue("Blurred Mongoose should be a 2/1") {
+                    mongoose.power shouldBe 2
+                    mongoose.toughness shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FaerieSquadronScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FaerieSquadronScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Faerie Squadron with kicker.
+ *
+ * Card reference:
+ * - Faerie Squadron ({U}): Creature — Faerie 1/1
+ *   Kicker {3}{U}
+ *   If this creature was kicked, it enters with two +1/+1 counters on it and with flying.
+ */
+class FaerieSquadronScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioTestBase.TestGame.getCounters(entityId: EntityId): Int {
+        return state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Faerie Squadron kicker") {
+
+            test("unkicked enters as 1/1 with no counters and no flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Faerie Squadron")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Faerie Squadron")
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val faerieId = game.findPermanent("Faerie Squadron")!!
+                withClue("Unkicked Faerie Squadron should have no counters") {
+                    game.getCounters(faerieId) shouldBe 0
+                }
+                val clientState = game.getClientState(1)
+                withClue("Unkicked Faerie Squadron should not have flying") {
+                    clientState.cards[faerieId]!!.keywords.contains(Keyword.FLYING) shouldBe false
+                }
+            }
+
+            test("kicked enters with two +1/+1 counters and flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Faerie Squadron")
+                    .withLandsOnBattlefield(1, "Island", 5) // {U} + {3}{U} kicker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Faerie Squadron"
+                }
+
+                val castResult = game.execute(CastSpell(playerId, cardId, wasKicked = true))
+                withClue("Kicked cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val faerieId = game.findPermanent("Faerie Squadron")!!
+                withClue("Kicked Faerie Squadron should have two +1/+1 counters") {
+                    game.getCounters(faerieId) shouldBe 2
+                }
+                val clientState = game.getClientState(1)
+                withClue("Kicked Faerie Squadron should have flying") {
+                    clientState.cards[faerieId]!!.keywords.contains(Keyword.FLYING) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/PrisonBarricadeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/PrisonBarricadeScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Prison Barricade with kicker.
+ *
+ * Card reference:
+ * - Prison Barricade ({1}{W}): Creature — Wall 1/3
+ *   Defender
+ *   Kicker {1}{W}
+ *   If this creature was kicked, it enters with a +1/+1 counter on it and with
+ *   "This creature can attack as though it didn't have defender."
+ *
+ * The kicked +1/+1 counter is the persistent marker; the defender-bypass is a
+ * CanAttackDespiteDefender static gated on the presence of that counter
+ * (Demon Wall pattern).
+ */
+class PrisonBarricadeScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioTestBase.TestGame.getCounters(entityId: EntityId): Int {
+        return state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Prison Barricade kicker") {
+
+            test("unkicked enters with no counter and cannot attack (defender)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Prison Barricade")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Prison Barricade")
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val barricadeId = game.findPermanent("Prison Barricade")!!
+                withClue("Unkicked Prison Barricade should have no counters") {
+                    game.getCounters(barricadeId) shouldBe 0
+                }
+            }
+
+            test("kicked enters with a +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Prison Barricade")
+                    .withLandsOnBattlefield(1, "Plains", 4) // {1}{W} + {1}{W} kicker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Prison Barricade"
+                }
+
+                val castResult = game.execute(CastSpell(playerId, cardId, wasKicked = true))
+                withClue("Kicked cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val barricadeId = game.findPermanent("Prison Barricade")!!
+                withClue("Kicked Prison Barricade should have a +1/+1 counter") {
+                    game.getCounters(barricadeId) shouldBe 1
+                }
+            }
+        }
+
+        context("Prison Barricade defender bypass") {
+
+            test("cannot attack with no counter (defender restriction applies)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Prison Barricade")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Prison Barricade" to 2))
+                withClue("Prison Barricade with no counter should not be able to attack") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("can attack when it has a +1/+1 counter (kicked)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Prison Barricade")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val barricadeId = game.findPermanent("Prison Barricade")!!
+                game.state = game.state.updateEntity(barricadeId) { container ->
+                    val counters = container.get<CountersComponent>() ?: CountersComponent()
+                    container.with(counters.withAdded(CounterType.PLUS_ONE_PLUS_ONE, 1))
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Prison Barricade" to 2))
+                withClue("Kicked Prison Barricade should be able to attack despite defender") {
+                    result.error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VodalianSerpentScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VodalianSerpentScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Vodalian Serpent with kicker.
+ *
+ * Card reference:
+ * - Vodalian Serpent ({3}{U}): Creature — Serpent 2/2
+ *   Kicker {2}
+ *   This creature can't attack unless defending player controls an Island.
+ *   If this creature was kicked, it enters with four +1/+1 counters on it.
+ */
+class VodalianSerpentScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioTestBase.TestGame.getCounters(entityId: EntityId): Int {
+        return state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Vodalian Serpent kicker") {
+
+            test("unkicked enters with no counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Vodalian Serpent")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Vodalian Serpent")
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val serpentId = game.findPermanent("Vodalian Serpent")!!
+                withClue("Unkicked Vodalian Serpent should have no counters") {
+                    game.getCounters(serpentId) shouldBe 0
+                }
+            }
+
+            test("kicked enters with four +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Vodalian Serpent")
+                    .withLandsOnBattlefield(1, "Island", 6) // {3}{U} + {2} kicker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Vodalian Serpent"
+                }
+
+                val castResult = game.execute(CastSpell(playerId, cardId, wasKicked = true))
+                withClue("Kicked cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val serpentId = game.findPermanent("Vodalian Serpent")!!
+                withClue("Kicked Vodalian Serpent should have four +1/+1 counters") {
+                    game.getCounters(serpentId) shouldBe 4
+                }
+            }
+        }
+
+        context("Vodalian Serpent attack restriction") {
+
+            test("cannot attack when defending player controls no Island") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vodalian Serpent")
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Vodalian Serpent" to 2))
+                withClue("Should not be able to attack player without an Island") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("can attack when defending player controls an Island") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vodalian Serpent")
+                    .withLandsOnBattlefield(2, "Island", 1)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Vodalian Serpent" to 2))
+                withClue("Should be able to attack player controlling an Island: ${result.error}") {
+                    result.error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BlurredMongoose.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BlurredMongoose.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blurred Mongoose
+ * {1}{G}
+ * Creature — Mongoose
+ * 2/1
+ * This spell can't be countered.
+ * Shroud (This creature can't be the target of spells or abilities.)
+ */
+val BlurredMongoose = card("Blurred Mongoose") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Mongoose"
+    power = 2
+    toughness = 1
+    oracleText = "This spell can't be countered.\n" +
+        "Shroud (This creature can't be the target of spells or abilities.)"
+
+    cantBeCountered = true
+    keywords(Keyword.SHROUD)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "183"
+        artist = "Heather Hudson"
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b073e3f-6a6f-495a-ab16-39d906b660f1.jpg?1562910191"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FaerieSquadron.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FaerieSquadron.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Faerie Squadron
+ * {U}
+ * Creature — Faerie
+ * 1/1
+ * Kicker {3}{U} (You may pay an additional {3}{U} as you cast this spell.)
+ * If this creature was kicked, it enters with two +1/+1 counters on it and with flying.
+ */
+val FaerieSquadron = card("Faerie Squadron") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie"
+    power = 1
+    toughness = 1
+    oracleText = "Kicker {3}{U} (You may pay an additional {3}{U} as you cast this spell.)\n" +
+        "If this creature was kicked, it enters with two +1/+1 counters on it and with flying."
+
+    keywordAbility(KeywordAbility.kicker("{3}{U}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self, Duration.Permanent)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "58"
+        artist = "rk post"
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c707c81-dbbd-43be-a79a-7bc92a584839.jpg?1562910474"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PrisonBarricade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PrisonBarricade.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Prison Barricade
+ * {1}{W}
+ * Creature — Wall
+ * 1/3
+ * Defender (This creature can't attack.)
+ * Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)
+ * If this creature was kicked, it enters with a +1/+1 counter on it and with
+ * "This creature can attack as though it didn't have defender."
+ *
+ * Modeled with the DemonWall pattern: the kicked +1/+1 counter is the persistent
+ * marker, and the "can attack despite defender" ability is a static gated on the
+ * presence of that counter.
+ */
+val PrisonBarricade = card("Prison Barricade") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Wall"
+    power = 1
+    toughness = 3
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\n" +
+        "If this creature was kicked, it enters with a +1/+1 counter on it and with " +
+        "\"This creature can attack as though it didn't have defender.\""
+
+    keywords(Keyword.DEFENDER)
+    keywordAbility(KeywordAbility.kicker("{1}{W}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    staticAbility {
+        ability = CanAttackDespiteDefender(
+            condition = Conditions.SourceHasCounter(CounterTypeFilter.Any)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Thomas Gianni"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/449c4800-8718-4593-a61e-03ad7f348c6d.jpg?1562908879"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianSerpent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianSerpent.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vodalian Serpent
+ * {3}{U}
+ * Creature — Serpent
+ * 2/2
+ * Kicker {2} (You may pay an additional {2} as you cast this spell.)
+ * This creature can't attack unless defending player controls an Island.
+ * If this creature was kicked, it enters with four +1/+1 counters on it.
+ */
+val VodalianSerpent = card("Vodalian Serpent") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Serpent"
+    power = 2
+    toughness = 2
+    oracleText = "Kicker {2} (You may pay an additional {2} as you cast this spell.)\n" +
+        "This creature can't attack unless defending player controls an Island.\n" +
+        "If this creature was kicked, it enters with four +1/+1 counters on it."
+
+    keywordAbility(KeywordAbility.kicker("{2}"))
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 4, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Christopher Moeller"
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/92adcf6c-ab14-414c-a5cb-56feae048c84.jpg?1562924617"
+    }
+}


### PR DESCRIPTION
## Summary

Adds four Invasion (INV) cards, all reusing existing SDK building blocks — no new engine code required. All four are first printed in Invasion, so their canonical definitions live in the `inv` set package.

- **Blurred Mongoose** ({1}{G}, 2/1 Mongoose) — Shroud + "This spell can't be countered" (`cantBeCountered` flag).
- **Prison Barricade** ({1}{W}, 1/3 Wall) — Defender, Kicker {1}{W}. If kicked, enters with a +1/+1 counter and can attack as though it didn't have defender. Modeled with the Demon Wall pattern: a `CanAttackDespiteDefender` static gated on `SourceHasCounter`, with the kicked +1/+1 counter as the persistent marker.
- **Faerie Squadron** ({U}, 1/1 Faerie) — Kicker {3}{U}. If kicked, enters with two +1/+1 counters and flying (ETB trigger granting `Duration.Permanent` flying).
- **Vodalian Serpent** ({3}{U}, 2/2 Serpent) — Kicker {2}. Can't attack unless defending player controls an Island (`CantAttackUnless`). If kicked, enters with four +1/+1 counters.

## Testing

Added scenario tests for each card covering kicked/unkicked branches, the defender bypass, the Island attack restriction, and shroud/uncounterable. All 12 tests pass:

```
./gradlew :game-server:test --tests "*BlurredMongooseScenarioTest" \
  --tests "*PrisonBarricadeScenarioTest" --tests "*FaerieSquadronScenarioTest" \
  --tests "*VodalianSerpentScenarioTest"
```

`mtg-sets` builds cleanly and `check-card-printing` confirms canonical placement in INV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)