### PR TITLE
Add Invasion cards: Elves group

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FirebrandRanger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FirebrandRanger.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Firebrand Ranger
+ * {1}{R}
+ * Creature — Human Soldier Ranger
+ * 2/1
+ * {G}, {T}: You may put a basic land card from your hand onto the battlefield.
+ */
+val FirebrandRanger = card("Firebrand Ranger") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier Ranger"
+    power = 2
+    toughness = 1
+    oracleText = "{G}, {T}: You may put a basic land card from your hand onto the battlefield."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{G}"),
+            Costs.Tap
+        )
+        effect = EffectPatterns.putFromHand(
+            filter = GameObjectFilter.BasicLand,
+            entersTapped = false
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "143"
+        artist = "Quinton Hoover"
+        flavorText = "A skilled ranger can glance at the mud on your boots and tell where you last camped."
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee05211e-cf08-4dea-9740-ed06f8682153.jpg?1562942810"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LlanowarElite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LlanowarElite.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Llanowar Elite
+ * {G}
+ * Creature — Elf
+ * 1/1
+ * Kicker {8}
+ * Trample
+ * If this creature was kicked, it enters with five +1/+1 counters on it.
+ */
+val LlanowarElite = card("Llanowar Elite") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf"
+    power = 1
+    toughness = 1
+    oracleText = "Kicker {8} (You may pay an additional {8} as you cast this spell.)\n" +
+        "Trample\n" +
+        "If this creature was kicked, it enters with five +1/+1 counters on it."
+
+    keywordAbility(KeywordAbility.kicker("{8}"))
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 5, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3e207863-de68-47e1-8c63-413b5fa48943.jpg?1562907508"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/NomadicElf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/NomadicElf.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nomadic Elf
+ * {1}{G}
+ * Creature — Elf Nomad
+ * 2/2
+ * {1}{G}: Add one mana of any color.
+ */
+val NomadicElf = card("Nomadic Elf") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Nomad"
+    oracleText = "{1}{G}: Add one mana of any color."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "200"
+        artist = "D. J. Cleland-Hura"
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b69e57a-5b19-450c-9cf5-c189e8505781.jpg?1562907011"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/QuirionTrailblazer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/QuirionTrailblazer.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Quirion Trailblazer
+ * {3}{G}
+ * Creature — Elf Scout
+ * 1/2
+ * When this creature enters, you may search your library for a basic land card,
+ * put that card onto the battlefield tapped, then shuffle.
+ */
+val QuirionTrailblazer = card("Quirion Trailblazer") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Scout"
+    power = 1
+    toughness = 2
+    oracleText = "When this creature enters, you may search your library for a basic land card, " +
+        "put that card onto the battlefield tapped, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            EffectPatterns.searchLibrary(
+                filter = GameObjectFilter.BasicLand,
+                count = 1,
+                destination = SearchDestination.BATTLEFIELD,
+                entersTapped = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "205"
+        artist = "Rebecca Guay"
+        flavorText = "\"All that matters is the path ahead.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2b258c1-5fb4-4072-bb32-ad364df1874a.jpg?1562934099"
+    }
+}


### PR DESCRIPTION
Adds four green/red creatures to the Invasion (INV) set:

- **Nomadic Elf** — `{1}{G}` 2/2 Elf Nomad. `{1}{G}: Add one mana of any color.`
- **Quirion Trailblazer** — `{3}{G}` 1/2 Elf Scout. ETB: may search library for a basic land, put it onto the battlefield tapped, then shuffle.
- **Llanowar Elite** — `{G}` 1/1 Elf with Trample and Kicker `{8}`. If kicked, enters with five +1/+1 counters.
- **Firebrand Ranger** — `{1}{R}` 2/1 Human Soldier Ranger. `{G}, {T}: You may put a basic land card from your hand onto the battlefield.`

All four reuse existing SDK primitives (`AddAnyColorMana`, `EffectPatterns.searchLibrary`, kicker + `WasKicked` + `AddCounters`, `EffectPatterns.putFromHand`) — no new engine mechanics. `just test-rules` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)