### PR TITLE
Add Invasion cards: Knights group

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BenalishLancer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BenalishLancer.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Benalish Lancer
+ * {2}{W}
+ * Creature — Human Knight
+ * 2/2
+ * Kicker {2}{W}
+ * If this creature was kicked, it enters with two +1/+1 counters on it and with first strike.
+ */
+val BenalishLancer = card("Benalish Lancer") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\n" +
+        "If this creature was kicked, it enters with two +1/+1 counters on it and with first strike."
+
+    keywordAbility(KeywordAbility.kicker("{2}{W}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self, Duration.Permanent),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a38d40a-e745-4fee-b179-f8c27e9b2fbd.jpg?1562906778"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BenalishTrapper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BenalishTrapper.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Benalish Trapper
+ * {1}{W}
+ * Creature — Human Soldier
+ * 1/2
+ * {W}, {T}: Tap target creature.
+ */
+val BenalishTrapper = card("Benalish Trapper") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 2
+    oracleText = "{W}, {T}: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target("target", TargetCreature())
+        effect = TapUntapEffect(
+            target = t,
+            tap = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Ken Meyer, Jr."
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e312653d-c3e1-4c79-90d2-0963419b618c.jpg?1562940560"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BlindingLightReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BlindingLightReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blinding Light reprint in Invasion.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Mirage's `cards/`
+ * package (earliest real printing); this file contributes only the Invasion-specific
+ * presentation row.
+ */
+val BlindingLightReprint = Printing(
+    oracleId = "6b315dc3-c330-4b30-b6ad-4da12ccf6ca3",
+    name = "Blinding Light",
+    setCode = "INV",
+    collectorNumber = "9",
+    scryfallId = "882c1e15-b508-4885-9626-4c8d2598a006",
+    artist = "Marc Fishman",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/882c1e15-b508-4885-9626-4c8d2598a006.jpg?1562922528",
+    releaseDate = "2000-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/GalinasKnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/GalinasKnight.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Galina's Knight
+ * {W}{U}
+ * Creature — Merfolk Knight
+ * 2/2
+ * Protection from red
+ */
+val GalinasKnight = card("Galina's Knight") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Merfolk Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from red"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.RED)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "248"
+        artist = "David Martin"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11b492d6-5e28-4f4b-942c-080d03cb0e92.jpg?1562898560"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mir/cards/BlindingLight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mir/cards/BlindingLight.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mir.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+
+/**
+ * Blinding Light
+ * {2}{W}
+ * Sorcery
+ * Tap all nonwhite creatures.
+ *
+ * Canonical printing: Mirage (1996), the earliest real expansion. Later printings
+ * (Portal, Starter 1999, Invasion) add `Printing` rows in their own packages.
+ */
+val BlindingLight = card("Blinding Light") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Tap all nonwhite creatures."
+
+    spell {
+        effect = ForEachInGroupEffect(GroupFilter.AllCreatures.notColor(Color.WHITE), TapUntapEffect(EffectTarget.Self, tap = true))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "5"
+        artist = "Hannibal King"
+        flavorText = "\"My shield will bear a shining sun so you will always be with me. / Inlaid with gold, it will shine like glowing embers.\"\n—\"Love Song of Night and Day\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99b2192a-78a5-4579-94ce-cccf773a809d.jpg?1587912357"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/PortalSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/PortalSet.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.por
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
 
 /**
  * Portal Set (1997)
@@ -27,6 +28,10 @@ object PortalSet : MtgSet {
 
     override val basicLands: List<CardDefinition> by lazy {
         CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }
 
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.por.cards"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BlindingLight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BlindingLight.kt
@@ -1,33 +1,23 @@
 package com.wingedsheep.mtg.sets.definitions.por.cards
 
-import com.wingedsheep.sdk.core.Color
-import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Printing
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
-import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
-import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
 
 /**
- * Blinding Light
- * {2}{W}
- * Sorcery
- * Tap all nonwhite creatures.
+ * Blinding Light reprint in Portal.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Mirage's `cards/`
+ * package (earliest real printing); this file contributes only the Portal-specific
+ * presentation row.
  */
-val BlindingLight = card("Blinding Light") {
-    manaCost = "{2}{W}"
-    colorIdentity = "W"
-    typeLine = "Sorcery"
-
-    spell {
-        effect = ForEachInGroupEffect(GroupFilter.AllCreatures.notColor(Color.WHITE), TapUntapEffect(EffectTarget.Self, tap = true))
-    }
-
-    metadata {
-        rarity = Rarity.RARE
-        collectorNumber = "8"
-        artist = "John Coulthart"
-        flavorText = "Let the unjust avert their faces from the light."
-        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ea283d2-8f00-4836-81b4-c041b0469dcb.jpg"
-    }
-}
+val BlindingLightReprint = Printing(
+    oracleId = "6b315dc3-c330-4b30-b6ad-4da12ccf6ca3",
+    name = "Blinding Light",
+    setCode = "POR",
+    collectorNumber = "8",
+    scryfallId = "4ea283d2-8f00-4836-81b4-c041b0469dcb",
+    artist = "John Coulthart",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4ea283d2-8f00-4836-81b4-c041b0469dcb.jpg?1562446633",
+    releaseDate = "1997-05-01",
+    rarity = Rarity.RARE,
+)


### PR DESCRIPTION
Adds four Invasion (INV) cards:

- **Benalish Lancer** — `{2}{W}` Human Knight 2/2 with Kicker `{2}{W}`; if kicked, enters with two +1/+1 counters and first strike (kicked-ETB triggered ability composing `AddCounters` + permanent `GrantKeyword(FIRST_STRIKE)`).
- **Benalish Trapper** — `{1}{W}` Human Soldier 1/2 with `{W}, {T}: Tap target creature.`
- **Galina's Knight** — `{W}{U}` Merfolk Knight 2/2 with protection from red.
- **Blinding Light** — `{2}{W}` Sorcery, "Tap all nonwhite creatures." Canonical `CardDefinition` moved to its earliest real printing (Mirage); Portal and Invasion now carry `Printing` reprint rows. Resolves prior canonical-placement drift flagged by `check-card-printing`.

All cards use existing SDK primitives — no new engine mechanics, so no new scenario tests were required. `just test-rules` passes and `mtg-sets` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)