### PR TITLE
Add Invasion cards: Kavu group

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavuScoutScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavuScoutScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kavu Scout's Domain static ability:
+ * "Domain — This creature gets +1/+0 for each basic land type among lands you control."
+ *
+ * Base stats are 0/2.
+ */
+class KavuScoutScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Kavu Scout Domain") {
+
+            test("with one basic land type, gets +1/+0") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kavu Scout")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kavuId = game.findPermanent("Kavu Scout")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power should be 0 base + 1 (one basic land type)") {
+                    projected.getPower(kavuId) shouldBe 1
+                }
+                withClue("Toughness stays at 2 (Domain only adds power)") {
+                    projected.getToughness(kavuId) shouldBe 2
+                }
+            }
+
+            test("with three basic land types, gets +3/+0") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kavu Scout")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kavuId = game.findPermanent("Kavu Scout")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power should be 0 base + 3 (three basic land types)") {
+                    projected.getPower(kavuId) shouldBe 3
+                }
+                withClue("Toughness stays at 2") {
+                    projected.getToughness(kavuId) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/PouncingKavuScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/PouncingKavuScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.WasKickedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Pouncing Kavu with kicker.
+ *
+ * Card reference:
+ * - Pouncing Kavu ({1}{R}): Creature — Kavu 1/1
+ *   Kicker {2}{R}
+ *   First strike
+ *   If this creature was kicked, it enters with two +1/+1 counters on it and with haste.
+ */
+class PouncingKavuScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private fun ScenarioTestBase.TestGame.getCounters(entityId: EntityId): Int {
+        return state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Pouncing Kavu kicker") {
+
+            test("unkicked enters as a 1/1 first striker with no counters and no haste") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Pouncing Kavu")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Pouncing Kavu")
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val kavuId = game.findPermanent("Pouncing Kavu")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Unkicked Pouncing Kavu should have no +1/+1 counters") {
+                    game.getCounters(kavuId) shouldBe 0
+                }
+                withClue("Should have first strike") {
+                    projected.hasKeyword(kavuId, Keyword.FIRST_STRIKE) shouldBe true
+                }
+                withClue("Unkicked Pouncing Kavu should NOT have haste") {
+                    projected.hasKeyword(kavuId, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("kicked enters with two +1/+1 counters and haste") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Pouncing Kavu")
+                    .withLandsOnBattlefield(1, "Mountain", 5) // {1}{R} + {2}{R} kicker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val playerId = game.player1Id
+                val hand = game.state.getHand(playerId)
+                val cardId = hand.find { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Pouncing Kavu"
+                }!!
+
+                val castResult = game.execute(CastSpell(playerId, cardId, wasKicked = true))
+                withClue("Kicked cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val kavuId = game.findPermanent("Pouncing Kavu")!!
+
+                withClue("Permanent should have WasKickedComponent") {
+                    (game.state.getEntity(kavuId)?.has<WasKickedComponent>() == true) shouldBe true
+                }
+                withClue("Kicked Pouncing Kavu should have two +1/+1 counters") {
+                    game.getCounters(kavuId) shouldBe 2
+                }
+
+                val projected = stateProjector.project(game.state)
+                withClue("Should have first strike") {
+                    projected.hasKeyword(kavuId, Keyword.FIRST_STRIKE) shouldBe true
+                }
+                withClue("Kicked Pouncing Kavu should have haste") {
+                    projected.hasKeyword(kavuId, Keyword.HASTE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RogueKavuScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RogueKavuScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rogue Kavu's attacks-alone trigger:
+ * "Whenever this creature attacks alone, it gets +2/+0 until end of turn."
+ *
+ * Base stats are 1/1.
+ */
+class RogueKavuScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Rogue Kavu attacks alone") {
+
+            test("gets +2/+0 when attacking alone") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Rogue Kavu")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attackResult = game.declareAttackers(mapOf("Rogue Kavu" to 2))
+                withClue("Declaring attack should succeed: ${attackResult.error}") {
+                    attackResult.error shouldBe null
+                }
+                // Resolve the attacks-alone trigger.
+                game.resolveStack()
+
+                val kavuId = game.findPermanent("Rogue Kavu")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power should be 1 base + 2 from attacking alone") {
+                    projected.getPower(kavuId) shouldBe 3
+                }
+                withClue("Toughness stays at 1 (+2/+0)") {
+                    projected.getToughness(kavuId) shouldBe 1
+                }
+            }
+
+            test("does not get the bonus when attacking alongside another creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Rogue Kavu")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attackResult = game.declareAttackers(
+                    mapOf("Rogue Kavu" to 2, "Grizzly Bears" to 2)
+                )
+                withClue("Declaring attack should succeed: ${attackResult.error}") {
+                    attackResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val kavuId = game.findPermanent("Rogue Kavu")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power should stay at base 1 (not attacking alone)") {
+                    projected.getPower(kavuId) shouldBe 1
+                }
+                withClue("Toughness should stay at base 1") {
+                    projected.getToughness(kavuId) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SkittishKavuScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SkittishKavuScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Skittish Kavu's conditional static ability:
+ * "This creature gets +1/+1 as long as no opponent controls a white or blue creature."
+ *
+ * Base stats are 1/1.
+ */
+class SkittishKavuScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Skittish Kavu conditional buff") {
+
+            test("is 2/2 when no opponent controls a white or blue creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Skittish Kavu")
+                    // Opponent controls a non-white, non-blue creature (Grizzly Bears is green)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kavuId = game.findPermanent("Skittish Kavu")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power should be buffed to 2") {
+                    projected.getPower(kavuId) shouldBe 2
+                }
+                withClue("Toughness should be buffed to 2") {
+                    projected.getToughness(kavuId) shouldBe 2
+                }
+            }
+
+            test("is 1/1 when an opponent controls a white creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Skittish Kavu")
+                    // Glory Seeker is a white creature
+                    .withCardOnBattlefield(2, "Glory Seeker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kavuId = game.findPermanent("Skittish Kavu")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power should stay at base 1") {
+                    projected.getPower(kavuId) shouldBe 1
+                }
+                withClue("Toughness should stay at base 1") {
+                    projected.getToughness(kavuId) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuScout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuScout.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kavu Scout
+ * {2}{R}
+ * Creature — Kavu Scout
+ * 0/2
+ * Domain — This creature gets +1/+0 for each basic land type among lands you control.
+ */
+val KavuScout = card("Kavu Scout") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu Scout"
+    power = 0
+    toughness = 2
+    oracleText = "Domain — This creature gets +1/+0 for each basic land type among lands you control."
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmounts.domain(),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "DiTerlizzi"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbc2670d-a3f4-47c2-b424-01fd379ff186.jpg?1562935954"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PouncingKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PouncingKavu.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pouncing Kavu
+ * {1}{R}
+ * Creature — Kavu
+ * 1/1
+ * Kicker {2}{R}
+ * First strike
+ * If this creature was kicked, it enters with two +1/+1 counters on it and with haste.
+ */
+val PouncingKavu = card("Pouncing Kavu") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu"
+    power = 1
+    toughness = 1
+    oracleText = "Kicker {2}{R} (You may pay an additional {2}{R} as you cast this spell.)\n" +
+        "First strike\n" +
+        "If this creature was kicked, it enters with two +1/+1 counters on it and with haste."
+
+    keywordAbility(KeywordAbility.kicker("{2}{R}"))
+    keywords(Keyword.FIRST_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self, Duration.Permanent)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e6e2e49-7bde-43c1-8caf-43d237dfc052.jpg?1562920517"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RogueKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RogueKavu.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.AttackPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rogue Kavu
+ * {1}{R}
+ * Creature — Kavu
+ * 1/1
+ * Whenever this creature attacks alone, it gets +2/+0 until end of turn.
+ */
+val RogueKavu = card("Rogue Kavu") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature attacks alone, it gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.attacks(requires = setOf(AttackPredicate.Alone))
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Darrell Riche"
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61e1a445-129d-4bb9-a8b0-3f55e3e0bc58.jpg?1562914814"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SkittishKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SkittishKavu.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Skittish Kavu
+ * {1}{R}
+ * Creature — Kavu
+ * 1/1
+ * This creature gets +1/+1 as long as no opponent controls a white or blue creature.
+ */
+val SkittishKavu = card("Skittish Kavu") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu"
+    power = 1
+    toughness = 1
+    oracleText = "This creature gets +1/+1 as long as no opponent controls a white or blue creature."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(1, 1, Filters.Self),
+            condition = Conditions.Not(
+                Exists(
+                    Player.Opponent,
+                    Zone.BATTLEFIELD,
+                    GameObjectFilter.Creature.withAnyColor(Color.WHITE, Color.BLUE)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "168"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be806378-50a7-4416-9d99-1ea2c1f2b7cb.jpg?1562933310"
+    }
+}


### PR DESCRIPTION
Adds four red Kavu creatures from Invasion (INV), each with a scenario test:

- **Kavu Scout** ({2}{R}, 0/2) — Domain: gets +1/+0 for each basic land type among lands you control.
- **Rogue Kavu** ({1}{R}, 1/1) — Whenever it attacks alone, it gets +2/+0 until end of turn.
- **Skittish Kavu** ({1}{R}, 1/1) — Gets +1/+1 as long as no opponent controls a white or blue creature.
- **Pouncing Kavu** ({1}{R}, 1/1) — Kicker {2}{R}, first strike; if kicked, enters with two +1/+1 counters and haste.

All implemented by composing existing SDK primitives (`GrantDynamicStatsEffect` + Domain, `Triggers.attacks(Alone)` + `ModifyStats`, `ConditionalStaticAbility` + `Exists`/`Not` with a white-or-blue creature filter, kicker + `EntersBattlefield`/`WasKicked` composite of counters + permanent haste). No new engine code required.

Tests: 8 new scenario tests pass; full `:rules-engine` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)