### PR TITLE
Add Invasion cards: Noble Panther, Treefolk Healer, Searing Rays, Reviving Dose

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SearingRaysScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SearingRaysScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Searing Rays.
+ *
+ * Card reference:
+ * - Searing Rays ({2}{R}): Sorcery
+ *   "Choose a color. Searing Rays deals damage to each player equal to the number of
+ *    creatures of that color that player controls."
+ *
+ * Exercises the ChooseColorThen + ForEachPlayer(DealDamage(Count(HasChosenColor))) composition:
+ * each player takes damage equal to the number of creatures of the chosen color *that player*
+ * controls — so the per-player Count must be scoped to the iterated player.
+ */
+class SearingRaysScenarioTest : ScenarioTestBase() {
+
+    // Mono-colored vanilla creatures so the chosen-color count is unambiguous.
+    private val greenBear = CardDefinition.creature(
+        name = "Green Bear", manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Bear")), power = 2, toughness = 2
+    )
+    private val blueDrake = CardDefinition.creature(
+        name = "Blue Drake", manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Drake")), power = 2, toughness = 2
+    )
+
+    init {
+        cardRegistry.register(greenBear)
+        cardRegistry.register(blueDrake)
+
+        context("Searing Rays color-scoped damage") {
+
+            // Caster (P1): two Green Bears, one Blue Drake.
+            // Opponent (P2): one Green Bear.
+            fun freshGame() = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardInHand(1, "Searing Rays")
+                .withCardOnBattlefield(1, "Green Bear")
+                .withCardOnBattlefield(1, "Green Bear")
+                .withCardOnBattlefield(1, "Blue Drake")
+                .withCardOnBattlefield(2, "Green Bear")
+                .withLandsOnBattlefield(1, "Mountain", 3) // pays {2}{R}
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            test("choosing green damages each player per their green creatures") {
+                val game = freshGame()
+                game.castSpell(1, "Searing Rays")
+                game.resolveStack()
+
+                val colorDecision = game.getPendingDecision()
+                withClue("Should pause for a color choice on resolution") {
+                    (colorDecision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.GREEN))
+                game.resolveStack()
+
+                withClue("Caster controls 2 green creatures -> takes 2 damage (20 -> 18)") {
+                    game.getLifeTotal(1) shouldBe 18
+                }
+                withClue("Opponent controls 1 green creature -> takes 1 damage (20 -> 19)") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+            }
+
+            test("choosing blue only counts blue creatures") {
+                val game = freshGame()
+                game.castSpell(1, "Searing Rays")
+                game.resolveStack()
+
+                val colorDecision = game.getPendingDecision()
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.BLUE))
+                game.resolveStack()
+
+                withClue("Caster controls 1 blue creature -> takes 1 damage (20 -> 19)") {
+                    game.getLifeTotal(1) shouldBe 19
+                }
+                withClue("Opponent controls no blue creatures -> takes no damage") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/NoblePanther.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/NoblePanther.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Noble Panther
+ * {1}{G}{W}
+ * Creature — Cat
+ * 3/3
+ * {1}: This creature gains first strike until end of turn.
+ */
+val NoblePanther = card("Noble Panther") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Cat"
+    power = 3
+    toughness = 3
+    oracleText = "{1}: This creature gains first strike until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self, Duration.EndOfTurn)
+        description = "{1}: This creature gains first strike until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "257"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f327818-8222-4295-8cef-118757b34d17.jpg?1562907700"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RevivingDose.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RevivingDose.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reviving Dose
+ * {2}{W}
+ * Instant
+ * You gain 3 life.
+ * Draw a card.
+ */
+val RevivingDose = card("Reviving Dose") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "You gain 3 life.\nDraw a card."
+
+    spell {
+        effect = Effects.GainLife(3).then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "D. Alexander Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d44dd88-ad20-4d89-8831-d2dfa6873428.jpg?1562923533"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SearingRays.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SearingRays.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Searing Rays
+ * {2}{R}
+ * Sorcery
+ * Choose a color. Searing Rays deals damage to each player equal to the number of
+ * creatures of that color that player controls.
+ */
+val SearingRays = card("Searing Rays") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose a color. Searing Rays deals damage to each player equal to the number of " +
+        "creatures of that color that player controls."
+
+    spell {
+        effect = Effects.ChooseColorThen(
+            then = ForEachPlayerEffect(
+                players = Player.Each,
+                effects = listOf(
+                    Effects.DealDamage(
+                        amount = DynamicAmount.Count(
+                            player = Player.You,
+                            zone = Zone.BATTLEFIELD,
+                            filter = GameObjectFilter(
+                                cardPredicates = listOf(
+                                    CardPredicate.IsCreature,
+                                    CardPredicate.HasChosenColor,
+                                ),
+                            ),
+                        ),
+                        target = EffectTarget.Controller,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Doug Chaffee"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f66ff2d-f2d2-4a6b-bf26-b510de60c0b6.jpg?1562911077"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TreefolkHealer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TreefolkHealer.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Treefolk Healer
+ * {4}{G}
+ * Creature — Treefolk Cleric
+ * 2/3
+ * {2}{W}, {T}: Prevent the next 2 damage that would be dealt to any target this turn.
+ */
+val TreefolkHealer = card("Treefolk Healer") {
+    manaCost = "{4}{G}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Treefolk Cleric"
+    power = 2
+    toughness = 3
+    oracleText = "{2}{W}, {T}: Prevent the next 2 damage that would be dealt to any target this turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.Tap)
+        val t = target("target", AnyTarget())
+        effect = Effects.PreventNextDamage(2, t)
+        description = "{2}{W}, {T}: Prevent the next 2 damage that would be dealt to any target this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "218"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73c6f5c0-686d-4b3a-add7-487f9fff5faa.jpg?1562918162"
+    }
+}


### PR DESCRIPTION
Adds four cards to the Invasion (INV) set. All four reuse existing SDK primitives — no new effects, keywords, triggers, conditions, or static abilities were introduced, so no SDK doc changes were needed.

## Cards added

- **Noble Panther** — `{1}{G}{W}` 3/3 Creature — Cat (rare). `{1}`: This creature gains first strike until end of turn. Uses `Effects.GrantKeyword(FIRST_STRIKE, Self, EndOfTurn)`.
- **Treefolk Healer** — `{4}{G}` 2/3 Creature — Treefolk Cleric (uncommon). `{2}{W}, {T}`: Prevent the next 2 damage that would be dealt to any target this turn. Uses `Costs.Composite(Mana, Tap)` + `Effects.PreventNextDamage(2, AnyTarget)`. Color identity is `GW` (activation cost includes `{W}`).
- **Searing Rays** — `{2}{R}` Sorcery (uncommon). Choose a color; deals damage to each player equal to the number of creatures of that color that player controls. Composes `ChooseColorThen` → `ForEachPlayer(Player.Each)` → `DealDamage(Count(Player.You, HasChosenColor), Controller)`. The chosen color flows from the effect context into the per-player `Count` filter via `CardPredicate.HasChosenColor`.
- **Reviving Dose** — `{2}{W}` Instant (common). You gain 3 life. Draw a card. Uses `Effects.GainLife(3).then(DrawCards(1))`.

## Skipped

None — all four implemented.

## Tests

- Added `SearingRaysScenarioTest` (the only card with a non-trivial composition): verifies per-player, color-scoped damage for both a "choose green" and "choose blue" case, confirming each player's `Count` is scoped to the creatures *that player* controls.
- `just test-rules` passes; the Searing Rays scenario test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)