### PR TITLE
Add Invasion cards: Sparring Golem, Metathran Zombie, Crown of Flames, Vigorous Charge

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionCardsScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionCardsScenarioTest.kt
@@ -1,0 +1,247 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for four Invasion (INV) cards:
+ *  - Sparring Golem ({3} 2/2 Artifact Creature — Golem; +1/+1 per blocker when blocked)
+ *  - Metathran Zombie ({1}{U} 1/1; {B}: Regenerate this creature)
+ *  - Crown of Flames ({R} Aura; {R}: enchanted creature gets +1/+0; {R}: bounce this Aura)
+ *  - Vigorous Charge ({G} Instant; Kicker {W}; trample + kicked lifegain on combat damage)
+ */
+class InvasionCardsScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Sparring Golem") {
+            test("gets +1/+1 for each creature blocking it") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Sparring Golem")  // 2/2
+                    .withCardOnBattlefield(2, "Grizzly Bears")   // 2/2
+                    .withCardOnBattlefield(2, "Glory Seeker")    // 2/2
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val golemId = game.findPermanent("Sparring Golem")!!
+                val bearId = game.findPermanent("Grizzly Bears")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+
+                game.execute(DeclareAttackers(game.player1Id, mapOf(golemId to game.player2Id)))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.execute(DeclareBlockers(game.player2Id, mapOf(
+                    bearId to listOf(golemId),
+                    seekerId to listOf(golemId)
+                )))
+                game.resolveStack()
+
+                val projected = projector.project(game.state)
+                withClue("Sparring Golem should be 4/4 after +2/+2 for two blockers") {
+                    projected.getPower(golemId) shouldBe 4
+                    projected.getToughness(golemId) shouldBe 4
+                }
+            }
+
+            test("is not buffed when unblocked") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Sparring Golem")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val golemId = game.findPermanent("Sparring Golem")!!
+                game.execute(DeclareAttackers(game.player1Id, mapOf(golemId to game.player2Id)))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+
+                val projected = projector.project(game.state)
+                withClue("Unblocked Sparring Golem stays 2/2") {
+                    projected.getPower(golemId) shouldBe 2
+                    projected.getToughness(golemId) shouldBe 2
+                }
+            }
+        }
+
+        context("Metathran Zombie") {
+            test("regenerates to survive lethal damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Metathran Zombie")  // 1/1
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val zombieId = game.findPermanent("Metathran Zombie")!!
+                val ability = cardRegistry.getCard("Metathran Zombie")!!.script.activatedAbilities.first()
+
+                val activate = game.execute(
+                    ActivateAbility(game.player1Id, zombieId, ability.id, emptyList())
+                )
+                withClue("Regenerate activation should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Regen shield (floating effect) should be present") {
+                    game.state.floatingEffects.isNotEmpty() shouldBe true
+                }
+
+                game.execute(PassPriority(game.player1Id))
+                game.castSpell(2, "Shock", zombieId)
+                game.resolveStack()
+
+                withClue("Metathran Zombie should survive via regeneration") {
+                    game.isOnBattlefield("Metathran Zombie") shouldBe true
+                }
+            }
+        }
+
+        context("Crown of Flames") {
+            test("pumps the enchanted creature +1/+0 and can bounce itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Crown of Flames")
+                    .withCardOnBattlefield(1, "Grizzly Bears")  // 2/2
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearId = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpell(1, "Crown of Flames", bearId)
+                withClue("Crown of Flames should attach: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val crownId = game.findPermanent("Crown of Flames")!!
+                val cardDef = cardRegistry.getCard("Crown of Flames")!!
+                val pumpAbility = cardDef.script.activatedAbilities[0]
+                val bounceAbility = cardDef.script.activatedAbilities[1]
+
+                // {R}: enchanted creature gets +1/+0
+                val pump = game.execute(ActivateAbility(game.player1Id, crownId, pumpAbility.id, emptyList()))
+                withClue("Pump activation should succeed: ${pump.error}") {
+                    pump.error shouldBe null
+                }
+                game.resolveStack()
+
+                val pumped = projector.project(game.state)
+                withClue("Enchanted Grizzly Bears should be 3/2 after +1/+0") {
+                    pumped.getPower(bearId) shouldBe 3
+                    pumped.getToughness(bearId) shouldBe 2
+                }
+
+                // {R}: return this Aura to its owner's hand
+                val bounce = game.execute(ActivateAbility(game.player1Id, crownId, bounceAbility.id, emptyList()))
+                withClue("Bounce activation should succeed: ${bounce.error}") {
+                    bounce.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Crown of Flames should be back in its owner's hand") {
+                    game.isInHand(1, "Crown of Flames") shouldBe true
+                    game.isOnBattlefield("Crown of Flames") shouldBe false
+                }
+            }
+        }
+
+        context("Vigorous Charge") {
+            test("kicked: grants trample and gains life equal to combat damage dealt") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardInHand(1, "Vigorous Charge")
+                    .withCardOnBattlefield(1, "Grizzly Bears")  // 2/2 attacker
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Plains", 1)     // kicker {W}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearId = game.findPermanent("Grizzly Bears")!!
+                val hand = game.state.getHand(game.player1Id)
+                val chargeId = hand.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Vigorous Charge"
+                }
+
+                val startLife = game.getLifeTotal(1)
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        chargeId,
+                        listOf(ChosenTarget.Permanent(bearId)),
+                        wasKicked = true
+                    )
+                )
+                withClue("Kicked Vigorous Charge cast should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = projector.project(game.state)
+                withClue("Target creature should have trample") {
+                    projected.hasKeyword(bearId, com.wingedsheep.sdk.core.Keyword.TRAMPLE) shouldBe true
+                }
+
+                // Attack with the unblocked bear; it deals 2 combat damage to the player.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.execute(DeclareAttackers(game.player1Id, mapOf(bearId to game.player2Id)))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("Controller should gain 2 life from the kicked lifegain trigger") {
+                    game.getLifeTotal(1) shouldBe startLife + 2
+                }
+            }
+
+            test("unkicked: grants trample but no lifegain") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardInHand(1, "Vigorous Charge")
+                    .withCardOnBattlefield(1, "Grizzly Bears")  // 2/2 attacker
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearId = game.findPermanent("Grizzly Bears")!!
+                val startLife = game.getLifeTotal(1)
+
+                val cast = game.castSpell(1, "Vigorous Charge", bearId)
+                withClue("Unkicked Vigorous Charge cast should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = projector.project(game.state)
+                withClue("Target creature should have trample even when unkicked") {
+                    projected.hasKeyword(bearId, com.wingedsheep.sdk.core.Keyword.TRAMPLE) shouldBe true
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.execute(DeclareAttackers(game.player1Id, mapOf(bearId to game.player2Id)))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("Controller should NOT gain life when the spell was not kicked") {
+                    game.getLifeTotal(1) shouldBe startLife
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrownOfFlames.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrownOfFlames.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Crown of Flames
+ * {R}
+ * Enchantment — Aura
+ * Enchant creature
+ * {R}: Enchanted creature gets +1/+0 until end of turn.
+ * {R}: Return this Aura to its owner's hand.
+ */
+val CrownOfFlames = card("Crown of Flames") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "{R}: Enchanted creature gets +1/+0 until end of turn.\n" +
+        "{R}: Return this Aura to its owner's hand."
+
+    auraTarget = Targets.Creature
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.EnchantedCreature)
+        description = "{R}: Enchanted creature gets +1/+0 until end of turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = MoveToZoneEffect(EffectTarget.Self, Zone.HAND)
+        description = "{R}: Return this Aura to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Christopher Moeller"
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a46239c-3de7-48ca-8f5c-b51f307fd0e5.jpg?1562913336"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MetathranZombie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MetathranZombie.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Metathran Zombie
+ * {1}{U}
+ * Creature — Metathran Zombie
+ * 1/1
+ * {B}: Regenerate this creature.
+ */
+val MetathranZombie = card("Metathran Zombie") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Metathran Zombie"
+    power = 1
+    toughness = 1
+    oracleText = "{B}: Regenerate this creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/6676a0f7-8213-4547-b2ac-b904cd418073.jpg?1562915761"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SparringGolem.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SparringGolem.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sparring Golem
+ * {3}
+ * Artifact Creature — Golem
+ * 2/2
+ * Whenever this creature becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.
+ */
+val SparringGolem = card("Sparring Golem") {
+    manaCost = "{3}"
+    typeLine = "Artifact Creature — Golem"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature becomes blocked, it gets +1/+1 until end of turn for each creature blocking it."
+
+    triggeredAbility {
+        trigger = Triggers.becomesBlocked(binding = TriggerBinding.SELF)
+        effect = Effects.ModifyStats(
+            DynamicAmounts.numberOfBlockers(),
+            DynamicAmounts.numberOfBlockers(),
+            EffectTarget.TriggeringEntity
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "312"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d829d9de-83fa-4feb-8efc-0075315163c6.jpg?1562938416"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VigorousCharge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VigorousCharge.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Vigorous Charge
+ * {G}
+ * Instant
+ * Kicker {W}
+ * Target creature gains trample until end of turn. Whenever that creature deals
+ * combat damage this turn, if this spell was kicked, you gain life equal to that damage.
+ */
+val VigorousCharge = card("Vigorous Charge") {
+    manaCost = "{G}"
+    colorIdentity = "GW"
+    typeLine = "Instant"
+    oracleText = "Kicker {W} (You may pay an additional {W} as you cast this spell.)\n" +
+        "Target creature gains trample until end of turn. Whenever that creature deals combat damage this turn, " +
+        "if this spell was kicked, you gain life equal to that damage."
+
+    keywordAbility(KeywordAbility.kicker("{W}"))
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = CompositeEffect(
+            listOf(
+                Effects.GrantKeyword(Keyword.TRAMPLE, t),
+                ConditionalEffect(
+                    condition = WasKicked,
+                    effect = GrantTriggeredAbilityEffect(
+                        ability = TriggeredAbility.create(
+                            trigger = Triggers.dealsDamage(damageType = DamageType.Combat).event,
+                            binding = Triggers.dealsDamage(damageType = DamageType.Combat).binding,
+                            effect = Effects.GainLife(
+                                DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+                            ),
+                            descriptionOverride = "Whenever this creature deals combat damage, you gain life equal to that damage."
+                        ),
+                        target = t
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "222"
+        artist = "Scott M. Fischer"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af6f57ad-d370-4c81-8da0-c15d87725ab1.jpg?1562930306"
+    }
+}


### PR DESCRIPTION
Adds four cards from the Invasion (INV) set. All reuse existing SDK primitives — no new engine mechanics were required.

## Cards added

| Card | Cost | Type | Implementation |
|------|------|------|----------------|
| **Sparring Golem** | {3} | Artifact Creature — Golem 2/2 | `becomesBlocked` (SELF) trigger → `ModifyStats(numberOfBlockers, numberOfBlockers)` on the triggering entity |
| **Metathran Zombie** | {1}{U} | Creature — Metathran Zombie 1/1 | `{B}` activated ability → `RegenerateEffect(Self)` |
| **Crown of Flames** | {R} | Enchantment — Aura | `{R}: Enchanted creature gets +1/+0` via `ModifyStats(1,0, EnchantedCreature)`; `{R}: Return this Aura to its owner's hand` via `MoveToZoneEffect(Self, HAND)` |
| **Vigorous Charge** | {G} | Instant (Kicker {W}) | `GrantKeyword(TRAMPLE)` to target; if kicked, also `GrantTriggeredAbility` granting "whenever this deals combat damage, gain life equal to that damage" (`TRIGGER_DAMAGE_AMOUNT`) — same shape as Commando Raid / Armadillo Cloak |

Vigorous Charge's lifegain grant is gated by `WasKicked` via `ConditionalEffect`; the granted trigger uses `Triggers.dealsDamage(DamageType.Combat)` so it fires on combat damage to any recipient.

## Tests

New `InvasionCardsScenarioTest` (6 tests, all passing):
- Sparring Golem: +2/+2 when double-blocked; unchanged when unblocked
- Metathran Zombie: survives lethal Shock via regeneration shield
- Crown of Flames: pumps enchanted creature +1/+0, then bounces itself to hand
- Vigorous Charge: kicked grants trample + 2 life on unblocked combat damage; unkicked grants trample with no lifegain

`just test-rules` and the new scenario test pass. None skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)