### PR TITLE
Add Invasion Kavu and red/black creatures

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AncientKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AncientKavu.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ancient Kavu
+ * {3}{R}
+ * Creature — Kavu
+ * 3/3
+ * {2}: This creature becomes colorless until end of turn.
+ */
+val AncientKavu = card("Ancient Kavu") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu"
+    power = 3
+    toughness = 3
+    oracleText = "{2}: This creature becomes colorless until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.ChangeColor(EffectTarget.Self, colors = emptySet())
+        description = "{2}: This creature becomes colorless until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Glen Angus"
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8ccb5d0-735b-443f-addd-8b70f5f2c60d.jpg?1562935287"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Duskwalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Duskwalker.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Duskwalker
+ * {B}
+ * Creature — Human Minion
+ * 1/1
+ * Kicker {3}{B}
+ * If this creature was kicked, it enters with two +1/+1 counters on it and with fear.
+ */
+val Duskwalker = card("Duskwalker") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Minion"
+    power = 1
+    toughness = 1
+    oracleText = "Kicker {3}{B} (You may pay an additional {3}{B} as you cast this spell.)\n" +
+        "If this creature was kicked, it enters with two +1/+1 counters on it and with fear. " +
+        "(It can't be blocked except by artifact creatures and/or black creatures.)"
+
+    keywordAbility(KeywordAbility.kicker("{3}{B}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.FEAR, EffectTarget.Self, Duration.Permanent),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "104"
+        artist = "David Martin"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39a4a026-f44e-40e1-9942-a3d8448aca70.jpg?1562906613"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Firescreamer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Firescreamer.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Firescreamer
+ * {3}{B}
+ * Creature — Kavu
+ * 2/2
+ * {R}: This creature gets +1/+0 until end of turn.
+ */
+val Firescreamer = card("Firescreamer") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Kavu"
+    power = 2
+    toughness = 2
+    oracleText = "{R}: This creature gets +1/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{R}: This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "106"
+        artist = "Alan Pollack"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/155a2213-bf6e-4a54-924b-e450b7d06f26.jpg?1562899300"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HoodedKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HoodedKavu.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hooded Kavu
+ * {2}{R}
+ * Creature — Kavu
+ * 2/2
+ * {B}: This creature gains fear until end of turn.
+ */
+val HoodedKavu = card("Hooded Kavu") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu"
+    power = 2
+    toughness = 2
+    oracleText = "{B}: This creature gains fear until end of turn. " +
+        "(It can't be blocked except by artifact creatures and/or black creatures.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.GrantKeyword(Keyword.FEAR, EffectTarget.Self)
+        description = "{B}: This creature gains fear until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "John Howe"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/5464b80a-22fe-42c7-a839-31667712fb2d.jpg?1562912199"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuRunner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuRunner.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Kavu Runner
+ * {3}{R}
+ * Creature — Kavu
+ * 3/3
+ * This creature has haste as long as no opponent controls a white or blue creature.
+ */
+val KavuRunner = card("Kavu Runner") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu"
+    power = 3
+    toughness = 3
+    oracleText = "This creature has haste as long as no opponent controls a white or blue creature."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.HASTE, Filters.Self),
+            condition = Conditions.Not(
+                Exists(
+                    Player.Opponent,
+                    Zone.BATTLEFIELD,
+                    GameObjectFilter.Creature.withAnyColor(Color.WHITE, Color.BLUE)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "150"
+        artist = "Douglas Shuler"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2bc1b462-4e3c-47cc-87c5-f6e29dd70c01.jpg?1562903915"
+    }
+}


### PR DESCRIPTION
Adds five Invasion (INV) common/uncommon creatures. All five compose existing SDK primitives — no engine changes, no new effects/triggers/conditions.

- **Ancient Kavu** ({3}{R}, 3/3 Kavu) — `{2}: This creature becomes colorless until end of turn.` via `Effects.ChangeColor(Self, colors = emptySet())`.
- **Hooded Kavu** ({2}{R}, 2/2 Kavu) — `{B}: This creature gains fear until end of turn.` via `Effects.GrantKeyword(FEAR, Self)`.
- **Kavu Runner** ({3}{R}, 3/3 Kavu) — has haste as long as no opponent controls a white or blue creature; `ConditionalStaticAbility` granting HASTE gated on `Not(Exists(opponent battlefield creature W/U))` (mirrors Skittish Kavu).
- **Firescreamer** ({3}{B}, 2/2 Kavu) — `{R}: This creature gets +1/+0 until end of turn.` via `Effects.ModifyStats(1, 0, Self)`.
- **Duskwalker** ({B}, 1/1 Human Minion) — Kicker {3}{B}; if kicked, enters with two +1/+1 counters and fear (kicked ETB `Composite(AddCounters, GrantKeyword(FEAR, Permanent))`, mirrors Benalish Lancer).

Verified against Scryfall (name/cost/type/P-T/oracle text/rarity/collector number/art). All image URIs return HTTP 200. `just test-rules` passes; `mtg-sets` compiles. INV implemented count 182 → 187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)