### PR TITLE
Add Invasion leech cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1122,7 +1122,9 @@ staticAbility {
   `OpponentsCastTargeting(GroupFilter)`, `FaceDownYouCast`, `MorphActivation`.
 - `modification: CostModification` — `ReduceGeneric(amount)`, `ReduceGenericBy(source)`,
   `ReduceColored(symbols)`, `ReduceColoredPerUnit(symbols, source)`, `IncreaseGeneric(amount)`,
-  `IncreaseGenericPerOtherSpellThisTurn(amountPerSpell)`, `IncreaseLife(amount)`.
+  `IncreaseColored(symbols)` (colored tax — adds colored pips, e.g. the Invasion Leeches'
+  "White spells you cast cost {W} more"), `IncreaseGenericPerOtherSpellThisTurn(amountPerSpell)`,
+  `IncreaseLife(amount)`.
   Reduction `source: CostReductionSource` covers fixed amounts, counts of permanents/cards in
   zones, target/condition gates, and a few mechanic-specific shapes — see
   `CostStaticAbilities.kt` for the full list.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -52,6 +52,7 @@ data class ModifySpellCost(
             is CostModification.ReduceColoredPerUnit ->
                 "cost ${modification.symbols} less to cast for each ${modification.countSource.description}"
             is CostModification.IncreaseGeneric -> "cost {${modification.amount}} more"
+            is CostModification.IncreaseColored -> "cost ${modification.symbols} more to cast"
             is CostModification.IncreaseGenericPerOtherSpellThisTurn ->
                 "cost {${modification.amountPerSpell}} more to cast for each other spell that player has cast this turn"
             is CostModification.IncreaseLife -> "cost an additional ${modification.amount} life to cast"
@@ -213,6 +214,14 @@ sealed interface CostModification {
     @SerialName("IncreaseGeneric")
     @Serializable
     data class IncreaseGeneric(val amount: Int) : CostModification
+
+    /**
+     * Add specific colored mana symbols to the cost (e.g. `"{W}"`), a colored tax effect.
+     * Used for the Invasion "Leech" creatures ("White spells you cast cost {W} more to cast").
+     */
+    @SerialName("IncreaseColored")
+    @Serializable
+    data class IncreaseColored(val symbols: String) : CostModification
 
     /**
      * Damping-Sphere-style scaling tax: increase by `amountPerSpell` for each spell

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AlabasterLeech.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AlabasterLeech.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Alabaster Leech
+ * {W}
+ * Creature — Leech
+ * 1/3
+ * White spells you cast cost {W} more to cast.
+ */
+val AlabasterLeech = card("Alabaster Leech") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Leech"
+    power = 1
+    toughness = 3
+    oracleText = "White spells you cast cost {W} more to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.WHITE)),
+            modification = CostModification.IncreaseColored("{W}"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "1"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "\"Its stones seem to serve a healing function, but removing them intact is an exhausting process.\"\n—Tolarian research notes"
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c86b45d9-aba6-4c09-8605-037754ba7fd4.jpg?1562935200"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AndraditeLeech.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AndraditeLeech.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Andradite Leech
+ * {2}{B}
+ * Creature — Leech
+ * 2/2
+ * Black spells you cast cost {B} more to cast.
+ * {B}: This creature gets +1/+1 until end of turn.
+ */
+val AndraditeLeech = card("Andradite Leech") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Leech"
+    power = 2
+    toughness = 2
+    oracleText = "Black spells you cast cost {B} more to cast.\n{B}: This creature gets +1/+1 until end of turn."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.BLACK)),
+            modification = CostModification.IncreaseColored("{B}"),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.ModifyStats(power = 1, toughness = 1, target = EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "93"
+        artist = "Wayne England"
+        flavorText = "\"Older specimens are completely encrusted with gems, which serve as both armor and weapons.\"\n—Tolarian research notes"
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6da0d4f3-9216-406c-8f3e-b9bb0a11dc75.jpg?1562916972"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/JadeLeech.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/JadeLeech.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Jade Leech
+ * {2}{G}{G}
+ * Creature — Leech
+ * 5/5
+ * Green spells you cast cost {G} more to cast.
+ */
+val JadeLeech = card("Jade Leech") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Leech"
+    power = 5
+    toughness = 5
+    oracleText = "Green spells you cast cost {G} more to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.GREEN)),
+            modification = CostModification.IncreaseColored("{G}"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "190"
+        artist = "John Howe"
+        flavorText = "\"It took magic to extract one of the stones and five people to carry it.\"\n—Tolarian research notes"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/3392171d-ed25-46a1-91cc-a4f24537617d.jpg?1562905388"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RubyLeech.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RubyLeech.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Ruby Leech
+ * {1}{R}
+ * Creature — Leech
+ * 2/2
+ * First strike
+ * Red spells you cast cost {R} more to cast.
+ */
+val RubyLeech = card("Ruby Leech") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Leech"
+    power = 2
+    toughness = 2
+    oracleText = "First strike\nRed spells you cast cost {R} more to cast."
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.RED)),
+            modification = CostModification.IncreaseColored("{R}"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "161"
+        artist = "Jacques Bredy"
+        flavorText = "\"Its gems didn't stop pulsating until they were completely removed.\"\n—Tolarian research notes"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be621b12-4f4e-43a6-b65e-da4223e742b5.jpg?1562933305"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SapphireLeech.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SapphireLeech.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Sapphire Leech
+ * {1}{U}
+ * Creature — Leech
+ * 2/2
+ * Flying
+ * Blue spells you cast cost {U} more to cast.
+ */
+val SapphireLeech = card("Sapphire Leech") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Leech"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\nBlue spells you cast cost {U} more to cast."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.BLUE)),
+            modification = CostModification.IncreaseColored("{U}"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "Ron Spencer"
+        flavorText = "\"The subject's wings are clearly vestigial. We suspect the gems somehow keep it aloft.\"\n—Tolarian research notes"
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6763ffd-9d89-4f26-871a-be24fbdef38d.jpg?1562941279"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -70,6 +70,7 @@ class CostCalculator(
         var totalIncrease = 0
         val coloredReductionSymbols = mutableListOf<ManaSymbol>()
         val coloredReductionWithOverflow = mutableListOf<ManaSymbol>()
+        val coloredIncreaseSymbols = mutableListOf<ManaSymbol>()
 
         // Self-reductions read from the spell card's own static abilities.
         for (ability in cardDef.script.staticAbilities) {
@@ -82,6 +83,7 @@ class CostCalculator(
                 addGenericIncrease = { totalIncrease += it },
                 addColoredReduction = { coloredReductionSymbols += it },
                 addColoredReductionWithOverflow = { coloredReductionWithOverflow += it },
+                addColoredIncrease = { coloredIncreaseSymbols += it },
             )
         }
 
@@ -105,6 +107,7 @@ class CostCalculator(
                 addGenericIncrease = { totalIncrease += it },
                 addColoredReduction = { coloredReductionSymbols += it },
                 addColoredReductionWithOverflow = { coloredReductionWithOverflow += it },
+                addColoredIncrease = { coloredIncreaseSymbols += it },
             )
         }
 
@@ -116,6 +119,9 @@ class CostCalculator(
         // increases first so a reduction that overshoots {0} doesn't leave a stale increase behind
         // (e.g. {U} +{1} −{2} → {U}, not {1}{U}).
         var effectiveCost = increaseGenericCost(cardDef.manaCost, totalIncrease)
+        if (coloredIncreaseSymbols.isNotEmpty()) {
+            effectiveCost = increaseColoredCost(effectiveCost, coloredIncreaseSymbols)
+        }
         effectiveCost = reduceGenericCost(effectiveCost, totalReduction)
         if (coloredReductionSymbols.isNotEmpty()) {
             effectiveCost = reduceColoredCost(effectiveCost, coloredReductionSymbols)
@@ -281,6 +287,7 @@ class CostCalculator(
         addGenericIncrease: (Int) -> Unit,
         addColoredReduction: (ManaSymbol) -> Unit,
         addColoredReductionWithOverflow: (ManaSymbol) -> Unit,
+        addColoredIncrease: (ManaSymbol) -> Unit,
     ) {
         when (modification) {
             is CostModification.ReduceGeneric -> addGenericReduction(modification.amount)
@@ -298,6 +305,11 @@ class CostCalculator(
                 repeat(units) { coloredSymbols.forEach(addColoredReductionWithOverflow) }
             }
             is CostModification.IncreaseGeneric -> addGenericIncrease(modification.amount)
+            is CostModification.IncreaseColored -> {
+                ManaCost.parse(modification.symbols).symbols
+                    .filterIsInstance<ManaSymbol.Colored>()
+                    .forEach(addColoredIncrease)
+            }
             is CostModification.IncreaseGenericPerOtherSpellThisTurn -> {
                 val spellsCast = state.playerSpellsCastThisTurn[casterId] ?: 0
                 addGenericIncrease(spellsCast * modification.amountPerSpell)
@@ -718,6 +730,15 @@ class CostCalculator(
         return state.controlledBattlefield(playerId).count { entityId ->
             projected.hasSubtype(entityId, subtype.value)
         }
+    }
+
+    /**
+     * Add specific colored mana symbols to a mana cost (colored tax effect).
+     * Each symbol in [symbolsToAdd] appends one matching colored pip. Does not affect generic mana.
+     */
+    private fun increaseColoredCost(cost: ManaCost, symbolsToAdd: List<ManaSymbol>): ManaCost {
+        if (symbolsToAdd.isEmpty()) return cost
+        return ManaCost(cost.symbols + symbolsToAdd)
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeechColoredTaxTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeechColoredTaxTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.ManaSymbol
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the colored spell-cost tax used by the Invasion "Leech" creatures
+ * ([CostModification.IncreaseColored]).
+ *
+ * Stand-in card: a {R} creature that taxes the controller's red spells by {R}
+ * ("Red spells you cast cost {R} more to cast"), mirroring Ruby Leech. Cost is
+ * checked directly through [CostCalculator] to avoid targeting/timing noise.
+ */
+class LeechColoredTaxTest : FunSpec({
+
+    val RedLeech = CardDefinition.creature(
+        name = "Red Leech",
+        manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Leech")),
+        power = 1,
+        toughness = 1,
+        oracleText = "Red spells you cast cost {R} more to cast.",
+        script = CardScript(
+            staticAbilities = listOf(
+                ModifySpellCost(
+                    target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.RED)),
+                    modification = CostModification.IncreaseColored("{R}"),
+                ),
+            ),
+        ),
+    )
+
+    fun redPips(cost: ManaCost): Int =
+        cost.symbols.count { it is ManaSymbol.Colored && (it as ManaSymbol.Colored).color == Color.RED }
+
+    data class Fixture(val driver: GameTestDriver, val calculator: CostCalculator, val registry: CardRegistry)
+
+    fun setup(): Fixture {
+        val registry = CardRegistry()
+        registry.register(TestCards.all)
+        registry.register(RedLeech)
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RedLeech)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Island" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(driver.activePlayer!!, "Red Leech")
+        return Fixture(driver, CostCalculator(registry), registry)
+    }
+
+    test("red spell you cast costs an extra {R}") {
+        val (driver, calculator, registry) = setup()
+        val bolt = registry.requireCard("Lightning Bolt")
+        // Lightning Bolt base {R} → taxed to {R}{R}.
+        val cost = calculator.calculateEffectiveCost(driver.state, bolt, driver.activePlayer!!)
+        cost.cmc shouldBe 2
+        redPips(cost) shouldBe 2
+        cost.genericAmount shouldBe 0
+    }
+
+    test("non-red spell you cast is not taxed") {
+        val (driver, calculator, registry) = setup()
+        val counter = registry.requireCard("Counterspell")
+        // Counterspell {U}{U} stays {U}{U}.
+        val cost = calculator.calculateEffectiveCost(driver.state, counter, driver.activePlayer!!)
+        cost.cmc shouldBe 2
+        redPips(cost) shouldBe 0
+    }
+
+    test("red spell cast by the opponent is not taxed") {
+        val (driver, calculator, registry) = setup()
+        val bolt = registry.requireCard("Lightning Bolt")
+        // The tax is YouCast-scoped: the opponent pays the base {R} only.
+        val cost = calculator.calculateEffectiveCost(driver.state, bolt, driver.player2)
+        cost.cmc shouldBe 1
+        redPips(cost) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeechColoredTaxTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeechColoredTaxTest.kt
@@ -47,7 +47,7 @@ class LeechColoredTaxTest : FunSpec({
     )
 
     fun redPips(cost: ManaCost): Int =
-        cost.symbols.count { it is ManaSymbol.Colored && (it as ManaSymbol.Colored).color == Color.RED }
+        cost.symbols.count { it is ManaSymbol.Colored && it.color == Color.RED }
 
     data class Fixture(val driver: GameTestDriver, val calculator: CostCalculator, val registry: CardRegistry)
 


### PR DESCRIPTION
Adds the five Invasion (INV) "Leech" creatures. Each one is a colored spell-cost tax: spells you cast of the matching color cost one extra colored pip.

## Cards
- **Alabaster Leech** — `{W}` 1/3. White spells you cast cost `{W}` more to cast.
- **Andradite Leech** — `{2}{B}` 2/2. Black spells you cast cost `{B}` more to cast; `{B}`: this creature gets +1/+1 until end of turn.
- **Jade Leech** — `{2}{G}{G}` 5/5. Green spells you cast cost `{G}` more to cast.
- **Ruby Leech** — `{1}{R}` 2/2, first strike. Red spells you cast cost `{R}` more to cast.
- **Sapphire Leech** — `{1}{U}` 2/2, flying. Blue spells you cast cost `{U}` more to cast.

## SDK / engine change
The leeches' tax adds a *colored* mana symbol, which the unified `ModifySpellCost` static ability could not previously express (only `IncreaseGeneric`). Added:
- `CostModification.IncreaseColored(symbols)` in `CostStaticAbilities.kt` (colored counterpart to `IncreaseGeneric`), plus its description text.
- `CostCalculator` wiring: a colored-increase accumulator and an `increaseColoredCost` helper that appends colored pips to the effective cost, applied before reductions per CR 601.2f.
- Updated `docs/card-sdk-language-reference.md`.

## Tests
`LeechColoredTaxTest` checks the `YouCast`-scoped colored tax directly through `CostCalculator`: a red spell you cast is taxed to `{R}{R}`, a blue spell is untaxed, and a red spell the opponent casts stays `{R}`. Full `rules-engine`, `mtg-sets`, `mtg-sdk`, and `game-server` suites pass. `just check-card-printing` confirms all five are canonical in INV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)