### PR TITLE
Add Invasion instants and sorceries

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -49,6 +49,7 @@ import com.wingedsheep.mtg.sets.definitions.tdm.TarkirDragonstormSet
 import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
 import com.wingedsheep.mtg.sets.definitions.tmp.TempestSet
 import com.wingedsheep.mtg.sets.definitions.usg.UrzasSagaSet
+import com.wingedsheep.mtg.sets.definitions.vis.VisionsSet
 import com.wingedsheep.mtg.sets.definitions.vow.InnistradCrimsonVowSet
 import com.wingedsheep.mtg.sets.definitions.war.WarOfTheSparkSet
 import com.wingedsheep.mtg.sets.definitions.woe.WildsOfEldrainSet
@@ -144,6 +145,7 @@ abstract class ScenarioTestBase : FunSpec() {
         register(TarkirDragonstormSet.cards)
         register(TempestSet.cards); register(TempestSet.basicLands)
         register(UrzasSagaSet.cards); register(UrzasSagaSet.basicLands)
+        register(VisionsSet.cards)
         register(WarOfTheSparkSet.cards)
         register(WildsOfEldrainSet.cards)
     }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ExplosiveGrowthScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ExplosiveGrowthScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Explosive Growth.
+ *
+ * Explosive Growth ({G}, Instant, Kicker {5}): "Target creature gets +2/+2 until end
+ * of turn. If this spell was kicked, that creature gets +5/+5 until end of turn instead."
+ */
+class ExplosiveGrowthScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Explosive Growth") {
+
+            test("unkicked gives target creature +2/+2") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Explosive Growth")
+                    .withLandsOnBattlefield(1, "Forest", 1) // {G}
+                    .withCardOnBattlefield(1, "Hill Giant") // 3/3
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val castResult = game.castSpell(1, "Explosive Growth", giant)
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+                withClue("Hill Giant should be 5/5 after +2/+2") {
+                    projected.getPower(giant) shouldBe 5
+                    projected.getToughness(giant) shouldBe 5
+                }
+            }
+
+            test("kicked gives target creature +5/+5 instead") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Explosive Growth")
+                    .withLandsOnBattlefield(1, "Forest", 6) // {G} + {5} kicker
+                    .withCardOnBattlefield(1, "Hill Giant") // 3/3
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Explosive Growth"
+                }
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId,
+                        cardId,
+                        targets = listOf(ChosenTarget.Permanent(giant)),
+                        wasKicked = true
+                    )
+                )
+                withClue("Kicked cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+                withClue("Hill Giant should be 8/8 after +5/+5 (kicked)") {
+                    projected.getPower(giant) shouldBe 8
+                    projected.getToughness(giant) shouldBe 8
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/LightningDartScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/LightningDartScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Lightning Dart.
+ *
+ * Lightning Dart ({1}{R}, Instant): "Lightning Dart deals 1 damage to target creature.
+ * If that creature is white or blue, Lightning Dart deals 4 damage to it instead."
+ *
+ * Exercises the resolution-time color check via Conditions.TargetMatchesFilter.
+ */
+class LightningDartScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lightning Dart") {
+
+            test("deals only 1 damage to a non-white, non-blue creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Lightning Dart")
+                    .withLandsOnBattlefield(1, "Mountain", 2) // {1}{R}
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3, red
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val castResult = game.castSpell(1, "Lightning Dart", giant)
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Red 3/3 takes only 1 damage and survives") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+            }
+
+            test("deals 4 damage to a white creature, killing it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Lightning Dart")
+                    .withLandsOnBattlefield(1, "Mountain", 2) // {1}{R}
+                    .withCardOnBattlefield(2, "Capashen Unicorn") // 1/2, white
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val unicorn = game.findPermanent("Capashen Unicorn")!!
+
+                val castResult = game.castSpell(1, "Lightning Dart", unicorn)
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("White 1/2 takes 4 damage and dies") {
+                    game.isOnBattlefield("Capashen Unicorn") shouldBe false
+                    game.isInGraveyard(2, "Capashen Unicorn") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RecklessSpiteScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RecklessSpiteScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Reckless Spite.
+ *
+ * Reckless Spite ({1}{B}{B}, Instant): "Destroy two target nonblack creatures.
+ * You lose 5 life." Canonical printing is Tempest; reprinted in Invasion.
+ */
+class RecklessSpiteScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Reckless Spite") {
+
+            test("destroys two nonblack creatures and the caster loses 5 life") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Reckless Spite")
+                    .withLandsOnBattlefield(1, "Swamp", 3) // {1}{B}{B}
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3, red
+                    .withCardOnBattlefield(2, "Capashen Unicorn") // 1/2, white
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val unicorn = game.findPermanent("Capashen Unicorn")!!
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Reckless Spite"
+                }
+
+                val castResult = game.execute(
+                    CastSpell(
+                        playerId,
+                        cardId,
+                        targets = listOf(ChosenTarget.Permanent(giant), ChosenTarget.Permanent(unicorn))
+                    )
+                )
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Both targeted nonblack creatures are destroyed") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isOnBattlefield("Capashen Unicorn") shouldBe false
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                    game.isInGraveyard(2, "Capashen Unicorn") shouldBe true
+                }
+                withClue("Caster loses 5 life: 20 -> 15") {
+                    game.getLifeTotal(1) shouldBe 15
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SimoonScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SimoonScenarioTest.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Simoon.
+ *
+ * Simoon ({R}{G}, Instant): "Simoon deals 1 damage to each creature target opponent
+ * controls." Canonical printing is Visions; reprinted in Invasion.
+ *
+ * Exercises the ControllerPredicate.ControlledByTargetOpponent filter path: only the
+ * targeted opponent's creatures are damaged, not the caster's.
+ */
+class SimoonScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Simoon") {
+
+            test("deals 1 damage to each creature the targeted opponent controls only") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Simoon")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1) // {R}{G}
+                    .withCardOnBattlefield(1, "Hill Giant") // caster's 3/3 — must be untouched
+                    .withCardOnBattlefield(2, "Jungle Lion") // opponent's 2/1 — dies
+                    .withCardOnBattlefield(2, "Coral Eel") // opponent's 2/1 — dies
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpellTargetingPlayer(1, "Simoon", 2)
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Each of the targeted opponent's 2/1 creatures dies to 1 damage") {
+                    game.isOnBattlefield("Jungle Lion") shouldBe false
+                    game.isOnBattlefield("Coral Eel") shouldBe false
+                    game.isInGraveyard(2, "Jungle Lion") shouldBe true
+                    game.isInGraveyard(2, "Coral Eel") shouldBe true
+                }
+                withClue("The caster's own creature takes no damage") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TangleScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TangleScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Tangle.
+ *
+ * Tangle ({1}{G}, Instant): "Prevent all combat damage that would be dealt this turn.
+ * Each attacking creature doesn't untap during its controller's next untap step."
+ *
+ * Exercises composing PreventAllCombatDamage with a ForEachInGroup over attacking
+ * creatures granting the DOESNT_UNTAP flag for Duration.UntilAfterAffectedControllersNextUntap.
+ */
+class TangleScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Tangle") {
+
+            test("prevents combat damage and keeps the attacker tapped through its next untap step") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Hill Giant") // 3/3 attacker
+                    .withCardInHand(2, "Tangle")
+                    .withLandsOnBattlefield(2, "Forest", 2) // {1}{G}
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val giantId = game.findPermanent("Hill Giant")!!
+                val startingLife = game.getLifeTotal(2)
+
+                val attackResult = game.execute(
+                    DeclareAttackers(game.player1Id, mapOf(giantId to game.player2Id))
+                )
+                withClue("Attack should succeed: ${attackResult.error}") {
+                    attackResult.error shouldBe null
+                }
+
+                withClue("Attacker is tapped after attacking") {
+                    game.state.getEntity(giantId)?.has<TappedComponent>() shouldBe true
+                }
+
+                // Active player passes priority so the defender can act.
+                game.passPriority()
+
+                // Defender casts Tangle (instant) while attackers are declared.
+                val castResult = game.castSpell(2, "Tangle")
+                withClue("Tangle should cast successfully: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Resolve combat: no damage should be dealt.
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                withClue("Defender takes no combat damage (all prevented)") {
+                    game.getLifeTotal(2) shouldBe startingLife
+                }
+
+                // Advance to the attacker's controller's (player 1's) next untap step.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passPriority()
+                game.passPriority()
+                // Player 2's turn now; play it out.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passPriority()
+                game.passPriority()
+
+                // Player 1's untap step has now occurred (via the upkeep advance).
+                withClue("It should be Player 1's turn again") {
+                    game.state.activePlayerId shouldBe game.player1Id
+                }
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                withClue("Hill Giant did not untap during its controller's next untap step") {
+                    game.state.getEntity(giantId)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -60,6 +60,7 @@ import com.wingedsheep.mtg.sets.definitions.scg.ScourgeSet
 import com.wingedsheep.mtg.sets.definitions.soi.ShadowsOverInnistradSet
 import com.wingedsheep.mtg.sets.definitions.tmp.TempestSet
 import com.wingedsheep.mtg.sets.definitions.usg.UrzasSagaSet
+import com.wingedsheep.mtg.sets.definitions.vis.VisionsSet
 import com.wingedsheep.mtg.sets.definitions.otj.OutlawsOfThunderJunctionSet
 import com.wingedsheep.mtg.sets.definitions.spm.SpiderManSet
 import com.wingedsheep.mtg.sets.definitions.tdm.TarkirDragonstormSet
@@ -85,6 +86,7 @@ object MtgSetCatalog {
         PortalSet,
         PortalSecondAgeSet,
         MirageSet,
+        VisionsSet,
         TempestSet,
         ExodusSet,
         UrzasSagaSet,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ExplosiveGrowth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ExplosiveGrowth.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Explosive Growth
+ * {G}
+ * Instant
+ * Kicker {5}
+ * Target creature gets +2/+2 until end of turn. If this spell was kicked,
+ * that creature gets +5/+5 until end of turn instead.
+ */
+val ExplosiveGrowth = card("Explosive Growth") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Kicker {5} (You may pay an additional {5} as you cast this spell.)\n" +
+        "Target creature gets +2/+2 until end of turn. If this spell was kicked, " +
+        "that creature gets +5/+5 until end of turn instead."
+
+    keywordAbility(KeywordAbility.kicker("{5}"))
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = ConditionalEffect(
+            condition = WasKicked,
+            effect = Effects.ModifyStats(5, 5, t),
+            elseEffect = Effects.ModifyStats(2, 2, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/eabc1e77-404c-436b-bde1-be1b21d00584.jpg?1562942177"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LightningDart.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LightningDart.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Lightning Dart
+ * {1}{R}
+ * Instant
+ * Lightning Dart deals 1 damage to target creature. If that creature is white
+ * or blue, Lightning Dart deals 4 damage to it instead.
+ */
+val LightningDart = card("Lightning Dart") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Lightning Dart deals 1 damage to target creature. If that creature is white or blue, " +
+        "Lightning Dart deals 4 damage to it instead."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(
+                Filters.Creature.withAnyColor(Color.WHITE, Color.BLUE)
+            ),
+            effect = Effects.DealDamage(4, t),
+            elseEffect = Effects.DealDamage(1, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "152"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54d05157-d154-4203-bf3e-add110cb1cee.jpg?1562912254"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RecklessSpiteReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RecklessSpiteReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reckless Spite reprint in Invasion.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Tempest's
+ * `cards/` package; this file contributes only the Invasion-specific presentation row.
+ */
+val RecklessSpiteReprint = Printing(
+    oracleId = "a684df3a-5441-4daa-86d1-c47a91b35e6a",
+    name = "Reckless Spite",
+    setCode = "INV",
+    collectorNumber = "121",
+    scryfallId = "2412497b-cae5-444d-9beb-7761d15cd5c5",
+    artist = "Chippy",
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/2412497b-cae5-444d-9beb-7761d15cd5c5.jpg?1562902258",
+    releaseDate = "2000-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SimoonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SimoonReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Simoon reprint in Invasion.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Visions'
+ * `cards/` package; this file contributes only the Invasion-specific presentation row.
+ */
+val SimoonReprint = Printing(
+    oracleId = "128e201a-f520-4917-a1a4-2f3836f1f92d",
+    name = "Simoon",
+    setCode = "INV",
+    collectorNumber = "272",
+    scryfallId = "84b1930d-2e4b-472f-98a9-008fd632f3be",
+    artist = "Tony Szczudlo",
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/84b1930d-2e4b-472f-98a9-008fd632f3be.jpg?1562921826",
+    releaseDate = "2000-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Tangle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Tangle.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tangle
+ * {1}{G}
+ * Instant
+ * Prevent all combat damage that would be dealt this turn.
+ * Each attacking creature doesn't untap during its controller's next untap step.
+ */
+val Tangle = card("Tangle") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt this turn.\n" +
+        "Each attacking creature doesn't untap during its controller's next untap step."
+
+    spell {
+        effect = Effects.PreventAllCombatDamage()
+            .then(
+                ForEachInGroupEffect(
+                    GroupFilter.AttackingCreatures,
+                    GrantKeywordEffect(
+                        AbilityFlag.DOESNT_UNTAP.name,
+                        EffectTarget.Self,
+                        Duration.UntilAfterAffectedControllersNextUntap
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "213"
+        artist = "John Avon"
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b37e39c-8aa4-4938-a492-7dac5de98dfb.jpg?1562916551"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/RecklessSpite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/RecklessSpite.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Reckless Spite
+ * {1}{B}{B}
+ * Instant
+ * Destroy two target nonblack creatures. You lose 5 life.
+ *
+ * Canonical printing is Tempest (earliest real expansion). Later printings
+ * (Invasion, etc.) contribute only `Printing(...)` rows.
+ */
+val RecklessSpite = card("Reckless Spite") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy two target nonblack creatures. You lose 5 life."
+
+    spell {
+        target = TargetCreature(count = 2, filter = TargetFilter.Creature.notColor(Color.BLACK))
+        effect = CompositeEffect(
+            listOf(
+                Effects.Destroy(EffectTarget.ContextTarget(0)),
+                Effects.Destroy(EffectTarget.ContextTarget(1)),
+                Effects.LoseLife(5, EffectTarget.PlayerRef(Player.You))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "152"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/9141daea-1f4f-4227-b7d7-20753e3cb4d4.jpg?1562055421"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/VisionsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/VisionsSet.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.vis
+
+import com.wingedsheep.mtg.sets.definitions.por.PortalSet
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Visions Set (1997)
+ *
+ * Visions was the second set in the Mirage block, a stand-alone expansion set
+ * on the plane of Jamuraa. It continued the Mirage block's themes and is the
+ * earliest printing of several cards later reprinted in Invasion.
+ *
+ * Set Code: VIS
+ * Release Date: February 3, 1997
+ * Card Count: 167
+ */
+object VisionsSet : MtgSet {
+
+    override val code = "VIS"
+    override val displayName = "Visions"
+    override val releaseDate = "1997-02-03"
+    override val block = "Mirage"
+    override val basicLandsFallback = PortalSet
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.vis.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/Simoon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/Simoon.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.vis.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Simoon
+ * {R}{G}
+ * Instant
+ * Simoon deals 1 damage to each creature target opponent controls.
+ *
+ * Canonical printing is Visions (earliest real expansion). Later printings
+ * (Invasion, etc.) contribute only `Printing(...)` rows.
+ */
+val Simoon = card("Simoon") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Instant"
+    oracleText = "Simoon deals 1 damage to each creature target opponent controls."
+
+    spell {
+        target = Targets.Opponent
+        effect = ForEachInGroupEffect(
+            GroupFilter(Filters.Creature.targetOpponentControls()),
+            DealDamageEffect(1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "136"
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/642d9239-82e0-4696-ad99-10796042d1f8.jpg?1587913163"
+    }
+}


### PR DESCRIPTION
Adds five Invasion (INV) spells. All are composed from existing SDK primitives — no new effect, condition, or filter types were added.

## Cards

- **Explosive Growth** `{G}` Instant, Kicker {5} — Target creature gets +2/+2 until end of turn; +5/+5 instead if kicked. `ConditionalEffect` on `WasKicked`.
- **Lightning Dart** `{1}{R}` Instant — 1 damage to target creature; 4 instead if it is white or blue. `Conditions.TargetMatchesFilter` + `Filters.Creature.withAnyColor(WHITE, BLUE)`.
- **Reckless Spite** `{1}{B}{B}` Instant — Destroy two target nonblack creatures; you lose 5 life. Canonical `CardDefinition` placed in Tempest (earliest real printing); Invasion contributes a `Printing` reprint row.
- **Tangle** `{1}{G}` Instant — Prevent all combat damage this turn; each attacking creature doesn't untap during its controller's next untap step. `PreventAllCombatDamage` + `ForEachInGroup(AttackingCreatures)` granting `DOESNT_UNTAP` for `Duration.UntilAfterAffectedControllersNextUntap`.
- **Simoon** `{R}{G}` Instant — 1 damage to each creature target opponent controls. `ForEachInGroup` over `Filters.Creature.targetOpponentControls()` (first card user of `ControllerPredicate.ControlledByTargetOpponent`). Canonical lives in a newly scaffolded **Visions (VIS)** set; Invasion contributes a `Printing` reprint row.

## Set scaffolding

- Scaffolds `VisionsSet` (VIS) and registers it in `MtgSetCatalog` and `ScenarioTestBase` so its single card (Simoon) resolves.

## Tests

- Scenario tests for all five cards in `game-server`. All pass, along with the full `rules-engine` and `mtg-sets` suites (catalog/discovery/printing checks).
- `just check-card-printing` reports the correct canonical placement for each card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)