### PR TITLE
Add Invasion counterspells and removal: Angelic Shield, Dismantling Blow, Exclude, Prohibit

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionCounterspellsScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionCounterspellsScenarioTest.kt
@@ -1,0 +1,257 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for four Invasion (INV) cards:
+ *  - Angelic Shield ({W}{U} Enchantment; creatures you control get +0/+1; Sacrifice: bounce target creature)
+ *  - Dismantling Blow ({2}{W} Instant; Kicker {2}{U}; destroy target artifact/enchantment, draw 2 if kicked)
+ *  - Exclude ({2}{U} Instant; counter target creature spell, draw a card)
+ *  - Prohibit ({1}{U} Instant; Kicker {2}; counter target spell if MV ≤ 2, or ≤ 4 if kicked)
+ */
+class InvasionCounterspellsScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Angelic Shield") {
+            test("gives creatures you control +0/+1 and can be sacrificed to bounce a creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardOnBattlefield(1, "Angelic Shield")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withCardOnBattlefield(2, "Glory Seeker")  // 2/2 opponent
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearsId = game.findPermanent("Grizzly Bears")!!
+                val seekerId = game.findPermanent("Glory Seeker")!!
+
+                // Anthem: your Grizzly Bears is 2/3, opponent's Glory Seeker is unaffected (2/2).
+                val projected = projector.project(game.state)
+                withClue("Grizzly Bears should be buffed to 2/3 by Angelic Shield") {
+                    projected.getToughness(bearsId) shouldBe 3
+                }
+                withClue("Opponent's Glory Seeker should be unaffected (2/2)") {
+                    projected.getToughness(seekerId) shouldBe 2
+                }
+
+                // Sacrifice Angelic Shield to bounce the opponent's Glory Seeker.
+                val shieldId = game.findPermanent("Angelic Shield")!!
+                val cardDef = cardRegistry.getCard("Angelic Shield")!!
+                val ability = cardDef.script.activatedAbilities.first()
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = shieldId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(seekerId))
+                    )
+                )
+                game.resolveStack()
+
+                withClue("Glory Seeker should be returned to its owner's hand") {
+                    game.isInHand(2, "Glory Seeker") shouldBe true
+                }
+                withClue("Angelic Shield should be sacrificed (in graveyard)") {
+                    game.isInGraveyard(1, "Angelic Shield") shouldBe true
+                }
+            }
+        }
+
+        context("Dismantling Blow") {
+            test("destroys target artifact without kicker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Dismantling Blow")
+                    .withLandsOnBattlefield(1, "Plains", 3) // {2}{W}
+                    .withCardOnBattlefield(2, "Icy Manipulator")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val icyId = game.findPermanent("Icy Manipulator")!!
+                val handSizeBefore = game.state.getHand(game.player1Id).size
+
+                game.castSpell(1, "Dismantling Blow", icyId)
+                game.resolveStack()
+
+                withClue("Icy Manipulator should be destroyed") {
+                    game.isInGraveyard(2, "Icy Manipulator") shouldBe true
+                }
+                // Cast the spell from hand (removes 1), no draw without kicker.
+                withClue("No cards drawn without kicker") {
+                    game.state.getHand(game.player1Id).size shouldBe handSizeBefore - 1
+                }
+            }
+
+            test("draws two cards when kicked") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Dismantling Blow")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLandsOnBattlefield(1, "Island", 3) // {2}{U} kicker
+                    .withCardOnBattlefield(2, "Icy Manipulator")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val icyId = game.findPermanent("Icy Manipulator")!!
+                val playerId = game.player1Id
+                val handSizeBefore = game.state.getHand(playerId).size
+                val cardId = game.state.getHand(playerId).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Dismantling Blow"
+                }
+
+                game.execute(
+                    CastSpell(
+                        playerId = playerId,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(icyId)),
+                        wasKicked = true,
+                    )
+                )
+                game.resolveStack()
+
+                withClue("Icy Manipulator should be destroyed") {
+                    game.isInGraveyard(2, "Icy Manipulator") shouldBe true
+                }
+                // -1 for the cast spell, +2 from the kicked draw → net +1.
+                withClue("Kicked Dismantling Blow draws two cards") {
+                    game.state.getHand(playerId).size shouldBe handSizeBefore + 1
+                }
+            }
+        }
+
+        context("Exclude") {
+            test("counters a creature spell and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Exclude")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.state.getHand(game.player1Id).size
+
+                // Opponent casts Grizzly Bears.
+                game.castSpell(2, "Grizzly Bears")
+                game.passPriority()
+
+                // Player1 responds with Exclude targeting the creature spell.
+                game.castSpellTargetingStackSpell(1, "Exclude", "Grizzly Bears")
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be countered (in graveyard)") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                // -1 Exclude cast, +1 draw → net 0.
+                withClue("Exclude draws a card") {
+                    game.state.getHand(game.player1Id).size shouldBe handBefore
+                }
+            }
+        }
+
+        context("Prohibit") {
+            test("counters a mana value 2 spell without kicker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Prohibit")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(2, "Grizzly Bears") // MV 2
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Grizzly Bears")
+                game.passPriority()
+                game.castSpellTargetingStackSpell(1, "Prohibit", "Grizzly Bears")
+                game.resolveStack()
+
+                withClue("MV 2 Grizzly Bears should be countered") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("does not counter a mana value 4 spell without kicker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Prohibit")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(2, "Hill Giant") // {3}{R} MV 4
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Hill Giant")
+                game.passPriority()
+                game.castSpellTargetingStackSpell(1, "Prohibit", "Hill Giant")
+                game.resolveStack()
+
+                withClue("MV 4 Hill Giant should NOT be countered (resolves to battlefield)") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+            }
+
+            test("counters a mana value 4 spell when kicked") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Prohibit")
+                    .withLandsOnBattlefield(1, "Island", 4) // {1}{U} + {2} kicker
+                    .withCardInHand(2, "Hill Giant")
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Hill Giant")
+                game.passPriority()
+
+                val playerId = game.player1Id
+                val prohibitId = game.state.getHand(playerId).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Prohibit"
+                }
+                val giantSpellId = game.state.stack.first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Hill Giant"
+                }
+                game.execute(
+                    CastSpell(
+                        playerId = playerId,
+                        cardId = prohibitId,
+                        targets = listOf(ChosenTarget.Spell(giantSpellId)),
+                        wasKicked = true,
+                    )
+                )
+                game.resolveStack()
+
+                withClue("Kicked Prohibit counters MV 4 Hill Giant") {
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AngelicShield.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AngelicShield.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Angelic Shield
+ * {W}{U}
+ * Enchantment
+ *
+ * Creatures you control get +0/+1.
+ * Sacrifice this enchantment: Return target creature to its owner's hand.
+ */
+val AngelicShield = card("Angelic Shield") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Enchantment"
+    oracleText = "Creatures you control get +0/+1.\n" +
+        "Sacrifice this enchantment: Return target creature to its owner's hand."
+
+    // Creatures you control get +0/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 0,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    // Sacrifice this enchantment: Return target creature to its owner's hand.
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        target = Targets.Creature
+        effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "228"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5aaa3e4e-4e08-4df2-9e0c-66e15a10fec4.jpg?1562913430"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DismantlingBlow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DismantlingBlow.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dismantling Blow
+ * {2}{W}
+ * Instant
+ * Kicker {2}{U}
+ * Destroy target artifact or enchantment. If this spell was kicked, draw two cards.
+ */
+val DismantlingBlow = card("Dismantling Blow") {
+    manaCost = "{2}{W}"
+    colorIdentity = "WU"
+    typeLine = "Instant"
+    oracleText = "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\n" +
+        "Destroy target artifact or enchantment. If this spell was kicked, draw two cards."
+
+    keywordAbility(KeywordAbility.kicker("{2}{U}"))
+
+    spell {
+        target = Targets.ArtifactOrEnchantment
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0)) then ConditionalEffect(
+            condition = WasKicked,
+            effect = Effects.DrawCards(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Mark Tedin"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39514d54-cb6c-4b3b-a3be-46db991be4d4.jpg?1562906533"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Exclude.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Exclude.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Exclude
+ * {2}{U}
+ * Instant
+ * Counter target creature spell.
+ * Draw a card.
+ */
+val Exclude = card("Exclude") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target creature spell.\nDraw a card."
+
+    spell {
+        target = Targets.CreatureSpell
+        effect = Effects.CounterSpell() then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Mark Romanoski"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aeb359c8-209c-455f-84b2-970e5678a9fa.jpg?1562930137"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Prohibit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Prohibit.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Prohibit
+ * {1}{U}
+ * Instant
+ * Kicker {2}
+ * Counter target spell if its mana value is 2 or less. If this spell was kicked,
+ * counter that spell if its mana value is 4 or less instead.
+ */
+val Prohibit = card("Prohibit") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Kicker {2} (You may pay an additional {2} as you cast this spell.)\n" +
+        "Counter target spell if its mana value is 2 or less. If this spell was kicked, " +
+        "counter that spell if its mana value is 4 or less instead."
+
+    keywordAbility(KeywordAbility.kicker("{2}"))
+
+    spell {
+        target = Targets.Spell
+        // If kicked, counter when the target's mana value is 4 or less; otherwise 2 or less.
+        effect = ConditionalEffect(
+            condition = WasKicked,
+            effect = ConditionalEffect(
+                condition = Conditions.TargetSpellManaValueAtMost(DynamicAmount.Fixed(4)),
+                effect = Effects.CounterSpell()
+            ),
+            elseEffect = ConditionalEffect(
+                condition = Conditions.TargetSpellManaValueAtMost(DynamicAmount.Fixed(2)),
+                effect = Effects.CounterSpell()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "67"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0daa5458-2a97-40d0-b18d-2381a7a68ee1.jpg?1562897807"
+    }
+}


### PR DESCRIPTION
## Summary

Implements four Invasion (INV) cards. All four compose existing SDK primitives — **no new engine mechanics were needed**, so no SDK changes or doc updates.

| Card | Cost | Implementation |
|------|------|----------------|
| **Angelic Shield** | `{W}{U}` Enchantment | `ModifyStats` anthem (+0/+1 to creatures you control) + `SacrificeSelf`-cost activated ability that `ReturnToHand`s a target creature |
| **Dismantling Blow** | `{2}{W}` Instant, Kicker `{2}{U}` | `Destroy` target artifact or enchantment, then `ConditionalEffect(WasKicked, DrawCards(2))` |
| **Exclude** | `{2}{U}` Instant | `CounterSpell()` on a creature-spell target, then `DrawCards(1)` |
| **Prohibit** | `{1}{U}` Instant, Kicker `{2}` | Nested `ConditionalEffect` on `WasKicked` gating `CounterSpell()` by `TargetSpellManaValueAtMost` (≤2 base, ≤4 kicked), mirroring Dispersal Shield |

INV is the earliest real printing for all four, and INV is already scaffolded — canonical `CardDefinition`s live directly in `definitions/inv/cards/`. `check-card-printing` confirms canonical placement. Cards auto-register via `CardDiscovery`.

## Tests

New `InvasionCounterspellsScenarioTest` (7 tests, all passing) covers:
- Angelic Shield anthem buff (projected toughness) + sacrifice-to-bounce.
- Dismantling Blow destroy (unkicked, no draw) and kicked (destroy + draw two).
- Exclude countering a creature spell and drawing.
- Prohibit gating: counters MV 2 unkicked, lets MV 4 resolve unkicked, counters MV 4 when kicked.

## Skipped

None — all four implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)