### PR TITLE
Add Invasion cards: Kavu Titan, Harrow, Thicket Elemental, Restock

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HarrowScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HarrowScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Harrow.
+ *
+ * Card reference:
+ * - Harrow ({2}{G}): Instant
+ *   As an additional cost to cast this spell, sacrifice a land.
+ *   Search your library for up to two basic land cards, put them onto the battlefield, then shuffle.
+ */
+class HarrowScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Harrow") {
+
+            test("sacrifices a land and puts two basic lands onto the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Harrow")
+                    .withLandsOnBattlefield(1, "Forest", 4) // {2}{G} + one to sacrifice
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val initialForests = game.findPermanents("Forest").size
+
+                val castResult = game.castSpellWithAdditionalSacrifice(1, "Harrow", "Forest")
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Pick two basic lands from the library.
+                val plains = game.state.getLibrary(game.player1Id).filter { id ->
+                    val n = game.state.getEntity(id)?.get<CardComponent>()?.name
+                    n == "Plains" || n == "Island"
+                }
+                game.selectCards(plains)
+                game.resolveStack()
+
+                withClue("One Forest was sacrificed (4 -> 3 remaining)") {
+                    game.findPermanents("Forest").size shouldBe initialForests - 1
+                }
+                withClue("Plains entered the battlefield") {
+                    game.isOnBattlefield("Plains") shouldBe true
+                }
+                withClue("Island entered the battlefield") {
+                    game.isOnBattlefield("Island") shouldBe true
+                }
+                withClue("Harrow is in the graveyard after resolving") {
+                    game.isInGraveyard(1, "Harrow") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavuTitanScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavuTitanScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.WasKickedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kavu Titan.
+ *
+ * Card reference:
+ * - Kavu Titan ({1}{G}): Creature — Kavu 2/2
+ *   Kicker {2}{G}
+ *   If this creature was kicked, it enters with three +1/+1 counters on it and with trample.
+ */
+class KavuTitanScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private fun ScenarioTestBase.TestGame.getCounters(entityId: EntityId): Int {
+        return state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Kavu Titan kicker") {
+
+            test("unkicked enters as a vanilla 2/2 with no counters and no trample") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Kavu Titan")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Kavu Titan")
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val titanId = game.findPermanent("Kavu Titan")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Unkicked Kavu Titan should have no +1/+1 counters") {
+                    game.getCounters(titanId) shouldBe 0
+                }
+                withClue("Unkicked Kavu Titan should NOT have trample") {
+                    projected.hasKeyword(titanId, Keyword.TRAMPLE) shouldBe false
+                }
+            }
+
+            test("kicked enters with three +1/+1 counters and trample") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Kavu Titan")
+                    .withLandsOnBattlefield(1, "Forest", 5) // {1}{G} + {2}{G} kicker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).find { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Kavu Titan"
+                }!!
+
+                val castResult = game.execute(CastSpell(playerId, cardId, wasKicked = true))
+                withClue("Kicked cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val titanId = game.findPermanent("Kavu Titan")!!
+
+                withClue("Permanent should have WasKickedComponent") {
+                    (game.state.getEntity(titanId)?.has<WasKickedComponent>() == true) shouldBe true
+                }
+                withClue("Kicked Kavu Titan should have three +1/+1 counters") {
+                    game.getCounters(titanId) shouldBe 3
+                }
+
+                val projected = stateProjector.project(game.state)
+                withClue("Kicked Kavu Titan should have trample") {
+                    projected.hasKeyword(titanId, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RestockScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RestockScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Restock.
+ *
+ * Card reference:
+ * - Restock ({3}{G}{G}): Sorcery
+ *   Return two target cards from your graveyard to your hand. Exile Restock.
+ */
+class RestockScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioTestBase.TestGame.graveyardCard(playerNumber: Int, name: String): EntityId {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getGraveyard(playerId).first { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+    }
+
+    init {
+        context("Restock") {
+
+            test("returns two target cards from graveyard to hand and exiles itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Restock")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withCardInGraveyard(1, "Llanowar Elite")
+                    .withCardInGraveyard(1, "Quirion Trailblazer")
+                    .withCardInGraveyard(1, "Recover")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val playerId = game.player1Id
+                val restockId = game.state.getHand(playerId).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Restock"
+                }
+
+                val target1 = game.graveyardCard(1, "Llanowar Elite")
+                val target2 = game.graveyardCard(1, "Quirion Trailblazer")
+                val targets = listOf(
+                    ChosenTarget.Card(target1, playerId, Zone.GRAVEYARD),
+                    ChosenTarget.Card(target2, playerId, Zone.GRAVEYARD)
+                )
+
+                val castResult = game.execute(CastSpell(playerId, restockId, targets))
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Llanowar Elite returned to hand") {
+                    game.isInHand(1, "Llanowar Elite") shouldBe true
+                }
+                withClue("Quirion Trailblazer returned to hand") {
+                    game.isInHand(1, "Quirion Trailblazer") shouldBe true
+                }
+                withClue("Recover remains in the graveyard (not targeted)") {
+                    game.isInGraveyard(1, "Recover") shouldBe true
+                }
+                withClue("Restock exiles itself instead of going to the graveyard") {
+                    game.isInGraveyard(1, "Restock") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ThicketElementalScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ThicketElementalScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Thicket Elemental.
+ *
+ * Card reference:
+ * - Thicket Elemental ({3}{G}{G}): Creature — Elemental 4/4
+ *   Kicker {1}{G}
+ *   When this creature enters, if it was kicked, you may reveal cards from the top of your library
+ *   until you reveal a creature card. If you do, put that card onto the battlefield and shuffle all
+ *   other cards revealed this way into your library.
+ */
+class ThicketElementalScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioTestBase.TestGame.castKicked(playerNumber: Int, name: String): com.wingedsheep.engine.core.ExecutionResult {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        val cardId = state.getHand(playerId).find { entityId ->
+            state.getEntity(entityId)?.get<CardComponent>()?.name == name
+        }!!
+        return execute(CastSpell(playerId, cardId, wasKicked = true))
+    }
+
+    init {
+        context("Thicket Elemental kicker") {
+
+            test("unkicked enters as a 4/4 with no ETB effect") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Thicket Elemental")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withCardInLibrary(1, "Llanowar Elite")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Thicket Elemental")
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Thicket Elemental is on the battlefield") {
+                    game.isOnBattlefield("Thicket Elemental") shouldBe true
+                }
+                withClue("Library creature was not pulled out (no trigger when unkicked)") {
+                    game.isOnBattlefield("Llanowar Elite") shouldBe false
+                }
+            }
+
+            test("kicked reveals until a creature and puts it onto the battlefield") {
+                // Library top-down: Forest, Plains, Llanowar Elite, Forest.
+                // Reveal until creature -> Llanowar Elite enters; revealed lands shuffle back.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Thicket Elemental")
+                    .withLandsOnBattlefield(1, "Forest", 7) // {3}{G}{G} + {1}{G} kicker
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Llanowar Elite")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val initialLibrary = game.librarySize(1)
+
+                val castResult = game.castKicked(1, "Thicket Elemental")
+                withClue("Kicked cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // "may" — say yes.
+                withClue("There should be a yes/no decision for the may ability") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Thicket Elemental is on the battlefield") {
+                    game.isOnBattlefield("Thicket Elemental") shouldBe true
+                }
+                withClue("Llanowar Elite was put onto the battlefield from the library") {
+                    game.isOnBattlefield("Llanowar Elite") shouldBe true
+                }
+                withClue("Library is smaller by one (the creature left; lands shuffled back)") {
+                    game.librarySize(1) shouldBe initialLibrary - 1
+                }
+            }
+
+            test("kicked but declining the may ability leaves the library intact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Thicket Elemental")
+                    .withLandsOnBattlefield(1, "Forest", 7)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Llanowar Elite")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val initialLibrary = game.librarySize(1)
+
+                game.castKicked(1, "Thicket Elemental")
+                game.resolveStack()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Declining leaves the library untouched") {
+                    game.librarySize(1) shouldBe initialLibrary
+                }
+                withClue("Llanowar Elite stays in the library") {
+                    game.isOnBattlefield("Llanowar Elite") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HarrowReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HarrowReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Harrow reprint in Invasion.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Tempest's `cards/`
+ * package (Harrow's earliest real-expansion printing); this file contributes only the
+ * Invasion-specific presentation row.
+ */
+val HarrowReprint = Printing(
+    oracleId = "705509e9-a034-4a5a-9c65-66f58748b8a2",
+    name = "Harrow",
+    setCode = "INV",
+    collectorNumber = "189",
+    scryfallId = "ed0f633e-7238-4d02-ad8b-06dd20453030",
+    artist = "Rob Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed0f633e-7238-4d02-ad8b-06dd20453030.jpg?1562942622",
+    releaseDate = "2000-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuTitan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuTitan.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kavu Titan
+ * {1}{G}
+ * Creature — Kavu
+ * 2/2
+ * Kicker {2}{G}
+ * If this creature was kicked, it enters with three +1/+1 counters on it and with trample.
+ */
+val KavuTitan = card("Kavu Titan") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Kavu"
+    power = 2
+    toughness = 2
+    oracleText = "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\n" +
+        "If this creature was kicked, it enters with three +1/+1 counters on it and with trample."
+
+    keywordAbility(KeywordAbility.kicker("{2}{G}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self, Duration.Permanent),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "194"
+        artist = "Todd Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c5fb86d-1d9a-4da2-bb5b-4266faa20197.jpg?1562904050"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Restock.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Restock.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Restock
+ * {3}{G}{G}
+ * Sorcery
+ * Return two target cards from your graveyard to your hand. Exile Restock.
+ */
+val Restock = card("Restock") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Return two target cards from your graveyard to your hand. Exile Restock."
+
+    spell {
+        target = TargetObject(
+            count = 2,
+            filter = TargetFilter(GameObjectFilter.Any.ownedByYou(), zone = Zone.GRAVEYARD)
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(MoveToZoneEffect(EffectTarget.ContextTarget(0), Zone.HAND))
+        )
+        selfExile()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "206"
+        artist = "Daren Bader"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11a013ff-7c99-445a-b9e0-0fc45036f068.jpg?1562898535"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ThicketElemental.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ThicketElemental.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+
+/**
+ * Thicket Elemental
+ * {3}{G}{G}
+ * Creature — Elemental
+ * 4/4
+ * Kicker {1}{G}
+ * When this creature enters, if it was kicked, you may reveal cards from the top of your library
+ * until you reveal a creature card. If you do, put that card onto the battlefield and shuffle all
+ * other cards revealed this way into your library.
+ */
+val ThicketElemental = card("Thicket Elemental") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    power = 4
+    toughness = 4
+    oracleText = "Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\n" +
+        "When this creature enters, if it was kicked, you may reveal cards from the top of your library " +
+        "until you reveal a creature card. If you do, put that card onto the battlefield and shuffle all " +
+        "other cards revealed this way into your library."
+
+    keywordAbility(KeywordAbility.kicker("{1}{G}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = MayEffect(
+            CompositeEffect(
+                listOf(
+                    GatherUntilMatchEffect(
+                        filter = GameObjectFilter.Creature,
+                        storeMatch = "found",
+                        storeRevealed = "allRevealed"
+                    ),
+                    // fromZone/toZone tag this as a zone-transition reveal so the client shows
+                    // the full reveal overlay including the matched creature (which lands on the
+                    // battlefield in the same update).
+                    RevealCollectionEffect(
+                        from = "allRevealed",
+                        fromZone = Zone.LIBRARY,
+                        toZone = Zone.BATTLEFIELD
+                    ),
+                    MoveCollectionEffect(
+                        from = "found",
+                        destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+                    ),
+                    ShuffleLibraryEffect()
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "214"
+        artist = "Ron Spencer"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f80a56ed-3ebb-4e20-bf6a-e27127f762e8.jpg?1562945003"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/Harrow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/Harrow.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Harrow
+ * {2}{G}
+ * Instant
+ * As an additional cost to cast this spell, sacrifice a land.
+ * Search your library for up to two basic land cards, put them onto the battlefield, then shuffle.
+ *
+ * Canonical printing: Tempest (1997) is Harrow's earliest real-expansion printing.
+ */
+val Harrow = card("Harrow") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a land.\n" +
+        "Search your library for up to two basic land cards, put them onto the battlefield, then shuffle."
+
+    additionalCost(AdditionalCost.SacrificePermanent(filter = GameObjectFilter.Land))
+
+    spell {
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            count = 2,
+            destination = SearchDestination.BATTLEFIELD,
+            shuffleAfter = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "230"
+        artist = "Eric David Anderson"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c207142-4880-4935-9827-b91bc7d9d643.jpg?1562053754"
+    }
+}


### PR DESCRIPTION
Implements four Invasion (INV) green cards. All four compose existing SDK primitives — no engine or SDK changes were required.

## Cards

- **Kavu Titan** `{1}{G}` Creature — Kavu 2/2. Kicker `{2}{G}`; if kicked, enters with three +1/+1 counters and trample. Modeled like Benalish Lancer: a `WasKicked` ETB trigger composing `AddCounters` + permanent `GrantKeyword(TRAMPLE)`.
- **Harrow** `{2}{G}` Instant. Additional cost: sacrifice a land. Searches for up to two basic lands onto the battlefield, then shuffles. Uses `AdditionalCost.SacrificePermanent` + `EffectPatterns.searchLibrary(count = 2, BATTLEFIELD)` (`ChooseUpTo` gives the "up to two" semantics).
  - The canonical `CardDefinition` lives in **Tempest** (`tmp`), Harrow's earliest real-expansion printing per `check-card-printing`. Invasion contributes a `Printing` row (`HarrowReprint`).
- **Thicket Elemental** `{3}{G}{G}` Creature — Elemental 4/4. Kicker `{1}{G}`; if kicked, *may* reveal cards until a creature card, put it onto the battlefield, and shuffle the rest back. Reuses the Polymorph-shaped `GatherUntilMatchEffect → RevealCollection → MoveCollection → ShuffleLibrary` composite wrapped in `MayEffect`.
- **Restock** `{3}{G}{G}` Sorcery. Returns two target cards from your graveyard to hand, then exiles itself. Two-target `TargetObject` over your graveyard + `ForEachTargetEffect(MoveToZone HAND)`; "Exile Restock" handled by the spell DSL `selfExile()` flag.

## Tests

Added scenario tests in `game-server` (all passing):
- `KavuTitanScenarioTest` — unkicked vanilla 2/2 vs. kicked 3 counters + trample.
- `HarrowScenarioTest` — sacrifice a land, fetch two basics, Harrow to graveyard.
- `ThicketElementalScenarioTest` — unkicked no-op, kicked reveal-until-creature, and declining the may ability.
- `RestockScenarioTest` — returns two graveyard targets to hand and self-exiles.

No cards were skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)