### PR TITLE
Add Invasion spells: Addle, Hypnotic Cloud, Skizzik, Urza's Rage

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionSpellsBatchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionSpellsBatchScenarioTest.kt
@@ -1,0 +1,245 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for a batch of Invasion spells: Addle, Hypnotic Cloud, Skizzik, Urza's Rage.
+ */
+class InvasionSpellsBatchScenarioTest : ScenarioTestBase() {
+
+    // Mono-colored vanilla creatures for unambiguous color/hand contents.
+    private val blueDrake = CardDefinition.creature(
+        name = "Blue Drake", manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Drake")), power = 2, toughness = 2
+    )
+    private val greenBear = CardDefinition.creature(
+        name = "Green Bear", manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Bear")), power = 2, toughness = 2
+    )
+
+    init {
+        cardRegistry.register(blueDrake)
+        cardRegistry.register(greenBear)
+
+        context("Addle") {
+            test("choosing a color discards a card of that color from target player's hand") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Addle")
+                    .withLandsOnBattlefield(1, "Swamp", 2) // {1}{B}
+                    .withCardInHand(2, "Blue Drake")
+                    .withCardInHand(2, "Green Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Addle", 2)
+                game.resolveStack()
+
+                val colorDecision = game.getPendingDecision()
+                withClue("Should pause for a color choice on resolution") {
+                    (colorDecision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.BLUE))
+                game.resolveStack()
+
+                // With only one blue card, the engine selects it automatically (or via prompt).
+                if (game.getPendingDecision() != null) {
+                    val drake = game.state.getHand(game.player2Id).first {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Blue Drake"
+                    }
+                    game.selectCards(listOf(drake))
+                    game.resolveStack()
+                }
+
+                withClue("Blue Drake should have been discarded") {
+                    game.isInGraveyard(2, "Blue Drake") shouldBe true
+                }
+                withClue("Green Bear (not the chosen color) should remain in hand") {
+                    game.isInGraveyard(2, "Green Bear") shouldBe false
+                }
+            }
+        }
+
+        context("Hypnotic Cloud") {
+            test("unkicked makes target player discard one card") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Hypnotic Cloud")
+                    .withLandsOnBattlefield(1, "Swamp", 2) // {1}{B}
+                    .withCardInHand(2, "Blue Drake")
+                    .withCardInHand(2, "Green Bear")
+                    .withCardInHand(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Hypnotic Cloud", 2)
+                game.resolveStack()
+
+                // Opponent chooses one card to discard.
+                game.getPendingDecision() shouldNotBe null
+                game.selectCards(listOf(game.findCardsInHand(2, "Hill Giant").first()))
+                game.resolveStack()
+
+                withClue("Opponent should have discarded exactly one card (3 -> 2)") {
+                    game.handSize(2) shouldBe 2
+                }
+                withClue("The chosen Hill Giant should be in the graveyard") {
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+            }
+
+            test("kicked makes target player discard three cards") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Hypnotic Cloud")
+                    .withLandsOnBattlefield(1, "Swamp", 6) // {1}{B} + {4} kicker
+                    .withCardInHand(2, "Blue Drake")
+                    .withCardInHand(2, "Green Bear")
+                    .withCardInHand(2, "Hill Giant")
+                    .withCardInHand(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Hypnotic Cloud"
+                }
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                        wasKicked = true
+                    )
+                )
+                game.resolveStack()
+
+                // Opponent (4 cards in hand) chooses three to discard.
+                game.getPendingDecision() shouldNotBe null
+                game.selectCards(
+                    listOf(
+                        game.findCardsInHand(2, "Blue Drake").first(),
+                        game.findCardsInHand(2, "Green Bear").first(),
+                        game.findCardsInHand(2, "Hill Giant").first(),
+                    )
+                )
+                game.resolveStack()
+
+                withClue("Kicked Hypnotic Cloud should make the opponent discard three cards (4 -> 1)") {
+                    game.handSize(2) shouldBe 1
+                }
+            }
+        }
+
+        context("Skizzik") {
+            test("unkicked Skizzik is sacrificed at the end step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Skizzik")
+                    .withLandsOnBattlefield(1, "Mountain", 4) // {3}{R}, no kicker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Skizzik")
+                game.resolveStack()
+                withClue("Skizzik should be on the battlefield after resolving") {
+                    game.isOnBattlefield("Skizzik") shouldBe true
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Unkicked Skizzik should be sacrificed at end step") {
+                    game.isOnBattlefield("Skizzik") shouldBe false
+                    game.isInGraveyard(1, "Skizzik") shouldBe true
+                }
+            }
+
+            test("kicked Skizzik survives the end step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Skizzik")
+                    .withLandsOnBattlefield(1, "Mountain", 5) // {3}{R} + {R} kicker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Skizzik"
+                }
+                game.execute(CastSpell(game.player1Id, cardId, wasKicked = true))
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Kicked Skizzik should still be on the battlefield after end step") {
+                    game.isOnBattlefield("Skizzik") shouldBe true
+                }
+            }
+        }
+
+        context("Urza's Rage") {
+            test("unkicked deals 3 damage to target player") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Urza's Rage")
+                    .withLandsOnBattlefield(1, "Mountain", 3) // {2}{R}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Urza's Rage", 2)
+                game.resolveStack()
+
+                withClue("Opponent should take 3 damage (20 -> 17)") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+            }
+
+            test("kicked deals 10 damage to target player") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Urza's Rage")
+                    .withLandsOnBattlefield(1, "Mountain", 12) // {2}{R} + {8}{R} kicker = 12 mana
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Urza's Rage"
+                }
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                        wasKicked = true
+                    )
+                )
+                game.resolveStack()
+
+                withClue("Opponent should take 10 damage (20 -> 10)") {
+                    game.getLifeTotal(2) shouldBe 10
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/SkizzikReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/SkizzikReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.dom.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skizzik reprint in Dominaria. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Invasion set's `cards/`
+ * package (Invasion is the card's earliest real printing); this file contributes
+ * only presentation data for the Dominaria printing.
+ */
+val SkizzikReprint = Printing(
+    oracleId = "0c77d37e-791c-415e-b369-55e93147ec34",
+    name = "Skizzik",
+    setCode = "DOM",
+    collectorNumber = "145",
+    scryfallId = "77af9d28-1639-47bd-b925-7f3d2eefd352",
+    artist = "Tomasz Jedruszek",
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/77af9d28-1639-47bd-b925-7f3d2eefd352.jpg?1615334491",
+    releaseDate = "2018-04-27",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Addle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Addle.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Addle
+ * {1}{B}
+ * Sorcery
+ * Choose a color. Target player reveals their hand and you choose a card of that
+ * color from it. That player discards that card.
+ */
+val Addle = card("Addle") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Choose a color. Target player reveals their hand and you choose a card of " +
+        "that color from it. That player discards that card."
+
+    spell {
+        val targetPlayer = target("target player", TargetPlayer())
+        effect = Effects.ChooseColorThen(
+            then = CompositeEffect(
+                listOf(
+                    RevealHandEffect(targetPlayer),
+                    GatherCardsEffect(
+                        source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                        storeAs = "targetHand",
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "targetHand",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                        chooser = Chooser.Controller,
+                        filter = GameObjectFilter(
+                            cardPredicates = listOf(CardPredicate.HasChosenColor),
+                        ),
+                        storeSelected = "toDiscard",
+                        prompt = "Choose a card of the chosen color to discard",
+                        alwaysPrompt = true,
+                        showAllCards = true,
+                    ),
+                    MoveCollectionEffect(
+                        from = "toDiscard",
+                        destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                        moveType = MoveType.Discard,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "91"
+        artist = "Ron Spears"
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e8afb9d0-affa-4599-bf29-729cfe64703b.jpg?1562941705"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HypnoticCloud.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HypnoticCloud.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Hypnotic Cloud
+ * {1}{B}
+ * Sorcery
+ * Kicker {4}
+ * Target player discards a card. If this spell was kicked, that player discards
+ * three cards instead.
+ */
+val HypnoticCloud = card("Hypnotic Cloud") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Kicker {4} (You may pay an additional {4} as you cast this spell.)\n" +
+        "Target player discards a card. If this spell was kicked, that player discards three cards instead."
+
+    keywordAbility(KeywordAbility.kicker("{4}"))
+
+    spell {
+        val targetPlayer = target("target player", TargetPlayer())
+        effect = ConditionalEffect(
+            condition = WasKicked,
+            effect = Effects.Discard(3, targetPlayer),
+            elseEffect = Effects.Discard(1, targetPlayer),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a7502ea2-7555-449e-baee-6ecef5573a3b.jpg?1562928792"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Skizzik.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Skizzik.kt
@@ -1,12 +1,11 @@
-package com.wingedsheep.mtg.sets.definitions.dom.cards
+package com.wingedsheep.mtg.sets.definitions.inv.cards
 
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.KeywordAbility
-import com.wingedsheep.sdk.scripting.conditions.NotCondition
-import com.wingedsheep.sdk.scripting.conditions.WasKicked
 import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
 
 /**
@@ -24,22 +23,23 @@ val Skizzik = card("Skizzik") {
     typeLine = "Creature — Elemental"
     power = 5
     toughness = 3
-    oracleText = "Kicker {R}\nTrample, haste\nAt the beginning of the end step, if this creature wasn't kicked, sacrifice it."
+    oracleText = "Kicker {R} (You may pay an additional {R} as you cast this spell.)\n" +
+        "Trample, haste\n" +
+        "At the beginning of the end step, if this creature wasn't kicked, sacrifice it."
 
-    keywordAbility(KeywordAbility.kicker("{R}"))
     keywords(Keyword.TRAMPLE, Keyword.HASTE)
+    keywordAbility(KeywordAbility.kicker("{R}"))
 
     triggeredAbility {
         trigger = Triggers.EachEndStep
-        triggerCondition = NotCondition(WasKicked)
+        triggerCondition = Conditions.Not(Conditions.WasKicked)
         effect = SacrificeSelfEffect
     }
 
     metadata {
-        rarity = Rarity.UNCOMMON
-        collectorNumber = "145"
-        artist = "Tomasz Jedruszek"
-        flavorText = "\"It skitters across Shiv, each tendril hitting the ground with a sharp snap.\""
-        imageUri = "https://cards.scryfall.io/normal/front/7/7/77af9d28-1639-47bd-b925-7f3d2eefd352.jpg?1615334491"
+        rarity = Rarity.RARE
+        collectorNumber = "169"
+        artist = "Ron Spencer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dc7732bc-e168-44d9-923a-db7e985bd6db.jpg?1562939314"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrzasRage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrzasRage.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Urza's Rage
+ * {2}{R}
+ * Instant
+ * Kicker {8}{R}
+ * This spell can't be countered.
+ * Urza's Rage deals 3 damage to any target. If this spell was kicked, instead it
+ * deals 10 damage to that permanent or player and the damage can't be prevented.
+ */
+val UrzasRage = card("Urza's Rage") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Kicker {8}{R} (You may pay an additional {8}{R} as you cast this spell.)\n" +
+        "This spell can't be countered.\n" +
+        "Urza's Rage deals 3 damage to any target. If this spell was kicked, instead it deals " +
+        "10 damage to that permanent or player and the damage can't be prevented."
+
+    cantBeCountered = true
+    keywordAbility(KeywordAbility.kicker("{8}{R}"))
+
+    spell {
+        val t = target("any target", Targets.Any)
+        effect = ConditionalEffect(
+            condition = WasKicked,
+            effect = DealDamageEffect(10, t, cantBePrevented = true),
+            elseEffect = Effects.DealDamage(3, t),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "178"
+        artist = "Matthew D. Wilson"
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61a25a35-3ae4-471e-adcd-d8baf2f77b68.jpg?1562914759"
+    }
+}


### PR DESCRIPTION
## Summary

Implements four Invasion (INV) cards. All use existing SDK primitives — no engine/SDK changes were needed.

| Card | Cost | Implementation |
|------|------|----------------|
| **Addle** | {1}{B} Sorcery | `Effects.ChooseColorThen` wrapping the Duress-style reveal → gather → `SelectFromCollection(HasChosenColor)` → discard pipeline. |
| **Hypnotic Cloud** | {1}{B} Sorcery, Kicker {4} | `ConditionalEffect(WasKicked)` toggling `Effects.Discard(1)` vs `Effects.Discard(3)` on a target player. |
| **Skizzik** | {3}{R} Creature, Kicker {R} | Trample, haste; `Triggers.EachEndStep` trigger with intervening-if `Conditions.Not(WasKicked)` → `SacrificeSelfEffect`. |
| **Urza's Rage** | {2}{R} Instant, Kicker {8}{R} | `cantBeCountered = true`; `ConditionalEffect(WasKicked)` deals 3, or `DealDamageEffect(10, cantBePrevented = true)` when kicked. |

## Reprint bookkeeping

Skizzik's earliest real printing is Invasion, so its canonical `CardDefinition` now lives in `inv/`. The pre-existing Dominaria `CardDefinition` (`dom/cards/Skizzik.kt`) is converted to a `Printing` reprint row (`dom/cards/SkizzikReprint.kt`). `just check-card-printing "Skizzik"` confirms the canonical sits in the earliest printing with the DOM reprint wired up.

## Testing

- New `InvasionSpellsBatchScenarioTest` — 7 tests covering kicked/unkicked branches for all four cards. All pass.
- Re-ran `MultiPrintingGameTest` and `KickerConditionTest` — pass (confirms the Skizzik reprint move didn't regress anything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)