### PR TITLE
Add Invasion Apprentices: Sunscape, Stormscape, Thornscape, Thunderscape

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionApprenticesScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionApprenticesScenarioTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the Invasion "Apprentice" cycle of 1/1 Human Wizards, each with two
+ * colored-mana + tap activated abilities:
+ *
+ * - Sunscape Apprentice {W}: {G},{T}: +1/+1; {U},{T}: put target creature you control on top of library.
+ * - Stormscape Apprentice {U}: {W},{T}: tap target creature; {B},{T}: target player loses 1 life.
+ * - Thornscape Apprentice {G}: {R},{T}: grant first strike; {W},{T}: tap target creature.
+ * - Thunderscape Apprentice {R}: {B},{T}: target player loses 1 life; {G},{T}: +1/+1.
+ *
+ * These cards introduce no new engine primitives — they compose existing facades
+ * (ModifyStats, PutOnTopOfLibrary, TapUntapEffect, LoseLife, GrantKeyword). The tests
+ * exercise one ability of each card to confirm wiring.
+ */
+class InvasionApprenticesScenarioTest : ScenarioTestBase() {
+
+    private fun firstStrikeOn(name: String) =
+        cardRegistry.getCard(name)!!.script.activatedAbilities
+
+    init {
+        context("Sunscape Apprentice") {
+            test("{G},{T} gives target creature +1/+1 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Sunscape Apprentice")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(green = 1)) }
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val source = game.findPermanent("Sunscape Apprentice")!!
+                val ability = firstStrikeOn("Sunscape Apprentice")[0]
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, source, ability.id, listOf(ChosenTarget.Permanent(bears)))
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                projected.getPower(bears) shouldBe 3
+                projected.getToughness(bears) shouldBe 3
+            }
+        }
+
+        context("Stormscape Apprentice") {
+            test("{B},{T} makes target player lose 1 life") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Stormscape Apprentice")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(black = 1)) }
+
+                val source = game.findPermanent("Stormscape Apprentice")!!
+                // ability[0] = {W} tap, ability[1] = {B} lose life
+                val ability = firstStrikeOn("Stormscape Apprentice")[1]
+                val startLife = game.state.getEntity(game.player2Id)?.get<LifeTotalComponent>()?.life ?: 0
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, source, ability.id, listOf(ChosenTarget.Player(game.player2Id)))
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                game.state.getEntity(game.player2Id)?.get<LifeTotalComponent>()?.life shouldBe (startLife - 1)
+            }
+        }
+
+        context("Thornscape Apprentice") {
+            test("{R},{T} grants first strike until end of turn") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Thornscape Apprentice")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(red = 1)) }
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val source = game.findPermanent("Thornscape Apprentice")!!
+                val ability = firstStrikeOn("Thornscape Apprentice")[0]
+
+                withClue("bears start without first strike") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe false
+                }
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, source, ability.id, listOf(ChosenTarget.Permanent(bears)))
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                game.state.projectedState.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+            }
+        }
+
+        context("Thunderscape Apprentice") {
+            test("{G},{T} gives target creature +1/+1 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Thunderscape Apprentice")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(green = 1)) }
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val source = game.findPermanent("Thunderscape Apprentice")!!
+                // ability[0] = {B} lose life, ability[1] = {G} +1/+1
+                val ability = firstStrikeOn("Thunderscape Apprentice")[1]
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, source, ability.id, listOf(ChosenTarget.Permanent(bears)))
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                projected.getPower(bears) shouldBe 3
+                projected.getToughness(bears) shouldBe 3
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StormscapeApprentice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StormscapeApprentice.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Stormscape Apprentice
+ * {U}
+ * Creature — Human Wizard
+ * 1/1
+ * {W}, {T}: Tap target creature.
+ * {B}, {T}: Target player loses 1 life.
+ */
+val StormscapeApprentice = card("Stormscape Apprentice") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{W}, {T}: Tap target creature.\n" +
+        "{B}, {T}: Target player loses 1 life."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = TapUntapEffect(target = t, tap = true)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap)
+        val t = target("target", TargetPlayer())
+        effect = Effects.LoseLife(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "75"
+        artist = "D. Alexander Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1eb42f39-9187-44e4-aa34-14ab31977199.jpg?1562901059"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SunscapeApprentice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SunscapeApprentice.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunscape Apprentice
+ * {W}
+ * Creature — Human Wizard
+ * 1/1
+ * {G}, {T}: Target creature gets +1/+1 until end of turn.
+ * {U}, {T}: Put target creature you control on top of its owner's library.
+ */
+val SunscapeApprentice = card("Sunscape Apprentice") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{G}, {T}: Target creature gets +1/+1 until end of turn.\n" +
+        "{U}, {T}: Put target creature you control on top of its owner's library."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(power = 1, toughness = 1, target = t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.PutOnTopOfLibrary(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Stephanie Law"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9d6bd19-77c9-4a1a-a2d5-6f9737693fea.jpg?1562929204"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ThornscapeApprentice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ThornscapeApprentice.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+
+/**
+ * Thornscape Apprentice
+ * {G}
+ * Creature — Human Wizard
+ * 1/1
+ * {R}, {T}: Target creature gains first strike until end of turn.
+ * {W}, {T}: Tap target creature.
+ */
+val ThornscapeApprentice = card("Thornscape Apprentice") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{R}, {T}: Target creature gains first strike until end of turn.\n" +
+        "{W}, {T}: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = TapUntapEffect(target = t, tap = true)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "215"
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/505da522-73a8-4232-ae1a-d3365f3e598f.jpg?1562911289"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ThunderscapeApprentice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ThunderscapeApprentice.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Thunderscape Apprentice
+ * {R}
+ * Creature — Human Wizard
+ * 1/1
+ * {B}, {T}: Target player loses 1 life.
+ * {G}, {T}: Target creature gets +1/+1 until end of turn.
+ */
+val ThunderscapeApprentice = card("Thunderscape Apprentice") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{B}, {T}: Target player loses 1 life.\n" +
+        "{G}, {T}: Target creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap)
+        val t = target("target", TargetPlayer())
+        effect = Effects.LoseLife(1, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(power = 1, toughness = 1, target = t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "D. Alexander Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75a0b075-5414-48d3-a2b1-47dc20213e96.jpg?1562918595"
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Invasion "Apprentice" cycle of {1-mana} 1/1 Human Wizards, each with two off-color mana + tap activated abilities. All four are pure compositions of existing effect facades — no new engine primitives were needed.

| Card | Cost | Abilities |
|------|------|-----------|
| Sunscape Apprentice | {W} | {G},{T}: target creature gets +1/+1 EOT · {U},{T}: put target creature you control on top of its owner's library |
| Stormscape Apprentice | {U} | {W},{T}: tap target creature · {B},{T}: target player loses 1 life |
| Thornscape Apprentice | {G} | {R},{T}: target creature gains first strike EOT · {W},{T}: tap target creature |
| Thunderscape Apprentice | {R} | {B},{T}: target player loses 1 life · {G},{T}: target creature gets +1/+1 EOT |

These mirror the already-implemented Nightscape Apprentice from the same cycle, reusing `Effects.ModifyStats`, `Effects.PutOnTopOfLibrary`, `TapUntapEffect`, `Effects.LoseLife`, and `Effects.GrantKeyword(FIRST_STRIKE)`.

## Tests

- New `InvasionApprenticesScenarioTest` exercises one activated ability per card (pump, lose-life, first strike, pump) — all pass.
- Full `:rules-engine` test suite passes.
- `just check-card-printing` confirms INV is the canonical (earliest) printing for all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)