### PR TITLE
Add Invasion Weavers: Hate, Rage, Might, Spirit, Sky

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionWeaversScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionWeaversScenarioTest.kt
@@ -1,0 +1,256 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the Invasion "Weaver" cycle of {1}{X} 2/1 Wizards, each with a
+ * `{2}: Target [color] or [color] creature [pump/gains keyword] until end of turn` ability.
+ *
+ * Hate Weaver   — blue/red gets +1/+0
+ * Spirit Weaver — green/blue gets +0/+1
+ * Rage Weaver   — black/green gains haste
+ * Might Weaver  — red/white gains trample
+ * Sky Weaver    — white/black gains flying
+ *
+ * Each ability targets only creatures of two specific colors. These tests verify the
+ * color-restricted [com.wingedsheep.sdk.scripting.filters.unified.TargetFilter]
+ * (`GameObjectFilter.Creature.withAnyColor(...)`) both accepts a legal-color target and
+ * rejects an off-color creature, and that the granted effect lands.
+ */
+class InvasionWeaversScenarioTest : ScenarioTestBase() {
+
+    init {
+        // Test creatures of each color (the registry only has set-registered cards, so
+        // define plain vanilla beaters inline to act as targets). The mana cost color
+        // drives the creature's color, which is what the Weaver target filters check.
+        listOf(
+            "Test White Bear" to "{1}{W}",
+            "Test Blue Bear" to "{1}{U}",
+            "Test Black Bear" to "{1}{B}",
+            "Test Red Bear" to "{1}{R}",
+            "Test Green Bear" to "{1}{G}",
+        ).forEach { (name, cost) ->
+            cardRegistry.register(
+                CardDefinition.creature(
+                    name = name,
+                    manaCost = ManaCost.parse(cost),
+                    subtypes = setOf(Subtype.BEAR),
+                    power = 2,
+                    toughness = 2,
+                )
+            )
+        }
+
+        context("Hate Weaver - {2}: target blue or red creature gets +1/+0") {
+            test("pumps a legal blue target's power") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Hate Weaver")
+                    .withCardOnBattlefield(1, "Test Blue Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(colorless = 2)) }
+
+                val targetId = game.findPermanent("Test Blue Bear")!!
+                val sourceId = game.findPermanent("Hate Weaver")!!
+                val ability = cardRegistry.getCard("Hate Weaver")!!.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, sourceId, ability.id, listOf(ChosenTarget.Permanent(targetId)))
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Blue Bear should be 3/2 after +1/+0") {
+                    game.state.projectedState.getPower(targetId) shouldBe 3
+                    game.state.projectedState.getToughness(targetId) shouldBe 2
+                }
+            }
+
+            test("cannot target a white creature") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Hate Weaver")
+                    .withCardOnBattlefield(1, "Test White Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(colorless = 2)) }
+
+                val targetId = game.findPermanent("Test White Bear")!!
+                val sourceId = game.findPermanent("Hate Weaver")!!
+                val ability = cardRegistry.getCard("Hate Weaver")!!.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, sourceId, ability.id, listOf(ChosenTarget.Permanent(targetId)))
+                )
+                withClue("White creature is not a legal blue-or-red target") { result.error shouldNotBe null }
+            }
+        }
+
+        context("Spirit Weaver - {2}: target green or blue creature gets +0/+1") {
+            test("buffs a legal green target's toughness") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Spirit Weaver")
+                    .withCardOnBattlefield(1, "Test Green Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(colorless = 2)) }
+
+                val targetId = game.findPermanent("Test Green Bear")!!
+                val sourceId = game.findPermanent("Spirit Weaver")!!
+                val ability = cardRegistry.getCard("Spirit Weaver")!!.script.activatedAbilities[0]
+
+                game.execute(
+                    ActivateAbility(game.player1Id, sourceId, ability.id, listOf(ChosenTarget.Permanent(targetId)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Green Bear should be 2/3 after +0/+1") {
+                    game.state.projectedState.getPower(targetId) shouldBe 2
+                    game.state.projectedState.getToughness(targetId) shouldBe 3
+                }
+            }
+        }
+
+        context("Rage Weaver - {2}: target black or green creature gains haste") {
+            test("grants haste to a legal black target") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Rage Weaver")
+                    .withCardOnBattlefield(1, "Test Black Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(colorless = 2)) }
+
+                val targetId = game.findPermanent("Test Black Bear")!!
+                val sourceId = game.findPermanent("Rage Weaver")!!
+                val ability = cardRegistry.getCard("Rage Weaver")!!.script.activatedAbilities[0]
+
+                game.execute(
+                    ActivateAbility(game.player1Id, sourceId, ability.id, listOf(ChosenTarget.Permanent(targetId)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Black Bear should have haste") {
+                    game.state.projectedState.hasKeyword(targetId, "HASTE") shouldBe true
+                }
+            }
+
+            test("cannot target a blue creature") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Rage Weaver")
+                    .withCardOnBattlefield(1, "Test Blue Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(colorless = 2)) }
+
+                val targetId = game.findPermanent("Test Blue Bear")!!
+                val sourceId = game.findPermanent("Rage Weaver")!!
+                val ability = cardRegistry.getCard("Rage Weaver")!!.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, sourceId, ability.id, listOf(ChosenTarget.Permanent(targetId)))
+                )
+                withClue("Blue creature is not a legal black-or-green target") { result.error shouldNotBe null }
+            }
+        }
+
+        context("Might Weaver - {2}: target red or white creature gains trample") {
+            test("grants trample to a legal red target") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Might Weaver")
+                    .withCardOnBattlefield(1, "Test Red Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(colorless = 2)) }
+
+                val targetId = game.findPermanent("Test Red Bear")!!
+                val sourceId = game.findPermanent("Might Weaver")!!
+                val ability = cardRegistry.getCard("Might Weaver")!!.script.activatedAbilities[0]
+
+                game.execute(
+                    ActivateAbility(game.player1Id, sourceId, ability.id, listOf(ChosenTarget.Permanent(targetId)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Red Bear should have trample") {
+                    game.state.projectedState.hasKeyword(targetId, "TRAMPLE") shouldBe true
+                }
+            }
+        }
+
+        context("Sky Weaver - {2}: target white or black creature gains flying") {
+            test("grants flying to a legal white target") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Sky Weaver")
+                    .withCardOnBattlefield(1, "Test White Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(colorless = 2)) }
+
+                val targetId = game.findPermanent("Test White Bear")!!
+                val sourceId = game.findPermanent("Sky Weaver")!!
+                val ability = cardRegistry.getCard("Sky Weaver")!!.script.activatedAbilities[0]
+
+                game.execute(
+                    ActivateAbility(game.player1Id, sourceId, ability.id, listOf(ChosenTarget.Permanent(targetId)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("White Bear should have flying") {
+                    game.state.projectedState.hasKeyword(targetId, "FLYING") shouldBe true
+                }
+            }
+
+            test("cannot target a green creature") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Sky Weaver")
+                    .withCardOnBattlefield(1, "Test Green Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { it.with(ManaPoolComponent(colorless = 2)) }
+
+                val targetId = game.findPermanent("Test Green Bear")!!
+                val sourceId = game.findPermanent("Sky Weaver")!!
+                val ability = cardRegistry.getCard("Sky Weaver")!!.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, sourceId, ability.id, listOf(ChosenTarget.Permanent(targetId)))
+                )
+                withClue("Green creature is not a legal white-or-black target") { result.error shouldNotBe null }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HateWeaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HateWeaver.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Hate Weaver
+ * {1}{B}
+ * Creature — Zombie Wizard
+ * 2/1
+ * {2}: Target blue or red creature gets +1/+0 until end of turn.
+ */
+val HateWeaver = card("Hate Weaver") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "{2}: Target blue or red creature gets +1/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withAnyColor(Color.BLUE, Color.RED)))
+        )
+        effect = Effects.ModifyStats(power = 1, toughness = 0, target = t)
+        description = "{2}: Target blue or red creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "108"
+        artist = "Roger Raupp"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/8328e131-b44d-4dd0-9ce4-454c6afe6fa6.jpg?1562921569"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MightWeaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MightWeaver.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Might Weaver
+ * {1}{G}
+ * Creature — Human Wizard
+ * 2/1
+ * {2}: Target red or white creature gains trample until end of turn.
+ */
+val MightWeaver = card("Might Weaver") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "{2}: Target red or white creature gains trample until end of turn. " +
+        "(It can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withAnyColor(Color.RED, Color.WHITE)))
+        )
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, target = t)
+        description = "{2}: Target red or white creature gains trample until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Larry Elmore"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/032a4ec7-82ce-4ea0-b0dd-ebc40823a014.jpg?1562895607"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RageWeaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RageWeaver.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Rage Weaver
+ * {1}{R}
+ * Creature — Human Wizard
+ * 2/1
+ * {2}: Target black or green creature gains haste until end of turn.
+ */
+val RageWeaver = card("Rage Weaver") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "{2}: Target black or green creature gains haste until end of turn. " +
+        "(It can attack and {T} this turn.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withAnyColor(Color.BLACK, Color.GREEN)))
+        )
+        effect = Effects.GrantKeyword(Keyword.HASTE, target = t)
+        description = "{2}: Target black or green creature gains haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "John Matson"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a654295d-b63c-4025-bf36-899023a8ba1d.jpg?1562928619"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SkyWeaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SkyWeaver.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sky Weaver
+ * {1}{U}
+ * Creature — Metathran Wizard
+ * 2/1
+ * {2}: Target white or black creature gains flying until end of turn.
+ */
+val SkyWeaver = card("Sky Weaver") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Metathran Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "{2}: Target white or black creature gains flying until end of turn. " +
+        "(It can't be blocked except by creatures with flying or reach.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withAnyColor(Color.WHITE, Color.BLACK)))
+        )
+        effect = Effects.GrantKeyword(Keyword.FLYING, target = t)
+        description = "{2}: Target white or black creature gains flying until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Christopher Moeller"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04974146-42a8-4f10-b443-67bfeaa54d5d.jpg?1562895878"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SpiritWeaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SpiritWeaver.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Spirit Weaver
+ * {1}{W}
+ * Creature — Human Wizard
+ * 2/1
+ * {2}: Target green or blue creature gets +0/+1 until end of turn.
+ */
+val SpiritWeaver = card("Spirit Weaver") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "{2}: Target green or blue creature gets +0/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withAnyColor(Color.GREEN, Color.BLUE)))
+        )
+        effect = Effects.ModifyStats(power = 0, toughness = 1, target = t)
+        description = "{2}: Target green or blue creature gets +0/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Matthew D. Wilson"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90b0ef47-cb22-4146-a17e-e49a6031a7e6.jpg?1562924202"
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Invasion (INV) cycle of five {1}{X} 2/1 Wizards, each with an activated ability that grants a color-restricted creature a buff or keyword until end of turn:

| Card | Cost | Type | Ability |
|------|------|------|---------|
| Hate Weaver | {1}{B} | Zombie Wizard | `{2}`: Target blue or red creature gets +1/+0 |
| Spirit Weaver | {1}{W} | Human Wizard | `{2}`: Target green or blue creature gets +0/+1 |
| Rage Weaver | {1}{R} | Human Wizard | `{2}`: Target black or green creature gains haste |
| Might Weaver | {1}{G} | Human Wizard | `{2}`: Target red or white creature gains trample |
| Sky Weaver | {1}{U} | Metathran Wizard | `{2}`: Target white or black creature gains flying |

## Implementation

All five cards are pure data compositions of existing SDK primitives — no new engine mechanics:

- Color-restricted targeting via `TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withAnyColor(...)))`
- Stat buffs via `Effects.ModifyStats`, keyword grants via `Effects.GrantKeyword(..., duration = EndOfTurn)`

INV is the earliest real printing for all five (verified with `just check-card-printing`), so the canonical `CardDefinition` lives in the INV set; auto-registered via `CardDiscovery`.

## Tests

Adds `InvasionWeaversScenarioTest` (8 tests, all passing) verifying:
- Each granted effect actually lands (power/toughness change, keyword present in projected state)
- The color-restricted target filter rejects off-color creatures (e.g. Sky Weaver cannot target a green creature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)