### PR TITLE
Add Invasion Kavu: Chameleon, Monarch, Rooting, Yavimaya, Vicious, Raging

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavuMonarchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavuMonarchScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kavu Monarch:
+ * - Kavu creatures have trample. (lord, affects all Kavu including itself)
+ * - Whenever another Kavu enters, put a +1/+1 counter on this creature.
+ *
+ * Base stats are 3/3.
+ */
+class KavuMonarchScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private fun ScenarioTestBase.TestGame.getCounters(entityId: EntityId): Int {
+        return state.entities[entityId]
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Kavu Monarch") {
+
+            test("grants trample to itself and other Kavu") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kavu Monarch")
+                    .withCardOnBattlefield(1, "Kavu Chameleon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val projected = stateProjector.project(game.state)
+                val monarchId = game.findPermanent("Kavu Monarch")!!
+                val chameleonId = game.findPermanent("Kavu Chameleon")!!
+
+                withClue("Kavu Monarch should have trample (lord affects itself)") {
+                    projected.hasKeyword(monarchId, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("Other Kavu should have trample") {
+                    projected.hasKeyword(chameleonId, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+
+            test("gets a +1/+1 counter when another Kavu enters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kavu Monarch")
+                    .withCardInHand(1, "Kavu Chameleon")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val monarchId = game.findPermanent("Kavu Monarch")!!
+                withClue("Monarch starts with no counters") {
+                    game.getCounters(monarchId) shouldBe 0
+                }
+
+                // Cast Kavu Chameleon (another Kavu entering).
+                val castResult = game.castSpell(1, "Kavu Chameleon")
+                withClue("Kavu Chameleon should cast: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Monarch should gain a +1/+1 counter when another Kavu enters") {
+                    game.getCounters(monarchId) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RootingKavuScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RootingKavuScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rooting Kavu's death trigger:
+ * "When this creature dies, you may exile it. If you do, shuffle all creature cards
+ * from your graveyard into your library."
+ *
+ * Uses Path of Peace ("Destroy target creature. Its owner gains 4 life.") to kill it.
+ */
+class RootingKavuScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rooting Kavu death trigger") {
+
+            test("exiles itself and shuffles creature cards from graveyard into library") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Rooting Kavu")
+                    .withCardInGraveyard(1, "Grizzly Bears")   // creature card -> library
+                    .withCardInGraveyard(1, "Raging Goblin")   // creature card -> library
+                    .withCardInGraveyard(1, "Path of Peace")   // non-creature -> stays
+                    .withCardInHand(2, "Path of Peace")
+                    .withLandsOnBattlefield(2, "Plains", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libraryBefore = game.librarySize(1)
+                val kavuId = game.findPermanent("Rooting Kavu")!!
+
+                // Opponent destroys Rooting Kavu.
+                val castResult = game.castSpell(2, "Path of Peace", kavuId)
+                withClue("Path of Peace should cast: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // The death trigger is a "may" — accept it.
+                withClue("Rooting Kavu's death trigger should prompt a yes/no choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Rooting Kavu should be exiled (not in graveyard)") {
+                    game.isInGraveyard(1, "Rooting Kavu") shouldBe false
+                }
+                withClue("Two creature cards shuffled from graveyard into library") {
+                    game.librarySize(1) shouldBe libraryBefore + 2
+                }
+                withClue("Grizzly Bears (creature) should leave the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+                withClue("Raging Goblin (creature) should leave the graveyard") {
+                    game.isInGraveyard(1, "Raging Goblin") shouldBe false
+                }
+                withClue("Path of Peace (non-creature) should remain in graveyard") {
+                    game.isInGraveyard(1, "Path of Peace") shouldBe true
+                }
+            }
+
+            test("declining the trigger leaves it in the graveyard and graveyard intact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Rooting Kavu")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInHand(2, "Path of Peace")
+                    .withLandsOnBattlefield(2, "Plains", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libraryBefore = game.librarySize(1)
+                val kavuId = game.findPermanent("Rooting Kavu")!!
+
+                game.castSpell(2, "Path of Peace", kavuId)
+                game.resolveStack()
+
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Rooting Kavu stays in the graveyard when declined") {
+                    game.isInGraveyard(1, "Rooting Kavu") shouldBe true
+                }
+                withClue("Grizzly Bears stays in graveyard when declined") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Library unchanged when declined") {
+                    game.librarySize(1) shouldBe libraryBefore
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ViciousKavuScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ViciousKavuScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Vicious Kavu:
+ * "Whenever this creature attacks, it gets +2/+0 until end of turn."
+ *
+ * Base stats are 2/2.
+ */
+class ViciousKavuScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Vicious Kavu attack trigger") {
+
+            test("gets +2/+0 when it attacks") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vicious Kavu")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attackResult = game.declareAttackers(mapOf("Vicious Kavu" to 2))
+                withClue("Declaring attack should succeed: ${attackResult.error}") {
+                    attackResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val kavuId = game.findPermanent("Vicious Kavu")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power should be 2 base + 2 from attacking") {
+                    projected.getPower(kavuId) shouldBe 4
+                }
+                withClue("Toughness stays at base 2 (+2/+0)") {
+                    projected.getToughness(kavuId) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/YavimayaKavuScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/YavimayaKavuScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Yavimaya Kavu's characteristic-defining ability:
+ * - power = number of red creatures on the battlefield
+ * - toughness = number of green creatures on the battlefield
+ *
+ * Yavimaya Kavu is itself both red and green, so it counts toward both.
+ */
+class YavimayaKavuScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Yavimaya Kavu CDA") {
+
+            test("counts itself when alone (1 red, 1 green)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Yavimaya Kavu")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kavuId = game.findPermanent("Yavimaya Kavu")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power = number of red creatures (just itself)") {
+                    projected.getPower(kavuId) shouldBe 1
+                }
+                withClue("Toughness = number of green creatures (just itself)") {
+                    projected.getToughness(kavuId) shouldBe 1
+                }
+            }
+
+            test("counts red and green creatures from all players") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Yavimaya Kavu")
+                    .withCardOnBattlefield(1, "Raging Goblin")    // red, controlled by P1
+                    .withCardOnBattlefield(2, "Grizzly Bears")    // green, controlled by P2
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kavuId = game.findPermanent("Yavimaya Kavu")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power = red creatures: Yavimaya Kavu + Raging Goblin = 2") {
+                    projected.getPower(kavuId) shouldBe 2
+                }
+                withClue("Toughness = green creatures: Yavimaya Kavu + Grizzly Bears = 2") {
+                    projected.getToughness(kavuId) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuChameleon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuChameleon.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kavu Chameleon
+ * {3}{G}{G}
+ * Creature — Kavu
+ * 4/4
+ * This spell can't be countered.
+ * {G}: This creature becomes the color of your choice until end of turn.
+ */
+val KavuChameleon = card("Kavu Chameleon") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Kavu"
+    power = 4
+    toughness = 4
+    oracleText = "This spell can't be countered.\n" +
+        "{G}: This creature becomes the color of your choice until end of turn."
+
+    cantBeCountered = true
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.ChangeColorToChosen(EffectTarget.Self)
+        description = "{G}: This creature becomes the color of your choice until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "191"
+        artist = "John Howe"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f726437b-a41a-4ee9-b0ee-e09327508615.jpg?1562944770"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuMonarch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuMonarch.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kavu Monarch
+ * {2}{R}{R}
+ * Creature — Kavu
+ * 3/3
+ * Kavu creatures have trample.
+ * Whenever another Kavu enters, put a +1/+1 counter on this creature.
+ *
+ * The trample lord affects all Kavu (any controller, including itself). The counter
+ * trigger fires on any other Kavu entering under any player's control (OTHER binding).
+ */
+val KavuMonarch = card("Kavu Monarch") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu"
+    power = 3
+    toughness = 3
+    oracleText = "Kavu creatures have trample.\n" +
+        "Whenever another Kavu enters, put a +1/+1 counter on this creature."
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.TRAMPLE,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Kavu"))
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype("Kavu"),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.AddCounters("+1/+1", 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "149"
+        artist = "Terese Nielsen"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea63dfd5-d8d7-45b8-8219-1cc2b3de5666.jpg?1562942087"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RagingKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RagingKavu.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raging Kavu
+ * {1}{R}{G}
+ * Creature — Kavu
+ * 3/1
+ * Flash
+ * Haste
+ */
+val RagingKavu = card("Raging Kavu") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Kavu"
+    power = 3
+    toughness = 1
+    oracleText = "Flash\nHaste"
+
+    keywords(Keyword.FLASH, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "262"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27573679-e9e5-4bfc-b5d5-85d4648b01b6.jpg?1562903028"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RootingKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RootingKavu.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rooting Kavu
+ * {2}{G}{G}
+ * Creature — Kavu
+ * 4/3
+ * When this creature dies, you may exile it. If you do, shuffle all creature cards
+ * from your graveyard into your library.
+ *
+ * The dies trigger functions from the graveyard (`triggerZone = Zone.GRAVEYARD`) so
+ * "exile it" can reference Self. Exiling the card always succeeds once the player
+ * chooses to, so the "if you do" shuffle is composed under the same MayEffect.
+ */
+val RootingKavu = card("Rooting Kavu") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Kavu"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature dies, you may exile it. If you do, shuffle all " +
+        "creature cards from your graveyard into your library."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerZone = Zone.GRAVEYARD
+        effect = MayEffect(
+            effect = CompositeEffect(
+                listOf(
+                    Effects.Exile(EffectTarget.Self),
+                    GatherCardsEffect(
+                        source = CardSource.FromZone(
+                            Zone.GRAVEYARD,
+                            Player.You,
+                            GameObjectFilter.Creature
+                        ),
+                        storeAs = "graveyardCreatures"
+                    ),
+                    MoveCollectionEffect(
+                        from = "graveyardCreatures",
+                        destination = CardDestination.ToZone(
+                            Zone.LIBRARY,
+                            Player.You,
+                            ZonePlacement.Shuffled
+                        )
+                    )
+                )
+            ),
+            descriptionOverride = "You may exile this creature. If you do, shuffle all " +
+                "creature cards from your graveyard into your library."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "207"
+        artist = "Heather Hudson"
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12c25a4c-d93a-402b-999f-0b9919123cc5.jpg?1562898755"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ViciousKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ViciousKavu.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vicious Kavu
+ * {1}{B}{R}
+ * Creature — Kavu
+ * 2/2
+ * Whenever this creature attacks, it gets +2/+0 until end of turn.
+ */
+val ViciousKavu = card("Vicious Kavu") {
+    manaCost = "{1}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Kavu"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature attacks, it gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(power = 2, toughness = 0, target = EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "284"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31e9e629-7c25-4d45-aa35-9ba5f95b43cb.jpg?1562905117"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/YavimayaKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/YavimayaKavu.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CharacteristicValue
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Yavimaya Kavu
+ * {2}{R}{G}
+ * Creature — Kavu
+ * Power and toughness are each defined dynamically (printed as * / *).
+ * Yavimaya Kavu's power is equal to the number of red creatures on the battlefield.
+ * Yavimaya Kavu's toughness is equal to the number of green creatures on the battlefield.
+ *
+ * Both counts span all players' battlefields (Player.Each) and include Yavimaya Kavu
+ * itself, which is both red and green.
+ */
+val YavimayaKavu = card("Yavimaya Kavu") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Kavu"
+    oracleText = "Yavimaya Kavu's power is equal to the number of red creatures on the battlefield.\n" +
+        "Yavimaya Kavu's toughness is equal to the number of green creatures on the battlefield."
+
+    dynamicPower = CharacteristicValue.dynamic(
+        DynamicAmount.AggregateBattlefield(
+            player = Player.Each,
+            filter = GameObjectFilter.Creature.withColor(Color.RED)
+        )
+    )
+
+    dynamicToughness = CharacteristicValue.dynamic(
+        DynamicAmount.AggregateBattlefield(
+            player = Player.Each,
+            filter = GameObjectFilter.Creature.withColor(Color.GREEN)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "291"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/1872f104-7cf1-41e3-b1b4-ca75c678e08b.jpg?1562899872"
+    }
+}


### PR DESCRIPTION
Implements six Kavu creatures for the Invasion (INV) set. All reuse existing SDK primitives — no new effects, triggers, conditions, or keywords were added.

## Cards

- **Kavu Chameleon** `{3}{G}{G}` 4/4 — `cantBeCountered = true`; `{G}: This creature becomes the color of your choice until end of turn.` via `Effects.ChangeColorToChosen`.
- **Kavu Monarch** `{2}{R}{R}` 3/3 — `GrantKeyword(TRAMPLE)` lord over all Kavu (any controller, including itself); OTHER-binding "whenever another Kavu enters" trigger adds a +1/+1 counter to itself.
- **Rooting Kavu** `{2}{G}{G}` 4/3 — dies trigger (`triggerZone = GRAVEYARD`) wrapping a `MayEffect` that exiles itself, then gathers creature cards from the controller's graveyard and shuffles them into the library.
- **Yavimaya Kavu** `{2}{R}{G}` */* — `dynamicPower` = red creatures on the battlefield, `dynamicToughness` = green creatures, counted across all players (`Player.Each`) including itself.
- **Vicious Kavu** `{1}{B}{R}` 2/2 — attacks trigger granting +2/+0 until end of turn.
- **Raging Kavu** `{1}{R}{G}` 3/1 — Flash + Haste.

## Tests

Scenario tests added for the mechanically interesting cards:
- `KavuMonarchScenarioTest` — trample lord (self + others) and +1/+1 counter on another Kavu entering.
- `RootingKavuScenarioTest` — accept (exile self + shuffle only creature cards, non-creatures stay) and decline paths.
- `YavimayaKavuScenarioTest` — CDA counting red/green creatures across both players.
- `ViciousKavuScenarioTest` — +2/+0 attack pump.

Kavu Chameleon and Raging Kavu reuse well-covered mechanics, so they have no dedicated scenario test.

All new tests pass; `:mtg-sets:test` (card-definition validation) is green. `scripts/card-status --cards INV` now lists all six as implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)