### PR TITLE
Add Invasion blue cards: Breaking Wave, Wash Out, Tidal Visionary, Distorting Wake

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionBlueBounceScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionBlueBounceScenarioTest.kt
@@ -1,0 +1,216 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for four Invasion blue cards that reuse existing primitives:
+ *
+ * - Breaking Wave ({2}{U}{U}) — "Simultaneously untap all tapped creatures and tap all
+ *   untapped creatures." Verifies the gather-both-then-swap composition is atomic (no
+ *   double flip).
+ * - Wash Out ({3}{U}) — "Return all permanents of the color of your choice to their
+ *   owners' hands." Verifies ChooseColorThen + gather(HasChosenColor) + move-to-hand.
+ * - Tidal Visionary ({U}) — "{T}: Target creature becomes the color of your choice until
+ *   end of turn." Verifies the single-color recolor via projected colors.
+ * - Distorting Wake ({X}{U}{U}{U}) — "Return X target nonland permanents to their owners'
+ *   hands." Verifies X-clamped multi-target bounce.
+ */
+class InvasionBlueBounceScenarioTest : ScenarioTestBase() {
+
+    private fun isTapped(game: TestGame, id: EntityId): Boolean =
+        game.state.getEntity(id)?.has<TappedComponent>() == true
+
+    // Mono-colored vanilla creatures so color/tap checks are unambiguous.
+    private val greenBear = CardDefinition.creature(
+        name = "Green Bear", manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Bear")), power = 2, toughness = 2
+    )
+    private val redOgre = CardDefinition.creature(
+        name = "Red Ogre", manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Ogre")), power = 3, toughness = 3
+    )
+
+    init {
+        cardRegistry.register(greenBear)
+        cardRegistry.register(redOgre)
+
+        context("Breaking Wave") {
+            test("simultaneously untaps tapped creatures and taps untapped creatures") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Breaking Wave")
+                    .withCardOnBattlefield(1, "Green Bear", tapped = true)  // should untap
+                    .withCardOnBattlefield(1, "Red Ogre", tapped = false)   // should tap
+                    .withCardOnBattlefield(2, "Green Bear", tapped = false) // should tap
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tappedBear = game.state.getBattlefield(game.player1Id)
+                    .first { game.state.getEntity(it)?.get<CardComponent>()?.name == "Green Bear" }
+                val untappedOgre = game.findPermanent("Red Ogre")!!
+                val oppBear = game.state.getBattlefield(game.player2Id)
+                    .first { game.state.getEntity(it)?.get<CardComponent>()?.name == "Green Bear" }
+
+                game.castSpell(1, "Breaking Wave")
+                game.resolveStack()
+
+                withClue("Originally tapped creature should be untapped") {
+                    isTapped(game, tappedBear) shouldBe false
+                }
+                withClue("Originally untapped creature should be tapped (not re-untapped)") {
+                    isTapped(game, untappedOgre) shouldBe true
+                }
+                withClue("Opponent's untapped creature should also be tapped") {
+                    isTapped(game, oppBear) shouldBe true
+                }
+            }
+        }
+
+        context("Wash Out") {
+            test("returns all permanents of the chosen color to owners' hands") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Wash Out")
+                    .withCardOnBattlefield(1, "Green Bear")
+                    .withCardOnBattlefield(2, "Green Bear")
+                    .withCardOnBattlefield(1, "Red Ogre")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Wash Out")
+                game.resolveStack()
+
+                val colorDecision = game.getPendingDecision()
+                withClue("Should pause for a color choice") {
+                    (colorDecision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.GREEN))
+                game.resolveStack()
+
+                withClue("All green creatures bounced to hand") {
+                    game.isOnBattlefield("Green Bear") shouldBe false
+                }
+                withClue("Each owner gets their green creature back") {
+                    game.state.getHand(game.player1Id).count {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Green Bear"
+                    } shouldBe 1
+                    game.state.getHand(game.player2Id).count {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Green Bear"
+                    } shouldBe 1
+                }
+                withClue("Red permanent of a different color is untouched") {
+                    game.isOnBattlefield("Red Ogre") shouldBe true
+                }
+            }
+        }
+
+        context("Tidal Visionary") {
+            test("recolors target creature to the chosen color") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Tidal Visionary")
+                    .withCardOnBattlefield(2, "Green Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val visionary = game.findPermanent("Tidal Visionary")!!
+                val bear = game.findPermanent("Green Bear")!!
+
+                withClue("Bear starts green") {
+                    game.state.projectedState.getColors(bear) shouldBe setOf("GREEN")
+                }
+
+                val ability = cardRegistry.getCard("Tidal Visionary")!!.script.activatedAbilities[0]
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = visionary,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(bear))
+                    )
+                )
+                withClue("Ability should activate: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val colorDecision = game.getPendingDecision()
+                withClue("Should pause for a color choice") {
+                    (colorDecision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.BLUE))
+                game.resolveStack()
+
+                withClue("Bear should now be blue") {
+                    game.state.projectedState.getColors(bear) shouldBe setOf("BLUE")
+                }
+            }
+        }
+
+        context("Distorting Wake") {
+            test("returns X target nonland permanents to owners' hands") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Distorting Wake")
+                    .withCardOnBattlefield(1, "Green Bear")
+                    .withCardOnBattlefield(2, "Red Ogre")
+                    .withLandsOnBattlefield(1, "Island", 5) // X=2 → {2}{U}{U}{U}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Green Bear")!!
+                val ogre = game.findPermanent("Red Ogre")!!
+                val wakeId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Distorting Wake"
+                }
+
+                val result = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = wakeId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(bear),
+                            ChosenTarget.Permanent(ogre)
+                        ),
+                        xValue = 2
+                    )
+                )
+                withClue("Cast should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Both targeted permanents bounced") {
+                    game.isOnBattlefield("Green Bear") shouldBe false
+                    game.isOnBattlefield("Red Ogre") shouldBe false
+                }
+                withClue("Each owner gets their permanent back") {
+                    game.state.getHand(game.player1Id).count {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Green Bear"
+                    } shouldBe 1
+                    game.state.getHand(game.player2Id).count {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Red Ogre"
+                    } shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BreakingWave.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BreakingWave.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Breaking Wave
+ * {2}{U}{U}
+ * Sorcery
+ * You may cast this spell as though it had flash if you pay {2} more to cast it.
+ * Simultaneously untap all tapped creatures and tap all untapped creatures.
+ *
+ * The "pay {2} more to cast as though it had flash" clause is the Ghitu Fire pattern:
+ * [KeywordAbility.flashKicker] — paying the extra cost unlocks instant-speed casting
+ * without otherwise changing the spell.
+ *
+ * "Simultaneously" matters: a naive untap-then-tap (or tap-then-untap) would re-flip the
+ * creatures it just touched. Instead both groups are snapshotted up front with two
+ * [GatherCardsEffect] steps (tapped creatures, untapped creatures) before any tapping
+ * happens, then the snapshots are applied via [TapUntapCollectionEffect]. Because the
+ * collections are captured before mutation, the swap is atomic.
+ */
+val BreakingWave = card("Breaking Wave") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "You may cast this spell as though it had flash if you pay {2} more to cast it. " +
+        "(You may cast it any time you could cast an instant.)\n" +
+        "Simultaneously untap all tapped creatures and tap all untapped creatures."
+
+    keywordAbility(KeywordAbility.flashKicker("{2}"))
+
+    spell {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.BattlefieldMatching(
+                    filter = GameObjectFilter.Creature.tapped(),
+                    player = Player.Each,
+                ),
+                storeAs = "breakingWave_tapped",
+            ),
+            GatherCardsEffect(
+                source = CardSource.BattlefieldMatching(
+                    filter = GameObjectFilter.Creature.untapped(),
+                    player = Player.Each,
+                ),
+                storeAs = "breakingWave_untapped",
+            ),
+            TapUntapCollectionEffect(collectionName = "breakingWave_tapped", tap = false),
+            TapUntapCollectionEffect(collectionName = "breakingWave_untapped", tap = true),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "48"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b39cd77-97aa-4099-8405-366f82079758.jpg?1562900378"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DistortingWake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DistortingWake.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Distorting Wake
+ * {X}{U}{U}{U}
+ * Sorcery
+ * Return X target nonland permanents to their owners' hands.
+ *
+ * X-clamped targeting (Builder's Bane pattern): [TargetPermanent.dynamicMaxCount] =
+ * [DynamicAmount.XValue] makes the targeting overlay's max selection track the X chosen
+ * at cast time. `optional = true` so X = 0 (legal but does nothing) resolves cleanly and
+ * a cast with fewer legal nonland permanents than X doesn't fizzle. The chosen targets
+ * are gathered and bounced via the standard gather → move-to-hand pipeline.
+ */
+val DistortingWake = card("Distorting Wake") {
+    manaCost = "{X}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return X target nonland permanents to their owners' hands."
+
+    spell {
+        target = TargetPermanent(
+            optional = true,
+            filter = TargetFilter.NonlandPermanent,
+            dynamicMaxCount = DynamicAmount.XValue,
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "distortingWake_targets"),
+            MoveCollectionEffect(
+                from = "distortingWake_targets",
+                destination = CardDestination.ToZone(Zone.HAND),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "52"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cf48eec9-96be-4f53-9d9a-c6f02d44c995.jpg?1562936657"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TidalVisionary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TidalVisionary.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tidal Visionary
+ * {U}
+ * Creature — Merfolk Wizard
+ * 1/1
+ * {T}: Target creature becomes the color of your choice until end of turn.
+ *
+ * Reuses the single-color recolor pattern from Blind Seer: [Effects.ChooseColorThen]
+ * pauses for a color choice, then [Effects.ChangeColorToChosen] applies the Layer-5
+ * color change for the rest of the turn.
+ */
+val TidalVisionary = card("Tidal Visionary") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Target creature becomes the color of your choice until end of turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Creature)
+        effect = Effects.ChooseColorThen(
+            then = Effects.ChangeColorToChosen(t),
+            prompt = "Choose a color"
+        )
+        description = "{T}: Target creature becomes the color of your choice until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "80"
+        artist = "Glen Angus"
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a72a3051-7f46-4b6b-b4fb-0f170d9687ab.jpg?1562928768"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WashOut.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/WashOut.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Wash Out
+ * {3}{U}
+ * Sorcery
+ * Return all permanents of the color of your choice to their owners' hands.
+ *
+ * Composes the chosen-color pattern (Searing Rays / Coalition Dragon cycle) with the
+ * gather→move-to-hand bounce pipeline: [Effects.ChooseColorThen] pauses for the color
+ * choice, then [GatherCardsEffect] snapshots every battlefield permanent whose colors
+ * include the chosen color (via [CardPredicate.HasChosenColor], read from the resolution
+ * context) and [MoveCollectionEffect] returns them to their owners' hands.
+ */
+val WashOut = card("Wash Out") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return all permanents of the color of your choice to their owners' hands."
+
+    spell {
+        effect = Effects.ChooseColorThen(
+            then = Effects.Composite(
+                GatherCardsEffect(
+                    source = CardSource.BattlefieldMatching(
+                        filter = GameObjectFilter(
+                            cardPredicates = listOf(CardPredicate.HasChosenColor),
+                        ),
+                        player = Player.Each,
+                    ),
+                    storeAs = "washOut_gathered",
+                ),
+                MoveCollectionEffect(
+                    from = "washOut_gathered",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                ),
+            ),
+            prompt = "Choose a color",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Matthew D. Wilson"
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/7719d043-5827-4479-825b-23d9e979ead7.jpg?1562918901"
+    }
+}


### PR DESCRIPTION
Implements four blue Invasion (INV) cards, all composed from existing SDK primitives — no new effect types or executors.

## Cards

- **Breaking Wave** ({2}{U}{U}, Sorcery) — "You may cast this spell as though it had flash if you pay {2} more to cast it. Simultaneously untap all tapped creatures and tap all untapped creatures."
  - Flash clause: `KeywordAbility.flashKicker("{2}")` (Ghitu Fire pattern).
  - Simultaneity: gathers tapped + untapped creatures into two snapshots first, then applies `TapUntapCollection` to each — so the swap is atomic and neither group re-flips the other.
- **Wash Out** ({3}{U}, Sorcery) — "Return all permanents of the color of your choice to their owners' hands."
  - `ChooseColorThen` + `GatherCards(BattlefieldMatching, HasChosenColor)` + `MoveCollection` to hand (chosen-color pattern from the Coalition Dragon cycle / Searing Rays).
- **Tidal Visionary** ({U}, 1/1 Merfolk Wizard) — "{T}: Target creature becomes the color of your choice until end of turn."
  - `ChooseColorThen` + `ChangeColorToChosen` (Blind Seer pattern, targeting a creature).
- **Distorting Wake** ({X}{U}{U}{U}, Sorcery) — "Return X target nonland permanents to their owners' hands."
  - X-clamped multi-target bounce: `TargetPermanent(dynamicMaxCount = XValue)` + gather chosen targets + move to hand (Builder's Bane targeting pattern).

## Tests

`InvasionBlueBounceScenarioTest` covers all four (atomic tap/untap swap, chosen-color mass bounce with owner-correct returns, single-target recolor via projected colors, X-target bounce). Full `just build` passes; printing verifier confirms INV is the canonical earliest printing for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)