### PR TITLE
Add Invasion: Undermine, Absorb, Spite//Malice, Void

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -429,6 +429,11 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `ChooseColorAndGrantProtectionToGroupEffect(filter)` — same, for a group.
 - `GrantProtectionFromColor(color, target, duration)` — grant protection from a **fixed** color to a target (no player choice); a thin recipe over `GrantKeyword("PROTECTION_FROM_<COLOR>")`. "{W}: Target creature gains protection from red until end of turn." (Crimson Acolyte).
 - `ChooseColorThenEffect(whenChosen)` — pick a color, then run a function of that color.
+- `Effects.ChooseNumberThen(then, minValue=0, maxValue=16, prompt)` — pick a number in `[minValue, maxValue]`,
+  then run `then` once with the chosen number exposed via the effect context as **X**. Atomic effects and filters
+  under `then` read it through `ManaValueEqualsX` (`.manaValueEqualsX()`). Compose with `CompositeEffect` for
+  multi-step cards (Void: destroy all artifacts/creatures with that mana value, then a target player reveals their
+  hand and discards all nonland cards with that mana value).
 - `GrantHexproofFromChosenColorEffect(target)` — hexproof from chosen color.
 - `ChooseCreatureTypeEffect(...)` — pause for creature-type pick.
 - `SelectTargetEffect(...)` — have a player pick from a valid set.
@@ -641,6 +646,8 @@ Every `TargetRequirement` carries count semantics (defaults shown):
 - `.power(n)` / `.minPower(n)` / `.maxPower(n)` — P/T comparator.
 - `.manaValue(n)` / `.manaValueAtMost(n)` / `.manaValueAtLeast(n)` — mana-value comparator.
 - `.manaValueAtMostX()` — mana value ≤ the X chosen for the source spell/ability.
+- `.manaValueEqualsX()` — mana value **exactly equal** to the number chosen for the source spell/ability
+  (set by `Effects.ChooseNumberThen`; resolution-time only — matches nothing without a chosen number). Used by Void.
 - `.manaValueAtMostEntity(ref)` — mana value ≤ a referenced entity's mana value (e.g. Kodama of the East Tree).
 - `.manaValueAtMostEntityManaSpent(ref)` — mana value ≤ the mana **actually spent** to cast a referenced
   entity. Reads the live `SpellOnStackComponent` buckets while the entity is still a spell, or the

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AbsorbScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AbsorbScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Absorb.
+ *
+ * Absorb ({W}{U}{U}, Instant):
+ *   "Counter target spell. You gain 3 life."
+ *
+ * Exercises the `CounterSpell then GainLife(3)` composition — the life gain goes to Absorb's
+ * caster, not the countered spell's controller.
+ */
+class AbsorbScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature("Test Bear", ManaCost.parse("{1}{G}"), setOf(Subtype("Bear")), 2, 2)
+        )
+
+        context("Absorb effect") {
+            test("counters a spell and the caster gains 3 life") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Absorb")
+                    .withCardInHand(2, "Test Bear")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearResult = game.castSpell(2, "Test Bear")
+                withClue("Test Bear should be cast: ${bearResult.error}") {
+                    bearResult.error shouldBe null
+                }
+                game.execute(PassPriority(game.player2Id))
+
+                val counterResult = game.castSpellTargetingStackSpell(1, "Absorb", "Test Bear")
+                withClue("Absorb should be cast: ${counterResult.error}") {
+                    counterResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Test Bear should be countered (in Opponent's graveyard)") {
+                    game.isOnBattlefield("Test Bear") shouldBe false
+                    game.isInGraveyard(2, "Test Bear") shouldBe true
+                }
+                withClue("Absorb's caster gains 3 life: 20 -> 23") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+                withClue("Opponent's life is unchanged") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SpiteMaliceScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SpiteMaliceScenarioTest.kt
@@ -1,0 +1,202 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario test for the split card Spite // Malice (CardLayout.SPLIT).
+ *
+ * Spite ({3}{U}, Instant): "Counter target noncreature spell."
+ * Malice ({3}{B}, Instant): "Destroy target nonblack creature. It can't be regenerated."
+ *
+ * Each half is cast independently via `CastSpell(faceIndex = ...)`. Exercises:
+ *  - Spite countering a noncreature spell, and being unable to target a creature spell.
+ *  - Malice destroying a nonblack creature, refusing a black creature, and ignoring a
+ *    regeneration shield (its "can't be regenerated" clause).
+ */
+class SpiteMaliceScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.sorcery("Test Cantrip", ManaCost.parse("{1}{U}"), "Draw a card.")
+        )
+        cardRegistry.register(
+            CardDefinition.creature("Test Bear", ManaCost.parse("{1}{G}"), setOf(Subtype("Bear")), 2, 2)
+        )
+        cardRegistry.register(
+            CardDefinition.creature("Green Zombie", ManaCost.parse("{1}{G}"), setOf(Subtype("Zombie")), 2, 2)
+        )
+        cardRegistry.register(
+            CardDefinition.creature("Black Brute", ManaCost.parse("{1}{B}"), setOf(Subtype("Zombie")), 2, 2)
+        )
+
+        context("Spite (face 0)") {
+            test("counters a noncreature spell") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Spite // Malice")
+                    .withCardInHand(2, "Test Cantrip")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(2, "Island", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Test Cantrip")
+                game.execute(PassPriority(game.player2Id))
+
+                val spiteId = cardInHand(game, game.player1Id, "Spite // Malice")
+                val cantripOnStack = spellOnStack(game, "Test Cantrip")
+                val result = game.execute(
+                    CastSpell(game.player1Id, spiteId, targets = listOf(ChosenTarget.Spell(cantripOnStack)), faceIndex = 0)
+                )
+                withClue("Spite should be cast: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Test Cantrip should be countered (in Opponent's graveyard)") {
+                    game.isInGraveyard(2, "Test Cantrip") shouldBe true
+                }
+            }
+
+            test("cannot counter a creature spell") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Spite // Malice")
+                    .withCardInHand(2, "Test Bear")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Test Bear")
+                game.execute(PassPriority(game.player2Id))
+
+                val spiteId = cardInHand(game, game.player1Id, "Spite // Malice")
+                val bearOnStack = spellOnStack(game, "Test Bear")
+                val result = game.execute(
+                    CastSpell(game.player1Id, spiteId, targets = listOf(ChosenTarget.Spell(bearOnStack)), faceIndex = 0)
+                )
+                withClue("Spite should not be castable against a creature spell") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+
+        context("Malice (face 1)") {
+            test("destroys a nonblack creature") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Spite // Malice")
+                    .withCardOnBattlefield(2, "Test Bear")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val maliceId = cardInHand(game, game.player1Id, "Spite // Malice")
+                val bear = game.findPermanent("Test Bear")!!
+                val result = game.execute(
+                    CastSpell(game.player1Id, maliceId, targets = listOf(ChosenTarget.Permanent(bear)), faceIndex = 1)
+                )
+                withClue("Malice should be cast: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Test Bear (nonblack) should be destroyed") {
+                    game.isOnBattlefield("Test Bear") shouldBe false
+                    game.isInGraveyard(2, "Test Bear") shouldBe true
+                }
+            }
+
+            test("cannot target a black creature") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Spite // Malice")
+                    .withCardOnBattlefield(2, "Black Brute")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val maliceId = cardInHand(game, game.player1Id, "Spite // Malice")
+                val brute = game.findPermanent("Black Brute")!!
+                val result = game.execute(
+                    CastSpell(game.player1Id, maliceId, targets = listOf(ChosenTarget.Permanent(brute)), faceIndex = 1)
+                )
+                withClue("Malice should not be castable against a black creature") {
+                    result.error shouldNotBe null
+                }
+                withClue("Black Brute should still be on the battlefield") {
+                    game.isOnBattlefield("Black Brute") shouldBe true
+                }
+            }
+
+            test("can't be regenerated — a regeneration shield does not save the creature") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(2, "Boneknitter")     // {1}{B}: Regenerate target Zombie
+                    .withCardOnBattlefield(2, "Green Zombie")     // nonblack Zombie to protect
+                    .withLandsOnBattlefield(2, "Swamp", 2)
+                    .withCardInHand(1, "Spite // Malice")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val boneknitterId = game.findPermanent("Boneknitter")!!
+                val zombieId = game.findPermanent("Green Zombie")!!
+
+                // Opponent puts a regeneration shield on the Green Zombie.
+                val ability = cardRegistry.getCard("Boneknitter")!!.script.activatedAbilities.first()
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player2Id,
+                        sourceId = boneknitterId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(zombieId))
+                    )
+                )
+                game.resolveStack()
+                game.execute(PassPriority(game.player2Id))
+
+                // Caster destroys it with Malice — the shield must not save it.
+                val maliceId = cardInHand(game, game.player1Id, "Spite // Malice")
+                val result = game.execute(
+                    CastSpell(game.player1Id, maliceId, targets = listOf(ChosenTarget.Permanent(zombieId)), faceIndex = 1)
+                )
+                withClue("Malice should be cast: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Green Zombie should be destroyed despite the regeneration shield") {
+                    game.isOnBattlefield("Green Zombie") shouldBe false
+                    game.isInGraveyard(2, "Green Zombie") shouldBe true
+                }
+            }
+        }
+    }
+
+    private fun cardInHand(game: TestGame, playerId: EntityId, name: String): EntityId =
+        game.state.getHand(playerId).first { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    private fun spellOnStack(game: TestGame, name: String): EntityId =
+        game.state.stack.first { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/UndermineScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/UndermineScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Undermine.
+ *
+ * Undermine ({U}{U}{B}, Instant):
+ *   "Counter target spell. Its controller loses 3 life."
+ *
+ * Exercises the `CounterSpell then LoseLife(EffectTarget.TargetController)` composition —
+ * in particular that the life loss is applied to the *countered spell's controller*, not the
+ * caster of Undermine.
+ */
+class UndermineScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature("Test Bear", ManaCost.parse("{1}{G}"), setOf(Subtype("Bear")), 2, 2)
+        )
+
+        context("Undermine effect") {
+            test("counters a spell and its controller loses 3 life") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Undermine")
+                    .withCardInHand(2, "Test Bear")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Opponent casts Test Bear; Caster responds with Undermine.
+                val bearResult = game.castSpell(2, "Test Bear")
+                withClue("Test Bear should be cast: ${bearResult.error}") {
+                    bearResult.error shouldBe null
+                }
+                game.execute(PassPriority(game.player2Id))
+
+                val counterResult = game.castSpellTargetingStackSpell(1, "Undermine", "Test Bear")
+                withClue("Undermine should be cast: ${counterResult.error}") {
+                    counterResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Test Bear should be countered (in Opponent's graveyard)") {
+                    game.isOnBattlefield("Test Bear") shouldBe false
+                    game.isInGraveyard(2, "Test Bear") shouldBe true
+                }
+                withClue("The countered spell's controller (Opponent) loses 3 life: 20 -> 17") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+                withClue("Undermine's caster does not lose life") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VoidScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VoidScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Void.
+ *
+ * Void ({3}{B}{R}, Sorcery):
+ *   "Choose a number. Destroy all artifacts and creatures with mana value equal to that
+ *    number. Then target player reveals their hand and discards all nonland cards with
+ *    mana value equal to the number."
+ *
+ * Exercises the new `Effects.ChooseNumberThen` combinator + `manaValueEqualsX()` filter
+ * predicate: the single chosen number drives both the board wipe and the discard.
+ */
+class VoidScenarioTest : ScenarioTestBase() {
+
+    init {
+        // Inline test cards with predictable mana values.
+        cardRegistry.register(
+            CardDefinition.creature("MV2 Bear", ManaCost.parse("{1}{G}"), setOf(Subtype("Bear")), 2, 2)
+        )
+        cardRegistry.register(
+            CardDefinition.creature("MV3 Ogre", ManaCost.parse("{2}{R}"), setOf(Subtype("Ogre")), 3, 3)
+        )
+        cardRegistry.register(
+            CardDefinition.artifact("MV2 Trinket", ManaCost.parse("{2}"))
+        )
+        cardRegistry.register(
+            CardDefinition.sorcery("MV2 Cantrip", ManaCost.parse("{1}{U}"), "Draw a card.")
+        )
+
+        context("Void effect") {
+            test("destroys MV-equal artifacts and creatures, discards MV-equal nonland cards") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Void")
+                    // Caster needs {3}{B}{R} = 5 mana
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    // Battlefield: an MV2 creature, MV2 artifact (both should die at number=2),
+                    // and an MV3 creature (should survive).
+                    .withCardOnBattlefield(2, "MV2 Bear")
+                    .withCardOnBattlefield(2, "MV2 Trinket")
+                    .withCardOnBattlefield(2, "MV3 Ogre")
+                    // Opponent's hand: an MV2 spell (discarded), an MV3 spell (kept), a land (kept).
+                    .withCardInHand(2, "MV2 Cantrip")
+                    .withCardInHand(2, "MV3 Ogre")
+                    .withCardInHand(2, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpellTargetingPlayer(1, "Void", 2)
+                withClue("Void should be cast successfully") {
+                    castResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Void should pause for a number choice") {
+                    game.hasPendingDecision() shouldBe true
+                    game.getPendingDecision().shouldBeInstanceOf<ChooseNumberDecision>()
+                }
+
+                // Choose 2.
+                game.chooseNumber(2)
+
+                // Board wipe: MV2 permanents destroyed, MV3 survives.
+                withClue("MV2 Bear should be destroyed") {
+                    game.isOnBattlefield("MV2 Bear") shouldBe false
+                    game.isInGraveyard(2, "MV2 Bear") shouldBe true
+                }
+                withClue("MV2 Trinket should be destroyed") {
+                    game.isOnBattlefield("MV2 Trinket") shouldBe false
+                    game.isInGraveyard(2, "MV2 Trinket") shouldBe true
+                }
+                withClue("MV3 Ogre should survive on the battlefield") {
+                    game.isOnBattlefield("MV3 Ogre") shouldBe true
+                }
+
+                // Discard: MV2 nonland card discarded; MV3 spell and land kept.
+                withClue("Opponent's MV2 Cantrip should be discarded") {
+                    game.isInHand(2, "MV2 Cantrip") shouldBe false
+                    game.isInGraveyard(2, "MV2 Cantrip") shouldBe true
+                }
+                withClue("Opponent's MV3 Ogre (in hand) should be kept") {
+                    game.isInHand(2, "MV3 Ogre") shouldBe true
+                }
+                withClue("Opponent's Forest (a land) should be kept") {
+                    game.isInHand(2, "Forest") shouldBe true
+                }
+            }
+
+            test("choosing a number with no matches destroys and discards nothing") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Void")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "MV2 Bear")
+                    .withCardInHand(2, "MV2 Cantrip")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Void", 2)
+                game.resolveStack()
+
+                // Choose 5 — nothing on board or in hand has MV 5.
+                game.chooseNumber(5)
+
+                withClue("MV2 Bear should survive (chosen number was 5)") {
+                    game.isOnBattlefield("MV2 Bear") shouldBe true
+                }
+                withClue("Opponent's MV2 Cantrip should be kept (chosen number was 5)") {
+                    game.isInHand(2, "MV2 Cantrip") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -35,6 +35,7 @@ import com.wingedsheep.sdk.scripting.effects.SetBasePowerEffect
 import com.wingedsheep.sdk.scripting.effects.ChooseColorAndGrantProtectionToGroupEffect
 import com.wingedsheep.sdk.scripting.effects.ChooseColorAndGrantProtectionToTargetEffect
 import com.wingedsheep.sdk.scripting.effects.ChooseColorThenEffect
+import com.wingedsheep.sdk.scripting.effects.ChooseNumberThenEffect
 import com.wingedsheep.sdk.scripting.effects.GrantHexproofFromChosenColorEffect
 import com.wingedsheep.sdk.scripting.effects.GrantCantBeBlockedByChosenColorEffect
 import com.wingedsheep.sdk.scripting.effects.GrantToxicEffect
@@ -1400,6 +1401,21 @@ object Effects {
         then: Effect,
         prompt: String = "Choose a color"
     ): Effect = ChooseColorThenEffect(then, prompt)
+
+    /**
+     * Choose a number, then run [then] with the chosen number exposed via the effect
+     * context (as X). Atomic effects and filters under [then] read it through
+     * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueEqualsX] (via
+     * `GameObjectFilter`/`GroupFilter` `manaValueEqualsX()`). Compose with [Composite]
+     * for multi-step cards (Void: destroy all, then reveal & discard). [minValue]/[maxValue]
+     * bound the legal choice.
+     */
+    fun ChooseNumberThen(
+        then: Effect,
+        minValue: Int = 0,
+        maxValue: Int = 16,
+        prompt: String = "Choose a number"
+    ): Effect = ChooseNumberThenEffect(then, minValue, maxValue, prompt)
 
     /**
      * Grant Toxic N to a target until end of turn. Resolves to a `TOXIC_<n>`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -505,3 +505,28 @@ data class TheRingTemptsYouEffect(
 
     override fun applyTextReplacement(replacer: TextReplacer): Effect = this
 }
+
+/**
+ * "Choose a number, then [effect]." The controller is prompted for an integer in
+ * [[minValue], [maxValue]]; the chosen number is stamped onto the effect context (as the
+ * X value) and [then] is executed once. Atomic effects and filters read the chosen number
+ * via [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueEqualsX] so the same
+ * combinator works for any "choose a number, act on objects with that mana value" card (Void).
+ *
+ * Compose [then] with [CompositeEffect] when several effects key off the chosen number.
+ */
+@SerialName("ChooseNumberThen")
+@Serializable
+data class ChooseNumberThenEffect(
+    val then: Effect,
+    val minValue: Int = 0,
+    val maxValue: Int = 16,
+    val prompt: String = "Choose a number"
+) : Effect {
+    override val description: String = "Choose a number. ${then.description}"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect {
+        val newThen = then.applyTextReplacement(replacer)
+        return if (newThen !== then) copy(then = newThen) else this
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -223,6 +223,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.ManaValueAtMostX
     )
 
+    /** Mana value exactly equal to the number chosen for the source spell/ability (Void) */
+    fun manaValueEqualsX() = copy(
+        cardPredicates = cardPredicates + CardPredicate.ManaValueEqualsX
+    )
+
     /** Mana value at least */
     fun manaValueAtLeast(min: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.ManaValueAtLeast(min)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -308,6 +308,19 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     }
 
     /**
+     * Mana value exactly equal to the number chosen for the source spell/ability.
+     * Resolves against [PredicateContext.xValue] at evaluation time. Used by effects
+     * that "choose a number" and then act on objects with that mana value (Void). When
+     * the chosen number is unbound, nothing matches.
+     */
+    @SerialName("ManaValueEqualsX")
+    @Serializable
+    data object ManaValueEqualsX : CardPredicate {
+        override val description: String = "with mana value equal to the chosen number"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
+    /**
      * Mana value at most the X chosen for the source spell/ability.
      * Resolves against [PredicateContext.xValue] at evaluation time, so it works
      * both at cast-time target validation and at resolution-time legality re-check.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Absorb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Absorb.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Absorb
+ * {W}{U}{U}
+ * Instant
+ * Counter target spell. You gain 3 life.
+ */
+val Absorb = card("Absorb") {
+    manaCost = "{W}{U}{U}"
+    colorIdentity = "WU"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. You gain 3 life."
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpell() then Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "226"
+        artist = "Andrew Goldhawk"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d6a0f3e-457f-41f5-be26-5fb249874f1a.jpg?1562913952"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SpiteMalice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SpiteMalice.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Spite // Malice (INV 293) — split-layout instant.
+ *
+ * Spite {3}{U} — Instant
+ *   Counter target noncreature spell.
+ *
+ * Malice {3}{B} — Instant
+ *   Destroy target nonblack creature. It can't be regenerated.
+ *
+ * Cast either half separately.
+ */
+val SpiteMalice = card("Spite // Malice") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "UB"
+
+    face("Spite") {
+        manaCost = "{3}{U}"
+        typeLine = "Instant"
+        oracleText = "Counter target noncreature spell."
+
+        spell {
+            target = Targets.NoncreatureSpell
+            effect = Effects.CounterSpell()
+        }
+    }
+
+    face("Malice") {
+        manaCost = "{3}{B}"
+        typeLine = "Instant"
+        oracleText = "Destroy target nonblack creature. It can't be regenerated."
+
+        spell {
+            val creature = target(
+                "target nonblack creature",
+                TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK))
+            )
+            effect = CantBeRegeneratedEffect(creature) then Effects.Destroy(creature)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "293"
+        artist = "David Martin"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/054f1845-196f-41c1-9682-042171cccd49.jpg?1562896042"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Undermine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Undermine.kt
@@ -20,7 +20,11 @@ val Undermine = card("Undermine") {
 
     spell {
         target = Targets.Spell
-        effect = Effects.CounterSpell() then Effects.LoseLife(3, EffectTarget.TargetController)
+        // Resolve the life loss while the spell is still on the stack so `TargetController`
+        // can read its controller; countering first moves the spell to the graveyard and the
+        // controller lookup silently fails. Both happen in one resolution, so the order is
+        // imperceptible to players.
+        effect = Effects.LoseLife(3, EffectTarget.TargetController) then Effects.CounterSpell()
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Undermine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Undermine.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Undermine
+ * {U}{U}{B}
+ * Instant
+ * Counter target spell. Its controller loses 3 life.
+ */
+val Undermine = card("Undermine") {
+    manaCost = "{U}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. Its controller loses 3 life."
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpell() then Effects.LoseLife(3, EffectTarget.TargetController)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "282"
+        artist = "Massimiliano Frezzato"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/2334bc71-5f85-47ff-b393-601a1e746a4e.jpg?1762258073"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Void.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Void.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Void
+ * {3}{B}{R}
+ * Sorcery
+ * Choose a number. Destroy all artifacts and creatures with mana value equal to that
+ * number. Then target player reveals their hand and discards all nonland cards with
+ * mana value equal to the number.
+ *
+ * "Choose a number" is modeled with [Effects.ChooseNumberThen], which stamps the chosen
+ * number onto the effect context as X. The board wipe and the discard both filter by
+ * [CardPredicate.ManaValueEqualsX] (`manaValueEqualsX()`), so a single chosen value drives
+ * both steps.
+ */
+val Void = card("Void") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Sorcery"
+    oracleText = "Choose a number. Destroy all artifacts and creatures with mana value equal to " +
+        "that number. Then target player reveals their hand and discards all nonland cards with " +
+        "mana value equal to the number."
+
+    spell {
+        val targetPlayer = target("target player", TargetPlayer())
+        effect = Effects.ChooseNumberThen(
+            then = CompositeEffect(
+                listOf(
+                    // Destroy all artifacts and creatures with mana value equal to the chosen number.
+                    Effects.DestroyAll(
+                        filter = GameObjectFilter(
+                            cardPredicates = listOf(
+                                CardPredicate.Or(listOf(CardPredicate.IsArtifact, CardPredicate.IsCreature)),
+                                CardPredicate.ManaValueEqualsX,
+                            ),
+                        ),
+                    ),
+                    // Target player reveals their hand and discards all nonland cards with that mana value.
+                    RevealHandEffect(targetPlayer),
+                    GatherCardsEffect(
+                        source = CardSource.FromZone(
+                            zone = Zone.HAND,
+                            player = Player.ContextPlayer(0),
+                            filter = GameObjectFilter(
+                                cardPredicates = listOf(
+                                    CardPredicate.IsNonland,
+                                    CardPredicate.ManaValueEqualsX,
+                                ),
+                            ),
+                        ),
+                        storeAs = "voidDiscard",
+                    ),
+                    MoveCollectionEffect(
+                        from = "voidDiscard",
+                        destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                        moveType = MoveType.Discard,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "287"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62dc1df7-b9db-4f5f-a340-08287cd3d9e5.jpg?1562915020"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ColorAndTypeContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ColorAndTypeContinuations.kt
@@ -71,6 +71,25 @@ data class ChooseColorThenContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the controller chooses a number for a
+ * [com.wingedsheep.sdk.scripting.effects.ChooseNumberThenEffect].
+ *
+ * The resumer stamps the chosen number onto [baseContext] as the X value and dispatches
+ * [then] through the standard effect runner, so any composition of atomic effects and
+ * filters can read it via `EffectContext.xValue` /
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueEqualsX] (Void).
+ */
+@Serializable
+data class ChooseNumberThenContinuation(
+    override val decisionId: String,
+    val controllerId: EntityId,
+    val sourceId: EntityId?,
+    val sourceName: String?,
+    val then: Effect,
+    val baseContext: EffectContext
+) : ContinuationFrame
+
+/**
  * Resume after the controller of an [com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect]
  * picks the mana color. The resumer re-runs the effect via the executor registry with
  * `manaColorChoice` populated on [baseContext], so dynamic amounts evaluate consistently.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -186,6 +186,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ChooseColorProtectionContinuation::class)
         subclass(ChooseColorProtectionTargetContinuation::class)
         subclass(ChooseColorThenContinuation::class)
+        subclass(ChooseNumberThenContinuation::class)
         subclass(ChooseManaColorContinuation::class)
         subclass(ChooseColorForTargetContinuation::class)
         subclass(ChooseAnyColorTapBonusContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -560,6 +560,8 @@ class TriggerMatcher(
                 cmc <= predicate.max
             }
             com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostX -> false
+            // Resolution-time chosen-number predicate; TriggerMatcher has no chosen-number context.
+            com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueEqualsX -> false
             // Entity-relative — TriggerMatcher has no entity context; predicate doesn't apply here.
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostEntity -> false
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostEntityManaSpent -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -26,6 +26,12 @@ data class EffectContext(
     val controllerId: EntityId,
     val opponentId: EntityId?,
     val targets: List<ChosenTarget> = emptyList(),
+    /**
+     * The X chosen for an X-cost spell/ability. Also reused by `ChooseNumberThenEffect` to
+     * carry a "choose a number" value into the inner effect (read via `CardPredicate.ManaValueEqualsX`,
+     * Void). These two uses share one slot, so a future card that both pays `{X}` *and* chooses a
+     * number would collide here — split the slot before authoring such a card.
+     */
     val xValue: Int? = null,
     /**
      * Total mana paid from the pool to cast this spell — sum of every `manaSpent{Color}`

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -246,6 +246,12 @@ class PredicateEvaluator {
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc <= predicate.max
             }
+            is CardPredicate.ManaValueEqualsX -> {
+                // The chosen number is stamped onto the context as xValue. Unbound = no match.
+                val xValue = context?.xValue ?: return false
+                val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
+                cmc == xValue
+            }
             is CardPredicate.ManaValueAtMostX -> {
                 // Null xValue means X is unbound (legal-action enumeration runs before the
                 // player chooses X). Match permissively so the cast action is offered; the
@@ -764,8 +770,10 @@ class PredicateEvaluator {
             // Mana value predicates
             is CardPredicate.ManaValueEquals -> record.manaValue == predicate.value
             is CardPredicate.ManaValueAtMost -> record.manaValue <= predicate.max
-            // ManaValueAtMostX is target-time only; without context it cannot match record-level history.
+            // ManaValueAtMostX / ManaValueEqualsX are resolution-time chosen-number predicates;
+            // without context they cannot match record-level cast history.
             CardPredicate.ManaValueAtMostX -> false
+            CardPredicate.ManaValueEqualsX -> false
             is CardPredicate.ManaValueAtLeast -> record.manaValue >= predicate.min
             // Entity-relative — no entity context for cast records
             is CardPredicate.ManaValueAtMostEntity -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
@@ -25,6 +25,7 @@ class ColorChoiceContinuationResumer(
         resumer(ChooseColorProtectionContinuation::class, ::resumeChooseColorProtection),
         resumer(ChooseColorProtectionTargetContinuation::class, ::resumeChooseColorProtectionTarget),
         resumer(ChooseColorThenContinuation::class, ::resumeChooseColorThen),
+        resumer(ChooseNumberThenContinuation::class, ::resumeChooseNumberThen),
         resumer(ChooseManaColorContinuation::class, ::resumeChooseManaColor),
         resumer(ChooseColorForTargetContinuation::class, ::resumeChooseColorForTarget),
         resumer(ChooseAnyColorTapBonusContinuation::class, ::resumeChooseAnyColorTapBonus)
@@ -163,6 +164,28 @@ class ColorChoiceContinuationResumer(
             state,
             listOf(continuation.then),
             contextWithColor
+        )
+
+        if (effectResult.isPaused) return effectResult.toExecutionResult()
+        return checkForMore(effectResult.state, effectResult.events.toList())
+    }
+
+    fun resumeChooseNumberThen(
+        state: GameState,
+        continuation: ChooseNumberThenContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is NumberChosenResponse) {
+            return ExecutionResult.error(state, "Expected number choice response for ChooseNumberThen effect")
+        }
+
+        // Stamp the chosen number as X so atomic effects/filters (manaValueEqualsX) read it.
+        val contextWithNumber = continuation.baseContext.copy(xValue = response.number)
+        val effectResult = effectRunner.executeRemainingEffects(
+            state,
+            listOf(continuation.then),
+            contextWithNumber
         )
 
         if (effectResult.isPaused) return effectResult.toExecutionResult()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -169,7 +169,10 @@ object TargetResolutionUtils {
                 }
                 else -> emptyList()
             }
-            else -> resolvePlayerTarget(effectTarget, context)?.let { listOf(it) } ?: emptyList()
+            // Use the state-aware resolver so state-dependent targets (e.g. TargetController,
+            // which reads the target spell/permanent's controller) resolve here too. It tries
+            // the stateless path first, so this stays a superset of the previous behavior.
+            else -> resolvePlayerTarget(effectTarget, context, state)?.let { listOf(it) } ?: emptyList()
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ChooseNumberThenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ChooseNumberThenExecutor.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.handlers.effects.composite
+
+import com.wingedsheep.engine.core.ChooseNumberThenContinuation
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.ChooseNumberThenEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ChooseNumberThenEffect] — generic "choose a number, then run X".
+ *
+ * Pauses for a number decision and pushes a [ChooseNumberThenContinuation] carrying the
+ * inner effect plus a snapshot of the current [EffectContext]. The resumer stamps the
+ * chosen number onto the context as the X value and dispatches the inner effect, so atomic
+ * effects/filters read the chosen number uniformly (e.g. `manaValueEqualsX()`). Used by Void.
+ */
+class ChooseNumberThenExecutor(
+    private val decisionHandler: DecisionHandler
+) : EffectExecutor<ChooseNumberThenEffect> {
+
+    override val effectType: KClass<ChooseNumberThenEffect> = ChooseNumberThenEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ChooseNumberThenEffect,
+        context: EffectContext
+    ): EffectResult {
+        val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
+
+        val decisionResult = decisionHandler.createNumberDecision(
+            state = state,
+            playerId = context.controllerId,
+            sourceId = context.sourceId,
+            sourceName = sourceName,
+            prompt = effect.prompt,
+            minValue = effect.minValue,
+            maxValue = effect.maxValue,
+            phase = DecisionPhase.RESOLUTION
+        )
+
+        val continuation = ChooseNumberThenContinuation(
+            decisionId = decisionResult.pendingDecision!!.id,
+            controllerId = context.controllerId,
+            sourceId = context.sourceId,
+            sourceName = sourceName,
+            then = effect.then,
+            baseContext = context
+        )
+
+        return EffectResult.paused(
+            decisionResult.state.pushContinuation(continuation),
+            decisionResult.pendingDecision,
+            decisionResult.events
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
@@ -47,6 +47,7 @@ class CompositeExecutors(
     private val flipTwoCoinsExecutor by lazy { FlipTwoCoinsExecutor(effectExecutor) }
     private val chooseActionEffectExecutor by lazy { ChooseActionEffectExecutor(effectExecutor) }
     private val repeatDynamicTimesExecutor by lazy { RepeatDynamicTimesExecutor(effectExecutor) }
+    private val chooseNumberThenExecutor by lazy { ChooseNumberThenExecutor(decisionHandler) }
 
     /**
      * Initialize the module with the parent registry's execute function.
@@ -80,6 +81,7 @@ class CompositeExecutors(
         flipTwoCoinsExecutor,
         repeatWhileExecutor,
         repeatDynamicTimesExecutor,
-        conditionalOnCollectionExecutor
+        conditionalOnCollectionExecutor,
+        chooseNumberThenExecutor
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -442,8 +442,9 @@ internal class AffectsFilterResolver {
         }
         is CardPredicate.ManaValueEquals -> card.manaValue == predicate.value
         is CardPredicate.ManaValueAtMost -> card.manaValue <= predicate.max
-        // ManaValueAtMostX is target-time only; layer-projection has no X context, so it never matches here.
+        // ManaValueAtMostX / ManaValueEqualsX are resolution-time only; layer-projection has no chosen-number context.
         CardPredicate.ManaValueAtMostX -> false
+        CardPredicate.ManaValueEqualsX -> false
         is CardPredicate.ManaValueAtLeast -> card.manaValue >= predicate.min
         // Entity-relative — layer-projection has no trigger/source context for filter purposes here.
         is CardPredicate.ManaValueAtMostEntity -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -851,8 +851,9 @@ class CostCalculator(
 
             is CardPredicate.ManaValueEquals -> cardDef.manaCost.cmc == predicate.value
             is CardPredicate.ManaValueAtMost -> cardDef.manaCost.cmc <= predicate.max
-            // CostCalculator has no X context; predicate has no static answer here.
+            // CostCalculator has no chosen-number context; predicate has no static answer here.
             CardPredicate.ManaValueAtMostX -> false
+            CardPredicate.ManaValueEqualsX -> false
             is CardPredicate.ManaValueAtLeast -> cardDef.manaCost.cmc >= predicate.min
             // CostCalculator has no entity context; predicate has no static answer here.
             is CardPredicate.ManaValueAtMostEntity -> false


### PR DESCRIPTION
Implements four Invasion (INV) cards.

## Cards

- **Undermine** `{U}{U}{B}` — Instant. Counter target spell. Its controller loses 3 life. (composed from existing `CounterSpell` + `LoseLife(EffectTarget.TargetController)`)
- **Absorb** `{W}{U}{U}` — Instant. Counter target spell. You gain 3 life. (`CounterSpell` + `GainLife`)
- **Spite // Malice** `{3}{U}` // `{3}{B}` — Split instant. Spite counters a noncreature spell; Malice destroys a nonblack creature that can't be regenerated. (`CardLayout.SPLIT`, existing facades)
- **Void** `{3}{B}{R}` — Sorcery. Choose a number; destroy all artifacts and creatures with that mana value; then target player reveals their hand and discards all nonland cards with that mana value.

## New mechanic: choose-a-number

Void introduces a reusable combinator rather than a card-specific executor:

- `Effects.ChooseNumberThen(then, minValue, maxValue, prompt)` — pauses for a number, stamps it onto the effect context as **X**, then runs `then` once. Mirrors the existing `ChooseColorThen` shape (executor + continuation + resumer in `ColorChoiceContinuationResumer`).
- `CardPredicate.ManaValueEqualsX` / `GameObjectFilter.manaValueEqualsX()` — match objects whose mana value equals the chosen number. Resolution-time only, mirroring `ManaValueAtMostX`; stubbed `false` in the context-free matchers (`AffectsFilterResolver`, `CostCalculator`, `TriggerMatcher`).

Void then composes `DestroyAll(artifacts/creatures with MV=X)` + reveal-hand + gather-and-discard (nonland, MV=X) — the one chosen number drives both halves.

## Tests

- `VoidScenarioTest` — destroy + discard at a matching number, and the no-match case.
- Full `rules-engine` and `game-server` scenario suites pass; `mtg-sets` (image URIs) pass.

## Docs

- `docs/card-sdk-language-reference.md` updated for `ChooseNumberThen`, `ManaValueEqualsX`, and `manaValueEqualsX()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)