### PR TITLE
Add Invasion enchantments: Aura Shards, Sterling Grove, Elfhame Sanctuary, Saproling Symbiosis

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -368,6 +368,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `Effects.Suspect(target)` — target becomes Suspected (MKM keyword). Composite: `SetSuspectedEffect` (named status, CR 701.60d dedup) + `GrantKeywordEffect(MENACE)` + `CantBlockEffect`.
 - `RemoveFromCombatEffect(target)` — yank target out of combat.
 - `SkipNextTurnEffect(target)` — target skips their next turn.
+- `Effects.SkipNextDrawStep(target = Controller)` (`SkipNextDrawStepEffect`) — target skips their next draw step. Adds a one-shot `SkipDrawStepComponent` marker consumed by `DrawPhaseManager.performDrawStep` (Elfhame Sanctuary's "you skip your draw step this turn").
 - `HijackNextTurnEffect(target)` — you control target's next turn.
 - `GrantCantBeBlockedByChosenColorEffect(target, duration)` — unblockable except by chosen color.
 - `CantCastSpellsEffect(target, until?)` — target can't cast spells.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AuraShardsScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AuraShardsScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Aura Shards.
+ *
+ * Aura Shards: {1}{G}{W}
+ * Enchantment
+ * Whenever a creature you control enters, you may destroy target artifact or enchantment.
+ */
+class AuraShardsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Aura Shards") {
+
+            test("a creature entering lets you destroy a target enchantment") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Aura Shards")
+                    .withCardOnBattlefield(2, "Collective Restraint")
+                    .withCardInHand(1, "Willow Dryad")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val enchantmentId = game.findPermanent("Collective Restraint")!!
+
+                // Casting and resolving the creature triggers Aura Shards' ETB ability.
+                game.castSpell(1, "Willow Dryad")
+                game.resolveStack()
+
+                // Optional "you may" first, then choose the target.
+                game.answerYesNo(true)
+                game.selectTargets(listOf(enchantmentId))
+                game.resolveStack()
+
+                withClue("Willow Dryad should be on the battlefield") {
+                    game.isOnBattlefield("Willow Dryad") shouldBe true
+                }
+                withClue("the targeted enchantment should be destroyed") {
+                    game.findPermanents("Collective Restraint").isEmpty() shouldBe true
+                    game.isInGraveyard(2, "Collective Restraint") shouldBe true
+                }
+            }
+
+            test("declining the trigger leaves the enchantment intact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Aura Shards")
+                    .withCardOnBattlefield(2, "Collective Restraint")
+                    .withCardInHand(1, "Willow Dryad")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Willow Dryad")
+                game.resolveStack()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("the enchantment should still be on the battlefield") {
+                    game.isOnBattlefield("Collective Restraint") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ElfhameSanctuaryScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ElfhameSanctuaryScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Elfhame Sanctuary.
+ *
+ * Elfhame Sanctuary: {1}{G}
+ * Enchantment
+ * At the beginning of your upkeep, you may search your library for a basic land card, reveal
+ * that card, put it into your hand, then shuffle. If you do, you skip your draw step this turn.
+ *
+ * Exercises the new SkipNextDrawStep effect / SkipDrawStepComponent gated by IfYouDoEffect:
+ * fetching a land skips the draw step; declining the search (selecting no card) draws normally.
+ */
+class ElfhameSanctuaryScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioTestBase.ScenarioBuilder.withCardsInLibrary(
+        playerNumber: Int, cardName: String, count: Int
+    ): ScenarioBuilder {
+        repeat(count) { withCardInLibrary(playerNumber, cardName) }
+        return this
+    }
+
+    init {
+        context("Elfhame Sanctuary upkeep trigger") {
+
+            test("fetching a basic land skips the draw step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elfhame Sanctuary")
+                    .withCardsInLibrary(1, "Forest", 5)
+                    .withCardsInLibrary(2, "Plains", 10)
+                    .withActivePlayer(1)
+                    .withTurnNumber(3)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                withClue("hand starts empty") { game.handSize(1) shouldBe 0 }
+
+                // Advance to upkeep; the search trigger surfaces a card-selection decision.
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("upkeep trigger should ask which basic land to fetch") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                val forest = game.state.getLibrary(game.player1Id).firstOrNull { id ->
+                    game.state.getEntity(id)
+                        ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                        ?.name == "Forest"
+                }!!
+                game.selectCards(listOf(forest))
+
+                withClue("fetched Forest should be in hand") { game.handSize(1) shouldBe 1 }
+
+                // Advance through the draw step into the main phase.
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                withClue("draw step was skipped, so hand still only holds the fetched land") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("declining the search performs a normal draw") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elfhame Sanctuary")
+                    .withCardsInLibrary(1, "Forest", 5)
+                    .withCardsInLibrary(2, "Plains", 10)
+                    .withActivePlayer(1)
+                    .withTurnNumber(3)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("upkeep trigger should ask which basic land to fetch") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                // Decline by choosing no card.
+                game.skipSelection()
+
+                withClue("declining leaves hand empty") { game.handSize(1) shouldBe 0 }
+
+                // Advance through the draw step into the main phase: a normal draw happens.
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                withClue("draw step was not skipped, so the player drew one card") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SaprolingSymbiosisScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SaprolingSymbiosisScenarioTest.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Saproling Symbiosis.
+ *
+ * Saproling Symbiosis: {3}{G}
+ * Sorcery
+ * You may cast this spell as though it had flash if you pay {2} more to cast it.
+ * Create a 1/1 green Saproling creature token for each creature you control.
+ */
+class SaprolingSymbiosisScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Saproling Symbiosis") {
+
+            test("creates one Saproling for each creature you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Willow Dryad")
+                    .withCardOnBattlefield(1, "Jungle Lion")
+                    .withCardInHand(1, "Saproling Symbiosis")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("two creatures controlled before casting") {
+                    (game.findPermanents("Willow Dryad").size + game.findPermanents("Jungle Lion").size) shouldBe 2
+                }
+
+                val castResult = game.castSpell(1, "Saproling Symbiosis")
+                withClue("cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("two creatures controlled → two Saproling tokens (tokens are not self-counted)") {
+                    game.findPermanents("Saproling Token").size shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SaprolingSymbiosisScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SaprolingSymbiosisScenarioTest.kt
@@ -24,14 +24,17 @@ class SaprolingSymbiosisScenarioTest : ScenarioTestBase() {
                     .withPlayers("Player", "Opponent")
                     .withCardOnBattlefield(1, "Willow Dryad")
                     .withCardOnBattlefield(1, "Jungle Lion")
+                    // The opponent controls a creature too — it must NOT be counted ("each
+                    // creature you control"), so the token count stays at 2.
+                    .withCardOnBattlefield(2, "Jungle Lion")
                     .withCardInHand(1, "Saproling Symbiosis")
                     .withLandsOnBattlefield(1, "Forest", 4)
                     .withActivePlayer(1)
                     .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
                     .build()
 
-                withClue("two creatures controlled before casting") {
-                    (game.findPermanents("Willow Dryad").size + game.findPermanents("Jungle Lion").size) shouldBe 2
+                withClue("three creatures in play before casting (two yours, one opponent's)") {
+                    (game.findPermanents("Willow Dryad").size + game.findPermanents("Jungle Lion").size) shouldBe 3
                 }
 
                 val castResult = game.castSpell(1, "Saproling Symbiosis")
@@ -40,7 +43,7 @@ class SaprolingSymbiosisScenarioTest : ScenarioTestBase() {
                 }
                 game.resolveStack()
 
-                withClue("two creatures controlled → two Saproling tokens (tokens are not self-counted)") {
+                withClue("two creatures YOU control → two Saproling tokens (opponent's creature and the tokens are not counted)") {
                     game.findPermanents("Saproling Token").size shouldBe 2
                 }
             }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SterlingGroveScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SterlingGroveScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sterling Grove.
+ *
+ * Sterling Grove: {G}{W}
+ * Enchantment
+ * Other enchantments you control have shroud.
+ * {1}, Sacrifice this enchantment: Search your library for an enchantment card, reveal it,
+ *   then shuffle and put that card on top.
+ */
+class SterlingGroveScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Sterling Grove") {
+
+            test("grants shroud to other enchantments you control but not to itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Sterling Grove")
+                    .withCardOnBattlefield(1, "Collective Restraint")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sterlingGrove = game.findPermanent("Sterling Grove")!!
+                val otherEnchantment = game.findPermanent("Collective Restraint")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("the other enchantment you control should have shroud") {
+                    projected.hasKeyword(otherEnchantment, Keyword.SHROUD) shouldBe true
+                }
+                withClue("Sterling Grove itself should NOT have shroud (\"other\" excludes the source)") {
+                    projected.hasKeyword(sterlingGrove, Keyword.SHROUD) shouldBe false
+                }
+            }
+
+            test("activated ability searches for an enchantment and puts it on top after shuffling") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Sterling Grove")
+                    .withLandsOnBattlefield(1, "Forest", 1) // {1} for the activation cost
+                    .withCardInLibrary(1, "Collective Restraint") // the only enchantment in the library
+                    .withCardInLibrary(1, "Jungle Lion")          // non-enchantment — must not be offered
+                    .withCardInLibrary(1, "Forest")               // non-enchantment — must not be offered
+                    .withCardInLibrary(2, "Forest")               // opponent needs a library
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val initialLibrarySize = game.state.getLibrary(game.player1Id).size
+
+                val sterlingGrove = game.findPermanent("Sterling Grove")!!
+                val ability = cardRegistry.getCard("Sterling Grove")!!.script.activatedAbilities.first()
+
+                val activate = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = sterlingGrove,
+                        abilityId = ability.id,
+                        targets = emptyList()
+                    )
+                )
+                withClue("activation should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                withClue("Sterling Grove should be sacrificed as part of the cost") {
+                    game.isOnBattlefield("Sterling Grove") shouldBe false
+                    game.isInGraveyard(1, "Sterling Grove") shouldBe true
+                }
+
+                game.resolveStack()
+
+                withClue("the search should ask which enchantment to find") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                val offeredNames = decision.options.mapNotNull { decision.cardInfo?.get(it)?.name }.toSet()
+                withClue("only the enchantment card may be offered (Enchantment filter), not the creature/land") {
+                    offeredNames shouldBe setOf("Collective Restraint")
+                }
+
+                val enchantmentId = decision.options.first { decision.cardInfo?.get(it)?.name == "Collective Restraint" }
+                game.selectCards(listOf(enchantmentId))
+
+                withClue("library size is unchanged — the card moved within the library, not out of it") {
+                    game.state.getLibrary(game.player1Id).size shouldBe initialLibrarySize
+                }
+                val topCard = game.state.getLibrary(game.player1Id).firstOrNull()
+                    ?.let { game.state.getEntity(it) }?.get<CardComponent>()
+                withClue("the found enchantment should end up on top of the library after the shuffle") {
+                    topCard?.name shouldBe "Collective Restraint"
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -141,6 +141,7 @@ import com.wingedsheep.sdk.scripting.effects.PreventionDirection
 import com.wingedsheep.sdk.scripting.effects.PreventionScope
 import com.wingedsheep.sdk.scripting.effects.PreventionSourceFilter
 import com.wingedsheep.sdk.scripting.effects.HijackNextTurnEffect
+import com.wingedsheep.sdk.scripting.effects.SkipNextDrawStepEffect
 import com.wingedsheep.sdk.scripting.effects.SkipNextTurnEffect
 import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
 import com.wingedsheep.sdk.scripting.effects.EffectChoice
@@ -1851,6 +1852,13 @@ object Effects {
      */
     fun SkipNextTurn(target: EffectTarget = EffectTarget.Controller): Effect =
         SkipNextTurnEffect(target)
+
+    /**
+     * Target player skips their next draw step.
+     * Used for cards like Elfhame Sanctuary ("you skip your draw step this turn").
+     */
+    fun SkipNextDrawStep(target: EffectTarget = EffectTarget.Controller): Effect =
+        SkipNextDrawStepEffect(target)
 
     /**
      * Controller controls the target player during that player's next turn (Mindslaver-style).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -53,6 +53,28 @@ data class SkipUntapEffect(
 }
 
 /**
+ * Target player skips their next draw step.
+ * Used for cards like Elfhame Sanctuary ("you skip your draw step this turn") and
+ * Howling Mine / Abundance-style draw-replacement riders.
+ *
+ * Adds a one-shot marker to the target player that the draw step consumes the next time
+ * it would occur (the same turn when applied during that turn's upkeep, or the player's
+ * next turn otherwise).
+ */
+@SerialName("SkipNextDrawStep")
+@Serializable
+data class SkipNextDrawStepEffect(
+    val target: EffectTarget = EffectTarget.Controller
+) : Effect {
+    override val description: String = when (target) {
+        EffectTarget.Controller -> "You skip your next draw step"
+        else -> "${target.description.replaceFirstChar { it.uppercase() }} skips their next draw step"
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
+}
+
+/**
  * You may play additional lands this turn.
  * Used for Summer Bloom: "You may play up to three additional lands this turn."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/AuraShardsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/AuraShardsReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aura Shards reprint in Commander 2011.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Invasion's `cards/`
+ * package; this file contributes only the Commander 2011 presentation row.
+ */
+val AuraShardsReprint = Printing(
+    oracleId = "8d03d050-391c-4311-8c42-4ee632d40fdc",
+    name = "Aura Shards",
+    setCode = "CMD",
+    collectorNumber = "182",
+    scryfallId = "a6222cc6-996e-4b73-af87-e837bf1eb921",
+    artist = "Ron Spencer",
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a6222cc6-996e-4b73-af87-e837bf1eb921.jpg?1745319955",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AuraShards.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AuraShards.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Aura Shards
+ * {1}{G}{W}
+ * Enchantment
+ * Whenever a creature you control enters, you may destroy target artifact or enchantment.
+ *
+ * The trigger fires for every creature you control entering (including the creature whose ETB
+ * triggered it). It is optional ("you may"), so a controller with no desirable target can decline;
+ * the target is chosen when the ability is put on the stack (CR 603.3d).
+ */
+val AuraShards = card("Aura Shards") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control enters, you may destroy target artifact or enchantment."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        optional = true
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Ron Spencer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df4039ef-af72-4267-ade9-fdb7c921279e.jpg?1562939873"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ElfhameSanctuary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ElfhameSanctuary.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Elfhame Sanctuary
+ * {1}{G}
+ * Enchantment
+ * At the beginning of your upkeep, you may search your library for a basic land card, reveal that
+ * card, put it into your hand, then shuffle. If you do, you skip your draw step this turn.
+ *
+ * The whole ability is optional ("you may"), so the controller chooses yes/no when it resolves.
+ * On accepting, the search runs (basic land, reveal, into hand, shuffle) and the controller's draw
+ * step for this turn is skipped via [Effects.SkipNextDrawStep] — the marker is consumed by the
+ * upcoming draw step.
+ */
+val ElfhameSanctuary = card("Elfhame Sanctuary") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, you may search your library for a basic land card, " +
+        "reveal that card, put it into your hand, then shuffle. If you do, you skip your draw step this turn."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        // The search is itself optional ("you may search ... for a basic land card") — the
+        // controller declines by choosing zero cards. IfYouDoEffect gates the draw-step skip on
+        // the search actually putting a card into hand (SuccessCriterion.Auto detects the terminal
+        // move into HAND), matching the "If you do, you skip your draw step this turn" clause.
+        effect = IfYouDoEffect(
+            action = EffectPatterns.searchLibrary(
+                filter = GameObjectFilter.BasicLand,
+                count = 1,
+                destination = SearchDestination.HAND,
+                reveal = true,
+                shuffleAfter = true
+            ),
+            ifYouDo = Effects.SkipNextDrawStep()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "185"
+        artist = "Alan Rabinowitz"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6ab9a90c-5fd8-4f8c-b692-f98a2974810c.jpg?1562916434"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SaprolingSymbiosis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SaprolingSymbiosis.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Saproling Symbiosis
+ * {3}{G}
+ * Sorcery
+ * You may cast this spell as though it had flash if you pay {2} more to cast it.
+ * Create a 1/1 green Saproling creature token for each creature you control.
+ *
+ * The flash-timing unlock reuses the shared FlashKicker plumbing (same as Ghitu Fire):
+ * paying {2} more lets the sorcery be cast at instant speed. The token count reads the number
+ * of creatures you control at resolution — tokens created by this spell are not counted because
+ * the amount is evaluated once before the tokens enter (CR 608.2g).
+ */
+val SaprolingSymbiosis = card("Saproling Symbiosis") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "You may cast this spell as though it had flash if you pay {2} more to cast it. " +
+        "(You may cast it any time you could cast an instant.)\n" +
+        "Create a 1/1 green Saproling creature token for each creature you control."
+
+    keywordAbility(KeywordAbility.flashKicker("{2}"))
+
+    spell {
+        effect = CreateTokenEffect(
+            count = DynamicAmount.Count(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling"),
+            imageUri = "/images/tokens/inv-saproling.jpeg"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "209"
+        artist = "Ciruelo"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2bb63748-5c84-43a0-8f17-a2a17f658337.jpg?1562903901"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SaprolingSymbiosis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SaprolingSymbiosis.kt
@@ -20,7 +20,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * The flash-timing unlock reuses the shared FlashKicker plumbing (same as Ghitu Fire):
  * paying {2} more lets the sorcery be cast at instant speed. The token count reads the number
  * of creatures you control at resolution — tokens created by this spell are not counted because
- * the amount is evaluated once before the tokens enter (CR 608.2g).
+ * the amount is evaluated once before the tokens enter (CR 608.2h).
  */
 val SaprolingSymbiosis = card("Saproling Symbiosis") {
     manaCost = "{3}{G}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SterlingGrove.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SterlingGrove.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Sterling Grove
+ * {G}{W}
+ * Enchantment
+ * Other enchantments you control have shroud.
+ * {1}, Sacrifice this enchantment: Search your library for an enchantment card, reveal it,
+ *   then shuffle and put that card on top.
+ *
+ * The shroud lord uses a battlefield-scoped [GrantKeyword] excluding the source itself, so Sterling
+ * Grove does not protect itself. The search ability shuffles first, then places the found card on
+ * top (CR ordering preserved by [SearchDestination.TOP_OF_LIBRARY] with `shuffleAfter = true`).
+ */
+val SterlingGrove = card("Sterling Grove") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Enchantment"
+    oracleText = "Other enchantments you control have shroud. (They can't be the targets of spells or abilities.)\n" +
+        "{1}, Sacrifice this enchantment: Search your library for an enchantment card, reveal it, " +
+        "then shuffle and put that card on top."
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.SHROUD,
+            GroupFilter.AllEnchantments.youControl().other()
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.Enchantment,
+            count = 1,
+            destination = SearchDestination.TOP_OF_LIBRARY,
+            reveal = true,
+            shuffleAfter = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "278"
+        artist = "Jeff Miracola"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40b26aa3-8169-4978-9554-bd2fc8e18e3b.jpg?1562907957"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DrawPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DrawPhaseManager.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.handlers.effects.drawing.DrawCardPrimitive
 import com.wingedsheep.engine.handlers.effects.drawing.DrawLoop
 import com.wingedsheep.engine.handlers.effects.drawing.DrawReplacementDispatcher
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.SkipDrawStepComponent
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.Effect
@@ -47,6 +48,16 @@ class DrawPhaseManager(
         if (isFirstTurnFirstPlayer) {
             return ExecutionResult.success(
                 state.withPriority(activePlayer),
+                listOf(StepChangedEvent(Step.DRAW))
+            )
+        }
+
+        // Skip the draw if a "skip your next draw step" marker is present (e.g., Elfhame
+        // Sanctuary). Consume the marker so it only skips one draw step.
+        if (state.getEntity(activePlayer)?.has<SkipDrawStepComponent>() == true) {
+            val consumed = state.updateEntity(activePlayer) { it.without<SkipDrawStepComponent>() }
+            return ExecutionResult.success(
+                consumed.withPriority(activePlayer),
                 listOf(StepChangedEvent(Step.DRAW))
             )
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -384,6 +384,7 @@ val engineSerializersModule = SerializersModule {
         subclass(LandDropsComponent::class)
         subclass(MulliganStateComponent::class)
         subclass(SkipCombatPhasesComponent::class)
+        subclass(SkipDrawStepComponent::class)
         subclass(SkipUntapComponent::class)
         subclass(PlayerLostComponent::class)
         subclass(LoseAtEndStepComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -64,6 +64,7 @@ class PlayerExecutors(
         PreventLandPlaysThisTurnExecutor(),
         SecretBidExecutor(decisionHandler),
         SkipCombatPhasesExecutor(),
+        SkipNextDrawStepExecutor(),
         SkipNextTurnExecutor(),
         SkipUntapExecutor(),
         TakeExtraTurnExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipNextDrawStepExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipNextDrawStepExecutor.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.SkipDrawStepComponent
+import com.wingedsheep.sdk.scripting.effects.SkipNextDrawStepEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [SkipNextDrawStepEffect].
+ * Adds [SkipDrawStepComponent] to the target player so their next draw step is skipped.
+ * The component is consumed by [com.wingedsheep.engine.core.DrawPhaseManager.performDrawStep].
+ */
+class SkipNextDrawStepExecutor : EffectExecutor<SkipNextDrawStepEffect> {
+
+    override val effectType: KClass<SkipNextDrawStepEffect> = SkipNextDrawStepEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: SkipNextDrawStepEffect,
+        context: EffectContext
+    ): EffectResult {
+        val target = effect.target
+        val targetPlayerId = when (target) {
+            is EffectTarget.Controller -> context.controllerId
+            is EffectTarget.PlayerRef -> {
+                when (target.player) {
+                    Player.You -> context.controllerId
+                    Player.Opponent, Player.TargetOpponent -> context.opponentId
+                        ?: return EffectResult.error(state, "No opponent found")
+                    else -> return EffectResult.error(state, "Unsupported player reference for SkipNextDrawStepEffect")
+                }
+            }
+            else -> return EffectResult.error(state, "Unsupported target for SkipNextDrawStepEffect")
+        }
+
+        val newState = state.updateEntity(targetPlayerId) { container ->
+            container.with(SkipDrawStepComponent)
+        }
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -236,6 +236,17 @@ data class SkipUntapComponent(
 ) : Component
 
 /**
+ * Marker component indicating that a player should skip their next draw step.
+ * Applied by effects like Elfhame Sanctuary ("you skip your draw step this turn").
+ *
+ * This component is consumed (removed) the next time that player's draw step would
+ * occur — the same turn when applied during that turn's upkeep, or the player's next
+ * turn otherwise. When consumed, the draw step performs no draw.
+ */
+@Serializable
+data object SkipDrawStepComponent : Component
+
+/**
  * Component marking that a player has lost the game.
  *
  * This is added when a player loses due to various game rules:


### PR DESCRIPTION
Implements four Invasion (INV) cards.

## Cards

- **Aura Shards** `{1}{G}{W}` — Enchantment. "Whenever a creature you control enters, you may destroy target artifact or enchantment." Optional triggered ability composed from existing primitives (`entersBattlefield` + `Effects.Destroy(Targets.ArtifactOrEnchantment)`). Also adds the Commander 2011 (`CMD`) reprint row, since that set is scaffolded.
- **Sterling Grove** `{G}{W}` — Enchantment. "Other enchantments you control have shroud" via `GrantKeyword(SHROUD, AllEnchantments.youControl().other())`, plus `{1}, Sacrifice: search your library for an enchantment, reveal, shuffle, put on top" (`searchLibrary(TOP_OF_LIBRARY, shuffleAfter = true)`).
- **Elfhame Sanctuary** `{1}{G}` — Enchantment. Upkeep search for a basic land into hand; if you do, skip your draw step this turn.
- **Saproling Symbiosis** `{3}{G}` — Sorcery. "Cast as though it had flash if you pay {2} more" reuses the shared FlashKicker plumbing (same as Ghitu Fire); creates a Saproling per creature you control.

## New engine mechanic: SkipNextDrawStep

Elfhame Sanctuary needed a general "skip your draw step" mechanic, which did not exist:

- SDK: `Effects.SkipNextDrawStep(target)` / `SkipNextDrawStepEffect`.
- Engine: `SkipNextDrawStepExecutor` adds a one-shot `SkipDrawStepComponent` to the player; `DrawPhaseManager.performDrawStep` consumes it and skips the draw. Registered for polymorphic serialization.
- The draw-step skip is gated with `IfYouDoEffect` (`SuccessCriterion.Auto`) so it only fires when the search actually puts a land into hand — declining the search draws normally.
- Documented in `docs/card-sdk-language-reference.md`.

## Tests

- `AuraShardsScenarioTest` — creature ETB destroys a target enchantment; declining leaves it intact.
- `SaprolingSymbiosisScenarioTest` — token count equals creatures controlled (tokens not self-counted).
- `ElfhameSanctuaryScenarioTest` — fetching a land skips the draw step; declining the search draws normally.

`./gradlew :mtg-sdk:test :rules-engine:test` and the new game-server scenario tests pass; full `./gradlew build` compiles. `just check-card-printing` is clean for all four cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)