### PR TITLE
Add Invasion cards: Annihilate, Bind, Breath of Darigaaz, Disrupt, Probe

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -677,6 +677,9 @@ work for abilities-on-stack (which carry no `CardComponent`).
   (Stifle).
 - `CardPredicate.IsTriggeredAbility` — triggered abilities only (excludes activated abilities and
   spells).
+- `CardPredicate.IsActivatedAbility` — activated abilities only (excludes triggered abilities and
+  spells). Mana abilities never use the stack, so they're never matched. Exposed as the
+  `Targets.ActivatedAbility` target requirement (Bind: "Counter target activated ability").
 - `CardPredicate.TargetsMatching(subfilter)` — true when the stack object's `TargetsComponent`
   includes at least one chosen target matching `subfilter`. Player targets are skipped. The
   subfilter inherits the outer `PredicateContext`, so `Land.youControl()` inside the subfilter

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
@@ -301,6 +301,13 @@ object Targets {
     )
 
     /**
+     * Target activated ability on the stack (not triggered abilities; mana abilities can't be targeted).
+     */
+    val ActivatedAbility: TargetRequirement = TargetObject(
+        filter = TargetFilter.ActivatedAbilityOnStack
+    )
+
+    /**
      * Target triggered ability you control on the stack.
      */
     val TriggeredAbilityYouControl: TargetRequirement = TargetObject(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -205,6 +205,12 @@ data class TargetFilter(
             zone = Zone.STACK
         )
 
+        /** Target activated ability on the stack (not triggered, not spells; mana abilities never use the stack) */
+        val ActivatedAbilityOnStack = TargetFilter(
+            GameObjectFilter(cardPredicates = listOf(CardPredicate.IsActivatedAbility)),
+            zone = Zone.STACK
+        )
+
         /** Target any spell or ability on the stack (spells and activated/triggered abilities) */
         val SpellOrAbilityOnStack = TargetFilter(GameObjectFilter.Companion.Any, zone = Zone.STACK)
     }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -621,7 +621,8 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     /**
      * Matches only activated abilities on the stack (not triggered abilities or spells).
      * Mana abilities never use the stack, so they can't be matched. Used by cards like
-     * Bind / Stifle's activated-only mode: "Counter target activated ability."
+     * Bind: "Counter target activated ability." (Stifle counters either kind and uses the
+     * broader [IsActivatedOrTriggeredAbility].)
      */
     @SerialName("IsActivatedAbility")
     @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -606,6 +606,18 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     }
 
     /**
+     * Matches only activated abilities on the stack (not triggered abilities or spells).
+     * Mana abilities never use the stack, so they can't be matched. Used by cards like
+     * Bind / Stifle's activated-only mode: "Counter target activated ability."
+     */
+    @SerialName("IsActivatedAbility")
+    @Serializable
+    data object IsActivatedAbility : CardPredicate {
+        override val description: String = "activated ability"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
+    /**
      * Matches a spell or ability on the stack at least one of whose chosen targets
      * matches [subfilter]. Player targets are skipped (they aren't card-like and have
      * no game-object filter to match against). Used by cards like Teferi's Response

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -61,6 +61,7 @@ import com.wingedsheep.mtg.sets.definitions.soi.ShadowsOverInnistradSet
 import com.wingedsheep.mtg.sets.definitions.tmp.TempestSet
 import com.wingedsheep.mtg.sets.definitions.usg.UrzasSagaSet
 import com.wingedsheep.mtg.sets.definitions.vis.VisionsSet
+import com.wingedsheep.mtg.sets.definitions.wth.WeatherlightSet
 import com.wingedsheep.mtg.sets.definitions.otj.OutlawsOfThunderJunctionSet
 import com.wingedsheep.mtg.sets.definitions.spm.SpiderManSet
 import com.wingedsheep.mtg.sets.definitions.tdm.TarkirDragonstormSet
@@ -87,6 +88,7 @@ object MtgSetCatalog {
         PortalSecondAgeSet,
         MirageSet,
         VisionsSet,
+        WeatherlightSet,
         TempestSet,
         ExodusSet,
         UrzasSagaSet,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BreathOfDarigaazReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BreathOfDarigaazReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Breath of Darigaaz reprint in Commander 2015.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Invasion's `cards/`
+ * package; this file contributes only the Commander 2015 presentation row.
+ */
+val BreathOfDarigaazReprint = Printing(
+    oracleId = "1954994f-17bf-4ea5-af72-60f9bfcb6569",
+    name = "Breath of Darigaaz",
+    setCode = "C15",
+    collectorNumber = "143",
+    scryfallId = "c15496b0-904b-4beb-a77f-70b4378a30bc",
+    artist = "Greg Hildebrandt & Tim Hildebrandt",
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c15496b0-904b-4beb-a77f-70b4378a30bc.jpg?1562709206",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/BreathOfDarigaazReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/BreathOfDarigaazReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Breath of Darigaaz reprint in Commander 2011.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Invasion's `cards/`
+ * package; this file contributes only the Commander 2011 presentation row.
+ */
+val BreathOfDarigaazReprint = Printing(
+    oracleId = "1954994f-17bf-4ea5-af72-60f9bfcb6569",
+    name = "Breath of Darigaaz",
+    setCode = "CMD",
+    collectorNumber = "112",
+    scryfallId = "7fcfa18a-72c5-43cf-8d90-308a73407082",
+    artist = "Greg Hildebrandt & Tim Hildebrandt",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7fcfa18a-72c5-43cf-8d90-308a73407082.jpg?1592713478",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Annihilate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Annihilate.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Annihilate
+ * {3}{B}{B}
+ * Instant
+ *
+ * Destroy target nonblack creature. It can't be regenerated.
+ * Draw a card.
+ */
+val Annihilate = card("Annihilate") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target nonblack creature. It can't be regenerated.\nDraw a card."
+
+    spell {
+        val creature = target(
+            "target nonblack creature",
+            TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK))
+        )
+        effect = CantBeRegeneratedEffect(creature) then
+            Effects.Destroy(creature) then
+            Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "94"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a3bf039-ecf6-477e-997c-e32c55323c01.jpg?1562909994"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Bind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Bind.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bind
+ * {1}{G}
+ * Instant
+ *
+ * Counter target activated ability. (Mana abilities can't be targeted.)
+ * Draw a card.
+ *
+ * Mana abilities don't use the stack, so they can never be a legal target — the
+ * `ActivatedAbility` target only enumerates activated abilities currently on the stack.
+ */
+val Bind = card("Bind") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Counter target activated ability. (Mana abilities can't be targeted.)\nDraw a card."
+
+    spell {
+        target = Targets.ActivatedAbility
+        effect = Effects.CounterAbility() then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "182"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cfa51783-9ef8-4e51-ba0d-ce8439d83bdf.jpg?1562936749"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BreathOfDarigaaz.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BreathOfDarigaaz.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Breath of Darigaaz
+ * {1}{R}
+ * Sorcery
+ * Kicker {2}
+ * Breath of Darigaaz deals 1 damage to each creature without flying and each player.
+ * If this spell was kicked, it deals 4 damage to each creature without flying and each
+ * player instead.
+ */
+val BreathOfDarigaaz = card("Breath of Darigaaz") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Kicker {2} (You may pay an additional {2} as you cast this spell.)\n" +
+        "Breath of Darigaaz deals 1 damage to each creature without flying and each player. " +
+        "If this spell was kicked, it deals 4 damage to each creature without flying and each player instead."
+
+    keywordAbility(KeywordAbility.kicker("{2}"))
+
+    fun damageToNonFliersAndPlayers(amount: Int): Effect = CompositeEffect(
+        listOf(
+            ForEachInGroupEffect(
+                GroupFilter.AllCreatures.withoutKeyword(Keyword.FLYING),
+                DealDamageEffect(amount, EffectTarget.Self)
+            ),
+            ForEachPlayerEffect(
+                players = Player.Each,
+                effects = listOf(
+                    Effects.DealDamage(amount, EffectTarget.Controller)
+                )
+            )
+        )
+    )
+
+    spell {
+        effect = ConditionalEffect(
+            condition = WasKicked,
+            effect = damageToNonFliersAndPlayers(4),
+            elseEffect = damageToNonFliersAndPlayers(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "138"
+        artist = "Greg Hildebrandt & Tim Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/480bb7e3-df03-454d-ada0-592ef8a4a6f0.jpg?1562909692"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Disrupt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Disrupt.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disrupt
+ * {U}
+ * Instant
+ *
+ * Counter target instant or sorcery spell unless its controller pays {1}.
+ * Draw a card.
+ */
+val Disrupt = card("Disrupt") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target instant or sorcery spell unless its controller pays {1}.\nDraw a card."
+
+    spell {
+        target = Targets.InstantOrSorcerySpell
+        effect = Effects.CounterUnlessPays("{1}") then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c000a02f-6b7e-4925-a938-59e645e980d7.jpg?1562933600"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DisruptReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DisruptReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disrupt reprint in Invasion.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Weatherlight's
+ * `cards/` package (Disrupt's earliest real-expansion printing); this file contributes
+ * only the Invasion presentation row.
+ */
+val DisruptReprint = Printing(
+    oracleId = "76347258-71d5-4874-adde-ff7aa932b808",
+    name = "Disrupt",
+    setCode = "INV",
+    collectorNumber = "51",
+    scryfallId = "c000a02f-6b7e-4925-a938-59e645e980d7",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/c/0/c000a02f-6b7e-4925-a938-59e645e980d7.jpg?1562933600",
+    releaseDate = "2000-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Probe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Probe.kt
@@ -19,6 +19,14 @@ import com.wingedsheep.sdk.scripting.targets.TargetPlayer
  * The target player is only relevant when the spell is kicked, so it is declared as an
  * optional target (minCount 0). When unkicked, no target need be chosen; the kicked
  * discard simply never resolves.
+ *
+ * Approximation: strictly, a *kicked* Probe requires a target player. Kicker is chosen
+ * while casting (CR 601.2b) and targets are then announced (CR 601.2c), so the targeted
+ * clause is only mandatory once the spell is kicked. The SDK has no kicker-conditional
+ * target requirement, so a kicked cast could legally be made with no target — in which
+ * case the discard fizzles. A dedicated card-specific primitive isn't worth it for one
+ * card; if a second kicked-only-target card appears, add a general "required-iff-kicked"
+ * target flag.
  */
 val Probe = card("Probe") {
     manaCost = "{2}{U}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Probe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Probe.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Probe
+ * {2}{U}
+ * Sorcery
+ * Kicker {1}{B}
+ * Draw three cards, then discard two cards. If this spell was kicked, target player
+ * discards two cards.
+ *
+ * The target player is only relevant when the spell is kicked, so it is declared as an
+ * optional target (minCount 0). When unkicked, no target need be chosen; the kicked
+ * discard simply never resolves.
+ */
+val Probe = card("Probe") {
+    manaCost = "{2}{U}"
+    colorIdentity = "UB"
+    typeLine = "Sorcery"
+    oracleText = "Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\n" +
+        "Draw three cards, then discard two cards. If this spell was kicked, target player discards two cards."
+
+    keywordAbility(KeywordAbility.kicker("{1}{B}"))
+
+    spell {
+        val targetPlayer = target("target player", TargetPlayer(optional = true))
+        effect = Effects.DrawCards(3) then
+            Effects.Discard(2) then
+            ConditionalEffect(
+                condition = WasKicked,
+                effect = Effects.Discard(2, targetPlayer)
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Eric Peterson"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2a58d18-3d52-4178-86b2-7590d4164e76.jpg?1562927868"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wth/WeatherlightSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wth/WeatherlightSet.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.wth
+
+import com.wingedsheep.mtg.sets.definitions.por.PortalSet
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Weatherlight Set (1997)
+ *
+ * Weatherlight was the third and final set in the Mirage block. It is the
+ * earliest printing of several cards later reprinted in Invasion (e.g. Disrupt).
+ *
+ * Set Code: WTH
+ * Release Date: June 9, 1997
+ * Card Count: 167
+ */
+object WeatherlightSet : MtgSet {
+
+    override val code = "WTH"
+    override val displayName = "Weatherlight"
+    override val releaseDate = "1997-06-09"
+    override val block = "Mirage"
+    override val basicLandsFallback = PortalSet
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.wth.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wth/cards/Disrupt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wth/cards/Disrupt.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.inv.cards
+package com.wingedsheep.mtg.sets.definitions.wth.cards
 
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
@@ -12,6 +12,9 @@ import com.wingedsheep.sdk.model.Rarity
  *
  * Counter target instant or sorcery spell unless its controller pays {1}.
  * Draw a card.
+ *
+ * Weatherlight is Disrupt's earliest real-expansion printing; the Invasion
+ * printing is a reprint row (see inv/cards/DisruptReprint.kt).
  */
 val Disrupt = card("Disrupt") {
     manaCost = "{U}"
@@ -25,9 +28,9 @@ val Disrupt = card("Disrupt") {
     }
 
     metadata {
-        rarity = Rarity.UNCOMMON
-        collectorNumber = "51"
-        artist = "Paolo Parente"
-        imageUri = "https://cards.scryfall.io/normal/front/c/0/c000a02f-6b7e-4925-a938-59e645e980d7.jpg?1562933600"
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6cc89b0-9acf-452b-ac1a-bc7e90eb32fc.jpg?1562803281"
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -125,6 +125,9 @@ class PredicateEvaluator {
         if (predicate is CardPredicate.IsTriggeredAbility) {
             return container.has<TriggeredAbilityOnStackComponent>()
         }
+        if (predicate is CardPredicate.IsActivatedAbility) {
+            return container.has<ActivatedAbilityOnStackComponent>()
+        }
         // Stack-relative targeting predicate: read the stack entity's TargetsComponent
         // and match each chosen target against the subfilter. Works for both spells and
         // activated/triggered abilities (none of which have CardComponent for the
@@ -466,6 +469,7 @@ class PredicateEvaluator {
             // Handled before CardComponent check above — unreachable here
             CardPredicate.IsActivatedOrTriggeredAbility -> false
             CardPredicate.IsTriggeredAbility -> false
+            CardPredicate.IsActivatedAbility -> false
             is CardPredicate.TargetsMatching -> false
         }
     }
@@ -800,6 +804,7 @@ class PredicateEvaluator {
             // Stack ability check — cast spells are not abilities
             CardPredicate.IsActivatedOrTriggeredAbility -> false
             CardPredicate.IsTriggeredAbility -> false
+            CardPredicate.IsActivatedAbility -> false
 
             // Stack-relative targeting predicate — historical cast records have no
             // chosen-target snapshot, so this always returns false here.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -478,7 +478,8 @@ internal class AffectsFilterResolver {
         is CardPredicate.HasSubtypeInEachStoredGroup -> false
         // Stack-only predicates — never match a battlefield entity being projected.
         CardPredicate.IsActivatedOrTriggeredAbility,
-        CardPredicate.IsTriggeredAbility -> false
+        CardPredicate.IsTriggeredAbility,
+        CardPredicate.IsActivatedAbility -> false
         is CardPredicate.TargetsMatching -> false
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -934,6 +934,7 @@ class CostCalculator(
 
             CardPredicate.IsActivatedOrTriggeredAbility -> false
             CardPredicate.IsTriggeredAbility -> false
+            CardPredicate.IsActivatedAbility -> false
             is CardPredicate.TargetsMatching -> false
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnnihilateTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnnihilateTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.Annihilate
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Annihilate.
+ *
+ * Annihilate: {3}{B}{B}
+ * Instant
+ * Destroy target nonblack creature. It can't be regenerated.
+ * Draw a card.
+ */
+class AnnihilateTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Annihilate))
+        return driver
+    }
+
+    test("destroys a nonblack creature and draws a card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Forest" to 10), startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(player2, "Grizzly Bears")
+        val annihilate = driver.putCardInHand(player1, "Annihilate")
+        driver.giveMana(player1, Color.BLACK, 5)
+        val handBefore = driver.getHandSize(player1)
+
+        val result = driver.castSpellWithTargets(player1, annihilate, listOf(ChosenTarget.Permanent(bears)))
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(player2, "Grizzly Bears") shouldBe null
+        // -1 for casting Annihilate, +1 for the draw
+        driver.getHandSize(player1) shouldBe handBefore
+    }
+
+    test("cannot target a black creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Forest" to 10), startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val blackCreature = driver.putCreatureOnBattlefield(player2, "Black Creature")
+        val annihilate = driver.putCardInHand(player1, "Annihilate")
+        driver.giveMana(player1, Color.BLACK, 5)
+
+        val result = driver.castSpellWithTargets(player1, annihilate, listOf(ChosenTarget.Permanent(blackCreature)))
+        result.isSuccess shouldBe false
+        driver.findPermanent(player2, "Black Creature") shouldBe blackCreature
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BindTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BindTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.Bind
+import com.wingedsheep.mtg.sets.definitions.scg.cards.CarrionFeeder
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Bind.
+ *
+ * Bind: {1}{G}
+ * Instant
+ * Counter target activated ability. (Mana abilities can't be targeted.)
+ * Draw a card.
+ *
+ * Exercises the new `CardPredicate.IsActivatedAbility` / `Targets.ActivatedAbility`
+ * target: it counters an activated ability, draws a card, and refuses a triggered ability
+ * as a target.
+ */
+class BindTest : FunSpec({
+
+    // Simple test creature with an ETB "gain 3 life" trigger (for the negative case)
+    val LifeGainCreature = card("Life Gain Creature") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Beast"
+        power = 2
+        toughness = 2
+
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.GainLife(3)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Bind, LifeGainCreature))
+        return driver
+    }
+
+    test("counters an activated ability and draws a card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Swamp" to 20),
+            startingLife = 20
+        )
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val feeder = driver.putCreatureOnBattlefield(player2, "Carrion Feeder")
+        driver.removeSummoningSickness(feeder)
+        val fodder = driver.putCreatureOnBattlefield(player2, "Grizzly Bears")
+
+        val bind = driver.putCardInHand(player1, "Bind")
+        driver.giveMana(player1, Color.GREEN, 1)
+        driver.giveMana(player1, Color.GREEN, 1)
+        val handBefore = driver.getHandSize(player1)
+
+        driver.passPriority(player1)
+
+        // Player 2 activates Carrion Feeder, sacrificing Grizzly Bears
+        val abilityId = CarrionFeeder.activatedAbilities[0].id
+        val activateResult = driver.submit(
+            ActivateAbility(
+                playerId = player2,
+                sourceId = feeder,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder))
+            )
+        )
+        activateResult.isSuccess shouldBe true
+
+        val abilityOnStack = driver.getTopOfStack()!!
+
+        // Player 2 passes; Player 1 responds with Bind targeting the activated ability
+        driver.passPriority(player2)
+        val castResult = driver.castSpellWithTargets(player1, bind, listOf(ChosenTarget.Spell(abilityOnStack)))
+        castResult.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        // The activated ability was countered — no +1/+1 counter on Carrion Feeder
+        driver.stackSize shouldBe 0
+        driver.state.getEntity(feeder)?.get<CountersComponent>() shouldBe null
+
+        // Bind drew a card (hand: -1 Bind cast, +1 drawn = net unchanged from pre-cast count)
+        driver.getHandSize(player1) shouldBe handBefore
+    }
+
+    test("cannot target a triggered ability") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Swamp" to 20),
+            startingLife = 20
+        )
+
+        val player1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Player 1 casts Life Gain Creature (ETB: gain 3 life)
+        val creature = driver.putCardInHand(player1, "Life Gain Creature")
+        driver.giveMana(player1, Color.GREEN, 2)
+        driver.castSpell(player1, creature)
+        driver.bothPass()
+
+        // Triggered ability is on the stack
+        driver.stackSize shouldBe 1
+        val triggeredAbilityOnStack = driver.getTopOfStack()!!
+
+        val bind = driver.putCardInHand(player1, "Bind")
+        driver.giveMana(player1, Color.GREEN, 1)
+        driver.giveMana(player1, Color.GREEN, 1)
+
+        // Targeting the triggered ability with Bind must be rejected
+        val castResult = driver.castSpellWithTargets(
+            player1, bind, listOf(ChosenTarget.Spell(triggeredAbilityOnStack))
+        )
+        castResult.isSuccess shouldBe false
+
+        // Trigger still resolves normally
+        driver.bothPass()
+        driver.getLifeTotal(player1) shouldBe 23
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreathOfDarigaazTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreathOfDarigaazTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.BreathOfDarigaaz
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Breath of Darigaaz.
+ *
+ * Breath of Darigaaz: {1}{R}
+ * Sorcery — Kicker {2}
+ * Deals 1 damage (4 if kicked) to each creature without flying and each player.
+ *
+ * Exercises the two axes that drove the card: fliers are spared, and the kicker
+ * switches the amount from 1 to 4.
+ */
+class BreathOfDarigaazTest : FunSpec({
+
+    val testFlyer = card("Test Flyer") {
+        manaCost = "{2}"
+        typeLine = "Creature — Bird"
+        power = 2
+        toughness = 2
+        keywords(Keyword.FLYING)
+    }
+
+    // 1 toughness: dies to the unkicked 1 damage.
+    val testGrounder = card("Test Grounder") {
+        manaCost = "{1}"
+        typeLine = "Creature — Beast"
+        power = 1
+        toughness = 1
+    }
+
+    // 4 toughness: survives 1 damage, dies only to the kicked 4 damage.
+    val testWall = card("Test Wall") {
+        manaCost = "{2}"
+        typeLine = "Creature — Wall"
+        power = 0
+        toughness = 4
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BreathOfDarigaaz, testFlyer, testGrounder, testWall))
+        return driver
+    }
+
+    test("unkicked deals 1 to non-fliers and each player, fliers spared") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val flyer = driver.putCreatureOnBattlefield(player2, "Test Flyer")
+        driver.putCreatureOnBattlefield(player2, "Test Grounder")
+        repeat(2) { driver.putLandOnBattlefield(player1, "Mountain") }
+        val breath = driver.putCardInHand(player1, "Breath of Darigaaz")
+
+        val result = driver.submit(
+            CastSpell(playerId = player1, cardId = breath, wasKicked = false, paymentStrategy = PaymentStrategy.AutoPay)
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        // Non-flier dies to 1 damage; flier untouched.
+        driver.findPermanent(player2, "Test Grounder") shouldBe null
+        driver.findPermanent(player2, "Test Flyer") shouldBe flyer
+        // Both players (including the caster) take 1.
+        driver.getLifeTotal(player1) shouldBe 19
+        driver.getLifeTotal(player2) shouldBe 19
+    }
+
+    test("kicked deals 4 to non-fliers and each player, fliers still spared") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val flyer = driver.putCreatureOnBattlefield(player2, "Test Flyer")
+        driver.putCreatureOnBattlefield(player2, "Test Wall")
+        repeat(4) { driver.putLandOnBattlefield(player1, "Mountain") }
+        val breath = driver.putCardInHand(player1, "Breath of Darigaaz")
+
+        val result = driver.submit(
+            CastSpell(playerId = player1, cardId = breath, wasKicked = true, paymentStrategy = PaymentStrategy.AutoPay)
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        // 4-toughness non-flier dies only because the spell was kicked; flier untouched.
+        driver.findPermanent(player2, "Test Wall") shouldBe null
+        driver.findPermanent(player2, "Test Flyer") shouldBe flyer
+        driver.getLifeTotal(player1) shouldBe 16
+        driver.getLifeTotal(player2) shouldBe 16
+    }
+
+    test("unkicked leaves a 4-toughness non-flier alive") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player2, "Test Wall")
+        repeat(2) { driver.putLandOnBattlefield(player1, "Mountain") }
+        val breath = driver.putCardInHand(player1, "Breath of Darigaaz")
+
+        driver.submit(
+            CastSpell(playerId = player1, cardId = breath, wasKicked = false, paymentStrategy = PaymentStrategy.AutoPay)
+        )
+        driver.bothPass()
+
+        // 1 damage is not lethal to the 4-toughness wall.
+        driver.findPermanent(player2, "Test Wall") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProbeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProbeTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.Probe
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Probe.
+ *
+ * Probe: {2}{U}
+ * Sorcery — Kicker {1}{B}
+ * Draw three cards, then discard two cards. If this spell was kicked, target player
+ * discards two cards.
+ *
+ * Exercises both kicker branches: unkicked needs no target and only the caster discards;
+ * kicked makes the targeted opponent discard two as well.
+ */
+class ProbeTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Probe))
+        return driver
+    }
+
+    test("unkicked: caster draws three and discards two, no opponent discard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Swamp" to 20), skipMulligans = true, startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val probe = driver.putCardInHand(player1, "Probe")
+        val handBefore = driver.getHandSize(player1)
+        val p2HandBefore = driver.getHandSize(player2)
+        repeat(3) { driver.putLandOnBattlefield(player1, "Island") }
+
+        driver.submit(
+            CastSpell(playerId = player1, cardId = probe, wasKicked = false, paymentStrategy = PaymentStrategy.AutoPay)
+        )
+        driver.bothPass()
+
+        // Caster chooses two cards to discard.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(player1, driver.getHand(player1).take(2))
+
+        // Net hand: -1 cast, +3 drawn, -2 discarded = unchanged from pre-cast count.
+        driver.getHandSize(player1) shouldBe handBefore
+        // Two cards discarded to the graveyard plus the resolved sorcery.
+        driver.getGraveyard(player1).size shouldBe 3
+        // Unkicked → opponent untouched.
+        driver.getHandSize(player2) shouldBe p2HandBefore
+        driver.getGraveyard(player2).size shouldBe 0
+    }
+
+    test("kicked: targeted opponent also discards two") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Swamp" to 20), skipMulligans = true, startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val probe = driver.putCardInHand(player1, "Probe")
+        val p2HandBefore = driver.getHandSize(player2)
+        repeat(3) { driver.putLandOnBattlefield(player1, "Island") }
+        repeat(3) { driver.putLandOnBattlefield(player1, "Swamp") }
+
+        driver.submit(
+            CastSpell(
+                playerId = player1,
+                cardId = probe,
+                targets = listOf(ChosenTarget.Player(player2)),
+                wasKicked = true,
+                paymentStrategy = PaymentStrategy.AutoPay
+            )
+        )
+        driver.bothPass()
+
+        // Caster discards two first.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(player1, driver.getHand(player1).take(2))
+
+        // Then the kicked clause makes the targeted opponent discard two.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(player2, driver.getHand(player2).take(2))
+
+        driver.getHandSize(player2) shouldBe p2HandBefore - 2
+        driver.getGraveyard(player2).size shouldBe 2
+    }
+})


### PR DESCRIPTION
## Summary

Adds five Invasion (INV) cards. Four use existing primitives only; Bind needs a small, general SDK addition.

| Card | Cost | Type | Effect |
|------|------|------|--------|
| Annihilate | {3}{B}{B} | Instant | Destroy target nonblack creature, can't be regenerated; draw a card |
| Bind | {1}{G} | Instant | Counter target activated ability; draw a card |
| Breath of Darigaaz | {1}{R} | Sorcery, Kicker {2} | 1 (4 if kicked) damage to each creature without flying and each player |
| Disrupt | {U} | Instant | Counter target instant/sorcery unless controller pays {1}; draw a card |
| Probe | {2}{U} | Sorcery, Kicker {1}{B} | Draw three, discard two; if kicked, target player discards two |

## SDK change (for Bind)

Bind counters only *activated* abilities, but the engine previously had only `IsActivatedOrTriggeredAbility` (too broad) and `IsTriggeredAbility`. Added the missing sibling:

- `CardPredicate.IsActivatedAbility` — matches activated abilities on the stack only. Mana abilities never use the stack, so they can't be targeted.
- `TargetFilter.ActivatedAbilityOnStack` + `Targets.ActivatedAbility` facade.
- Wired through `PredicateEvaluator` (stack pre-check + the two exhaustive `when` fallthroughs), `AffectsFilterResolver`, and `CostCalculator`.
- Documented in the SDK language reference.

## Notes

- Probe's target player is only relevant when kicked, so it's declared as an optional target (minCount 0).
- Breath of Darigaaz mirrors the existing Canopy Surge (uses `GroupFilter.AllCreatures.withoutKeyword(FLYING)`).

## Tests

- `AnnihilateTest` — destroys a nonblack creature and draws; black creature rejected as a target.
- `BindTest` — counters an activated ability and draws; a triggered ability is rejected as a target.

Existing `StifleTest` and `PredicateEvaluatorRecordTest` still pass, confirming the predicate wiring is non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)