### PR TITLE
Add Invasion cards: Liberate, Mourning, Obliterate, Rout, Winnow

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1333,6 +1333,11 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
   only — no targets/triggering/kicker — so it evaluates identically in resolution and in
   projection, which lets it gate a `ConditionalStaticAbility`. Used by the Invasion djinn cycle
   ("as long as [color] is the most common color among all permanents…" — Goham/Halam/Ruham/Sulam/Zanam).
+- `AnotherPermanentWithSameNameAsTarget(targetIndex = 0)` — true when at least one *other*
+  battlefield permanent shares the exact card name of the context target at `targetIndex`. The
+  target itself is excluded, so a lone copy never satisfies its own check; tokens compare by name
+  like any other permanent. Resolution-only (reads a chosen target). Used by Winnow ("Destroy
+  target nonland permanent if another permanent with the same name is on the battlefield").
 - `YouHaveCitysBlessing` — you have City's Blessing (10+ permanents).
 - `SourceIsRingBearer` — the source permanent is your Ring-bearer (CR 701.52e).
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionDestructionBatchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionDestructionBatchScenarioTest.kt
@@ -1,0 +1,195 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for a batch of Invasion (INV) cards:
+ *  - Liberate ({1}{W} Instant; exile your creature, return at next end step)
+ *  - Mourning ({1}{B} Aura; enchanted creature gets -2/-0; {B}: bounce this Aura)
+ *  - Obliterate ({6}{R}{R} Sorcery; can't be countered; destroy all artifacts/creatures/lands)
+ *  - Rout ({3}{W}{W} Sorcery; optional flash for {2}; destroy all creatures)
+ *  - Winnow ({1}{W} Instant; destroy target nonland permanent if a same-named permanent exists; draw)
+ */
+class InvasionDestructionBatchScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Liberate") {
+            test("exiles your creature, returning it at the next end step") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Liberate")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2) // {1}{W}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearId = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Liberate", bearId)
+                withClue("Liberate should cast: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be exiled while Liberate resolves") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Grizzly Bears should return to the battlefield at the end step") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+        }
+
+        context("Mourning") {
+            test("gives enchanted creature -2/-0 and can bounce itself for {B}") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Mourning")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2 to weaken
+                    .withLandsOnBattlefield(1, "Swamp", 3) // {1}{B} cast + {B} bounce
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearId = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Mourning", bearId)
+                withClue("Mourning should attach: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val weakened = projector.project(game.state)
+                withClue("Enchanted Grizzly Bears should be 0/2 after -2/-0") {
+                    weakened.getPower(bearId) shouldBe 0
+                    weakened.getToughness(bearId) shouldBe 2
+                }
+
+                val mourningId = game.findPermanent("Mourning")!!
+                val bounceAbility = cardRegistry.getCard("Mourning")!!.script.activatedAbilities[0]
+                val bounce = game.execute(ActivateAbility(game.player1Id, mourningId, bounceAbility.id, emptyList()))
+                withClue("Bounce should succeed: ${bounce.error}") { bounce.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Mourning should be back in its owner's hand") {
+                    game.isInHand(1, "Mourning") shouldBe true
+                    game.isOnBattlefield("Mourning") shouldBe false
+                }
+                val restored = projector.project(game.state)
+                withClue("Grizzly Bears should be 2/2 again once Mourning leaves") {
+                    restored.getPower(bearId) shouldBe 2
+                }
+            }
+        }
+
+        context("Obliterate") {
+            test("destroys all artifacts, creatures, and lands") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Obliterate")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Sparring Golem") // artifact creature
+                    .withLandsOnBattlefield(1, "Mountain", 8) // {6}{R}{R}
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Obliterate")
+                game.resolveStack()
+
+                withClue("All creatures should be destroyed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isOnBattlefield("Sparring Golem") shouldBe false
+                }
+                withClue("All lands should be destroyed") {
+                    game.isOnBattlefield("Mountain") shouldBe false
+                    game.isOnBattlefield("Forest") shouldBe false
+                }
+            }
+        }
+
+        context("Rout") {
+            test("destroys all creatures") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Rout")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Sparring Golem")
+                    .withLandsOnBattlefield(1, "Plains", 5) // {3}{W}{W}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Rout")
+                game.resolveStack()
+
+                withClue("Rout should destroy every creature") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isOnBattlefield("Sparring Golem") shouldBe false
+                }
+                withClue("Lands should survive Rout") {
+                    game.isOnBattlefield("Plains") shouldBe true
+                }
+            }
+        }
+
+        context("Winnow") {
+            test("destroys the target when another permanent shares its name") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Winnow")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // duplicate name on battlefield
+                    .withCardInLibrary(1, "Plains")
+                    .withLandsOnBattlefield(1, "Plains", 2) // {1}{W}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val targetBear = game.findPermanents("Grizzly Bears").first()
+                val handBefore = game.handSize(1)
+                game.castSpell(1, "Winnow", targetBear)
+                game.resolveStack()
+
+                withClue("One Grizzly Bears should be destroyed, the other remains") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 1
+                }
+                withClue("Winnow always draws a card") {
+                    game.handSize(1) shouldBe (handBefore - 1 + 1)
+                }
+            }
+
+            test("does not destroy the target when no other permanent shares its name, but still draws") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Winnow")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // lone copy
+                    .withCardInLibrary(1, "Plains")
+                    .withLandsOnBattlefield(1, "Plains", 2) // {1}{W}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val targetBear = game.findPermanent("Grizzly Bears")!!
+                val handBefore = game.handSize(1)
+                game.castSpell(1, "Winnow", targetBear)
+                game.resolveStack()
+
+                withClue("Lone Grizzly Bears should survive (no same-named permanent)") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("Winnow still draws a card even when nothing is destroyed") {
+                    game.handSize(1) shouldBe (handBefore - 1 + 1)
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionDestructionBatchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionDestructionBatchScenarioTest.kt
@@ -1,12 +1,17 @@
 package com.wingedsheep.gameserver.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PassPriority
 import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Scenario tests for a batch of Invasion (INV) cards:
@@ -114,6 +119,37 @@ class InvasionDestructionBatchScenarioTest : ScenarioTestBase() {
                     game.isOnBattlefield("Forest") shouldBe false
                 }
             }
+
+            test("can't be countered: Undermine fails to stop it and the board still wipes") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Obliterate")
+                    .withCardInHand(2, "Undermine") // {U}{U}{B}: counter target spell
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 8) // {6}{R}{R}
+                    .withLandsOnBattlefield(2, "Island", 2)
+                    .withLandsOnBattlefield(2, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Obliterate")
+                withClue("Obliterate should cast: ${cast.error}") { cast.error shouldBe null }
+                game.execute(PassPriority(game.player1Id))
+
+                val counter = game.castSpellTargetingStackSpell(2, "Undermine", "Obliterate")
+                withClue("Undermine may still target an uncounterable spell: ${counter.error}") {
+                    counter.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Obliterate resolves despite Undermine — the creature is destroyed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("Obliterate is not countered; it resolves into its owner's graveyard") {
+                    game.isInGraveyard(1, "Obliterate") shouldBe true
+                }
+            }
         }
 
         context("Rout") {
@@ -139,6 +175,53 @@ class InvasionDestructionBatchScenarioTest : ScenarioTestBase() {
                     game.isOnBattlefield("Plains") shouldBe true
                 }
             }
+
+            test("flash-kicker mode lets it wipe the board on the opponent's turn") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Rout")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 7) // {3}{W}{W} + {2} flash kicker
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val casterId = game.player1Id
+                val routId = game.state.getHand(casterId).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Rout"
+                }
+                val cast = game.execute(CastSpell(playerId = casterId, cardId = routId, wasKicked = true))
+                withClue("Flash-kicker cast on opponent's turn should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Rout cast for its flash kicker still destroys every creature") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("sorcery-speed cast on the opponent's turn is rejected without the kicker") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Rout")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 7)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val casterId = game.player1Id
+                val routId = game.state.getHand(casterId).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Rout"
+                }
+                val cast = game.execute(CastSpell(playerId = casterId, cardId = routId, wasKicked = false))
+                withClue("Sorcery-speed Rout on the opponent's turn must be blocked") {
+                    cast.error shouldNotBe null
+                }
+            }
         }
 
         context("Winnow") {
@@ -162,8 +245,8 @@ class InvasionDestructionBatchScenarioTest : ScenarioTestBase() {
                 withClue("One Grizzly Bears should be destroyed, the other remains") {
                     game.findPermanents("Grizzly Bears").size shouldBe 1
                 }
-                withClue("Winnow always draws a card") {
-                    game.handSize(1) shouldBe (handBefore - 1 + 1)
+                withClue("Winnow always draws a card (casting spends it, the draw replaces it)") {
+                    game.handSize(1) shouldBe handBefore
                 }
             }
 
@@ -187,7 +270,7 @@ class InvasionDestructionBatchScenarioTest : ScenarioTestBase() {
                     game.isOnBattlefield("Grizzly Bears") shouldBe true
                 }
                 withClue("Winnow still draws a card even when nothing is destroyed") {
-                    game.handSize(1) shouldBe (handBefore - 1 + 1)
+                    game.handSize(1) shouldBe handBefore
                 }
             }
         }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -224,6 +224,13 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TargetSharesMostCommonColor(targetIndex)
 
     /**
+     * If another permanent with the same name as the target is on the battlefield.
+     * The target permanent itself is excluded from the comparison. Used by Winnow.
+     */
+    fun AnotherPermanentWithSameNameAsTarget(targetIndex: Int = 0): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.AnotherPermanentWithSameNameAsTarget(targetIndex)
+
+    /**
      * If [color] is the most common color among all permanents on the battlefield, or is tied
      * for most common. Board-derived, so it works as a `ConditionalStaticAbility` gate. Used by
      * the Invasion djinn cycle (Goham/Halam/Ruham/Sulam/Zanam).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -148,6 +148,26 @@ data class TargetMatchesFilter(
 }
 
 /**
+ * Condition: "if another permanent with the same name as [target] is on the battlefield".
+ *
+ * Resolves the context target at [targetIndex], reads its card name, and returns true when at
+ * least one *other* battlefield permanent shares that exact name. The target permanent itself is
+ * excluded from the comparison (so a single copy never satisfies its own check). Tokens compare by
+ * name like any other permanent.
+ *
+ * Used by Winnow: "Destroy target nonland permanent if another permanent with the same name is on
+ * the battlefield."
+ */
+@SerialName("AnotherPermanentWithSameNameAsTarget")
+@Serializable
+data class AnotherPermanentWithSameNameAsTarget(
+    val targetIndex: Int = 0
+) : Condition {
+    override val description: String = "if another permanent with the same name is on the battlefield"
+    override fun applyTextReplacement(replacer: TextReplacer): Condition = this
+}
+
+/**
  * Condition: "if [target] shares a color with the most common color among all permanents
  * or a color tied for most common".
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/RoutReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/RoutReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rout reprint in Commander 2017. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in INV.
+ */
+val RoutReprint = Printing(
+    oracleId = "d69aa624-23d1-406a-b7e0-9140a6f57929",
+    name = "Rout",
+    setCode = "C17",
+    collectorNumber = "71",
+    scryfallId = "3eb01bba-798f-418c-8e45-387b96c9e732",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/3/e/3eb01bba-798f-418c-8e45-387b96c9e732.jpg?1562605808",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Liberate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Liberate.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Liberate
+ * {1}{W}
+ * Instant
+ * Exile target creature you control. Return that card to the battlefield under its
+ * owner's control at the beginning of the next end step.
+ *
+ * A "blink" of your own creature: [EffectPatterns.exileUntilEndStep] exiles the target
+ * and schedules a delayed trigger at the next end step that returns it to the
+ * battlefield. Cards return to the battlefield under their owner's control by default,
+ * matching the oracle wording.
+ */
+val Liberate = card("Liberate") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Exile target creature you control. Return that card to the battlefield " +
+        "under its owner's control at the beginning of the next end step."
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = EffectPatterns.exileUntilEndStep(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "21"
+        artist = "Alan Pollack"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96794470-31ea-478f-b11c-dc8342a508e2.jpg?1562925324"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Mourning.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Mourning.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mourning
+ * {1}{B}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets -2/-0.
+ * {B}: Return this Aura to its owner's hand.
+ */
+val Mourning = card("Mourning") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets -2/-0.\n" +
+        "{B}: Return this Aura to its owner's hand."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(-2, 0)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = MoveToZoneEffect(EffectTarget.Self, Zone.HAND)
+        description = "{B}: Return this Aura to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Terese Nielsen"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/4649d881-709f-4ed0-91de-744d232a82f5.jpg?1562909240"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Obliterate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Obliterate.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Obliterate
+ * {6}{R}{R}
+ * Sorcery
+ * This spell can't be countered.
+ * Destroy all artifacts, creatures, and lands. They can't be regenerated.
+ *
+ * "All artifacts, creatures, and lands" is a single destruction event over the
+ * combined filter, so everything goes to the graveyard simultaneously (and leaves /
+ * dies triggers all see the same game state).
+ */
+val Obliterate = card("Obliterate") {
+    manaCost = "{6}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "This spell can't be countered.\n" +
+        "Destroy all artifacts, creatures, and lands. They can't be regenerated."
+
+    cantBeCountered = true
+
+    spell {
+        effect = Effects.DestroyAll(
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature or GameObjectFilter.Land,
+            noRegenerate = true,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "156"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdabde40-2143-4677-b7b4-ea8fbf9b1f25.jpg?1562936357"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Rout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Rout.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Rout
+ * {3}{W}{W}
+ * Sorcery
+ * You may cast this spell as though it had flash if you pay {2} more to cast it.
+ * Destroy all creatures. They can't be regenerated.
+ *
+ * The "pay {2} more to cast as though it had flash" clause is the Breaking Wave /
+ * Ghitu Fire pattern: [KeywordAbility.flashKicker] — paying the extra cost unlocks
+ * instant-speed casting without otherwise changing the spell.
+ */
+val Rout = card("Rout") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "You may cast this spell as though it had flash if you pay {2} more to cast it. " +
+        "(You may cast it any time you could cast an instant.)\n" +
+        "Destroy all creatures. They can't be regenerated."
+
+    keywordAbility(KeywordAbility.flashKicker("{2}"))
+
+    spell {
+        effect = Effects.DestroyAll(
+            filter = GameObjectFilter.Creature,
+            noRegenerate = true,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "34"
+        artist = "Ron Spencer"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94bc55ed-b89b-4e22-b3f1-4ce0f8d180d7.jpg?1562924999"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Winnow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Winnow.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Winnow
+ * {1}{W}
+ * Instant
+ * Destroy target nonland permanent if another permanent with the same name is on the
+ * battlefield.
+ * Draw a card.
+ *
+ * The destruction is gated by [Conditions.AnotherPermanentWithSameNameAsTarget], evaluated
+ * against the chosen target at resolution. The "Draw a card" clause is unconditional, so it
+ * happens whether or not the permanent is destroyed.
+ */
+val Winnow = card("Winnow") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target nonland permanent if another permanent with the same name " +
+        "is on the battlefield.\n" +
+        "Draw a card."
+
+    spell {
+        val permanent = target("target nonland permanent", Targets.NonlandPermanent)
+        effect = ConditionalEffect(
+            condition = Conditions.AnotherPermanentWithSameNameAsTarget(),
+            effect = Effects.Destroy(permanent),
+        ) then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "45"
+        artist = "Roger Raupp"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d61748dd-4010-47da-8717-ca0147877057.jpg?1562937982"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -59,6 +59,7 @@ import com.wingedsheep.sdk.scripting.conditions.WasCastFromHand
 import com.wingedsheep.sdk.scripting.conditions.WasCastFromZone
 import com.wingedsheep.engine.state.components.battlefield.CastFromGraveyardComponent
 import com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentHadSubtype
+import com.wingedsheep.sdk.scripting.conditions.AnotherPermanentWithSameNameAsTarget
 import com.wingedsheep.sdk.scripting.conditions.TargetMatchesFilter
 import com.wingedsheep.sdk.scripting.conditions.TargetSharesMostCommonColor
 import com.wingedsheep.sdk.scripting.conditions.ColorIsMostCommon
@@ -214,6 +215,8 @@ class ConditionEvaluator {
             is TriggeringSpellHasSingleTarget -> ifResolution { evaluateTriggeringSpellHasSingleTarget(state, it) }
             is TargetMatchesFilter -> ifResolution { evaluateTargetMatchesFilter(state, condition, it) }
             is TargetSharesMostCommonColor -> ifResolution { evaluateTargetSharesMostCommonColor(state, condition, it) }
+            is AnotherPermanentWithSameNameAsTarget ->
+                ifResolution { evaluateAnotherPermanentWithSameNameAsTarget(state, condition, it) }
             is IsInPhase -> ifResolution { evaluateIsInPhase(state, condition, it) }
             is YouWereAttackedThisStep -> ifResolution { evaluateYouWereAttackedThisStep(state, it) }
             is IsFirstSpellOfTypeCastThisTurn -> ifResolution { evaluateFirstSpellOfType(state, condition, it) }
@@ -667,6 +670,27 @@ class ConditionEvaluator {
             ?.entityId ?: return false
         val projected = state.projectedState
         return projected.getColors(entityId).any { it in mostCommonColors(state, projected) }
+    }
+
+    /**
+     * "If another permanent with the same name as the target is on the battlefield": resolve the
+     * target permanent, read its card name, and return true when at least one *other* battlefield
+     * permanent shares that exact name. The target itself is excluded so a single copy never
+     * satisfies its own check.
+     */
+    private fun evaluateAnotherPermanentWithSameNameAsTarget(
+        state: GameState,
+        condition: AnotherPermanentWithSameNameAsTarget,
+        context: EffectContext
+    ): Boolean {
+        val target = context.targets.getOrNull(condition.targetIndex) ?: return false
+        val entityId = (target as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent)
+            ?.entityId ?: return false
+        val targetName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: return false
+        return state.getBattlefield().any { otherId ->
+            otherId != entityId &&
+                state.getEntity(otherId)?.get<CardComponent>()?.name == targetName
+        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.engine.state.components.combat.PlayerAttackedThisTurnComp
 import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.RingBearerComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
@@ -677,6 +678,10 @@ class ConditionEvaluator {
      * target permanent, read its card name, and return true when at least one *other* battlefield
      * permanent shares that exact name. The target itself is excluded so a single copy never
      * satisfies its own check.
+     *
+     * A face-down permanent has no name (CR 708.2), so it neither matches anything (as the target)
+     * nor counts as a same-named permanent (as a candidate) — face-down entities are skipped on
+     * both sides even though they retain a hidden [CardComponent.name].
      */
     private fun evaluateAnotherPermanentWithSameNameAsTarget(
         state: GameState,
@@ -686,10 +691,13 @@ class ConditionEvaluator {
         val target = context.targets.getOrNull(condition.targetIndex) ?: return false
         val entityId = (target as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent)
             ?.entityId ?: return false
-        val targetName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: return false
+        val targetEntity = state.getEntity(entityId) ?: return false
+        if (targetEntity.has<FaceDownComponent>()) return false
+        val targetName = targetEntity.get<CardComponent>()?.name ?: return false
         return state.getBattlefield().any { otherId ->
-            otherId != entityId &&
-                state.getEntity(otherId)?.get<CardComponent>()?.name == targetName
+            if (otherId == entityId) return@any false
+            val other = state.getEntity(otherId) ?: return@any false
+            !other.has<FaceDownComponent>() && other.get<CardComponent>()?.name == targetName
         }
     }
 


### PR DESCRIPTION
Implements five Invasion (INV) cards, each canonical in its earliest real printing (INV).

## Cards

- **Liberate** `{1}{W}` Instant — Exile target creature you control; return it to the battlefield under its owner's control at the next end step. Uses `EffectPatterns.exileUntilEndStep`.
- **Mourning** `{1}{B}` Aura — Enchanted creature gets -2/-0; `{B}`: return this Aura to its owner's hand. `ModifyStats(-2, 0)` static + bounce activated ability (Shimmering Wings / Crown of Flames shape).
- **Obliterate** `{6}{R}{R}` Sorcery — Can't be countered; destroy all artifacts, creatures, and lands (no regeneration). Single `Effects.DestroyAll` over the combined `Artifact or Creature or Land` filter so everything is destroyed simultaneously; `cantBeCountered = true`.
- **Rout** `{3}{W}{W}` Sorcery — Optionally cast as though it had flash for `{2}` more; destroy all creatures (no regeneration). Uses `KeywordAbility.flashKicker("{2}")` (Breaking Wave pattern).
- **Winnow** `{1}{W}` Instant — Destroy target nonland permanent if another permanent with the same name is on the battlefield; draw a card. The destroy is gated by a new condition; the draw is unconditional.

## SDK addition

- `Conditions.AnotherPermanentWithSameNameAsTarget(targetIndex = 0)` — true when at least one *other* battlefield permanent shares the exact card name of the chosen target (the target itself is excluded). Added the SDK condition type, the `Conditions` facade entry, the `ConditionEvaluator` resolution branch, and a `card-sdk-language-reference.md` entry.

## Tests

`InvasionDestructionBatchScenarioTest` covers all five cards, including Liberate's exile-then-return-at-end-step, Mourning's -2/-0 and self-bounce, Obliterate/Rout board wipes, and both Winnow branches (destroys with a duplicate present, no-ops without one, and always draws). All scenario, discovery, validation, and condition tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)