### PR TITLE
Sealed deckbuild gym env + GymEnv abstraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,3 +111,4 @@ continuations, layer system, mana, priority): [`docs/architecture-principles.md`
 | [`data-contracts.md`](docs/data-contracts.md) | Client/server JSON payloads |
 | [`web-client-architecture.md`](docs/web-client-architecture.md) | Frontend architecture, WebSocket API |
 | [`e2e-test-patterns.md`](docs/e2e-test-patterns.md) | Playwright fixtures, GamePage helpers, scenario config |
+| [`gym-deckbuild-env.md`](docs/gym-deckbuild-env.md) | Sealed deckbuild gym env (build → play pipeline) + how to supply your own win-rate reward |

--- a/docs/gym-deckbuild-env.md
+++ b/docs/gym-deckbuild-env.md
@@ -1,0 +1,139 @@
+# Deckbuild environment (sealed)
+
+A second kind of gym environment, alongside the game env: instead of *playing* Magic, the agent
+*builds a deck* from an opened sealed pool. It exists so we can test an agent's **deckbuilding
+judgment** — colour/curve/card-evaluation — as a first-class capability, and then feed the deck it
+built into a game env to see how it actually performs.
+
+> This is a sibling of the game env documented in `gym-self-play-testing.md`. Both implement the
+> same `GymEnv` interface (`observe` / `step` / `fork`) and return a discriminated `Observation`
+> (`type: "Game"` or `type: "Deckbuild"`), so one driver loop works for either.
+
+---
+
+## Why it's its own environment (not a pre-game phase)
+
+Deckbuilding doesn't touch the engine's `(GameState, GameAction)` model — there is no game yet: no
+stack, no priority, no turns, no zones-in-play. Its observation space (a card pool), action space
+(add / remove / finalize), and terminal condition (a legal deck) are all different from a game's.
+Forcing it in as a "pending decision" on a `GameState` that doesn't exist would be the wrong
+abstraction. So it's a distinct `GymEnv` implementation (`DeckbuildEnvironment`), and the wire
+`Observation` became a sealed union to carry both shapes.
+
+---
+
+## API
+
+### Create
+
+```
+POST /envs/deckbuild
+{ "setCode": "BLB", "boosterCount": 6, "targetSize": 40 }
+   → { "envId": "...", "observation": { "type": "Deckbuild", ... } }
+```
+
+`setCode` must be sealed-supported in the server's booster generator. The response observation lists
+the opened pool.
+
+### Observation (`type: "Deckbuild"`)
+
+- `pool` — each distinct opened card as a `PoolCardView` (`name`, `manaCost`, `manaValue`,
+  `colors`, `types`, `subtypes`, `pt`, `oracleText`, and `remaining` = copies still available to add).
+- `basics` — the basic lands you may add without limit (one entry per land name).
+- `selected` — the current decklist (`cardName → count`); `selectedCount` is its total.
+- `targetSize` — minimum legal size; `FINALIZE` unlocks once `selectedCount` reaches it.
+- `deckScore` — intrinsic quality estimate, **only populated once `terminated`** (see below).
+- `legalActions`, `terminated`, `stateDigest`, `agentToAct` — the common `Observation` fields.
+
+### Drive it with the same step loop
+
+`legalActions` enumerates the build moves; `POST /envs/{id}/step {actionId}` applies one and returns
+the next observation. Kinds:
+
+| kind | meaning |
+|------|---------|
+| `ADD_CARD` | add one copy of a pool card (offered only while `remaining > 0`) |
+| `ADD_BASIC` | add one basic land (unlimited) |
+| `REMOVE_CARD` | remove one copy of a selected card |
+| `FINALIZE` | commit the deck (offered only once `selectedCount ≥ targetSize`) |
+
+On `FINALIZE` the env is `terminated`, `agentToAct` becomes null, and `selected` is the finished
+decklist. `fork` works (branch a build for search); snapshot/restore are game-only.
+
+### Then play what you built
+
+The env is deliberately **decoupled** from play. Take the terminal `selected` map and start a game:
+
+```
+POST /envs  { "players": [ { "deck": { "type": "Explicit", "cards": <selected> } }, … ] }
+```
+
+---
+
+## Reward: delayed, and across two environments
+
+This is the subtle part, and it's intentional.
+
+`deckScore` is an **intrinsic** estimate (summed `LimitedCardRater` ratings of the non-land cards —
+calibrated to 17Lands data). It's a cheap, immediate proxy: useful for smoke-testing and for shaping,
+but it is **not ground truth**. A deck's real value is **how often it wins**, and you can't know that
+at finalize time — you only learn it by *playing games with the deck*, which happens in a **separate
+game env, after the deckbuild env has already terminated**.
+
+So the reward is both **delayed** (it arrives after a whole game, or many) and **cross-environment**
+(the env that earns the reward is not the env that made the decisions). The deckbuild env cannot
+return it.
+
+### The gym is reward-agnostic — you supply the reward
+
+The environment never imposes a reward. It emits observations, the finalized deck, and an optional
+intrinsic score. **Your training loop owns the reward signal and the credit assignment.** That means
+you are free to supply your own reward/penalty based on whether the deck actually wins — and that is
+the intended way to evaluate deckbuilding properly. Concretely:
+
+```
+1. build:    open a deckbuild env → step ADD/REMOVE → FINALIZE
+             → record the action trajectory τ and the finished deck D
+2. evaluate: play N games in game envs with D
+                - vs a fixed baseline (e.g. the heuristic build from the SAME pool — buildHeuristicSealedDeck),
+                - or a mirror, or a rotating opponent pool
+             → win_rate = wins / N        # this is YOUR reward, computed however you like
+3. assign:   return R = win_rate (optionally blended with intrinsic: R = w·win_rate + (1-w)·deckScore/scale)
+             as the terminal return for the whole build trajectory τ
+4. learn:    credit-assign R across τ's add/remove/finalize steps (REINFORCE / advantage / your method)
+```
+
+Steps 1, 3 and 4 are yours; the gym just provides the deckbuild env (step 1) and the game envs
+(step 2). Nothing in the contract assumes the intrinsic score is the reward — ignore `deckScore`
+entirely if you only trust win-rate, or blend the two to cut early-training variance.
+
+### Why split it this way
+
+Because the reward boundary genuinely crosses environments, modelling build and play as **one** env
+would force that env to also run games to score itself — coupling deckbuilding to the entire game
+engine and to an opponent policy, and collapsing two very different decision processes into one. Two
+envs joined by a reward your loop computes keeps each single-purpose: the deckbuild env is fast and
+pure (no engine), the game env is unchanged, and you can swap the evaluation (baseline, opponent
+pool, number of games, shaping) without touching either env.
+
+### Practical notes
+
+- **Variance:** a single game is a noisy label (mulligans, draws, who's on the play). Average over
+  many games and fix the opponent(s); the heuristic build from the same pool is a strong,
+  reproducible baseline to play against.
+- **Shaping / curriculum:** blend `deckScore` early (dense, immediate) and anneal toward pure
+  win-rate (sparse, true) as training stabilises.
+- **Search:** `fork` a partially-built env to explore alternative completions (MCTS over card
+  choices); `stateDigest` dedupes equivalent partial builds.
+- **Mana base:** the env doesn't enforce a sensible land count — a deck that never casts its spells
+  will simply lose, and the win-rate reward will reflect that. That's the point.
+
+---
+
+## Status / limits
+
+- Sealed only. Draft (pick-1-of-N across passed packs) would be a third `GymEnv` type under the same
+  surface — not yet built.
+- `setCode` is required (no random-set deckbuild yet).
+- The intrinsic `deckScore` ignores lands and counts only card quality, not curve or colour
+  consistency — treat it as a rough prior, not a verdict.

--- a/gym-server/src/main/kotlin/com/wingedsheep/gym/server/controller/EnvController.kt
+++ b/gym-server/src/main/kotlin/com/wingedsheep/gym/server/controller/EnvController.kt
@@ -1,7 +1,8 @@
 package com.wingedsheep.gym.server.controller
 
 import com.wingedsheep.engine.core.DecisionResponse
-import com.wingedsheep.gym.contract.TrainingObservation
+import com.wingedsheep.gym.contract.Observation
+import com.wingedsheep.gym.service.DeckbuildConfig
 import com.wingedsheep.gym.service.EnvConfig
 import com.wingedsheep.gym.service.EnvId
 import com.wingedsheep.gym.service.MultiEnvService
@@ -171,6 +172,31 @@ class EnvController(
         return CreateEnvResponse(created.envId, created.observation.observation)
     }
 
+    @Operation(
+        summary = "Create a new deckbuild env",
+        description = """
+            Opens `boosterCount` boosters from `setCode` into a sealed pool and returns a
+            `DeckbuildObservation` (the `type` discriminator is `"Deckbuild"`). The agent then
+            drives the same `/envs/{id}/step` loop using the enumerated build actions —
+            `ADD_CARD`, `ADD_BASIC`, `REMOVE_CARD`, `FINALIZE` — until it commits a
+            `targetSize`-card deck. On `FINALIZE` the env is `terminated`; the terminal
+            observation's `selected` map is the finished decklist, which the caller feeds to a
+            game env via `POST /envs` with `{"deck": {"type": "Explicit", "cards": <selected>}}`.
+
+            `setCode` must be sealed-supported in the server's booster generator.
+
+            Note: `deckScore` on the terminal observation is only an *intrinsic* card-quality
+            estimate. A deck's real value is its win-rate when played — a delayed reward that
+            lands in a separate game env, which the training loop supplies itself. See
+            docs/gym-deckbuild-env.md.
+        """
+    )
+    @PostMapping("/deckbuild")
+    fun createDeckbuild(@RequestBody config: DeckbuildConfig): CreateEnvResponse {
+        val created = multiEnvService.createDeckbuild(config)
+        return CreateEnvResponse(created.envId, created.observation.observation)
+    }
+
     @Operation(summary = "List live env IDs")
     @GetMapping
     fun list(): List<EnvId> = multiEnvService.listEnvs().toList()
@@ -183,7 +209,7 @@ class EnvController(
     fun reset(
         @PathVariable id: String,
         @RequestBody config: EnvConfig
-    ): TrainingObservation =
+    ): Observation =
         multiEnvService.reset(EnvId(id), config).observation
 
     @Operation(
@@ -208,7 +234,7 @@ class EnvController(
     fun observe(
         @PathVariable id: String,
         @RequestParam(required = false) revealAll: Boolean?
-    ): TrainingObservation =
+    ): Observation =
         multiEnvService.observe(EnvId(id), revealAll).observation
 
     // =========================================================================
@@ -223,7 +249,7 @@ class EnvController(
     fun step(
         @PathVariable id: String,
         @RequestBody body: StepBody
-    ): TrainingObservation =
+    ): Observation =
         multiEnvService.step(StepRequest(EnvId(id), body.actionId)).observation
 
     @Operation(
@@ -252,7 +278,7 @@ class EnvController(
     fun submitDecision(
         @PathVariable id: String,
         @RequestBody response: DecisionResponse
-    ): TrainingObservation =
+    ): Observation =
         multiEnvService.submitDecision(EnvId(id), response).observation
 
     // =========================================================================
@@ -283,6 +309,6 @@ class EnvController(
     fun restore(
         @PathVariable id: String,
         @RequestBody body: RestoreBody
-    ): TrainingObservation =
+    ): Observation =
         multiEnvService.restore(EnvId(id), body.handle).observation
 }

--- a/gym-server/src/main/kotlin/com/wingedsheep/gym/server/dto/GymDtos.kt
+++ b/gym-server/src/main/kotlin/com/wingedsheep/gym/server/dto/GymDtos.kt
@@ -1,18 +1,20 @@
 package com.wingedsheep.gym.server.dto
 
-import com.wingedsheep.gym.contract.TrainingObservation
+import com.wingedsheep.gym.contract.Observation
 import com.wingedsheep.gym.service.EnvId
 import com.wingedsheep.gym.service.SnapshotHandle
 import kotlinx.serialization.Serializable
 
 /**
- * Response for `POST /envs`. Combines the new env's ID with its opening
- * observation so a Python trainer only has to round-trip once to start.
+ * Response for `POST /envs` (and `POST /envs/deckbuild`). Combines the new env's ID
+ * with its opening observation so a caller only has to round-trip once to start.
+ * The [observation] is a discriminated union — `TrainingObservation` for a game env,
+ * `DeckbuildObservation` for a deckbuild env (see the `type` field).
  */
 @Serializable
 data class CreateEnvResponse(
     val envId: EnvId,
-    val observation: TrainingObservation
+    val observation: Observation
 )
 
 /** Body for `POST /envs/{id}/step`. */
@@ -30,7 +32,7 @@ data class StepBatchItem(
 @Serializable
 data class StepBatchResult(
     val envId: EnvId,
-    val observation: TrainingObservation
+    val observation: Observation
 )
 
 /** Body for `POST /envs/{id}/restore`. */

--- a/gym-server/src/test/kotlin/com/wingedsheep/gym/server/controller/EnvControllerTest.kt
+++ b/gym-server/src/test/kotlin/com/wingedsheep/gym/server/controller/EnvControllerTest.kt
@@ -138,7 +138,7 @@ class EnvControllerTest : FunSpec() {
             val created = json.decodeFromString<CreateEnvResponse>(createResponse.body())
 
             created.envId.value.shouldNotBe("")
-            created.observation.players.size shouldBe 2
+            (created.observation as TrainingObservation).players.size shouldBe 2
             created.observation.terminated.shouldBeFalse()
             created.observation.legalActions.shouldNotBeEmpty()
 
@@ -207,7 +207,7 @@ class EnvControllerTest : FunSpec() {
             val created = json.decodeFromString<CreateEnvResponse>(
                 postJson("/envs", json.encodeToString(twoPlayerConfig())).body()
             )
-            val initialTurn = created.observation.turnNumber
+            val initialTurn = (created.observation as TrainingObservation).turnNumber
 
             repeat(3) {
                 val obs = json.decodeFromString<TrainingObservation>(

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameGymEnv.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameGymEnv.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.gym
+
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.gym.contract.ActionRegistry
+import com.wingedsheep.gym.contract.ObservationBuilder
+import com.wingedsheep.gym.contract.ObservationResult
+import com.wingedsheep.gym.contract.ResolvedAction
+import com.wingedsheep.gym.service.SnapshotCodec
+import com.wingedsheep.gym.service.SnapshotHandle
+
+/**
+ * [GymEnv] adapter over a [GameEnvironment] — a game of Magic.
+ *
+ * Holds the per-env bookkeeping that used to live in `MultiEnvService.EnvEntry`
+ * (perspective, default reveal flag, the live [ActionRegistry] from the last
+ * observation) so the service layer can treat every env type the same. The
+ * underlying [GameEnvironment] is left untouched, since the trainer SPI drives
+ * it directly.
+ */
+class GameGymEnv(
+    val environment: GameEnvironment,
+    private val perspectivePlayerIndex: Int,
+    private val defaultRevealAll: Boolean,
+    private val observationBuilder: ObservationBuilder = ObservationBuilder()
+) : GymEnv {
+
+    @Volatile
+    private var registry: ActionRegistry = ActionRegistry.EMPTY
+
+    override val isTerminal: Boolean get() = environment.state.gameOver
+
+    override fun observe(revealAll: Boolean?): ObservationResult =
+        build(revealAll ?: defaultRevealAll)
+
+    override fun step(actionId: Int): ObservationResult {
+        executeResolved(registry.resolve(actionId), actionId)
+        return build(defaultRevealAll)
+    }
+
+    override fun fork(): GymEnv =
+        GameGymEnv(environment.fork(), perspectivePlayerIndex, defaultRevealAll, observationBuilder)
+            .also { it.build(defaultRevealAll) }
+
+    // --- game-only operations (used by MultiEnvService via cast) -------------
+
+    /** Re-initialise the underlying game in place. */
+    fun reset(gameConfig: GameConfig): ObservationResult {
+        environment.reset(gameConfig)
+        return build(defaultRevealAll)
+    }
+
+    /** Submit a raw `DecisionResponse` while paused on a complex decision. */
+    fun submitDecision(response: DecisionResponse): ObservationResult {
+        val pending = environment.state.pendingDecision
+            ?: throw IllegalStateException("Env is not paused on a decision")
+        check(response.decisionId == pending.id) {
+            "Decision ID mismatch: response=${response.decisionId}, pending=${pending.id}"
+        }
+        environment.step(SubmitDecision(pending.playerId, response))
+        return build(defaultRevealAll)
+    }
+
+    fun snapshot(codec: SnapshotCodec): SnapshotHandle =
+        codec.save(state = environment.state, playerIds = environment.playerIds, stepCount = 0)
+
+    fun restore(codec: SnapshotCodec, handle: SnapshotHandle): ObservationResult {
+        val snap = codec.load(handle)
+        environment.restore(snap.state, snap.playerIds, snap.stepCount)
+        return build(defaultRevealAll)
+    }
+
+    // --- internals -----------------------------------------------------------
+
+    private fun build(revealAll: Boolean): ObservationResult {
+        val perspective = environment.playerIds.getOrNull(perspectivePlayerIndex)
+            ?: throw IllegalStateException("Env has no player at index $perspectivePlayerIndex")
+        val result = observationBuilder.build(
+            environment.state, perspective, environment.legalActions(), revealAll
+        )
+        registry = result.registry
+        return result
+    }
+
+    private fun executeResolved(resolved: ResolvedAction, actionId: Int) {
+        when (resolved) {
+            is ResolvedAction.Legal -> environment.step(resolved.action)
+            is ResolvedAction.Decision -> {
+                val pending = environment.state.pendingDecision
+                    ?: throw IllegalStateException("Registry has a decision response but env is not paused")
+                environment.step(SubmitDecision(pending.playerId, resolved.response))
+            }
+            ResolvedAction.Unknown ->
+                throw IllegalArgumentException("Action ID $actionId is not valid for the current step")
+        }
+    }
+}

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GymEnv.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GymEnv.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.gym
+
+import com.wingedsheep.gym.contract.ObservationResult
+
+/**
+ * A self-contained gym environment the service layer can drive uniformly.
+ *
+ * Two implementations exist:
+ * - [GameGymEnv] — a game of Magic (wraps [GameEnvironment]).
+ * - [com.wingedsheep.gym.deckbuild.DeckbuildEnvironment] — turning a sealed pool into a deck.
+ *
+ * Each env owns its own action bookkeeping: `observe` produces the observation an agent
+ * acts on, and `step` resolves an action ID *from the most recent observation* and advances.
+ * Game-specific operations (decision submission, snapshot/restore, reset) live on
+ * [GameGymEnv] only; the service casts when it needs them.
+ */
+interface GymEnv {
+
+    /** True once the env reached a terminal state (game over, or deck finalized). */
+    val isTerminal: Boolean
+
+    /**
+     * Current observation without advancing. [revealAll] is honoured by game envs
+     * (unmask opponent hand/libraries) and ignored by deckbuild envs, which have no
+     * hidden information. Passing null uses the env's configured default.
+     */
+    fun observe(revealAll: Boolean? = null): ObservationResult
+
+    /**
+     * Advance by the action with [actionId] from the most recent observation.
+     * @throws IllegalArgumentException if the ID is stale / not valid this step.
+     */
+    fun step(actionId: Int): ObservationResult
+
+    /** Branch this env. Children diverge independently from the next [step] on. */
+    fun fork(): GymEnv
+}

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/DeckbuildObservation.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/DeckbuildObservation.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.gym.contract
+
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Observation for a **deckbuild** env — a solitaire environment in which one agent
+ * turns an opened sealed pool into a legal deck.
+ *
+ * The agent reads [pool] (and the unlimited [basics]), then drives [Observation.legalActions]
+ * — `ADD_CARD` / `REMOVE_CARD` / `ADD_BASIC` / `FINALIZE` — until the deck is legal and it
+ * commits with `FINALIZE`. On finalize the env is [Observation.terminated]; [selected] is the
+ * finished decklist (`cardName → count`) the caller feeds to a game env via
+ * `DeckSpec.Explicit`, and [deckScore] is an intrinsic quality estimate (see
+ * `com.wingedsheep.ai.engine.LimitedCardRater`).
+ *
+ * Unlike a game observation there is no hidden information and no engine `pendingDecision`;
+ * the whole pool is visible and every choice is an enumerated legal action.
+ */
+@Serializable
+@SerialName("Deckbuild")
+data class DeckbuildObservation(
+    override val schemaHash: String,
+
+    /** The (synthetic) player building this deck. */
+    override val agentToAct: EntityId?,
+
+    /** The opened sealed pool — each distinct card with how many copies remain unselected. */
+    val pool: List<PoolCardView>,
+
+    /** Basic lands available to add without limit (one entry per land name). */
+    val basics: List<PoolCardView>,
+
+    /** Current decklist: card name → count (includes added basics). */
+    val selected: Map<String, Int>,
+
+    /** Total cards currently in [selected]. */
+    val selectedCount: Int,
+
+    /** Minimum legal deck size; `FINALIZE` is affordable once [selectedCount] reaches it. */
+    val targetSize: Int,
+
+    /** Intrinsic deck-quality estimate. Only populated once [Observation.terminated]. */
+    val deckScore: Double? = null,
+
+    override val pendingDecision: PendingDecisionView? = null,
+    override val legalActions: List<LegalActionView>,
+    override val terminated: Boolean,
+    override val stateDigest: String
+) : Observation
+
+/**
+ * A card as seen in a deckbuild pool. Carries enough for an agent to evaluate it —
+ * name, cost, color/type, P/T, and oracle text — plus how many copies are still
+ * available to add ([remaining]).
+ */
+@Serializable
+data class PoolCardView(
+    val name: String,
+    val manaCost: String,
+    val manaValue: Int,
+    val colors: Set<String>,
+    val types: Set<String>,
+    val subtypes: Set<String>,
+    /** "power/toughness" for creatures, null otherwise. */
+    val pt: String? = null,
+    val oracleText: String = "",
+    /** Copies of this card still available to add (selected copies subtracted). */
+    val remaining: Int
+)

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -505,11 +505,12 @@ class ObservationBuilder(
 }
 
 /**
- * Build output pairing a [TrainingObservation] with its server-side
- * [ActionRegistry]. The observation is safe to serialize; the registry must
- * be retained on the server so it can resolve incoming action IDs.
+ * Build output pairing an [Observation] with its server-side [ActionRegistry].
+ * The observation is safe to serialize; the registry must be retained on the
+ * server so it can resolve incoming action IDs. Both game envs ([TrainingObservation])
+ * and deckbuild envs ([DeckbuildObservation]) produce this shape.
  */
 data class ObservationResult(
-    val observation: TrainingObservation,
+    val observation: Observation,
     val registry: ActionRegistry
 )

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/SchemaHash.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/SchemaHash.kt
@@ -10,5 +10,5 @@ package com.wingedsheep.gym.contract
  * itself is arbitrary; uniqueness is what matters.
  */
 object SchemaHash {
-    const val CURRENT: String = "argentum-gym-contract@v1.1-oracle-text"
+    const val CURRENT: String = "argentum-gym-contract@v1.2-observation-union"
 }

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
@@ -5,10 +5,42 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Root payload sent to a training agent after every `reset()` / `step()`.
+ * The payload an agent receives from any gym environment after `observe` / `step`.
+ *
+ * A gym env is no longer only a game of Magic — deckbuilding is its own env type
+ * ([DeckbuildObservation]) — so the wire observation is a discriminated union. The
+ * `type` field tells a client which variant it holds: `"Game"` for an in-progress
+ * match, `"Deckbuild"` for a sealed-pool build. The fields hoisted here are the ones
+ * every env exposes so a generic driver loop (read `legalActions`, pick one, `step`,
+ * stop on `terminated`) works without knowing the variant up front.
+ */
+@Serializable
+sealed interface Observation {
+    /** Sha256 of the canonical schema — clients compare to abort on drift. */
+    val schemaHash: String
+
+    /** The player/agent who must act next, or null when [terminated]. */
+    val agentToAct: EntityId?
+
+    /** Non-null only for in-game complex decisions; always null for deckbuild. */
+    val pendingDecision: PendingDecisionView?
+
+    /** Every action available to [agentToAct] this step. Action IDs are per-step. */
+    val legalActions: List<LegalActionView>
+
+    /** True once the env reached a terminal state (game over, or deck finalized). */
+    val terminated: Boolean
+
+    /** Deterministic hash of the observable state, for MCTS transposition tables. */
+    val stateDigest: String
+}
+
+/**
+ * Root payload for a **game** env, sent to a training agent after every `reset()` / `step()`.
  *
  * Designed for RL consumers (neural policies, MCTS) — not for human display.
  * The schema is stable across card sets; new mechanics appear as strings in
@@ -19,15 +51,16 @@ import kotlinx.serialization.Serializable
  * time the environment advances and must not be cached across steps.
  */
 @Serializable
+@SerialName("Game")
 data class TrainingObservation(
     /** Sha256 of the canonical schema. Python clients compare this to abort on drift. */
-    val schemaHash: String,
+    override val schemaHash: String,
 
     /** The player whose information-set this observation represents. */
     val perspectivePlayerId: EntityId,
 
     /** The player who needs to act next, or null if the game is over. */
-    val agentToAct: EntityId?,
+    override val agentToAct: EntityId?,
 
     val turnNumber: Int,
     val phase: Phase,
@@ -48,13 +81,13 @@ data class TrainingObservation(
     val stack: List<StackItemView>,
 
     /** Non-null when the engine paused for a player decision. */
-    val pendingDecision: PendingDecisionView?,
+    override val pendingDecision: PendingDecisionView?,
 
     /** All actions available to [agentToAct]. Empty when the game is over. */
-    val legalActions: List<LegalActionView>,
+    override val legalActions: List<LegalActionView>,
 
     /** True if the game ended naturally. */
-    val terminated: Boolean,
+    override val terminated: Boolean,
 
     /** Set if [terminated] and there is a winner (null = draw or ongoing). */
     val winnerId: EntityId?,
@@ -64,8 +97,8 @@ data class TrainingObservation(
      * tables in MCTS. Two observations with the same digest describe the same
      * information-set from the same perspective.
      */
-    val stateDigest: String
-)
+    override val stateDigest: String
+) : Observation
 
 /** Per-player summary. Counts reflect what [perspectivePlayerId] can see. */
 @Serializable

--- a/gym/src/main/kotlin/com/wingedsheep/gym/deckbuild/DeckbuildEnvironment.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/deckbuild/DeckbuildEnvironment.kt
@@ -1,0 +1,189 @@
+package com.wingedsheep.gym.deckbuild
+
+import com.wingedsheep.ai.engine.LimitedCardRater
+import com.wingedsheep.gym.GymEnv
+import com.wingedsheep.gym.contract.ActionRegistry
+import com.wingedsheep.gym.contract.DeckbuildObservation
+import com.wingedsheep.gym.contract.LegalActionView
+import com.wingedsheep.gym.contract.ObservationResult
+import com.wingedsheep.gym.contract.PoolCardView
+import com.wingedsheep.gym.contract.SchemaHash
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * A solitaire [GymEnv] in which one agent turns an opened sealed [pool] into a legal deck.
+ *
+ * The agent sees the whole pool (no hidden information) and drives the build through
+ * enumerated legal actions — `ADD_CARD`, `REMOVE_CARD`, `ADD_BASIC`, `FINALIZE`. It commits
+ * with `FINALIZE` once the deck reaches [targetSize]; the env then terminates and exposes the
+ * finished list via [finalDeck] / [DeckbuildObservation.selected] plus an intrinsic
+ * [DeckbuildObservation.deckScore]. The caller feeds that list to a game env (`DeckSpec.Explicit`)
+ * to actually play it.
+ *
+ * This deliberately does **not** use the engine's `(GameState, GameAction)` model — there is no
+ * game yet — which is exactly why deckbuilding is its own env type rather than a pre-game
+ * pause inside a game env.
+ *
+ * @param pool the opened sealed pool (duplicates included; copies cap how many can be added)
+ * @param basics one [CardDefinition] per basic-land name the agent may add without limit
+ */
+class DeckbuildEnvironment(
+    pool: List<CardDefinition>,
+    basics: List<CardDefinition>,
+    val builderId: EntityId = EntityId.generate(),
+    val targetSize: Int = 40,
+    private val schemaHash: String = SchemaHash.CURRENT,
+) : GymEnv {
+
+    /** Available copies per pool card name. */
+    private val poolCounts: Map<String, Int> = pool.groupingBy { it.name }.eachCount()
+
+    /** Representative definition per name (pool + basics), for views and rating. */
+    private val cardByName: Map<String, CardDefinition> =
+        (pool + basics).associateBy { it.name }
+
+    private val basicNames: List<String> = basics.map { it.name }.distinct().sorted()
+
+    /** Current decklist, insertion-ordered for stable enumeration. */
+    private val selected = LinkedHashMap<String, Int>()
+
+    private var finalized = false
+
+    /** Action list for the most recent observation; `step` indexes into it. */
+    private var actions: List<DeckbuildAction> = emptyList()
+
+    override val isTerminal: Boolean get() = finalized
+
+    /** The finished decklist once finalized, else null. */
+    val finalDeck: Map<String, Int>? get() = if (finalized) LinkedHashMap(selected) else null
+
+    private fun selectedCount(): Int = selected.values.sum()
+
+    private fun remainingOf(name: String): Int =
+        (poolCounts[name] ?: 0) - (selected[name] ?: 0)
+
+    // --- GymEnv --------------------------------------------------------------
+
+    override fun observe(revealAll: Boolean?): ObservationResult {
+        val acts = buildActions()
+        actions = acts
+        val obs = DeckbuildObservation(
+            schemaHash = schemaHash,
+            agentToAct = if (finalized) null else builderId,
+            pool = poolCounts.keys.sorted().map { poolView(it, remainingOf(it)) },
+            basics = basicNames.map { poolView(it, targetSize) },
+            selected = LinkedHashMap(selected),
+            selectedCount = selectedCount(),
+            targetSize = targetSize,
+            deckScore = if (finalized) scoreDeck() else null,
+            legalActions = acts.mapIndexed { idx, a -> a.toView(idx) },
+            terminated = finalized,
+            stateDigest = digest()
+        )
+        return ObservationResult(obs, ActionRegistry.EMPTY)
+    }
+
+    override fun step(actionId: Int): ObservationResult {
+        require(!finalized) { "Deck already finalized; env is terminal" }
+        val action = actions.getOrNull(actionId)
+            ?: throw IllegalArgumentException("Action ID $actionId is not valid for the current step")
+        apply(action)
+        return observe()
+    }
+
+    override fun fork(): GymEnv {
+        // Rebuild an equivalent pool/basics from the immutable indices, then copy build state.
+        val poolList = poolCounts.flatMap { (name, n) -> List(n) { cardByName.getValue(name) } }
+        val basicsList = basicNames.map { cardByName.getValue(it) }
+        val copy = DeckbuildEnvironment(poolList, basicsList, builderId, targetSize, schemaHash)
+        copy.selected.putAll(selected)
+        copy.finalized = finalized
+        copy.observe()
+        return copy
+    }
+
+    // --- actions -------------------------------------------------------------
+
+    private fun buildActions(): List<DeckbuildAction> {
+        if (finalized) return emptyList()
+        val out = mutableListOf<DeckbuildAction>()
+        poolCounts.keys.sorted().forEach { if (remainingOf(it) > 0) out += DeckbuildAction.AddCard(it) }
+        basicNames.forEach { out += DeckbuildAction.AddBasic(it) }
+        selected.keys.sorted().forEach { out += DeckbuildAction.RemoveCard(it) }
+        if (selectedCount() >= targetSize) out += DeckbuildAction.Finalize
+        return out
+    }
+
+    private fun apply(action: DeckbuildAction) {
+        when (action) {
+            is DeckbuildAction.AddCard -> {
+                if (remainingOf(action.name) > 0) selected.merge(action.name, 1, Int::plus)
+            }
+            is DeckbuildAction.AddBasic -> selected.merge(action.name, 1, Int::plus)
+            is DeckbuildAction.RemoveCard -> {
+                val cur = selected[action.name] ?: return
+                if (cur <= 1) selected.remove(action.name) else selected[action.name] = cur - 1
+            }
+            DeckbuildAction.Finalize -> {
+                check(selectedCount() >= targetSize) { "Cannot finalize: ${selectedCount()} < $targetSize" }
+                finalized = true
+            }
+        }
+    }
+
+    // --- views / scoring -----------------------------------------------------
+
+    private fun poolView(name: String, remaining: Int): PoolCardView {
+        val card = cardByName[name]
+        return PoolCardView(
+            name = name,
+            manaCost = card?.manaCost?.toString() ?: "",
+            manaValue = card?.cmc ?: 0,
+            colors = card?.colors?.mapTo(mutableSetOf()) { it.name } ?: emptySet(),
+            types = card?.typeLine?.cardTypes?.mapTo(mutableSetOf()) { it.name } ?: emptySet(),
+            subtypes = card?.typeLine?.subtypes?.mapTo(mutableSetOf()) { it.value } ?: emptySet(),
+            pt = card?.creatureStats?.let { "${it.power.description}/${it.toughness.description}" },
+            oracleText = card?.oracleText ?: "",
+            remaining = remaining
+        )
+    }
+
+    /** Intrinsic quality: summed limited rating of the non-land cards in the deck. */
+    private fun scoreDeck(): Double =
+        selected.entries.sumOf { (name, count) ->
+            val card = cardByName[name]
+            if (card == null || card.isLand) 0.0 else LimitedCardRater.rate(card) * count
+        }
+
+    private fun digest(): String =
+        buildString {
+            append(if (finalized) "F|" else "B|")
+            selected.toSortedMap().forEach { (n, c) -> append(n).append(':').append(c).append(';') }
+        }
+}
+
+/** The moves available while building a deck. */
+private sealed interface DeckbuildAction {
+    fun toView(id: Int): LegalActionView
+
+    data class AddCard(val name: String) : DeckbuildAction {
+        override fun toView(id: Int) =
+            LegalActionView(id, "ADD_CARD", "Add $name", affordable = true)
+    }
+
+    data class AddBasic(val name: String) : DeckbuildAction {
+        override fun toView(id: Int) =
+            LegalActionView(id, "ADD_BASIC", "Add basic $name", affordable = true)
+    }
+
+    data class RemoveCard(val name: String) : DeckbuildAction {
+        override fun toView(id: Int) =
+            LegalActionView(id, "REMOVE_CARD", "Remove $name", affordable = true)
+    }
+
+    object Finalize : DeckbuildAction {
+        override fun toView(id: Int) =
+            LegalActionView(id, "FINALIZE", "Finalize deck", affordable = true)
+    }
+}

--- a/gym/src/main/kotlin/com/wingedsheep/gym/service/DeckResolver.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/service/DeckResolver.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.gym.service
 import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.ai.engine.SealedDeckGenerator
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
 
 /**
@@ -28,6 +29,20 @@ class DeckResolver(
             val deckMap = spec.setCode?.let { sealed.generate(it) } ?: sealed.generate()
             expandCounts(deckMap)
         }
+    }
+
+    /**
+     * Open a sealed pool **without** building a deck — for the deckbuild env, which lets an
+     * agent make the build choices itself. Returns the opened cards plus the basic-land
+     * definitions (one art variant per land name) the agent may add without limit.
+     */
+    fun openSealedPool(setCode: String, boosterCount: Int = 6): SealedPool {
+        val bg = requireNotNull(boosterGenerator) {
+            "Opening a sealed pool requires a BoosterGenerator"
+        }
+        val pool = bg.generateSealedPool(setCode, boosterCount)
+        val basics = bg.getBasicLands(setCode).values.toList()
+        return SealedPool(pool, basics)
     }
 
     /**
@@ -59,3 +74,9 @@ class DeckResolver(
     private fun expandCounts(cards: Map<String, Int>): Deck =
         Deck(cards.flatMap { (name, count) -> List(count) { name } })
 }
+
+/** An opened sealed pool: the [pool] cards, plus the [basics] an agent may add without limit. */
+data class SealedPool(
+    val pool: List<CardDefinition>,
+    val basics: List<CardDefinition>
+)

--- a/gym/src/main/kotlin/com/wingedsheep/gym/service/EnvConfig.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/service/EnvConfig.kt
@@ -52,6 +52,31 @@ data class EnvConfig(
     }
 }
 
+/**
+ * Everything needed to spin up a new **deckbuild** env (`POST /envs/deckbuild`).
+ *
+ * Opens [boosterCount] boosters from [setCode] into a sealed pool, then hands the agent
+ * an enumerated build interface (add / remove / finalize) until it commits a [targetSize]-card
+ * deck. The finished list is exposed on the terminal observation for the caller to feed into a
+ * game env via [DeckSpec.Explicit].
+ */
+@Serializable
+data class DeckbuildConfig(
+    /** Set to open boosters from (e.g. "BLB"). Must be sealed-supported in the booster generator. */
+    val setCode: String,
+
+    /** Number of 15-card boosters to open. Tournament sealed = 6. */
+    val boosterCount: Int = 6,
+
+    /** Minimum legal deck size; `FINALIZE` unlocks once the build reaches it. */
+    val targetSize: Int = 40
+) {
+    init {
+        require(boosterCount > 0) { "boosterCount must be positive" }
+        require(targetSize > 0) { "targetSize must be positive" }
+    }
+}
+
 /** A single player's identity + deck. */
 @Serializable
 data class PlayerSpec(

--- a/gym/src/main/kotlin/com/wingedsheep/gym/service/MultiEnvService.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/service/MultiEnvService.kt
@@ -4,12 +4,11 @@ import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.engine.core.DecisionResponse
 import com.wingedsheep.engine.core.GameConfig
 import com.wingedsheep.engine.core.PlayerConfig
-import com.wingedsheep.engine.core.SubmitDecision
 import com.wingedsheep.gym.GameEnvironment
-import com.wingedsheep.gym.contract.ActionRegistry
-import com.wingedsheep.gym.contract.ObservationBuilder
+import com.wingedsheep.gym.GameGymEnv
+import com.wingedsheep.gym.GymEnv
 import com.wingedsheep.gym.contract.ObservationResult
-import com.wingedsheep.gym.contract.ResolvedAction
+import com.wingedsheep.gym.deckbuild.DeckbuildEnvironment
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.model.EntityId
 import java.util.concurrent.Callable
@@ -20,19 +19,22 @@ import java.util.concurrent.ConcurrentHashMap
  * exposes create / reset / observe / step / fork / snapshot / dispose methods
  * that HTTP, gRPC, or an in-process training loop can call directly.
  *
+ * Environments are polymorphic ([GymEnv]): game envs ([GameGymEnv]) and deckbuild
+ * envs ([DeckbuildEnvironment]) share the observe/step/fork surface. Operations that
+ * only make sense for a game (decision submission, snapshot/restore, reset) require a
+ * [GameGymEnv] and reject other env kinds.
+ *
  * ## Threading
  *
  * Each env is single-threaded — two calls naming the same [EnvId] must not
- * overlap or they race on mutable `GameEnvironment` fields. The intended use
- * is: a trainer owns an env and calls it sequentially, possibly interleaved
- * with N other envs which run in parallel via [stepBatch]. If a caller
- * manually issues concurrent calls to the same env, behaviour is undefined.
+ * overlap or they race on mutable env fields. The intended use is: a trainer
+ * owns an env and calls it sequentially, possibly interleaved with N other
+ * envs which run in parallel via [stepBatch].
  *
  * ## Registry regeneration
  *
- * Every `reset` / `step` rebuilds the [ActionRegistry] for that env. Stored
- * handles from a previous step are invalidated and resolving them returns
- * `Unknown`.
+ * Every `reset` / `step` rebuilds the env's action mapping. Action IDs from a
+ * previous step are invalidated.
  */
 class MultiEnvService(
     val cardRegistry: CardRegistry,
@@ -40,77 +42,46 @@ class MultiEnvService(
     val workerPool: EnvWorkerPool = EnvWorkerPool(),
     val snapshotCodec: SnapshotCodec = SnapshotCodec()
 ) {
-    private val envs = ConcurrentHashMap<EnvId, EnvEntry>()
-    private val observationBuilder = ObservationBuilder()
+    private val envs = ConcurrentHashMap<EnvId, GymEnv>()
     val deckResolver: DeckResolver = DeckResolver(cardRegistry, boosterGenerator)
-
-    /** Book-keeping for a single active environment. */
-    private class EnvEntry(
-        val environment: GameEnvironment,
-        val perspectivePlayerIndex: Int,
-        val revealAll: Boolean,
-        @Volatile var registry: ActionRegistry = ActionRegistry.EMPTY
-    )
 
     // =========================================================================
     // Lifecycle
     // =========================================================================
 
     /**
-     * Create a new env and run `reset` immediately. The returned observation
+     * Create a new game env and run `reset` immediately. The returned observation
      * is the opening state (post-mulligan if [EnvConfig.skipMulligans]).
      */
     fun create(config: EnvConfig): CreatedEnv {
-        val playerConfigs = config.players.map { spec ->
-            PlayerConfig(
-                name = spec.name,
-                deck = deckResolver.resolve(spec.deck),
-                startingLife = spec.startingLife,
-                playerId = spec.playerId
-            )
-        }
-        val gameConfig = GameConfig(
-            players = playerConfigs,
-            startingHandSize = config.startingHandSize,
-            skipMulligans = config.skipMulligans,
-            useHandSmoother = config.useHandSmoother,
-            startingPlayerIndex = config.startingPlayerIndex
-        )
-
+        val gameConfig = config.toGameConfig()
         val env = GameEnvironment.create(cardRegistry)
         env.reset(gameConfig)
-
+        val gymEnv = GameGymEnv(env, config.perspectivePlayerIndex, config.revealAll)
         val envId = EnvId.generate()
-        val entry = EnvEntry(env, config.perspectivePlayerIndex, config.revealAll)
-        envs[envId] = entry
-
-        val observation = buildObservation(envId, entry)
-        return CreatedEnv(envId, observation)
+        envs[envId] = gymEnv
+        return CreatedEnv(envId, gymEnv.observe())
     }
 
-    /** Reset an existing env while keeping the same [EnvId]. Config reuses the constructor's cards. */
-    fun reset(envId: EnvId, config: EnvConfig): ObservationResult {
-        val oldEntry = requireEntry(envId)
-        val playerConfigs = config.players.map { spec ->
-            PlayerConfig(
-                name = spec.name,
-                deck = deckResolver.resolve(spec.deck),
-                startingLife = spec.startingLife,
-                playerId = spec.playerId
-            )
-        }
-        val gameConfig = GameConfig(
-            players = playerConfigs,
-            startingHandSize = config.startingHandSize,
-            skipMulligans = config.skipMulligans,
-            useHandSmoother = config.useHandSmoother,
-            startingPlayerIndex = config.startingPlayerIndex
+    /**
+     * Create a new **deckbuild** env: open a sealed pool from [DeckbuildConfig.setCode]
+     * and hand the agent the build interface. The opening observation lists the pool.
+     */
+    fun createDeckbuild(config: DeckbuildConfig): CreatedEnv {
+        val sealed = deckResolver.openSealedPool(config.setCode, config.boosterCount)
+        val env = DeckbuildEnvironment(
+            pool = sealed.pool,
+            basics = sealed.basics,
+            targetSize = config.targetSize
         )
-        oldEntry.environment.reset(gameConfig)
-        val newEntry = EnvEntry(oldEntry.environment, config.perspectivePlayerIndex, config.revealAll)
-        envs[envId] = newEntry
-        return buildObservation(envId, newEntry)
+        val envId = EnvId.generate()
+        envs[envId] = env
+        return CreatedEnv(envId, env.observe())
     }
+
+    /** Reset an existing game env while keeping the same [EnvId]. */
+    fun reset(envId: EnvId, config: EnvConfig): ObservationResult =
+        requireGameEnv(envId).reset(config.toGameConfig())
 
     /** Drop envs from the registry. Idempotent. */
     fun dispose(envIds: Collection<EnvId>) {
@@ -120,139 +91,81 @@ class MultiEnvService(
     fun listEnvs(): Set<EnvId> = envs.keys.toSet()
 
     // =========================================================================
-    // Observations
+    // Observations / stepping
     // =========================================================================
 
     /** Get the current observation without advancing state. */
-    fun observe(envId: EnvId, revealAll: Boolean? = null): ObservationResult {
-        val entry = requireEntry(envId)
-        val view = revealAll ?: entry.revealAll
-        return buildObservation(envId, entry, revealAll = view)
-    }
-
-    // =========================================================================
-    // Stepping
-    // =========================================================================
+    fun observe(envId: EnvId, revealAll: Boolean? = null): ObservationResult =
+        requireEnv(envId).observe(revealAll)
 
     /**
      * Advance a single env by the given [StepRequest.actionId]. The ID must
-     * come from the most-recent observation for that env — any older ID is
-     * treated as invalid.
+     * come from the most-recent observation for that env.
      */
-    fun step(request: StepRequest): ObservationResult {
-        val entry = requireEntry(request.envId)
-        val resolved = entry.registry.resolve(request.actionId)
-        executeResolved(entry, resolved, request.actionId)
-        return buildObservation(request.envId, entry)
-    }
+    fun step(request: StepRequest): ObservationResult =
+        requireEnv(request.envId).step(request.actionId)
 
-    /**
-     * Advance N envs in parallel. Each env is processed single-threaded
-     * inside its own task; envs do not share state so this is safe.
-     */
+    /** Advance N envs in parallel. Each env is single-threaded inside its own task. */
     fun stepBatch(requests: List<StepRequest>): List<Pair<EnvId, ObservationResult>> {
         if (requests.isEmpty()) return emptyList()
-        val tasks = requests.map { req ->
-            Callable { req.envId to step(req) }
-        }
+        val tasks = requests.map { req -> Callable { req.envId to step(req) } }
         return workerPool.invokeAll(tasks)
     }
 
     /**
-     * Submit a raw `DecisionResponse` for an env that is paused on a complex
-     * pending decision (multi-select, distribute, order, search, etc.).
-     * Simple decisions (yes/no, choose-number, choose-mode, choose-color,
-     * choose-option, single-select cards) should be driven via [step] with a
-     * folded action ID instead.
+     * Submit a raw `DecisionResponse` for a game env paused on a complex pending
+     * decision. Simple decisions are driven via [step] with a folded action ID.
      */
-    fun submitDecision(envId: EnvId, response: DecisionResponse): ObservationResult {
-        val entry = requireEntry(envId)
-        val pending = entry.environment.state.pendingDecision
-            ?: throw IllegalStateException("Env $envId is not paused on a decision")
-        check(response.decisionId == pending.id) {
-            "Decision ID mismatch: response=${response.decisionId}, pending=${pending.id}"
-        }
-        entry.environment.step(SubmitDecision(pending.playerId, response))
-        return buildObservation(envId, entry)
-    }
+    fun submitDecision(envId: EnvId, response: DecisionResponse): ObservationResult =
+        requireGameEnv(envId).submitDecision(response)
 
     // =========================================================================
     // Fork / snapshot / restore
     // =========================================================================
 
-    /**
-     * Fork an env N times. Because `GameState` is immutable, each fork shares
-     * the base state with the source for free; subsequent steps on each
-     * child diverge independently.
-     */
+    /** Fork an env N times. Children diverge independently from the next step on. */
     fun fork(srcEnvId: EnvId, count: Int = 1): List<EnvId> {
         require(count > 0) { "fork count must be positive" }
-        val src = requireEntry(srcEnvId)
+        val src = requireEnv(srcEnvId)
         return List(count) {
-            val forkedEnv = src.environment.fork()
             val newId = EnvId.generate()
-            val newEntry = EnvEntry(forkedEnv, src.perspectivePlayerIndex, src.revealAll)
-            envs[newId] = newEntry
-            // Rebuild the registry so freshly-forked envs have valid action IDs.
-            buildObservation(newId, newEntry)
+            envs[newId] = src.fork()
             newId
         }
     }
 
-    fun snapshot(envId: EnvId): SnapshotHandle {
-        val entry = requireEntry(envId)
-        return snapshotCodec.save(
-            state = entry.environment.state,
-            playerIds = entry.environment.playerIds,
-            stepCount = 0 // stepCount reset on restore — training code doesn't rely on it
-        )
-    }
+    fun snapshot(envId: EnvId): SnapshotHandle =
+        requireGameEnv(envId).snapshot(snapshotCodec)
 
-    /**
-     * Restore an env to a previously-snapshotted state. The perspective and
-     * reveal settings are preserved; only the underlying [com.wingedsheep.engine.state.GameState]
-     * changes.
-     */
-    fun restore(envId: EnvId, handle: SnapshotHandle): ObservationResult {
-        val entry = requireEntry(envId)
-        val snap = snapshotCodec.load(handle)
-        entry.environment.restore(snap.state, snap.playerIds, snap.stepCount)
-        return buildObservation(envId, entry)
-    }
+    /** Restore a game env to a previously-snapshotted state. */
+    fun restore(envId: EnvId, handle: SnapshotHandle): ObservationResult =
+        requireGameEnv(envId).restore(snapshotCodec, handle)
 
     // =========================================================================
     // Internals
     // =========================================================================
 
-    private fun executeResolved(entry: EnvEntry, resolved: ResolvedAction, actionId: Int) {
-        when (resolved) {
-            is ResolvedAction.Legal -> entry.environment.step(resolved.action)
-            is ResolvedAction.Decision -> {
-                val pending = entry.environment.state.pendingDecision
-                    ?: throw IllegalStateException("Registry has a decision response but env is not paused")
-                entry.environment.step(SubmitDecision(pending.playerId, resolved.response))
-            }
-            ResolvedAction.Unknown ->
-                throw IllegalArgumentException("Action ID $actionId is not valid for the current step")
-        }
-    }
+    private fun EnvConfig.toGameConfig(): GameConfig = GameConfig(
+        players = players.map { spec ->
+            PlayerConfig(
+                name = spec.name,
+                deck = deckResolver.resolve(spec.deck),
+                startingLife = spec.startingLife,
+                playerId = spec.playerId
+            )
+        },
+        startingHandSize = startingHandSize,
+        skipMulligans = skipMulligans,
+        useHandSmoother = useHandSmoother,
+        startingPlayerIndex = startingPlayerIndex
+    )
 
-    private fun buildObservation(
-        envId: EnvId,
-        entry: EnvEntry,
-        revealAll: Boolean = entry.revealAll
-    ): ObservationResult {
-        val env = entry.environment
-        val perspective = env.playerIds.getOrNull(entry.perspectivePlayerIndex)
-            ?: throw IllegalStateException("Env $envId has no player at index ${entry.perspectivePlayerIndex}")
-        val legalActions = env.legalActions()
-        val result = observationBuilder.build(env.state, perspective, legalActions, revealAll)
-        entry.registry = result.registry
-        return result
-    }
-
-    private fun requireEntry(envId: EnvId): EnvEntry =
+    private fun requireEnv(envId: EnvId): GymEnv =
         envs[envId] ?: throw NoSuchElementException("Unknown envId: $envId")
+
+    private fun requireGameEnv(envId: EnvId): GameGymEnv =
+        requireEnv(envId) as? GameGymEnv
+            ?: throw IllegalStateException("Env $envId is not a game env; operation not supported")
 }
 
 /** Result of [MultiEnvService.create] — the new env's ID plus its opening observation. */

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -53,7 +53,7 @@ class TrainingObservationTest : FunSpec({
         val perspective = env.playerIds[0]
         val result = ObservationBuilder().build(env.state, perspective, env.legalActions())
 
-        val obs = result.observation
+        val obs = result.observation as TrainingObservation
         obs.perspectivePlayerId shouldBe perspective
         obs.players.size shouldBe 2
         obs.agentToAct.shouldNotBeNull()
@@ -93,7 +93,7 @@ class TrainingObservationTest : FunSpec({
         val opponent = env.playerIds[1]
 
         val masked = ObservationBuilder().build(env.state, me, env.legalActions())
-            .observation
+            .observation as TrainingObservation
         val myHand = masked.zones.single { it.ownerId == me && it.zoneType == Zone.HAND }
         val theirHand = masked.zones.single { it.ownerId == opponent && it.zoneType == Zone.HAND }
         myHand.hidden.shouldBeFalse()
@@ -106,7 +106,7 @@ class TrainingObservationTest : FunSpec({
         masked.zones.filter { it.zoneType == Zone.LIBRARY }.forEach { it.hidden.shouldBeTrue() }
 
         val revealed = ObservationBuilder().build(env.state, me, env.legalActions(), revealAll = true)
-            .observation
+            .observation as TrainingObservation
         val theirHandRevealed = revealed.zones.single { it.ownerId == opponent && it.zoneType == Zone.HAND }
         theirHandRevealed.hidden.shouldBeFalse()
         theirHandRevealed.cards.size shouldBe theirHandRevealed.size
@@ -118,7 +118,7 @@ class TrainingObservationTest : FunSpec({
         val env = newEnv()
         val me = env.playerIds[0]
 
-        val obs = ObservationBuilder().build(env.state, me, env.legalActions()).observation
+        val obs = ObservationBuilder().build(env.state, me, env.legalActions()).observation as TrainingObservation
         val myHand = obs.zones.single { it.ownerId == me && it.zoneType == Zone.HAND }
 
         // At least one card should be in the opening hand; every card there

--- a/gym/src/test/kotlin/com/wingedsheep/gym/deckbuild/DeckbuildEnvironmentTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/deckbuild/DeckbuildEnvironmentTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.gym.deckbuild
+
+import com.wingedsheep.gym.contract.DeckbuildObservation
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for the deckbuild env: the add/remove/finalize loop, pool-copy limits,
+ * unlimited basics, the finalize gate, and the intrinsic deck score.
+ */
+class DeckbuildEnvironmentTest : FunSpec({
+
+    fun bear(name: String) =
+        CardDefinition.creature(name, ManaCost.parse("{1}{G}"), setOf(Subtype.of("Bear")), 2, 2)
+
+    val forest = CardDefinition.basicLand("Forest", Subtype.of("Forest"))
+
+    /** A pool of 3 distinct creatures, 2 copies each. */
+    fun pool() = listOf("Grizzly", "Runeclaw", "Balduvian").flatMap { listOf(bear(it), bear(it)) }
+
+    fun obs(env: DeckbuildEnvironment) = env.observe().observation as DeckbuildObservation
+
+    fun idOf(env: DeckbuildEnvironment, kind: String, nameContains: String): Int =
+        obs(env).legalActions.first { it.kind == kind && it.description.contains(nameContains) }.actionId
+
+    test("opening observation lists the pooled cards with their copy counts") {
+        val env = DeckbuildEnvironment(pool(), listOf(forest), targetSize = 5)
+        val o = obs(env)
+        o.terminated.shouldBeFalse()
+        o.selectedCount shouldBe 0
+        o.pool.map { it.name }.toSet() shouldBe setOf("Grizzly", "Runeclaw", "Balduvian")
+        o.pool.all { it.remaining == 2 }.shouldBeTrue()
+        // basics are offered separately and addable
+        o.basics.map { it.name } shouldContain "Forest"
+    }
+
+    test("adding a card decrements its remaining count and grows the deck") {
+        val env = DeckbuildEnvironment(pool(), listOf(forest), targetSize = 5)
+        env.step(idOf(env, "ADD_CARD", "Grizzly"))
+        val o = obs(env)
+        o.selected["Grizzly"] shouldBe 1
+        o.selectedCount shouldBe 1
+        o.pool.first { it.name == "Grizzly" }.remaining shouldBe 1
+    }
+
+    test("cannot add more copies than the pool holds") {
+        val env = DeckbuildEnvironment(pool(), listOf(forest), targetSize = 5)
+        env.step(idOf(env, "ADD_CARD", "Grizzly"))
+        env.step(idOf(env, "ADD_CARD", "Grizzly"))
+        val o = obs(env)
+        o.selected["Grizzly"] shouldBe 2
+        // No ADD_CARD for Grizzly remains once both copies are taken.
+        o.legalActions.any { it.kind == "ADD_CARD" && it.description.contains("Grizzly") }.shouldBeFalse()
+    }
+
+    test("basics can be added without limit") {
+        val env = DeckbuildEnvironment(pool(), listOf(forest), targetSize = 5)
+        repeat(10) { env.step(idOf(env, "ADD_BASIC", "Forest")) }
+        obs(env).selected["Forest"] shouldBe 10
+    }
+
+    test("remove undoes an add") {
+        val env = DeckbuildEnvironment(pool(), listOf(forest), targetSize = 5)
+        env.step(idOf(env, "ADD_CARD", "Grizzly"))
+        env.step(idOf(env, "REMOVE_CARD", "Grizzly"))
+        val o = obs(env)
+        o.selected.containsKey("Grizzly").shouldBeFalse()
+        o.pool.first { it.name == "Grizzly" }.remaining shouldBe 2
+    }
+
+    test("FINALIZE is gated on reaching the target size, then terminates with a score") {
+        val env = DeckbuildEnvironment(pool(), listOf(forest), targetSize = 5)
+        // Below target: no FINALIZE offered.
+        obs(env).legalActions.any { it.kind == "FINALIZE" }.shouldBeFalse()
+
+        // 3 spells + 2 basics = 5.
+        env.step(idOf(env, "ADD_CARD", "Grizzly"))
+        env.step(idOf(env, "ADD_CARD", "Runeclaw"))
+        env.step(idOf(env, "ADD_CARD", "Balduvian"))
+        env.step(idOf(env, "ADD_BASIC", "Forest"))
+        env.step(idOf(env, "ADD_BASIC", "Forest"))
+        obs(env).selectedCount shouldBe 5
+
+        env.step(idOf(env, "FINALIZE", "Finalize"))
+        val o = obs(env)
+        o.terminated.shouldBeTrue()
+        o.agentToAct.shouldBeNull()
+        o.legalActions.isEmpty().shouldBeTrue()
+        o.deckScore.shouldNotBeNull()
+        // Three rated creatures contribute a positive score; basics contribute nothing.
+        o.deckScore!! shouldBeGreaterThan 0.0
+        env.isTerminal.shouldBeTrue()
+        env.finalDeck shouldBe mapOf("Grizzly" to 1, "Runeclaw" to 1, "Balduvian" to 1, "Forest" to 2)
+    }
+
+    test("fork preserves the in-progress selection but diverges after") {
+        val env = DeckbuildEnvironment(pool(), listOf(forest), targetSize = 5)
+        env.step(idOf(env, "ADD_CARD", "Grizzly"))
+        val forked = env.fork() as DeckbuildEnvironment
+        (forked.observe().observation as DeckbuildObservation).selected["Grizzly"] shouldBe 1
+
+        forked.step(idOf(forked, "ADD_CARD", "Runeclaw"))
+        // The source is unaffected by the fork's extra pick.
+        obs(env).selected.containsKey("Runeclaw").shouldBeFalse()
+        (forked.observe().observation as DeckbuildObservation).selected["Runeclaw"] shouldBe 1
+    }
+})

--- a/gym/src/test/kotlin/com/wingedsheep/gym/service/MultiEnvServiceTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/service/MultiEnvServiceTest.kt
@@ -2,7 +2,9 @@ package com.wingedsheep.gym.service
 
 import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.gym.contract.Observation
 import com.wingedsheep.gym.contract.ResolvedAction
+import com.wingedsheep.gym.contract.TrainingObservation
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.mtg.sets.definitions.blb.BloomburrowSet
 import com.wingedsheep.mtg.sets.definitions.por.PortalSet
@@ -25,6 +27,8 @@ import io.kotest.matchers.shouldNotBe
  * disposal. Uses Portal for deterministic creature decks and Bloomburrow
  * for the sealed-deck path.
  */
+private val Observation.asGame: TrainingObservation get() = this as TrainingObservation
+
 class MultiEnvServiceTest : FunSpec({
 
     fun registry(): CardRegistry = CardRegistry().apply {
@@ -67,7 +71,7 @@ class MultiEnvServiceTest : FunSpec({
 
         created.envId.value.shouldNotBe("")
         created.observation.observation.terminated.shouldBeFalse()
-        created.observation.observation.players shouldHaveSize 2
+        created.observation.observation.asGame.players shouldHaveSize 2
         created.observation.observation.legalActions.shouldNotBeEmpty()
         svc.listEnvs() shouldContainAll setOf(created.envId)
     }
@@ -93,7 +97,7 @@ class MultiEnvServiceTest : FunSpec({
 
         val after = svc.reset(envId, twoPlayerConfig())
         // After reset, the env should be back at turn 1 with legal actions.
-        after.observation.turnNumber shouldBe 1
+        after.observation.asGame.turnNumber shouldBe 1
         after.observation.legalActions.shouldNotBeEmpty()
         // EnvId is preserved across reset.
         svc.listEnvs() shouldContainAll setOf(envId)
@@ -322,18 +326,18 @@ class MultiEnvServiceTest : FunSpec({
         val svc = MultiEnvService(registry())
         val created = svc.create(twoPlayerConfig(perspective = 1))
 
-        val me = created.observation.observation.perspectivePlayerId
-        created.observation.observation.players
+        val me = created.observation.observation.asGame.perspectivePlayerId
+        created.observation.observation.asGame.players
             .first { it.isPerspective }.id shouldBe me
 
-        val opponent = created.observation.observation.players.first { !it.isPerspective }
+        val opponent = created.observation.observation.asGame.players.first { !it.isPerspective }
         // Opponent hand should be hidden by default.
-        val opponentHand = created.observation.observation.zones
+        val opponentHand = created.observation.observation.asGame.zones
             .first { it.ownerId == opponent.id && it.zoneType == com.wingedsheep.sdk.core.Zone.HAND }
         opponentHand.hidden.shouldBeTrue()
 
         // Now observe with revealAll=true — opponent hand becomes visible.
-        val revealed = svc.observe(created.envId, revealAll = true).observation
+        val revealed = svc.observe(created.envId, revealAll = true).observation.asGame
         val openedHand = revealed.zones.first {
             it.ownerId == opponent.id && it.zoneType == com.wingedsheep.sdk.core.Zone.HAND
         }
@@ -352,7 +356,7 @@ class MultiEnvServiceTest : FunSpec({
         val turnsSeen = mutableListOf<Int>()
         repeat(8) {
             val obs = svc.observe(envId).observation
-            turnsSeen += obs.turnNumber
+            turnsSeen += obs.asGame.turnNumber
             if (obs.terminated) return@repeat
             val nextId = obs.legalActions.firstOrNull()?.actionId ?: return@repeat
             svc.step(StepRequest(envId, nextId))


### PR DESCRIPTION
## What

Models **deckbuilding as a first-class gym environment**, so an agent can build a deck from a sealed pool (and we can test that capability), instead of the server auto-building it with a heuristic. The `Env`-abstraction refactor is folded in, as requested.

## Env refactor

- New **`GymEnv`** interface (`observe` / `step` / `fork`), implemented by:
  - **`GameGymEnv`** — a thin adapter over the **untouched** `GameEnvironment` (the trainer SPI still drives it directly), absorbing the per-env bookkeeping that lived in `MultiEnvService`.
  - **`DeckbuildEnvironment`** — the new env type.
- The wire `Observation` is now a **sealed union**: `TrainingObservation` (`type: "Game"`) + `DeckbuildObservation` (`type: "Deckbuild"`). Common fields are hoisted to the interface so a generic driver loop works for either. `SchemaHash` bumped to `v1.2-observation-union`.
- `MultiEnvService` stores `GymEnv` and delegates; game-only ops (decision/reset/snapshot/restore) require a `GameGymEnv`.

## Deckbuild env

- **`POST /envs/deckbuild`** `{setCode, boosterCount, targetSize}` opens a sealed pool (no auto-build) and returns it.
- The agent drives `ADD_CARD` / `ADD_BASIC` / `REMOVE_CARD` / `FINALIZE` through the normal `/envs/{id}/step` loop. On finalize the env is terminal; the observation carries the finished decklist (`selected`) and an intrinsic `LimitedCardRater` `deckScore`.
- **Decoupled from play**: feed `selected` into a game env via `DeckSpec.Explicit`.

## Reward (answering the design questions)

`deckScore` is only an **intrinsic proxy**. A deck's real value is its **win-rate**, which is **delayed and cross-environment** (you learn it by playing games in a *separate* game env after the build env terminated). The gym stays **reward-agnostic**: the env emits observations + the finished deck + the optional intrinsic score, and the **training loop supplies its own win-rate reward** and does credit assignment over the build trajectory. This is exactly why deckbuild is its own env rather than a pre-game phase. Full writeup + worked pipeline in [`docs/gym-deckbuild-env.md`](docs/gym-deckbuild-env.md).

## Tests / verification

- New `DeckbuildEnvironmentTest` (add/remove/finalize, copy limits, unlimited basics, finalize gate, score, fork).
- Updated `MultiEnvServiceTest`, `TrainingObservationTest`, `EnvControllerTest` for the sealed `Observation`.
- `:gym:build :gym-server:build :gym-trainer:build` all green.
- Manual end-to-end against a running server: opened a BLB sealed pool → built a 40-card deck step-by-step → finalized (score 88.76) → started a game env with the built deck (33-card library after opening hand). ✔

## Notes

- Sealed only; draft (pick-1-of-N) would be a third `GymEnv` type under the same surface — not in scope here.
- Independent of the `docs/gym-self-play-testing` branch; this PR is self-contained off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)