### PR TITLE
Add Invasion cards: Alloy Golem, Armored Guardian, Benalish Heralds, Bog Initiate

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AlloyGolem.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AlloyGolem.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GrantChosenColor
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Alloy Golem
+ * {6}
+ * Artifact Creature — Golem
+ * 4/4
+ *
+ * As this creature enters, choose a color.
+ * This creature is the chosen color. (It's still an artifact.)
+ *
+ * The golem starts colorless, so "adding" the chosen color (Layer 5) is equivalent
+ * to it becoming that color while remaining an artifact.
+ */
+val AlloyGolem = card("Alloy Golem") {
+    manaCost = "{6}"
+    typeLine = "Artifact Creature — Golem"
+    power = 4
+    toughness = 4
+    oracleText = "As this creature enters, choose a color.\n" +
+        "This creature is the chosen color. (It's still an artifact.)"
+
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+
+    staticAbility {
+        ability = GrantChosenColor(GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "297"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1fb6d6a1-9d71-405b-9c93-1a7f06c67abd.jpg?1562901306"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArmoredGuardian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArmoredGuardian.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Armored Guardian
+ * {3}{W}{U}
+ * Creature — Cat Soldier
+ * 2/5
+ *
+ * {1}{W}{W}: Target creature you control gains protection from the color of your choice
+ *            until end of turn.
+ * {1}{U}{U}: This creature gains shroud until end of turn.
+ */
+val ArmoredGuardian = card("Armored Guardian") {
+    manaCost = "{3}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Cat Soldier"
+    power = 2
+    toughness = 5
+    oracleText = "{1}{W}{W}: Target creature you control gains protection from the color of your choice until end of turn.\n" +
+        "{1}{U}{U}: This creature gains shroud until end of turn. (It can't be the target of spells or abilities.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}{W}")
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.ChooseColorAndGrantProtectionToTarget(t)
+        description = "{1}{W}{W}: Target creature you control gains protection from the color of your choice until end of turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}{U}")
+        effect = Effects.GrantKeyword(Keyword.SHROUD, EffectTarget.Self)
+        description = "{1}{U}{U}: This creature gains shroud until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "230"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6de5e1bd-1d31-4f9f-b18d-d6f49bc7ef10.jpg?1562917002"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BenalishHeralds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BenalishHeralds.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Benalish Heralds
+ * {3}{W}
+ * Creature — Human Soldier
+ * 2/4
+ *
+ * {3}{U}, {T}: Draw a card.
+ */
+val BenalishHeralds = card("Benalish Heralds") {
+    manaCost = "{3}{W}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 4
+    oracleText = "{3}{U}, {T}: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{U}"), Costs.Tap)
+        effect = Effects.DrawCards(1)
+        description = "{3}{U}, {T}: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Don Hazeltine"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13c6e51d-54eb-4e5b-9ec9-54521b16b8d1.jpg?1562898954"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BogInitiate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BogInitiate.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bog Initiate
+ * {1}{B}
+ * Creature — Human Wizard
+ * 1/1
+ *
+ * {1}: Add {B}.
+ */
+val BogInitiate = card("Bog Initiate") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{1}: Add {B}."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "rk post"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/8962dc3b-24ca-4c3c-ba1d-933c29cf7b73.jpg?1562922788"
+    }
+}


### PR DESCRIPTION
## Summary

Adds four Invasion (INV) cards, all built from existing SDK primitives — no new engine mechanics, executors, or scenario tests required.

| Card | Cost | Type | P/T | Mechanic |
|------|------|------|-----|----------|
| Alloy Golem | {6} | Artifact Creature — Golem | 4/4 | Enters: choose a color; the golem is the chosen color (still an artifact) |
| Armored Guardian | {3}{W}{U} | Creature — Cat Soldier | 2/5 | {1}{W}{W}: target creature you control gains protection from a chosen color; {1}{U}{U}: gains shroud until EOT |
| Benalish Heralds | {3}{W} | Creature — Human Soldier | 2/4 | {3}{U}, {T}: Draw a card |
| Bog Initiate | {1}{B} | Creature — Human Wizard | 1/1 | {1}: Add {B} |

## Implementation notes

- **Alloy Golem** uses `EntersWithChoice(ChoiceType.COLOR)` + `GrantChosenColor(GroupFilter.source())` — the colorless golem starts colorless, so adding the chosen color (Layer 5) is equivalent to becoming that color while remaining an artifact. Mirrors the Quirion Elves / Shimmerwilds Growth chosen-color pattern.
- **Armored Guardian** reuses `Effects.ChooseColorAndGrantProtectionToTarget` (as in Thornscape Master) and `Effects.GrantKeyword(Keyword.SHROUD, EffectTarget.Self)` (as in Glimmering Angel).
- **Benalish Heralds** and **Bog Initiate** are plain activated abilities (`Effects.DrawCards`, `Effects.AddMana`); Bog Initiate's is flagged `manaAbility = true`.
- All four auto-register via `CardDiscovery`; no set-file edits needed.

## Testing

- `./gradlew :mtg-sets:compileKotlin` — clean
- `./gradlew :rules-engine:test --tests "*Test"` — BUILD SUCCESSFUL
- Each card's name, mana cost, type line, P/T, and oracle text re-verified against Scryfall (set=inv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)