### PR TITLE
Add Kav Landseeker to Edge of Eternities with skipCurrentTurn delayed…

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 237 / 261
+**Implemented:** 238 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -120,7 +120,7 @@
 - [x] Kavaron, Memorial World
 - [x] Kavaron Skywarden
 - [x] Kavaron Turbodrone
-- [ ] Kav Landseeker
+- [x] Kav Landseeker
 - [x] Knight Luminary
 - [x] Larval Scoutlander
 - [x] Lashwhip Predator

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -332,5 +332,5 @@ counter"), the 0 untap, and the −3 tutor are expressible.
 
 Poison counters (Virulent Silencer), token doubling (Exalted Sunborn), devour-land (Famished
 Worldsire), "mana spent" for X-counters (Astelli Reclaimer), and "your next turn" delayed-trigger
-timing (Kav Landseeker — `CreateDelayedTriggerEffect.skipCurrentTurn` flag) were previously listed
+timing (Kav Landseeker — `CreateDelayedTriggerEffect.timing = DelayedTriggerTiming.NEXT_TURN`) were previously listed
 here and are now implemented; their entries have been removed.

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -4,7 +4,7 @@ Engine features required to implement the remaining EOE cards. Each section list
 unblocks, the exact oracle clause that can't be expressed with current primitives, and a sketch of
 the engine/SDK work needed.
 
-As of the latest pass, **235 / 261** booster cards are implemented. The 26 cards below remain
+As of the latest pass, **238 / 261** booster cards are implemented. The cards below remain
 blocked on the engine features listed here. Cards whose every clause maps to an existing primitive
 have already been implemented and are not listed.
 
@@ -110,19 +110,6 @@ it as a characteristic-defining P/T (Layer 7b set-base from a dynamic value, app
 **Plan:** Add an ETB "sacrifice this unless you pay <cost>" intervening-choice effect where the
 alternative cost is tapping an untapped permanent you control. The "enters tapped" and the
 any-color mana ability are already expressible.
-
----
-
-## 8. Delayed trigger that always fires on the controller's *next* turn's end step
-
-**Cards:** Kav Landseeker.
-
-**Clause:** "At the beginning of the end step on your next turn, sacrifice that token."
-
-**Plan:** `CreateDelayedTriggerEffect.onControllerNextTurn` fires at the *next upcoming* end step on
-the controller's turn — i.e. it fires *this* turn if the current-turn end step hasn't started. Add a
-flag/variant that unconditionally skips the current turn and fires on the controller's following
-turn's end step. The Menace body and the ETB "create a Lander" are already expressible.
 
 ---
 
@@ -344,5 +331,6 @@ counter"), the 0 untap, and the −3 tutor are expressible.
 ## Already covered elsewhere
 
 Poison counters (Virulent Silencer), token doubling (Exalted Sunborn), devour-land (Famished
-Worldsire), and "mana spent" for X-counters (Astelli Reclaimer) were previously listed here and are
-now implemented; their entries have been removed.
+Worldsire), "mana spent" for X-counters (Astelli Reclaimer), and "your next turn" delayed-trigger
+timing (Kav Landseeker — `CreateDelayedTriggerEffect.skipCurrentTurn` flag) were previously listed
+here and are now implemented; their entries have been removed.

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,9 +3,9 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (24)
+## Status: cards still blocked on engine work (23)
 
-The booster set is at **237 / 261**. The cards below are the only unimplemented ones; each is
+The booster set is at **238 / 261**. The cards below are the only unimplemented ones; each is
 blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
 summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
 parentheses).
@@ -19,7 +19,6 @@ parentheses).
 | Bioengineered Future | "Each creature you control enters with an additional +1/+1 counter ... for each land that entered ... this turn" | Continuous extra-ETB-counters + lands-entered-this-turn tracker (§5) |
 | Dyadrine, Synthesis Amalgam | "enters with ... +1/+1 counters ... equal to the amount of mana spent to cast it" | Mana-spent `DynamicAmount` in ETB replacement (§6) |
 | Cosmogoyf | power/toughness = "number of cards you own in exile" (+1) | CDA P/T from cards-in-exile count (§7) |
-| Kav Landseeker | "At the beginning of the end step on your next turn, sacrifice that token" | Delayed trigger that always fires next turn's end step (§8) |
 | Territorial Bruntar | "exile cards from the top ... until you exile a nonland card. You may cast that card this turn" | Impulse-until-nonland effect (§9) |
 | Zero Point Ballad | "Destroy all creatures with toughness X or less" + reanimate one destroyed this way | Dynamic-toughness mass destroy + reanimate-from-batch (§10) |
 | Weapons Manufacturing | create the noncreature "Munitions" artifact token with a leaves-battlefield damage trigger | Noncreature tokens with embedded triggers (§11) |

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1049,15 +1049,19 @@ Triggers.youCastSpell(
 - `DelayedTriggeredAbility` — registered now, fires at a specific future step (Astral Slide).
 - `Effects.GrantTriggeredAbilityEffect` — grant a triggered ability for a duration; `GrantTriggeredAbilityExecutor` uses
   projected state and supports leaves-battlefield-to-zone triggers.
-- `CreateDelayedTriggerEffect(step, effect, fireOnlyOnControllersTurn, onControllerNextTurn, skipCurrentTurn, …)` —
-  the data-side facade. The boolean flags control *when* the trigger may first fire:
-  - `fireOnlyOnControllersTurn` — only matches when the active player equals the controller.
-  - `onControllerNextTurn` — "at the beginning of your next end step": defers to next turn only if
-    the controller's current-turn end step has already begun (END/CLEANUP); otherwise the current
-    turn's end step qualifies. (Systems Override.)
-  - `skipCurrentTurn` — stricter "on your next turn"-style timing: the current turn never qualifies
-    regardless of step. Pair with `fireOnlyOnControllersTurn = true` to land on the controller's
-    upcoming own turn rather than an intervening opponent turn. (Kav Landseeker.)
+- `CreateDelayedTriggerEffect(step, effect, fireOnlyOnControllersTurn, timing, …)` —
+  the data-side facade. Two orthogonal axes control *when* the trigger may first fire:
+  - `fireOnlyOnControllersTurn` — gates *whose* turn: only matches when the active player equals
+    the controller.
+  - `timing: DelayedTriggerTiming` — gates *which* turn is the earliest eligible one:
+    - `CURRENT_TURN_OR_LATER` (default) — no turn floor; the next upcoming occurrence of `step`,
+      which may be the current turn. (Astral Slide exile-until-end-step.)
+    - `NEXT_END_STEP` — "at the beginning of your next end step": defers to next turn only if the
+      controller's current-turn end step has already begun (END/CLEANUP); otherwise the current
+      turn's end step qualifies. (Dragonhawk, Fate's Tempest.)
+    - `NEXT_TURN` — stricter "on your next turn"-style timing: the current turn never qualifies
+      regardless of step. Pair with `fireOnlyOnControllersTurn = true` to land on the controller's
+      upcoming own turn rather than an intervening opponent turn. (Kav Landseeker.)
 
 ---
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1049,6 +1049,15 @@ Triggers.youCastSpell(
 - `DelayedTriggeredAbility` — registered now, fires at a specific future step (Astral Slide).
 - `Effects.GrantTriggeredAbilityEffect` — grant a triggered ability for a duration; `GrantTriggeredAbilityExecutor` uses
   projected state and supports leaves-battlefield-to-zone triggers.
+- `CreateDelayedTriggerEffect(step, effect, fireOnlyOnControllersTurn, onControllerNextTurn, skipCurrentTurn, …)` —
+  the data-side facade. The boolean flags control *when* the trigger may first fire:
+  - `fireOnlyOnControllersTurn` — only matches when the active player equals the controller.
+  - `onControllerNextTurn` — "at the beginning of your next end step": defers to next turn only if
+    the controller's current-turn end step has already begun (END/CLEANUP); otherwise the current
+    turn's end step qualifies. (Systems Override.)
+  - `skipCurrentTurn` — stricter "on your next turn"-style timing: the current turn never qualifies
+    regardless of step. Pair with `fireOnlyOnControllersTurn = true` to land on the controller's
+    upcoming own turn rather than an intervening opponent turn. (Kav Landseeker.)
 
 ---
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavLandseekerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavLandseekerScenarioTest.kt
@@ -7,7 +7,8 @@ import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 
 /**
- * Scenario tests for Kav Landseeker, which exercises the [skipCurrentTurn] flag on
+ * Scenario tests for Kav Landseeker, which exercises the
+ * [com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming.NEXT_TURN] timing on
  * [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect].
  *
  * Oracle: "When this creature enters, create a Lander token. At the beginning of the end

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavLandseekerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KavLandseekerScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kav Landseeker, which exercises the [skipCurrentTurn] flag on
+ * [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect].
+ *
+ * Oracle: "When this creature enters, create a Lander token. At the beginning of the end
+ * step on your next turn, sacrifice that token."
+ *
+ * The "on your next turn" timing must NOT fire on the same turn Kav enters, even if Kav
+ * resolves before the END step. It must also skip past the opponent's intervening end
+ * step and land on the controller's following own end step.
+ */
+class KavLandseekerScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("Lander is NOT sacrificed at end of the turn Kav Landseeker enters") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Kav Landseeker")
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Plains")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withActivePlayer(1)
+                .build()
+
+            game.castSpell(1, "Kav Landseeker")
+            game.resolveStack()
+
+            withClue("Lander should be on the battlefield after Kav's ETB") {
+                game.isOnBattlefield("Lander") shouldBe true
+            }
+
+            // Walk to end step of the SAME turn. The delayed trigger must not fire.
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            if (game.state.stack.isNotEmpty()) {
+                game.resolveStack()
+            }
+
+            withClue("Lander must still be on the battlefield at end of current turn") {
+                game.isOnBattlefield("Lander") shouldBe true
+            }
+        }
+
+        test("Lander survives the opponent's end step and is sacrificed at controller's next end step") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Kav Landseeker")
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Plains")
+                .withCardInLibrary(2, "Plains")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withActivePlayer(1)
+                .build()
+
+            game.castSpell(1, "Kav Landseeker")
+            game.resolveStack()
+
+            withClue("Lander should be on the battlefield after Kav's ETB") {
+                game.isOnBattlefield("Lander") shouldBe true
+            }
+
+            // End of Player1's turn — Lander must survive.
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            if (game.state.stack.isNotEmpty()) game.resolveStack()
+            withClue("Lander survives Player1's end step (same turn it was created)") {
+                game.isOnBattlefield("Lander") shouldBe true
+            }
+
+            // Advance into Player2's turn and to their end step. fireOnlyOnControllersTurn
+            // must keep the trigger from firing for Player1 on Player2's end step.
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            if (game.state.stack.isNotEmpty()) game.resolveStack()
+            withClue("Lander survives Player2's end step") {
+                game.isOnBattlefield("Lander") shouldBe true
+            }
+
+            // Player1's next turn — end step should now sacrifice the Lander.
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            if (game.state.stack.isNotEmpty()) game.resolveStack()
+
+            withClue("Lander should be sacrificed at Player1's next end step") {
+                game.isOnBattlefield("Lander") shouldBe false
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -491,6 +491,44 @@ data class PayOrSufferEffect(
 }
 
 /**
+ * The earliest turn a step-based [CreateDelayedTriggerEffect] may fire. A single
+ * mutually-exclusive axis (replaces the former onControllerNextTurn / skipCurrentTurn
+ * booleans, whose presence/absence encoded these three states).
+ *
+ * Orthogonal to [CreateDelayedTriggerEffect.fireOnlyOnControllersTurn], which gates
+ * *whose* turn the trigger may fire on, not *which* turn is the earliest eligible one.
+ */
+@Serializable
+enum class DelayedTriggerTiming {
+    /**
+     * No turn floor: the trigger fires at the next upcoming occurrence of its step,
+     * which may be the current turn. Default — Astral Slide-style exile-until-end-step.
+     */
+    @SerialName("CurrentTurnOrLater")
+    CURRENT_TURN_OR_LATER,
+
+    /**
+     * "At the beginning of your next end step" timing: the current turn's end step
+     * still qualifies if it hasn't begun yet; only once it has started (END or CLEANUP
+     * on the controller's turn) does the trigger defer to the controller's following
+     * turn. Typically paired with [CreateDelayedTriggerEffect.fireOnlyOnControllersTurn]
+     * = true. (Dragonhawk, Fate's Tempest.)
+     */
+    @SerialName("NextEndStep")
+    NEXT_END_STEP,
+
+    /**
+     * "On your next turn" timing: the current turn never qualifies, regardless of step;
+     * the trigger fires no earlier than the next turn. Pair with
+     * [CreateDelayedTriggerEffect.fireOnlyOnControllersTurn] = true to land on the
+     * controller's upcoming own turn rather than an intervening opponent turn.
+     * (Kav Landseeker.)
+     */
+    @SerialName("NextTurn")
+    NEXT_TURN
+}
+
+/**
  * Create a delayed triggered ability that fires at a specific step.
  *
  * When executed, bakes any context-dependent target references (ContextTarget)
@@ -537,24 +575,11 @@ data class CreateDelayedTriggerEffect(
      */
     val expiry: DelayedTriggerExpiry = DelayedTriggerExpiry.EndOfTurn,
     /**
-     * If true, applies "your next end step" timing semantics: the trigger fires at
-     * the next upcoming end step on the controller's turn. If the controller's
-     * current-turn end step hasn't started yet, the trigger fires this turn; only if
-     * it's already started (END or CLEANUP step on the controller's turn) is the
-     * trigger deferred to the controller's following turn. Typically combined with
-     * [fireOnlyOnControllersTurn] = true.
+     * The earliest turn this step-based delayed trigger may fire. See
+     * [DelayedTriggerTiming]. Orthogonal to [fireOnlyOnControllersTurn], which gates
+     * whose turn the trigger fires on.
      */
-    val onControllerNextTurn: Boolean = false,
-    /**
-     * If true, the trigger is deferred past the current turn unconditionally — it
-     * cannot fire until a turn whose number is greater than the current turn, no
-     * matter the current step. Use this for "on your next turn"-style timing where
-     * the current turn's end step must NOT satisfy the trigger even if it hasn't
-     * begun yet (e.g. Kav Landseeker). Typically combined with
-     * [fireOnlyOnControllersTurn] = true so the trigger lands on the controller's
-     * upcoming turn rather than an intervening opponent turn.
-     */
-    val skipCurrentTurn: Boolean = false
+    val timing: DelayedTriggerTiming = DelayedTriggerTiming.CURRENT_TURN_OR_LATER
 ) : Effect {
     override val description: String = when {
         trigger != null -> "create a delayed trigger that fires on ${trigger.event::class.simpleName}"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -544,7 +544,17 @@ data class CreateDelayedTriggerEffect(
      * trigger deferred to the controller's following turn. Typically combined with
      * [fireOnlyOnControllersTurn] = true.
      */
-    val onControllerNextTurn: Boolean = false
+    val onControllerNextTurn: Boolean = false,
+    /**
+     * If true, the trigger is deferred past the current turn unconditionally — it
+     * cannot fire until a turn whose number is greater than the current turn, no
+     * matter the current step. Use this for "on your next turn"-style timing where
+     * the current turn's end step must NOT satisfy the trigger even if it hasn't
+     * begun yet (e.g. Kav Landseeker). Typically combined with
+     * [fireOnlyOnControllersTurn] = true so the trigger lands on the controller's
+     * upcoming turn rather than an intervening opponent turn.
+     */
+    val skipCurrentTurn: Boolean = false
 ) : Effect {
     override val description: String = when {
         trigger != null -> "create a delayed trigger that fires on ${trigger.event::class.simpleName}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DragonhawkFatesTempest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DragonhawkFatesTempest.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamagePerEntityInZoneEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
@@ -59,7 +60,7 @@ val DragonhawkFatesTempest = card("Dragonhawk, Fate's Tempest") {
         CreateDelayedTriggerEffect(
             step = Step.END,
             fireOnlyOnControllersTurn = true,
-            onControllerNextTurn = true,
+            timing = DelayedTriggerTiming.NEXT_END_STEP,
             effect = DealDamagePerEntityInZoneEffect(
                 collectionName = "exiledCards",
                 zone = Zone.EXILE,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavLandseeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavLandseeker.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
 import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
 import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -37,7 +38,7 @@ val KavLandseeker = card("Kav Landseeker") {
     // ETB: create a Lander, then schedule a sacrifice on the controller's next end step.
     // PipelineTarget(CREATED_TOKENS, 0) addresses the just-created Lander; the delayed-trigger
     // executor bakes it into a concrete entity id so the trigger still resolves after the
-    // pipeline context is gone. skipCurrentTurn = true defers past this turn no matter the
+    // pipeline context is gone. timing = NEXT_TURN defers past this turn no matter the
     // current step; fireOnlyOnControllersTurn = true lands the trigger on the controller's
     // upcoming turn rather than an intervening opponent turn.
     triggeredAbility {
@@ -51,7 +52,7 @@ val KavLandseeker = card("Kav Landseeker") {
                         target = EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
                     ),
                     fireOnlyOnControllersTurn = true,
-                    skipCurrentTurn = true
+                    timing = DelayedTriggerTiming.NEXT_TURN
                 )
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavLandseeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavLandseeker.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kav Landseeker
+ * {3}{R}
+ * Creature — Kavu Soldier
+ * Menace
+ * When this creature enters, create a Lander token. At the beginning of the end step on your next
+ * turn, sacrifice that token.
+ * 4/3
+ */
+val KavLandseeker = card("Kav Landseeker") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu Soldier"
+    power = 4
+    toughness = 3
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "When this creature enters, create a Lander token. At the beginning of the end step on your " +
+        "next turn, sacrifice that token. (It's an artifact with \"{2}, {T}, Sacrifice this token: " +
+        "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\")"
+
+    keywords(Keyword.MENACE)
+
+    // ETB: create a Lander, then schedule a sacrifice on the controller's next end step.
+    // PipelineTarget(CREATED_TOKENS, 0) addresses the just-created Lander; the delayed-trigger
+    // executor bakes it into a concrete entity id so the trigger still resolves after the
+    // pipeline context is gone. skipCurrentTurn = true defers past this turn no matter the
+    // current step; fireOnlyOnControllersTurn = true lands the trigger on the controller's
+    // upcoming turn rather than an intervening opponent turn.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CompositeEffect(
+            listOf(
+                Effects.CreateLander(),
+                CreateDelayedTriggerEffect(
+                    step = Step.END,
+                    effect = SacrificeTargetEffect(
+                        target = EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
+                    ),
+                    fireOnlyOnControllersTurn = true,
+                    skipCurrentTurn = true
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Karl Kopinski"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a5a7e89-50e3-43cb-af93-d7d80a630c11.jpg?1752947111"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
 import com.wingedsheep.sdk.scripting.effects.DealDamagePerEntityInZoneEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.DestroyAllEquipmentOnTargetEffect
@@ -54,23 +55,24 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
         // entity id so matching later is cheap and doesn't need the original context.
         val watchedEntityId = effect.watchedTarget?.let { context.resolveTarget(it) }
 
-        // "At the beginning of your next end step" fires at the next upcoming end step
-        // on the controller's turn. If we're still before the end step on the controller's
-        // current turn, that end step qualifies — don't skip to the following turn.
-        // Only bump notBeforeTurn when the current turn's end step has already begun (or passed),
-        // i.e. we're in END or CLEANUP on the controller's turn.
-        //
-        // skipCurrentTurn ("on your next turn") is stricter: the current turn never
-        // qualifies, regardless of step. Combine with fireOnlyOnControllersTurn = true
-        // to land on the controller's upcoming turn.
-        val notBeforeTurn = when {
-            effect.skipCurrentTurn -> state.turnNumber + 1
-            effect.onControllerNextTurn -> {
+        // The earliest turn this delayed trigger may fire, derived from effect.timing:
+        //  - NEXT_END_STEP ("at the beginning of your next end step"): fires at the next
+        //    upcoming end step on the controller's turn. If we're still before the end step
+        //    on the controller's current turn, that end step qualifies — don't skip to the
+        //    following turn. Only bump notBeforeTurn when the current turn's end step has
+        //    already begun (or passed), i.e. we're in END or CLEANUP on the controller's turn.
+        //  - NEXT_TURN ("on your next turn") is stricter: the current turn never qualifies,
+        //    regardless of step. Combine with fireOnlyOnControllersTurn = true to land on the
+        //    controller's upcoming turn.
+        //  - CURRENT_TURN_OR_LATER: no turn floor.
+        val notBeforeTurn = when (effect.timing) {
+            DelayedTriggerTiming.NEXT_TURN -> state.turnNumber + 1
+            DelayedTriggerTiming.NEXT_END_STEP -> {
                 val onControllersTurn = context.controllerId == state.activePlayerId
                 val endStepAlreadyStarted = state.step == Step.END || state.step == Step.CLEANUP
                 if (onControllersTurn && endStepAlreadyStarted) state.turnNumber + 1 else null
             }
-            else -> null
+            DelayedTriggerTiming.CURRENT_TURN_OR_LATER -> null
         }
 
         val delayedTrigger = DelayedTriggeredAbility(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -59,12 +59,18 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
         // current turn, that end step qualifies — don't skip to the following turn.
         // Only bump notBeforeTurn when the current turn's end step has already begun (or passed),
         // i.e. we're in END or CLEANUP on the controller's turn.
-        val notBeforeTurn = if (effect.onControllerNextTurn) {
-            val onControllersTurn = context.controllerId == state.activePlayerId
-            val endStepAlreadyStarted = state.step == Step.END || state.step == Step.CLEANUP
-            if (onControllersTurn && endStepAlreadyStarted) state.turnNumber + 1 else null
-        } else {
-            null
+        //
+        // skipCurrentTurn ("on your next turn") is stricter: the current turn never
+        // qualifies, regardless of step. Combine with fireOnlyOnControllersTurn = true
+        // to land on the controller's upcoming turn.
+        val notBeforeTurn = when {
+            effect.skipCurrentTurn -> state.turnNumber + 1
+            effect.onControllerNextTurn -> {
+                val onControllersTurn = context.controllerId == state.activePlayerId
+                val endStepAlreadyStarted = state.step == Step.END || state.step == Step.CLEANUP
+                if (onControllersTurn && endStepAlreadyStarted) state.turnNumber + 1 else null
+            }
+            else -> null
         }
 
         val delayedTrigger = DelayedTriggeredAbility(


### PR DESCRIPTION
…-trigger flag

Adds a `skipCurrentTurn` boolean to `CreateDelayedTriggerEffect` for "on your next turn"-style timing: the trigger is deferred past the current turn regardless of step. Combined with `fireOnlyOnControllersTurn`, it lands on the controller's upcoming own turn — distinct from `onControllerNextTurn`, which still lets the current turn's end step satisfy the trigger if it hasn't begun yet.