### PR TITLE
Add Invasion cards batch C: Crusading Knight, Vodalian Hypnotist, Shoreline Raider, Slinking Serpent

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CrusadingKnightScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CrusadingKnightScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Crusading Knight:
+ * "Protection from black. This creature gets +1/+1 for each Swamp your opponents control."
+ *
+ * Base stats are 2/2.
+ */
+class CrusadingKnightScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Crusading Knight dynamic stats") {
+
+            test("with no opponent Swamps, stays 2/2") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Crusading Knight")
+                    .withLandsOnBattlefield(1, "Swamp", 3) // own Swamps don't count
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val knightId = game.findPermanent("Crusading Knight")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power should stay at base 2 — your own Swamps don't count") {
+                    projected.getPower(knightId) shouldBe 2
+                }
+                withClue("Toughness should stay at base 2") {
+                    projected.getToughness(knightId) shouldBe 2
+                }
+            }
+
+            test("with three opponent Swamps, gets +3/+3") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Crusading Knight")
+                    .withLandsOnBattlefield(2, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val knightId = game.findPermanent("Crusading Knight")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Power should be 2 base + 3 (three opponent Swamps)") {
+                    projected.getPower(knightId) shouldBe 5
+                }
+                withClue("Toughness should be 2 base + 3") {
+                    projected.getToughness(knightId) shouldBe 5
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ShorelineRaiderScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ShorelineRaiderScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Shoreline Raider: "Protection from Kavu" (Rule 702.16).
+ *
+ * Protection from Kavu means a Kavu creature cannot block Shoreline Raider (the "B" in DEBT).
+ */
+class ShorelineRaiderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Shoreline Raider protection from Kavu") {
+
+            test("Kavu creature cannot block Shoreline Raider") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Shoreline Raider") // 2/2, pro Kavu
+                    .withCardOnBattlefield(2, "Kavu Climber")     // 3/3 Kavu
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Shoreline Raider" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val blockResult = game.declareBlockers(mapOf(
+                    "Kavu Climber" to listOf("Shoreline Raider")
+                ))
+                withClue("Kavu creature should not be able to block a creature with protection from Kavu") {
+                    blockResult.error shouldNotBe null
+                }
+            }
+
+            test("non-Kavu creature CAN block Shoreline Raider") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Shoreline Raider") // 2/2, pro Kavu
+                    .withCardOnBattlefield(2, "Grizzly Bears")    // 2/2, non-Kavu
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Shoreline Raider" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val blockResult = game.declareBlockers(mapOf(
+                    "Grizzly Bears" to listOf("Shoreline Raider")
+                ))
+                withClue("Non-Kavu creature should be able to block: ${blockResult.error}") {
+                    blockResult.error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SlinkingSerpentScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SlinkingSerpentScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Slinking Serpent: "Forestwalk" (Rule 702.14).
+ *
+ * Slinking Serpent (2/3) can't be blocked as long as the defending player controls a Forest.
+ */
+class SlinkingSerpentScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Slinking Serpent forestwalk") {
+
+            test("has forestwalk keyword") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Slinking Serpent")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val serpentId = game.findPermanent("Slinking Serpent")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("Slinking Serpent should have forestwalk") {
+                    projected.hasKeyword(serpentId, Keyword.FORESTWALK) shouldBe true
+                }
+            }
+
+            test("cannot be blocked when defender controls a Forest") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Slinking Serpent")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2 potential blocker
+                    .withLandsOnBattlefield(2, "Forest", 1)    // defender controls a Forest
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Slinking Serpent" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val blockResult = game.declareBlockers(mapOf(
+                    "Grizzly Bears" to listOf("Slinking Serpent")
+                ))
+                withClue("Slinking Serpent should be unblockable while defender controls a Forest") {
+                    blockResult.error shouldNotBe null
+                }
+            }
+
+            test("can be blocked when defender controls no Forest") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Slinking Serpent")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Island", 1) // no Forest
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Slinking Serpent" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val blockResult = game.declareBlockers(mapOf(
+                    "Grizzly Bears" to listOf("Slinking Serpent")
+                ))
+                withClue("Slinking Serpent should be blockable when defender has no Forest: ${blockResult.error}") {
+                    blockResult.error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VodalianHypnotistScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VodalianHypnotistScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Vodalian Hypnotist:
+ * "{2}{B}, {T}: Target player discards a card. Activate only as a sorcery."
+ */
+class VodalianHypnotistScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Vodalian Hypnotist discard ability") {
+
+            test("forces target player to discard at sorcery speed") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vodalian Hypnotist")
+                    .withLandsOnBattlefield(1, "Swamp", 3) // pay {2}{B}
+                    .withCardInHand(2, "Forest")           // opponent's only card -> auto-discard
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hypnotistId = game.findPermanent("Vodalian Hypnotist")!!
+                val ability = cardRegistry.getCard("Vodalian Hypnotist")!!.script.activatedAbilities.first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = hypnotistId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                )
+                withClue("Activation should be legal at sorcery speed during main phase: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Opponent should have discarded their only card") {
+                    game.handSize(2) shouldBe 0
+                }
+            }
+
+            test("cannot be activated at instant speed (opponent's turn)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vodalian Hypnotist")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInHand(2, "Forest")
+                    .withActivePlayer(2) // opponent's turn — not a legal sorcery-speed window for player 1
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hypnotistId = game.findPermanent("Vodalian Hypnotist")!!
+                val ability = cardRegistry.getCard("Vodalian Hypnotist")!!.script.activatedAbilities.first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = hypnotistId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                )
+                withClue("Sorcery-speed ability should be rejected on the opponent's turn") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrusadingKnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrusadingKnight.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Crusading Knight
+ * {2}{W}{W}
+ * Creature — Human Knight
+ * 2/2
+ * Protection from black
+ * This creature gets +1/+1 for each Swamp your opponents control.
+ */
+val CrusadingKnight = card("Crusading Knight") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from black\nThis creature gets +1/+1 for each Swamp your opponents control."
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLACK)))
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmount.Count(
+                player = Player.Opponent,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Land.withSubtype("Swamp")
+            ),
+            toughnessBonus = DynamicAmount.Count(
+                player = Player.Opponent,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Land.withSubtype("Swamp")
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "12"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "\"My only dream is to destroy the nightmares of others.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4ab4640-1871-41dd-bd21-64741e21ba37.jpg?1562928291"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShorelineRaider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShorelineRaider.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Shoreline Raider
+ * {2}{U}
+ * Creature — Merfolk
+ * 2/2
+ * Protection from Kavu
+ */
+val ShorelineRaider = card("Shoreline Raider") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from Kavu"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Subtype("Kavu")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Nelson DeCastro"
+        flavorText = "\"This strange new beast makes for an excellent meal. Get me more.\"\n—Empress Galina"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d895b3b8-2acc-4c9f-8341-f651c1255b7c.jpg?1562938535"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SlinkingSerpent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SlinkingSerpent.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Slinking Serpent
+ * {2}{U}{B}
+ * Creature — Serpent
+ * 2/3
+ * Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)
+ */
+val SlinkingSerpent = card("Slinking Serpent") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Serpent"
+    power = 2
+    toughness = 3
+    oracleText = "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)"
+
+    keywords(Keyword.FORESTWALK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "274"
+        artist = "Wayne England"
+        flavorText = "It winds its way through undergrowth as easily as it swims through shallows."
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/070a7004-5a28-4ccb-8640-ad6b07b51ece.jpg?1562896404"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianHypnotist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianHypnotist.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Vodalian Hypnotist
+ * {1}{U}
+ * Creature — Merfolk Wizard
+ * 1/1
+ * {2}{B}, {T}: Target player discards a card. Activate only as a sorcery.
+ */
+val VodalianHypnotist = card("Vodalian Hypnotist") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{2}{B}, {T}: Target player discards a card. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        val targetPlayer = target("target player", TargetPlayer())
+        effect = Effects.Discard(1, targetPlayer)
+        description = "{2}{B}, {T}: Target player discards a card. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Rebecca Guay"
+        flavorText = "\"Deceit is the heart of war.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/721fd877-0a28-4002-8b47-058bac4ac44d.jpg?1562917815"
+    }
+}


### PR DESCRIPTION
Adds four Invasion (INV) original cards, all implemented with existing SDK primitives (no new effects/keywords/engine changes).

## Cards

| Card | Cost | P/T | Implementation |
|------|------|-----|----------------|
| **Crusading Knight** | {2}{W}{W} | 2/2 | Protection from black + `GrantDynamicStatsEffect` driven by `DynamicAmount.Count(Player.Opponent, BATTLEFIELD, Land.withSubtype("Swamp"))` for "+1/+1 for each Swamp your opponents control" |
| **Vodalian Hypnotist** | {1}{U} | 1/1 | Sorcery-speed activated ability ({2}{B}, {T}) → target player discards a card, using `TimingRule.SorcerySpeed` |
| **Shoreline Raider** | {2}{U} | 2/2 | Protection from Kavu via `ProtectionScope.Subtype("Kavu")` |
| **Slinking Serpent** | {2}{U}{B} | 2/3 | Innate Forestwalk keyword |

## Tests

New scenario tests (all passing):
- `CrusadingKnightScenarioTest` — own Swamps don't count; three opponent Swamps grant +3/+3.
- `VodalianHypnotistScenarioTest` — discard at sorcery speed; rejected on opponent's turn.
- `ShorelineRaiderScenarioTest` — Kavu can't block, non-Kavu can.
- `SlinkingSerpentScenarioTest` — has forestwalk; unblockable when defender controls a Forest, blockable otherwise.

`just check-card-printing` confirms INV is the canonical (earliest) printing for all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)