### PR TITLE
Add Invasion cards: Obsidian Acolyte, Phyrexian Slayer, Rainbow Crow, Viashino Grappler

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ObsidianAcolyteScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ObsidianAcolyteScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Obsidian Acolyte.
+ *
+ * {1}{W} 1/1 Human Cleric with protection from black and
+ * "{W}: Target creature gains protection from black until end of turn."
+ *
+ * Exercises [com.wingedsheep.sdk.dsl.Effects.GrantProtectionFromColor]: a fixed-color
+ * protection grant (no player color choice), composed from the `PROTECTION_FROM_<COLOR>`
+ * string keyword via the existing GrantKeyword path. Mirrors Crimson Acolyte (red variant).
+ */
+class ObsidianAcolyteScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Obsidian Acolyte - grant protection from black (fixed color)") {
+
+            test("activated ability grants the target protection from black until end of turn") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Obsidian Acolyte")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 green — will gain protection
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { container ->
+                    container.with(ManaPoolComponent(white = 1))
+                }
+
+                val bearsId = game.findPermanent("Grizzly Bears")!!
+                val acolyteId = game.findPermanent("Obsidian Acolyte")!!
+                val ability = cardRegistry.getCard("Obsidian Acolyte")!!.script.activatedAbilities[0]
+
+                withClue("Grizzly Bears should not start with protection from black") {
+                    game.state.projectedState.hasKeyword(bearsId, "PROTECTION_FROM_BLACK") shouldBe false
+                }
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = acolyteId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(bearsId))
+                    )
+                )
+                withClue("Activation should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Grizzly Bears should now have protection from black") {
+                    game.state.projectedState.hasKeyword(bearsId, "PROTECTION_FROM_BLACK") shouldBe true
+                }
+            }
+
+            test("granted protection from black stops a black spell from targeting the creature") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Obsidian Acolyte")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(2, "Agonizing Demise") // {3}{B} black removal — should not be able to target after grant
+                    .withLandsOnBattlefield(2, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.state = game.state.updateEntity(game.player1Id) { container ->
+                    container.with(ManaPoolComponent(white = 1))
+                }
+
+                val bearsId = game.findPermanent("Grizzly Bears")!!
+                val acolyteId = game.findPermanent("Obsidian Acolyte")!!
+                val ability = cardRegistry.getCard("Obsidian Acolyte")!!.script.activatedAbilities[0]
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = acolyteId,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(bearsId))
+                    )
+                )
+                game.resolveStack()
+
+                // Opponent attempts to target the protected Grizzly Bears with a black spell — should fail.
+                val killResult = game.castSpell(2, "Agonizing Demise", bearsId)
+                withClue("Black spell should not be able to target a creature with protection from black") {
+                    killResult.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/PhyrexianSlayerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/PhyrexianSlayerScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Phyrexian Slayer.
+ *
+ * {3}{B} 2/2 Phyrexian Minion
+ * Flying
+ * Whenever this creature becomes blocked by a white creature, destroy that creature. It can't be regenerated.
+ *
+ * Reuses the becomes-blocked SELF trigger (filtered by white creature), exposing the
+ * blocker as the triggering entity — same pattern as Phyrexian Reaper (green variant).
+ */
+class PhyrexianSlayerScenarioTest : ScenarioTestBase() {
+
+    // Inline test creatures — avoids depending on specific set cards being registered.
+    // Reach lets them block the flying Slayer; color is derived from the mana cost.
+    private val whiteBlocker = CardDefinition.creature(
+        name = "White Vanilla Reach",
+        manaCost = ManaCost.parse("{2}{W}"),
+        subtypes = setOf(Subtype("Human")),
+        power = 2, toughness = 3,
+        keywords = setOf(Keyword.REACH),
+    )
+
+    private val greenBlocker = CardDefinition.creature(
+        name = "Green Vanilla Reach",
+        manaCost = ManaCost.parse("{2}{G}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 2, toughness = 3,
+        keywords = setOf(Keyword.REACH),
+    )
+
+    init {
+        cardRegistry.register(whiteBlocker)
+        cardRegistry.register(greenBlocker)
+
+        context("Phyrexian Slayer becomes-blocked trigger") {
+
+            test("destroys a white creature that blocks it") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Phyrexian Slayer") // 2/2 flyer
+                    .withCardOnBattlefield(2, "White Vanilla Reach") // white blocker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val slayerId = game.findPermanent("Phyrexian Slayer")!!
+                val blockerId = game.findPermanent("White Vanilla Reach")!!
+
+                game.execute(DeclareAttackers(game.player1Id, mapOf(slayerId to game.player2Id)))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val blockResult = game.execute(
+                    DeclareBlockers(game.player2Id, mapOf(blockerId to listOf(slayerId)))
+                )
+                withClue("Block should succeed: ${blockResult.error}") {
+                    blockResult.error shouldBe null
+                }
+
+                // Becomes-blocked trigger fires — resolve it.
+                game.resolveStack()
+
+                withClue("White blocker should be destroyed by the becomes-blocked trigger") {
+                    game.findPermanent("White Vanilla Reach") shouldBe null
+                }
+            }
+
+            test("does not destroy a non-white creature that blocks it") {
+                val game = scenario()
+                    .withPlayers("Attacker", "Defender")
+                    .withCardOnBattlefield(1, "Phyrexian Slayer")
+                    .withCardOnBattlefield(2, "Green Vanilla Reach") // non-white blocker
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val slayerId = game.findPermanent("Phyrexian Slayer")!!
+                val blockerId = game.findPermanent("Green Vanilla Reach")!!
+
+                game.execute(DeclareAttackers(game.player1Id, mapOf(slayerId to game.player2Id)))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                game.execute(DeclareBlockers(game.player2Id, mapOf(blockerId to listOf(slayerId))))
+                game.resolveStack()
+
+                withClue("Green blocker should survive — trigger only matches white creatures") {
+                    game.findPermanent("Green Vanilla Reach") shouldBe blockerId
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ObsidianAcolyte.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ObsidianAcolyte.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Obsidian Acolyte
+ * {1}{W}
+ * Creature — Human Cleric
+ * 1/1
+ * Protection from black
+ * {W}: Target creature gains protection from black until end of turn.
+ */
+val ObsidianAcolyte = card("Obsidian Acolyte") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "Protection from black\n{W}: Target creature gains protection from black until end of turn."
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLACK)))
+
+    activatedAbility {
+        cost = Costs.Mana("{W}")
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantProtectionFromColor(Color.BLACK, t)
+        description = "{W}: Target creature gains protection from black until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "Matthew D. Wilson"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/868efcee-bb13-4b6f-b81b-99408685e4c4.jpg?1562922212"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PhyrexianSlayer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PhyrexianSlayer.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Phyrexian Slayer
+ * {3}{B}
+ * Creature — Phyrexian Minion
+ * 2/2
+ * Flying
+ * Whenever this creature becomes blocked by a white creature, destroy that creature.
+ * It can't be regenerated.
+ *
+ * "That creature" is the white blocker (not a target). The becomes-blocked SELF trigger
+ * with a white-creature filter fires once per matching blocker, exposing the blocker as
+ * [EffectTarget.TriggeringEntity]. Mirrors Phyrexian Reaper (green blocker variant).
+ */
+val PhyrexianSlayer = card("Phyrexian Slayer") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Minion"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\nWhenever this creature becomes blocked by a white creature, destroy that creature. It can't be regenerated."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.becomesBlocked(
+            filter = GameObjectFilter.Creature.withColor(Color.WHITE),
+            binding = TriggerBinding.SELF,
+        )
+        effect = CantBeRegeneratedEffect(EffectTarget.TriggeringEntity) then
+                MoveToZoneEffect(EffectTarget.TriggeringEntity, Zone.GRAVEYARD, byDestruction = true)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Sam Wood"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fa8c604-343f-4c94-ac25-439ab1845c19.jpg?1562914368"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RainbowCrow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RainbowCrow.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rainbow Crow
+ * {3}{U}
+ * Creature — Bird
+ * 2/2
+ * Flying
+ * {1}: This creature becomes the color of your choice until end of turn.
+ */
+val RainbowCrow = card("Rainbow Crow") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n{1}: This creature becomes the color of your choice until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.ChangeColorToChosen(EffectTarget.Self)
+        description = "{1}: This creature becomes the color of your choice until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "69"
+        artist = "Edward P. Beard, Jr."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e622ad2-473f-489e-b4cf-bbdcc44d0cde.jpg?1562920499"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ViashinoGrappler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ViashinoGrappler.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Viashino Grappler
+ * {2}{R}
+ * Creature — Lizard
+ * 3/1
+ * {G}: This creature gains trample until end of turn.
+ */
+val ViashinoGrappler = card("Viashino Grappler") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard"
+    power = 3
+    toughness = 1
+    oracleText = "{G}: This creature gains trample until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+        description = "{G}: This creature gains trample until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "179"
+        artist = "Mark Romanoski"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a94aeb4-349c-4394-848d-c1c9133856e2.jpg?1562910116"
+    }
+}


### PR DESCRIPTION
Adds four Invasion-original cards (INV is the canonical set). All implemented with existing SDK facades — no engine changes required.

## Cards

- **Obsidian Acolyte** `{1}{W}` 1/1 Human Cleric — Protection from black; `{W}`: Target creature gains protection from black until end of turn. Mirrors Crimson Acolyte via `Effects.GrantProtectionFromColor(BLACK)`.
- **Phyrexian Slayer** `{3}{B}` 2/2 Phyrexian Minion — Flying; whenever it becomes blocked by a white creature, destroy that creature (can't be regenerated). Reuses the becomes-blocked SELF trigger (white-creature filter) + `CantBeRegenerated` + destroy, same pattern as Phyrexian Reaper.
- **Rainbow Crow** `{3}{U}` 2/2 Bird — Flying; `{1}`: becomes the color of your choice until end of turn. Uses `Effects.ChangeColorToChosen`, like Kavu Chameleon.
- **Viashino Grappler** `{2}{R}` 3/1 Lizard — `{G}`: gains trample until end of turn. Uses `Effects.GrantKeyword(TRAMPLE)` on self.

## Tests

- `ObsidianAcolyteScenarioTest` — grants protection from black; a black spell can no longer target the protected creature.
- `PhyrexianSlayerScenarioTest` — destroys a white blocker on block; leaves a non-white blocker alive.
- Rainbow Crow and Viashino Grappler rely on already-tested facades (Kavu Chameleon / Llanowar Elite analogues), so no new scenario tests were added for them.

`MtgSetCatalogTest` and both new scenario tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)