### PR TITLE
Fix two engine crashes surfaced by random-action play on Bloomburrow

### DIFF
--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/RandomActionBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/RandomActionBenchmark.kt
@@ -4,7 +4,7 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
+import com.wingedsheep.mtg.sets.MtgSetCatalog
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
@@ -22,20 +22,23 @@ import kotlin.time.measureTime
  * Measures raw engine throughput: enumerate legal actions → pick random → process.
  *
  * Disabled by default. Run with:
- *   ./gradlew :rules-engine:test --tests "*.RandomActionBenchmark" -Dbenchmark=true
- *   ./gradlew :rules-engine:test --tests "*.RandomActionBenchmark" -Dbenchmark=true -DbenchmarkGames=100
+ *   ./gradlew :ai:test --tests "*.RandomActionBenchmark" -Dbenchmark=true
+ *   ./gradlew :ai:test --tests "*.RandomActionBenchmark" -Dbenchmark=true -DbenchmarkGames=100
+ *   ./gradlew :ai:test --tests "*.RandomActionBenchmark" -Dbenchmark=true -DbenchmarkGames=200 -DbenchmarkSet=BLB
  */
 class RandomActionBenchmark : FunSpec({
 
     val numGames = System.getProperty("benchmarkGames")?.toIntOrNull() ?: 20
     val benchmarkEnabled = System.getProperty("benchmark") == "true"
+    val setCode = System.getProperty("benchmarkSet") ?: "POR"
 
-    test("benchmark: $numGames random-action games in parallel").config(enabled = benchmarkEnabled) {
+    test("benchmark: $numGames random-action games in parallel ($setCode)").config(enabled = benchmarkEnabled) {
+        val set = MtgSetCatalog.requireByCode(setCode)
         val registry = CardRegistry().apply {
-            register(PortalSet.cards)
-            register(PortalSet.basicLands)
+            register(set.cards)
+            register(set.basicLands)
         }
-        val allCards = PortalSet.cards
+        val allCards = set.cards
         val cores = Runtime.getRuntime().availableProcessors()
         val pool = Executors.newFixedThreadPool(cores)
         val completionService = ExecutorCompletionService<RandomGameResult>(pool)
@@ -59,6 +62,7 @@ class RandomActionBenchmark : FunSpec({
 
             val results = (1..numGames).map { completionService.take().get() }
 
+            val crashed = results.filter { it.crashError != null }
             val completed = results.count { it.gameOver }
             val avgTurns = results.map { it.turns }.average()
             val avgActions = results.map { it.actions }.average()
@@ -69,6 +73,14 @@ class RandomActionBenchmark : FunSpec({
             println()
             println("--- SUMMARY ($numGames games, random actions) ---")
             println("Completed:  $completed / ${results.size} (${completed * 100 / results.size}%)")
+            println("Crashed:    ${crashed.size} / ${results.size} (engine exceptions)")
+            if (crashed.isNotEmpty()) {
+                println()
+                println("--- ENGINE EXCEPTIONS (distinct, with game count) ---")
+                crashed.groupingBy { it.crashError!! }.eachCount()
+                    .entries.sortedByDescending { it.value }
+                    .forEach { (msg, n) -> println("  [${n}x] $msg") }
+            }
             println("Turns:      avg=${String.format("%.1f", avgTurns)}, min=${results.minOf { it.turns }}, max=${results.maxOf { it.turns }}")
             println("Actions:    avg=${avgActions.roundToInt()}, min=${results.minOf { it.actions }}, max=${results.maxOf { it.actions }}")
             println("CPU/game:   avg=${avgMs.roundToInt()}ms, min=${results.minOf { it.durationMs }}ms, max=${results.maxOf { it.durationMs }}ms")
@@ -100,7 +112,8 @@ class RandomActionBenchmark : FunSpec({
 private data class RandomGameResult(
     val turns: Int, val actions: Int, val durationMs: Long,
     val winner: String, val gameOver: Boolean,
-    val enumerateNs: Long = 0, val processNs: Long = 0, val decisionNs: Long = 0
+    val enumerateNs: Long = 0, val processNs: Long = 0, val decisionNs: Long = 0,
+    val crashError: String? = null
 )
 
 /**
@@ -132,50 +145,57 @@ private fun playRandomGame(
     var lastProgressTurn = 0
     var lastProgressAction = 0
     var stuckCount = 0
+    var crashError: String? = null
 
     val duration = measureTime {
-        while (!state.gameOver && state.turnNumber < maxTurns) {
-            // Stuck detection
-            if (actionCount - lastProgressAction > 1000 && state.turnNumber == lastProgressTurn) {
-                stuckCount++
-                if (stuckCount >= 3) break
-            }
-            if (state.turnNumber > lastProgressTurn) {
-                lastProgressTurn = state.turnNumber
-                lastProgressAction = actionCount
-                stuckCount = 0
-            }
+        try {
+            while (!state.gameOver && state.turnNumber < maxTurns) {
+                // Stuck detection
+                if (actionCount - lastProgressAction > 1000 && state.turnNumber == lastProgressTurn) {
+                    stuckCount++
+                    if (stuckCount >= 3) break
+                }
+                if (state.turnNumber > lastProgressTurn) {
+                    lastProgressTurn = state.turnNumber
+                    lastProgressAction = actionCount
+                    stuckCount = 0
+                }
 
-            val pendingDecision = state.pendingDecision
-            val action = if (pendingDecision != null) {
-                val t0 = System.nanoTime()
-                val response = randomDecisionResponse(pendingDecision, rng)
-                decisionNs += System.nanoTime() - t0
-                SubmitDecision(pendingDecision.playerId, response)
-            } else {
-                val priorityPlayer = state.priorityPlayerId ?: break
-                val t0 = System.nanoTime()
-                val legalActions = enumerator.enumerate(state, priorityPlayer)
-                enumerateNs += System.nanoTime() - t0
-                val affordable = legalActions.filter { it.affordable }
-                if (affordable.isEmpty()) break
-                affordable[rng.nextInt(affordable.size)].action
-            }
+                val pendingDecision = state.pendingDecision
+                val action = if (pendingDecision != null) {
+                    val t0 = System.nanoTime()
+                    val response = randomDecisionResponse(pendingDecision, rng)
+                    decisionNs += System.nanoTime() - t0
+                    SubmitDecision(pendingDecision.playerId, response)
+                } else {
+                    val priorityPlayer = state.priorityPlayerId ?: break
+                    val t0 = System.nanoTime()
+                    val legalActions = enumerator.enumerate(state, priorityPlayer)
+                    enumerateNs += System.nanoTime() - t0
+                    val affordable = legalActions.filter { it.affordable }
+                    if (affordable.isEmpty()) break
+                    affordable[rng.nextInt(affordable.size)].action
+                }
 
-            val t0 = System.nanoTime()
-            val r = processor.process(state, action).result
-            processNs += System.nanoTime() - t0
-            if (r.error != null) {
-                // If random action failed, just pass priority
-                val t1 = System.nanoTime()
-                val fallback = processor.process(state, PassPriority(action.playerId)).result
-                processNs += System.nanoTime() - t1
-                if (fallback.error != null) break
-                state = fallback.state
-            } else {
-                state = r.state
+                val t0 = System.nanoTime()
+                val r = processor.process(state, action).result
+                processNs += System.nanoTime() - t0
+                if (r.error != null) {
+                    // If random action failed, just pass priority
+                    val t1 = System.nanoTime()
+                    val fallback = processor.process(state, PassPriority(action.playerId)).result
+                    processNs += System.nanoTime() - t1
+                    if (fallback.error != null) break
+                    state = fallback.state
+                } else {
+                    state = r.state
+                }
+                actionCount++
             }
-            actionCount++
+        } catch (e: Throwable) {
+            // An engine exception (not a returned error) — record it and end this game
+            // rather than killing the whole benchmark run.
+            crashError = "${e::class.simpleName}: ${e.message}"
         }
     }
 
@@ -184,6 +204,7 @@ private fun playRandomGame(
         actions = actionCount,
         durationMs = duration.inWholeMilliseconds,
         winner = when {
+            crashError != null -> "crash"
             !state.gameOver -> "timeout"
             state.winnerId == p1 -> "P1"
             state.winnerId == p2 -> "P2"
@@ -192,7 +213,8 @@ private fun playRandomGame(
         gameOver = state.gameOver,
         enumerateNs = enumerateNs,
         processNs = processNs,
-        decisionNs = decisionNs
+        decisionNs = decisionNs,
+        crashError = crashError
     )
 }
 

--- a/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
@@ -26,6 +26,7 @@ tasks.withType<Test>().configureEach {
     systemProperty("benchmarkGames", System.getProperty("benchmarkGames") ?: "10")
     systemProperty("benchmarkMaxTurns", System.getProperty("benchmarkMaxTurns") ?: "50")
     systemProperty("benchmarkOutputDir", System.getProperty("benchmarkOutputDir") ?: System.getProperty("java.io.tmpdir"))
+    systemProperty("benchmarkSet", System.getProperty("benchmarkSet") ?: "POR")
 
     // Forward per-player benchmark config
     for (prefix in listOf("p1", "p2")) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -547,6 +547,12 @@ class TriggerMatcher(
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsInstant -> cardComponent.typeLine.isInstant
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsSorcery -> cardComponent.typeLine.isSorcery
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsBasicLand -> cardComponent.typeLine.isLand && cardComponent.typeLine.supertypes.contains(com.wingedsheep.sdk.core.Supertype.BASIC)
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPermanent -> cardComponent.typeLine.isPermanent
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonland -> !cardComponent.typeLine.isLand
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNoncreature -> !cardComponent.typeLine.isCreature
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonenchantment -> !cardComponent.typeLine.isEnchantment
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLegendary -> cardComponent.typeLine.isLegendary
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonlegendary -> !cardComponent.typeLine.isLegendary
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
                 cardComponent.typeLine.hasSubtype(predicate.subtype)
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasAnyOfSubtypes ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1093,10 +1093,13 @@ class ActivateAbilityHandler(
         // the eligible restricted mana for the cost — and any unconsumed remainder stays
         // restricted in the pool instead of laundering into unrestricted mana.
         for (source in solution.sources) {
-            // ManaSolver always emits a manaProduced entry per tapped source; a missing
-            // entry would indicate a solver bug, not a runtime gap to swallow silently.
-            val production = solution.manaProduced[source.entityId]
-                ?: error("solution.sources contains ${source.name} without a matching manaProduced entry")
+            // A tapped source may legitimately have no manaProduced entry: ManaSolver taps
+            // extra sources to pay the *internal* activation cost of a mana ability (e.g. the
+            // {1} in Hidden Grotto's "{1}, {T}: Add one mana of any color"). That mana is
+            // consumed by the ability's own cost rather than flowing into the spell/ability
+            // payment pool, so the solver intentionally omits it from manaProduced. Such a
+            // source is still tapped above; it just contributes nothing to the pool here.
+            val production = solution.manaProduced[source.entityId] ?: continue
             val color = production.color
             val restriction = if (color != null) {
                 source.colorRestrictions[color] ?: source.restriction

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HiddenGrottoTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HiddenGrottoTest.kt
@@ -6,11 +6,23 @@ import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.blb.cards.HiddenGrotto
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import java.util.UUID
 
 /**
  * Tests for Hidden Grotto.
@@ -28,6 +40,26 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 class HiddenGrottoTest : FunSpec({
 
     val anyColorAbilityId = HiddenGrotto.activatedAbilities[1].id
+
+    // A creature with a non-mana {G}{G} activated pump ability. Activating it auto-taps for
+    // {G}{G}; with only one Forest available, the solver routes the second {G} through Hidden
+    // Grotto's any-color ability, which itself costs {1} — funded by tapping a basic. That
+    // basic lands in solution.sources with no manaProduced entry (its mana is consumed by the
+    // activation cost), which previously made autoTapForManaCost throw.
+    val pumpAbilityId = AbilityId(UUID.randomUUID().toString())
+    val grottoBeast = CardDefinition(
+        name = "Grotto Beast",
+        manaCost = ManaCost.parse("{2}{G}"),
+        typeLine = TypeLine.creature(setOf(Subtype("Beast"))),
+        creatureStats = CreatureStats(2, 2),
+        script = CardScript.permanent(
+            ActivatedAbility(
+                id = pumpAbilityId,
+                cost = AbilityCost.Mana(ManaCost.parse("{G}{G}")),
+                effect = Effects.ModifyStats(1, 1, EffectTarget.Self),
+            )
+        )
+    )
 
     test("cannot activate {1}, {T}: Add one mana of any color using its own mana ability") {
         val driver = GameTestDriver()
@@ -96,6 +128,35 @@ class HiddenGrottoTest : FunSpec({
         result.isSuccess shouldBe true
         // Forest pays one {G}; Hidden Grotto's any-color ability pays the other {G}
         // but requires {1} — which must come from tapping the Swamp.
+        driver.isTapped(forest) shouldBe true
+        driver.isTapped(grotto) shouldBe true
+        driver.isTapped(swamp) shouldBe true
+    }
+
+    test("activating an ability auto-taps a basic to fund Grotto's {1} without crashing") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(grottoBeast))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Plains" to 20))
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val forest = driver.putPermanentOnBattlefield(activePlayer, "Forest")
+        val grotto = driver.putPermanentOnBattlefield(activePlayer, "Hidden Grotto")
+        val swamp = driver.putPermanentOnBattlefield(activePlayer, "Swamp")
+        val beast = driver.putPermanentOnBattlefield(activePlayer, "Grotto Beast")
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = beast,
+                abilityId = pumpAbilityId
+            )
+        )
+
+        // {G}{G}: Forest pays one {G}; Hidden Grotto's any-color ability pays the other {G},
+        // and its own {1} is funded by tapping the Swamp.
+        result.isSuccess shouldBe true
         driver.isTapped(forest) shouldBe true
         driver.isTapped(grotto) shouldBe true
         driver.isTapped(swamp) shouldBe true


### PR DESCRIPTION
## Summary

A 200-game random-action benchmark over Bloomburrow (BLB) sealed decks crashed **20/200 games** on two distinct `IllegalStateException`s. Both are engine defects, not card-specific. After the fixes the same run completes **200/200 with 0 engine exceptions**.

## Bug 1 — ManaSolver / auto-tap contract mismatch (17 of 20 crashes)

`ManaSolver.solve()` deliberately taps extra sources to pay the *internal* activation cost of a mana ability — e.g. the `{1}` in Hidden Grotto's `{1}, {T}: Add one mana of any color`. By design those sources land in `solution.sources` with **no** `manaProduced` entry: their mana is consumed by the activation cost, not by the spell/ability being paid for.

`ActivateAbilityHandler.autoTapForManaCost` assumed every source had a `manaProduced` entry and `error()`ed out otherwise, crashing any game where auto-tap routed mana through a filter land:

```
IllegalStateException: solution.sources contains Swamp without a matching manaProduced entry
```

**Fix:** skip sources with no `manaProduced` entry — they are still tapped, they just contribute nothing to the floating pool. Corrected the misleading comment that claimed the solver always emits an entry per tapped source.

This crash only hit the **activate-ability** path. The existing `HiddenGrottoTest` only covered the **cast-spell** path (which uses the solver's internal accounting as payment, not the pool), so it never exercised this branch.

## Bug 2 — TriggerMatcher missing predicate branches (3 of 20 crashes)

`TriggerMatcher.matchesCardPredicate` had no branch for `IsPermanent`, so its deliberate guard threw when a trigger filtered on "nonland permanent" (e.g. Rottenmouth Viper):

```
IllegalStateException: TriggerMatcher.matchesCardPredicate has no branch for IsPermanent.
```

**Fix:** added `IsPermanent`, `IsNonland`, `IsNoncreature`, `IsNonenchantment`, `IsLegendary`, `IsNonlegendary`, mirroring the canonical `PredicateEvaluator`.

## Verification

- New regression test in `HiddenGrottoTest` — *"activating an ability auto-taps a basic to fund Grotto's {1} without crashing"* — reproduces the exact activate-ability path (throws before the fix, passes after). All 5 tests in the class pass.
- Full 200-game BLB random-action benchmark: **200/200 completed, 0 crashes** (was 180/200, 20 crashes).

## Tooling changes (also in this PR)

- `RandomActionBenchmark` now takes a `-DbenchmarkSet=<code>` system property (was hardcoded to Portal) and isolates per-game exceptions, so one crash no longer aborts the whole run — it reports a per-exception crash breakdown instead.
- `buildSrc/kotlin-jvm.gradle.kts` forwards the new `benchmarkSet` property to the test JVM.

Run it with:
```bash
./gradlew :ai:test --tests "*.RandomActionBenchmark" -Dbenchmark=true -DbenchmarkGames=200 -DbenchmarkSet=BLB
```

No SDK changes — the predicates already existed; the engine just wasn't handling them in one of its two predicate evaluators. No DSL-reference update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)