### PR TITLE
Add Invasion cards batch A

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArchaeologicalDig.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArchaeologicalDig.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Archaeological Dig (INV 320)
+ * Land
+ * {T}: Add {C}.
+ * {T}, Sacrifice this land: Add one mana of any color.
+ */
+val ArchaeologicalDig = card("Archaeological Dig") {
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n{T}, Sacrifice this land: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "320"
+        artist = "Don Hazeltine"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35f55af0-5a46-4900-b3d0-ca796b710e07.jpg?1562905889"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArtifactMutation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArtifactMutation.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Artifact Mutation (INV 231)
+ * {R}{G}
+ * Instant
+ * Destroy target artifact. It can't be regenerated. Create X 1/1 green Saproling creature tokens,
+ * where X is that artifact's mana value.
+ *
+ * The token count reads the destroyed artifact's mana value via [DynamicAmount.EntityProperty];
+ * mana value is a card characteristic that survives the move to the graveyard, so the count
+ * resolves correctly after [Effects.Destroy] (CR 608.2g — last-known information). Mirrors
+ * [AuraMutation]. If the artifact is an illegal target on resolution the whole spell is countered
+ * by the rules and no Saprolings are created.
+ *
+ * "It can't be regenerated" is currently not enforced for the single-target [Effects.Destroy]
+ * facade (only the [Effects.DestroyAll] pipeline carries a `noRegenerate` flag). This matches the
+ * existing precedent for single-target destroy-and-can't-regenerate spells in this set
+ * (e.g. Plague Spores); artifact regeneration shields are rare in practice.
+ */
+val ArtifactMutation = card("Artifact Mutation") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact. It can't be regenerated. Create X 1/1 green Saproling " +
+        "creature tokens, where X is that artifact's mana value."
+
+    spell {
+        val t = target("target artifact", Targets.Artifact)
+        effect = Effects.Destroy(t) then CreateTokenEffect(
+            count = DynamicAmount.EntityProperty(
+                entity = EntityReference.Target(0),
+                numericProperty = EntityNumericProperty.ManaValue
+            ),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling"),
+            imageUri = "/images/tokens/inv-saproling.jpeg"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "231"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5eef49c-a80f-4622-ba77-999f9151c841.jpg?1562937931"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AssaultBattery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AssaultBattery.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Assault // Battery (INV 295) — split-layout spell (CR 709).
+ *
+ * Assault {R} — Sorcery
+ *   Assault deals 2 damage to any target.
+ *
+ * Battery {3}{G} — Sorcery
+ *   Create a 3/3 green Elephant creature token.
+ *
+ * Cast either half from hand; only the chosen half goes on the stack (CR 709.4).
+ */
+val AssaultBattery = card("Assault // Battery") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "RG"
+
+    face("Assault") {
+        manaCost = "{R}"
+        typeLine = "Sorcery"
+        oracleText = "Assault deals 2 damage to any target."
+
+        spell {
+            target("any target", Targets.Any)
+            effect = Effects.DealDamage(2, EffectTarget.ContextTarget(0))
+        }
+    }
+
+    face("Battery") {
+        manaCost = "{3}{G}"
+        typeLine = "Sorcery"
+        oracleText = "Create a 3/3 green Elephant creature token."
+
+        spell {
+            effect = Effects.CreateToken(
+                power = 3,
+                toughness = 3,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Elephant"),
+                imageUri = "https://cards.scryfall.io/normal/front/3/d/3dc13cf6-665a-4d92-836f-b2e10ca08ecd.jpg?1561756962"
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "295"
+        artist = "Ben Thompson"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0ec6a889-c941-4898-a2f6-4d3863faf535.jpg?1562898037"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BarrinsUnmaking.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BarrinsUnmaking.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.TargetSharesMostCommonColor
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Barrin's Unmaking (INV 46)
+ * {1}{U}
+ * Instant
+ * Return target permanent to its owner's hand if that permanent shares a color with the most
+ * common color among all permanents or a color tied for most common.
+ *
+ * Reuses [TargetSharesMostCommonColor] (shared with Tsabo's Assassin) gating a
+ * [Effects.ReturnToHand] via [ConditionalEffect]. The condition is evaluated at resolution against
+ * the board's current color distribution (CR 608.2); if the target permanent doesn't share the
+ * most-common color it stays put.
+ */
+val BarrinsUnmaking = card("Barrin's Unmaking") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target permanent to its owner's hand if that permanent shares a color " +
+        "with the most common color among all permanents or a color tied for most common."
+
+    spell {
+        target("target permanent", Targets.Permanent)
+        effect = ConditionalEffect(
+            condition = TargetSharesMostCommonColor(),
+            effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Luca Zontini"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d4cecb0-12b5-4678-b5e7-8cec8fc86cef.jpg?1562910648"
+    }
+}


### PR DESCRIPTION
Adds four cards from the Invasion (INV) set. All four are composed entirely from existing SDK primitives — no engine, effect, condition, or DSL changes were needed, so no `card-sdk-language-reference.md` update applies.

## Cards added

| Card | Cost | Notes |
|------|------|-------|
| **Archaeological Dig** (320) | Land | `{T}: Add {C}` + `{T}, Sacrifice this land: Add one mana of any color`. Same shape as Ancient Spring (`AddColorlessMana` / `AddAnyColorMana` mana abilities). |
| **Artifact Mutation** (231) | `{R}{G}` | Destroy target artifact, then create X 1/1 green Saprolings where X is its mana value. Direct analog of Aura Mutation (`Destroy` then `CreateTokenEffect` with `DynamicAmount.EntityProperty(ManaValue)`). |
| **Assault // Battery** (295) | split | Split-layout spell (CR 709). Assault `{R}`: 2 damage to any target. Battery `{3}{G}`: create a 3/3 green Elephant token. Same `CardLayout.SPLIT` + `face { }` pattern as Wax // Wane / Stand // Deliver. |
| **Barrin's Unmaking** (46) | `{1}{U}` | `ConditionalEffect` gated by the existing `TargetSharesMostCommonColor` condition (shared with Tsabo's Assassin) returning the target permanent to its owner's hand. |

## Skipped

None — all four cards were implemented.

## Notes

- "It can't be regenerated" on Artifact Mutation is not enforced by the single-target `Effects.Destroy` facade (only the `DestroyAll` pipeline carries a `noRegenerate` flag). This follows the existing precedent for single-target destroy-and-can't-regenerate spells in this set (e.g. Plague Spores); artifact regeneration shields are rare. Documented in the card's KDoc.

## Testing

- `:mtg-sets:compileKotlin` — clean.
- `:mtg-sets:test` `MtgSetCatalogTest` + `CardImageUriTest` — pass (validates all cards load and image URIs are well-formed; all five Scryfall image URLs verified HTTP 200).
- `:rules-engine:test` `ColorIsMostCommonTest` — pass (exercises the shared most-common-color condition used by Barrin's Unmaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)