### PR TITLE
Add Invasion cards batch B

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1118,6 +1118,12 @@ staticAbility {
   `CantAttackUnless` (which is defender-relative), this depends on the whole proposed attacker
   group, so it's validated against the other declared attackers at declaration time (projected
   state; self never counts as its own co-attacker).
+- `AttackerCountLimit(maxAttackers)` / `BlockerCountLimit(maxBlockers)` — global combat caps
+  (Dueling Grounds — "No more than one creature can attack/block each combat"). Constrain the
+  *total* declared attacker/blocker set across all players, not a single creature, so they are
+  enforced as a whole-declaration check in `AttackPhaseManager`/`BlockPhaseManager` rather than a
+  per-creature rule. While any permanent with the ability is on the battlefield, declaring more
+  than the smallest cap is rejected. (`BlockerCountLimit` counts distinct blocking creatures.)
 
 **Spell cost statics — `ModifySpellCost`**
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DuelingGroundsScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DuelingGroundsScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Dueling Grounds.
+ *
+ * Card reference:
+ * - Dueling Grounds ({1}{G}{W}): Enchantment
+ *   "No more than one creature can attack each combat.
+ *    No more than one creature can block each combat."
+ *
+ * Exercises the global [com.wingedsheep.sdk.scripting.AttackerCountLimit] /
+ * [com.wingedsheep.sdk.scripting.BlockerCountLimit] static abilities, which constrain the whole
+ * declared attacker/blocker set rather than a single creature.
+ */
+class DuelingGroundsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dueling Grounds attacker cap") {
+
+            test("rejects declaring two attackers") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dueling Grounds")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val result = game.declareAttackers(mapOf("Grizzly Bears" to 2, "Hill Giant" to 2))
+
+                withClue("Declaring two attackers should be rejected by Dueling Grounds") {
+                    result.error shouldNotBe null
+                }
+            }
+
+            test("allows declaring a single attacker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dueling Grounds")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val result = game.declareAttackers(mapOf("Grizzly Bears" to 2))
+
+                withClue("Declaring one attacker should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+            }
+        }
+
+        context("Dueling Grounds blocker cap") {
+
+            test("rejects declaring two blockers") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dueling Grounds")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Devoted Hero")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Hill Giant" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val result = game.declareBlockers(
+                    mapOf(
+                        "Grizzly Bears" to listOf("Hill Giant"),
+                        "Devoted Hero" to listOf("Hill Giant")
+                    )
+                )
+
+                withClue("Declaring two blockers should be rejected by Dueling Grounds") {
+                    result.error shouldNotBe null
+                }
+            }
+
+            test("allows declaring a single blocker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dueling Grounds")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Devoted Hero")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Hill Giant" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val result = game.declareBlockers(mapOf("Grizzly Bears" to listOf("Hill Giant")))
+
+                withClue("Declaring one blocker should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -299,3 +299,41 @@ data class CantBeAttackedWithout(
         "Creatures without ${requiredKeyword.displayName.lowercase()} can't attack you"
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
 }
+
+/**
+ * Global cap on how many creatures may attack in a single combat (Dueling Grounds —
+ * "No more than one creature can attack each combat").
+ *
+ * Unlike per-creature restrictions, this constrains the *total* declared attacker set
+ * regardless of controller, so it is enforced as a whole-declaration check rather than a
+ * per-attacker [AttackRestrictionRule]. While any permanent with this ability is on the
+ * battlefield, an attack declaration with more than [maxAttackers] attackers is illegal.
+ */
+@SerialName("AttackerCountLimit")
+@Serializable
+data class AttackerCountLimit(
+    val maxAttackers: Int
+) : StaticAbility {
+    override val description: String =
+        "No more than $maxAttackers creature${if (maxAttackers == 1) "" else "s"} can attack each combat"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}
+
+/**
+ * Global cap on how many creatures may block in a single combat (Dueling Grounds —
+ * "No more than one creature can block each combat").
+ *
+ * Constrains the *total* declared blocker set regardless of controller, so it is enforced as
+ * a whole-declaration check rather than a per-blocker rule. While any permanent with this
+ * ability is on the battlefield, a block declaration with more than [maxBlockers] blockers is
+ * illegal.
+ */
+@SerialName("BlockerCountLimit")
+@Serializable
+data class BlockerCountLimit(
+    val maxBlockers: Int
+) : StaticAbility {
+    override val description: String =
+        "No more than $maxBlockers creature${if (maxBlockers == 1) "" else "s"} can block each combat"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CinderShade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CinderShade.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cinder Shade
+ * {1}{B}{R}
+ * Creature — Shade
+ * 1/1
+ * {B}: This creature gets +1/+1 until end of turn.
+ * {R}, Sacrifice this creature: It deals damage equal to its power to target creature.
+ */
+val CinderShade = card("Cinder Shade") {
+    manaCost = "{1}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Shade"
+    power = 1
+    toughness = 1
+    oracleText = "{B}: This creature gets +1/+1 until end of turn.\n" +
+        "{R}, Sacrifice this creature: It deals damage equal to its power to target creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{R}"),
+            Costs.SacrificeSelf
+        )
+        val t = target("target creature", Targets.Creature)
+        // Power is read from the sacrifice-time snapshot (Rule 608.2h — "as it last
+        // existed on the battlefield"), since the source has already left play.
+        effect = Effects.DealDamage(DynamicAmounts.sacrificedPower(), t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "240"
+        artist = "Nelson DeCastro"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8dd933a-19ed-4d30-a94a-bfb2f66f8f13.jpg?1562932184"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CollapsingBorders.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CollapsingBorders.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Collapsing Borders
+ * {3}{R}
+ * Enchantment
+ * Domain — At the beginning of each player's upkeep, that player gains 1 life for each
+ * basic land type among lands they control. Then this enchantment deals 3 damage to that player.
+ */
+val CollapsingBorders = card("Collapsing Borders") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Domain — At the beginning of each player's upkeep, that player gains 1 life for each " +
+        "basic land type among lands they control. Then this enchantment deals 3 damage to that player."
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        // Domain is computed for the upkeep player (the lands *they* control), and both the
+        // life gain and the 3 damage are applied to that same player.
+        effect = Effects.GainLife(
+            DynamicAmounts.domain(Player.TriggeringPlayer),
+            EffectTarget.PlayerRef(Player.TriggeringPlayer)
+        ) then Effects.DealDamage(3, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "141"
+        artist = "Glen Angus"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc019633-788e-4095-9610-6c0a432f7656.jpg?1562936001"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DefilingTears.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DefilingTears.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.effects.GrantActivatedAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Defiling Tears
+ * {2}{B}
+ * Instant
+ * Until end of turn, target creature becomes black, gets +1/-1, and gains "{B}: Regenerate this creature."
+ */
+val DefilingTears = card("Defiling Tears") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target creature becomes black, gets +1/-1, and gains \"{B}: Regenerate this creature.\""
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.ChangeColor(t, setOf(Color.BLACK)) then
+            Effects.ModifyStats(1, -1, t) then
+            GrantActivatedAbilityEffect(
+                ability = ActivatedAbility(
+                    id = AbilityId.generate(),
+                    cost = AbilityCost.Mana(ManaCost.parse("{B}")),
+                    effect = RegenerateEffect(EffectTarget.Self)
+                ),
+                target = t
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "rk post"
+        flavorText = "Serra's living warriors looked on in horror. \"Where is our Lady now?\" they cried."
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db7cba29-9472-4874-bd54-37edf70645b2.jpg?1562939101"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DuelingGrounds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DuelingGrounds.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AttackerCountLimit
+import com.wingedsheep.sdk.scripting.BlockerCountLimit
+
+/**
+ * Dueling Grounds
+ * {1}{G}{W}
+ * Enchantment
+ * No more than one creature can attack each combat.
+ * No more than one creature can block each combat.
+ */
+val DuelingGrounds = card("Dueling Grounds") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Enchantment"
+    oracleText = "No more than one creature can attack each combat.\n" +
+        "No more than one creature can block each combat."
+
+    staticAbility {
+        ability = AttackerCountLimit(maxAttackers = 1)
+    }
+
+    staticAbility {
+        ability = BlockerCountLimit(maxBlockers = 1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "245"
+        artist = "Pete Venters"
+        flavorText = "\"You think you can stop me?\" hissed Tsabo. \"I think I can kill you,\" replied Gerrard."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52760183-bee0-4ce0-96c0-074b88f78980.jpg?1562911742"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AttackTax
+import com.wingedsheep.sdk.scripting.AttackerCountLimit
 import com.wingedsheep.sdk.scripting.CantAttackUnlessCoAttacker
 import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import com.wingedsheep.engine.handlers.PredicateEvaluator
@@ -99,6 +100,13 @@ internal class AttackPhaseManager(
         val coAttackerValidation = validateCoAttackerRequirements(state, projected, attackers.keys)
         if (coAttackerValidation != null) {
             return ExecutionResult.error(state, coAttackerValidation)
+        }
+
+        // Check global attacker-count caps (Dueling Grounds — "No more than one creature can
+        // attack each combat"). Applies to the whole declared attacker set, not per creature.
+        val attackerCountValidation = validateGlobalAttackerCount(state, attackers.keys)
+        if (attackerCountValidation != null) {
+            return ExecutionResult.error(state, attackerCountValidation)
         }
 
         // Check must-attack requirements (Taunt)
@@ -331,6 +339,33 @@ internal class AttackPhaseManager(
                     return "${cardComponent.name} ${restriction.description}"
                 }
             }
+        }
+        return null
+    }
+
+    /**
+     * Validate global attacker-count caps. While any permanent with [AttackerCountLimit] is on
+     * the battlefield (e.g. Dueling Grounds), the total number of declared attackers across all
+     * players may not exceed the smallest such cap. Returns an error message when violated.
+     */
+    private fun validateGlobalAttackerCount(
+        state: GameState,
+        attackerIds: Set<EntityId>
+    ): String? {
+        var cap: Int? = null
+        var capDescription = ""
+        for (permId in state.getBattlefield()) {
+            val cardComponent = state.getEntity(permId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
+            for (ability in cardDef.staticAbilities.filterIsInstance<AttackerCountLimit>()) {
+                if (cap == null || ability.maxAttackers < cap) {
+                    cap = ability.maxAttackers
+                    capDescription = ability.description
+                }
+            }
+        }
+        if (cap != null && attackerIds.size > cap) {
+            return capDescription
         }
         return null
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.sdk.scripting.BlockerCountLimit
 import com.wingedsheep.sdk.scripting.CanBlockAnyNumber
 import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
 import com.wingedsheep.sdk.scripting.CantBlock
@@ -77,6 +78,13 @@ internal class BlockPhaseManager(
         val maxBlockersValidation = validateMaxBlockersRequirements(state, blockers)
         if (maxBlockersValidation != null) {
             return ExecutionResult.error(state, maxBlockersValidation)
+        }
+
+        // Check global blocker-count caps (Dueling Grounds — "No more than one creature can
+        // block each combat"). Counts distinct blocking creatures across all players.
+        val blockerCountValidation = validateGlobalBlockerCount(state, blockers.keys)
+        if (blockerCountValidation != null) {
+            return ExecutionResult.error(state, blockerCountValidation)
         }
 
         // Check "must be blocked" requirements (Alluring Scent, etc.)
@@ -488,6 +496,33 @@ internal class BlockPhaseManager(
                 val countText = if (limit == 1) "more than one creature" else "more than $limit creatures"
                 return "${attackerCard.name} can't be blocked by $countText"
             }
+        }
+        return null
+    }
+
+    /**
+     * Validate global blocker-count caps. While any permanent with [BlockerCountLimit] is on the
+     * battlefield (e.g. Dueling Grounds), the total number of distinct blocking creatures across
+     * all players may not exceed the smallest such cap. Returns an error message when violated.
+     */
+    private fun validateGlobalBlockerCount(
+        state: GameState,
+        blockerIds: Set<EntityId>
+    ): String? {
+        var cap: Int? = null
+        var capDescription = ""
+        for (permId in state.getBattlefield()) {
+            val cardComponent = state.getEntity(permId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
+            for (ability in cardDef.staticAbilities.filterIsInstance<BlockerCountLimit>()) {
+                if (cap == null || ability.maxBlockers < cap) {
+                    cap = ability.maxBlockers
+                    capDescription = ability.description
+                }
+            }
+        }
+        if (cap != null && blockerIds.size > cap) {
+            return capDescription
         }
         return null
     }


### PR DESCRIPTION
Implements four Invasion (INV) cards. All four canonical to INV (verified earliest printing via `check-card-printing`).

## Cards
- **Cinder Shade** ({1}{B}{R} Creature — Shade, 1/1) — `{B}: +1/+1 until end of turn` and `{R}, Sacrifice this creature: It deals damage equal to its power to target creature.` Pure composition: `Costs.SacrificeSelf` + `DynamicAmounts.sacrificedPower()` (reads the sacrifice-time P/T snapshot per CR 608.2h), same shape as Airdrop Condor.
- **Collapsing Borders** ({3}{R} Enchantment) — Domain upkeep trigger: at each player's upkeep, that player gains 1 life per basic land type among lands they control, then takes 3 damage. Uses `DynamicAmounts.domain(Player.TriggeringPlayer)` + `GainLife`/`DealDamage` on the triggering player.
- **Defiling Tears** ({2}{B} Instant) — Until end of turn, target creature becomes black, gets +1/-1, and gains `{B}: Regenerate this creature.` Composes `ChangeColor` + `ModifyStats` + `GrantActivatedAbilityEffect` (Run Wild pattern).
- **Dueling Grounds** ({1}{G}{W} Enchantment) — "No more than one creature can attack each combat. No more than one creature can block each combat."

## New SDK mechanic (for Dueling Grounds)
Added two parameterized global combat-restriction static abilities — `AttackerCountLimit(maxAttackers)` and `BlockerCountLimit(maxBlockers)`. Unlike per-creature restrictions, these cap the *total* declared attacker/blocker set across all players, so they are enforced as whole-declaration checks in `AttackPhaseManager.validateGlobalAttackerCount` / `BlockPhaseManager.validateGlobalBlockerCount` (smallest cap wins if multiple are in play; `BlockerCountLimit` counts distinct blocking creatures). An over-cap declaration is rejected with a clear message; the existing combat enumerator emits the same single `DeclareAttackers`/`DeclareBlockers` action and the chosen subset is validated on submission, consistent with how co-attacker/band constraints already work.

`docs/card-sdk-language-reference.md` updated with both new static abilities.

## Tests
- New `DuelingGroundsScenarioTest` (game-server): rejects 2 attackers / allows 1; rejects 2 blockers / allows 1 — all passing.
- `:rules-engine:test`, `:mtg-sets:test` green; combat regression checks (Aggravated Assault, Leery Fogbeast) green.
- The other three cards reuse existing, already-tested facades, so no new engine code and no extra scenario tests were needed.

Nothing skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)