### PR TITLE
Add Invasion cards batch C

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -144,6 +144,11 @@ player to pay against an alternative consequence.
 
 - `PayCost.Mana(ManaCost)` — pay mana (auto-taps lands via the solver). "...unless you pay {U}{U}"
   (Vaporous Djinn).
+- `PayCost.OwnManaCost` — pay the mana cost of the permanent the cost applies to (its *own* mana
+  cost, read from `CardComponent.manaCost` at payment time). Use for granted abilities like
+  Essence Leak ("...sacrifice this permanent unless you pay its mana cost"), where the affected
+  permanent — not a fixed cost — owns the mana cost. The engine resolves it into a concrete
+  `PayCost.Mana` against that permanent before prompting.
 - `PayCost.PayLife(amount)` — pay N life; offered only when the player has more than N life.
   "...unless you pay 3 life."
 - `PayCost.Discard(filter = Any, count = 1, random = false)` — discard cards matching `filter`.
@@ -1352,6 +1357,12 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
   target itself is excluded, so a lone copy never satisfies its own check; tokens compare by name
   like any other permanent. Resolution-only (reads a chosen target). Used by Winnow ("Destroy
   target nonland permanent if another permanent with the same name is on the battlefield").
+- `EnchantedPermanentMatches(filter)` — true when the permanent the source Aura is attached to
+  matches a `GameObjectFilter` (color, type, etc.), evaluated in projected state via the Aura's
+  `AttachedToComponent`. General-purpose counterpart to the narrow `EnchantedCreatureIsLegendary` /
+  `EnchantedCreatureHasSubtype` conditions. Works as a `ConditionalStaticAbility` gate (also in the
+  trigger resolver for conditionally-granted abilities). Used by Essence Leak ("as long as enchanted
+  permanent is red or green…", `GameObjectFilter.Permanent.withAnyColor(Color.RED, Color.GREEN)`).
 - `YouHaveCitysBlessing` — you have City's Blessing (10+ permanents).
 - `SourceIsRingBearer` — the source permanent is your Ring-bearer (CR 701.52e).
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionBatchCScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionBatchCScenarioTest.kt
@@ -1,0 +1,220 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the Invasion "batch C" cards:
+ *   - Essence Leak  ({U} Aura) — conditional granted upkeep pay-or-sacrifice ("pay its mana cost")
+ *   - Juntu Stakes  ({2} Artifact) — creatures with power 1 or less don't untap
+ *   - Kavu Lair     ({2}{G} Enchantment) — power-4+ creature enters → its controller draws
+ *
+ * Exercises the new engine pieces: PayCost.OwnManaCost and the EnchantedPermanentMatches condition.
+ */
+class InvasionBatchCScenarioTest : ScenarioTestBase() {
+
+    private fun isTapped(game: TestGame, entityId: EntityId): Boolean =
+        game.state.getEntity(entityId)?.get<TappedComponent>() != null
+
+    init {
+        context("Juntu Stakes — power 1 or less don't untap") {
+            test("a power-1 creature stays tapped through its untap step; a power-2 creature untaps") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Juntu Stakes")
+                    .withCardOnBattlefield(1, "Storm Crow", tapped = true)    // 1/2 — should NOT untap
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = true) // 2/2 — should untap
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                    .build()
+
+                val stormCrow = game.findPermanent("Storm Crow")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // Advance from P2's turn into P1's untap + upkeep so P1's permanents untap.
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                withClue("Storm Crow (power 1) does not untap") {
+                    isTapped(game, stormCrow) shouldBe true
+                }
+                withClue("Grizzly Bears (power 2) untaps normally") {
+                    isTapped(game, bears) shouldBe false
+                }
+            }
+        }
+
+        context("Kavu Lair — power 4+ enters → controller draws") {
+            test("casting a 5/5 creature draws a card for its controller") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Kavu Lair")
+                    .withCardInHand(1, "Hulking Cyclops")          // 5/5, {3}{R}{R}
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                val castResult = game.castSpell(1, "Hulking Cyclops")
+                withClue("Hulking Cyclops casts: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Hulking Cyclops resolved onto the battlefield") {
+                    game.isOnBattlefield("Hulking Cyclops") shouldBe true
+                }
+                // Spent the card from hand (-1) but drew one from Kavu Lair (+1): net same count.
+                withClue("Kavu Lair drew P1 a card for the power-5 creature entering") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("a power-3 creature entering does not draw") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Kavu Lair")
+                    .withCardInHand(1, "Hill Giant")               // 3/3, {3}{R}
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                val castResult = game.castSpell(1, "Hill Giant")
+                withClue("Hill Giant casts: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Hill Giant resolved onto the battlefield") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+                // Spent the card (-1), no draw: hand shrinks by one.
+                withClue("Kavu Lair does not trigger for a power-3 creature") {
+                    game.handSize(1) shouldBe handBefore - 1
+                }
+            }
+        }
+
+        context("Essence Leak — conditional upkeep pay-or-sacrifice") {
+            test("on a green creature, paying its mana cost on upkeep keeps it") {
+                // P1 has enough untapped mana ({1}{G}) on the upkeep to pay Grizzly Bears'
+                // own mana cost, so the granted ability offers the pay-or-sacrifice choice.
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // green, {1}{G}
+                    .withCardInHand(1, "Essence Leak")
+                    .withLandsOnBattlefield(1, "Island", 1)        // for the {U} cast
+                    .withLandsOnBattlefield(1, "Forest", 2)        // untapped each upkeep → pays {1}{G}
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val castResult = game.castSpell(1, "Essence Leak", bears)
+                withClue("Essence Leak casts onto Grizzly Bears: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Advance around the table to P1's NEXT upkeep ("your upkeep" = the
+                // enchanted permanent's controller, P1). P2's upkeep en route does not trigger.
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN) // P1 postcombat (this turn)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)               // P2 upkeep
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN) // P2 postcombat
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)               // P1 upkeep
+                game.resolveStack()
+
+                withClue("granted upkeep trigger pauses for pay-its-mana-cost-or-sacrifice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                // Pay Grizzly Bears' own mana cost to keep it.
+                game.answerYesNo(true)
+
+                withClue("Grizzly Bears survives when its controller pays its mana cost") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("on a green creature, declining (or unable to pay) sacrifices it") {
+                // P1 has no spare mana on the upkeep, so the granted ability auto-resolves
+                // to its suffer clause: the enchanted permanent is sacrificed.
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // green, {1}{G}
+                    .withCardInHand(1, "Essence Leak")
+                    .withLandsOnBattlefield(1, "Island", 1)        // only enough for the {U} cast
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Essence Leak", bears)
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("Grizzly Bears is sacrificed when its mana cost can't be paid") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("on a blue creature, the granted ability is inactive — no decision pends") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Storm Crow")        // blue (not red/green)
+                    .withCardInHand(1, "Essence Leak")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crow = game.findPermanent("Storm Crow")!!
+                val castResult = game.castSpell(1, "Essence Leak", crow)
+                withClue("Essence Leak casts onto Storm Crow: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Advance to P1's NEXT upkeep, same as the green case.
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN) // P1 postcombat (this turn)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)               // P2 upkeep
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN) // P2 postcombat
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)               // P1 upkeep
+                game.resolveStack()
+
+                withClue("no decision pends — Storm Crow is neither red nor green") {
+                    game.hasPendingDecision() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -244,6 +244,14 @@ object Conditions {
     fun EnchantedCreatureIsLegendary(): ConditionInterface =
         com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureIsLegendary
 
+    /**
+     * If the permanent enchanted by the source Aura matches [filter] (color, type, etc.).
+     * General-purpose; e.g. `EnchantedPermanentMatches(GameObjectFilter.Permanent.anyColorOf(Color.RED, Color.GREEN))`
+     * for Essence Leak's "as long as enchanted permanent is red or green".
+     */
+    fun EnchantedPermanentMatches(filter: com.wingedsheep.sdk.scripting.GameObjectFilter): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.EnchantedPermanentMatches(filter)
+
     // =========================================================================
     // Life Total Conditions (via Compare)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -68,6 +68,25 @@ data object EnchantedCreatureIsLegendary : Condition {
 }
 
 /**
+ * Condition: "if enchanted permanent matches [filter]".
+ *
+ * Resolves the source Aura's `AttachedToComponent` and checks the attached permanent
+ * against a [GameObjectFilter] in projected state. The general-purpose counterpart to
+ * [EnchantedCreatureHasSubtype] / [EnchantedCreatureIsLegendary]: works for color, type,
+ * or any other filterable property. Used by Essence Leak ("as long as enchanted permanent
+ * is red or green"). The attachment may be any permanent, not just a creature.
+ */
+@SerialName("EnchantedPermanentMatches")
+@Serializable
+data class EnchantedPermanentMatches(val filter: GameObjectFilter) : Condition {
+    override val description: String = "if enchanted permanent is ${filter.description}"
+    override fun applyTextReplacement(replacer: TextReplacer): Condition {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Condition: "if it was historic" (legendary, artifact, or Saga).
  * Checks the triggering entity's card definition for the historic quality.
  * Used for Curator's Ward's "if it was historic" intervening-if condition.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/PayCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/PayCost.kt
@@ -32,6 +32,22 @@ sealed interface PayCost : TextReplaceable<PayCost> {
     }
 
     /**
+     * Pay the mana cost of the permanent the cost applies to (its own mana cost).
+     *
+     * Resolved at payment time by reading the source permanent's `CardComponent.manaCost`,
+     * so it works for granted abilities like Essence Leak ("...sacrifice this permanent
+     * unless you pay its mana cost"), where the affected permanent — not a fixed cost — owns
+     * the mana cost. The engine converts this into a concrete [Mana] cost against that
+     * permanent before prompting.
+     */
+    @SerialName("OwnManaCost")
+    @Serializable
+    data object OwnManaCost : PayCost {
+        override val description: String = "its mana cost"
+        override fun applyTextReplacement(replacer: TextReplacer): PayCost = this
+    }
+
+    /**
      * Discard one or more cards matching a filter.
      * "...unless you discard a land card"
      *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/EssenceLeak.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/EssenceLeak.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Essence Leak
+ * {U}
+ * Enchantment — Aura
+ * Enchant permanent
+ * As long as enchanted permanent is red or green, it has "At the beginning of your
+ * upkeep, sacrifice this permanent unless you pay its mana cost."
+ *
+ * Modeled as a [ConditionalStaticAbility] gating a [GrantTriggeredAbility] over the
+ * attached permanent ([GroupFilter.attachedCreature], which is scope-by-attachment and
+ * works for any permanent type). The condition [Conditions.EnchantedPermanentMatches]
+ * checks the enchanted permanent's color in projected state. The granted upkeep trigger
+ * fires on the enchanted permanent's controller ([Triggers.YourUpkeep]) and uses a
+ * [PayOrSufferEffect] with [PayCost.OwnManaCost] — "pay its mana cost" reads the enchanted
+ * permanent's own mana cost — otherwise that permanent ([EffectTarget.Self]) is sacrificed.
+ */
+val EssenceLeak = card("Essence Leak") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant permanent\n" +
+        "As long as enchanted permanent is red or green, it has \"At the beginning of your " +
+        "upkeep, sacrifice this permanent unless you pay its mana cost.\""
+
+    auraTarget = Targets.Permanent
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantTriggeredAbility(
+                ability = TriggeredAbility.create(
+                    trigger = Triggers.YourUpkeep.event,
+                    binding = Triggers.YourUpkeep.binding,
+                    effect = PayOrSufferEffect(
+                        cost = PayCost.OwnManaCost,
+                        suffer = Effects.SacrificeTarget(EffectTarget.Self)
+                    )
+                ),
+                filter = GroupFilter.attachedCreature()
+            ),
+            condition = Conditions.EnchantedPermanentMatches(
+                GameObjectFilter.Permanent.withAnyColor(Color.RED, Color.GREEN)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "55"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/9099b2e6-9ed8-4a9c-97ca-77cc47678228.jpg?1562924181"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ExoticCurse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ExoticCurse.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Exotic Curse
+ * {2}{B}
+ * Enchantment — Aura
+ * Enchant creature
+ * Domain — Enchanted creature gets -1/-1 for each basic land type among lands you control.
+ */
+val ExoticCurse = card("Exotic Curse") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Domain — Enchanted creature gets -1/-1 for each basic land type among lands you control."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        val negDomain = DynamicAmount.Multiply(DynamicAmounts.domain(), -1)
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.attachedCreature(),
+            powerBonus = negDomain,
+            toughnessBonus = negDomain
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Dany Orizio"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8ee35d99-9a8a-421b-bf43-74446909d87d.jpg?1562923839"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/JuntuStakes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/JuntuStakes.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Juntu Stakes
+ * {2}
+ * Artifact
+ * Creatures with power 1 or less don't untap during their controllers' untap steps.
+ */
+val JuntuStakes = card("Juntu Stakes") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "Creatures with power 1 or less don't untap during their controllers' untap steps."
+
+    staticAbility {
+        ability = GrantKeyword(
+            AbilityFlag.DOESNT_UNTAP.name,
+            filter = GroupFilter(GameObjectFilter.Creature.powerAtMost(1))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "304"
+        artist = "Mark Brill"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3ab7cf53-f62d-47e1-af70-ab12be0d22e2.jpg?1562906885"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuLair.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuLair.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+
+/**
+ * Kavu Lair
+ * {2}{G}
+ * Enchantment
+ * Whenever a creature with power 4 or greater enters, its controller draws a card.
+ */
+val KavuLair = card("Kavu Lair") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature with power 4 or greater enters, its controller draws a card."
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            ZoneChangeEvent(filter = GameObjectFilter.Creature.powerAtLeast(4), to = Zone.BATTLEFIELD),
+            TriggerBinding.ANY
+        )
+        controlledByTriggeringEntityController = true
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "193"
+        artist = "Chippy"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4581b53-23a0-4ca6-a77c-97d79e7a6570.jpg?1562944142"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -277,10 +277,29 @@ class TriggerAbilityResolver(
             val allStaticAbilities = sourceDef.script.effectiveStaticAbilities(classLevel)
 
             for (ability in allStaticAbilities) {
-                if (ability is GrantTriggeredAbility &&
-                    ability.filter.scope is Scope.AttachedTo
-                ) {
-                    result.add(ability.ability)
+                when (ability) {
+                    is GrantTriggeredAbility ->
+                        if (ability.filter.scope is Scope.AttachedTo) result.add(ability.ability)
+
+                    // "As long as enchanted permanent is X, it has '<triggered ability>'" —
+                    // a conditional grant (e.g. Essence Leak). Only contribute the granted ability
+                    // while the gating condition holds, evaluated with the Aura as the source so
+                    // EnchantedPermanentMatches resolves the attached permanent.
+                    is ConditionalStaticAbility -> {
+                        val grant = ability.ability as? GrantTriggeredAbility ?: continue
+                        if (grant.filter.scope !is Scope.AttachedTo) continue
+                        val controllerId = state.projectedState.getController(permanentId) ?: continue
+                        val context = EffectContext(
+                            sourceId = permanentId,
+                            controllerId = controllerId,
+                            opponentId = null
+                        )
+                        if (ConditionEvaluator().evaluate(state, ability.condition, context)) {
+                            result.add(grant.ability)
+                        }
+                    }
+
+                    else -> {}
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -42,6 +42,7 @@ import com.wingedsheep.sdk.scripting.conditions.Compare
 import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureHasSubtype
+import com.wingedsheep.sdk.scripting.conditions.EnchantedPermanentMatches
 import com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureIsLegendary
 import com.wingedsheep.sdk.scripting.conditions.Exists
 import com.wingedsheep.sdk.scripting.conditions.IsInPhase
@@ -166,6 +167,7 @@ class ConditionEvaluator {
 
             is EnchantedCreatureHasSubtype -> evaluateEnchantedCreatureHasSubtypeCtx(state, condition, ctx)
             is EnchantedCreatureIsLegendary -> evaluateEnchantedCreatureIsLegendaryCtx(state, ctx)
+            is EnchantedPermanentMatches -> evaluateEnchantedPermanentMatchesCtx(state, condition, ctx)
 
             // Player-relative trackers (resolve [Player] against the current context).
             is PlayerAttackedWithCreaturesThisTurn -> evaluateAttackedWithCreaturesCtx(state, condition, ctx)
@@ -376,6 +378,26 @@ class ConditionEvaluator {
             is Projection -> return false
         }
         return "LEGENDARY" in ctx.projectedStateFor(state).getTypes(creatureId)
+    }
+
+    private fun evaluateEnchantedPermanentMatchesCtx(
+        state: GameState,
+        condition: EnchantedPermanentMatches,
+        ctx: ConditionEvaluationContext
+    ): Boolean {
+        val sourceId = ctx.sourceId ?: return false
+        val attached = state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId
+        val permanentId = attached ?: when (ctx) {
+            is Resolution -> sourceId  // resolution-mode fallback (granted-ability scope)
+            is Projection -> return false
+        }
+        val projected = ctx.projectedStateFor(state)
+        val predicateContext = when (ctx) {
+            is Resolution -> PredicateContext.fromEffectContext(ctx.effectContext)
+            is Projection -> ctx.controllerId?.let { PredicateContext(controllerId = it) }
+                ?: PredicateContext(controllerId = sourceId)
+        }
+        return PredicateEvaluator().matches(state, projected, permanentId, condition.filter, predicateContext)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -394,8 +394,13 @@ class ConditionEvaluator {
         val projected = ctx.projectedStateFor(state)
         val predicateContext = when (ctx) {
             is Resolution -> PredicateContext.fromEffectContext(ctx.effectContext)
-            is Projection -> ctx.controllerId?.let { PredicateContext(controllerId = it) }
-                ?: PredicateContext(controllerId = sourceId)
+            is Projection -> {
+                // "You" (for any controller predicate in [filter]) is the Aura's controller.
+                // Fall back to the source's projected controller rather than miscasting the
+                // source entity id as a player id; if even that is unknown, we can't evaluate.
+                val controller = ctx.controllerId ?: projected.getController(sourceId) ?: return false
+                PredicateContext(controllerId = controller)
+            }
         }
         return PredicateEvaluator().matches(state, projected, permanentId, condition.filter, predicateContext)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -217,6 +217,7 @@ class TurnFaceUpHandler(
             }
             is PayCost.Choice -> return "Choice morph costs are not supported"
             is PayCost.Tap -> return "Tap morph costs are not supported"
+            is PayCost.OwnManaCost -> return "Own-mana-cost morph costs are not supported"
         }
 
         return null
@@ -472,6 +473,7 @@ class TurnFaceUpHandler(
             }
             is PayCost.Choice -> return ExecutionResult.error(currentState, "Choice morph costs are not supported")
             is PayCost.Tap -> return ExecutionResult.error(currentState, "Tap morph costs are not supported")
+            is PayCost.OwnManaCost -> return ExecutionResult.error(currentState, "Own-mana-cost morph costs are not supported")
         }
 
         // Turn the creature face up and add static ability components

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -69,6 +69,8 @@ class PayOrSufferExecutor(
             is PayCost.Sacrifice -> handleSacrificeCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
             is PayCost.PayLife -> handlePayLifeCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
             is PayCost.Mana -> handleManaCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
+            is PayCost.OwnManaCost ->
+                handleManaCost(state, effect, context, PayCost.Mana(sourceCard.manaCost), sourceId, sourceCard.name, payingPlayerId)
             is PayCost.Exile -> handleExileCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
             is PayCost.Choice -> handleChoiceCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
             is PayCost.Tap -> handleTapCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
@@ -621,6 +623,10 @@ class PayOrSufferExecutor(
                 life > cost.amount
             }
             is PayCost.Mana -> ManaSolver(cardRegistry).canPay(state, playerId, cost.cost)
+            is PayCost.OwnManaCost -> {
+                val ownCost = state.getEntity(sourceId)?.get<CardComponent>()?.manaCost
+                ownCost != null && ManaSolver(cardRegistry).canPay(state, playerId, ownCost)
+            }
             is PayCost.Exile -> findValidCardsInZone(state, playerId, cost.filter, cost.zone).size >= cost.count
             is PayCost.Choice -> cost.options.any { canPayCost(state, playerId, it, sourceId) }
             is PayCost.Tap -> findValidUntappedPermanentsOnBattlefield(state, playerId, cost.filter, sourceId).size >= cost.count

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -69,6 +69,9 @@ class PayOrSufferExecutor(
             is PayCost.Sacrifice -> handleSacrificeCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
             is PayCost.PayLife -> handlePayLifeCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
             is PayCost.Mana -> handleManaCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
+            // "...pay its mana cost": pay the affected permanent's own mana cost. A permanent
+            // with no mana cost (a land, a token) has an empty ManaCost, which resolves to {0}
+            // and is trivially payable, so such a permanent is always kept.
             is PayCost.OwnManaCost ->
                 handleManaCost(state, effect, context, PayCost.Mana(sourceCard.manaCost), sourceId, sourceCard.name, payingPlayerId)
             is PayCost.Exile -> handleExileCost(state, effect, context, cost, sourceId, sourceCard.name, payingPlayerId)
@@ -624,6 +627,8 @@ class PayOrSufferExecutor(
             }
             is PayCost.Mana -> ManaSolver(cardRegistry).canPay(state, playerId, cost.cost)
             is PayCost.OwnManaCost -> {
+                // Null only when the source entity/CardComponent is missing; an empty mana cost
+                // (lands, tokens) is {0} and always payable — see the execute branch above.
                 val ownCost = state.getEntity(sourceId)?.get<CardComponent>()?.manaCost
                 ownCost != null && ManaSolver(cardRegistry).canPay(state, playerId, ownCost)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
@@ -180,6 +180,9 @@ class TurnFaceUpEnumerator : ActionEnumerator {
                 is PayCost.Tap -> {
                     // Tap morph costs not supported
                 }
+                is PayCost.OwnManaCost -> {
+                    // Own-mana-cost morph costs not supported
+                }
             }
         }
 


### PR DESCRIPTION
Implements four Invasion (INV) cards via the `add-card` workflow.

## Cards added

- **Exotic Curse** — `{2}{B}` Aura. Domain: enchanted creature gets -1/-1 for each basic land type among lands you control. Composed from `GrantDynamicStatsEffect` + `DynamicAmounts.domain()` negated with `Multiply(-1)` (mirrors Withering Hex). No engine changes.
- **Juntu Stakes** — `{2}` Artifact. Creatures with power 1 or less don't untap during their controllers' untap steps. `GrantKeyword(DOESNT_UNTAP)` over a battlefield `Creature.powerAtMost(1)` group, reusing the existing untap-prevention ability flag. No engine changes.
- **Kavu Lair** — `{2}{G}` Enchantment. Whenever a power-4+ creature enters, its controller draws. `ZoneChangeEvent(Creature.powerAtLeast(4))` trigger with `controlledByTriggeringEntityController` (mirrors Death Match). No engine changes.
- **Essence Leak** — `{U}` Aura. While the enchanted permanent is red or green, it has "At the beginning of your upkeep, sacrifice this permanent unless you pay its mana cost."

None skipped.

## Engine / SDK additions (for Essence Leak)

Both are general-purpose and reusable:

- **`PayCost.OwnManaCost`** — pay the affected permanent's *own* mana cost (read from `CardComponent.manaCost` at payment time), resolved into a concrete `PayCost.Mana` inside `PayOrSufferExecutor`. The two morph cost sites reject it explicitly.
- **`Conditions.EnchantedPermanentMatches(filter)`** — generalizes the narrow `EnchantedCreatureIsLegendary` / `EnchantedCreatureHasSubtype` conditions to any `GameObjectFilter` (color, type, …), evaluated against the Aura's `AttachedToComponent` in both resolution and projection.
- `TriggerAbilityResolver.getAttachedGrantedTriggeredAbilities` now unwraps `ConditionalStaticAbility`-wrapped grants (mirroring the existing `GrantWard` path), so a conditionally-granted triggered ability is detected while its gate holds.

## Tests

- `InvasionBatchCScenarioTest` (game-server): Juntu Stakes untap suppression (power 1 vs 2), Kavu Lair draw on power-5 / no-draw on power-3, and Essence Leak pay-its-mana-cost (survives) / can't-pay (sacrificed) / inactive-on-blue.
- Full `:rules-engine:test`, `:mtg-sets:test`, and related game-server scenario tests (VileConsumption, morph, Death Match) pass.

## Docs

- Updated `docs/card-sdk-language-reference.md` (PayCost and Conditions sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)