### PR TITLE
Seeded deterministic RNG for reproducible game runs

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -82,6 +82,7 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.ProtectionScope
@@ -157,7 +158,11 @@ abstract class ScenarioTestBase : FunSpec() {
      */
     inner class ScenarioBuilder {
         private val entityIdCounter = AtomicLong(1000)
-        private var state = GameState()
+        // Seed the deterministic RNG with fresh entropy per scenario build so coin flips and other
+        // "at random" effects vary across repeated builds — scenario tests that run a setup N times
+        // to observe both branches of a flip (Goblin Psychopath, Grip of Chaos) depend on this. A
+        // bare GameState() would reuse seed 0 every build and freeze the outcome.
+        private var state = GameState(rng = GameRng.seeded(System.nanoTime()))
 
         private var player1Id: EntityId? = null
         private var player2Id: EntityId? = null

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ProtocolTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ProtocolTestBase.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
@@ -110,7 +111,9 @@ abstract class ProtocolTestBase : FunSpec() {
      */
     inner class ScenarioBuilder {
         private val entityIdCounter = AtomicLong(1000)
-        private var state = GameState()
+        // Fresh-entropy RNG seed per build so "at random" effects vary across repeated builds —
+        // see the matching note in ScenarioTestBase.ScenarioBuilder.
+        private var state = GameState(rng = GameRng.seeded(System.nanoTime()))
 
         private var player1Id: EntityId = EntityId.of("player-1")
         private var player2Id: EntityId = EntityId.of("player-2")

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
@@ -299,8 +299,14 @@ class GameEnvironment private constructor(
 
             val action = if (pendingDecision != null) {
                 val decision = pendingDecision!!
-                val response = selector?.respondToDecision(state, decision)
-                    ?: defaultDecisionResponder.respond(state, decision, player)
+                // A selector signals "I don't handle decisions" by throwing
+                // UnsupportedOperationException (see RandomActionSelector); fall back to the
+                // built-in responder in that case, as its contract promises.
+                val response = try {
+                    selector?.respondToDecision(state, decision)
+                } catch (e: UnsupportedOperationException) {
+                    null
+                } ?: defaultDecisionResponder.respond(state, decision, player)
                 SubmitDecision(player, response)
             } else {
                 val actions = legalActions()

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/GameRng.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/GameRng.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.sdk.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A pure, immutable, deterministic pseudo-random number generator.
+ *
+ * Every draw returns a value paired with the *next* [GameRng] — the generator never mutates in
+ * place. This is what lets the engine stay a pure function `(GameState, GameAction) -> Result`
+ * while still flipping coins and shuffling libraries: the RNG state lives inside [GameState] and is
+ * threaded back out with the rest of the new state. Two games started from the same seed and fed
+ * the same actions therefore produce byte-identical states — the property replays, MCTS rollouts,
+ * and the cross-engine parity harness all rely on.
+ *
+ * The algorithm is SplitMix64 (Steele, Lea & Flood 2014): a fixed-increment Weyl sequence run
+ * through a strong finalizing mix. It is fast, has a full 2^64 period, passes the standard
+ * statistical batteries, and — crucially here — is trivially serializable as a single [Long] and
+ * supports cheap [split] into independent sub-streams.
+ *
+ * Do NOT use this for anything security-sensitive; it is not cryptographic.
+ */
+@Serializable
+data class GameRng(val state: Long) {
+
+    /** Returns a uniformly distributed 64-bit value and the advanced generator. */
+    fun nextLong(): Pair<Long, GameRng> {
+        val newState = state + GOLDEN_GAMMA
+        return mix64(newState) to GameRng(newState)
+    }
+
+    /**
+     * Returns a uniformly distributed value in `[0, bound)` and the advanced generator.
+     *
+     * Uses rejection sampling on the top 31 bits so the result is unbiased even when [bound] is
+     * not a power of two (the same technique as `java.util.Random.nextInt`).
+     */
+    fun nextInt(bound: Int): Pair<Int, GameRng> {
+        require(bound > 0) { "bound must be positive, was $bound" }
+        var rng = this
+        while (true) {
+            val (raw, next) = rng.nextLong()
+            rng = next
+            val bits = (raw ushr 33).toInt() // 31-bit non-negative
+            val value = bits % bound
+            // Reject the few high values that would skew the distribution.
+            if (bits - value + (bound - 1) >= 0) return value to rng
+        }
+    }
+
+    /** Returns a fair coin flip and the advanced generator. */
+    fun nextBoolean(): Pair<Boolean, GameRng> {
+        val (raw, next) = nextLong()
+        return ((raw ushr 63) != 0L) to next
+    }
+
+    /** Returns a uniformly distributed double in `[0, 1)` and the advanced generator. */
+    fun nextDouble(): Pair<Double, GameRng> {
+        val (raw, next) = nextLong()
+        return ((raw ushr 11) * DOUBLE_UNIT) to next
+    }
+
+    /**
+     * Returns a new list with [list]'s elements in a uniformly random order and the advanced
+     * generator. Implemented as an in-place Fisher–Yates on a copy, so the input is untouched.
+     */
+    fun <T> shuffle(list: List<T>): Pair<List<T>, GameRng> {
+        if (list.size < 2) return list.toList() to this
+        val arr = list.toMutableList()
+        var rng = this
+        for (i in arr.indices.reversed()) {
+            if (i == 0) break
+            val (j, next) = rng.nextInt(i + 1)
+            rng = next
+            val tmp = arr[i]
+            arr[i] = arr[j]
+            arr[j] = tmp
+        }
+        return arr.toList() to rng
+    }
+
+    /**
+     * Returns a uniformly chosen element of [list] and the advanced generator.
+     * @throws NoSuchElementException if [list] is empty.
+     */
+    fun <T> pick(list: List<T>): Pair<T, GameRng> {
+        if (list.isEmpty()) throw NoSuchElementException("Cannot pick from an empty list")
+        val (i, next) = nextInt(list.size)
+        return list[i] to next
+    }
+
+    /**
+     * Forks an independent sub-stream off this generator. Returns `(child, parent')`: the child is
+     * seeded from a freshly mixed output so it diverges immediately, and the parent advances past
+     * the draw. Use this to give an isolated event (e.g. each player's opening shuffle) its own
+     * stream so adding or removing an unrelated random event elsewhere doesn't perturb it.
+     */
+    fun split(): Pair<GameRng, GameRng> {
+        val (childSeed, advanced) = nextLong()
+        return GameRng(childSeed) to advanced
+    }
+
+    companion object {
+        /** The odd "golden ratio" increment for the Weyl sequence (SplitMix64). */
+        private const val GOLDEN_GAMMA: Long = -0x61c8864680b583ebL // 0x9E3779B97F4A7C15
+        private const val DOUBLE_UNIT: Double = 1.0 / (1L shl 53)
+
+        /** Construct a generator from a user-supplied seed. */
+        fun seeded(seed: Long): GameRng = GameRng(seed)
+
+        /** SplitMix64 finalizing mix: scrambles a Weyl-sequence value into a strong 64-bit output. */
+        private fun mix64(z0: Long): Long {
+            var z = z0
+            z = (z xor (z ushr 30)) * -0x40a7b892e31b1a47L // 0xBF58476D1CE4E5B9
+            z = (z xor (z ushr 27)) * -0x6b2fb644ecceee15L // 0x94D049BB133111EB
+            return z xor (z ushr 31)
+        }
+    }
+}

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/model/GameRngTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/model/GameRngTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.sdk.model
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.doubles.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.serialization.json.Json
+import kotlin.math.abs
+
+class GameRngTest : DescribeSpec({
+
+    describe("determinism") {
+        it("produces the same sequence from the same seed") {
+            val a = generateSequence(GameRng.seeded(42L)) { it.nextLong().second }
+                .drop(1).take(100).map { it.state }.toList()
+            val b = generateSequence(GameRng.seeded(42L)) { it.nextLong().second }
+                .drop(1).take(100).map { it.state }.toList()
+            a shouldContainExactly b
+        }
+
+        it("produces different sequences from different seeds") {
+            val (a, _) = GameRng.seeded(1L).nextLong()
+            val (b, _) = GameRng.seeded(2L).nextLong()
+            a shouldNotBe b
+        }
+
+        it("never mutates the receiver — re-drawing yields the same value") {
+            val rng = GameRng.seeded(7L)
+            val (first, _) = rng.nextLong()
+            val (again, _) = rng.nextLong()
+            first shouldBe again
+        }
+    }
+
+    describe("nextInt") {
+        it("stays within [0, bound)") {
+            var rng = GameRng.seeded(123L)
+            repeat(10_000) {
+                val (v, next) = rng.nextInt(6)
+                v shouldBeGreaterThanOrEqual 0
+                v shouldBeLessThan 6
+                rng = next
+            }
+        }
+
+        it("rejects a non-positive bound") {
+            try {
+                GameRng.seeded(1L).nextInt(0)
+                throw AssertionError("expected IllegalArgumentException")
+            } catch (e: IllegalArgumentException) {
+                // expected
+            }
+        }
+
+        it("is roughly uniform across buckets") {
+            var rng = GameRng.seeded(999L)
+            val counts = IntArray(10)
+            val n = 100_000
+            repeat(n) {
+                val (v, next) = rng.nextInt(10)
+                counts[v]++
+                rng = next
+            }
+            val expected = n / 10.0
+            counts.forEach { abs(it - expected) shouldBeLessThan expected } // within 100% of expected
+        }
+    }
+
+    describe("nextDouble") {
+        it("stays within [0, 1)") {
+            var rng = GameRng.seeded(55L)
+            repeat(10_000) {
+                val (v, next) = rng.nextDouble()
+                v shouldBeGreaterThanOrEqual 0.0
+                v shouldBeLessThan 1.0
+                rng = next
+            }
+        }
+    }
+
+    describe("shuffle") {
+        it("is a permutation — preserves the multiset of elements") {
+            val input = (1..52).toList()
+            val (shuffled, _) = GameRng.seeded(2024L).shuffle(input)
+            shuffled shouldContainExactlyInAnyOrder input
+        }
+
+        it("does not mutate the input list") {
+            val input = (1..10).toList()
+            GameRng.seeded(1L).shuffle(input)
+            input shouldContainExactly (1..10).toList()
+        }
+
+        it("is deterministic for a given seed") {
+            val input = (1..20).toList()
+            val (a, _) = GameRng.seeded(8L).shuffle(input)
+            val (b, _) = GameRng.seeded(8L).shuffle(input)
+            a shouldContainExactly b
+        }
+
+        it("handles empty and singleton lists") {
+            GameRng.seeded(1L).shuffle(emptyList<Int>()).first shouldBe emptyList()
+            GameRng.seeded(1L).shuffle(listOf(7)).first shouldBe listOf(7)
+        }
+    }
+
+    describe("pick") {
+        it("returns an element of the list") {
+            val list = listOf("a", "b", "c")
+            val (v, _) = GameRng.seeded(3L).pick(list)
+            (v in list) shouldBe true
+        }
+    }
+
+    describe("split") {
+        it("yields a child stream that diverges from the parent") {
+            val (child, parent) = GameRng.seeded(100L).split()
+            child.state shouldNotBe parent.state
+            val (childVal, _) = child.nextLong()
+            val (parentVal, _) = parent.nextLong()
+            childVal shouldNotBe parentVal
+        }
+
+        it("is deterministic — same seed splits the same way") {
+            val (c1, p1) = GameRng.seeded(5L).split()
+            val (c2, p2) = GameRng.seeded(5L).split()
+            c1 shouldBe c2
+            p1 shouldBe p2
+        }
+    }
+
+    describe("serialization") {
+        it("round-trips through JSON preserving stream position") {
+            val rng = GameRng.seeded(77L).nextLong().second.nextLong().second
+            val json = Json.encodeToString(GameRng.serializer(), rng)
+            val restored = Json.decodeFromString(GameRng.serializer(), json)
+            restored shouldBe rng
+            // A restored generator continues the identical sequence.
+            rng.nextLong().first shouldBe restored.nextLong().first
+        }
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -168,7 +168,11 @@ class GameInitializer(
 
         // 1. Create player entities
         for (playerConfig in config.players) {
-            val playerId = playerConfig.playerId ?: EntityId.generate()
+            val playerId = playerConfig.playerId ?: run {
+                val (id, s) = state.newEntity()
+                state = s
+                id
+            }
             playerIds.add(playerId)
 
             val startingLife = formatStartingLife ?: playerConfig.startingLife
@@ -219,7 +223,8 @@ class GameInitializer(
 
             if (commanderName != null) {
                 val cardDef = cardRegistry.requireCard(commanderName)
-                val cardId = EntityId.generate()
+                val (cardId, stateWithId) = state.newEntity()
+                state = stateWithId
                 val cardContainer = createCardEntity(cardDef, playerId, playerConfig.deck.commanderPrinting).with(
                     com.wingedsheep.engine.state.components.identity.CommanderComponent(ownerId = playerId)
                 )
@@ -236,7 +241,8 @@ class GameInitializer(
             }
             for (entry in libraryEntries) {
                 val cardDef = cardRegistry.requireCard(entry.name)
-                val cardId = EntityId.generate()
+                val (cardId, stateWithId) = state.newEntity()
+                state = stateWithId
                 val cardContainer = createCardEntity(cardDef, playerId, entry.printing)
                 state = state.withEntity(cardId, cardContainer)
                 state = state.addToZone(ZoneKey(playerId, Zone.LIBRARY), cardId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardEntry
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
 import com.wingedsheep.sdk.model.PrintingRef
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.scripting.KeywordAbility
@@ -60,6 +61,15 @@ data class GameConfig(
      * 20-life / 7-card / no-commander behaviour without changes.
      */
     val format: Format = Format.Standard,
+
+    /**
+     * Seed for the game's deterministic RNG (turn order, library shuffles, coin flips, every
+     * "at random" choice). When null, the initializer draws a fresh seed from entropy so live
+     * play stays random — but the chosen seed is always recorded on [InitializationResult.seed],
+     * so any game can be reproduced after the fact by replaying with that seed. Supply an explicit
+     * value for reproducible runs (replays, MCTS, the cross-engine parity harness, tests).
+     */
+    val seed: Long? = null,
 )
 
 /**
@@ -68,7 +78,13 @@ data class GameConfig(
 data class InitializationResult(
     val state: GameState,
     val events: List<GameEvent>,
-    val playerIds: List<EntityId>
+    val playerIds: List<EntityId>,
+    /**
+     * The seed actually used to initialize [state]'s RNG — either [GameConfig.seed] or, when that
+     * was null, the freshly drawn entropy seed. Persist this alongside the game to make it
+     * reproducible.
+     */
+    val seed: Long,
 )
 
 /**
@@ -120,7 +136,11 @@ class GameInitializer(
         require(config.players.size >= 2) { "Need at least 2 players" }
 
         val events = mutableListOf<GameEvent>()
-        var state = GameState(format = config.format)
+        // Resolve the seed up front: explicit when supplied, otherwise fresh entropy. Either way it
+        // is recorded on the result so the game is reproducible later. This clock read is the one
+        // sanctioned non-determinism boundary — once seeded, the engine is a pure function again.
+        val resolvedSeed: Long = config.seed ?: System.nanoTime()
+        var state = GameState(format = config.format, rng = GameRng.seeded(resolvedSeed))
         val playerIds = mutableListOf<EntityId>()
 
         // Validate Commander-format prerequisites up front. Each player must designate a
@@ -172,7 +192,9 @@ class GameInitializer(
             val idx = config.startingPlayerIndex
             playerIds.subList(idx, playerIds.size) + playerIds.subList(0, idx)
         } else {
-            playerIds.shuffled()
+            val (order, shuffledState) = state.nextRandom { shuffle(playerIds) }
+            state = shuffledState
+            order
         }
         state = state.copy(
             turnOrder = shuffledOrder,
@@ -258,7 +280,7 @@ class GameInitializer(
             )
         }
 
-        return InitializationResult(state, events, playerIds)
+        return InitializationResult(state, events, playerIds, resolvedSeed)
     }
 
     /**
@@ -366,8 +388,8 @@ class GameInitializer(
      */
     private fun shuffleLibrary(state: GameState, playerId: EntityId): GameState {
         val libraryKey = ZoneKey(playerId, Zone.LIBRARY)
-        val library = state.getZone(libraryKey).shuffled()
-        return state.copy(zones = state.zones + (libraryKey to library))
+        val (library, newState) = state.nextRandom { shuffle(state.getZone(libraryKey)) }
+        return newState.copy(zones = newState.zones + (libraryKey to library))
     }
 
     /**
@@ -460,14 +482,16 @@ class GameInitializer(
 
         println("[HandSmoother] deck=${library.size} cards, landRatio=${"%.3f".format(deckLandRatio)}, colorRatios=$deckColorRatios")
 
-        // Generate candidate hands
+        // Generate candidate hands. Thread the RNG through each candidate shuffle so hand smoothing
+        // is reproducible too; carry the advanced state into the rest of the routine below.
+        var workingState = state
         val candidates = mutableListOf<List<EntityId>>()
         val effectiveCandidateCount = candidateCount.coerceIn(2, 3)
 
         repeat(effectiveCandidateCount) {
-            val shuffledLibrary = library.shuffled()
-            val candidateHand = shuffledLibrary.takeLast(count)
-            candidates.add(candidateHand)
+            val (shuffledLibrary, advanced) = workingState.nextRandom { shuffle(library) }
+            workingState = advanced
+            candidates.add(shuffledLibrary.takeLast(count))
         }
 
         // Score each candidate and select the best one
@@ -485,8 +509,8 @@ class GameInitializer(
             println("[HandSmoother] candidate ${index + 1}: ${landCount} lands, score=${"%.4f".format(score)}$selected")
         }
 
-        // Apply the selected hand to the state
-        var currentState = state
+        // Apply the selected hand to the state (continuing from the RNG-advanced workingState).
+        var currentState = workingState
         val events = mutableListOf<GameEvent>()
         val drawnCardIds = mutableListOf<EntityId>()
 
@@ -497,8 +521,9 @@ class GameInitializer(
         }
 
         // Shuffle the remaining library
-        newLibrary = newLibrary.shuffled().toMutableList()
-        currentState = currentState.copy(zones = currentState.zones + (libraryKey to newLibrary))
+        val (shuffledRemaining, advancedState) = currentState.nextRandom { shuffle(newLibrary) }
+        newLibrary = shuffledRemaining.toMutableList()
+        currentState = advancedState.copy(zones = advancedState.zones + (libraryKey to newLibrary))
 
         // Add cards to hand
         for (cardId in bestCandidate) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -324,6 +324,7 @@ class CostHandler(
                 CostPaymentResult.success(newState, manaPool, events)
             }
             is AbilityCost.Discard -> {
+                var workState = state
                 val toDiscard: List<EntityId> = if (cost.atRandom) {
                     // Engine chooses the discarded cards at random — no player selection.
                     val eligible = findMatchingCardsUnified(
@@ -332,7 +333,9 @@ class CostHandler(
                     if (eligible.size < cost.count) {
                         return CostPaymentResult.failure("Not enough cards to discard at random")
                     }
-                    eligible.shuffled().take(cost.count)
+                    val (shuffled, advanced) = state.nextRandom { shuffle(eligible) }
+                    workState = advanced
+                    shuffled.take(cost.count)
                 } else {
                     if (choices.discardChoices.size < cost.count) {
                         return CostPaymentResult.failure("Must choose ${cost.count} card(s) to discard")
@@ -341,7 +344,7 @@ class CostHandler(
                 }
 
                 val result = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
-                    .discardCards(state, controllerId, toDiscard)
+                    .discardCards(workState, controllerId, toDiscard)
                 CostPaymentResult.success(result.state, manaPool, result.events)
             }
             is AbilityCost.DiscardHand -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/MulliganHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/MulliganHandler.kt
@@ -103,8 +103,8 @@ class MulliganHandler {
         // 2. Shuffle library (clearing any per-card reveals first)
         newState = com.wingedsheep.engine.handlers.effects.library.LibraryRevealUtils
             .clearLibraryReveals(newState, playerId)
-        val shuffledLibrary = newState.getZone(libraryKey).shuffled()
-        newState = newState.copy(zones = newState.zones + (libraryKey to shuffledLibrary))
+        val (shuffledLibrary, shuffledState) = newState.nextRandom { shuffle(newState.getZone(libraryKey)) }
+        newState = shuffledState.copy(zones = shuffledState.zones + (libraryKey to shuffledLibrary))
         events.add(LibraryShuffledEvent(playerId))
 
         // 3. Update mulligan count

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
@@ -24,7 +24,6 @@ import com.wingedsheep.engine.state.permissions.MayPlayPermission
 import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.SourcePlottedOnPriorTurn
 import kotlin.reflect.KClass
@@ -201,9 +200,10 @@ class PlotCardHandler(
             c.with(PlottedComponent(controllerId = action.playerId, turnPlotted = currentState.turnNumber))
                 .with(PlayWithoutPayingCostComponent(controllerId = action.playerId, permanent = true))
         }
-        currentState = currentState.addMayPlayPermission(
+        val (permId, stateWithPerm) = currentState.newEntity()
+        currentState = stateWithPerm.addMayPlayPermission(
             MayPlayPermission(
-                id = EntityId.generate(),
+                id = permId,
                 cardIds = setOf(action.cardId),
                 controllerId = action.playerId,
                 sourceId = action.cardId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ChainSpellContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ChainSpellContinuationResumer.kt
@@ -195,8 +195,14 @@ class ChainSpellContinuationResumer(
         // Targets are re-chosen via the chain target flow, so modeTargetsOrdered
         // is not inherited (the copy controller picks a new target above).
         val sourceSpell = continuation.sourceId?.let { state.getEntity(it)?.get<SpellOnStackComponent>() }
+        val (effectiveState, sourceId) = if (continuation.sourceId != null) {
+            state to continuation.sourceId
+        } else {
+            val (id, s) = state.newEntity()
+            s to id
+        }
         val ability = TriggeredAbilityOnStackComponent(
-            sourceId = continuation.sourceId ?: EntityId.generate(),
+            sourceId = sourceId,
             sourceName = effect.spellName,
             controllerId = continuation.copyControllerId,
             effect = copyEffect,
@@ -208,7 +214,7 @@ class ChainSpellContinuationResumer(
         val targets = listOf(chosenTarget)
         val targetRequirements = listOf(copyTargetReq)
 
-        val putResult = services.stackResolver.putTriggeredAbility(state, ability, targets, targetRequirements)
+        val putResult = services.stackResolver.putTriggeredAbility(effectiveState, ability, targets, targetRequirements)
 
         if (!putResult.isSuccess) {
             return putResult

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CombatContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CombatContinuationResumer.kt
@@ -182,11 +182,14 @@ class CombatContinuationResumer(
         val originalShield = if (shieldIndex >= 0) updatedEffects.removeAt(shieldIndex) else null
 
         val timestamp = originalShield?.timestamp ?: state.timestamp
+        var workingState = state
         for ((sourceId, preventionAmount) in response.distribution) {
             if (preventionAmount <= 0) continue
+            val (effectId, advanced) = workingState.newEntity()
+            workingState = advanced
             updatedEffects.add(
                 ActiveFloatingEffect(
-                    id = EntityId(java.util.UUID.randomUUID().toString()),
+                    id = effectId,
                     effect = FloatingEffectData(
                         layer = Layer.ABILITY,
                         modification = SerializableModification.PreventNextDamage(preventionAmount, onlyFromSource = sourceId),
@@ -201,7 +204,7 @@ class CombatContinuationResumer(
             )
         }
 
-        val newState = state.copy(floatingEffects = updatedEffects)
+        val newState = workingState.copy(floatingEffects = updatedEffects)
 
         return services.combatManager.applyCombatDamage(newState, firstStrike = continuation.firstStrike)
     }
@@ -254,14 +257,19 @@ class CombatContinuationResumer(
         val chosenSourceId = response.selectedCards.firstOrNull()
             ?: return ExecutionResult.error(state, "No source selected")
 
-        val deflectSourceId = continuation.sourceId ?: EntityId.generate()
+        val (effectiveState, deflectSourceId) = if (continuation.sourceId != null) {
+            state to continuation.sourceId
+        } else {
+            val (id, s) = state.newEntity()
+            s to id
+        }
 
         val context = EffectContext(
             sourceId = continuation.sourceId,
             controllerId = continuation.controllerId,
             opponentId = null
         )
-        val newState = state.addFloatingEffect(
+        val newState = effectiveState.addFloatingEffect(
             layer = Layer.ABILITY,
             modification = SerializableModification.DeflectNextDamageFromSource(
                 damageSourceId = chosenSourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -739,9 +739,10 @@ class LibraryAndZoneContinuationResumer(
         var stateWithGrant = afterBottom.updateEntity(continuation.cascadeCardId) { container ->
             container.with(PlayWithoutPayingCostComponent(controllerId = continuation.playerId))
         }
-        stateWithGrant = stateWithGrant.addMayPlayPermission(
+        val (permId, stateWithPerm) = stateWithGrant.newEntity()
+        stateWithGrant = stateWithPerm.addMayPlayPermission(
             MayPlayPermission(
-                id = EntityId.generate(),
+                id = permId,
                 cardIds = setOf(continuation.cascadeCardId),
                 controllerId = continuation.playerId,
                 sourceId = continuation.sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -466,8 +466,8 @@ object ZoneTransitionService {
                 currentState = com.wingedsheep.engine.handlers.effects.library.LibraryRevealUtils
                     .clearLibraryReveals(currentState, ownerId)
                 val libraryZone = ZoneKey(ownerId, Zone.LIBRARY)
-                val library = currentState.getZone(libraryZone).shuffled()
-                currentState = currentState.copy(zones = currentState.zones + (libraryZone to library))
+                val (library, shuffledState) = currentState.nextRandom { shuffle(currentState.getZone(libraryZone)) }
+                currentState = shuffledState.copy(zones = shuffledState.zones + (libraryZone to library))
                 allEvents.add(com.wingedsheep.engine.core.LibraryShuffledEvent(ownerId))
             }
         }
@@ -607,8 +607,8 @@ object ZoneTransitionService {
                 state.copy(zones = state.zones + (libraryZoneKey to currentLibrary + entityId))
             }
             LibraryPlacement.Shuffled -> {
-                val newLibrary = (currentLibrary + entityId).shuffled()
-                state.copy(zones = state.zones + (libraryZoneKey to newLibrary))
+                val (newLibrary, shuffledState) = state.nextRandom { shuffle(currentLibrary + entityId) }
+                shuffledState.copy(zones = shuffledState.zones + (libraryZoneKey to newLibrary))
             }
             is LibraryPlacement.NthFromTop -> {
                 val insertIndex = placement.position.coerceAtMost(currentLibrary.size)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/GrantKeywordToAttackersBlockedByExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/GrantKeywordToAttackersBlockedByExecutor.kt
@@ -6,8 +6,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
-import com.wingedsheep.engine.mechanics.layers.addFloatingEffects
-import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.combat.BlockedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -42,8 +41,9 @@ class GrantKeywordToAttackersBlockedByExecutor : EffectExecutor<GrantKeywordToAt
         }
 
         // Create floating effects granting the keyword to each attacker
-        val floatingEffects = attackerIds.map { attackerId ->
-            state.createFloatingEffect(
+        var newState = state
+        for (attackerId in attackerIds) {
+            newState = newState.addFloatingEffect(
                 layer = Layer.ABILITY,
                 modification = SerializableModification.GrantKeyword(effect.keyword),
                 affectedEntities = setOf(attackerId),
@@ -51,8 +51,6 @@ class GrantKeywordToAttackersBlockedByExecutor : EffectExecutor<GrantKeywordToAt
                 context = context
             )
         }
-
-        val newState = state.addFloatingEffects(floatingEffects)
 
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
         val events = attackerIds.mapNotNull { attackerId ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinExecutor.kt
@@ -27,7 +27,7 @@ class FlipCoinExecutor(
         effect: FlipCoinEffect,
         context: EffectContext
     ): EffectResult {
-        val won = kotlin.random.Random.nextBoolean()
+        val (won, advanced) = state.nextRandom { nextBoolean() }
 
         val sourceId = context.sourceId
         val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
@@ -36,10 +36,10 @@ class FlipCoinExecutor(
         val subEffect = if (won) effect.wonEffect else effect.lostEffect
 
         if (subEffect == null) {
-            return EffectResult.success(state, listOf(event))
+            return EffectResult.success(advanced, listOf(event))
         }
 
-        val result = effectExecutor(state, subEffect, context)
+        val result = effectExecutor(advanced, subEffect, context)
         return result.copy(events = listOf(event) + result.events)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipTwoCoinsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipTwoCoinsExecutor.kt
@@ -25,8 +25,8 @@ class FlipTwoCoinsExecutor(
         effect: FlipTwoCoinsEffect,
         context: EffectContext
     ): EffectResult {
-        val coin1 = kotlin.random.Random.nextBoolean()
-        val coin2 = kotlin.random.Random.nextBoolean()
+        val (coin1, s1) = state.nextRandom { nextBoolean() }
+        val (coin2, s2) = s1.nextRandom { nextBoolean() }
 
         val sourceId = context.sourceId
         val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
@@ -43,10 +43,10 @@ class FlipTwoCoinsExecutor(
         }
 
         if (subEffect == null) {
-            return EffectResult.success(state, events)
+            return EffectResult.success(s2, events)
         }
 
-        val result = effectExecutor(state, subEffect, context)
+        val result = effectExecutor(s2, subEffect, context)
         return result.copy(events = events + result.events)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CascadeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CascadeExecutor.kt
@@ -160,7 +160,9 @@ class CascadeExecutor(
         ): List<EngineGameEvent> {
             val events = mutableListOf<EngineGameEvent>()
             var current = state
-            for (cardId in cards.shuffled()) {
+            val (shuffledCards, advanced) = current.nextRandom { shuffle(cards) }
+            current = advanced
+            for (cardId in shuffledCards) {
                 val result = ZoneTransitionService.moveToZone(
                     state = current,
                     entityId = cardId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
@@ -73,9 +73,10 @@ class CastFromCollectionWithoutPayingCostExecutor(
         var newState = state.updateEntity(cardId) { container ->
             container.with(PlayWithoutPayingCostComponent(controllerId = controllerId))
         }
-        newState = newState.addMayPlayPermission(
+        val (permId, stateWithPerm) = newState.newEntity()
+        newState = stateWithPerm.addMayPlayPermission(
             MayPlayPermission(
-                id = EntityId.generate(),
+                id = permId,
                 cardIds = setOf(cardId),
                 controllerId = controllerId,
                 sourceId = context.sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
@@ -38,9 +38,10 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
 
         var newState = state
         if (collection.isNotEmpty()) {
-            newState = newState.addMayPlayPermission(
+            val (permId, stateWithPerm) = newState.newEntity()
+            newState = stateWithPerm.addMayPlayPermission(
                 MayPlayPermission(
-                    id = EntityId.generate(),
+                    id = permId,
                     cardIds = collection.toSet(),
                     controllerId = controllerId,
                     sourceId = context.sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GrantFreeCastTargetFromExileExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GrantFreeCastTargetFromExileExecutor.kt
@@ -42,9 +42,10 @@ class GrantFreeCastTargetFromExileExecutor : EffectExecutor<GrantFreeCastTargetF
             updated
         }
 
-        newState = newState.addMayPlayPermission(
+        val (permId, stateWithPerm) = newState.newEntity()
+        newState = stateWithPerm.addMayPlayPermission(
             MayPlayPermission(
-                id = EntityId.generate(),
+                id = permId,
                 cardIds = setOf(targetId),
                 controllerId = controllerId,
                 sourceId = context.sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
@@ -62,8 +62,8 @@ class MoveCollectionExecutor(
                 val destPlayerId = resolvePlayer(destination.player, context, state)
                 if (destPlayerId != null) {
                     val destZoneKey = ZoneKey(destPlayerId, Zone.LIBRARY)
-                    val library = state.getZone(destZoneKey)
-                    val newState = state.copy(zones = state.zones + (destZoneKey to library.shuffled()))
+                    val (shuffledLibrary, shuffledState) = state.nextRandom { shuffle(state.getZone(destZoneKey)) }
+                    val newState = shuffledState.copy(zones = shuffledState.zones + (destZoneKey to shuffledLibrary))
                     return EffectResult.success(newState, listOf(LibraryShuffledEvent(destPlayerId)))
                 }
             }
@@ -194,9 +194,13 @@ class MoveCollectionExecutor(
         }
 
         // Random ordering: shuffle the cards before placing them (player has no knowledge of order)
-        val orderedCards = if (order == CardOrder.Random) cards.shuffled() else cards
+        val (orderedCards, stateForMove) = if (order == CardOrder.Random) {
+            state.nextRandom { shuffle(cards) }
+        } else {
+            cards to state
+        }
 
-        val result = moveCardsToZone(state, context, orderedCards, destination, destPlayerId, revealed, moveType, faceDown, noRegenerate, storeMovedAs, underOwnersControl, revealToSelf)
+        val result = moveCardsToZone(stateForMove, context, orderedCards, destination, destPlayerId, revealed, moveType, faceDown, noRegenerate, storeMovedAs, underOwnersControl, revealToSelf)
 
         // Random library placement: the mover doesn't know where the cards landed, so strip
         // their reveal markers. moveCardsToZone marks moved cards as revealed to the controller
@@ -659,8 +663,8 @@ class MoveCollectionExecutor(
                 val destZoneKey = ZoneKey(libraryOwnerId, Zone.LIBRARY)
                 // Strip reveals before shuffling — once shuffled, no one knows positions any more
                 newState = LibraryRevealUtils.clearLibraryReveals(newState, libraryOwnerId)
-                val library = newState.getZone(destZoneKey)
-                newState = newState.copy(zones = newState.zones + (destZoneKey to library.shuffled()))
+                val (shuffledLibrary, shuffledState) = newState.nextRandom { shuffle(newState.getZone(destZoneKey)) }
+                newState = shuffledState.copy(zones = shuffledState.zones + (destZoneKey to shuffledLibrary))
                 events.add(LibraryShuffledEvent(libraryOwnerId))
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -182,12 +182,13 @@ class SelectFromCollectionExecutor : EffectExecutor<SelectFromCollectionEffect> 
             is SelectionMode.Random -> {
                 // No player decision — engine randomly picks N cards
                 val count = minOf(amountEvaluator.evaluate(state, selection.count, context), restrictionCeiling)
-                val selected = eligibleCards.shuffled().take(count)
+                val (shuffledEligible, stateAfterShuffle) = state.nextRandom { shuffle(eligibleCards) }
+                val selected = shuffledEligible.take(count)
                 val collections = mutableMapOf(effect.storeSelected to selected)
                 if (remainderName != null) {
                     collections[remainderName] = cards.filter { it !in selected }
                 }
-                EffectResult.success(state).copy(updatedCollections = collections)
+                EffectResult.success(stateAfterShuffle).copy(updatedCollections = collections)
             }
 
             is SelectionMode.ChooseAnyNumber -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ShuffleLibraryExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ShuffleLibraryExecutor.kt
@@ -30,11 +30,11 @@ class ShuffleLibraryExecutor : EffectExecutor<ShuffleLibraryEffect> {
         // Strip reveals before shuffling — once shuffled, no player can claim
         // to know positions any more, even cards previously revealed via Scry/Surveil.
         val cleared = LibraryRevealUtils.clearLibraryReveals(state, targetId)
-        val library = cleared.getZone(libraryZone).shuffled()
+        val (library, advanced) = cleared.nextRandom { shuffle(cleared.getZone(libraryZone)) }
 
-        val newZones = cleared.zones + (libraryZone to library)
+        val newZones = advanced.zones + (libraryZone to library)
         return EffectResult.success(
-            cleared.copy(zones = newZones),
+            advanced.copy(zones = newZones),
             listOf(LibraryShuffledEvent(targetId))
         )
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/abilities/GrantToEnchantedCreatureTypeGroupExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/abilities/GrantToEnchantedCreatureTypeGroupExecutor.kt
@@ -6,12 +6,10 @@ import com.wingedsheep.engine.core.StatsModifiedEvent
 import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.Sublayer
-import com.wingedsheep.engine.mechanics.layers.addFloatingEffects
-import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -106,49 +104,41 @@ class GrantToEnchantedCreatureTypeGroupExecutor : EffectExecutor<GrantToEnchante
         }
 
         // Create floating effects
-        val floatingEffects = mutableListOf<ActiveFloatingEffect>()
+        var newState = state
 
         if (effect.powerModifier != 0 || effect.toughnessModifier != 0) {
-            floatingEffects.add(
-                state.createFloatingEffect(
-                    layer = Layer.POWER_TOUGHNESS,
-                    sublayer = Sublayer.MODIFICATIONS,
-                    modification = SerializableModification.ModifyPowerToughness(
-                        powerMod = effect.powerModifier,
-                        toughnessMod = effect.toughnessModifier
-                    ),
-                    affectedEntities = affectedEntities,
-                    duration = effect.duration,
-                    context = context
-                )
+            newState = newState.addFloatingEffect(
+                layer = Layer.POWER_TOUGHNESS,
+                sublayer = Sublayer.MODIFICATIONS,
+                modification = SerializableModification.ModifyPowerToughness(
+                    powerMod = effect.powerModifier,
+                    toughnessMod = effect.toughnessModifier
+                ),
+                affectedEntities = affectedEntities,
+                duration = effect.duration,
+                context = context
             )
         }
 
         if (keyword != null) {
-            floatingEffects.add(
-                state.createFloatingEffect(
-                    layer = Layer.ABILITY,
-                    modification = SerializableModification.GrantKeyword(keyword.name),
-                    affectedEntities = affectedEntities,
-                    duration = effect.duration,
-                    context = context
-                )
+            newState = newState.addFloatingEffect(
+                layer = Layer.ABILITY,
+                modification = SerializableModification.GrantKeyword(keyword.name),
+                affectedEntities = affectedEntities,
+                duration = effect.duration,
+                context = context
             )
         }
 
         for (color in effect.protectionColors) {
-            floatingEffects.add(
-                state.createFloatingEffect(
-                    layer = Layer.ABILITY,
-                    modification = SerializableModification.GrantProtectionFromColor(color.name),
-                    affectedEntities = affectedEntities,
-                    duration = effect.duration,
-                    context = context
-                )
+            newState = newState.addFloatingEffect(
+                layer = Layer.ABILITY,
+                modification = SerializableModification.GrantProtectionFromColor(color.name),
+                affectedEntities = affectedEntities,
+                duration = effect.duration,
+                context = context
             )
         }
-
-        val newState = state.addFloatingEffects(floatingEffects)
 
         return EffectResult.success(newState, events)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/ExchangeControlExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/ExchangeControlExecutor.kt
@@ -6,8 +6,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
-import com.wingedsheep.engine.mechanics.layers.addFloatingEffects
-import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -61,8 +60,11 @@ class ExchangeControlExecutor : EffectExecutor<ExchangeControlEffect> {
         // If both creatures already have the same controller, no-op
         if (controller1 == controller2) return EffectResult.success(state)
 
+        // Capture the base timestamp before threading state so that +1 is stable
+        val baseTimestamp = state.timestamp
+
         // Create floating effect: target1 gets controller2
-        val floating1 = state.createFloatingEffect(
+        var newState = state.addFloatingEffect(
             layer = Layer.CONTROL,
             modification = SerializableModification.ChangeController(controller2),
             affectedEntities = setOf(target1Id),
@@ -73,18 +75,18 @@ class ExchangeControlExecutor : EffectExecutor<ExchangeControlEffect> {
         // Create floating effect: target2 gets controller1.
         // +1 preserves deterministic ordering between the two effects within Layer.CONTROL
         // (they affect different entities, so this is cosmetic, but matches the prior behavior).
-        val floating2 = state.createFloatingEffect(
+        newState = newState.addFloatingEffect(
             layer = Layer.CONTROL,
             modification = SerializableModification.ChangeController(controller1),
             affectedEntities = setOf(target2Id),
             duration = Duration.Permanent,
             context = context,
-            timestamp = state.timestamp + 1
+            timestamp = baseTimestamp + 1
         )
 
         // Rule 302.6: each creature has a new controller and hasn't been under their
         // control continuously since that player's most recent turn began.
-        val newState = state.addFloatingEffects(listOf(floating1, floating2))
+        newState = newState
             .updateEntity(target1Id) { it.with(SummoningSicknessComponent) }
             .updateEntity(target2Id) { it.with(SummoningSicknessComponent) }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByActivePlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByActivePlayerExecutor.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
-import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -58,16 +58,15 @@ class GainControlByActivePlayerExecutor : EffectExecutor<GainControlByActivePlay
 
         // Create new floating effect — use controllerId override since control goes to active player
         val controlContext = context.copy(controllerId = newControllerId)
-        val floatingEffect = state.createFloatingEffect(
-            layer = Layer.CONTROL,
-            modification = SerializableModification.ChangeController(newControllerId),
-            affectedEntities = setOf(targetId),
-            duration = com.wingedsheep.sdk.scripting.Duration.Permanent,
-            context = controlContext
-        )
-
         // Rule 302.6: new controller hasn't had this permanent since their most recent turn began.
-        val newState = state.copy(floatingEffects = filteredEffects + floatingEffect)
+        val newState = state.copy(floatingEffects = filteredEffects)
+            .addFloatingEffect(
+                layer = Layer.CONTROL,
+                modification = SerializableModification.ChangeController(newControllerId),
+                affectedEntities = setOf(targetId),
+                duration = com.wingedsheep.sdk.scripting.Duration.Permanent,
+                context = controlContext
+            )
             .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
 
         val events = listOf(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostExecutor.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
-import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -75,16 +75,15 @@ class GainControlByMostExecutor : EffectExecutor<GainControlByMostEffect> {
         }
 
         val controlContext = context.copy(controllerId = newControllerId)
-        val floatingEffect = state.createFloatingEffect(
-            layer = Layer.CONTROL,
-            modification = SerializableModification.ChangeController(newControllerId),
-            affectedEntities = setOf(targetId),
-            duration = Duration.Permanent,
-            context = controlContext
-        )
-
         // Rule 302.6: the new controller hasn't controlled this permanent since their most recent turn began.
-        val newState = state.copy(floatingEffects = filteredEffects + floatingEffect)
+        val newState = state.copy(floatingEffects = filteredEffects)
+            .addFloatingEffect(
+                layer = Layer.CONTROL,
+                modification = SerializableModification.ChangeController(newControllerId),
+                affectedEntities = setOf(targetId),
+                duration = Duration.Permanent,
+                context = controlContext
+            )
             .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
 
         val events = listOf(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
-import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -53,17 +53,15 @@ class GainControlExecutor : EffectExecutor<GainControlEffect> {
               targetId in floating.effect.affectedEntities)
         }
 
-        // Create new floating effect
-        val floatingEffect = state.createFloatingEffect(
-            layer = Layer.CONTROL,
-            modification = SerializableModification.ChangeController(newControllerId),
-            affectedEntities = setOf(targetId),
-            duration = effect.duration,
-            context = context
-        )
-
         // Rule 302.6: new controller hasn't had this permanent since their most recent turn began.
-        val newState = state.copy(floatingEffects = filteredEffects + floatingEffect)
+        val newState = state.copy(floatingEffects = filteredEffects)
+            .addFloatingEffect(
+                layer = Layer.CONTROL,
+                modification = SerializableModification.ChangeController(newControllerId),
+                affectedEntities = setOf(targetId),
+                duration = effect.duration,
+                context = context
+            )
             .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
 
         val events = listOf(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
-import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -58,15 +58,15 @@ class GiveControlToTargetPlayerExecutor : EffectExecutor<GiveControlToTargetPlay
             state.copy(floatingEffects = filteredEffects)
         } else {
             val controlContext = context.copy(controllerId = newControllerId)
-            val floatingEffect = state.createFloatingEffect(
-                layer = Layer.CONTROL,
-                modification = SerializableModification.ChangeController(newControllerId),
-                affectedEntities = setOf(targetId),
-                duration = effect.duration,
-                context = controlContext
-            )
             // Rule 302.6: new controller hasn't had this permanent since their most recent turn began.
-            state.copy(floatingEffects = filteredEffects + floatingEffect)
+            state.copy(floatingEffects = filteredEffects)
+                .addFloatingEffect(
+                    layer = Layer.CONTROL,
+                    modification = SerializableModification.ChangeController(newControllerId),
+                    affectedEntities = setOf(targetId),
+                    duration = effect.duration,
+                    context = controlContext
+                )
                 .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/AnimateLandExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/AnimateLandExecutor.kt
@@ -6,8 +6,7 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.Sublayer
-import com.wingedsheep.engine.mechanics.layers.addFloatingEffects
-import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.scripting.effects.AnimateLandEffect
 import kotlin.reflect.KClass
@@ -40,7 +39,7 @@ class AnimateLandExecutor : EffectExecutor<AnimateLandEffect> {
         val affectedEntities = setOf(targetId)
 
         // Floating effect 1: Add "Creature" type on Layer.TYPE
-        val addTypeEffect = state.createFloatingEffect(
+        var newState = state.addFloatingEffect(
             layer = Layer.TYPE,
             modification = SerializableModification.AddType("CREATURE"),
             affectedEntities = affectedEntities,
@@ -49,7 +48,7 @@ class AnimateLandExecutor : EffectExecutor<AnimateLandEffect> {
         )
 
         // Floating effect 2: Set base P/T on Layer.POWER_TOUGHNESS, Sublayer.SET_VALUES
-        val setPTEffect = state.createFloatingEffect(
+        newState = newState.addFloatingEffect(
             layer = Layer.POWER_TOUGHNESS,
             sublayer = Sublayer.SET_VALUES,
             modification = SerializableModification.SetPowerToughness(effect.power, effect.toughness),
@@ -57,8 +56,6 @@ class AnimateLandExecutor : EffectExecutor<AnimateLandEffect> {
             duration = effect.duration,
             context = context
         )
-
-        val newState = state.addFloatingEffects(listOf(addTypeEffect, setPTEffect))
 
         return EffectResult.success(newState)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/BecomeCreatureExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/BecomeCreatureExecutor.kt
@@ -3,12 +3,10 @@ package com.wingedsheep.engine.handlers.effects.permanent.types
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.Sublayer
-import com.wingedsheep.engine.mechanics.layers.addFloatingEffects
-import com.wingedsheep.engine.mechanics.layers.createFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureEffect
 import kotlin.reflect.KClass
@@ -39,72 +37,68 @@ class BecomeCreatureExecutor : EffectExecutor<BecomeCreatureEffect> {
 
         val affectedEntities = setOf(targetId)
 
-        val floatingEffects = mutableListOf<ActiveFloatingEffect>()
-
         // Layer 4 (TYPE): Add CREATURE type
-        floatingEffects.add(state.createFloatingEffect(
+        var newState = state.addFloatingEffect(
             layer = Layer.TYPE,
             modification = SerializableModification.AddType("CREATURE"),
             affectedEntities = affectedEntities,
             duration = effect.duration,
             context = context
-        ))
+        )
 
         // Layer 4 (TYPE): Remove specified types (e.g., PLANESWALKER)
         for (type in effect.removeTypes) {
-            floatingEffects.add(state.createFloatingEffect(
+            newState = newState.addFloatingEffect(
                 layer = Layer.TYPE,
                 modification = SerializableModification.RemoveType(type),
                 affectedEntities = affectedEntities,
                 duration = effect.duration,
                 context = context
-            ))
+            )
         }
 
         // Layer 4 (TYPE): Set creature subtypes
         if (effect.creatureTypes.isNotEmpty()) {
-            floatingEffects.add(state.createFloatingEffect(
+            newState = newState.addFloatingEffect(
                 layer = Layer.TYPE,
                 modification = SerializableModification.SetCreatureSubtypes(effect.creatureTypes),
                 affectedEntities = affectedEntities,
                 duration = effect.duration,
                 context = context
-            ))
+            )
         }
 
         // Layer 5 (COLOR): Change color if specified
         if (effect.colors != null) {
-            floatingEffects.add(state.createFloatingEffect(
+            newState = newState.addFloatingEffect(
                 layer = Layer.COLOR,
                 modification = SerializableModification.ChangeColor(effect.colors!!),
                 affectedEntities = affectedEntities,
                 duration = effect.duration,
                 context = context
-            ))
+            )
         }
 
         // Layer 6 (ABILITY): Grant keywords
         for (keyword in effect.keywords) {
-            floatingEffects.add(state.createFloatingEffect(
+            newState = newState.addFloatingEffect(
                 layer = Layer.ABILITY,
                 modification = SerializableModification.GrantKeyword(keyword.name),
                 affectedEntities = affectedEntities,
                 duration = effect.duration,
                 context = context
-            ))
+            )
         }
 
         // Layer 7b (POWER_TOUGHNESS, SET_VALUES): Set base P/T
-        floatingEffects.add(state.createFloatingEffect(
+        newState = newState.addFloatingEffect(
             layer = Layer.POWER_TOUGHNESS,
             sublayer = Sublayer.SET_VALUES,
             modification = SerializableModification.SetPowerToughness(effect.power, effect.toughness),
             affectedEntities = affectedEntities,
             duration = effect.duration,
             context = context
-        ))
-
-        val newState = state.addFloatingEffects(floatingEffects)
+        )
 
         return EffectResult.success(newState)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CreatePermanentEmblemExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CreatePermanentEmblemExecutor.kt
@@ -13,7 +13,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ChosenCreatureTypeComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.EmblemSourceComponent
-import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.effects.CreatePermanentEmblemEffect
 import kotlin.reflect.KClass
@@ -61,7 +60,7 @@ class CreatePermanentEmblemExecutor : EffectExecutor<CreatePermanentEmblemEffect
         // filters resolve correctly), the chosen creature type (so chosenSubtypeKey filters
         // find a ChosenCreatureTypeComponent), and an EmblemSourceComponent that lets the
         // client transformer surface a badge on the controller's player effects panel.
-        val emblemId = EntityId.generate()
+        val (emblemId, stateWithId) = state.newEntity()
         var emblemContainer: ComponentContainer = ComponentContainer.EMPTY
             .with(ControllerComponent(controllerId))
             .with(EmblemSourceComponent(sourceName = sourceName, description = resolvedDescription))
@@ -69,7 +68,7 @@ class CreatePermanentEmblemExecutor : EffectExecutor<CreatePermanentEmblemEffect
             emblemContainer = emblemContainer.with(ChosenCreatureTypeComponent(chosenType))
         }
 
-        var newState = state.withEntity(emblemId, emblemContainer)
+        var newState = stateWithId.withEntity(emblemId, emblemContainer)
         val emblemContext = context.copy(sourceId = emblemId)
 
         // Power/toughness modification (Layer 7c).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -868,8 +868,9 @@ class PayOrSufferExecutor(
             }
 
             // Randomly select cards to discard
-            val cardsToDiscard = validCards.shuffled().take(count)
-            var newState = state
+            val (shuffledValid, stateAfterShuffle) = state.nextRandom { shuffle(validCards) }
+            val cardsToDiscard = shuffledValid.take(count)
+            var newState = stateAfterShuffle
             val events = mutableListOf<GameEvent>()
 
             for (cardId in cardsToDiscard) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyEachSpellCastExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyEachSpellCastExecutor.kt
@@ -26,8 +26,13 @@ class CopyEachSpellCastExecutor : EffectExecutor<CopyEachSpellCastEffect> {
         effect: CopyEachSpellCastEffect,
         context: EffectContext
     ): EffectResult {
-        val sourceId = context.sourceId ?: EntityId.generate()
-        val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Unknown"
+        val (effectiveState, sourceId) = if (context.sourceId != null) {
+            state to context.sourceId
+        } else {
+            val (id, s) = state.newEntity()
+            s to id
+        }
+        val sourceName = effectiveState.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Unknown"
 
         val pending = PendingSpellCopy(
             controllerId = context.controllerId,
@@ -36,7 +41,7 @@ class CopyEachSpellCastExecutor : EffectExecutor<CopyEachSpellCastEffect> {
             sourceName = sourceName,
             persistent = true
         )
-        val newState = state.copy(
+        val newState = effectiveState.copy(
             pendingSpellCopies = state.pendingSpellCopies + pending
         )
         return EffectResult.success(newState)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyNextSpellCastExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyNextSpellCastExecutor.kt
@@ -26,8 +26,13 @@ class CopyNextSpellCastExecutor : EffectExecutor<CopyNextSpellCastEffect> {
         effect: CopyNextSpellCastEffect,
         context: EffectContext
     ): EffectResult {
-        val sourceId = context.sourceId ?: EntityId.generate()
-        val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Unknown"
+        val (effectiveState, sourceId) = if (context.sourceId != null) {
+            state to context.sourceId
+        } else {
+            val (id, s) = state.newEntity()
+            s to id
+        }
+        val sourceName = effectiveState.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Unknown"
 
         val pending = PendingSpellCopy(
             controllerId = context.controllerId,
@@ -35,7 +40,7 @@ class CopyNextSpellCastExecutor : EffectExecutor<CopyNextSpellCastEffect> {
             sourceId = sourceId,
             sourceName = sourceName
         )
-        val newState = state.copy(
+        val newState = effectiveState.copy(
             pendingSpellCopies = state.pendingSpellCopies + pending
         )
         return EffectResult.success(newState)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellExecutor.kt
@@ -124,15 +124,21 @@ class CopyTargetSpellExecutor(
                 )
                 return EffectResult.from(ExecutionResult.success(mutated, copyResult.events))
             }
+            val (effectiveState, sourceId) = if (context.sourceId != null) {
+                state to context.sourceId
+            } else {
+                val (id, s) = state.newEntity()
+                s to id
+            }
             val copyAbility = TriggeredAbilityOnStackComponent(
-                sourceId = context.sourceId ?: EntityId.generate(),
+                sourceId = sourceId,
                 sourceName = spellName,
                 controllerId = context.controllerId,
                 effect = spellEffect,
                 description = "Copy of $spellName"
             )
             return EffectResult.from(applyKeywordsToCopy(
-                stackResolver.putTriggeredAbility(state, copyAbility),
+                stackResolver.putTriggeredAbility(effectiveState, copyAbility),
                 effect.keywordsForCopy
             ))
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ReselectTargetRandomlyExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ReselectTargetRandomlyExecutor.kt
@@ -63,17 +63,17 @@ class ReselectTargetRandomlyExecutor : EffectExecutor<ReselectTargetRandomlyEffe
         }
 
         // 4. Randomly pick one (may be the same as current — per ruling)
-        val chosenTargetId = legalTargets.random()
+        val (chosenTargetId, stateAfterPick) = state.nextRandom { pick(legalTargets) }
 
         // 5. Build the new ChosenTarget based on what was chosen
-        val newTarget = buildChosenTarget(state, chosenTargetId, currentTarget)
-            ?: return EffectResult.success(state)
+        val newTarget = buildChosenTarget(stateAfterPick, chosenTargetId, currentTarget)
+            ?: return EffectResult.success(stateAfterPick)
 
         // 6. Update the target on the stack entity
         val newTargetsComponent = targetsComponent.copy(
             targets = listOf(newTarget)
         )
-        val newState = state.updateEntity(triggeringEntityId) { container ->
+        val newState = stateAfterPick.updateEntity(triggeringEntityId) { container ->
             container.with(newTargetsComponent)
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateChosenTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateChosenTokenExecutor.kt
@@ -16,7 +16,6 @@ import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.TypeLine
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CreatureStats
-import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.sdk.scripting.effects.CreateChosenTokenEffect
 import kotlin.reflect.KClass
@@ -150,7 +149,7 @@ class CreateChosenTokenExecutor(
         // Look up token art — try each creature type until a match is found
         val tokenImageUri = creatureTypes.firstNotNullOfOrNull { TOKEN_IMAGES[it] }
 
-        val tokenId = EntityId.generate()
+        val (tokenId, stateWithId) = state.newEntity()
         val tokenName = "${creatureTypes.joinToString(" ")} Token"
         val tokenComponent = CardComponent(
             cardDefinitionId = "token:$tokenName",
@@ -170,7 +169,7 @@ class CreateChosenTokenExecutor(
             SummoningSicknessComponent
         )
 
-        var newState = state.withEntity(tokenId, container)
+        var newState = stateWithId.withEntity(tokenId, container)
         newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
             .place(newState, context.controllerId, tokenId)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
@@ -64,7 +64,8 @@ class CreatePredefinedTokenExecutor(
         val createdTokenIds = mutableListOf<EntityId>()
 
         repeat(effect.count) {
-            val tokenId = EntityId.generate()
+            val (tokenId, stateWithId) = newState.newEntity()
+            newState = stateWithId
             createdTokenIds.add(tokenId)
 
             val tokenComponent = CardComponent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateRoleTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateRoleTokenExecutor.kt
@@ -67,7 +67,8 @@ class CreateRoleTokenExecutor(
         }
 
         // Create the Role token entity
-        val tokenId = EntityId.generate()
+        val (tokenId, stateWithId) = newState.newEntity()
+        newState = stateWithId
 
         val tokenComponent = CardComponent(
             cardDefinitionId = effect.roleName,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
@@ -107,7 +107,7 @@ class CreateTokenCopyOfChosenPermanentExecutor(
             val chosenCard = chosenContainer.get<CardComponent>()
                 ?: return EffectResult.success(state)
 
-            val tokenId = EntityId.generate()
+            val (tokenId, stateWithId) = state.newEntity()
 
             // Copy the chosen permanent's CardComponent
             val tokenCard = chosenCard.copy(ownerId = controllerId)
@@ -125,7 +125,7 @@ class CreateTokenCopyOfChosenPermanentExecutor(
                 container = staticAbilityHandler.addReplacementEffectComponent(container)
             }
 
-            var newState = state.withEntity(tokenId, container)
+            var newState = stateWithId.withEntity(tokenId, container)
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
@@ -61,8 +61,8 @@ class CreateTokenCopyOfEquippedCreatureExecutor(
 
         val controllerId = context.controllerId
 
-        var newState = state
-        val tokenId = EntityId.generate()
+        val (tokenId, stateWithId) = state.newEntity()
+        var newState = stateWithId
 
         // Copy the equipped creature's CardComponent
         var tokenCard = equippedCard.copy(ownerId = controllerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -60,7 +60,8 @@ class CreateTokenCopyOfSourceExecutor(
         val createdTokens = mutableListOf<EntityId>()
 
         repeat(effect.count) {
-            val tokenId = EntityId.generate()
+            val (tokenId, stateWithId) = newState.newEntity()
+            newState = stateWithId
             createdTokens.add(tokenId)
 
             // Copy the source's CardComponent, setting the token's owner to the controller

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -71,7 +71,8 @@ class CreateTokenCopyOfTargetExecutor(
         val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
 
         repeat(count) {
-            val tokenId = EntityId.generate()
+            val (tokenId, stateWithId) = newState.newEntity()
+            newState = stateWithId
             val op = effect.overridePower
             val ot = effect.overrideToughness
             val overrideStats = if (op != null && ot != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -86,7 +86,8 @@ class CreateTokenExecutor(
         val createdTokens = mutableListOf<EntityId>()
 
         repeat(count) {
-            val tokenId = EntityId.generate()
+            val (tokenId, stateWithId) = newState.newEntity()
+            newState = stateWithId
             createdTokens.add(tokenId)
 
             // Create token entity

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -221,7 +221,8 @@ object TokenCreationReplacementHelper {
         val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
 
         repeat(count) {
-            val tokenId = EntityId.generate()
+            val (tokenId, stateWithId) = newState.newEntity()
+            newState = stateWithId
             val tokenCard = equippedCard.copy(ownerId = controllerId)
 
             val components = mutableListOf<Component>(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ExileAndGrantOwnerPlayPermissionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ExileAndGrantOwnerPlayPermissionExecutor.kt
@@ -11,7 +11,6 @@ import com.wingedsheep.engine.state.components.identity.PlayWithCostIncreaseComp
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
 import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.ExileAndGrantOwnerPlayPermissionEffect
 import kotlin.reflect.KClass
 
@@ -37,9 +36,10 @@ class ExileAndGrantOwnerPlayPermissionExecutor : EffectExecutor<ExileAndGrantOwn
 
         val transition = ZoneTransitionService.moveToZone(state, targetId, Zone.EXILE)
 
-        var newState = transition.state.addMayPlayPermission(
+        val (permId, stateWithId) = transition.state.newEntity()
+        var newState = stateWithId.addMayPlayPermission(
             MayPlayPermission(
-                id = EntityId.generate(),
+                id = permId,
                 cardIds = setOf(targetId),
                 controllerId = ownerId,
                 sourceId = context.sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/WarpExileExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/WarpExileExecutor.kt
@@ -10,7 +10,6 @@ import com.wingedsheep.engine.state.components.identity.WarpExiledComponent
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
 import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.WarpExileEffect
 import kotlin.reflect.KClass
 
@@ -60,9 +59,10 @@ class WarpExileExecutor : EffectExecutor<WarpExileEffect> {
             c.with(WarpExiledComponent(controllerId = context.controllerId))
         }
 
-        newState = newState.addMayPlayPermission(
+        val (permId, stateWithPerm) = newState.newEntity()
+        newState = stateWithPerm.addMayPlayPermission(
             MayPlayPermission(
-                id = EntityId.generate(),
+                id = permId,
                 cardIds = setOf(targetId),
                 controllerId = context.controllerId,
                 sourceId = context.sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/FloatingEffectFactory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/FloatingEffectFactory.kt
@@ -27,7 +27,9 @@ fun GameState.addFloatingEffect(
     dynamicGroupFilter: GroupFilter? = null,
     timestamp: Long = this.timestamp
 ): GameState {
+    val (effectId, stateWithId) = newEntity()
     val effect = createFloatingEffect(
+        id = effectId,
         layer = layer,
         modification = modification,
         affectedEntities = affectedEntities,
@@ -37,7 +39,7 @@ fun GameState.addFloatingEffect(
         dynamicGroupFilter = dynamicGroupFilter,
         timestamp = timestamp
     )
-    return copy(floatingEffects = floatingEffects + effect)
+    return stateWithId.copy(floatingEffects = stateWithId.floatingEffects + effect)
 }
 
 /**
@@ -57,11 +59,12 @@ fun GameState.createFloatingEffect(
     context: EffectContext,
     sublayer: Sublayer? = null,
     dynamicGroupFilter: GroupFilter? = null,
-    timestamp: Long = this.timestamp
+    timestamp: Long = this.timestamp,
+    id: EntityId
 ): ActiveFloatingEffect {
     val sourceName = context.sourceId?.let { getEntity(it)?.get<CardComponent>()?.name }
     return ActiveFloatingEffect(
-        id = EntityId.generate(),
+        id = id,
         effect = FloatingEffectData(
             layer = layer,
             sublayer = sublayer,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -341,14 +341,14 @@ class StackResolver(
         targetRequirements: List<TargetRequirement> = emptyList()
     ): ExecutionResult {
         // Create a new entity for the ability on the stack
-        val abilityId = EntityId.generate()
+        val (abilityId, stateWithId) = state.newEntity()
 
         var container = ComponentContainer.of(ability)
         if (targets.isNotEmpty()) {
             container = container.with(TargetsComponent(targets, targetRequirements))
         }
 
-        var newState = state.withEntity(abilityId, container)
+        var newState = stateWithId.withEntity(abilityId, container)
         newState = newState.pushToStack(abilityId)
             .copy(priorityPassedBy = emptySet())
 
@@ -420,7 +420,7 @@ class StackResolver(
             ?: return ExecutionResult.error(state, "Source is not a spell on stack: $sourceSpellId")
         val sourceTargets = sourceContainer.get<TargetsComponent>()
 
-        val copyId = EntityId.generate()
+        val (copyId, stateWithId) = state.newEntity()
         val copyController = controllerId ?: sourceSpell.casterId
 
         val effectiveModes = chosenModes ?: sourceSpell.chosenModes
@@ -470,7 +470,7 @@ class StackResolver(
             )
         )
 
-        var newState = state.withEntity(copyId, container)
+        var newState = stateWithId.withEntity(copyId, container)
         newState = newState.pushToStack(copyId).copy(priorityPassedBy = emptySet())
 
         val events = mutableListOf<GameEvent>(
@@ -507,14 +507,14 @@ class StackResolver(
         targets: List<ChosenTarget> = emptyList(),
         targetRequirements: List<TargetRequirement> = emptyList()
     ): ExecutionResult {
-        val abilityId = EntityId.generate()
+        val (abilityId, stateWithId) = state.newEntity()
 
         var container = ComponentContainer.of(ability)
         if (targets.isNotEmpty()) {
             container = container.with(TargetsComponent(targets, targetRequirements))
         }
 
-        var newState = state.withEntity(abilityId, container)
+        var newState = stateWithId.withEntity(abilityId, container)
         newState = newState.pushToStack(abilityId)
             .copy(priorityPassedBy = emptySet())
 
@@ -1324,9 +1324,10 @@ class StackResolver(
 
                 // CR 715.3d — Adventure exiled by its own resolution: re-grant cast-from-exile.
                 if (pausedAdventureFaceExile && pausedDestZone == Zone.EXILE) {
-                    pausedState = pausedState.addMayPlayPermission(
+                    val (permId, stateWithPerm) = pausedState.newEntity()
+                    pausedState = stateWithPerm.addMayPlayPermission(
                         com.wingedsheep.engine.state.permissions.MayPlayPermission(
-                            id = com.wingedsheep.sdk.model.EntityId.generate(),
+                            id = permId,
                             cardIds = setOf(spellId),
                             controllerId = spellComponent.casterId,
                             permanent = true,
@@ -1416,9 +1417,10 @@ class StackResolver(
         // the prior removeMayPlayPermissionsForCard so the cast-from-exile enumerator picks
         // it up on the next priority pass.
         if (adventureFaceExile && destinationZone == Zone.EXILE) {
-            newState = newState.addMayPlayPermission(
+            val (permId, stateWithPerm) = newState.newEntity()
+            newState = stateWithPerm.addMayPlayPermission(
                 com.wingedsheep.engine.state.permissions.MayPlayPermission(
-                    id = com.wingedsheep.sdk.model.EntityId.generate(),
+                    id = permId,
                     cardIds = setOf(spellId),
                     controllerId = spellComponent.casterId,
                     permanent = true,
@@ -1913,9 +1915,10 @@ class StackResolver(
             updated
         }
         if (grantFreeCast) {
-            newState = newState.addMayPlayPermission(
+            val (permId, stateWithPerm) = newState.newEntity()
+            newState = stateWithPerm.addMayPlayPermission(
                 com.wingedsheep.engine.state.permissions.MayPlayPermission(
-                    id = com.wingedsheep.sdk.model.EntityId.generate(),
+                    id = permId,
                     cardIds = setOf(spellId),
                     controllerId = controllerId,
                     permanent = true,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
 import kotlinx.serialization.Serializable
 
 /**
@@ -136,6 +137,23 @@ data class GameState(
      * field semantics.
      */
     val mayPlayPermissions: List<com.wingedsheep.engine.state.permissions.MayPlayPermission> = emptyList(),
+
+    /**
+     * Deterministic RNG state for every random game event (shuffles, coin flips, "at random"
+     * choices). Threaded purely: a draw returns a value plus the advanced generator, which the
+     * caller writes back via [nextRandom]. Two games seeded identically and fed the same actions
+     * therefore reproduce byte-identically — see [GameRng]. Defaults to a fixed seed so existing
+     * tests/persisted states are unaffected; [com.wingedsheep.engine.core.GameInitializer] reseeds
+     * it from [com.wingedsheep.engine.core.GameConfig.seed] (or fresh entropy) at game start.
+     */
+    val rng: GameRng = GameRng(0L),
+
+    /**
+     * Monotonic counter backing deterministic entity-id minting via [newEntity]. Kept in state (not
+     * a process-global) so id generation is a pure function of the game — a prerequisite for
+     * byte-identical replays/parity. Live IDs look like `e0`, `e1`, … See [EntityId].
+     */
+    val nextEntityId: Long = 0L,
 ) {
     /**
      * Cached projection of the game state with all continuous effects (Rule 613) applied.
@@ -425,6 +443,25 @@ data class GameState(
      * Advance to the next timestamp (returns new state).
      */
     fun tick(): GameState = copy(timestamp = timestamp + 1)
+
+    /**
+     * Draw a random value, advancing the stored generator. The [draw] lambda receives the current
+     * [rng] and returns `(value, nextRng)` — e.g. `state.nextRandom { nextBoolean() }` for a coin
+     * flip or `state.nextRandom { shuffle(library) }` for a shuffle. Returns the drawn value paired
+     * with the new [GameState] carrying the advanced generator; the caller must thread that state
+     * onward, exactly like [tick].
+     */
+    fun <T> nextRandom(draw: GameRng.() -> Pair<T, GameRng>): Pair<T, GameState> {
+        val (value, advanced) = rng.draw()
+        return value to copy(rng = advanced)
+    }
+
+    /**
+     * Mint a fresh, deterministic [EntityId] and return it with the state whose counter has been
+     * advanced. Replaces [EntityId.generate] anywhere the id must be reproducible across runs.
+     */
+    fun newEntity(): Pair<EntityId, GameState> =
+        EntityId("e$nextEntityId") to copy(nextEntityId = nextEntityId + 1)
 
     /**
      * Set the priority player (returns new state).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/ReproducibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/ReproducibilityTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * End-to-end determinism guarantees for the seeded RNG (Phases 1–5).
+ *
+ * The contract these tests pin down — and that the cross-engine parity harness, replays, and MCTS
+ * rollouts all depend on — is: **a game seeded with the same value produces a byte-identical
+ * [GameState]**, down to library order and entity ids. We assert this with structural `==` on the
+ * whole state. `GameState.projectedState` is a non-constructor lazy `val`, so it is excluded from
+ * the data class `equals`; the comparison covers every persisted field, including `rng`,
+ * `nextEntityId`, `zones`, and `entities`.
+ */
+class ReproducibilityTest : FunSpec({
+
+    fun registry(): CardRegistry = CardRegistry().apply { register(TestCards.all) }
+
+    // A 40-card, two-type deck so shuffles are non-trivial — a same-order coincidence across two
+    // different seeds is astronomically unlikely.
+    fun config(seed: Long?) = GameConfig(
+        players = listOf(
+            PlayerConfig("Alice", Deck.of("Forest" to 17, "Grizzly Bears" to 23)),
+            PlayerConfig("Bob", Deck.of("Forest" to 17, "Grizzly Bears" to 23)),
+        ),
+        skipMulligans = true,
+        seed = seed,
+    )
+
+    fun libraryNames(state: com.wingedsheep.engine.state.GameState, playerIndex: Int): List<String> {
+        val playerId = state.turnOrder[playerIndex]
+        return state.getZone(ZoneKey(playerId, Zone.LIBRARY)).map {
+            state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name ?: "?"
+        }
+    }
+
+    test("same seed produces a byte-identical game state") {
+        val a = GameInitializer(registry()).initializeGame(config(seed = 12345L))
+        val b = GameInitializer(registry()).initializeGame(config(seed = 12345L))
+
+        // The whole state is structurally equal: turn order, every library's order, all entity ids,
+        // the rng stream position, and the entity counter.
+        a.state shouldBe b.state
+        a.seed shouldBe 12345L
+        b.seed shouldBe 12345L
+    }
+
+    test("different seeds produce different shuffles") {
+        val a = GameInitializer(registry()).initializeGame(config(seed = 1L))
+        val b = GameInitializer(registry()).initializeGame(config(seed = 2L))
+
+        // Library order must differ (the whole point of seeding) ...
+        a.state shouldNotBe b.state
+        libraryNames(a.state, 0) shouldNotBe libraryNames(b.state, 0)
+
+        // ... but entity ids are NOT a function of the seed — they're minted from a deterministic
+        // counter in creation order, so both runs assign the same ids regardless of seed.
+        a.state.entities.keys shouldContainExactly b.state.entities.keys
+        a.state.nextEntityId shouldBe b.state.nextEntityId
+    }
+
+    test("an unseeded game records a seed that reproduces it exactly") {
+        // Live play passes seed = null; the initializer draws fresh entropy and records it.
+        val live = GameInitializer(registry()).initializeGame(config(seed = null))
+
+        // Replaying with the recorded seed reconstructs the identical state.
+        val replay = GameInitializer(registry()).initializeGame(config(seed = live.seed))
+        replay.state shouldBe live.state
+    }
+
+    test("two unseeded games differ (entropy seeding is actually random)") {
+        val a = GameInitializer(registry()).initializeGame(config(seed = null))
+        val b = GameInitializer(registry()).initializeGame(config(seed = null))
+        // Different entropy seeds → different recorded seeds → different shuffles.
+        a.seed shouldNotBe b.seed
+        a.state shouldNotBe b.state
+    }
+
+    test("entity ids are deterministic, counter-based handles (not random uuids)") {
+        val state = GameInitializer(registry()).initializeGame(config(seed = 7L)).state
+        // Every minted id is of the form e<n>, and the counter equals the number of entities created.
+        state.entities.keys.all { it.value.matches(Regex("e\\d+")) } shouldBe true
+        state.nextEntityId shouldBe state.entities.size.toLong()
+    }
+})


### PR DESCRIPTION
## Seeded, deterministic RNG for reproducible game runs

Adds end-to-end determinism to the engine: a game seeded with the same value plays out **byte-identically**, down to library order and entity ids. This is the foundation for reproducible replays, MCTS rollouts, and the cross-engine parity harness discussed with another engine author (running seeded games and diffing each step against Forge / phase-rs).

### Why the RNG lives in `GameState`
The engine is `(GameState, GameAction) -> ExecutionResult` over an immutable `GameState`. A process-global `Random` would break replay, MCTS (which re-applies actions to the same state), and parity stepping. So the RNG **state lives inside `GameState`** and advances functionally — each draw returns `(value, nextRng)` threaded back out with the new state, exactly like the existing `timestamp`/`tick()` discipline.

### What changed (6 commits, one per phase)
1. **`GameRng`** — pure, immutable, serializable SplitMix64 in `mtg-sdk` (`nextInt/nextBoolean/nextDouble/shuffle/pick/split`), with unit tests.
2. **`GameState`** gains `rng` + `nextEntityId`, with pure `nextRandom { }` and `newEntity()` helpers. Both are constructor fields on the `@Serializable` data class, so they serialize automatically.
3. **`GameConfig.seed`** — `null` ⇒ fresh entropy at init, but the chosen seed is **always recorded** on `InitializationResult.seed`, so any live game is reproducible after the fact. Turn-order + library shuffles routed through `state.rng`.
4. **In-game RNG executors** threaded through `state.rng`: coin flips, shuffle effects, zone-transition/mulligan shuffles, at-random discards, random selection, random move-ordering, cascade, random target reselection.
5. **Deterministic entity ids** via `state.newEntity()` at every production minting site (players, cards, tokens, token/spell copies, stack abilities, emblems, exile permissions, floating effects). `createFloatingEffect`'s `id` is now required so no site silently mints a random id. Ids are now `e0`, `e1`, … in creation order.
6. **`ReproducibilityTest`** — same seed ⇒ byte-identical `GameState` (structural `==` over the whole state); different seeds differ; an unseeded game's recorded seed replays exactly.

### Deliberately out of scope
- **Booster/sealed generation** (`BoosterGenerator`) — pre-game pool layer (no `GameState`), already seedable via its own `distributionSeed`. Not part of the in-game step function the parity harness compares.
- **Decision/band/continuation IDs** stay `UUID` strings — opaque server↔client correlation tokens, not game state, and never matched across engines anyway. Making these deterministic too (for literally-every-byte-stable same-engine replays) is a clean follow-up if wanted.

### Testing
- New: `GameRngTest` (14 cases), `ReproducibilityTest` (5 cases).
- Full `:rules-engine:test` and `:mtg-sdk:test` green; all downstream modules (`game-server`, `gym*`, `ai`, `mtg-sets`) compile.

### Follow-ups (not in this PR)
- Short determinism note in `docs/architecture-principles.md` (alongside the existing timestamp/replay section).
- Wire an explicit seed through `game-server` / `gym` so seeds surface in replays and self-play (engine supports it; callers still pass `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
