### PR TITLE
Add Sami, Wildcat Captain and Thrumming Hivepool (EOE affinity pair)

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 238 / 261
+**Implemented:** 240 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -183,7 +183,7 @@
 - [x] Sacred Foundry
 - [x] Sami's Curiosity
 - [x] Sami, Ship's Engineer
-- [ ] Sami, Wildcat Captain
+- [x] Sami, Wildcat Captain
 - [x] Scour for Scrap
 - [x] Scout for Survivors
 - [x] Scrounge for Eternity
@@ -240,7 +240,7 @@
 - [x] The Endstone
 - [x] The Eternity Elevator
 - [x] The Seriema
-- [ ] Thrumming Hivepool
+- [x] Thrumming Hivepool
 - [x] Timeline Culler
 - [x] Tractor Beam
 - [x] Tragic Trajectory

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -184,17 +184,21 @@ aura-attached "copy of enchanted permanent" token source.
 
 ---
 
-## 14. Affinity granted to the spells you cast / affinity for a subtype
+## 14. Affinity granted to the spells you cast / affinity for a subtype — RESOLVED
 
 **Cards:** Sami, Wildcat Captain (affinity for artifacts on all your spells);
 Thrumming Hivepool (affinity for Slivers on itself).
 
 **Clause:** "Spells you cast have affinity for artifacts." / "Affinity for Slivers."
 
-**Plan:** Affinity for artifacts exists as a per-card keyword, but (a) granting it to *all spells a
-player casts* via a static, and (b) an affinity-for-`<subtype>` variant, are both missing. Sami's
-double strike + vigilance and Hivepool's Sliver anthem / upkeep Sliver tokens are already
-expressible.
+**Resolution:** No new engine work needed.
+- `KeywordAbility.AffinityForSubtype` already exists, so Hivepool's "Affinity for Slivers"
+  is just `KeywordAbility.AffinityForSubtype(Subtype.SLIVER)`.
+- Per CR 702.41a, "affinity for artifacts" is *defined* as "this spell costs {1} less for
+  each artifact you control", so Sami's "spells you cast have affinity for artifacts" is
+  mechanically identical to a battlefield-sourced
+  `ModifySpellCost(YouCast(Any), ReduceGenericBy(ArtifactsYouControl))` — no separate
+  "granted affinity" plumbing required.
 
 ---
 

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,9 +3,9 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (23)
+## Status: cards still blocked on engine work (21)
 
-The booster set is at **238 / 261**. The cards below are the only unimplemented ones; each is
+The booster set is at **240 / 261**. The cards below are the only unimplemented ones; each is
 blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
 summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
 parentheses).
@@ -24,8 +24,6 @@ parentheses).
 | Weapons Manufacturing | create the noncreature "Munitions" artifact token with a leaves-battlefield damage trigger | Noncreature tokens with embedded triggers (§11) |
 | Lightstall Inquisitor | "each opponent exiles a card from their hand and may play that card ..." (+cost/tapped) | Opponent exile-from-hand-may-play with modifiers (§12) |
 | Moonlit Meditation | "instead create that many tokens that are copies of enchanted permanent" (once/turn) | Token-creation replacement → copies (§13) |
-| Sami, Wildcat Captain | "Spells you cast have affinity for artifacts" | Affinity granted to your spells (§14) |
-| Thrumming Hivepool | "Affinity for Slivers" | Affinity for a subtype (§14) |
 | Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Grant Warp to hand cards (§15) |
 | Terminal Velocity | put a permanent from hand and grant it haste + an LTB trigger + an end-step self-sac | Grant arbitrary abilities to a put-in permanent (§16) |
 | Terrasymbiosis | "Whenever you put ... +1/+1 counters on a creature ... draw that many. Do this only once each turn." | Once-per-turn gating for triggered abilities (§17) |

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SamiWildcatCaptain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SamiWildcatCaptain.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Sami, Wildcat Captain
+ * {4}{R}{W}
+ * Legendary Creature — Human Artificer Rogue
+ * 4/4
+ *
+ * Double strike, vigilance
+ * Spells you cast have affinity for artifacts. (They cost {1} less to cast for each
+ * artifact you control.)
+ *
+ * Per CR 702.41a, "affinity for artifacts" means "this spell costs {1} less to cast for
+ * each artifact you control" — granting affinity to your spells is mechanically identical
+ * to a battlefield-sourced [SpellCostTarget.YouCast] reduction by the artifact count, so
+ * no dedicated "granted affinity" engine path is needed.
+ */
+val SamiWildcatCaptain = card("Sami, Wildcat Captain") {
+    manaCost = "{4}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Human Artificer Rogue"
+    power = 4
+    toughness = 4
+    oracleText = "Double strike, vigilance\n" +
+        "Spells you cast have affinity for artifacts. (They cost {1} less to cast for each artifact you control.)"
+
+    keywords(Keyword.DOUBLE_STRIKE, Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+            modification = CostModification.ReduceGenericBy(CostReductionSource.ArtifactsYouControl),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "226"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/bed64207-9193-4770-8f8f-e3203289d5a6.jpg?1752947484"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ThrummingHivepool.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ThrummingHivepool.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thrumming Hivepool
+ * {6}
+ * Artifact
+ *
+ * Affinity for Slivers (This spell costs {1} less to cast for each Sliver you control.)
+ * Slivers you control have double strike and haste.
+ * At the beginning of your upkeep, create two 1/1 colorless Sliver creature tokens.
+ */
+val ThrummingHivepool = card("Thrumming Hivepool") {
+    manaCost = "{6}"
+    typeLine = "Artifact"
+    oracleText = "Affinity for Slivers (This spell costs {1} less to cast for each Sliver you control.)\n" +
+        "Slivers you control have double strike and haste.\n" +
+        "At the beginning of your upkeep, create two 1/1 colorless Sliver creature tokens."
+
+    keywordAbility(KeywordAbility.AffinityForSubtype(Subtype.SLIVER))
+
+    val sliversYouControl = GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver").youControl())
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.DOUBLE_STRIKE, sliversYouControl)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, sliversYouControl)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Sliver")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "247"
+        artist = "Rob Rey"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85caf659-7b43-462e-a342-34703d46eb57.jpg?1752947564"
+        ruling("2025-07-25", "The mana value of a spell isn't changed by alternative costs, cost increases, or cost reductions. For example, if you cast Thrumming Hivepool (an artifact with affinity for Slivers), its mana value is 6 no matter how many Slivers you controlled when you cast it.")
+    }
+}


### PR DESCRIPTION
## Summary
- Add **Thrumming Hivepool** ({6} artifact) — Affinity for Slivers via the existing
  `KeywordAbility.AffinityForSubtype(Subtype.SLIVER)`; two `GrantKeyword` statics give
  Slivers you control double strike and haste; upkeep trigger creates two 1/1 colorless
  Sliver tokens.
- Add **Sami, Wildcat Captain** ({4}{R}{W} 4/4 legendary, double strike + vigilance).
  Per CR 702.41a, "spells you cast have affinity for artifacts" is mechanically identical
  to a battlefield `ModifySpellCost(YouCast(Any), ReduceGenericBy(ArtifactsYouControl))`,
  so it reuses the existing static-ability path — no new engine plumbing.
- Resolve `missing-effects.md` §14 (Affinity granted to your spells / affinity for a
  subtype) and drop both rows from `problem-cards.md`. EOE booster set is now at
  **240 / 261** with 21 cards still blocked on engine work.
