### PR TITLE
Add Invasion cards: Shivan Harvest, Reckless Assault, Savage Offensive

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RecklessAssault.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RecklessAssault.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Reckless Assault
+ * {2}{B}{R}
+ * Enchantment
+ * {1}, Pay 2 life: This enchantment deals 1 damage to any target.
+ */
+val RecklessAssault = card("Reckless Assault") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Enchantment"
+    oracleText = "{1}, Pay 2 life: This enchantment deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.PayLife(2))
+        target = AnyTarget()
+        effect = Effects.DealDamage(1, EffectTarget.ContextTarget(0))
+        description = "{1}, Pay 2 life: This enchantment deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "263"
+        artist = "Jeff Easley"
+        flavorText = "\"How will you fight an enemy that cares nothing for itself?\"\n—The Blind Seer"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff0f568e-4d3a-40a5-b72a-63040ec5402d.jpg?1562946506"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SavageOffensive.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SavageOffensive.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Savage Offensive
+ * {1}{R}
+ * Sorcery
+ * Kicker {G}
+ * Creatures you control gain first strike until end of turn. If this spell was kicked,
+ * they get +1/+1 until end of turn.
+ */
+val SavageOffensive = card("Savage Offensive") {
+    manaCost = "{1}{R}"
+    colorIdentity = "RG"
+    typeLine = "Sorcery"
+    oracleText = "Kicker {G} (You may pay an additional {G} as you cast this spell.)\n" +
+        "Creatures you control gain first strike until end of turn. If this spell was kicked, " +
+        "they get +1/+1 until end of turn."
+
+    keywordAbility(KeywordAbility.kicker("{G}"))
+
+    spell {
+        effect = EffectPatterns.grantKeywordToAll(Keyword.FIRST_STRIKE, Filters.Group.creaturesYouControl) then
+            ConditionalEffect(
+                condition = WasKicked,
+                effect = EffectPatterns.modifyStatsForAll(1, 1, Filters.Group.creaturesYouControl)
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "162"
+        artist = "Greg Hildebrandt & Tim Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/356744f3-e444-4f4e-bf00-80bb6b2ef76f.jpg?1562905776"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShivanHarvest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShivanHarvest.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Shivan Harvest
+ * {1}{R}
+ * Enchantment
+ * {1}{R}, Sacrifice a creature: Destroy target nonbasic land.
+ */
+val ShivanHarvest = card("Shivan Harvest") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "{1}{R}, Sacrifice a creature: Destroy target nonbasic land."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.Sacrifice(Filters.Creature))
+        target = TargetPermanent(
+            filter = TargetFilter(
+                GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.IsLand,
+                        CardPredicate.Not(CardPredicate.IsBasicLand),
+                    )
+                )
+            )
+        )
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+        description = "{1}{R}, Sacrifice a creature: Destroy target nonbasic land."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "167"
+        artist = "Daren Bader"
+        flavorText = "\"The blood of your ancestors ran heavy on this soil. Now it's your turn to sacrifice for the glory of Shiv.\"\n—Viashino heretic"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/47dbd765-d7ea-4181-bd22-5c749ad081af.jpg?1562909648"
+    }
+}


### PR DESCRIPTION
Implements three cards from Invasion (INV), each composing existing SDK primitives — no engine changes required.

## Cards

- **Shivan Harvest** ({1}{R} Enchantment) — `{1}{R}, Sacrifice a creature: Destroy target nonbasic land.` Activated ability using a composite mana + sacrifice cost and a `TargetPermanent` restricted to nonbasic lands (`IsLand` + `Not(IsBasicLand)`), then `Effects.Destroy`.
- **Reckless Assault** ({2}{B}{R} Enchantment) — `{1}, Pay 2 life: This enchantment deals 1 damage to any target.` Activated ability with mana + pay-life cost, `AnyTarget`, `Effects.DealDamage(1)` (the enchantment is the implicit damage source).
- **Savage Offensive** ({1}{R} Sorcery, Kicker {G}) — Creatures you control gain first strike until end of turn; if kicked, they also get +1/+1. Composed via `EffectPatterns.grantKeywordToAll(FIRST_STRIKE, creaturesYouControl)` then a `WasKicked`-gated `EffectPatterns.modifyStatsForAll(1, 1, ...)`.

## Verification

- INV is the earliest real printing for all three; canonical `CardDefinition`s placed in the INV set (auto-discovered, no manual registration). `just check-card-printing` passes for each.
- Image URIs taken from Scryfall (verified HTTP 200).
- `:mtg-sets:compileKotlin` clean; `just test-rules` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)