### PR TITLE
Add Invasion cards: Reviving Vapors, Seer's Vision, Manipulate Fate

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1252,6 +1252,10 @@ concerns — the `ClientStateTransformer` reveals the top card for `PlayFromTopO
   play, no full public reveal. (Precognition Field = instants/sorceries)
 - `LookAtTopOfLibrary` — *private*: the controller may look at their own top card any time (revealed
   only to them, not opponents). (Lens of Clarity, Vizier of the Menagerie)
+- `OpponentsPlayWithHandsRevealed` — visibility-only, the opponent-facing sibling of
+  `RevealTopOfLibrary`: each opponent of the controller plays with their hand publicly visible to
+  that controller (no other game effect). Handled entirely by the client state transformer's
+  hand-masking seam. (**Seer's Vision**)
 
 > Multiple lord effects on one card → multiple `staticAbility { }` blocks.
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -306,6 +306,25 @@ data object LookAtFaceDownCreatures : StaticAbility {
 }
 
 /**
+ * Your opponents play with their hands revealed.
+ * Used for Seer's Vision and similar "opponents reveal hands" enchantments.
+ *
+ * This is a visibility-only static ability, the opponent-facing sibling of
+ * [RevealTopOfLibrary]. Each opponent of this ability's controller plays with their
+ * hand publicly visible to that controller. It grants no other game effect.
+ *
+ * The engine treats it purely as a masking concern: the [com.wingedsheep] ClientStateTransformer
+ * reveals an opponent's hand to a viewing player who controls a permanent with this
+ * ability. No projector/state change is involved.
+ */
+@SerialName("OpponentsPlayWithHandsRevealed")
+@Serializable
+data object OpponentsPlayWithHandsRevealed : StaticAbility {
+    override val description: String = "Your opponents play with their hands revealed."
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}
+
+/**
  * You may cast this card from specified zones (e.g., graveyard, exile).
  * This is an intrinsic property of the card, checked when the card is in a matching zone.
  * Used for Squee, the Immortal (graveyard + exile).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ManipulateFate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ManipulateFate.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Manipulate Fate
+ * {1}{U}
+ * Sorcery
+ *
+ * Search your library for three cards, exile them, then shuffle.
+ * Draw a card.
+ *
+ * Composed from the atomic library pipeline: Gather (your library) → Select up to three
+ * (you can find fewer if the library doesn't hold three) → Move to exile → shuffle → draw.
+ */
+val ManipulateFate = card("Manipulate Fate") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for three cards, exile them, then shuffle.\nDraw a card."
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                // Search your library.
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.LIBRARY, Player.You, GameObjectFilter.Any),
+                    storeAs = "searchable"
+                ),
+                // Choose up to three cards.
+                SelectFromCollectionEffect(
+                    from = "searchable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(3)),
+                    chooser = Chooser.Controller,
+                    storeSelected = "exiled",
+                    prompt = "Choose up to three cards to exile"
+                ),
+                // Exile them.
+                MoveCollectionEffect(
+                    from = "exiled",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.You)
+                ),
+                // Then shuffle.
+                ShuffleLibraryEffect(EffectTarget.Controller),
+                // Draw a card.
+                Effects.DrawCards(1)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "60"
+        artist = "John Matson"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5bb52acb-dedb-4ed6-a6da-8c036f2b2958.jpg?1562913616"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RevivingVapors.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/RevivingVapors.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Reviving Vapors
+ * {2}{W}{U}
+ * Instant
+ *
+ * Reveal the top three cards of your library and put one of them into your hand.
+ * You gain life equal to that card's mana value. Put all other cards revealed this
+ * way into your graveyard.
+ *
+ * Composed from the atomic reveal pipeline: Gather (top 3, revealed) → Select exactly 1
+ * (caster's pick, remainder stored) → Move chosen to hand → gain life equal to its mana
+ * value via [DynamicAmount.StoredCardManaValue] → move the remainder to the graveyard.
+ */
+val RevivingVapors = card("Reviving Vapors") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Instant"
+    oracleText = "Reveal the top three cards of your library and put one of them into your hand. " +
+        "You gain life equal to that card's mana value. Put all other cards revealed this way " +
+        "into your graveyard."
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                // 1. Reveal the top three cards of your library.
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(3), Player.You),
+                    storeAs = "revealed",
+                    revealed = true
+                ),
+                // 2. Put one of them into your hand (rest become the remainder).
+                SelectFromCollectionEffect(
+                    from = "revealed",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "chosen",
+                    storeRemainder = "rest",
+                    prompt = "Choose a card to put into your hand",
+                    alwaysPrompt = true
+                ),
+                // 3. Move the chosen card to your hand.
+                MoveCollectionEffect(
+                    from = "chosen",
+                    destination = CardDestination.ToZone(Zone.HAND, Player.You)
+                ),
+                // 4. You gain life equal to that card's mana value.
+                Effects.GainLife(DynamicAmount.StoredCardManaValue("chosen"), EffectTarget.Controller),
+                // 5. Put all other cards revealed this way into your graveyard.
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "265"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/47a23c32-e122-400b-b252-e636ea2e684b.jpg?1562909595"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SeersVision.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SeersVision.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Seer's Vision
+ * {2}{U}{B}
+ * Enchantment
+ *
+ * Your opponents play with their hands revealed.
+ * Sacrifice this enchantment: Look at target player's hand and choose a card from it.
+ * That player discards that card. Activate only as a sorcery.
+ *
+ * The "play with hands revealed" clause is the visibility-only static
+ * [OpponentsPlayWithHandsRevealed] (the opponent-facing sibling of RevealTopOfLibrary,
+ * handled entirely by the client state transformer's hand-masking seam).
+ *
+ * The sacrifice ability composes the standard look-at-hand pipeline: gather the target
+ * player's hand → controller picks one card (shown all cards) → discard it. "Look at"
+ * (not "reveal") means the hand is only shown to the controller during the choice, which
+ * the gather/select pipeline already does without a public RevealHandEffect.
+ */
+val SeersVision = card("Seer's Vision") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Enchantment"
+    oracleText = "Your opponents play with their hands revealed.\n" +
+        "Sacrifice this enchantment: Look at target player's hand and choose a card from it. " +
+        "That player discards that card. Activate only as a sorcery."
+
+    staticAbility {
+        ability = OpponentsPlayWithHandsRevealed
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        timing = TimingRule.SorcerySpeed
+        val targetPlayer = target("target player", TargetPlayer())
+        effect = CompositeEffect(
+            listOf(
+                // Look at target player's hand.
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "targetHand"
+                ),
+                // You choose a card from it.
+                SelectFromCollectionEffect(
+                    from = "targetHand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    storeSelected = "toDiscard",
+                    prompt = "Choose a card for that player to discard",
+                    alwaysPrompt = true,
+                    showAllCards = true
+                ),
+                // That player discards that card.
+                MoveCollectionEffect(
+                    from = "toDiscard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    moveType = MoveType.Discard
+                )
+            )
+        )
+        description = "Sacrifice this enchantment: Look at target player's hand and choose a card from it. " +
+            "That player discards that card. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "270"
+        artist = "Rebecca Guay"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c94618a-808c-4b3c-8f34-45e64d0414d3.jpg?1562897588"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -37,6 +37,7 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.LookAtFaceDownCreatures
 import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
 import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
 import com.wingedsheep.sdk.scripting.conditions.AllConditions
@@ -345,8 +346,12 @@ class ClientStateTransformer(
             Zone.LIBRARY -> false
             // During a Mindslaver-style hijack the controller (actor) sees what the
             // affected player sees of their own hand. Spectators never gain visibility.
+            // A non-spectator viewer also sees an opponent's hand while they control a
+            // permanent that makes their opponents play with hands revealed (Seer's Vision).
             Zone.HAND -> debugMode || zoneKey.ownerId == viewingPlayerId ||
-                (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId)
+                (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId) ||
+                (!isSpectator && zoneKey.ownerId != viewingPlayerId &&
+                    revealsOpponentHandsTo(state, viewingPlayerId))
             Zone.BATTLEFIELD,
             Zone.GRAVEYARD,
             Zone.STACK,
@@ -366,6 +371,21 @@ class ClientStateTransformer(
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
             if (cardDef.script.staticAbilities.any { it is PlayFromTopOfLibrary || it is RevealTopOfLibrary }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Check if [playerId] controls a permanent with [OpponentsPlayWithHandsRevealed]
+     * (e.g., Seer's Vision). While they do, their opponents' hands are visible to them.
+     */
+    private fun revealsOpponentHandsTo(state: GameState, playerId: EntityId): Boolean {
+        for (entityId in state.getBattlefield(playerId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            if (cardDef.script.staticAbilities.any { it is OpponentsPlayWithHandsRevealed }) {
                 return true
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeersVisionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeersVisionTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.mtg.sets.definitions.inv.cards.SeersVision
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+
+/**
+ * Seer's Vision (INV #270) — the new [com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed]
+ * static ability.
+ *
+ * "Your opponents play with their hands revealed." This is the opponent-facing sibling of
+ * Goblin Spy's `RevealTopOfLibrary`: while a player controls Seer's Vision, each opponent's hand
+ * is publicly visible to that controller. The visibility is applied entirely by the
+ * [ClientStateTransformer] hand-masking seam — these tests pin that the opponent's hand cards
+ * become visible to the Seer's Vision controller (and to nobody else).
+ *
+ * The sacrifice-to-discard ability composes already-tested atomic effects (gather hand → select →
+ * discard, identical to Addle), so it is not re-exercised here.
+ */
+class SeersVisionTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SeersVision))
+        return driver
+    }
+
+    fun transformer(d: GameTestDriver): ClientStateTransformer =
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+
+    test("opponent's hand is revealed to the Seer's Vision controller") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Swamp" to 20),
+            startingLife = 20
+        )
+
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Seer's Vision")
+        val opponentCard = driver.putCardInHand(opponent, "Lightning Bolt")
+
+        // From the controller's viewpoint, the opponent's hand card is visible.
+        val view = transformer(driver).transform(driver.state, viewingPlayerId = controller)
+
+        view.cards.keys shouldContain opponentCard
+        val opponentHand = view.zones.first {
+            it.zoneId.ownerId == opponent && it.zoneId.zoneType == Zone.HAND
+        }
+        opponentHand.cardIds shouldContain opponentCard
+    }
+
+    test("opponent's hand is NOT revealed without Seer's Vision") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Swamp" to 20),
+            startingLife = 20
+        )
+
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val opponentCard = driver.putCardInHand(opponent, "Lightning Bolt")
+
+        // With no reveal source, the controller must not see the opponent's hand card.
+        val view = transformer(driver).transform(driver.state, viewingPlayerId = controller)
+
+        view.cards.keys shouldNotContain opponentCard
+    }
+
+    test("the Seer's Vision controller's own hand is not exposed to the opponent") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Swamp" to 20),
+            startingLife = 20
+        )
+
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Seer's Vision")
+        val controllerCard = driver.putCardInHand(controller, "Lightning Bolt")
+
+        // The opponent controls no reveal source, so the controller's hand stays hidden from them.
+        val view = transformer(driver).transform(driver.state, viewingPlayerId = opponent)
+
+        view.cards.keys shouldNotContain controllerCard
+    }
+})


### PR DESCRIPTION
Implements three Invasion (INV) cards via the add-card workflow.

## Cards

- **Reviving Vapors** `{2}{W}{U}` Instant — Reveal the top three cards of your library and put one into your hand. Gain life equal to that card's mana value. Put the rest into your graveyard. Composed entirely from existing atomic effects: `GatherCards(top 3, revealed)` → `SelectFromCollection(exactly 1, remainder)` → `MoveCollection(→ hand)` → `GainLife(StoredCardManaValue)` → `MoveCollection(→ graveyard)`. No engine changes.
- **Manipulate Fate** `{1}{U}` Sorcery — Search your library for (up to) three cards, exile them, then shuffle. Draw a card. Composed from the library gather/select/move-to-exile pipeline (`Player.You`) + `ShuffleLibrary` + `DrawCards(1)`. No engine changes.
- **Seer's Vision** `{2}{U}{B}` Enchantment — "Your opponents play with their hands revealed." Sacrifice this enchantment: look at target player's hand, choose a card, that player discards it (sorcery speed).

## New SDK / engine work (Seer's Vision)

- Added `OpponentsPlayWithHandsRevealed`, a visibility-only static ability — the opponent-facing sibling of `RevealTopOfLibrary`. While a player controls a permanent with it, each opponent's hand is publicly visible to that controller.
- Wired purely through the `ClientStateTransformer` hand-masking seam (new `revealsOpponentHandsTo` helper + a clause in `isZoneVisibleTo` for the `HAND` zone). No projector or state change.
- The sacrifice-to-discard ability reuses the already-tested gather → select → discard atoms (same shape as Addle), so no new effect types were needed.
- Updated `docs/card-sdk-language-reference.md` (static abilities section) for the new static.

## Tests

- New `SeersVisionTest` (rules-engine) pins the hand-visibility behavior: opponent's hand is revealed to the Seer's Vision controller, not revealed without it, and the controller's own hand is not exposed to the opponent.
- Full `:rules-engine:test` suite passes; `:mtg-sets:test` and `:game-server:compileTestKotlin` pass. `just check-card-printing` confirms all three are canonical in their earliest real printing (INV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)