### PR TITLE
Show a type-change badge when a land becomes another basic land type

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DreamThrushScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DreamThrushScenarioTest.kt
@@ -122,6 +122,35 @@ class DreamThrushScenarioTest : ScenarioTestBase() {
                     projected.hasSubtype(mountain, "Island") shouldBe false
                 }
             }
+
+            test("the land surfaces a type-change badge while it is the chosen type") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Dream Thrush")
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+
+                fun typeChangeBadges() = game.getClientState(1).cards.values
+                    .first { it.id == forest }
+                    .activeEffects
+                    .filter { it.icon == "type-change" }
+
+                withClue("Before the change the land has no type-change badge") {
+                    typeChangeBadges() shouldBe emptyList()
+                }
+
+                game.changeLandType(forest, "Island")
+
+                withClue("After becoming an Island the land surfaces exactly one type-change badge") {
+                    val badges = typeChangeBadges()
+                    badges.size shouldBe 1
+                    badges[0].name shouldBe "Island"
+                }
+            }
         }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -2207,6 +2207,35 @@ class ClientStateTransformer(
                 }
             }
 
+            // Surface a "type-change" badge when a land's basic land types are replaced
+            // (e.g., Slimy Kavu / Dream Thrush "target land becomes a Swamp"). The type
+            // line text already reflects this, but a battlefield permanent is read by its
+            // art, so the badge makes the change visible. Driven from projected state so
+            // superseded transformations (re-targeting the same land) don't stack.
+            // Dream Thrush's chosen-type variant resolves to a concrete SetBasicLandTypes
+            // at execution time, so the floating effect is always SetBasicLandTypes here.
+            val hasSetBasicLandTypes = state.floatingEffects.any {
+                entityId in it.effect.affectedEntities &&
+                    it.effect.modification is SerializableModification.SetBasicLandTypes
+            }
+            if (hasSetBasicLandTypes) {
+                val basicLandTypes = com.wingedsheep.sdk.core.Subtype.ALL_BASIC_LAND_TYPES
+                val baseLandTypes = baseSubtypes.filter { it in basicLandTypes }.toSet()
+                val projectedLandTypes = projectedState.getSubtypes(entityId)
+                    .filter { it in basicLandTypes }
+                if (projectedLandTypes.isNotEmpty() && projectedLandTypes.toSet() != baseLandTypes) {
+                    val joined = projectedLandTypes.joinToString(" ")
+                    effects.add(
+                        ClientCardEffect(
+                            effectId = "land_type_changed",
+                            name = joined,
+                            description = "Land types are now $joined",
+                            icon = "type-change"
+                        )
+                    )
+                }
+            }
+
             // Surface a single "color-change" badge when a ChangeColor floating effect
             // is replacing this entity's colors. Driven from projected state so
             // superseded transformations don't stack (Tam re-targeting same creature).


### PR DESCRIPTION
## What

When a land "becomes a Swamp" (Slimy Kavu) or "becomes the basic land type of your choice" (Dream Thrush), the change now surfaces a visible **type-change badge** on the permanent.

## Why

These effects apply a Layer 4 `SetBasicLandTypes` floating modification. The projected type line was already correct (`Land — Swamp`, mana abilities updated), but a battlefield permanent is recognized by its art, so the change was easy to miss. Creature-subtype changes (`SetCreatureSubtypes` / `AddSubtype`) already get a `type-change` badge — lands were the gap.

## Change

- `ClientStateTransformer.buildCardActiveEffects` now emits a `type-change` badge for permanents under a `SetBasicLandTypes` floating effect, computed from projected state so re-targeting the same land doesn't stack duplicate badges (mirrors the existing creature-subtype path).
- The `type-change` icon already exists in `CardOverlays.tsx`, so there is **no web-client change**.
- Added a badge-assertion test to `DreamThrushScenarioTest` (same `SetBasicLandTypes` path covers Slimy Kavu).

## Testing

`DreamThrushScenarioTest` — all 3 tests pass (incl. the new badge test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)