### PR TITLE
Fix split-card faces not surfacing their targets in legal actions

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionSplitCardsScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionSplitCardsScenarioTest.kt
@@ -5,12 +5,19 @@ import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.session.GameSession
+import com.wingedsheep.gameserver.session.PlayerSession
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
 
 /**
  * Scenario tests for the Invasion split cards (Pain // Suffering, Stand // Deliver, Wax // Wane)
@@ -49,6 +56,61 @@ class InvasionSplitCardsScenarioTest : ScenarioTestBase() {
                     game.state.getHand(game.player2Id).none {
                         game.state.getEntity(it)?.get<CardComponent>()?.name == "Forest"
                     } shouldBe true
+                }
+            }
+
+            // Regression: the legal-action enumerator must read each split face's own
+            // targetRequirements. Previously the SPLIT branch emitted a bare cast action with no
+            // validTargets, so the client reported "no valid targets available" when casting Pain.
+            test("legal actions surface both faces' targets (enumerator regression)") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Pain // Suffering")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val session = GameSession(cardRegistry = cardRegistry)
+                val mockWs1 = mockk<WebSocketSession>(relaxed = true) { every { id } returns "ws1" }
+                val mockWs2 = mockk<WebSocketSession>(relaxed = true) { every { id } returns "ws2" }
+                session.injectStateForTesting(
+                    game.state,
+                    mapOf(
+                        game.player1Id to PlayerSession(mockWs1, game.player1Id, "Player1"),
+                        game.player2Id to PlayerSession(mockWs2, game.player2Id, "Player2"),
+                    )
+                )
+
+                val legalActions = session.getLegalActions(game.player1Id)
+
+                val painAction = legalActions.find { it.description == "Cast Pain" }
+                withClue("Legal actions should include 'Cast Pain'") { painAction.shouldNotBeNull() }
+                withClue("Pain (target player) must require targets") {
+                    painAction!!.requiresTargets shouldBe true
+                }
+                withClue("Pain should offer both players as valid targets") {
+                    val vt = painAction!!.validTargets
+                    vt.shouldNotBeNull()
+                    vt shouldContain game.player1Id
+                    vt shouldContain game.player2Id
+                }
+
+                val sufferingAction = legalActions.find { it.description == "Cast Suffering" }
+                withClue("Legal actions should include 'Cast Suffering'") { sufferingAction.shouldNotBeNull() }
+                withClue("Suffering (target land) must require targets") {
+                    sufferingAction!!.requiresTargets shouldBe true
+                }
+                val targetLand = game.state.getBattlefield(game.player2Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Forest"
+                }
+                withClue("Suffering should offer the opponent's land as a valid target") {
+                    sufferingAction!!.validTargets.shouldNotBeNull()
+                    sufferingAction.validTargets!! shouldContain targetLand
                 }
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardFace
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.KeywordAbility
@@ -83,31 +84,8 @@ class CastSpellEnumerator : ActionEnumerator {
             }
 
             if (cardDef.layout == com.wingedsheep.sdk.model.CardLayout.SPLIT && cardDef.cardFaces.isNotEmpty()) {
-                val isSorceryFace = cardDef.cardFaces.all { face ->
-                    !face.typeLine.isInstant
-                }
-                if (isSorceryFace && !context.canPlaySorcerySpeed) continue
-                val cachedSources = context.availableManaSources
                 cardDef.cardFaces.forEachIndexed { faceIndex, face ->
-                    val effectiveCost = context.costCalculator
-                        .calculateEffectiveCostWithAlternativeBase(state, cardDef, face.manaCost, playerId)
-                    val canAffordFace = context.manaSolver
-                        .canPay(state, playerId, effectiveCost, precomputedSources = cachedSources)
-                    if (!canAffordFace) return@forEachIndexed
-                    val autoTapPreviewFace = if (context.skipAutoTapPreview) null else {
-                        context.manaSolver
-                            .solve(state, playerId, effectiveCost, precomputedSources = cachedSources)
-                            ?.sources?.map { it.entityId }
-                    }
-                    result.add(
-                        LegalAction(
-                            actionType = "CastSpell",
-                            description = "Cast ${face.name}",
-                            action = CastSpell(playerId, cardId, faceIndex = faceIndex),
-                            manaCostString = effectiveCost.toString(),
-                            autoTapPreview = autoTapPreviewFace,
-                        )
-                    )
+                    enumerateSplitFace(context, cardId, cardDef, faceIndex, face, result)
                 }
                 continue
             }
@@ -1650,6 +1628,103 @@ class CastSpellEnumerator : ActionEnumerator {
             autoTapPreview = modeAutoTapPreview,
             targetInfos = modeTargetInfos,
             allTargetRequirementsSatisfied = allTargetRequirementsSatisfied
+        )
+    }
+
+    // =========================================================================
+    // Split face (CR 709)
+    // =========================================================================
+
+    /**
+     * Emit a [LegalAction] for casting one face of a split-layout card from hand (CR 709.4 —
+     * only the chosen half goes on the stack and is evaluated for legality).
+     *
+     * Each face has its own mana cost, type line (so timing is per-face), and — crucially —
+     * its own `targetRequirements`. Reading the face's targets here is what makes targeted
+     * split halves (Pain // Suffering, Stand // Deliver, Wax // Wane) actually offer their
+     * targets to the client; without it the cast surfaces with no valid targets even though
+     * the validation layer ([CastSpellHandler]) reads from the face script and expects them.
+     *
+     * Modal effects, alternative costs, blight, behold, kicker, and convoke on a split half
+     * are not yet wired up — cards that need them can extend this method later.
+     */
+    private fun enumerateSplitFace(
+        context: EnumerationContext,
+        cardId: EntityId,
+        cardDef: CardDefinition,
+        faceIndex: Int,
+        face: CardFace,
+        result: MutableList<LegalAction>,
+    ) {
+        val state = context.state
+        val playerId = context.playerId
+
+        // Per-face timing: the chosen half's own type line governs sorcery-speed restriction.
+        if (!face.typeLine.isInstant && !context.canPlaySorcerySpeed) return
+
+        val cachedSources = context.availableManaSources
+        val effectiveCost = context.costCalculator
+            .calculateEffectiveCostWithAlternativeBase(state, cardDef, face.manaCost, playerId)
+        if (!context.manaSolver.canPay(state, playerId, effectiveCost, precomputedSources = cachedSources)) return
+
+        val autoTapPreview = if (context.skipAutoTapPreview) null else {
+            context.manaSolver
+                .solve(state, playerId, effectiveCost, precomputedSources = cachedSources)
+                ?.sources?.map { it.entityId }
+        }
+        val manaCostString = effectiveCost.toString()
+
+        val targetReqs = face.script.targetRequirements
+        if (targetReqs.isEmpty()) {
+            result.add(
+                LegalAction(
+                    actionType = "CastSpell",
+                    description = "Cast ${face.name}",
+                    action = CastSpell(playerId, cardId, faceIndex = faceIndex),
+                    manaCostString = manaCostString,
+                    autoTapPreview = autoTapPreview,
+                )
+            )
+            return
+        }
+
+        val targetInfos = context.targetUtils.buildTargetInfos(state, playerId, targetReqs)
+        if (!context.targetUtils.allRequirementsSatisfied(targetInfos)) return
+        val firstReq = targetReqs.first()
+        val firstInfo = targetInfos.first()
+
+        // Auto-select a sole legal player target (e.g. "target player" in a 2-player game where
+        // only one player is legal), matching the normal cast path's UX.
+        val canAutoSelect = targetReqs.size == 1 &&
+            context.targetUtils.shouldAutoSelectPlayerTarget(firstReq, firstInfo.validTargets)
+        if (canAutoSelect) {
+            val autoTarget = ChosenTarget.Player(firstInfo.validTargets.first())
+            result.add(
+                LegalAction(
+                    actionType = "CastSpell",
+                    description = "Cast ${face.name}",
+                    action = CastSpell(playerId, cardId, faceIndex = faceIndex, targets = listOf(autoTarget)),
+                    manaCostString = manaCostString,
+                    autoTapPreview = autoTapPreview,
+                )
+            )
+            return
+        }
+
+        result.add(
+            LegalAction(
+                actionType = "CastSpell",
+                description = "Cast ${face.name}",
+                action = CastSpell(playerId, cardId, faceIndex = faceIndex),
+                validTargets = firstInfo.validTargets,
+                requiresTargets = true,
+                targetCount = firstReq.count,
+                minTargets = firstReq.effectiveMinCount,
+                targetDescription = firstReq.description,
+                targetRequirements = if (targetInfos.size > 1) targetInfos else null,
+                manaCostString = manaCostString,
+                autoTapPreview = autoTapPreview,
+            )
         )
     }
 


### PR DESCRIPTION
## Problem

Casting the **Pain** half of **Pain // Suffering** (\"Target player discards a card\") reported **\"no valid targets available\"** even with legal players to target. The same affected every targeted split-card face (Stand // Deliver, Wax // Wane).

## Root cause

`CastSpellEnumerator`'s split-layout branch (CR 709) emitted a bare `CastSpell` action per face — it read each face's **mana cost** but never its **`targetRequirements`**. For a normal spell the enumerator builds `validTargets`/`requiresTargets` from `script.targetRequirements`; for a split card those live on `cardFaces[faceIndex].script`, which the branch skipped entirely.

The validation layer (`CastSpellHandler`) *does* read from the face script and expects targets, so the existing scenario tests (which hand-feed targets into `CastSpell`) passed — masking the gap at the enumeration layer the client actually consumes.

## Fix

Extract `enumerateSplitFace`, mirroring the existing `enumerateAdventureFace`:

- reads `face.script.targetRequirements` and builds target infos,
- emits the action with `validTargets` / `requiresTargets` / `targetDescription`,
- auto-selects a sole legal player target (matching the normal cast path's UX),
- evaluates **timing per face** — the chosen half's own type line governs sorcery-speed — instead of skipping the whole card when every face is a sorcery.

## Tests

Adds an enumerator regression test asserting both faces of Pain // Suffering surface their targets via `getLegalActions` (would fail before this change). Full `InvasionSplitCardsScenarioTest` suite passes (8 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)