### PR TITLE
Fix auto-tap silently sacrificing mixed mana sources (Irrigation Ditch)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -118,6 +118,16 @@ data class ManaSource(
      */
     val requiresSacrifice: Boolean = false,
     /**
+     * Colors this source can produce *only* by sacrificing itself, when it also has at
+     * least one non-sacrifice mana ability (e.g. Irrigation Ditch — `{T}: Add {W}` plus
+     * `{T}, Sacrifice this land: Add {G}{U}`). The source-level [requiresSacrifice] flag
+     * stays false for such mixed sources (the {W} path is sacrifice-free), so the auto-pay
+     * solver must drop these specific colors instead — otherwise it would silently pick the
+     * sacrifice ability to produce {G}/{U}. Manual mana-source selection still offers the
+     * sacrifice ability for these colors so the choice is explicit.
+     */
+    val colorsRequiringSacrifice: Set<Color> = emptySet(),
+    /**
      * Tapping this source also requires tapping another permanent (e.g. Springleaf
      * Drum — "{T}, Tap an untapped creature you control: Add one mana of any color").
      * Auto-pay refuses to pick these because silently tapping someone else's permanent
@@ -290,6 +300,14 @@ class ManaSolver(
             .filter { source ->
                 if (source.restriction == null || spellContext == null) true
                 else source.restriction.isSatisfiedBy(spellContext)
+            }
+            // Drop colors a mixed source can only make by sacrificing itself (e.g. Irrigation
+            // Ditch's {G}{U}, kept behind its sacrifice-free {W} ability). Auto-pay must not
+            // silently sacrifice; the {W} path remains usable, and manual selection still
+            // offers the sacrifice ability for these colors.
+            .map { source ->
+                if (source.colorsRequiringSacrifice.isEmpty()) source
+                else source.copy(producesColors = source.producesColors - source.colorsRequiringSacrifice)
             }
 
         if (availableSources.isEmpty() && cost.cmc > 0) {
@@ -813,6 +831,11 @@ class ManaSolver(
             val perColorRestrictions = mutableMapOf<Color, ManaRestriction?>()
             // Track the minimum mana-cost-to-activate per color (cheapest ability producing it)
             val perColorActivationCost = mutableMapOf<Color, Int>()
+            // Track which colors are produceable WITHOUT sacrificing the source. A color is
+            // sacrifice-free if any accepted ability producing it has no SacrificeSelf cost.
+            // Colors in `combinedColors` but not here can only be made by sacrificing — the
+            // auto-pay solver must not pick those (see ManaSource.colorsRequiringSacrifice).
+            val sacrificeFreeColors = mutableSetOf<Color>()
             // Spell riders contributed per color by abilities on this source (e.g.
             // Cavern of Souls' "Add one mana of any color" carries
             // MakesSpellUncounterable on every color it can produce, while its
@@ -993,6 +1016,11 @@ class ManaSolver(
                     else minOf(existing, abilityActivationManaCost)
                 }
 
+                // Record which colors this ability can produce without sacrifice.
+                if (!abilityRequiresSacrifice) {
+                    sacrificeFreeColors.addAll(effectColors)
+                }
+
                 // Track per-color restrictions: null means unrestricted
                 for (color in effectColors) {
                     val existing = perColorRestrictions[color]
@@ -1052,6 +1080,13 @@ class ManaSolver(
                 // preferred and the source is offered without sacrifice.
                 val requiresSacrifice = anyAcceptedWithSac && !anyAcceptedWithoutSac
 
+                // Colors this mixed source can only produce by sacrificing. When the whole
+                // source is sacrifice-bound (requiresSacrifice == true) this stays empty — the
+                // source is dropped from auto-pay entirely by the existing filter, so there's
+                // no need to also tag individual colors.
+                val colorsRequiringSacrifice = if (requiresSacrifice) emptySet()
+                else combinedColors - sacrificeFreeColors
+
                 // Same rule for the tap-another-permanent sub-cost: surface it only when
                 // every accepted ability requires the secondary tap. If any plain mana
                 // ability was accepted, that path is preferred.
@@ -1079,6 +1114,7 @@ class ManaSolver(
                     colorRestrictions = restrictedColors,
                     colorActivationManaCost = colorActivationCosts,
                     requiresSacrifice = requiresSacrifice,
+                    colorsRequiringSacrifice = colorsRequiringSacrifice,
                     hasContextSensitiveAbilities = hasMixedRestrictions,
                     tapPermanentsSubCost = tapPermanentsSubCost,
                 )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IrrigationDitchAutoTapTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IrrigationDitchAutoTapTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.IrrigationDitch
+import com.wingedsheep.mtg.sets.definitions.inv.cards.NomadicElf
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Irrigation Ditch has a sacrifice-free mana ability *and* a sacrifice one:
+ *   {T}: Add {W}
+ *   {T}, Sacrifice this land: Add {G}{U}
+ *
+ * The auto-pay solver must never silently sacrifice the land to produce the {G}/{U}.
+ * Because the source also has the sacrifice-free {W} ability, the whole-source
+ * `requiresSacrifice` flag is false, so the fix tags {G}/{U} individually as
+ * sacrifice-only and strips them from the auto-pay source list.
+ */
+class IrrigationDitchAutoTapTest : FunSpec({
+
+    // Minimal {W} creature so we can prove the sacrifice-free white ability still auto-taps.
+    val whiteBear = card("White Bear") {
+        manaCost = "{W}"
+        typeLine = "Creature — Bear"
+        power = 1
+        toughness = 1
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(IrrigationDitch, NomadicElf, whiteBear))
+        return driver
+    }
+
+    test("auto-pay refuses to sacrifice Irrigation Ditch to cast Nomadic Elf ({1}{G})") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ditch = driver.putPermanentOnBattlefield(activePlayer, "Irrigation Ditch")
+        driver.putPermanentOnBattlefield(activePlayer, "Island")
+        val elf = driver.putCardInHand(activePlayer, "Nomadic Elf")
+
+        // The only source of {G} is Irrigation Ditch's "{T}, Sacrifice: Add {G}{U}" ability.
+        // Auto-pay must not pick it — there is no sacrifice-free way to make green.
+        val result = driver.castSpell(activePlayer, elf)
+
+        result.isSuccess shouldBe false
+        // Irrigation Ditch was NOT sacrificed: still on the battlefield, untapped.
+        driver.findPermanent(activePlayer, "Irrigation Ditch") shouldBe ditch
+        driver.isTapped(ditch) shouldBe false
+        driver.getGraveyardCardNames(activePlayer).contains("Irrigation Ditch") shouldBe false
+    }
+
+    test("auto-pay still uses Irrigation Ditch's sacrifice-free {W} ability") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ditch = driver.putPermanentOnBattlefield(activePlayer, "Irrigation Ditch")
+        val bear = driver.putCardInHand(activePlayer, "White Bear")
+
+        // {W}: Irrigation Ditch's plain "{T}: Add {W}" ability covers it without sacrificing.
+        val result = driver.castSpell(activePlayer, bear)
+
+        result.isSuccess shouldBe true
+        // Tapped for {W}, but still on the battlefield (not sacrificed).
+        driver.isTapped(ditch) shouldBe true
+        driver.findPermanent(activePlayer, "Irrigation Ditch") shouldBe ditch
+        driver.getGraveyardCardNames(activePlayer).contains("Irrigation Ditch") shouldBe false
+    }
+})


### PR DESCRIPTION
## Problem

With Irrigation Ditch + Island in play, auto-tapping to cast **Nomadic Elf** (`{1}{G}`) succeeds by **silently sacrificing Irrigation Ditch** — which shouldn't happen.

Irrigation Ditch has two mana abilities:
- `{T}: Add {W}` (sacrifice-free)
- `{T}, Sacrifice this land: Add {G}{U}` (sacrifice)

The solver marks a source `requiresSacrifice` only when *every* accepted mana ability requires sacrifice. For a mixed source like Irrigation Ditch the flag stays `false` (the `{W}` path is sacrifice-free), so the auto-pay filter `.filter { !it.requiresSacrifice }` let it through — and the solver then produced `{G}`/`{U}` by sacrificing the land without asking. Auto-pay must never silently sacrifice a permanent (same rule that already filters Treasure tokens).

## Fix

Track per-color which colors a mixed source can produce **only** by sacrificing itself (`ManaSource.colorsRequiringSacrifice`), computed alongside the existing per-color activation-cost / restriction machinery in `findAvailableManaSources`. In `solve()`, strip those colors from the auto-pay source list.

- The sacrifice-free `{W}` path remains fully usable for auto-pay.
- Fully-sacrifice sources (Treasure) are still dropped wholesale by the existing flag — `colorsRequiringSacrifice` is left empty for them.
- Manual mana-source selection is unchanged: it still offers the sacrifice ability so the player can opt in explicitly.
- `canPay()` still reports the spell as affordable via `calculateSacrificeSelfBonusMana()`, matching existing Treasure-ward behavior.

## Tests

New `IrrigationDitchAutoTapTest`:
- **auto-pay refuses to sacrifice Irrigation Ditch to cast Nomadic Elf** — the cast fails and the Ditch stays untapped on the battlefield (this test fails on `main`).
- **auto-pay still uses Irrigation Ditch's sacrifice-free `{W}` ability** — a `{W}` spell auto-taps the Ditch without sacrificing it.

Full `:rules-engine:test` suite passes, including all existing mana/sacrifice tests (HiddenGrotto, WardPaidWithTreasure, WardPaidWithSpringleafDrum, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)