### PR TITLE
Add Invasion cards: Tsabo's Web, Orim's Touch, Turf Wound

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -381,6 +381,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `HijackNextTurnEffect(target)` — you control target's next turn.
 - `GrantCantBeBlockedByChosenColorEffect(target, duration)` — unblockable except by chosen color.
 - `CantCastSpellsEffect(target, until?)` — target can't cast spells.
+- `Effects.CantPlayLandsThisTurn(target = Controller)` (`PreventLandPlaysThisTurnEffect`) — the target player can't
+  play lands for the rest of this turn (sets remaining land drops to 0). Defaults to the controller (Rock Jockey);
+  pass `EffectTarget.ContextTarget(n)` for "target player can't play lands this turn" cards like Turf Wound.
 
 ### Forced sacrifice / discard
 
@@ -700,6 +703,11 @@ work for abilities-on-stack (which carry no `CardComponent`).
   includes at least one chosen target matching `subfilter`. Player targets are skipped. The
   subfilter inherits the outer `PredicateContext`, so `Land.youControl()` inside the subfilter
   resolves against the outer chooser. Used by Teferi's Response.
+- `CardPredicate.HasNonManaActivatedAbility` — matches a permanent whose printed activated abilities
+  include at least one that isn't a mana ability and isn't a loyalty ability (battlefield-activatable).
+  Backed by the precomputed `CardComponent.hasNonManaActivatedAbility` flag (set at entity creation from
+  `CardDefinition.hasNonManaActivatedAbility`), so abilities granted by other continuous effects are not
+  counted. Used by Tsabo's Web ("each land with an activated ability that isn't a mana ability …").
 
 ### `StatePredicate` — battlefield state checks
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -430,6 +430,7 @@ abstract class ScenarioTestBase : FunSpec() {
                 ownerId = ownerId,
                 spellEffect = cardDef.spellEffect,
                 imageUri = cardDef.metadata.imageUri,
+                hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             )
 
             var container = ComponentContainer.of(

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionTsabosWebTurfWoundOrimsTouchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionTsabosWebTurfWoundOrimsTouchScenarioTest.kt
@@ -1,0 +1,186 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.LandDropsComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Invasion cards introducing new engine mechanics:
+ *  - Turf Wound ({2}{R} Instant): target player can't play lands this turn; draw a card
+ *    (exercises the targeted PreventLandPlaysThisTurnEffect).
+ *  - Orim's Touch ({W} Instant, Kicker {1}): prevent next 2 (or 4 if kicked) damage to any target.
+ *  - Tsabo's Web ({2} Artifact): ETB draw; each land with a non-mana activated ability doesn't
+ *    untap (exercises CardPredicate.HasNonManaActivatedAbility + DOESNT_UNTAP grant).
+ */
+class InvasionTsabosWebTurfWoundOrimsTouchScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    // A land whose only activated ability is a NON-mana ability ("{T}: Draw a card").
+    private val tappingLand = card("Vault Land") {
+        typeLine = "Land"
+        oracleText = "{T}: Draw a card."
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    // A plain creature attacker for the Orim's Touch prevention test.
+    private val bear = CardDefinition.creature(
+        name = "Test Bear", manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Bear")), power = 2, toughness = 2
+    )
+
+    init {
+        cardRegistry.register(tappingLand)
+        cardRegistry.register(bear)
+
+        context("Turf Wound") {
+            test("target player can't play lands this turn and caster draws a card") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Turf Wound")
+                    .withLandsOnBattlefield(1, "Mountain", 3) // {2}{R}
+                    .withCardInLibrary(1, "Mountain")          // something to draw
+                    .withCardInHand(2, "Forest")               // a land the opponent would try to play
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpellTargetingPlayer(1, "Turf Wound", 2)
+                game.resolveStack()
+
+                withClue("Opponent's remaining land drops should be set to 0") {
+                    game.state.getEntity(game.player2Id)?.get<LandDropsComponent>()?.remaining shouldBe 0
+                }
+                withClue("Caster should have drawn a card (cast one, drew one -> net same hand size)") {
+                    // -1 for casting Turf Wound, +1 for the draw.
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+
+        context("Orim's Touch") {
+            test("unkicked prevents the next 2 damage to a player") {
+                val game = scenario()
+                    .withPlayers("Defender", "Attacker")
+                    .withCardInHand(1, "Orim's Touch")
+                    .withLandsOnBattlefield(1, "Plains", 1) // {W}
+                    .withCardOnBattlefield(2, "Test Bear")  // 2/2 attacker
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)                   // defender holds priority to cast at instant speed
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startLife = game.getLifeTotal(1)
+
+                // Defender casts Orim's Touch on themselves to pre-empt the incoming 2 damage.
+                val orimCast = game.castSpellTargetingPlayer(1, "Orim's Touch", 1)
+                withClue("Orim's Touch cast should succeed: ${orimCast.error}") {
+                    orimCast.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("A prevention shield should exist on the defender after resolution") {
+                    game.state.floatingEffects.any { game.player1Id in it.effect.affectedEntities } shouldBe true
+                }
+
+                val bearId = game.findPermanent("Test Bear")!!
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.execute(DeclareAttackers(game.player2Id, mapOf(bearId to game.player1Id)))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("All 2 combat damage should have been prevented") {
+                    game.getLifeTotal(1) shouldBe startLife
+                }
+            }
+
+            test("kicked prevents up to 4 damage") {
+                val game = scenario()
+                    .withPlayers("Defender", "Attacker")
+                    .withCardInHand(1, "Orim's Touch")
+                    .withLandsOnBattlefield(1, "Plains", 2) // {W} + kicker {1}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hand = game.state.getHand(game.player1Id)
+                val touchId = hand.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Orim's Touch"
+                }
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        touchId,
+                        listOf(ChosenTarget.Player(game.player1Id)),
+                        wasKicked = true
+                    )
+                )
+                withClue("Kicked Orim's Touch should cast successfully: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+                // Resolution succeeding (no error) confirms the kicked branch was reachable;
+                // the prevention amount is exercised by the unkicked combat test above.
+            }
+        }
+
+        context("Tsabo's Web") {
+            test("ETB draws a card; land with a non-mana activated ability doesn't untap") {
+                val game = scenario()
+                    .withPlayers("Owner", "Opponent")
+                    .withCardOnBattlefield(1, "Vault Land")  // non-mana activated ability
+                    .withLandsOnBattlefield(1, "Forest", 1)  // mana-only; should still untap
+                    .withCardInHand(1, "Tsabo's Web")
+                    .withLandsOnBattlefield(1, "Island", 2)  // {2} to cast
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Tsabo's Web")
+                game.resolveStack() // artifact enters
+                game.resolveStack() // ETB draw trigger
+
+                withClue("Tsabo's Web ETB should draw a card (cast one, drew one)") {
+                    game.handSize(1) shouldBe handBefore
+                }
+
+                val vaultLandId = game.findPermanent("Vault Land")!!
+                val projected = projector.project(game.state)
+                withClue("A land with a non-mana activated ability should be granted DOESNT_UNTAP") {
+                    projected.hasKeyword(vaultLandId, AbilityFlag.DOESNT_UNTAP) shouldBe true
+                }
+
+                val forestId = game.findPermanent("Forest")!!
+                withClue("A plain mana-only land should NOT be affected") {
+                    projected.hasKeyword(forestId, AbilityFlag.DOESNT_UNTAP) shouldBe false
+                }
+
+                game.findPermanent("Tsabo's Web") shouldNotBe null
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionTsabosWebTurfWoundOrimsTouchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionTsabosWebTurfWoundOrimsTouchScenarioTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.gameserver.scenarios
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.DeclareAttackers
 import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -42,15 +43,17 @@ class InvasionTsabosWebTurfWoundOrimsTouchScenarioTest : ScenarioTestBase() {
         }
     }
 
-    // A plain creature attacker for the Orim's Touch prevention test.
-    private val bear = CardDefinition.creature(
-        name = "Test Bear", manaCost = ManaCost.parse("{G}"),
-        subtypes = setOf(Subtype("Bear")), power = 2, toughness = 2
+    // A 5-power attacker for the Orim's Touch prevention tests. Power > 4 so the unkicked
+    // (prevent 2) and kicked (prevent 4) branches deal *different* amounts of unprevented
+    // damage — that's what distinguishes the two prevention amounts.
+    private val ogre = CardDefinition.creature(
+        name = "Test Ogre", manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Ogre")), power = 5, toughness = 5
     )
 
     init {
         cardRegistry.register(tappingLand)
-        cardRegistry.register(bear)
+        cardRegistry.register(ogre)
 
         context("Turf Wound") {
             test("target player can't play lands this turn and caster draws a card") {
@@ -80,12 +83,12 @@ class InvasionTsabosWebTurfWoundOrimsTouchScenarioTest : ScenarioTestBase() {
         }
 
         context("Orim's Touch") {
-            test("unkicked prevents the next 2 damage to a player") {
+            test("unkicked prevents exactly the next 2 damage; the rest gets through") {
                 val game = scenario()
                     .withPlayers("Defender", "Attacker")
                     .withCardInHand(1, "Orim's Touch")
                     .withLandsOnBattlefield(1, "Plains", 1) // {W}
-                    .withCardOnBattlefield(2, "Test Bear")  // 2/2 attacker
+                    .withCardOnBattlefield(2, "Test Ogre")   // 5/5 attacker
                     .withActivePlayer(2)
                     .withPriorityPlayer(1)                   // defender holds priority to cast at instant speed
                     .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
@@ -93,7 +96,7 @@ class InvasionTsabosWebTurfWoundOrimsTouchScenarioTest : ScenarioTestBase() {
 
                 val startLife = game.getLifeTotal(1)
 
-                // Defender casts Orim's Touch on themselves to pre-empt the incoming 2 damage.
+                // Defender casts Orim's Touch (unkicked) on themselves to blunt the incoming 5 damage.
                 val orimCast = game.castSpellTargetingPlayer(1, "Orim's Touch", 1)
                 withClue("Orim's Touch cast should succeed: ${orimCast.error}") {
                     orimCast.error shouldBe null
@@ -103,31 +106,36 @@ class InvasionTsabosWebTurfWoundOrimsTouchScenarioTest : ScenarioTestBase() {
                     game.state.floatingEffects.any { game.player1Id in it.effect.affectedEntities } shouldBe true
                 }
 
-                val bearId = game.findPermanent("Test Bear")!!
+                val ogreId = game.findPermanent("Test Ogre")!!
                 game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
-                game.execute(DeclareAttackers(game.player2Id, mapOf(bearId to game.player1Id)))
+                game.execute(DeclareAttackers(game.player2Id, mapOf(ogreId to game.player1Id)))
                 game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
                 game.resolveStack()
 
-                withClue("All 2 combat damage should have been prevented") {
-                    game.getLifeTotal(1) shouldBe startLife
+                withClue("Exactly 2 of the 5 combat damage should be prevented, so 3 gets through") {
+                    game.getLifeTotal(1) shouldBe startLife - 3
                 }
             }
 
-            test("kicked prevents up to 4 damage") {
+            test("kicked prevents exactly the next 4 damage; the rest gets through") {
                 val game = scenario()
                     .withPlayers("Defender", "Attacker")
                     .withCardInHand(1, "Orim's Touch")
                     .withLandsOnBattlefield(1, "Plains", 2) // {W} + kicker {1}
-                    .withActivePlayer(1)
+                    .withCardOnBattlefield(2, "Test Ogre")   // 5/5 attacker
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)                   // defender holds priority to cast at instant speed
                     .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
                     .build()
+
+                val startLife = game.getLifeTotal(1)
 
                 val hand = game.state.getHand(game.player1Id)
                 val touchId = hand.first {
                     game.state.getEntity(it)?.get<CardComponent>()?.name == "Orim's Touch"
                 }
 
+                // Defender casts Orim's Touch *kicked* on themselves.
                 val cast = game.execute(
                     CastSpell(
                         game.player1Id,
@@ -140,8 +148,16 @@ class InvasionTsabosWebTurfWoundOrimsTouchScenarioTest : ScenarioTestBase() {
                     cast.error shouldBe null
                 }
                 game.resolveStack()
-                // Resolution succeeding (no error) confirms the kicked branch was reachable;
-                // the prevention amount is exercised by the unkicked combat test above.
+
+                val ogreId = game.findPermanent("Test Ogre")!!
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.execute(DeclareAttackers(game.player2Id, mapOf(ogreId to game.player1Id)))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("The kicked branch should prevent 4 (not 2) of the 5 damage, so only 1 gets through") {
+                    game.getLifeTotal(1) shouldBe startLife - 1
+                }
             }
         }
 
@@ -180,6 +196,37 @@ class InvasionTsabosWebTurfWoundOrimsTouchScenarioTest : ScenarioTestBase() {
                 }
 
                 game.findPermanent("Tsabo's Web") shouldNotBe null
+            }
+
+            test("a tapped land with a non-mana ability stays tapped through its controller's untap step") {
+                // Player 2's turn is ending; advancing to Player 1's upkeep passes through
+                // Player 1's untap step, which is where DOESNT_UNTAP actually takes effect.
+                val game = scenario()
+                    .withPlayers("Owner", "Opponent")
+                    .withCardOnBattlefield(1, "Tsabo's Web")
+                    .withCardOnBattlefield(1, "Vault Land", tapped = true) // non-mana activated ability
+                    .withCardOnBattlefield(1, "Forest", tapped = true)     // mana-only; should untap
+                    .withActivePlayer(2)
+                    .inPhase(Phase.ENDING, Step.END)
+                    .build()
+
+                val vaultLandId = game.findPermanent("Vault Land")!!
+                val forestId = game.findPermanent("Forest")!!
+
+                withClue("Both lands start tapped") {
+                    game.state.getEntity(vaultLandId)!!.has<TappedComponent>() shouldBe true
+                    game.state.getEntity(forestId)!!.has<TappedComponent>() shouldBe true
+                }
+
+                // Advance into Player 1's turn, through Player 1's untap step.
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                withClue("Vault Land (non-mana activated ability) must NOT untap") {
+                    game.state.getEntity(vaultLandId)!!.has<TappedComponent>() shouldBe true
+                }
+                withClue("Forest (mana-only) untaps normally") {
+                    game.state.getEntity(forestId)!!.has<TappedComponent>() shouldBe false
+                }
             }
         }
     }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -45,6 +45,7 @@ import com.wingedsheep.sdk.scripting.effects.CantBlockEffect
 import com.wingedsheep.sdk.scripting.effects.SetSuspectedEffect
 import com.wingedsheep.sdk.scripting.effects.CantBlockGroupEffect
 import com.wingedsheep.sdk.scripting.effects.CantCastSpellsEffect
+import com.wingedsheep.sdk.scripting.effects.PreventLandPlaysThisTurnEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
 import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
@@ -1861,6 +1862,14 @@ object Effects {
      */
     fun CantCastSpells(target: EffectTarget = EffectTarget.PlayerRef(Player.Opponent), duration: Duration = Duration.EndOfTurn): Effect =
         CantCastSpellsEffect(target, duration)
+
+    /**
+     * A player can't play lands for the rest of this turn (sets remaining land drops to 0).
+     * Defaults to the controller (Rock Jockey); pass a target for "target player can't
+     * play lands this turn" cards like Turf Wound.
+     */
+    fun CantPlayLandsThisTurn(target: EffectTarget = EffectTarget.Controller): Effect =
+        PreventLandPlaysThisTurnEffect(target)
 
     /**
      * Target player skips their next turn.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
@@ -249,6 +249,18 @@ data class CardDefinition(
     /** Activated abilities on this card */
     val activatedAbilities get() = script.activatedAbilities
 
+    /**
+     * True if this card has at least one intrinsic activated ability that isn't a mana
+     * ability and isn't a loyalty ability, activatable from the battlefield. Used by static
+     * filters like Tsabo's Web ("each land with an activated ability that isn't a mana ability").
+     */
+    val hasNonManaActivatedAbility: Boolean
+        get() = script.activatedAbilities.any {
+            !it.isManaAbility &&
+                !it.isPlaneswalkerAbility &&
+                it.activateFromZone == com.wingedsheep.sdk.core.Zone.BATTLEFIELD
+        }
+
     /** Static abilities (continuous effects) on this card */
     val staticAbilities get() = script.staticAbilities
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -128,14 +128,18 @@ data class TakeExtraTurnEffect(
 }
 
 /**
- * Prevent the controller from playing lands for the rest of this turn.
+ * Prevent the target player from playing lands for the rest of this turn.
  * Sets the player's remaining land drops to 0.
- * Used for cards like Rock Jockey.
+ * Defaults to the controller (e.g. Rock Jockey); pass a [EffectTarget.PlayerRef]
+ * for "target player can't play lands this turn" cards like Turf Wound.
  */
 @SerialName("PreventLandPlaysThisTurn")
 @Serializable
-data object PreventLandPlaysThisTurnEffect : Effect {
-    override val description: String = "You can't play lands this turn"
+data class PreventLandPlaysThisTurnEffect(
+    val target: EffectTarget = EffectTarget.Controller
+) : Effect {
+    override val description: String =
+        "${target.description.replaceFirstChar { it.uppercase() }} can't play lands this turn"
 
     override fun applyTextReplacement(replacer: TextReplacer): Effect = this
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -138,8 +138,11 @@ data class TakeExtraTurnEffect(
 data class PreventLandPlaysThisTurnEffect(
     val target: EffectTarget = EffectTarget.Controller
 ) : Effect {
-    override val description: String =
-        "${target.description.replaceFirstChar { it.uppercase() }} can't play lands this turn"
+    override val description: String = when (target) {
+        is EffectTarget.Controller -> "You can't play lands this turn"
+        is EffectTarget.ContextTarget -> "Target player can't play lands this turn"
+        else -> "${target.description.replaceFirstChar { it.uppercase() }} can't play lands this turn"
+    }
 
     override fun applyTextReplacement(replacer: TextReplacer): Effect = this
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -632,6 +632,20 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     }
 
     /**
+     * Matches a permanent that has at least one intrinsic activated ability that isn't a
+     * mana ability (and isn't a loyalty ability). Backed by the precomputed
+     * `CardComponent.hasNonManaActivatedAbility` flag, so abilities granted by other
+     * continuous effects are not counted. Used by Tsabo's Web: "Each land with an activated
+     * ability that isn't a mana ability doesn't untap during its controller's untap step."
+     */
+    @SerialName("HasNonManaActivatedAbility")
+    @Serializable
+    data object HasNonManaActivatedAbility : CardPredicate {
+        override val description: String = "with an activated ability that isn't a mana ability"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
+    /**
      * Matches a spell or ability on the stack at least one of whose chosen targets
      * matches [subfilter]. Player targets are skipped (they aren't card-like and have
      * no game-object filter to match against). Used by cards like Teferi's Response

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/OrimsTouch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/OrimsTouch.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Orim's Touch
+ * {W}
+ * Instant
+ * Kicker {1}
+ *
+ * Prevent the next 2 damage that would be dealt to any target this turn. If this
+ * spell was kicked, prevent the next 4 damage that would be dealt to that permanent
+ * or player this turn instead.
+ */
+val OrimsTouch = card("Orim's Touch") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Kicker {1} (You may pay an additional {1} as you cast this spell.)\n" +
+        "Prevent the next 2 damage that would be dealt to any target this turn. " +
+        "If this spell was kicked, prevent the next 4 damage that would be dealt to " +
+        "that permanent or player this turn instead."
+
+    keywordAbility(KeywordAbility.kicker("{1}"))
+
+    spell {
+        target = Targets.Any
+        effect = ConditionalEffect(
+            condition = WasKicked,
+            effect = Effects.PreventNextDamage(4, EffectTarget.ContextTarget(0)),
+            elseEffect = Effects.PreventNextDamage(2, EffectTarget.ContextTarget(0))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Roger Raupp"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/559f551e-7891-4c6d-8798-a25c0255fa3b.jpg?1562912440"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TsabosWeb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TsabosWeb.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * Tsabo's Web
+ * {2}
+ * Artifact
+ *
+ * When this artifact enters, draw a card.
+ * Each land with an activated ability that isn't a mana ability doesn't untap during
+ * its controller's untap step.
+ *
+ * The "non-mana activated ability" check reflects a land's printed abilities only (via
+ * the precomputed CardComponent.hasNonManaActivatedAbility flag); abilities granted to a
+ * land by another continuous effect are not counted.
+ */
+val TsabosWeb = card("Tsabo's Web") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, draw a card.\n" +
+        "Each land with an activated ability that isn't a mana ability doesn't untap " +
+        "during its controller's untap step."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = AbilityFlag.DOESNT_UNTAP.name,
+            filter = GroupFilter(
+                GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.IsLand,
+                        CardPredicate.HasNonManaActivatedAbility
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "317"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0dee69f8-cceb-41b9-a0ee-6b2ac9f4bad9.jpg?1562897866"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TurfWound.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TurfWound.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Turf Wound
+ * {2}{R}
+ * Instant
+ *
+ * Target player can't play lands this turn.
+ * Draw a card.
+ */
+val TurfWound = card("Turf Wound") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target player can't play lands this turn.\nDraw a card."
+
+    spell {
+        target = Targets.Player
+        effect = Effects.Composite(
+            Effects.CantPlayLandsThisTurn(EffectTarget.ContextTarget(0)),
+            Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Thomas Gianni"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/91392e9f-f96a-4ac5-b1f1-c73540cf249e.jpg?1562924301"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/RockJockey.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/RockJockey.kt
@@ -2,11 +2,11 @@ package com.wingedsheep.mtg.sets.definitions.scg.cards
 
 import com.wingedsheep.sdk.dsl.Conditions
 
+import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.conditions.NotCondition
-import com.wingedsheep.sdk.scripting.effects.PreventLandPlaysThisTurnEffect
 
 /**
  * Rock Jockey
@@ -30,7 +30,7 @@ val RockJockey = card("Rock Jockey") {
 
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = PreventLandPlaysThisTurnEffect
+        effect = Effects.CantPlayLandsThisTurn()
     }
 
     metadata {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -351,6 +351,7 @@ class GameInitializer(
                 spellEffect = cardDef.spellEffect,
                 imageUri = printing?.imageUri ?: cardDef.metadata.imageUri,
                 backFaceImageUri = printing?.backFaceImageUri ?: cardDef.backFace?.metadata?.imageUri,
+                hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             ),
             OwnerComponent(ownerId),
             ControllerComponent(ownerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -178,6 +178,7 @@ class PredicateEvaluator {
             CardPredicate.IsNontoken -> !container.has<TokenComponent>()
             CardPredicate.IsLegendary -> "LEGENDARY" in types
             CardPredicate.IsNonlegendary -> "LEGENDARY" !in types
+            CardPredicate.HasNonManaActivatedAbility -> card.hasNonManaActivatedAbility
 
             // Color predicates - use projected colors
             is CardPredicate.HasColor -> predicate.color.name in colors
@@ -813,6 +814,9 @@ class PredicateEvaluator {
             CardPredicate.IsActivatedOrTriggeredAbility -> false
             CardPredicate.IsTriggeredAbility -> false
             CardPredicate.IsActivatedAbility -> false
+
+            // A cast-spell record has no battlefield permanent to inspect for activated abilities.
+            CardPredicate.HasNonManaActivatedAbility -> false
 
             // Stack-relative targeting predicate — historical cast records have no
             // chosen-target snapshot, so this always returns false here.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PreventLandPlaysThisTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PreventLandPlaysThisTurnExecutor.kt
@@ -21,7 +21,8 @@ class PreventLandPlaysThisTurnExecutor : EffectExecutor<PreventLandPlaysThisTurn
         effect: PreventLandPlaysThisTurnEffect,
         context: EffectContext
     ): EffectResult {
-        val playerId = context.controllerId
+        val playerId = context.resolvePlayerTarget(effect.target)
+            ?: return EffectResult.error(state, "No valid target for prevent land plays effect")
 
         val currentLandDrops = state.getEntity(playerId)?.get<LandDropsComponent>()
             ?: return EffectResult.error(state, "Player has no LandDropsComponent")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -412,6 +412,7 @@ internal class AffectsFilterResolver {
         CardPredicate.IsNontoken -> !container.has<com.wingedsheep.engine.state.components.identity.TokenComponent>()
         CardPredicate.IsLegendary -> "LEGENDARY" in types
         CardPredicate.IsNonlegendary -> "LEGENDARY" !in types
+        CardPredicate.HasNonManaActivatedAbility -> card.hasNonManaActivatedAbility
         is CardPredicate.HasSubtype -> if (isFaceDown) false else subtypes.any { it.equals(predicate.subtype.value, ignoreCase = true) }
         is CardPredicate.NotSubtype -> if (isFaceDown) true else subtypes.none { it.equals(predicate.subtype.value, ignoreCase = true) }
         is CardPredicate.HasAnyOfSubtypes -> if (isFaceDown) false else predicate.subtypes.any { sub -> subtypes.any { it.equals(sub.value, ignoreCase = true) } }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -831,6 +831,7 @@ class CostCalculator(
             CardPredicate.IsNontoken -> true
             CardPredicate.IsLegendary -> typeLine.isLegendary
             CardPredicate.IsNonlegendary -> !typeLine.isLegendary
+            CardPredicate.HasNonManaActivatedAbility -> cardDef.hasNonManaActivatedAbility
 
             is CardPredicate.HasColor -> predicate.color in cardDef.colors
             is CardPredicate.NotColor -> predicate.color !in cardDef.colors

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
@@ -30,6 +30,14 @@ data class CardComponent(
     val spellEffect: Effect? = null,
     val imageUri: String? = null,
     val backFaceImageUri: String? = null,
+    /**
+     * Precomputed from the card definition: does this card have at least one intrinsic
+     * activated ability that isn't a mana ability (and isn't a loyalty ability)? Used by
+     * static filters such as Tsabo's Web ("each land with an activated ability that isn't
+     * a mana ability"). This reflects the card's printed abilities only — abilities granted
+     * by other continuous effects are not counted here.
+     */
+    val hasNonManaActivatedAbility: Boolean = false,
 ) : Component {
     // Convenience accessors
     val isCreature: Boolean get() = typeLine.isCreature


### PR DESCRIPTION
Implements three Invasion (INV) cards via the add-card workflow.

## Cards

- **Tsabo's Web** ({2} Artifact, rare) — "When this artifact enters, draw a card. Each land with an activated ability that isn't a mana ability doesn't untap during its controller's untap step." ETB draw + a static `GrantKeyword(DOESNT_UNTAP)` over lands matching the new `CardPredicate.HasNonManaActivatedAbility`. The untap step already honors `DOESNT_UNTAP`.
- **Orim's Touch** ({W} Instant, common; Kicker {1}) — "Prevent the next 2 damage that would be dealt to any target this turn. If kicked, prevent 4 instead." Composes `Effects.PreventNextDamage` inside `ConditionalEffect(WasKicked, …)`.
- **Turf Wound** ({2}{R} Instant, common) — "Target player can't play lands this turn. Draw a card." Composite of the now-targeted `PreventLandPlaysThisTurnEffect` + draw.

## SDK / engine changes

- Generalized `PreventLandPlaysThisTurnEffect` from a `data object` to a `data class` with a `target` (default = controller). New facade `Effects.CantPlayLandsThisTurn(target)`. Migrated Rock Jockey to the facade; its executor now resolves the target.
- Added `CardPredicate.HasNonManaActivatedAbility`, backed by a precomputed `CardComponent.hasNonManaActivatedAbility` flag (computed via `CardDefinition.hasNonManaActivatedAbility` = has a printed activated ability that isn't a mana ability and isn't a loyalty ability). Set in `GameInitializer` and the scenario-test card factory. Wired through the exhaustive predicate matchers in `PredicateEvaluator`, `AffectsFilterResolver`, and `CostCalculator`.
  - Known limitation (documented in code + the SDK reference): reflects a land's *printed* abilities only — abilities granted by other continuous effects are not counted.
- Updated `docs/card-sdk-language-reference.md` for the new effect facade and predicate.

## Tests

- New `InvasionTsabosWebTurfWoundOrimsTouchScenarioTest` (game-server) covering all three cards, including the unkicked/kicked Orim's Touch branches and the Tsabo's Web positive (non-mana land) / negative (mana-only land) untap cases.
- Full `:rules-engine:test` and `:mtg-sdk:test` suites pass, including the polymorphic-registration and serialization round-trip hygiene tests; Rock Jockey regression test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)