### PR TITLE
Add Invasion cards: Shivan Emissary, Sleeper's Robe, Smoldering Tar, Trench Wurm, Twilight's Call

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShivanEmissary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShivanEmissary.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Shivan Emissary
+ * {2}{R}
+ * Creature — Human Wizard
+ * 1/1
+ * Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)
+ * When this creature enters, if it was kicked, destroy target nonblack creature.
+ * It can't be regenerated.
+ */
+val ShivanEmissary = card("Shivan Emissary") {
+    manaCost = "{2}{R}"
+    colorIdentity = "RB"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\n" +
+        "When this creature enters, if it was kicked, destroy target nonblack creature. It can't be regenerated."
+
+    keywordAbility(KeywordAbility.kicker("{1}{B}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        val creature = target(
+            "target nonblack creature",
+            TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK))
+        )
+        effect = CantBeRegeneratedEffect(creature) then Effects.Destroy(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "166"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/945c596e-492e-4cf5-857c-4ddbbdd78485.jpg?1562924931"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SleepersRobe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SleepersRobe.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Sleeper's Robe
+ * {U}{B}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature has fear.
+ * Whenever enchanted creature deals combat damage to an opponent, you may draw a card.
+ */
+val SleepersRobe = card("Sleeper's Robe") {
+    manaCost = "{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has fear. (It can't be blocked except by artifact creatures and/or black creatures.)\n" +
+        "Whenever enchanted creature deals combat damage to an opponent, you may draw a card."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FEAR, GroupFilter.attachedCreature())
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.Opponent,
+            binding = TriggerBinding.ATTACHED,
+        )
+        effect = MayEffect(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "273"
+        artist = "Alan Pollack"
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/3411f0fd-8b85-4d0d-a202-701a24ffac9f.jpg?1562905482"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SmolderingTar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SmolderingTar.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Smoldering Tar
+ * {2}{B}{R}
+ * Enchantment
+ * At the beginning of your upkeep, target player loses 1 life.
+ * Sacrifice this enchantment: It deals 4 damage to target creature. Activate only as a sorcery.
+ */
+val SmolderingTar = card("Smoldering Tar") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, target player loses 1 life.\n" +
+        "Sacrifice this enchantment: It deals 4 damage to target creature. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        val player = target("target player", Targets.Player)
+        effect = Effects.LoseLife(1, EffectTarget.ContextTarget(0))
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        timing = TimingRule.SorcerySpeed
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(4, EffectTarget.ContextTarget(0))
+        description = "Sacrifice this enchantment: It deals 4 damage to target creature. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "275"
+        artist = "David Day"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fcdc55c0-c8ac-49d5-969b-9bf0ee8e696c.jpg?1562946036"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TrenchWurm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TrenchWurm.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Trench Wurm
+ * {3}{B}
+ * Creature — Wurm
+ * 3/3
+ * {2}{R}, {T}: Destroy target nonbasic land.
+ */
+val TrenchWurm = card("Trench Wurm") {
+    manaCost = "{3}{B}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Wurm"
+    power = 3
+    toughness = 3
+    oracleText = "{2}{R}, {T}: Destroy target nonbasic land."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.Tap)
+        target = TargetPermanent(
+            filter = TargetFilter(
+                GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.IsLand,
+                        CardPredicate.Not(CardPredicate.IsBasicLand),
+                    )
+                )
+            )
+        )
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+        description = "{2}{R}, {T}: Destroy target nonbasic land."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "127"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b076f85-d1bf-491a-af9d-f35b8e1bd163.jpg?1562900334"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TwilightsCall.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TwilightsCall.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Twilight's Call
+ * {4}{B}{B}
+ * Sorcery
+ * You may cast this spell as though it had flash if you pay {2} more to cast it.
+ * Each player returns all creature cards from their graveyard to the battlefield.
+ *
+ * The flash clause is the generalised "pay {N} more to cast as though it had flash"
+ * optional additional cost ([KeywordAbility.flashKicker]) — the same shape as Ghitu Fire.
+ * The reanimation gathers every creature card in every graveyard (multi-player
+ * [Player.Each]) and returns them under their owners' control.
+ */
+val TwilightsCall = card("Twilight's Call") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "You may cast this spell as though it had flash if you pay {2} more to cast it. " +
+        "(You may cast it any time you could cast an instant.)\n" +
+        "Each player returns all creature cards from their graveyard to the battlefield."
+
+    keywordAbility(KeywordAbility.flashKicker("{2}"))
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.Each,
+                        filter = GameObjectFilter.Creature
+                    ),
+                    storeAs = "graveyardCreatures"
+                ),
+                MoveCollectionEffect(
+                    from = "graveyardCreatures",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                    underOwnersControl = true
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "130"
+        artist = "Mark Romanoski"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c97c8a5-33b3-4f7f-a224-bb4df7b4bcc0.jpg?1562907233"
+    }
+}


### PR DESCRIPTION
Adds five Invasion (INV) cards. All use existing engine mechanics, so there are no SDK/engine changes and no new scenario tests were required.

## Cards

- **Shivan Emissary** ({2}{R} 1/1 Human Wizard) — Kicker {1}{B}; when it enters, if kicked, destroy target nonblack creature (can't be regenerated). Composes `KeywordAbility.kicker` + `WasKicked`-gated ETB trigger + `CantBeRegeneratedEffect` then `Effects.Destroy`, mirroring Benalish Emissary / Annihilate.
- **Sleeper's Robe** ({U}{B} Aura) — Enchant creature; enchanted creature has fear; whenever it deals combat damage to an opponent, you may draw a card. `GrantKeyword(FEAR)` over the attached creature + `Triggers.dealsDamage(Combat, Opponent, ATTACHED)` → `MayEffect(DrawCards(1))`, mirroring One with Nature.
- **Smoldering Tar** ({2}{B}{R} Enchantment) — Upkeep trigger: target player loses 1 life. Activated `Sacrifice: deal 4 to target creature` at sorcery speed (`TimingRule.SorcerySpeed`), mirroring Pyre Zombie + Seer's Vision.
- **Trench Wurm** ({3}{B} 3/3 Wurm) — `{2}{R}, {T}: Destroy target nonbasic land` (nonbasic-land target filter from Shivan Harvest).
- **Twilight's Call** ({4}{B}{B} Sorcery) — `flashKicker("{2}")` for the "pay {2} more to cast as though it had flash" clause (same primitive as Ghitu Fire); gather all creature cards from every graveyard and return them under their owners' control (Gather → MoveCollection pipeline, like Bringer of the Last Gift).

## Testing

- `:mtg-sets:compileKotlin` — clean
- `:mtg-sets:test` — pass (includes card-definition validation that loads every card)
- `:rules-engine:test` — pass (benchmarks excluded; suite is `*Test`)
- `scripts/card-status --set INV` confirms all five now register as implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)