### PR TITLE
Add Invasion cards: Empress Galina, Hanna, Marauding Knight, Plague Spitter, Shackles

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -14,6 +14,7 @@ import com.wingedsheep.mtg.sets.definitions.dom.DominariaSet
 import com.wingedsheep.mtg.sets.definitions.dsk.DuskmournSet
 import com.wingedsheep.mtg.sets.definitions.ecl.LorwynEclipsedSet
 import com.wingedsheep.mtg.sets.definitions.eoe.EdgeOfEternitiesSet
+import com.wingedsheep.mtg.sets.definitions.exo.ExodusSet
 import com.wingedsheep.mtg.sets.definitions.fdn.FoundationsSet
 import com.wingedsheep.mtg.sets.definitions.fin.FinalFantasySet
 import com.wingedsheep.mtg.sets.definitions.frf.FateReforgedSet
@@ -112,6 +113,7 @@ abstract class ScenarioTestBase : FunSpec() {
         register(DominariaUnitedSet.cards)
         register(DuskmournSet.cards)
         register(EdgeOfEternitiesSet.cards); register(EdgeOfEternitiesSet.basicLands)
+        register(ExodusSet.cards)
         register(FinalFantasySet.cards)
         register(FateReforgedSet.cards)
         register(FoundationsSet.cards)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EmpressGalinaScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EmpressGalinaScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Empress Galina.
+ *
+ * {3}{U}{U} Legendary Creature — Merfolk Noble 1/3
+ * "{U}{U}, {T}: Gain control of target legendary permanent. (This effect lasts indefinitely.)"
+ */
+class EmpressGalinaScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Empress Galina steals a legendary permanent") {
+            test("activating the ability gives the controller control of a target legendary") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Empress Galina")
+                    .withCardOnBattlefield(2, "Blind Seer")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Give the controller {U}{U} for the activation cost.
+                game.state = game.state.updateEntity(game.player1Id) { container ->
+                    container.with(ManaPoolComponent(blue = 2))
+                }
+
+                val galina = game.findPermanent("Empress Galina")!!
+                val blindSeer = game.findPermanent("Blind Seer")!!
+
+                // Sanity: Blind Seer starts under the opponent's control.
+                withClue("Blind Seer starts controlled by the opponent") {
+                    game.state.projectedState.getController(blindSeer) shouldBe game.player2Id
+                }
+
+                val ability = cardRegistry.getCard("Empress Galina")!!.script.activatedAbilities[0]
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = galina,
+                        abilityId = ability.id,
+                        targets = listOf(ChosenTarget.Permanent(blindSeer))
+                    )
+                )
+                withClue("Activation should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Blind Seer should now be controlled by Empress Galina's controller") {
+                    game.state.projectedState.getController(blindSeer) shouldBe game.player1Id
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HannaShipsNavigatorScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HannaShipsNavigatorScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Hanna, Ship's Navigator.
+ *
+ * {1}{W}{U} Legendary Creature — Human Artificer 1/2
+ * "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand."
+ */
+class HannaShipsNavigatorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hanna returns an artifact or enchantment from the graveyard") {
+            test("returns an artifact card from your graveyard to your hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Hanna, Ship's Navigator")
+                    .withCardInGraveyard(1, "Tigereye Cameo")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Pay {1}{W}{U}.
+                game.state = game.state.updateEntity(game.player1Id) { container ->
+                    container.with(ManaPoolComponent(white = 1, blue = 1, colorless = 1))
+                }
+
+                val hanna = game.findPermanent("Hanna, Ship's Navigator")!!
+                val cameo = game.state.getZone(game.player1Id, com.wingedsheep.sdk.core.Zone.GRAVEYARD)
+                    .first { game.state.getEntity(it)
+                        ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Tigereye Cameo" }
+
+                withClue("Tigereye Cameo starts in the graveyard") {
+                    game.isInGraveyard(1, "Tigereye Cameo") shouldBe true
+                }
+
+                val ability = cardRegistry.getCard("Hanna, Ship's Navigator")!!.script.activatedAbilities[0]
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = hanna,
+                        abilityId = ability.id,
+                        targets = listOf(
+                            ChosenTarget.Card(cameo, game.player1Id, com.wingedsheep.sdk.core.Zone.GRAVEYARD)
+                        )
+                    )
+                )
+                withClue("Activation should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Tigereye Cameo should now be in hand") {
+                    game.isInHand(1, "Tigereye Cameo") shouldBe true
+                }
+                withClue("Tigereye Cameo should no longer be in the graveyard") {
+                    game.isInGraveyard(1, "Tigereye Cameo") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/PlagueSpitterScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/PlagueSpitterScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Plague Spitter.
+ *
+ * {2}{B} Creature — Phyrexian Horror 2/2
+ * "At the beginning of your upkeep, this creature deals 1 damage to each creature and each player."
+ * "When this creature dies, it deals 1 damage to each creature and each player."
+ */
+class PlagueSpitterScenarioTest : ScenarioTestBase() {
+
+    private val xenobear = CardDefinition.creature(
+        name = "Test 1/1", manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Bear")), power = 1, toughness = 1
+    )
+    private val toughBear = CardDefinition.creature(
+        name = "Test 2/2", manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Bear")), power = 2, toughness = 2
+    )
+
+    init {
+        cardRegistry.register(xenobear)
+        cardRegistry.register(toughBear)
+
+        context("Plague Spitter upkeep trigger") {
+            test("deals 1 damage to each creature and each player at upkeep") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Plague Spitter")
+                    .withCardOnBattlefield(2, "Test 1/1")
+                    .withCardOnBattlefield(2, "Test 2/2")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("Both players take 1 damage from the upkeep trigger") {
+                    game.getLifeTotal(1) shouldBe 19
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("The 1/1 dies to 1 damage") {
+                    game.isOnBattlefield("Test 1/1") shouldBe false
+                }
+                withClue("The 2/2 survives 1 damage") {
+                    game.isOnBattlefield("Test 2/2") shouldBe true
+                }
+                withClue("Plague Spitter itself (2/2) survives 1 damage") {
+                    game.isOnBattlefield("Plague Spitter") shouldBe true
+                }
+            }
+        }
+
+        context("Plague Spitter dies trigger") {
+            test("deals 1 damage to each creature and each player when it dies") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Smother")
+                    .withCardOnBattlefield(1, "Plague Spitter")
+                    .withCardOnBattlefield(2, "Test 1/1")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spitter = game.findPermanent("Plague Spitter")!!
+
+                // Destroy Plague Spitter with Smother; its dies trigger then deals 1 to all.
+                game.castSpell(1, "Smother", spitter)
+                game.resolveStack()
+
+                withClue("Plague Spitter is dead") {
+                    game.isOnBattlefield("Plague Spitter") shouldBe false
+                }
+                withClue("Both players take 1 damage from the dies trigger") {
+                    game.getLifeTotal(1) shouldBe 19
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("The opposing 1/1 dies to the dies trigger's 1 damage") {
+                    game.isOnBattlefield("Test 1/1") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ShacklesScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ShacklesScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Shackles (EXO canonical, reprinted in INV).
+ *
+ * Card reference:
+ * - Shackles ({2}{W}): Enchantment — Aura
+ *   "Enchant creature"
+ *   "Enchanted creature doesn't untap during its controller's untap step."
+ *   "{W}: Return this Aura to its owner's hand."
+ *
+ * Verifies the DOESNT_UNTAP ability flag granted to the enchanted creature both shows
+ * up in projected state and is respected by the untap step.
+ */
+class ShacklesScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Shackles keeps the enchanted creature tapped") {
+            test("enchanted creature gains DOESNT_UNTAP in projected state") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Shackles")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val castResult = game.castSpell(1, "Shackles", bears)
+                withClue("Cast should succeed") { castResult.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Shackles should be on the battlefield") {
+                    game.isOnBattlefield("Shackles") shouldBe true
+                }
+
+                val projected = stateProjector.project(game.state)
+                withClue("Enchanted creature should have DOESNT_UNTAP") {
+                    projected.hasKeyword(bears, AbilityFlag.DOESNT_UNTAP) shouldBe true
+                }
+            }
+
+            test("enchanted creature stays tapped through its controller's untap step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Shackles")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Shackles", bears)
+                game.resolveStack()
+
+                withClue("Creature should be tapped before opponent's untap step") {
+                    game.state.getEntity(bears)!!.has<TappedComponent>() shouldBe true
+                }
+
+                // Advance into the opponent's turn, through their untap step.
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                withClue("Enchanted creature must NOT untap during its controller's untap step") {
+                    game.state.getEntity(bears)!!.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/exo/cards/Shackles.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/exo/cards/Shackles.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.exo.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shackles
+ * {2}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature doesn't untap during its controller's untap step.
+ * {W}: Return this Aura to its owner's hand.
+ *
+ * "Doesn't untap during its controller's untap step" is granted to the enchanted creature
+ * as the DOESNT_UNTAP ability flag; the untap step (BeginningPhaseManager.performUntapStep)
+ * skips any permanent whose projected keywords contain it.
+ */
+val Shackles = card("Shackles") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature doesn't untap during its controller's untap step.\n" +
+        "{W}: Return this Aura to its owner's hand."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{W}")
+        effect = MoveToZoneEffect(EffectTarget.Self, Zone.HAND)
+        description = "{W}: Return this Aura to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Heather Hudson"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5315668-b8ef-49ab-a8f5-144adc7bcd84.jpg?1562088793"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/EmpressGalina.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/EmpressGalina.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.GainControlEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Empress Galina
+ * {3}{U}{U}
+ * Legendary Creature — Merfolk Noble
+ * 1/3
+ * {U}{U}, {T}: Gain control of target legendary permanent. (This effect lasts indefinitely.)
+ *
+ * GainControlEffect defaults to Duration.Permanent, matching "lasts indefinitely".
+ */
+val EmpressGalina = card("Empress Galina") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Merfolk Noble"
+    power = 1
+    toughness = 3
+    oracleText = "{U}{U}, {T}: Gain control of target legendary permanent. (This effect lasts indefinitely.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}{U}"), Costs.Tap)
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.legendary()))
+        )
+        effect = GainControlEffect(t)
+        description = "{U}{U}, {T}: Gain control of target legendary permanent."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "54"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/6851dbc7-f072-41e7-a899-897445d99425.jpg?1562916018"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HannaShipsNavigator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/HannaShipsNavigator.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Hanna, Ship's Navigator
+ * {1}{W}{U}
+ * Legendary Creature — Human Artificer
+ * 1/2
+ * {1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand.
+ */
+val HannaShipsNavigator = card("Hanna, Ship's Navigator") {
+    manaCost = "{1}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Artificer"
+    power = 1
+    toughness = 2
+    oracleText = "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}{U}"), Costs.Tap)
+        val t = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.ArtifactOrEnchantment.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.ReturnToHand(t)
+        description = "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "249"
+        artist = "Dave Dorman"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83a4e48d-6452-4245-bdad-63fe3263550e.jpg?1562921669"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MaraudingKnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MaraudingKnight.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Marauding Knight
+ * {2}{B}{B}
+ * Creature — Phyrexian Zombie Knight
+ * 2/2
+ * Protection from white
+ * This creature gets +1/+1 for each Plains your opponents control.
+ */
+val MaraudingKnight = card("Marauding Knight") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Zombie Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from white\nThis creature gets +1/+1 for each Plains your opponents control."
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.WHITE)))
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmount.Count(
+                player = Player.Opponent,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Land.withSubtype("Plains")
+            ),
+            toughnessBonus = DynamicAmount.Count(
+                player = Player.Opponent,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Land.withSubtype("Plains")
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "110"
+        artist = "Daren Bader"
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/cea2a7de-c67e-4541-be8c-e5ef7b64d94a.jpg?1562936560"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PlagueSpitter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PlagueSpitter.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Plague Spitter
+ * {2}{B}
+ * Creature — Phyrexian Horror
+ * 2/2
+ * At the beginning of your upkeep, this creature deals 1 damage to each creature and each player.
+ * When this creature dies, it deals 1 damage to each creature and each player.
+ */
+val PlagueSpitter = card("Plague Spitter") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Horror"
+    power = 2
+    toughness = 2
+    oracleText = "At the beginning of your upkeep, this creature deals 1 damage to each creature and each player.\n" +
+        "When this creature dies, it deals 1 damage to each creature and each player."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = ForEachInGroupEffect(GroupFilter.AllCreatures, DealDamageEffect(1, EffectTarget.Self)) then
+            Effects.DealDamage(1, EffectTarget.PlayerRef(Player.Each))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = ForEachInGroupEffect(GroupFilter.AllCreatures, DealDamageEffect(1, EffectTarget.Self)) then
+            Effects.DealDamage(1, EffectTarget.PlayerRef(Player.Each))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "119"
+        artist = "Chippy"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/8845e6bd-40ee-45ca-a099-53f19ff20a8a.jpg?1562922550"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShacklesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ShacklesReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shackles reprint in Invasion. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Exodus (the card's earliest real-expansion printing); this file contributes
+ * only presentation data for the INV print.
+ */
+val ShacklesReprint = Printing(
+    oracleId = "05861ff2-ec85-43d1-b641-c5d2da819c03",
+    name = "Shackles",
+    setCode = "INV",
+    collectorNumber = "37",
+    scryfallId = "35b3da05-9a3e-4827-96b8-5de244128db3",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/35b3da05-9a3e-4827-96b8-5de244128db3.jpg?1562905863",
+    releaseDate = "2000-10-02",
+    rarity = Rarity.COMMON,
+)


### PR DESCRIPTION
## Summary

Adds five cards, all built from existing SDK primitives — **no engine changes required**.

| Card | Set | Mechanic |
|------|-----|----------|
| Empress Galina | INV | `{U}{U}, {T}`: `GainControlEffect` targeting a legendary permanent (`Duration.Permanent` = "lasts indefinitely") |
| Hanna, Ship's Navigator | INV | `{1}{W}{U}, {T}`: return target artifact/enchantment card from your graveyard to hand (`TargetObject` in GRAVEYARD + `Effects.ReturnToHand`) |
| Marauding Knight | INV | Protection from white + `GrantDynamicStatsEffect` (+1/+1 per Plains opponents control) — mirrors Crusading Knight |
| Plague Spitter | INV | Upkeep + dies triggers each deal 1 damage to each creature and each player (Dry Spell / Fire Tempest pattern) |
| Shackles | EXO (canonical) / INV (reprint) | Aura granting the `DOESNT_UNTAP` ability flag via `GrantKeyword`; `{W}`: return this Aura to its owner's hand |

## Notes

- **Shackles canonical placement**: Shackles' earliest real-expansion printing is **Exodus (1998)**, which is scaffolded, so the canonical `CardDefinition` lives there and INV gets a `Printing` row (`ShacklesReprint.kt`). Verified with `just check-card-printing "Shackles"`.
- The "doesn't untap" mechanic needs no new engine code: `BeginningPhaseManager.performUntapStep` already skips permanents whose projected keywords contain `DOESNT_UNTAP`, and `GrantKeyword("DOESNT_UNTAP")` populates that set on the enchanted creature.
- Registered `ExodusSet` in `ScenarioTestBase` so the EXO-canonical Shackles is available to scenario tests.

## Tests

- New scenario tests for Empress Galina, Hanna, Plague Spitter (upkeep + dies), and Shackles (projected keyword + untap-step behavior) — all pass.
- Marauding Knight has no dedicated test: it's a direct analog of the already-tested Crusading Knight.
- Regression: `InvasionCardsScenarioTest`, `MultiPrintingGameTest`, and `:mtg-sets:test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)