### PR TITLE
Add Invasion cards: Aether Rift, Cauldron Dance, Chaotic Strike, Dredge, Overload

### DIFF
--- a/backlog/invasion-engine-gaps.md
+++ b/backlog/invasion-engine-gaps.md
@@ -825,6 +825,34 @@ filter.
 
 ---
 
+### #22 — "[Effect] unless any player pays N life" punisher · Aether Rift ⛔ NOT DONE
+
+**What exists.** `AnyPlayerMayPayEffect(cost, consequence)` runs `consequence` **when a player pays**,
+and its executor (`AnyPlayerMayPayExecutor` + `AnyPlayerMayPayContinuation` resumer) only supports
+`PayCost.Sacrifice`. `PayOrSufferEffect` supports `PayLife` but is **single-player** (the controller),
+not "any player". Neither expresses the *inverted* "the consequence happens **unless** some player pays".
+
+**The gap (two parts).**
+1. **Inverted branch** — a consequence that fires only when *no* player paid (add an `ifNoOnePaid`
+   branch to `AnyPlayerMayPayEffect`, mirroring `OptionalCostEffect.ifNotPaid`).
+2. **`PayCost.PayLife` support in the any-player path** — the executor/continuation hard-code the
+   sacrifice flow (card-selection decision); a life-payment path needs a yes/no decision per player in
+   APNAP order plus the life deduction (the logic already exists in
+   `SacrificeAndPayContinuationResumer.resumePayOrSufferPayLife`, but for the single-player effect).
+
+→ **Aether Rift** ("…return it from your graveyard to the battlefield **unless any player pays 5
+life**"). Skipped this PR — it's a multi-file engine change (executor + continuation + resumer + an
+inverted branch) rather than card authoring. The rest of the card (upkeep trigger → discard a card at
+random → gate on "discarded a creature card") is all buildable today
+(`Triggers.YourUpkeep` + a `GatherCards(HAND) → SelectFromCollection(Random, 1) → MoveCollection(GRAVEYARD)`
+discard pipeline + `ConditionalOnCollectionEffect`); only the punisher tail is blocked.
+
+**Leverage.** "[do X] unless any player pays [life/mana]" is a recurring punisher idiom (Tariff,
+Falter-likes, many older reanimators), so the inverted branch + `PayLife` any-player support unlock a
+family, not just Aether Rift.
+
+---
+
 ## Suggested build order (highest leverage first)
 
 0. **Close the already-buildable cards** (#6 ✅, #12, #20 ✅, Coalition Victory ✅, Rewards of Diversity ✅) —

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionCombatTricksScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionCombatTricksScenarioTest.kt
@@ -1,0 +1,241 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.inv.InvasionSet
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainAnyOf
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for four Invasion cards that compose existing engine primitives:
+ *
+ * - Dredge {B} — Sacrifice a creature or land. Draw a card.
+ * - Overload {R} (Kicker {2}) — Destroy target artifact if MV ≤ 2 (kicked: ≤ 5).
+ * - Chaotic Strike {1}{R} — combat coin-flip pump + draw.
+ * - Cauldron Dance {4}{B}{R} — combat reanimate (haste, bounce at end) + put-from-hand
+ *   (haste, sacrifice at end).
+ *
+ * No new engine mechanics were added; these tests verify the compositions resolve end to end.
+ */
+class InvasionCombatTricksScenarioTest : ScenarioTestBase() {
+
+    private val testBear = CardDefinition.creature(
+        "Test Bear", ManaCost.parse("{1}{G}"), setOf(Subtype("Bear")), 2, 2
+    )
+    private val cheapArtifact = CardDefinition.artifact("Cheap Trinket", ManaCost.parse("{1}"))
+    private val pricyArtifact = CardDefinition.artifact("Pricy Engine", ManaCost.parse("{4}"))
+
+    init {
+        cardRegistry.register(InvasionSet.cards)
+        cardRegistry.register(testBear)
+        cardRegistry.register(cheapArtifact)
+        cardRegistry.register(pricyArtifact)
+
+        context("Dredge") {
+            test("sacrifices a creature and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dredge")
+                    .withCardOnBattlefield(1, "Test Bear")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInLibrary(1, "Test Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val bear = game.findPermanent("Test Bear")!!
+                val castResult = game.castSpell(1, "Dredge")
+                withClue("Cast should succeed: ${castResult.error}") { castResult.error shouldBe null }
+                game.resolveStack()
+                // Both the Bear and the tapped Swamp are legal sacrifices → choose the Bear.
+                if (game.hasPendingDecision()) {
+                    game.selectCards(listOf(bear))
+                }
+
+                withClue("Test Bear should have been sacrificed") {
+                    game.isOnBattlefield("Test Bear") shouldBe false
+                }
+                // -1 for Dredge cast, sacrifice removes nothing from hand, +1 drawn
+                withClue("Net hand size: cast Dredge (-1) then drew (+1) = unchanged from start") {
+                    game.handSize(1) shouldBe handBefore - 1 + 1
+                }
+            }
+        }
+
+        context("Overload") {
+            test("unkicked destroys a mana-value-1 artifact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Overload")
+                    .withCardOnBattlefield(2, "Cheap Trinket")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val artifact = game.findPermanent("Cheap Trinket")!!
+                val castResult = game.castSpell(1, "Overload", artifact)
+                withClue("Cast should succeed: ${castResult.error}") { castResult.error shouldBe null }
+                game.resolveStack()
+
+                withClue("MV 1 artifact destroyed without kicker") {
+                    game.isOnBattlefield("Cheap Trinket") shouldBe false
+                }
+            }
+
+            test("unkicked does NOT destroy a mana-value-4 artifact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Overload")
+                    .withCardOnBattlefield(2, "Pricy Engine")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val artifact = game.findPermanent("Pricy Engine")!!
+                val castResult = game.castSpell(1, "Overload", artifact)
+                withClue("Cast should succeed: ${castResult.error}") { castResult.error shouldBe null }
+                game.resolveStack()
+
+                withClue("MV 4 artifact survives an unkicked Overload (threshold 2)") {
+                    game.isOnBattlefield("Pricy Engine") shouldBe true
+                }
+            }
+
+            test("kicked destroys a mana-value-4 artifact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Overload")
+                    .withCardOnBattlefield(2, "Pricy Engine")
+                    .withLandsOnBattlefield(1, "Mountain", 3) // {R} + kicker {2}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val artifact = game.findPermanent("Pricy Engine")!!
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).first {
+                    game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Overload"
+                }
+                val castResult = game.execute(
+                    CastSpell(playerId, cardId, listOf(ChosenTarget.Permanent(artifact)), wasKicked = true)
+                )
+                withClue("Kicked cast should succeed: ${castResult.error}") { castResult.error shouldBe null }
+                game.resolveStack()
+
+                withClue("MV 4 artifact destroyed when kicked (threshold 5)") {
+                    game.isOnBattlefield("Pricy Engine") shouldBe false
+                }
+            }
+        }
+
+        context("Chaotic Strike") {
+            test("resolves during combat: target ends at 2/2 or 3/3 and you draw a card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Chaotic Strike")
+                    .withCardOnBattlefield(1, "Test Bear")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Test Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Test Bear" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                if (game.state.priorityPlayerId != null && game.state.priorityPlayerId != game.state.activePlayerId) {
+                    game.passPriority()
+                }
+
+                val bear = game.findPermanent("Test Bear")!!
+                val castResult = game.castSpell(1, "Chaotic Strike", bear)
+                withClue("Cast during declare-blockers should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("Win flip → 3/3, lose flip → 2/2 (base bear is 2/2)") {
+                    listOf(projected.getPower(bear)) shouldContainAnyOf listOf(2, 3)
+                    listOf(projected.getToughness(bear)) shouldContainAnyOf listOf(2, 3)
+                }
+                withClue("Cast Chaotic Strike (-1) and drew (+1) = unchanged") {
+                    game.handSize(1) shouldBe handBefore - 1 + 1
+                }
+            }
+
+            test("cannot be cast outside combat") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Chaotic Strike")
+                    .withCardOnBattlefield(1, "Test Bear")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Test Bear")!!
+                val castResult = game.castSpell(1, "Chaotic Strike", bear)
+                withClue("Casting in main phase should be rejected") {
+                    (castResult.error != null) shouldBe true
+                }
+            }
+        }
+
+        context("Cauldron Dance") {
+            test("reanimates a graveyard creature with haste during combat") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Cauldron Dance")
+                    .withCardInGraveyard(1, "Test Bear")
+                    .withCardOnBattlefield(1, "Test Bear")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Test Bear" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                if (game.state.priorityPlayerId != null && game.state.priorityPlayerId != game.state.activePlayerId) {
+                    game.passPriority()
+                }
+
+                val graveBear = game.state.getGraveyard(game.player1Id).first {
+                    game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Test Bear"
+                }
+                val castResult = game.castSpellTargetingGraveyardCard(1, "Cauldron Dance", listOf(graveBear))
+                withClue("Cast during combat should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+                // The optional put-from-hand part may offer a selection (hand has no creatures);
+                // skip it if prompted.
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                }
+
+                withClue("Reanimated Test Bear joins the attacker → two Test Bears on the battlefield") {
+                    game.findPermanents("Test Bear").size shouldBe 2
+                }
+                withClue("The reanimated creature left the graveyard") {
+                    game.isInGraveyard(1, "Test Bear") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CauldronDance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CauldronDance.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cauldron Dance
+ * {4}{B}{R}
+ * Instant
+ * Cast this spell only during combat.
+ * Return target creature card from your graveyard to the battlefield. That creature gains
+ * haste. Return it to your hand at the beginning of the next end step.
+ * You may put a creature card from your hand onto the battlefield. That creature gains haste.
+ * Its controller sacrifices it at the beginning of the next end step.
+ */
+val CauldronDance = card("Cauldron Dance") {
+    manaCost = "{4}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Instant"
+    oracleText = "Cast this spell only during combat.\n" +
+        "Return target creature card from your graveyard to the battlefield. That creature gains " +
+        "haste. Return it to your hand at the beginning of the next end step.\n" +
+        "You may put a creature card from your hand onto the battlefield. That creature gains haste. " +
+        "Its controller sacrifices it at the beginning of the next end step."
+
+    spell {
+        castOnlyDuring(Phase.COMBAT)
+        target = Targets.CreatureCardInYourGraveyard
+
+        // Part 1 — reanimate the targeted graveyard creature, give it haste, and bounce
+        // it to its owner's hand at the next end step.
+        val reanimate = Effects.Composite(
+            GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "reanimated"),
+            MoveCollectionEffect(
+                from = "reanimated",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+            ),
+            ConditionalOnCollectionEffect(
+                collection = "reanimated",
+                ifNotEmpty = Effects.Composite(
+                    Effects.GrantKeyword(
+                        keyword = Keyword.HASTE,
+                        target = EffectTarget.PipelineTarget("reanimated", 0),
+                        duration = Duration.Permanent
+                    ),
+                    CreateDelayedTriggerEffect(
+                        step = Step.END,
+                        effect = Effects.ReturnToHand(EffectTarget.PipelineTarget("reanimated", 0))
+                    )
+                )
+            )
+        )
+
+        // Part 2 — optionally drop a creature from hand, give it haste, and sacrifice it
+        // at the next end step.
+        val fromHand = EffectPatterns.putFromHand(
+            filter = GameObjectFilter.Creature
+        ).then(
+            ConditionalOnCollectionEffect(
+                collection = "putting",
+                ifNotEmpty = Effects.Composite(
+                    Effects.GrantKeyword(
+                        keyword = Keyword.HASTE,
+                        target = EffectTarget.PipelineTarget("putting", 0),
+                        duration = Duration.Permanent
+                    ),
+                    CreateDelayedTriggerEffect(
+                        step = Step.END,
+                        effect = Effects.SacrificeTarget(EffectTarget.PipelineTarget("putting", 0))
+                    )
+                )
+            )
+        )
+
+        effect = reanimate then fromHand
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "238"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8dadcae0-f2b2-487c-bb93-0a2c073044c0.jpg?1562923646"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ChaoticStrike.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ChaoticStrike.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.FlipCoinEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Chaotic Strike
+ * {1}{R}
+ * Instant
+ * Cast this spell only during combat after blockers are declared.
+ * Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn.
+ * Draw a card.
+ *
+ * Timing note: modeled as "cast only during the declare blockers step" — the canonical
+ * "after blockers are declared" window. The engine has no general "blockers declared"
+ * cast condition, so the rarely-used combat-damage-step window is not exposed.
+ */
+val ChaoticStrike = card("Chaotic Strike") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Cast this spell only during combat after blockers are declared.\n" +
+        "Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn.\n" +
+        "Draw a card."
+
+    spell {
+        castOnlyDuring(Step.DECLARE_BLOCKERS)
+        target = Targets.Creature
+        effect = FlipCoinEffect(
+            wonEffect = Effects.ModifyStats(1, 1, EffectTarget.ContextTarget(0))
+        ) then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "140"
+        artist = "Massimiliano Frezzato"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/061df8e4-6947-4bbb-9fe7-52ca4fd95d65.jpg?1762258062"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Dredge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Dredge.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Dredge
+ * {B}
+ * Instant
+ * Sacrifice a creature or land.
+ * Draw a card.
+ */
+val Dredge = card("Dredge") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Sacrifice a creature or land.\nDraw a card."
+
+    spell {
+        effect = EffectPatterns.sacrifice(
+            filter = GameObjectFilter.CreatureOrLand,
+            then = Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "103"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68bfa3d5-0f0b-4684-9567-f1478da01df7.jpg?1562916105"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Overload.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Overload.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Overload
+ * {R}
+ * Instant
+ * Kicker {2}
+ * Destroy target artifact if its mana value is 2 or less. If this spell was kicked,
+ * destroy that artifact if its mana value is 5 or less instead.
+ */
+private fun destroyIfManaValueAtMost(max: Int): Effect =
+    ConditionalEffect(
+        condition = Compare(
+            left = DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.ManaValue),
+            operator = ComparisonOperator.LTE,
+            right = DynamicAmount.Fixed(max)
+        ),
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+    )
+
+val Overload = card("Overload") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Kicker {2} (You may pay an additional {2} as you cast this spell.)\n" +
+        "Destroy target artifact if its mana value is 2 or less. If this spell was kicked, " +
+        "destroy that artifact if its mana value is 5 or less instead."
+
+    keywordAbility(KeywordAbility.kicker("{2}"))
+
+    spell {
+        target = Targets.Artifact
+        effect = ConditionalEffect(
+            condition = WasKicked,
+            effect = destroyIfManaValueAtMost(5),
+            elseEffect = destroyIfManaValueAtMost(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Gary Ruddell"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c91fca91-7296-422e-b251-d571b710ff71.jpg?1562935385"
+    }
+}


### PR DESCRIPTION
Implements four of five requested Invasion (INV) cards. All four compose existing engine primitives — no new engine code.

## Cards added

- **Dredge** `{B}` — Instant. `EffectPatterns.sacrifice(GameObjectFilter.CreatureOrLand)` then `Effects.DrawCards(1)`.
- **Overload** `{R}` (Kicker `{2}`) — Instant. Destroy target artifact if MV ≤ 2 (kicked: ≤ 5). Modeled as `ConditionalEffect(WasKicked, …)` choosing the threshold, each branch a `ConditionalEffect(Compare(EntityProperty(Target(0), ManaValue), LTE, n), Destroy)`.
- **Chaotic Strike** `{1}{R}` — Instant. `castOnlyDuring(Step.DECLARE_BLOCKERS)` + `FlipCoinEffect(wonEffect = ModifyStats(1,1))` then unconditional `DrawCards(1)`.
- **Cauldron Dance** `{4}{B}{R}` — Instant. `castOnlyDuring(Phase.COMBAT)`. Reanimate target graveyard creature (haste, bounce to hand at next end step) + optional put-from-hand creature (haste, sacrifice at next end step), built from the `CardSource.ChosenTargets` / `EffectPatterns.putFromHand` pipelines + `CreateDelayedTriggerEffect`. Mirrors the Meek Attack shape for the temporary-creature half.

## Test

`InvasionCombatTricksScenarioTest` (game-server) exercises all four cards end to end — 7 tests, all passing:
Dredge sacrifice+draw; Overload unkicked-destroys-MV1 / unkicked-spares-MV4 / kicked-destroys-MV4; Chaotic Strike combat resolve (+ outside-combat rejection); Cauldron Dance combat reanimation.

## Skipped: Aether Rift

Aether Rift's tail — *"return it from your graveyard to the battlefield **unless any player pays 5 life**"* — needs an inverted "any player may pay" punisher with `PayCost.PayLife` support. `AnyPlayerMayPayEffect` only fires its consequence **when** a player pays and its executor/continuation only support `PayCost.Sacrifice`; there's no single-player `PayOrSuffer` equivalent for "any player". Implementing it is a multi-file engine change (executor + continuation + resumer + an inverted branch), so per the task's guidance it was skipped rather than ballooning this PR. The rest of the card (upkeep trigger → discard at random → gate on creature card) is buildable today. Documented as gap #22 in `backlog/invasion-engine-gaps.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)