### PR TITLE
Improve choose-number overlay and lay split cards out horizontally

### DIFF
--- a/web-client/src/components/decisions/ChooseNumberDecisionUI.tsx
+++ b/web-client/src/components/decisions/ChooseNumberDecisionUI.tsx
@@ -24,11 +24,13 @@ function ManaDistributionUI({
   firstColor,
   secondColor,
   total,
+  onMinimize,
 }: {
   decision: ChooseNumberDecision
   firstColor: string
   secondColor: string
   total: number
+  onMinimize?: (() => void) | undefined
 }) {
   const [firstAmount, setFirstAmount] = useState(0)
   const submitNumberDecision = useGameStore((s) => s.submitNumberDecision)
@@ -139,10 +141,17 @@ function ManaDistributionUI({
         </button>
       </div>
 
-      {/* Confirm */}
-      <button onClick={handleConfirm} className={styles.confirmButton}>
-        Add Mana
-      </button>
+      {/* Confirm + optional View Battlefield */}
+      <div className={styles.buttonContainer}>
+        {onMinimize && (
+          <button onClick={onMinimize} className={styles.viewBattlefieldButton}>
+            View Battlefield
+          </button>
+        )}
+        <button onClick={handleConfirm} className={styles.confirmButton}>
+          Add Mana
+        </button>
+      </div>
     </>
   )
 }
@@ -246,8 +255,10 @@ const manaDistStyles: Record<string, React.CSSProperties> = {
  */
 export function ChooseNumberDecisionUI({
   decision,
+  onMinimize,
 }: {
   decision: ChooseNumberDecision
+  onMinimize?: () => void
 }) {
   // Check if this is a mana distribution prompt
   const manaDistribution = useMemo(() => parseManaDistributionPrompt(decision.prompt), [decision.prompt])
@@ -259,6 +270,7 @@ export function ChooseNumberDecisionUI({
         firstColor={manaDistribution.firstColor}
         secondColor={manaDistribution.secondColor}
         total={manaDistribution.total}
+        onMinimize={onMinimize}
       />
     )
   }
@@ -267,14 +279,21 @@ export function ChooseNumberDecisionUI({
   const [selectedNumber, setSelectedNumber] = useState(decision.minValue)
   const submitNumberDecision = useGameStore((s) => s.submitNumberDecision)
 
+  const clamp = (n: number) => Math.min(decision.maxValue, Math.max(decision.minValue, n))
+
   const handleConfirm = () => {
-    submitNumberDecision(selectedNumber)
+    submitNumberDecision(clamp(selectedNumber))
   }
 
-  // Generate number options
-  const numbers = []
-  for (let i = decision.minValue; i <= decision.maxValue; i++) {
-    numbers.push(i)
+  // A short range is fastest to tap as a button grid; a wide range (e.g.
+  // "any number", sent as 0–99) becomes an unusable wall of buttons, so we
+  // switch to a stepper with direct numeric entry.
+  const rangeSize = decision.maxValue - decision.minValue + 1
+  const useStepper = rangeSize > 12
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const parsed = parseInt(e.target.value, 10)
+    setSelectedNumber(Number.isNaN(parsed) ? decision.minValue : clamp(parsed))
   }
 
   return (
@@ -289,23 +308,66 @@ export function ChooseNumberDecisionUI({
         </p>
       )}
 
-      {/* Number selection buttons */}
-      <div className={styles.numberContainer}>
-        {numbers.map((num) => (
-          <button
-            key={num}
-            onClick={() => setSelectedNumber(num)}
-            className={`${styles.numberButton} ${selectedNumber === num ? styles.numberButtonSelected : ''}`}
-          >
-            {num}
-          </button>
-        ))}
-      </div>
+      {useStepper ? (
+        <>
+          <div className={styles.stepperContainer}>
+            <button
+              type="button"
+              className={styles.stepperButton}
+              onClick={() => setSelectedNumber((n) => clamp(n - 1))}
+              disabled={selectedNumber <= decision.minValue}
+              aria-label="Decrease"
+            >
+              −
+            </button>
+            <input
+              type="number"
+              className={styles.stepperInput}
+              min={decision.minValue}
+              max={decision.maxValue}
+              value={selectedNumber}
+              onChange={handleInputChange}
+            />
+            <button
+              type="button"
+              className={styles.stepperButton}
+              onClick={() => setSelectedNumber((n) => clamp(n + 1))}
+              disabled={selectedNumber >= decision.maxValue}
+              aria-label="Increase"
+            >
+              +
+            </button>
+          </div>
+          <p className={styles.stepperRangeHint}>
+            {decision.minValue} – {decision.maxValue}
+          </p>
+        </>
+      ) : (
+        /* Number selection buttons */
+        <div className={styles.numberContainer}>
+          {Array.from({ length: rangeSize }, (_, i) => decision.minValue + i).map((num) => (
+            <button
+              key={num}
+              onClick={() => setSelectedNumber(num)}
+              className={`${styles.numberButton} ${selectedNumber === num ? styles.numberButtonSelected : ''}`}
+            >
+              {num}
+            </button>
+          ))}
+        </div>
+      )}
 
-      {/* Confirm button */}
-      <button onClick={handleConfirm} className={styles.confirmButton}>
-        Confirm
-      </button>
+      {/* Confirm + optional View Battlefield */}
+      <div className={styles.buttonContainer}>
+        {onMinimize && (
+          <button onClick={onMinimize} className={styles.viewBattlefieldButton}>
+            View Battlefield
+          </button>
+        )}
+        <button onClick={handleConfirm} className={styles.confirmButton}>
+          Confirm
+        </button>
+      </div>
     </>
   )
 }

--- a/web-client/src/components/decisions/DecisionUI.module.css
+++ b/web-client/src/components/decisions/DecisionUI.module.css
@@ -361,6 +361,64 @@
   border-width: 3px;
 }
 
+/* Stepper — used for wide ranges (e.g. "any number") where a button grid
+ * would be an unusable wall of buttons. */
+.stepperContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  margin-top: var(--space-6);
+}
+
+.stepperButton {
+  width: 56px;
+  height: 56px;
+  font-size: var(--font-2xl);
+  line-height: 1;
+  background-color: var(--bg-surface-6);
+  color: var(--text-primary);
+  border: 2px solid var(--text-disabled);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  font-weight: var(--font-weight-semibold);
+  transition: all var(--transition-fast);
+}
+
+.stepperButton:hover:not(:disabled) {
+  border-color: var(--text-muted);
+  background-color: var(--bg-surface-5);
+}
+
+.stepperButton:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.stepperInput {
+  width: 110px;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-2xl);
+  font-weight: var(--font-weight-semibold);
+  text-align: center;
+  background-color: var(--bg-surface-6);
+  color: var(--text-primary);
+  border: 2px solid var(--text-disabled);
+  border-radius: var(--radius-lg);
+}
+
+.stepperInput:focus {
+  outline: none;
+  border-color: #66aaff;
+}
+
+.stepperRangeHint {
+  margin: var(--space-3) 0 0 0;
+  text-align: center;
+  font-size: var(--font-sm);
+  color: var(--text-muted);
+}
+
 /* =========================================================================
  * Card Container
  * ========================================================================= */

--- a/web-client/src/components/decisions/DecisionUI.tsx
+++ b/web-client/src/components/decisions/DecisionUI.tsx
@@ -60,11 +60,11 @@ export function DecisionUI() {
   const pendingDecision = useGameStore((state) => state.pendingDecision)
   const gameState = useGameStore((state) => state.gameState)
   const responsive = useResponsive()
-  const [yesNoMinimized, setYesNoMinimized] = useState(false)
+  const [decisionMinimized, setDecisionMinimized] = useState(false)
 
   // Reset minimized state when decision changes
   useEffect(() => {
-    setYesNoMinimized(false)
+    setDecisionMinimized(false)
   }, [pendingDecision?.id])
 
   if (!pendingDecision) return null
@@ -103,11 +103,11 @@ export function DecisionUI() {
         return null
       }
     }
-    if (yesNoMinimized) {
+    if (decisionMinimized) {
       return (
         <button
           className={styles.floatingReturnButton}
-          onClick={() => setYesNoMinimized(false)}
+          onClick={() => setDecisionMinimized(false)}
         >
           Return to decision
         </button>
@@ -118,7 +118,7 @@ export function DecisionUI() {
         <YesNoDecisionUI
           decision={pendingDecision}
           gameState={gameState}
-          onMinimize={() => setYesNoMinimized(true)}
+          onMinimize={() => setDecisionMinimized(true)}
         />
       </div>
     )
@@ -126,9 +126,22 @@ export function DecisionUI() {
 
   // Handle ChooseNumberDecision (e.g., "Choose how many cards to draw")
   if (pendingDecision.type === 'ChooseNumberDecision') {
+    if (decisionMinimized) {
+      return (
+        <button
+          className={styles.floatingReturnButton}
+          onClick={() => setDecisionMinimized(false)}
+        >
+          Return to decision
+        </button>
+      )
+    }
     return (
       <div className={styles.overlay}>
-        <ChooseNumberDecisionUI decision={pendingDecision} />
+        <ChooseNumberDecisionUI
+          decision={pendingDecision}
+          onMinimize={() => setDecisionMinimized(true)}
+        />
       </div>
     )
   }

--- a/web-client/src/components/game/card/CardPreview.tsx
+++ b/web-client/src/components/game/card/CardPreview.tsx
@@ -120,12 +120,14 @@ export function CardPreview() {
   if (hasStatModifications) extraHeight += 80 + GAP
   if (card.keywords.length > 0 || (card.abilityFlags && card.abilityFlags.length > 0)) extraHeight += 40 + GAP
 
-  // Rooms (CR 709.5) — display the printed-portrait image rotated landscape, and
-  // dim the locked half with an upright lock chip. Source image stores face[1] on top
-  // and face[0] on bottom; after +90° (CW) rotation that maps face[1] → right of
-  // visible, face[0] → left.
+  // Split-layout cards (CR 709) — Rooms and classic Invasion split spells like
+  // Pain // Suffering — are printed portrait with the two halves stacked, so display
+  // the image rotated +90° (CW) to read landscape with the halves side by side. Source
+  // stores face[1] on top and face[0] on bottom; after rotation face[1] → right, face[0]
+  // → left. Rooms additionally dim the locked half with an upright lock chip (below).
   const isRoom = card.isRoom === true
-  const roomImageRotateDeg: 0 | 90 = isRoom ? 90 : 0
+  const isSplit = card.cardFaces != null && card.cardFaces.length === 2
+  const splitImageRotateDeg: 0 | 90 = isSplit ? 90 : 0
 
   // Mana cost overlay badge for the card image (only for hand cards)
   const previewOverlay = (
@@ -232,7 +234,7 @@ export function CardPreview() {
       pos={hoverPosition}
       rulings={card.rulings}
       extraHeight={extraHeight}
-      imageRotateDeg={roomImageRotateDeg}
+      imageRotateDeg={splitImageRotateDeg}
       overlay={previewOverlay}
     >
       {/* Stats box (for creatures with modifications) */}

--- a/web-client/src/components/ui/ActionMenu.tsx
+++ b/web-client/src/components/ui/ActionMenu.tsx
@@ -373,12 +373,14 @@ export function ActionMenu() {
     return (
       <div className={styles.container}>
         <div className={styles.panel}>
-          {/* Large card image — rotated landscape for Rooms (CR 709.5) */}
+          {/* Large card image — rotated landscape for split-layout cards (CR 709):
+              Rooms and classic split spells like Pain // Suffering are printed portrait
+              with the two halves stacked. */}
           {cardImageUrl && (
             <CardImage
               imageUrl={cardImageUrl}
               cardName={cardInfo?.name ?? 'Card'}
-              rotateDeg={cardInfo?.isRoom ? 90 : 0}
+              rotateDeg={cardInfo?.cardFaces?.length === 2 ? 90 : 0}
             />
           )}
 


### PR DESCRIPTION
## Summary

Three frontend UI improvements:

### 1. "View Battlefield" button on the choose-a-number overlay
`ChooseNumberDecisionUI` now accepts an optional `onMinimize` and renders a **View Battlefield** button next to Confirm (and next to "Add Mana" in the mana-distribution variant), matching the other decision overlays. `DecisionUI.tsx` wires it through a generalized `decisionMinimized` state (renamed from `yesNoMinimized`), reusing the same floating "Return to decision" button.

### 2. Stepper for wide number ranges
"Any number" decisions arrive as `0–99`, which previously rendered ~100 buttons. The default UI now switches to a **stepper** (− / numeric input / + with a `min – max` hint) whenever the range exceeds 12; small ranges keep the fast button grid.

### 3. Horizontal layout for split-layout cards
Rooms and classic Invasion split spells (e.g. Pain // Suffering) are printed portrait with the two halves stacked. The hover preview and action window now rotate them +90° to read landscape, generalizing the existing Room-only rotation to any 2-face split card. The server already populates `cardFaces` for all `SPLIT`-layout cards (Adventure faces get an empty list), so `cardFaces.length === 2` cleanly targets exactly the portrait-stored split cards.

## Testing
Pure frontend layout changes; `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)