### PR TITLE
Show spells payable only by a composite sacrifice mana ability as affordable

### DIFF
--- a/manual-scenarios/cards/i/irrigation-ditch-autotap-nomadic-elf.json
+++ b/manual-scenarios/cards/i/irrigation-ditch-autotap-nomadic-elf.json
@@ -1,0 +1,28 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Nomadic Elf"],
+    "battlefield": [
+      {"name": "Irrigation Ditch", "tapped": false},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Forest", "Goblin Spy"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Swamp", "Mountain", "Duskwalker"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -30,6 +30,7 @@ import com.wingedsheep.sdk.scripting.effects.AddDynamicManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.values.ManaColorSet
 import com.wingedsheep.sdk.scripting.effects.ManaRestriction
 import com.wingedsheep.sdk.scripting.effects.ManaSpellRider
@@ -1810,26 +1811,47 @@ class ManaSolver(
                 // Honor activation restrictions (e.g. "only during your turn").
                 if (!activationRestrictionsSatisfied(state, playerId, entityId, ability)) continue
 
-                when (val effect = ability.effect) {
-                    is AddManaOfChoiceEffect -> if (effect.colorSet is ManaColorSet.AnyColor) {
-                        val amount = (effect.amount as? DynamicAmount.Fixed)?.amount ?: 1
-                        anyColorTotal += amount
-                    }
-                    is AddManaEffect -> {
-                        val amount = (effect.amount as? DynamicAmount.Fixed)?.amount ?: 1
-                        specificColorTotal[effect.color] =
-                            (specificColorTotal[effect.color] ?: 0) + amount
-                    }
-                    is AddColorlessManaEffect -> {
-                        val amount = (effect.amount as? DynamicAmount.Fixed)?.amount ?: 1
-                        colorlessTotal += amount
-                    }
-                    else -> {}
+                // Recurse into the effect so multi-mana sacrifice abilities expressed as a
+                // CompositeEffect (e.g. Irrigation Ditch's "{T}, Sacrifice: Add {G}{U}",
+                // `Effects.Composite(AddMana(GREEN), AddMana(BLUE))`) are counted in full
+                // rather than dropping to the unhandled `else` branch and contributing zero.
+                val produced = manaProducedByEffect(ability.effect)
+                anyColorTotal += produced.anyColorMana
+                for ((color, amount) in produced.specificMana) {
+                    specificColorTotal[color] = (specificColorTotal[color] ?: 0) + amount
                 }
+                colorlessTotal += produced.colorlessMana
             }
         }
 
         return TapPermanentsBonusMana(anyColorTotal, specificColorTotal, colorlessTotal)
+    }
+
+    /**
+     * Mana produced by a single mana-ability effect, recursing into [CompositeEffect].
+     *
+     * Used by the "bonus mana" affordability helpers (e.g. [calculateSacrificeSelfBonusMana])
+     * so an ability that adds several mana via `Effects.Composite(AddMana(...), AddMana(...))`
+     * is counted in full. Without the recursion such an effect falls into the `else` branch and
+     * contributes nothing, so a spell payable only by that ability is wrongly reported
+     * unaffordable (Irrigation Ditch's {G}{U} → casting Nomadic Elf, {1}{G}).
+     */
+    private fun manaProducedByEffect(effect: Effect): TapPermanentsBonusMana = when (effect) {
+        is AddManaOfChoiceEffect ->
+            if (effect.colorSet is ManaColorSet.AnyColor) {
+                TapPermanentsBonusMana(anyColorMana = (effect.amount as? DynamicAmount.Fixed)?.amount ?: 1)
+            } else {
+                TapPermanentsBonusMana()
+            }
+        is AddManaEffect ->
+            TapPermanentsBonusMana(
+                specificMana = mapOf(effect.color to ((effect.amount as? DynamicAmount.Fixed)?.amount ?: 1))
+            )
+        is AddColorlessManaEffect ->
+            TapPermanentsBonusMana(colorlessMana = (effect.amount as? DynamicAmount.Fixed)?.amount ?: 1)
+        is CompositeEffect ->
+            effect.effects.fold(TapPermanentsBonusMana()) { acc, sub -> acc + manaProducedByEffect(sub) }
+        else -> TapPermanentsBonusMana()
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IrrigationDitchAutoTapTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IrrigationDitchAutoTapTest.kt
@@ -1,9 +1,12 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.inv.cards.IrrigationDitch
 import com.wingedsheep.mtg.sets.definitions.inv.cards.NomadicElf
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
@@ -15,10 +18,10 @@ import io.kotest.matchers.shouldBe
  *   {T}: Add {W}
  *   {T}, Sacrifice this land: Add {G}{U}
  *
- * The auto-pay solver must never silently sacrifice the land to produce the {G}/{U}.
- * Because the source also has the sacrifice-free {W} ability, the whole-source
- * `requiresSacrifice` flag is false, so the fix tags {G}/{U} individually as
- * sacrifice-only and strips them from the auto-pay source list.
+ * Sacrificing for {G}{U} is a legal way to pay — so a spell that needs green (Nomadic Elf,
+ * {1}{G}) must be *shown as playable*. But, exactly like sacrificing a Treasure for mana, the
+ * sacrifice has to be a deliberate player action: the auto-pay solver must never silently
+ * sacrifice the land. The {W} path is sacrifice-free and stays available to auto-pay.
  */
 class IrrigationDitchAutoTapTest : FunSpec({
 
@@ -36,6 +39,27 @@ class IrrigationDitchAutoTapTest : FunSpec({
         return driver
     }
 
+    test("Nomadic Elf ({1}{G}) is shown as playable via Irrigation Ditch's sacrifice ability") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(activePlayer, "Irrigation Ditch")
+        driver.putPermanentOnBattlefield(activePlayer, "Island")
+        driver.putCardInHand(activePlayer, "Nomadic Elf")
+
+        // Affordable: the only green comes from "{T}, Sacrifice: Add {G}{U}", but the spell is
+        // still a legal play (the player can opt into the sacrifice), so canPay reports true...
+        val solver = ManaSolver(driver.cardRegistry)
+        solver.canPay(driver.state, activePlayer, ManaCost.parse("{1}{G}")) shouldBe true
+
+        // ...and it surfaces as a legal cast action for the player to choose.
+        val actions = LegalActionEnumerator.create(driver.cardRegistry).enumerate(driver.state, activePlayer)
+        val offered = actions.any { it.toString().contains("Nomadic Elf", ignoreCase = true) }
+        offered shouldBe true
+    }
+
     test("auto-pay refuses to sacrifice Irrigation Ditch to cast Nomadic Elf ({1}{G})") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
@@ -47,7 +71,8 @@ class IrrigationDitchAutoTapTest : FunSpec({
         val elf = driver.putCardInHand(activePlayer, "Nomadic Elf")
 
         // The only source of {G} is Irrigation Ditch's "{T}, Sacrifice: Add {G}{U}" ability.
-        // Auto-pay must not pick it — there is no sacrifice-free way to make green.
+        // Auto-pay must not pick it — there is no sacrifice-free way to make green, and the
+        // sacrifice must be a deliberate choice.
         val result = driver.castSpell(activePlayer, elf)
 
         result.isSuccess shouldBe false


### PR DESCRIPTION
## Problem

With **Irrigation Ditch** + **Island** in play and **Nomadic Elf** (`{1}{G}`) in hand, the Elf was *not* offered as a legal cast. But it *should* be: Irrigation Ditch's `{T}, Sacrifice this land: Add {G}{U}` is a legal way to produce the green, so the spell is castable — the player just has to deliberately opt into the sacrifice (exactly like sacrificing a Treasure for mana).

Auto-pay correctly refuses to silently sacrifice the land already (via `ManaSource.colorsRequiringSacrifice`, added in 8679fb478). The remaining gap was purely **affordability/visibility**: the spell never showed up as playable.

## Root cause

`canPay` counts tap+sacrifice mana abilities through `calculateSacrificeSelfBonusMana`, but that helper's `when` only handled a *single* `AddManaEffect` / `AddManaOfChoiceEffect` / `AddColorlessManaEffect`. Irrigation Ditch's sacrifice ability is `Effects.Composite(AddMana(GREEN), AddMana(BLUE))` — a `CompositeEffect` that fell into the `else -> {}` branch and contributed **zero**. So the `{G}{U}` was invisible to affordability and the spell was hidden.

Treasures work because their ability is a single `AddManaOfChoiceEffect`.

## Fix

Extract `manaProducedByEffect(effect)`, which recurses into `CompositeEffect`, and use it in `calculateSacrificeSelfBonusMana` so multi-mana sacrifice abilities are counted in full. `solve()` / auto-pay are untouched, so the sacrifice remains a **deliberate** player choice.

## Tests

`IrrigationDitchAutoTapTest`:
- **(new)** Nomadic Elf `{1}{G}` is shown as playable — `canPay` is true *and* it's enumerated as a legal cast.
- auto-pay refuses to sacrifice Irrigation Ditch (unchanged — still must not silently sacrifice).
- auto-pay still uses the sacrifice-free `{T}: Add {W}` path.

Full `:rules-engine:test` suite passes (incl. Treasure/ward auto-pay tests).

A manual repro scenario is included at `manual-scenarios/cards/i/irrigation-ditch-autotap-nomadic-elf.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)