### PR TITLE
Add Invasion cards (batch A): dragons, attendants & legends

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CrosisThePurgerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CrosisThePurgerScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Crosis, the Purger.
+ *
+ * Card reference:
+ * - Crosis, the Purger ({3}{U}{B}{R}): 6/6 Legendary Creature — Dragon, Flying
+ *   "Whenever Crosis deals combat damage to a player, you may pay {2}{B}. If you do, choose a color,
+ *    then that player reveals their hand and discards all cards of that color."
+ *
+ * The damaged player ([com.wingedsheep.sdk.scripting.references.Player.TriggeringPlayer]) reveals and
+ * discards every card of the chosen color via `CardPredicate.HasChosenColor`.
+ */
+class CrosisThePurgerScenarioTest : ScenarioTestBase() {
+
+    private val blueCard = CardDefinition.creature(
+        name = "Blue Bird", manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Bird")), power = 1, toughness = 1
+    )
+    private val redCard = CardDefinition.creature(
+        name = "Red Goblin", manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Goblin")), power = 1, toughness = 1
+    )
+
+    init {
+        cardRegistry.register(blueCard)
+        cardRegistry.register(redCard)
+
+        context("Crosis combat-damage trigger") {
+
+            fun freshGame() = scenario()
+                .withPlayers("Attacker", "Defender")
+                .withCardOnBattlefield(1, "Crosis, the Purger")
+                .withCardInHand(2, "Blue Bird")
+                .withCardInHand(2, "Blue Bird")
+                .withCardInHand(2, "Red Goblin")
+                .withLandsOnBattlefield(1, "Swamp", 3) // pays {2}{B}
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            fun dealCombatDamage(game: TestGame) {
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Crosis, the Purger" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+
+                var iterations = 0
+                while (!game.hasPendingDecision() && iterations < 50) {
+                    val p = game.state.priorityPlayerId ?: break
+                    game.execute(PassPriority(p))
+                    iterations++
+                }
+            }
+
+            test("paying and choosing blue discards both blue cards but not the red one") {
+                val game = freshGame()
+                dealCombatDamage(game)
+
+                withClue("Crosis's combat-damage trigger should ask whether to pay {2}{B}") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                game.answerYesNo(true)
+                game.submitManaSourcesAutoPay()
+
+                val colorDecision = game.getPendingDecision()
+                withClue("Should pause for a color choice after paying") {
+                    (colorDecision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.BLUE))
+
+                withClue("Both blue cards discarded, red one kept") {
+                    game.handSize(2) shouldBe 1
+                    game.graveyardSize(2) shouldBe 2
+                    game.isInGraveyard(2, "Blue Bird") shouldBe true
+                }
+            }
+
+            test("declining the payment discards nothing") {
+                val game = freshGame()
+                dealCombatDamage(game)
+
+                game.answerYesNo(false)
+
+                withClue("Declining {2}{B} should discard nothing") {
+                    game.handSize(2) shouldBe 3
+                    game.graveyardSize(2) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DarigaazTheIgniterScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DarigaazTheIgniterScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Darigaaz, the Igniter.
+ *
+ * Card reference:
+ * - Darigaaz, the Igniter ({3}{B}{R}{G}): 6/6 Legendary Creature — Dragon, Flying
+ *   "Whenever Darigaaz deals combat damage to a player, you may pay {2}{R}. If you do, choose a color,
+ *    then that player reveals their hand and Darigaaz deals damage to the player equal to the number
+ *    of cards of that color revealed this way."
+ *
+ * The combat damage (6) drops the defender to 14; the trigger then deals damage equal to the count
+ * of chosen-color cards in the defender's revealed hand.
+ */
+class DarigaazTheIgniterScenarioTest : ScenarioTestBase() {
+
+    private val redCard = CardDefinition.creature(
+        name = "Red Goblin", manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Goblin")), power = 1, toughness = 1
+    )
+    private val blueCard = CardDefinition.creature(
+        name = "Blue Bird", manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Bird")), power = 1, toughness = 1
+    )
+
+    init {
+        cardRegistry.register(redCard)
+        cardRegistry.register(blueCard)
+
+        context("Darigaaz combat-damage trigger") {
+
+            fun freshGame() = scenario()
+                .withPlayers("Attacker", "Defender")
+                .withCardOnBattlefield(1, "Darigaaz, the Igniter")
+                .withCardInHand(2, "Red Goblin")
+                .withCardInHand(2, "Red Goblin")
+                .withCardInHand(2, "Blue Bird")
+                .withLandsOnBattlefield(1, "Mountain", 3) // pays {2}{R}
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            fun dealCombatDamage(game: TestGame) {
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Darigaaz, the Igniter" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+
+                var iterations = 0
+                while (!game.hasPendingDecision() && iterations < 50) {
+                    val p = game.state.priorityPlayerId ?: break
+                    game.execute(PassPriority(p))
+                    iterations++
+                }
+            }
+
+            test("choosing red deals damage equal to the two red cards in hand") {
+                val game = freshGame()
+                dealCombatDamage(game)
+
+                withClue("Darigaaz's combat-damage trigger should ask whether to pay {2}{R}") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                game.answerYesNo(true)
+                game.submitManaSourcesAutoPay()
+
+                val colorDecision = game.getPendingDecision()
+                withClue("Should pause for a color choice after paying") {
+                    (colorDecision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.RED))
+
+                // 20 - 6 combat - 2 (two red cards) = 12.
+                withClue("Defender takes 6 combat + 2 damage for two red cards") {
+                    game.getLifeTotal(2) shouldBe 12
+                }
+            }
+
+            test("declining the payment deals only combat damage") {
+                val game = freshGame()
+                dealCombatDamage(game)
+
+                game.answerYesNo(false)
+
+                withClue("Declining {2}{R} deals only the 6 combat damage") {
+                    game.getLifeTotal(2) shouldBe 14
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DromarTheBanisherScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DromarTheBanisherScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Dromar, the Banisher.
+ *
+ * Card reference:
+ * - Dromar, the Banisher ({3}{W}{U}{B}): 6/6 Legendary Creature — Dragon, Flying
+ *   "Whenever Dromar deals combat damage to a player, you may pay {2}{U}. If you do, choose a color,
+ *    then return all creatures of that color to their owners' hands."
+ *
+ * The chosen-color creature bounce is the creature-only variant of Wash Out's pipeline.
+ */
+class DromarTheBanisherScenarioTest : ScenarioTestBase() {
+
+    private val redCreature = CardDefinition.creature(
+        name = "Red Goblin", manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Goblin")), power = 2, toughness = 2
+    )
+    private val greenCreature = CardDefinition.creature(
+        name = "Green Bear", manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Bear")), power = 2, toughness = 2
+    )
+
+    init {
+        cardRegistry.register(redCreature)
+        cardRegistry.register(greenCreature)
+
+        context("Dromar combat-damage trigger") {
+
+            fun freshGame() = scenario()
+                .withPlayers("Attacker", "Defender")
+                .withCardOnBattlefield(1, "Dromar, the Banisher")
+                .withCardOnBattlefield(2, "Red Goblin")
+                .withCardOnBattlefield(2, "Red Goblin")
+                .withCardOnBattlefield(2, "Green Bear")
+                .withLandsOnBattlefield(1, "Island", 3) // pays {2}{U}
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            fun dealCombatDamage(game: TestGame) {
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Dromar, the Banisher" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+
+                var iterations = 0
+                while (!game.hasPendingDecision() && iterations < 50) {
+                    val p = game.state.priorityPlayerId ?: break
+                    game.execute(PassPriority(p))
+                    iterations++
+                }
+            }
+
+            test("choosing red returns both red creatures but leaves the green one") {
+                val game = freshGame()
+                dealCombatDamage(game)
+
+                withClue("Dromar's combat-damage trigger should ask whether to pay {2}{U}") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                game.answerYesNo(true)
+                game.submitManaSourcesAutoPay()
+
+                val colorDecision = game.getPendingDecision()
+                withClue("Should pause for a color choice after paying") {
+                    (colorDecision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.RED))
+
+                withClue("Both red creatures bounced, green creature stays") {
+                    game.findAllPermanents("Red Goblin").size shouldBe 0
+                    game.findAllPermanents("Green Bear").size shouldBe 1
+                    game.handSize(2) shouldBe 2
+                }
+            }
+
+            test("declining the payment bounces nothing") {
+                val game = freshGame()
+                dealCombatDamage(game)
+
+                game.answerYesNo(false)
+
+                withClue("Declining {2}{U} should bounce nothing") {
+                    game.findAllPermanents("Red Goblin").size shouldBe 2
+                    game.findAllPermanents("Green Bear").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KangeeAerieKeeperScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KangeeAerieKeeperScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.inv.InvasionSet
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kangee, Aerie Keeper.
+ *
+ * Card reference:
+ * - Kangee, Aerie Keeper {2}{W}{U} — Legendary Creature — Bird Wizard 2/2
+ *   Kicker {X}{2}, Flying
+ *   When Kangee enters, if it was kicked, put X feather counters on it.
+ *   Other Bird creatures get +1/+1 for each feather counter on Kangee.
+ *
+ * Test cases:
+ * 1. Unkicked — no feather counters; other Birds unmodified; Kangee doesn't pump itself.
+ * 2. Kicked X=2 — two feather counters; other Birds get +2/+2; Kangee itself unchanged.
+ */
+class KangeeAerieKeeperScenarioTest : ScenarioTestBase() {
+
+    private val vanillaBird = card("Vanilla Sparrow") {
+        manaCost = "{1}{W}"
+        colorIdentity = "W"
+        typeLine = "Creature — Bird"
+        power = 1
+        toughness = 1
+    }
+
+    init {
+        cardRegistry.register(InvasionSet.cards)
+        cardRegistry.register(vanillaBird)
+
+        context("Kangee, Aerie Keeper") {
+
+            test("unkicked: no feather counters, other Birds unmodified") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Kangee, Aerie Keeper")
+                    .withCardOnBattlefield(1, "Vanilla Sparrow")
+                    .withLandsOnBattlefield(1, "Plains", 3) // {2}{W}
+                    .withLandsOnBattlefield(1, "Island", 1) // {U}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Kangee, Aerie Keeper")
+                withClue("Cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                val bird = game.findPermanent("Vanilla Sparrow")!!
+                withClue("With no feather counters, other Birds stay 1/1") {
+                    projected.getPower(bird) shouldBe 1
+                    projected.getToughness(bird) shouldBe 1
+                }
+            }
+
+            test("kicked X=2: two feather counters pump other Birds +2/+2 but not Kangee") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Kangee, Aerie Keeper")
+                    .withCardOnBattlefield(1, "Vanilla Sparrow")
+                    .withLandsOnBattlefield(1, "Plains", 7) // {2}{W} + {X}{2} generic (X=2)
+                    .withLandsOnBattlefield(1, "Island", 1) // {U}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Kangee, Aerie Keeper"
+                }
+
+                val castResult = game.execute(
+                    CastSpell(playerId, cardId, wasKicked = true, xValue = 2)
+                )
+                withClue("Kicked cast should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                val kangee = game.findPermanent("Kangee, Aerie Keeper")!!
+                val bird = game.findPermanent("Vanilla Sparrow")!!
+
+                withClue("Other Bird gets +2/+2 (1/1 -> 3/3) from two feather counters") {
+                    projected.getPower(bird) shouldBe 3
+                    projected.getToughness(bird) shouldBe 3
+                }
+                withClue("Kangee doesn't pump itself (excludeSelf): stays 2/2") {
+                    projected.getPower(kangee) shouldBe 2
+                    projected.getToughness(kangee) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MolimoMaroSorcererScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MolimoMaroSorcererScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Molimo, Maro-Sorcerer.
+ *
+ * Card reference:
+ * - Molimo, Maro-Sorcerer {4}{G}{G}{G} — Legendary Creature — Elemental Sorcerer (star/star)
+ *   Trample
+ *   Molimo's power and toughness are each equal to the number of lands you control.
+ *
+ * Characteristic-defining ability: base P/T equals the controller's land count (lands only count
+ * for the controller, not opponents).
+ */
+class MolimoMaroSorcererScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Molimo, Maro-Sorcerer") {
+
+            test("P/T equals the number of lands you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Molimo, Maro-Sorcerer")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withLandsOnBattlefield(2, "Mountain", 3) // opponent lands don't count
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val projected = game.state.projectedState
+                val molimo = game.findPermanent("Molimo, Maro-Sorcerer")!!
+                withClue("Molimo is 5/5 with five controlled lands (opponent's lands ignored)") {
+                    projected.getPower(molimo) shouldBe 5
+                    projected.getToughness(molimo) shouldBe 5
+                }
+            }
+
+            test("P/T scales with additional lands") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Molimo, Maro-Sorcerer")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val projected = game.state.projectedState
+                val molimo = game.findPermanent("Molimo, Maro-Sorcerer")!!
+                withClue("Molimo is 8/8 with eight controlled lands") {
+                    projected.getPower(molimo) shouldBe 8
+                    projected.getToughness(molimo) shouldBe 8
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrosisThePurger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrosisThePurger.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Crosis, the Purger
+ * {3}{U}{B}{R}
+ * Legendary Creature — Dragon
+ * 6/6
+ * Flying
+ * Whenever Crosis deals combat damage to a player, you may pay {2}{B}. If you do, choose a color,
+ * then that player reveals their hand and discards all cards of that color.
+ *
+ * One of the five Coalition Dragons (cf. [RithTheAwakener], [TrevaTheRenewer]). The damaged
+ * player is [Player.TriggeringPlayer]. Composes the chosen-color pattern with a reveal →
+ * gather-by-chosen-color → discard pipeline (cf. [Addle], [Void]): [Effects.ChooseColorThen]
+ * pauses for the color (chosen during resolution per the 2004-10-04 ruling), then every card of
+ * that color in the triggering player's hand is discarded via [CardPredicate.HasChosenColor].
+ */
+val CrosisThePurger = card("Crosis, the Purger") {
+    manaCost = "{3}{U}{B}{R}"
+    colorIdentity = "UBR"
+    typeLine = "Legendary Creature — Dragon"
+    power = 6
+    toughness = 6
+    oracleText = "Flying\nWhenever Crosis deals combat damage to a player, you may pay {2}{B}. If you do, " +
+        "choose a color, then that player reveals their hand and discards all cards of that color."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}{B}"),
+            effect = Effects.ChooseColorThen(
+                then = CompositeEffect(
+                    listOf(
+                        RevealHandEffect(EffectTarget.PlayerRef(Player.TriggeringPlayer)),
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(
+                                zone = Zone.HAND,
+                                player = Player.TriggeringPlayer,
+                                filter = GameObjectFilter(
+                                    cardPredicates = listOf(CardPredicate.HasChosenColor),
+                                ),
+                            ),
+                            storeAs = "crosisDiscard",
+                        ),
+                        MoveCollectionEffect(
+                            from = "crosisDiscard",
+                            destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.TriggeringPlayer),
+                            moveType = MoveType.Discard,
+                        ),
+                    ),
+                ),
+                prompt = "Choose a color",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "242"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5f336d8-12a4-482d-8ffd-c205858c72ba.jpg?1562941160"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrosissAttendant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/CrosissAttendant.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Crosis's Attendant
+ * {5}
+ * Artifact Creature — Golem
+ * 3/3
+ * {1}, Sacrifice this creature: Add {U}{B}{R}.
+ *
+ * One of the Invasion "Attendant" cycle (cf. [RithsAttendant]) — each sacrifices for the three
+ * colors of the matching dragon (Crosis = Blue/Black/Red). A mana ability: no targets, no stack.
+ */
+val CrosissAttendant = card("Crosis's Attendant") {
+    manaCost = "{5}"
+    colorIdentity = "UBR"
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 3
+    oracleText = "{1}, Sacrifice this creature: Add {U}{B}{R}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.BLUE),
+            Effects.AddMana(Color.BLACK),
+            Effects.AddMana(Color.RED)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "300"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45edc18c-2046-4d0e-92fe-a6cf4aaf1c6f.jpg?1562909185"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DarigaazTheIgniter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DarigaazTheIgniter.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Darigaaz, the Igniter
+ * {3}{B}{R}{G}
+ * Legendary Creature — Dragon
+ * 6/6
+ * Flying
+ * Whenever Darigaaz deals combat damage to a player, you may pay {2}{R}. If you do, choose a color,
+ * then that player reveals their hand and Darigaaz deals damage to the player equal to the number
+ * of cards of that color revealed this way.
+ *
+ * One of the five Coalition Dragons (cf. [RithTheAwakener], [TrevaTheRenewer]). The damaged player
+ * is [Player.TriggeringPlayer]. After the optional {2}{R} payment, [Effects.ChooseColorThen]
+ * pauses for the color, the player reveals their hand, then Darigaaz deals damage equal to the
+ * count of chosen-color cards in that revealed hand — modeled as an `AggregateZone` over the
+ * triggering player's hand filtered by [CardPredicate.HasChosenColor].
+ */
+val DarigaazTheIgniter = card("Darigaaz, the Igniter") {
+    manaCost = "{3}{B}{R}{G}"
+    colorIdentity = "BRG"
+    typeLine = "Legendary Creature — Dragon"
+    power = 6
+    toughness = 6
+    oracleText = "Flying\nWhenever Darigaaz deals combat damage to a player, you may pay {2}{R}. If you do, " +
+        "choose a color, then that player reveals their hand and Darigaaz deals damage to the player " +
+        "equal to the number of cards of that color revealed this way."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}{R}"),
+            effect = Effects.ChooseColorThen(
+                then = CompositeEffect(
+                    listOf(
+                        RevealHandEffect(EffectTarget.PlayerRef(Player.TriggeringPlayer)),
+                        Effects.DealDamage(
+                            amount = DynamicAmounts.zone(
+                                player = Player.TriggeringPlayer,
+                                zone = Zone.HAND,
+                                filter = GameObjectFilter(
+                                    cardPredicates = listOf(CardPredicate.HasChosenColor),
+                                ),
+                            ).count(),
+                            target = EffectTarget.PlayerRef(Player.TriggeringPlayer),
+                            damageSource = EffectTarget.Self,
+                        ),
+                    ),
+                ),
+                prompt = "Choose a color",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "243"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54dcf5e3-4303-41a3-b54c-24a9d462ce07.jpg?1562912267"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DarigaazsAttendant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DarigaazsAttendant.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Darigaaz's Attendant
+ * {5}
+ * Artifact Creature — Golem
+ * 3/3
+ * {1}, Sacrifice this creature: Add {B}{R}{G}.
+ *
+ * One of the Invasion "Attendant" cycle (cf. [RithsAttendant]) — each sacrifices for the three
+ * colors of the matching dragon (Darigaaz = Black/Red/Green). A mana ability: no targets, no stack.
+ */
+val DarigaazsAttendant = card("Darigaaz's Attendant") {
+    manaCost = "{5}"
+    colorIdentity = "BRG"
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 3
+    oracleText = "{1}, Sacrifice this creature: Add {B}{R}{G}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.BLACK),
+            Effects.AddMana(Color.RED),
+            Effects.AddMana(Color.GREEN)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "301"
+        artist = "Brom"
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f22b575-443a-4c06-8e75-d4140cbd3660.jpg?1562917206"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DromarTheBanisher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DromarTheBanisher.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Dromar, the Banisher
+ * {3}{W}{U}{B}
+ * Legendary Creature — Dragon
+ * 6/6
+ * Flying
+ * Whenever Dromar deals combat damage to a player, you may pay {2}{U}. If you do, choose a color,
+ * then return all creatures of that color to their owners' hands.
+ *
+ * One of the five Coalition Dragons (cf. [RithTheAwakener], [TrevaTheRenewer]). After the optional
+ * {2}{U} payment, [Effects.ChooseColorThen] pauses for the color, then every creature of that color
+ * on the battlefield (any controller) is gathered via [CardPredicate.HasChosenColor] and returned to
+ * its owner's hand — the creature-only variant of [WashOut]'s bounce pipeline.
+ */
+val DromarTheBanisher = card("Dromar, the Banisher") {
+    manaCost = "{3}{W}{U}{B}"
+    colorIdentity = "WUB"
+    typeLine = "Legendary Creature — Dragon"
+    power = 6
+    toughness = 6
+    oracleText = "Flying\nWhenever Dromar deals combat damage to a player, you may pay {2}{U}. If you do, " +
+        "choose a color, then return all creatures of that color to their owners' hands."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}{U}"),
+            effect = Effects.ChooseColorThen(
+                then = CompositeEffect(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.BattlefieldMatching(
+                                filter = GameObjectFilter.Creature.withChosenColor(),
+                                player = Player.Each,
+                            ),
+                            storeAs = "dromarBounce",
+                        ),
+                        MoveCollectionEffect(
+                            from = "dromarBounce",
+                            destination = CardDestination.ToZone(Zone.HAND),
+                        ),
+                    ),
+                ),
+                prompt = "Choose a color",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "244"
+        artist = "Dave Dorman"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cfcc3c72-fff5-454c-814c-eb952fd23ba9.jpg?1562936774"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DromarsAttendant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/DromarsAttendant.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Dromar's Attendant
+ * {5}
+ * Artifact Creature — Golem
+ * 3/3
+ * {1}, Sacrifice this creature: Add {W}{U}{B}.
+ *
+ * One of the Invasion "Attendant" cycle (cf. [RithsAttendant]) — each sacrifices for the three
+ * colors of the matching dragon (Dromar = White/Blue/Black). A mana ability: no targets, no stack.
+ */
+val DromarsAttendant = card("Dromar's Attendant") {
+    manaCost = "{5}"
+    colorIdentity = "WUB"
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 3
+    oracleText = "{1}, Sacrifice this creature: Add {W}{U}{B}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.WHITE),
+            Effects.AddMana(Color.BLUE),
+            Effects.AddMana(Color.BLACK)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "303"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24936fa9-41a3-4da5-91cf-c28fa45f47c9.jpg?1562902350"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KangeeAerieKeeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KangeeAerieKeeper.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kangee, Aerie Keeper
+ * {2}{W}{U}
+ * Legendary Creature — Bird Wizard
+ * 2/2
+ * Kicker {X}{2}
+ * Flying
+ * When Kangee enters, if it was kicked, put X feather counters on it.
+ * Other Bird creatures get +1/+1 for each feather counter on Kangee.
+ *
+ * Kicker {X}{2} is a variable optional cost (cf. [VerdelothTheAncient]): the kicked cast prompts
+ * for X, which flows to the ETB trigger via [DynamicAmount.XValue]. The lord bonus reads the live
+ * feather-counter count off Kangee via [DynamicAmounts.countersOnSelf] (cf. [com.wingedsheep.mtg.sets.definitions.jud.cards.SoulcatchersAerie]),
+ * scaling other Birds by that amount; `excludeSelf` keeps Kangee from pumping itself.
+ */
+val KangeeAerieKeeper = card("Kangee, Aerie Keeper") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Bird Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "Kicker {X}{2} (You may pay an additional {X}{2} as you cast this spell.)\n" +
+        "Flying\n" +
+        "When Kangee enters, if it was kicked, put X feather counters on it.\n" +
+        "Other Bird creatures get +1/+1 for each feather counter on Kangee."
+
+    keywordAbility(KeywordAbility.kicker("{X}{2}"))
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        effect = Effects.AddDynamicCounters(Counters.FEATHER, DynamicAmount.XValue, EffectTarget.Self)
+    }
+
+    staticAbility {
+        val featherCount = DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.FEATHER))
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Bird"), excludeSelf = true),
+            powerBonus = featherCount,
+            toughnessBonus = featherCount
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "253"
+        artist = "Mark Romanoski"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3afd7e8e-4fcc-4003-9791-7baf10ef1880.jpg?1562906943"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KeldonNecropolis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KeldonNecropolis.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Keldon Necropolis
+ * Legendary Land
+ * {T}: Add {C}.
+ * {4}{R}, {T}, Sacrifice a creature: Keldon Necropolis deals 2 damage to any target.
+ */
+val KeldonNecropolis = card("Keldon Necropolis") {
+    typeLine = "Legendary Land"
+    colorIdentity = "R"
+    oracleText = "{T}: Add {C}.\n" +
+        "{4}{R}, {T}, Sacrifice a creature: Keldon Necropolis deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{4}{R}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Creature),
+        )
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, anyTarget, damageSource = EffectTarget.Self)
+        description = "{4}{R}, {T}, Sacrifice a creature: Keldon Necropolis deals 2 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "325"
+        artist = "Franz Vohwinkel"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f0cccf6-b79b-4fff-89aa-801341598532.jpg?1562911005"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LotusGuardian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LotusGuardian.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Lotus Guardian
+ * {7}
+ * Artifact Creature — Dragon
+ * 4/4
+ * Flying
+ * {T}: Add one mana of any color.
+ */
+val LotusGuardian = card("Lotus Guardian") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n{T}: Add one mana of any color."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "305"
+        artist = "Dana Knutson"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/ddfc6396-5377-4ab3-9c10-8abcdeae2aa1.jpg?1562939672"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MetathranAerostat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MetathranAerostat.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Metathran Aerostat
+ * {2}{U}{U}
+ * Creature — Metathran
+ * 2/2
+ * Flying
+ * {X}{U}: You may put a creature card with mana value X from your hand onto the battlefield.
+ * If you do, return this creature to its owner's hand.
+ *
+ * The {X}{U} activation stamps X onto the ability's context, so the candidate filter uses
+ * [CardPredicate.ManaValueEqualsX] (cf. [Void]). Gather creatures of that mana value from hand →
+ * optionally select one (the "may") → put it onto the battlefield. If a creature was actually put,
+ * [ConditionalOnCollectionEffect] returns the Aerostat itself to its owner's hand.
+ */
+val MetathranAerostat = card("Metathran Aerostat") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Metathran"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "{X}{U}: You may put a creature card with mana value X from your hand onto the battlefield. " +
+        "If you do, return this creature to its owner's hand."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{X}{U}")
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.HAND,
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature.copy(
+                            cardPredicates = GameObjectFilter.Creature.cardPredicates +
+                                CardPredicate.ManaValueEqualsX,
+                        ),
+                    ),
+                    storeAs = "aerostatCandidates",
+                ),
+                SelectFromCollectionEffect(
+                    from = "aerostatCandidates",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "aerostatPutting",
+                    prompt = "You may put a creature card with that mana value onto the battlefield",
+                ),
+                MoveCollectionEffect(
+                    from = "aerostatPutting",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You),
+                ),
+                ConditionalOnCollectionEffect(
+                    collection = "aerostatPutting",
+                    ifNotEmpty = Effects.ReturnToHand(EffectTarget.Self),
+                ),
+            ),
+        )
+        description = "{X}{U}: You may put a creature card with mana value X from your hand onto " +
+            "the battlefield. If you do, return this creature to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "61"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/59f34850-fb6f-4ac5-8309-4d53d770e28c.jpg?1562913282"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MetathranTransport.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MetathranTransport.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Metathran Transport
+ * {1}{U}{U}
+ * Creature — Metathran
+ * 1/3
+ * Flying
+ * This creature can't be blocked by blue creatures.
+ * {U}: Target creature becomes blue until end of turn.
+ */
+val MetathranTransport = card("Metathran Transport") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Metathran"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n" +
+        "This creature can't be blocked by blue creatures.\n" +
+        "{U}: Target creature becomes blue until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withColor(Color.BLUE))
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.ChangeColor(target = t, colors = setOf(Color.BLUE))
+        description = "{U}: Target creature becomes blue until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Glen Angus"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4fa9048d-1599-44a5-b4b2-45382c5b238d.jpg?1562911137"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MolimoMaroSorcerer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/MolimoMaroSorcerer.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Molimo, Maro-Sorcerer
+ * {4}{G}{G}{G}
+ * Legendary Creature — Elemental Sorcerer
+ * Power/toughness: star/star
+ * Trample
+ * Molimo's power and toughness are each equal to the number of lands you control.
+ *
+ * Characteristic-defining ability (cf. [com.wingedsheep.mtg.sets.definitions.ons.cards.HeedlessOne]):
+ * `dynamicStats` sets base power and toughness to the same dynamic value (lands you control), so
+ * the printed star/star values are replaced in Layer 7b.
+ */
+val MolimoMaroSorcerer = card("Molimo, Maro-Sorcerer") {
+    manaCost = "{4}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Elemental Sorcerer"
+    oracleText = "Trample\nMolimo's power and toughness are each equal to the number of lands you control."
+
+    dynamicStats(DynamicAmounts.landsYouControl())
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "199"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/750d3475-ae72-42c1-ae4d-638f8e7c6d1a.jpg?1562918463"
+    }
+}


### PR DESCRIPTION
Implements 12 Invasion (INV) cards. All canonical to INV (verified earliest real printing via `check-card-printing`). Every card composes existing SDK primitives — no new effects, triggers, conditions, keywords, or static abilities were added.

## Cards added
- **Crosis's Attendant** — {5} 3/3 Golem; `{1}, Sac: Add {U}{B}{R}` (mirrors the Rith's Attendant cycle).
- **Darigaaz's Attendant** — {5} 3/3 Golem; `{1}, Sac: Add {B}{R}{G}`.
- **Dromar's Attendant** — {5} 3/3 Golem; `{1}, Sac: Add {W}{U}{B}`.
- **Crosis, the Purger** — 6/6 Dragon, flying; combat-damage trigger → pay {2}{B}, choose a color, that player reveals their hand and discards all cards of that color (reuses the Treva/Rith chosen-color + Addle/Void discard pipeline).
- **Darigaaz, the Igniter** — 6/6 Dragon, flying; combat-damage trigger → pay {2}{R}, choose a color, deals damage equal to the number of cards of that color in the revealed hand (`AggregateZone` over `HasChosenColor`).
- **Dromar, the Banisher** — 6/6 Dragon, flying; combat-damage trigger → pay {2}{U}, choose a color, return all creatures of that color to hand (creature-only variant of Wash Out's bounce pipeline).
- **Kangee, Aerie Keeper** — 2/2 Bird Wizard, Kicker {X}{2}, flying; ETB if kicked puts X feather counters; other Birds get +1/+1 per feather counter (`GrantDynamicStatsEffect` + `countersOnSelf`, like Soulcatchers' Aerie).
- **Keldon Necropolis** — Legendary Land; `{T}: Add {C}` and `{4}{R}, {T}, Sacrifice a creature: 2 damage to any target`.
- **Lotus Guardian** — {7} 4/4 artifact Dragon, flying; `{T}: Add one mana of any color`.
- **Metathran Aerostat** — {2}{U}{U} 2/2, flying; `{X}{U}: You may put a creature of mana value X from your hand onto the battlefield. If you do, return this to its owner's hand.`
- **Metathran Transport** — {1}{U}{U} 1/3, flying; can't be blocked by blue creatures; `{U}: Target creature becomes blue`.
- **Molimo, Maro-Sorcerer** — {4}{G}{G}{G} Elemental Sorcerer, trample; CDA P/T equal to lands you control (`dynamicStats`).

## Tests
Added scenario tests for the three dragons (pay/decline + chosen-color outcomes), Kangee (unkicked vs kicked X=2 lord scaling, excludeSelf), and Molimo (CDA scaling, opponent lands ignored). The Attendants, Lotus Guardian, Keldon Necropolis, and Metathran Transport/Aerostat reuse only existing primitives.

`just build`, `just test-rules`, and the new scenario tests all pass. (A flaky `:gym:test` failed once during `just build` and passed on rerun — the gym module has no dependency on card content.)

## Skipped
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)