### PR TITLE
Add Aether Rift to Invasion

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -423,6 +423,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `PhaseOutEffect(target = Self)` — phase the target permanent out (Rule 702.26); facade `Effects.PhaseOut(target)`. While phased out it's treated as though it doesn't exist (excluded from `getBattlefield`, so from projection, triggers, combat, targeting, and SBAs) and phases back in before its controller's next untap step. Indirect phasing (attached Auras/Equipment) is handled automatically. Used as the `suffer` branch of a pay-or-phase trigger (Vaporous Djinn: "phases out unless you pay {U}{U}" = `PayOrSufferEffect(PayCost.Mana(...), Effects.PhaseOut())`).
 - `MarkExileOnDeathEffect(target)` — replace next "to graveyard" with "to exile".
 - `OptionalCostEffect(cost, effect)` — pay cost to trigger an effect.
+- `Effects.AnyPlayerMayPay(cost, consequence)` / `Effects.UnlessAnyPlayerPays(cost, effect)` —
+  back the single `AnyPlayerMayPayEffect(cost, consequence?, consequenceIfNonePaid?)`, which asks
+  each player in APNAP order whether to pay `cost`. The first to pay runs `consequence` and stops
+  the loop; if no one pays, `consequenceIfNonePaid` runs. `AnyPlayerMayPay` reads the
+  "if a player does, X" direction (Prowling Pangolin); `UnlessAnyPlayerPays` reads the inverse
+  "X unless any player pays" direction (Aether Rift: "return it… unless any player pays 5 life").
+  Supported costs: `PayCost.Sacrifice` (card selection) and `PayCost.PayLife` (yes/no). The
+  surrounding pipeline's stored collections are carried into whichever consequence fires, so the
+  consequence can reference cards gathered earlier in the same resolution (e.g. the discarded card,
+  via `MoveCollection(from = "discarded", …)`).
 - `StoreResultEffect(effect, as)` — stash an effect's result for later reference.
 - `StoreCountEffect(effect, as)` — stash a count for later reference.
 - `RepeatWhileEffect(condition, effect, maxIterations?)` — run effect repeatedly while condition holds.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AetherRiftScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AetherRiftScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Aether Rift (Invasion).
+ *
+ * Aether Rift ({1}{R}{G}, Enchantment):
+ *   "At the beginning of your upkeep, discard a card at random. If you discard a creature card
+ *    this way, return it from your graveyard to the battlefield unless any player pays 5 life."
+ *
+ * Composed from the random-discard pipeline + a [Conditions.CollectionContainsMatch] gate +
+ * [Effects.UnlessAnyPlayerPays] (PayLife 5). The "any player may pay" loop asks each player in
+ * APNAP order; the reanimation only happens if no one pays.
+ *
+ * Each player's hand holds exactly one card so the random discard is deterministic.
+ */
+class AetherRiftScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Aether Rift — discard at random, then maybe reanimate") {
+
+            test("no one pays 5 life: the discarded creature returns to the battlefield") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Aether Rift")
+                    .withCardInHand(1, "Elvish Warrior")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("the discarded creature triggers the pay-5-life decision (active player first)") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                // Active player (P1) declines.
+                game.answerYesNo(false)
+                withClue("the opponent is then offered the chance to pay") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                // Opponent (P2) also declines — no one paid.
+                game.answerYesNo(false)
+
+                withClue("Elvish Warrior returns from the graveyard to the battlefield") {
+                    game.isOnBattlefield("Elvish Warrior") shouldBe true
+                }
+                withClue("it is no longer in the graveyard") {
+                    game.isInGraveyard(1, "Elvish Warrior") shouldBe false
+                }
+                withClue("no life was paid by either player") {
+                    game.getLifeTotal(1) shouldBe 20
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+
+            test("a player pays 5 life: the discarded creature stays in the graveyard") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Aether Rift")
+                    .withCardInHand(1, "Elvish Warrior")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                // Active player (P1) declines, then the opponent (P2) pays 5 life.
+                game.answerYesNo(false)
+                game.answerYesNo(true)
+
+                withClue("the opponent paid 5 life (20 -> 15)") {
+                    game.getLifeTotal(2) shouldBe 15
+                }
+                withClue("Elvish Warrior is NOT returned — it stays in the graveyard") {
+                    game.isOnBattlefield("Elvish Warrior") shouldBe false
+                    game.isInGraveyard(1, "Elvish Warrior") shouldBe true
+                }
+            }
+
+            test("discarding a non-creature card asks no one to pay and reanimates nothing") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Aether Rift")
+                    .withCardInHand(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("no pay decision is presented when the discarded card isn't a creature") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("the discarded land is in the graveyard, not the battlefield") {
+                    game.isInGraveyard(1, "Forest") shouldBe true
+                    game.isOnBattlefield("Forest") shouldBe false
+                }
+                withClue("no life was paid") {
+                    game.getLifeTotal(1) shouldBe 20
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/a/aether-rift.json
+++ b/manual-scenarios/cards/a/aether-rift.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Hill Giant"
+    ],
+    "battlefield": [
+      {"name": "Aether Rift"},
+      {"name": "Mountain"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Mountain", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "phase": "BEGINNING",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -47,6 +47,8 @@ import com.wingedsheep.sdk.scripting.effects.CantBlockGroupEffect
 import com.wingedsheep.sdk.scripting.effects.CantCastSpellsEffect
 import com.wingedsheep.sdk.scripting.effects.PreventLandPlaysThisTurnEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
+import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
 import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.effects.GrantDamageBonusEffect
@@ -348,6 +350,22 @@ object Effects {
      * Delegates to the EffectPatterns pipeline: ForEachPlayer(EachOpponent) → Gather → Select → Move.
      */
     fun EachOpponentDiscards(count: Int = 1): Effect = EffectPatterns.eachOpponentDiscards(count)
+
+    /**
+     * "Any player may [cost]. If a player does, [consequence]."
+     * Each player in APNAP order is offered the cost; the first to pay triggers [consequence].
+     * (Prowling Pangolin: "any player may sacrifice two creatures. If a player does, sacrifice this.")
+     */
+    fun AnyPlayerMayPay(cost: PayCost, consequence: Effect): Effect =
+        AnyPlayerMayPayEffect(cost = cost, consequence = consequence)
+
+    /**
+     * "[effect] unless any player pays [cost]." — the inverse reading of [AnyPlayerMayPay].
+     * Each player in APNAP order may pay; if any does, nothing happens. If none pays, [effect] runs.
+     * (Aether Rift: "return it from your graveyard to the battlefield unless any player pays 5 life.")
+     */
+    fun UnlessAnyPlayerPays(cost: PayCost, effect: Effect): Effect =
+        AnyPlayerMayPayEffect(cost = cost, consequence = null, consequenceIfNonePaid = effect)
 
     /**
      * Each player returns a permanent they control to its owner's hand.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -757,32 +757,53 @@ data class MayPayXForEffect(
 }
 
 /**
- * "Any player may [cost]. If a player does, [consequence]."
+ * "Any player may [cost]." with branching outcomes based on whether anyone paid.
  *
  * Each player in APNAP order gets the chance to pay the cost. As soon as
- * any player does, the consequence is executed and no further players are asked.
- * If no player pays, nothing happens.
+ * any player does, [consequence] is executed and no further players are asked.
+ * If no player pays, [consequenceIfNonePaid] is executed instead.
  *
- * Example: Prowling Pangolin - "Any player may sacrifice two creatures.
- * If a player does, sacrifice Prowling Pangolin."
+ * This single primitive covers both directions of the template:
+ *  - "any player may [cost]; if a player does, [X]" → set [consequence] (Prowling Pangolin).
+ *  - "[X] unless any player pays [cost]" → set [consequenceIfNonePaid] (Aether Rift). Use the
+ *    [com.wingedsheep.sdk.dsl.Effects.UnlessAnyPlayerPays] facade for this reading.
+ *
+ * Either consequence may be null (no effect for that branch). The effect runs inside a
+ * pipeline transparently: the surrounding pipeline's stored collections / chosen values are
+ * carried into whichever consequence fires, so a consequence can reference a collection built
+ * earlier in the same resolution (e.g. "return the discarded card this way").
+ *
+ * Supported costs: [PayCost.Sacrifice] (card selection) and [PayCost.PayLife] (yes/no).
  *
  * @property cost The cost any player may choose to pay
- * @property consequence The effect that happens if a player pays
+ * @property consequence The effect that happens if a player pays (null = nothing)
+ * @property consequenceIfNonePaid The effect that happens if no player pays (null = nothing)
  */
 @SerialName("AnyPlayerMayPay")
 @Serializable
 data class AnyPlayerMayPayEffect(
     val cost: PayCost,
-    val consequence: Effect
+    val consequence: Effect? = null,
+    val consequenceIfNonePaid: Effect? = null
 ) : Effect {
-    override val description: String =
-        "Any player may ${cost.description}. If a player does, ${consequence.description}"
+    override val description: String = buildString {
+        when {
+            consequenceIfNonePaid != null && consequence == null ->
+                append("${consequenceIfNonePaid.description} unless any player ${cost.description}")
+            else -> {
+                append("Any player may ${cost.description}.")
+                if (consequence != null) append(" If a player does, ${consequence.description}.")
+                if (consequenceIfNonePaid != null) append(" If no player does, ${consequenceIfNonePaid.description}.")
+            }
+        }
+    }
 
     override fun applyTextReplacement(replacer: TextReplacer): Effect {
         val newCost = cost.applyTextReplacement(replacer)
-        val newConsequence = consequence.applyTextReplacement(replacer)
-        return if (newCost !== cost || newConsequence !== consequence)
-            copy(cost = newCost, consequence = newConsequence) else this
+        val newConsequence = consequence?.applyTextReplacement(replacer)
+        val newConsequenceIfNonePaid = consequenceIfNonePaid?.applyTextReplacement(replacer)
+        return if (newCost !== cost || newConsequence !== consequence || newConsequenceIfNonePaid !== consequenceIfNonePaid)
+            copy(cost = newCost, consequence = newConsequence, consequenceIfNonePaid = newConsequenceIfNonePaid) else this
     }
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
@@ -194,7 +194,10 @@ object CardValidator {
             is MayPayManaEffect -> collectIndicesRecursive(effect.effect, indices)
             is ModalEffect -> effect.modes.forEach { collectIndicesRecursive(it.effect, indices) }
             is PayOrSufferEffect -> collectIndicesRecursive(effect.suffer, indices)
-            is AnyPlayerMayPayEffect -> collectIndicesRecursive(effect.consequence, indices)
+            is AnyPlayerMayPayEffect -> {
+                effect.consequence?.let { collectIndicesRecursive(it, indices) }
+                effect.consequenceIfNonePaid?.let { collectIndicesRecursive(it, indices) }
+            }
             is ForEachInGroupEffect -> collectIndicesRecursive(effect.effect, indices)
             is FlipCoinEffect -> {
                 effect.wonEffect?.let { collectIndicesRecursive(it, indices) }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AetherRift.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/AetherRift.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aether Rift
+ * {1}{R}{G}
+ * Enchantment
+ * At the beginning of your upkeep, discard a card at random. If you discard a creature card
+ * this way, return it from your graveyard to the battlefield unless any player pays 5 life.
+ *
+ * Composed from the standard random-discard pipeline (Gather hand → Select random → MoveCollection
+ * to graveyard, storing the discarded card as "discarded") gated by
+ * [Conditions.CollectionContainsMatch] on the discarded card. The reanimation is wrapped in
+ * [Effects.UnlessAnyPlayerPays]: the discarded creature returns to the battlefield from "discarded"
+ * unless any player pays 5 life in APNAP order.
+ *
+ * Rulings (2009-10-01): the card is genuinely discarded first (discard triggers fire). Then, in
+ * turn order, each player may pay 5 life; if none does, the creature is put onto the battlefield.
+ */
+val AetherRift = card("Aether Rift") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, discard a card at random. If you discard a " +
+        "creature card this way, return it from your graveyard to the battlefield unless any " +
+        "player pays 5 life."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = CompositeEffect(
+            listOf(
+                // Discard a card at random, remembering it as "discarded".
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.You),
+                    storeAs = "hand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hand",
+                    selection = SelectionMode.Random(DynamicAmount.Fixed(1)),
+                    storeSelected = "discarded"
+                ),
+                MoveCollectionEffect(
+                    from = "discarded",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+                    moveType = MoveType.Discard
+                ),
+                // If the discarded card was a creature, return it unless any player pays 5 life.
+                ConditionalEffect(
+                    condition = Conditions.CollectionContainsMatch("discarded", GameObjectFilter.Creature),
+                    effect = Effects.UnlessAnyPlayerPays(
+                        cost = PayCost.PayLife(5),
+                        effect = MoveCollectionEffect(
+                            from = "discarded",
+                            destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You)
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "227"
+        artist = "Heather Hudson"
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/692c186a-997c-4f7e-a339-bf84884e1019.jpg?1562916173"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
@@ -136,9 +136,12 @@ data class PayOrSufferChoiceContinuation(
  * @property sourceName Name of the source for display
  * @property controllerId The controller of the source permanent
  * @property cost The cost being offered
- * @property consequence The effect to execute if any player pays
+ * @property consequence The effect to execute if any player pays (null = nothing)
+ * @property consequenceIfNonePaid The effect to execute if no player pays (null = nothing)
  * @property requiredCount Number of items required (for sacrifice costs)
  * @property filter The filter for valid selections (for sacrifice costs)
+ * @property storedCollections Pipeline collections carried into whichever consequence fires, so a
+ *   consequence can reference cards gathered earlier in the same resolution ("…this way").
  */
 @Serializable
 data class AnyPlayerMayPayContinuation(
@@ -149,9 +152,11 @@ data class AnyPlayerMayPayContinuation(
     val sourceName: String,
     val controllerId: EntityId,
     val cost: PayCost,
-    val consequence: Effect,
+    val consequence: Effect? = null,
+    val consequenceIfNonePaid: Effect? = null,
     val requiredCount: Int,
-    val filter: GameObjectFilter
+    val filter: GameObjectFilter,
+    val storedCollections: Map<String, List<EntityId>> = emptyMap()
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -553,6 +553,11 @@ class SacrificeAndPayContinuationResumer(
 
     /**
      * Resume after a player decides whether to pay for "any player may [cost]" effects.
+     *
+     * Dispatches on the cost type: [PayCost.Sacrifice] expects a card selection, [PayCost.PayLife]
+     * a yes/no. If the current player pays, [AnyPlayerMayPayContinuation.consequence] runs. If they
+     * decline, the next eligible player is asked; once none remain,
+     * [AnyPlayerMayPayContinuation.consequenceIfNonePaid] runs.
      */
     fun resumeAnyPlayerMayPay(
         state: GameState,
@@ -560,52 +565,89 @@ class SacrificeAndPayContinuationResumer(
         response: DecisionResponse,
         checkForMore: CheckForMore
     ): ExecutionResult {
-        if (response !is CardsSelectedResponse) {
-            return ExecutionResult.error(state, "Expected card selection response for any player may pay")
-        }
-
-        val selectedPermanents = response.selectedCards
         val playerId = continuation.currentPlayerId
 
-        // If player selected enough permanents, they paid the cost
-        if (selectedPermanents.size >= continuation.requiredCount) {
-            // Sacrifice the selected permanents
-            var newState = state
-            val events = mutableListOf<GameEvent>()
+        when (continuation.cost) {
+            is PayCost.Sacrifice -> {
+                if (response !is CardsSelectedResponse) {
+                    return ExecutionResult.error(state, "Expected card selection response for any player may pay")
+                }
+                val selectedPermanents = response.selectedCards
+                if (selectedPermanents.size < continuation.requiredCount) {
+                    return askNextPlayerForAnyPlayerMayPay(state, continuation, checkForMore)
+                }
 
-            events.add(PermanentsSacrificedEvent(playerId, selectedPermanents))
+                var newState = state
+                val events = mutableListOf<GameEvent>()
+                events.add(PermanentsSacrificedEvent(playerId, selectedPermanents))
+                for (permanentId in selectedPermanents) {
+                    val transitionResult = ZoneTransitionService.moveToZone(newState, permanentId, Zone.GRAVEYARD)
+                    newState = transitionResult.state
+                    events.addAll(transitionResult.events)
+                }
+                return runAnyPlayerMayPayConsequence(newState, continuation, continuation.consequence, events, checkForMore)
+            }
 
-            for (permanentId in selectedPermanents) {
-                val transitionResult = ZoneTransitionService.moveToZone(
-                    newState, permanentId, Zone.GRAVEYARD
+            is PayCost.PayLife -> {
+                if (response !is YesNoResponse) {
+                    return ExecutionResult.error(state, "Expected yes/no response for any player may pay life")
+                }
+                if (!response.choice) {
+                    return askNextPlayerForAnyPlayerMayPay(state, continuation, checkForMore)
+                }
+
+                val lifeToPay = continuation.requiredCount
+                val currentLife = state.getEntity(playerId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+                val newLife = currentLife - lifeToPay
+                var newState = state.updateEntity(playerId) {
+                    it.with(com.wingedsheep.engine.state.components.identity.LifeTotalComponent(newLife))
+                }
+                newState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(newState, playerId)
+                val events = mutableListOf<GameEvent>(
+                    LifeChangedEvent(
+                        playerId = playerId,
+                        oldLife = currentLife,
+                        newLife = newLife,
+                        reason = LifeChangeReason.PAYMENT
+                    )
                 )
-                newState = transitionResult.state
-                events.addAll(transitionResult.events)
+                return runAnyPlayerMayPayConsequence(newState, continuation, continuation.consequence, events, checkForMore)
             }
 
-            // Now execute the consequence (e.g., sacrifice the source)
-            val context = EffectContext(
-                sourceId = continuation.sourceId,
-                controllerId = continuation.controllerId,
-                opponentId = null
+            else -> return ExecutionResult.error(
+                state,
+                "Unsupported cost type for AnyPlayerMayPay resume: ${continuation.cost::class.simpleName}"
             )
-            val consequenceResult = services.effectExecutorRegistry.execute(newState, continuation.consequence, context).toExecutionResult()
-            val allEvents = events + consequenceResult.events
-
-            return if (consequenceResult.isPaused) {
-                consequenceResult
-            } else {
-                checkForMore(consequenceResult.state, allEvents)
-            }
         }
+    }
 
-        // Player declined - find next player who can pay
-        return askNextPlayerForAnyPlayerMayPay(state, continuation, checkForMore)
+    /**
+     * Execute one of the AnyPlayerMayPay consequence branches (may be null = nothing), carrying the
+     * pipeline's stored collections so the effect can reference cards gathered earlier this resolution.
+     */
+    private fun runAnyPlayerMayPayConsequence(
+        state: GameState,
+        continuation: AnyPlayerMayPayContinuation,
+        consequence: com.wingedsheep.sdk.scripting.effects.Effect?,
+        priorEvents: List<GameEvent>,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (consequence == null) return checkForMore(state, priorEvents)
+        val context = EffectContext(
+            sourceId = continuation.sourceId,
+            controllerId = continuation.controllerId,
+            opponentId = null,
+            pipeline = PipelineState(storedCollections = continuation.storedCollections)
+        )
+        val result = services.effectExecutorRegistry.execute(state, consequence, context).toExecutionResult()
+        val allEvents = priorEvents + result.events
+        return if (result.isPaused) result else checkForMore(result.state, allEvents)
     }
 
     /**
      * Find and ask the next eligible player for "any player may [cost]" effects.
-     * If no player can pay, nothing happens and execution continues.
+     * If no player can pay, runs the "none paid" consequence (e.g., reanimate the discarded card).
      */
     private fun askNextPlayerForAnyPlayerMayPay(
         state: GameState,
@@ -615,56 +657,91 @@ class SacrificeAndPayContinuationResumer(
         val predicateEvaluator = PredicateEvaluator()
         val cost = continuation.cost
         val projected = state.projectedState
+        val decisionHandler = DecisionHandler()
 
-        // Find next player who can pay among remaining players
         for ((index, nextPlayerId) in continuation.remainingPlayers.withIndex()) {
-            if (cost is PayCost.Sacrifice) {
-                val battlefieldZone = ZoneKey(nextPlayerId, Zone.BATTLEFIELD)
-                val battlefield = state.getZone(battlefieldZone)
-                val context = PredicateContext(controllerId = nextPlayerId)
-
-                val validPermanents = battlefield.filter { permanentId ->
-                    predicateEvaluator.matches(state, projected, permanentId, cost.filter, context)
+            val remainingAfter = continuation.remainingPlayers.drop(index + 1)
+            when (cost) {
+                is PayCost.Sacrifice -> {
+                    val battlefield = state.getZone(ZoneKey(nextPlayerId, Zone.BATTLEFIELD))
+                    val context = PredicateContext(controllerId = nextPlayerId)
+                    val validPermanents = battlefield.filter { permanentId ->
+                        predicateEvaluator.matches(state, projected, permanentId, cost.filter, context)
+                    }
+                    if (validPermanents.size >= cost.count) {
+                        val prompt = "You may sacrifice ${cost.count} ${cost.filter.description}s to cause ${continuation.sourceName} to be sacrificed, or skip"
+                        val decisionResult = decisionHandler.createCardSelectionDecision(
+                            state = state,
+                            playerId = nextPlayerId,
+                            sourceId = continuation.sourceId,
+                            sourceName = continuation.sourceName,
+                            prompt = prompt,
+                            options = validPermanents,
+                            minSelections = 0,
+                            maxSelections = cost.count,
+                            ordered = false,
+                            phase = DecisionPhase.RESOLUTION,
+                            useTargetingUI = true
+                        )
+                        val newContinuation = continuation.copy(
+                            decisionId = decisionResult.pendingDecision!!.id,
+                            currentPlayerId = nextPlayerId,
+                            remainingPlayers = remainingAfter
+                        )
+                        val stateWithContinuation = decisionResult.state.pushContinuation(newContinuation)
+                        return ExecutionResult.paused(
+                            stateWithContinuation,
+                            decisionResult.pendingDecision,
+                            decisionResult.events
+                        )
+                    }
                 }
 
-                if (validPermanents.size >= cost.count) {
-                    // This player can pay - ask them
-                    val prompt = "You may sacrifice ${cost.count} ${cost.filter.description}s to cause ${continuation.sourceName} to be sacrificed, or skip"
-                    val decisionHandler = DecisionHandler()
-
-                    val decisionResult = decisionHandler.createCardSelectionDecision(
-                        state = state,
-                        playerId = nextPlayerId,
-                        sourceId = continuation.sourceId,
-                        sourceName = continuation.sourceName,
-                        prompt = prompt,
-                        options = validPermanents,
-                        minSelections = 0,
-                        maxSelections = cost.count,
-                        ordered = false,
-                        phase = DecisionPhase.RESOLUTION,
-                        useTargetingUI = true
-                    )
-
-                    val newContinuation = continuation.copy(
-                        decisionId = decisionResult.pendingDecision!!.id,
-                        currentPlayerId = nextPlayerId,
-                        remainingPlayers = continuation.remainingPlayers.drop(index + 1)
-                    )
-
-                    val stateWithContinuation = decisionResult.state.pushContinuation(newContinuation)
-
-                    return ExecutionResult.paused(
-                        stateWithContinuation,
-                        decisionResult.pendingDecision,
-                        decisionResult.events
-                    )
+                is PayCost.PayLife -> {
+                    val life = state.getEntity(nextPlayerId)
+                        ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 0
+                    if (life >= cost.amount) {
+                        val decisionId = java.util.UUID.randomUUID().toString()
+                        val prompt = "Pay ${cost.amount} life to prevent ${continuation.sourceName}'s effect?"
+                        val decision = YesNoDecision(
+                            id = decisionId,
+                            playerId = nextPlayerId,
+                            prompt = prompt,
+                            context = DecisionContext(
+                                sourceId = continuation.sourceId,
+                                sourceName = continuation.sourceName,
+                                phase = DecisionPhase.RESOLUTION
+                            ),
+                            yesText = "Pay ${cost.amount} life",
+                            noText = "Don't pay"
+                        )
+                        val newContinuation = continuation.copy(
+                            decisionId = decisionId,
+                            currentPlayerId = nextPlayerId,
+                            remainingPlayers = remainingAfter
+                        )
+                        val stateWithContinuation = state.withPendingDecision(decision).pushContinuation(newContinuation)
+                        return ExecutionResult.paused(
+                            stateWithContinuation,
+                            decision,
+                            listOf(
+                                DecisionRequestedEvent(
+                                    decisionId = decisionId,
+                                    playerId = nextPlayerId,
+                                    decisionType = "YES_NO",
+                                    prompt = prompt
+                                )
+                            )
+                        )
+                    }
                 }
+
+                else -> {}
             }
         }
 
-        // No player can pay - nothing happens, Pangolin stays
-        return checkForMore(state, emptyList())
+        // No player paid - run the "none paid" branch.
+        return runAnyPlayerMayPayConsequence(state, continuation, continuation.consequenceIfNonePaid, emptyList(), checkForMore)
     }
 
     fun resumeUntapChoice(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
@@ -3,30 +3,37 @@ package com.wingedsheep.engine.handlers.effects.player
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.costs.PayCost
+import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
  * Executor for AnyPlayerMayPayEffect.
  *
- * Handles "any player may [cost]. If a player does, [consequence]."
+ * Handles "any player may [cost]." with two branching outcomes:
+ *  - As soon as any player pays, [AnyPlayerMayPayEffect.consequence] runs and no further players
+ *    are asked ("any player may sacrifice…; if a player does, …" — Prowling Pangolin).
+ *  - If no player pays, [AnyPlayerMayPayEffect.consequenceIfNonePaid] runs instead
+ *    ("…unless any player pays N life" — Aether Rift).
  *
- * Each player in APNAP order gets the chance to pay the cost.
- * As soon as any player pays, the consequence is executed.
- * If no player pays, nothing happens.
- *
- * Example: Prowling Pangolin - "Any player may sacrifice two creatures.
- * If a player does, sacrifice Prowling Pangolin."
+ * Players are asked in APNAP order; players who can't pay are skipped. Supported costs are
+ * [PayCost.Sacrifice] (card selection) and [PayCost.PayLife] (yes/no). The surrounding pipeline's
+ * stored collections are threaded into whichever consequence fires so it can reference cards
+ * gathered earlier in the same resolution.
  */
 class AnyPlayerMayPayExecutor(
-    private val decisionHandler: DecisionHandler = DecisionHandler()
+    private val decisionHandler: DecisionHandler = DecisionHandler(),
+    private val executeEffect: ((GameState, Effect, EffectContext) -> EffectResult)? = null
 ) : EffectExecutor<AnyPlayerMayPayEffect> {
 
     override val effectType: KClass<AnyPlayerMayPayEffect> = AnyPlayerMayPayEffect::class
@@ -54,7 +61,7 @@ class AnyPlayerMayPayExecutor(
 
     /**
      * Ask the next player in APNAP order if they want to pay the cost.
-     * Skips players who can't pay.
+     * Skips players who can't pay. If no one is left to ask, runs the "none paid" consequence.
      */
     private fun askNextPlayer(
         state: GameState,
@@ -75,14 +82,18 @@ class AnyPlayerMayPayExecutor(
             index++
         }
 
-        // No more players can pay - nothing happens
+        // No more players can pay - run the "none paid" branch (e.g., reanimate the card).
         if (index >= playerOrder.size) {
-            return EffectResult.success(state)
+            return runConsequence(state, effect.consequenceIfNonePaid, context.controllerId, sourceId, context.pipeline.storedCollections)
         }
 
         val playerId = playerOrder[index]
         return when (val cost = effect.cost) {
             is PayCost.Sacrifice -> askPlayerToSacrifice(
+                state, effect, context, cost, sourceId, sourceName,
+                playerId, playerOrder, index
+            )
+            is PayCost.PayLife -> askPlayerToPayLife(
                 state, effect, context, cost, sourceId, sourceName,
                 playerId, playerOrder, index
             )
@@ -100,6 +111,11 @@ class AnyPlayerMayPayExecutor(
             is PayCost.Sacrifice -> {
                 val validPermanents = findValidPermanentsOnBattlefield(state, playerId, cost.filter, sourceId)
                 validPermanents.size >= cost.count
+            }
+            // CR 119.4: a player may pay life only if their life total is at least the amount.
+            is PayCost.PayLife -> {
+                val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+                life >= cost.amount
             }
             else -> false
         }
@@ -134,15 +150,13 @@ class AnyPlayerMayPayExecutor(
             useTargetingUI = true
         )
 
-        val continuation = AnyPlayerMayPayContinuation(
+        val continuation = anyPlayerMayPayContinuation(
+            effect, context,
             decisionId = decisionResult.pendingDecision!!.id,
             currentPlayerId = playerId,
             remainingPlayers = playerOrder.drop(currentIndex + 1),
             sourceId = sourceId,
             sourceName = sourceName,
-            controllerId = context.controllerId,
-            cost = effect.cost,
-            consequence = effect.consequence,
             requiredCount = cost.count,
             filter = cost.filter
         )
@@ -154,6 +168,108 @@ class AnyPlayerMayPayExecutor(
             decisionResult.pendingDecision,
             decisionResult.events
         )
+    }
+
+    private fun askPlayerToPayLife(
+        state: GameState,
+        effect: AnyPlayerMayPayEffect,
+        context: EffectContext,
+        cost: PayCost.PayLife,
+        sourceId: EntityId,
+        sourceName: String,
+        playerId: EntityId,
+        playerOrder: List<EntityId>,
+        currentIndex: Int
+    ): EffectResult {
+        val decisionId = UUID.randomUUID().toString()
+        val prompt = "Pay ${cost.amount} life to prevent $sourceName's effect?"
+
+        val decision = YesNoDecision(
+            id = decisionId,
+            playerId = playerId,
+            prompt = prompt,
+            context = DecisionContext(
+                sourceId = sourceId,
+                sourceName = sourceName,
+                phase = DecisionPhase.RESOLUTION
+            ),
+            yesText = "Pay ${cost.amount} life",
+            noText = "Don't pay"
+        )
+
+        val continuation = anyPlayerMayPayContinuation(
+            effect, context,
+            decisionId = decisionId,
+            currentPlayerId = playerId,
+            remainingPlayers = playerOrder.drop(currentIndex + 1),
+            sourceId = sourceId,
+            sourceName = sourceName,
+            requiredCount = cost.amount,
+            filter = com.wingedsheep.sdk.scripting.GameObjectFilter.Any
+        )
+
+        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
+
+        return EffectResult.paused(
+            stateWithContinuation,
+            decision,
+            listOf(
+                DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = playerId,
+                    decisionType = "YES_NO",
+                    prompt = prompt
+                )
+            )
+        )
+    }
+
+    private fun anyPlayerMayPayContinuation(
+        effect: AnyPlayerMayPayEffect,
+        context: EffectContext,
+        decisionId: String,
+        currentPlayerId: EntityId,
+        remainingPlayers: List<EntityId>,
+        sourceId: EntityId,
+        sourceName: String,
+        requiredCount: Int,
+        filter: com.wingedsheep.sdk.scripting.GameObjectFilter
+    ): AnyPlayerMayPayContinuation = AnyPlayerMayPayContinuation(
+        decisionId = decisionId,
+        currentPlayerId = currentPlayerId,
+        remainingPlayers = remainingPlayers,
+        sourceId = sourceId,
+        sourceName = sourceName,
+        controllerId = context.controllerId,
+        cost = effect.cost,
+        consequence = effect.consequence,
+        consequenceIfNonePaid = effect.consequenceIfNonePaid,
+        requiredCount = requiredCount,
+        filter = filter,
+        storedCollections = context.pipeline.storedCollections
+    )
+
+    /**
+     * Run one of the two consequence branches (may be null = nothing). Carries the pipeline's
+     * stored collections so the effect can reference cards gathered earlier this resolution.
+     */
+    private fun runConsequence(
+        state: GameState,
+        consequence: Effect?,
+        controllerId: EntityId,
+        sourceId: EntityId,
+        storedCollections: Map<String, List<EntityId>>
+    ): EffectResult {
+        if (consequence == null) return EffectResult.success(state)
+        val executor = executeEffect ?: return EffectResult.success(state)
+        val context = EffectContext(
+            sourceId = sourceId,
+            controllerId = controllerId,
+            opponentId = null,
+            pipeline = PipelineState(storedCollections = storedCollections)
+        )
+        return executor(state, consequence, context)
     }
 
     private fun findValidPermanentsOnBattlefield(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -40,7 +40,7 @@ class PlayerExecutors(
     override fun executors(): List<EffectExecutor<*>> = listOf(
         AmassExecutor(effectExecutor),
         AddCombatPhaseExecutor(),
-        AnyPlayerMayPayExecutor(),
+        AnyPlayerMayPayExecutor(executeEffect = effectExecutor),
         CantCastSpellsExecutor(),
         CreateGlobalTriggeredAbilityUntilEndOfTurnExecutor(),
         CreateGlobalTriggeredAbilityWithDurationExecutor(),


### PR DESCRIPTION
## Aether Rift (Invasion)

`{1}{R}{G}` Enchantment — *"At the beginning of your upkeep, discard a card at random. If you discard a creature card this way, return it from your graveyard to the battlefield unless any player pays 5 life."*

### How it's built (composed, not card-specific)
The upkeep trigger is a pipeline:
1. Gather hand → `SelectFromCollection(Random 1)` → `MoveCollection` to graveyard (discard), storing the card as `"discarded"`.
2. `ConditionalEffect(CollectionContainsMatch("discarded", Creature))` gates the rest — non-creatures prompt no one.
3. `Effects.UnlessAnyPlayerPays(PayLife(5), MoveCollection("discarded" → battlefield))` — APNAP pay loop; reanimates only if nobody pays.

### Engine generalization (the reusable part)
`AnyPlayerMayPayEffect` was sacrifice-only with a single "if a player pays" consequence. It's now one machine with two readings:
- `consequence` (now optional) — runs when someone pays (Prowling Pangolin, unchanged).
- `consequenceIfNonePaid` — runs when no one pays (the "unless any player pays" template).
- Added `PayCost.PayLife` support (yes/no per player) alongside sacrifice in both executor and resumer.
- The pipeline's `storedCollections` are threaded into whichever branch fires, so the consequence can reference cards gathered earlier in the same resolution.

Two facades expose both directions: `Effects.AnyPlayerMayPay` and `Effects.UnlessAnyPlayerPays`.

### Verification
- New `AetherRiftScenarioTest` (nobody pays → reanimate; a player pays → stays dead; non-creature → no prompt) — green.
- `VileConsumption` (PayOrSuffer life path) and full `rules-engine` + `mtg-sdk` suites — green; Prowling Pangolin's effect type untouched.
- `just check-card-printing "Aether Rift"` confirms canonical placement in `inv` (its only printing).
- Every field verified against Scryfall (cost, type, oracle text, rarity 227 / Heather Hudson, image HTTP 200).
- SDK reference doc updated; playable scenario at `manual-scenarios/cards/a/aether-rift.json`.

### Notes
- Per "any player," the controller is also offered the chance to pay (asked first, APNAP order) — rules-correct. The reanimated creature returns under your control.
- No frontend changes needed — the pay-5-life decision routes through the existing `YesNoDecisionUI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)