### PR TITLE
Add Invasion cards (batch B): masters & spells

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionBatchBScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/InvasionBatchBScenarioTest.kt
@@ -1,0 +1,256 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Invasion "batch B": the spellcaster masters and a few spells/permanents
+ * that compose existing primitives in non-trivial ways.
+ *
+ *  - Nightscape Master: {U}{U},{T} bounce target creature; {R}{R},{T} deal 2 damage.
+ *  - Phyrexian Infiltrator: {2}{U}{U} exchange control of itself and target creature.
+ *  - Reya Dawnbringer: upkeep "may return target creature card from your graveyard to the battlefield".
+ *  - Stalking Assassin: {3}{U},{T} tap; {3}{B},{T} destroy target tapped creature.
+ *  - Sway of Illusion: any number of target creatures become a chosen color; draw a card.
+ */
+class InvasionBatchBScenarioTest : ScenarioTestBase() {
+
+    private val greenBear = CardDefinition.creature(
+        name = "Green Bear", manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Bear")), power = 2, toughness = 2
+    )
+    private val redOgre = CardDefinition.creature(
+        name = "Red Ogre", manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Ogre")), power = 2, toughness = 2
+    )
+
+    private fun setMana(game: TestGame, white: Int = 0, blue: Int = 0, black: Int = 0, red: Int = 0, green: Int = 0, colorless: Int = 0) {
+        game.state = game.state.updateEntity(game.player1Id) { container ->
+            container.with(ManaPoolComponent(white = white, blue = blue, black = black, red = red, green = green, colorless = colorless))
+        }
+    }
+
+    private fun activate(game: TestGame, sourceName: String, abilityIndex: Int, targets: List<ChosenTarget> = emptyList()) {
+        val sourceId = game.findPermanent(sourceName)!!
+        val ability = cardRegistry.getCard(sourceName)!!.script.activatedAbilities[abilityIndex]
+        val result = game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = sourceId,
+                abilityId = ability.id,
+                targets = targets
+            )
+        )
+        withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+    }
+
+    init {
+        cardRegistry.register(greenBear)
+        cardRegistry.register(redOgre)
+
+        context("Nightscape Master") {
+            test("{U}{U},{T} returns target creature to its owner's hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Nightscape Master")
+                    .withCardOnBattlefield(2, "Green Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Green Bear")!!
+                setMana(game, blue = 2)
+                activate(game, "Nightscape Master", 0, listOf(ChosenTarget.Permanent(bear)))
+                game.resolveStack()
+
+                withClue("Green Bear should be bounced off the battlefield") {
+                    game.findPermanent("Green Bear") shouldBe null
+                }
+                withClue("Green Bear should be in its owner's (Player 2) hand") {
+                    game.state.getHand(game.player2Id).any {
+                        game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Green Bear"
+                    } shouldBe true
+                }
+            }
+
+            test("{R}{R},{T} deals 2 damage to target creature, killing a 2/2") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Nightscape Master")
+                    .withCardOnBattlefield(2, "Green Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Green Bear")!!
+                setMana(game, red = 2)
+                activate(game, "Nightscape Master", 1, listOf(ChosenTarget.Permanent(bear)))
+                game.resolveStack()
+
+                withClue("Green Bear should die from 2 damage") {
+                    game.isInGraveyard(2, "Green Bear") shouldBe true
+                }
+            }
+        }
+
+        context("Phyrexian Infiltrator") {
+            test("exchanges control of itself and a target creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Phyrexian Infiltrator")
+                    .withCardOnBattlefield(2, "Green Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val infiltrator = game.findPermanent("Phyrexian Infiltrator")!!
+                val bear = game.findPermanent("Green Bear")!!
+                setMana(game, blue = 2, colorless = 2)
+                activate(game, "Phyrexian Infiltrator", 0, listOf(ChosenTarget.Permanent(bear)))
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("Player 2 should now control the Infiltrator") {
+                    projected.getController(infiltrator) shouldBe game.player2Id
+                }
+                withClue("Player 1 should now control the Green Bear") {
+                    projected.getController(bear) shouldBe game.player1Id
+                }
+            }
+        }
+
+        context("Reya Dawnbringer") {
+            test("upkeep trigger may return a creature card from graveyard to the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Reya Dawnbringer")
+                    .withCardInGraveyard(1, "Green Bear")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                // Pass into the upkeep step so the beginning-of-upkeep trigger fires.
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+                game.answerYesNo(true)
+                val bearInGy = game.state.getGraveyard(game.player1Id).first {
+                    game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Green Bear"
+                }
+                game.selectTargets(listOf(bearInGy))
+                game.resolveStack()
+
+                withClue("Green Bear should be returned to the battlefield under Player 1's control") {
+                    game.findPermanent("Green Bear") shouldNotBe null
+                }
+            }
+        }
+
+        context("Stalking Assassin") {
+            test("{3}{U},{T} taps a creature, then {3}{B},{T} destroys a tapped creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stalking Assassin")
+                    .withCardOnBattlefield(1, "Stalking Assassin")
+                    .withCardOnBattlefield(2, "Green Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val assassins = game.findPermanents("Stalking Assassin")
+                val tapper = assassins[0]
+                val destroyer = assassins[1]
+                val bear = game.findPermanent("Green Bear")!!
+
+                // Tap the bear with the first assassin.
+                val tapAbility = cardRegistry.getCard("Stalking Assassin")!!.script.activatedAbilities[0]
+                setMana(game, blue = 1, colorless = 3)
+                game.execute(
+                    ActivateAbility(game.player1Id, tapper, tapAbility.id, listOf(ChosenTarget.Permanent(bear)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Green Bear should be tapped") {
+                    game.state.getEntity(bear)?.has<TappedComponent>() shouldBe true
+                }
+
+                // Destroy the now-tapped bear with the second assassin.
+                val destroyAbility = cardRegistry.getCard("Stalking Assassin")!!.script.activatedAbilities[1]
+                setMana(game, black = 1, colorless = 3)
+                game.execute(
+                    ActivateAbility(game.player1Id, destroyer, destroyAbility.id, listOf(ChosenTarget.Permanent(bear)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Green Bear should be destroyed") {
+                    game.isInGraveyard(2, "Green Bear") shouldBe true
+                }
+            }
+        }
+
+        context("Sway of Illusion") {
+            test("makes target creatures the chosen color and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sway of Illusion")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(1, "Green Bear")
+                    .withCardOnBattlefield(2, "Red Ogre")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Green Bear")!!
+                val ogre = game.findPermanent("Red Ogre")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Sway of Illusion"
+                }
+                val handBefore = game.handSize(1)
+
+                game.execute(
+                    CastSpell(
+                        game.player1Id, cardId,
+                        targets = listOf(ChosenTarget.Permanent(bear), ChosenTarget.Permanent(ogre))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val colorDecision = game.getPendingDecision()
+                withClue("Should pause for a color choice") {
+                    (colorDecision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.WHITE))
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("Green Bear should now be white") {
+                    projected.hasColor(bear, Color.WHITE) shouldBe true
+                }
+                withClue("Red Ogre should now be white") {
+                    projected.hasColor(ogre, Color.WHITE) shouldBe true
+                }
+                withClue("A card should have been drawn (cast 1 from hand, drew 1 → net same size, minus the spell)") {
+                    // Started with just the spell; cast it (−1) then drew (+1).
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/NightscapeMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/NightscapeMaster.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+
+/**
+ * Nightscape Master
+ * {2}{B}{B}
+ * Creature — Zombie Wizard
+ * 2/2
+ * {U}{U}, {T}: Return target creature to its owner's hand.
+ * {R}{R}, {T}: This creature deals 2 damage to target creature.
+ */
+val NightscapeMaster = card("Nightscape Master") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{U}{U}, {T}: Return target creature to its owner's hand.\n" +
+        "{R}{R}, {T}: This creature deals 2 damage to target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}{U}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}{R}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = DealDamageEffect(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "113"
+        artist = "Andrew Goldhawk"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d86174b8-dd9e-4ece-bc23-4f9ac50bccd3.jpg?1562938505"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PhyrexianInfiltrator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PhyrexianInfiltrator.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Phyrexian Infiltrator
+ * {2}{B}
+ * Creature — Phyrexian Minion
+ * 2/2
+ * {2}{U}{U}: Exchange control of this creature and target creature. (This effect lasts indefinitely.)
+ */
+val PhyrexianInfiltrator = card("Phyrexian Infiltrator") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Minion"
+    power = 2
+    toughness = 2
+    oracleText = "{2}{U}{U}: Exchange control of this creature and target creature. (This effect lasts indefinitely.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}{U}")
+        val t = target("target", Targets.Creature)
+        effect = Effects.ExchangeControl(EffectTarget.Self, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "116"
+        artist = "Darrell Riche"
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/224b8254-553d-4d88-8163-1f15e1244bd2.jpg?1562901847"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PhyrexianLens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PhyrexianLens.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Lens
+ * {3}
+ * Artifact
+ * {T}, Pay 1 life: Add one mana of any color.
+ */
+val PhyrexianLens = card("Phyrexian Lens") {
+    manaCost = "{3}"
+    typeLine = "Artifact"
+    oracleText = "{T}, Pay 1 life: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "307"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6ec9a91d-7af0-44a8-839f-fb9960be0ddd.jpg?1562917154"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PlanarPortal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PlanarPortal.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Planar Portal
+ * {6}
+ * Artifact
+ * {6}, {T}: Search your library for a card, put that card into your hand, then shuffle.
+ */
+val PlanarPortal = card("Planar Portal") {
+    manaCost = "{6}"
+    typeLine = "Artifact"
+    oracleText = "{6}, {T}: Search your library for a card, put that card into your hand, then shuffle."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.Tap)
+        effect = EffectPatterns.searchLibrary()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "308"
+        artist = "Mark Tedin"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24315eaa-ef55-4fd6-9145-e75b3de6f492.jpg?1562902264"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ReyaDawnbringer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ReyaDawnbringer.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+
+/**
+ * Reya Dawnbringer
+ * {6}{W}{W}{W}
+ * Legendary Creature — Angel
+ * 4/6
+ * Flying
+ * At the beginning of your upkeep, you may return target creature card from your graveyard to the battlefield.
+ */
+val ReyaDawnbringer = card("Reya Dawnbringer") {
+    manaCost = "{6}{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Angel"
+    power = 4
+    toughness = 6
+    oracleText = "Flying\n" +
+        "At the beginning of your upkeep, you may return target creature card from your graveyard to the battlefield."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        val t = target("target creature card from your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = MayEffect(MoveToZoneEffect(t, Zone.BATTLEFIELD))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "33"
+        artist = "Matthew D. Wilson"
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1e0e72b-e65e-4578-b610-9f529daa32d7.jpg?1562940371"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ScavengedWeaponry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ScavengedWeaponry.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Scavenged Weaponry
+ * {2}{B}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, draw a card.
+ * Enchanted creature gets +1/+1.
+ */
+val ScavengedWeaponry = card("Scavenged Weaponry") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, draw a card.\n" +
+        "Enchanted creature gets +1/+1."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "Alan Pollack"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e8072a9-2699-4c6c-9556-67d91bd67a4b.jpg?1562910890"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StalkingAssassin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StalkingAssassin.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+
+/**
+ * Stalking Assassin
+ * {1}{U}{B}
+ * Creature — Human Assassin
+ * 1/1
+ * {3}{U}, {T}: Tap target creature.
+ * {3}{B}, {T}: Destroy target tapped creature.
+ */
+val StalkingAssassin = card("Stalking Assassin") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Human Assassin"
+    power = 1
+    toughness = 1
+    oracleText = "{3}{U}, {T}: Tap target creature.\n" +
+        "{3}{B}, {T}: Destroy target tapped creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{U}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = TapUntapEffect(target = t, tap = true)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{B}"), Costs.Tap)
+        val t = target("target", Targets.TappedCreature)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "277"
+        artist = "Dana Knutson"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff8cc71f-3070-497f-908f-35aa13a8a857.jpg?1562946631"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StormscapeMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StormscapeMaster.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Stormscape Master
+ * {2}{U}{U}
+ * Creature — Human Wizard
+ * 2/2
+ * {W}{W}, {T}: Target creature gains protection from the color of your choice until end of turn.
+ * {B}{B}, {T}: Target player loses 2 life and you gain 2 life.
+ */
+val StormscapeMaster = card("Stormscape Master") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{W}{W}, {T}: Target creature gains protection from the color of your choice until end of turn.\n" +
+        "{B}{B}, {T}: Target player loses 2 life and you gain 2 life."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}{W}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ChooseColorAndGrantProtectionToTarget(t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}{B}"), Costs.Tap)
+        val t = target("target", TargetPlayer())
+        effect = Effects.Composite(
+            Effects.LoseLife(2, t),
+            Effects.GainLife(2, EffectTarget.Controller)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "76"
+        artist = "Hannibal King"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b704165-4587-48f1-8830-c5a07ec666cc.jpg?1562926376"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StrengthOfUnity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/StrengthOfUnity.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Strength of Unity
+ * {3}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * Domain — Enchanted creature gets +1/+1 for each basic land type among lands you control.
+ */
+val StrengthOfUnity = card("Strength of Unity") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Domain — Enchanted creature gets +1/+1 for each basic land type among lands you control."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.attachedCreature(),
+            powerBonus = DynamicAmounts.domain(),
+            toughnessBonus = DynamicAmounts.domain()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Andrew Goldhawk"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a9d4ff8-af35-413f-9aa2-f4c6e34fade2.jpg?1562900233"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SunscapeMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SunscapeMaster.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sunscape Master
+ * {2}{W}{W}
+ * Creature — Human Wizard
+ * 2/2
+ * {G}{G}, {T}: Creatures you control get +2/+2 until end of turn.
+ * {U}{U}, {T}: Return target creature to its owner's hand.
+ */
+val SunscapeMaster = card("Sunscape Master") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{G}{G}, {T}: Creatures you control get +2/+2 until end of turn.\n" +
+        "{U}{U}, {T}: Return target creature to its owner's hand."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}{G}"), Costs.Tap)
+        effect = ForEachInGroupEffect(
+            GroupFilter.AllCreaturesYouControl,
+            ModifyStatsEffect(2, 2, EffectTarget.Self)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}{U}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "42"
+        artist = "Alan Rabinowitz"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/ebb7203d-529d-45d2-8e03-cd342c153f38.jpg?1562942364"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SwayOfIllusion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/SwayOfIllusion.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sway of Illusion
+ * {1}{U}
+ * Instant
+ * Any number of target creatures become the color of your choice until end of turn.
+ * Draw a card.
+ */
+val SwayOfIllusion = card("Sway of Illusion") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Any number of target creatures become the color of your choice until end of turn.\n" +
+        "Draw a card."
+
+    spell {
+        target = TargetCreature(unlimited = true)
+        effect = Effects.ChooseColorThen(
+            then = ForEachTargetEffect(
+                effects = listOf(Effects.ChangeColorToChosen(EffectTarget.ContextTarget(0)))
+            ),
+            prompt = "Choose a color"
+        ) then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "77"
+        artist = "Greg Hildebrandt & Tim Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff65e386-9aec-4deb-a4ec-d9a97bd87645.jpg?1562946589"
+    }
+}


### PR DESCRIPTION
Adds 11 Invasion (INV) cards, all composed from existing SDK facades — no new engine effects, executors, keywords, or conditions.

## Cards added
- **Nightscape Master** — `{U}{U},{T}` bounce target creature; `{R}{R},{T}` deal 2 damage to target creature.
- **Stormscape Master** — `{W}{W},{T}` chosen-color protection; `{B}{B},{T}` target player loses 2 life and you gain 2.
- **Sunscape Master** — `{G}{G},{T}` creatures you control get +2/+2 EOT; `{U}{U},{T}` bounce target creature.
- **Phyrexian Infiltrator** — `{2}{U}{U}`: exchange control of itself and target creature (`ExchangeControlEffect`, permanent).
- **Phyrexian Lens** — `{T}, Pay 1 life`: add one mana of any color (mana ability).
- **Planar Portal** — `{6},{T}`: search your library for a card to hand, then shuffle.
- **Reya Dawnbringer** — Flying; upkeep "may return target creature card from your graveyard to the battlefield".
- **Scavenged Weaponry** — Aura; ETB draw a card; enchanted creature gets +1/+1.
- **Stalking Assassin** — `{3}{U},{T}` tap target creature; `{3}{B},{T}` destroy target tapped creature.
- **Strength of Unity** — Aura; Domain — enchanted creature gets +1/+1 per basic land type among your lands.
- **Sway of Illusion** — Any number of target creatures become a chosen color until end of turn; draw a card (unlimited-target `ForEachTargetEffect` inside `ChooseColorThen`).

## Tests
- `InvasionBatchBScenarioTest` covers Nightscape Master (both abilities), Phyrexian Infiltrator control exchange, Reya's upkeep reanimation, Stalking Assassin tap-then-destroy, and Sway of Illusion (multi-target color change + draw). All pass.
- Full `:mtg-sets:test`, `:game-server` batch test, and `:rules-engine` Invasion tests pass; all 11 Scryfall image URIs verified HTTP 200.

## Skipped
- **Spinal Embrace** — "Cast only during combat. Untap target creature you don't control and gain control of it; it gains haste; at the beginning of the next end step, sacrifice it. If you do, you gain life equal to its toughness." The control-steal + haste + delayed sacrifice all compose cleanly, but "gain life equal to its toughness" requires the end-step delayed trigger to read the sacrificed creature's toughness. The current delayed-trigger context carries no targets, and `SacrificeTargetEffect` does not record an LKI snapshot (only cost-sacrifice does), so no existing `DynamicAmount` resolves the toughness in that context. Implementing it correctly needs an engine change (e.g. a `SpecificEntity` `EntityReference` plus baking the life amount into the delayed trigger), which was out of scope for a composition-only batch. Left unimplemented to avoid a one-off; build stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)