### PR TITLE
Add Invasion cards (batch C): Teferi, emissaries & artifacts

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -640,6 +640,9 @@ Every `TargetRequirement` carries count semantics (defaults shown):
 **Chained predicates**
 
 - `.youControl()` / `.controlledByOpponent()` — control predicate.
+- `.targetPlayerControls(target)` — controlled by a referenced player. Resolves `EffectTarget`
+  bindings/context targets, plus `EffectTarget.ControllerOfTriggeringEntity` (controller of the
+  entity that fired the trigger — e.g. Tectonic Instability "tap all lands its controller controls").
 - `.withSubtype(s)` / `.withKeyword(k)` — type/ability predicate.
 - `.ofColor(c)` / `.ofColors(set)` — color predicate.
 - `.withColor(c)` / `.withAnyColor(c…)` / `.notColor(c)` — fixed-color predicates (`CardPredicate.HasColor`/`NotColor`).
@@ -1144,8 +1147,11 @@ staticAbility {
   any mana — declining is a clean no-op that leaves the player in `DECLARE_ATTACKERS` to re-declare.
   The same prompt/cancel pattern applies to block-tax floating effects (e.g. Whipgrass Entangler)
   via `AttackBlockTaxPerCreatureType`.
-- `CantBeAttackedWithout(keyword)` — Form of the Dragon-style "Creatures without flying can't
-  attack you." defender-side restriction.
+- `CantBeAttackedWithout(keyword, attackerFilter = null)` — Form of the Dragon-style "Creatures
+  without flying can't attack you." defender-side restriction. Optional `attackerFilter` narrows
+  which attackers are restricted (evaluated with the source permanent as predicate source, so
+  chosen-color/subtype predicates resolve against it) — e.g. Teferi's Moat:
+  `CantBeAttackedWithout(Keyword.FLYING, GameObjectFilter.Creature.sharingChosenColorWithSource())`.
 - `CantAttackUnlessCoAttacker(coAttackerFilter, filter = source)` — "This creature can't attack
   unless [a creature matching coAttackerFilter] also attacks" (Scarred Puma). Unlike
   `CantAttackUnless` (which is defender-relative), this depends on the whole proposed attacker

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TectonicInstabilityScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TectonicInstabilityScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Tectonic Instability.
+ *
+ * Tectonic Instability: {2}{R} Enchantment
+ * Whenever a land enters, tap all lands its controller controls.
+ *
+ * Exercises the new `EffectTarget.ControllerOfTriggeringEntity` resolution in the
+ * `ControlledByReferencedPlayer` controller predicate: the trigger taps every land controlled
+ * by the entering land's controller (and only that controller's).
+ */
+class TectonicInstabilityScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.playLand(playerNumber: Int, landName: String): com.wingedsheep.engine.core.ExecutionResult {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        val cardId = state.getHand(playerId).find { entityId ->
+            state.getEntity(entityId)?.get<CardComponent>()?.name == landName
+        } ?: error("Card '$landName' not found in player $playerNumber's hand")
+        return execute(PlayLand(playerId, cardId))
+    }
+
+    private fun TestGame.allTapped(playerNumber: Int, landName: String): Boolean {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        val lands = findAllPermanents(landName).filter {
+            state.getEntity(it)?.get<CardComponent>()?.ownerId == playerId
+        }
+        return lands.isNotEmpty() && lands.all { state.getEntity(it)?.has<TappedComponent>() == true }
+    }
+
+    init {
+        context("Tectonic Instability") {
+
+            test("playing a land taps all lands that player controls") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tectonic Instability")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInHand(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val result = game.playLand(1, "Forest")
+                withClue("Play land should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("All of player 1's Mountains should be tapped") {
+                    game.allTapped(1, "Mountain") shouldBe true
+                }
+                withClue("The newly-played Forest should also be tapped") {
+                    game.allTapped(1, "Forest") shouldBe true
+                }
+            }
+
+            test("only the entering land's controller is affected") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tectonic Instability")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLandsOnBattlefield(2, "Island", 2)
+                    .withCardInHand(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.playLand(1, "Forest")
+                game.resolveStack()
+
+                withClue("Player 1's Mountains should be tapped") {
+                    game.allTapped(1, "Mountain") shouldBe true
+                }
+                withClue("Player 2's Islands should be untapped") {
+                    val islands = game.findAllPermanents("Island")
+                    islands.none { game.state.getEntity(it)?.has<TappedComponent>() == true } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TeferisMoatScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TeferisMoatScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.state.components.identity.ChosenColorComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Teferi's Moat.
+ *
+ * Teferi's Moat: {3}{W}{U} Enchantment
+ * As this enchantment enters, choose a color.
+ * Creatures of the chosen color without flying can't attack you.
+ *
+ * Exercises the new `CantBeAttackedWithout(keyword, attackerFilter)` parameter: only attackers
+ * sharing the chosen color are restricted; other-color and flying creatures are unaffected.
+ */
+class TeferisMoatScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.chooseColor(color: Color) {
+        val decision = getPendingDecision()
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<ChooseColorDecision>()
+        submitDecision(ColorChosenResponse(decision.id, color))
+    }
+
+    init {
+        context("Teferi's Moat") {
+
+            test("choosing green stores the chosen color on the enchantment") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Teferi's Moat")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val result = game.castSpell(1, "Teferi's Moat")
+                withClue("Cast should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack() // resolve the enchantment; pauses for the color choice
+                game.chooseColor(Color.GREEN)
+                game.resolveStack()
+
+                val moatId = game.findPermanent("Teferi's Moat")!!
+                val chosen = game.state.getEntity(moatId)?.get<ChosenColorComponent>()
+                withClue("Chosen color should be stored") {
+                    chosen.shouldNotBeNull()
+                    chosen.color shouldBe Color.GREEN
+                }
+            }
+
+            test("non-flying creature of the chosen color can't attack the controller") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Teferi's Moat")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(2, "Elvish Aberration") // green, no flying
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Teferi's Moat")
+                game.resolveStack()
+                game.chooseColor(Color.GREEN)
+                game.resolveStack()
+
+                // Hand over to the opponent's combat
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val attackerId = game.findPermanent("Elvish Aberration")!!
+                val result = game.execute(
+                    DeclareAttackers(game.player2Id, mapOf(attackerId to game.player1Id))
+                )
+                withClue("Green non-flier should not be able to attack the Moat's controller") {
+                    result.error shouldNotBe null
+                }
+            }
+
+            test("creature of a different color can attack normally") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Teferi's Moat")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(2, "Elvish Aberration") // green, no flying
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Choose red — the green Elvish Aberration is not restricted.
+                game.castSpell(1, "Teferi's Moat")
+                game.resolveStack()
+                game.chooseColor(Color.RED)
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val attackerId = game.findPermanent("Elvish Aberration")!!
+                val result = game.execute(
+                    DeclareAttackers(game.player2Id, mapOf(attackerId to game.player1Id))
+                )
+                withClue("Off-color creature should be able to attack: ${result.error}") {
+                    result.error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TsabosDecreeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TsabosDecreeScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Tsabo's Decree.
+ *
+ * Tsabo's Decree: {5}{B} Instant
+ * Choose a creature type. Target player reveals their hand and discards all creature cards of
+ * that type. Then destroy all creatures of that type that player controls. They can't be
+ * regenerated.
+ *
+ * Composes ChooseCreatureType + RevealHand + a chosen-subtype discard + a chosen-subtype board
+ * wipe, all keyed off the same chosen type via `HasChosenSubtype`.
+ */
+class TsabosDecreeScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.chooseCreatureType(typeName: String) {
+        val decision = getPendingDecision()
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val index = decision.options.indexOf(typeName)
+        withClue("Creature type '$typeName' should be an option") {
+            (index >= 0) shouldBe true
+        }
+        submitDecision(OptionChosenResponse(decision.id, index))
+    }
+
+    init {
+        context("Tsabo's Decree") {
+
+            test("destroys creatures of the chosen type and discards matching cards") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Tsabo's Decree")
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardOnBattlefield(2, "Nomadic Elf")     // Elf — destroyed
+                    .withCardOnBattlefield(2, "Ardent Soldier")  // Human Soldier — survives
+                    .withCardInHand(2, "Nomadic Elf")            // Elf card — discarded
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val result = game.castSpellTargetingPlayer(1, "Tsabo's Decree", 2)
+                withClue("Cast should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack() // resolve the instant; pauses for the creature-type choice
+                game.chooseCreatureType("Elf")
+                game.resolveStack()
+
+                withClue("Opponent's Elf creature should be destroyed") {
+                    game.isOnBattlefield("Nomadic Elf") shouldBe false
+                }
+                withClue("Opponent's non-Elf creature should survive") {
+                    game.isOnBattlefield("Ardent Soldier") shouldBe true
+                }
+                withClue("The Elf card in hand should have been discarded") {
+                    game.isInHand(2, "Nomadic Elf") shouldBe false
+                    game.isInGraveyard(2, "Nomadic Elf") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -288,15 +288,27 @@ data class CanAttackDespiteDefender(
  * This is a defender-side restriction — the engine checks the defending player's battlefield
  * for permanents with this ability, and blocks any attacker that lacks the required keyword.
  *
+ * An optional [attackerFilter] narrows which attackers the restriction applies to. When set,
+ * only attackers matching the filter (evaluated with this permanent as the predicate source,
+ * so chosen-color/subtype predicates resolve against it) are restricted; all others may attack
+ * freely. Used for Teferi's Moat: "Creatures of the chosen color without flying can't attack
+ * you." When null (the default) the restriction applies to every attacker (Form of the Dragon).
+ *
  * @property requiredKeyword The keyword attackers must have (e.g., FLYING)
+ * @property attackerFilter Optional filter limiting which attackers are restricted
  */
 @SerialName("CantBeAttackedWithout")
 @Serializable
 data class CantBeAttackedWithout(
-    val requiredKeyword: Keyword
+    val requiredKeyword: Keyword,
+    val attackerFilter: com.wingedsheep.sdk.scripting.GameObjectFilter? = null
 ) : StaticAbility {
     override val description: String =
-        "Creatures without ${requiredKeyword.displayName.lowercase()} can't attack you"
+        if (attackerFilter == null) {
+            "Creatures without ${requiredKeyword.displayName.lowercase()} can't attack you"
+        } else {
+            "${attackerFilter.description} without ${requiredKeyword.displayName.lowercase()} can't attack you"
+        }
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TaintedWell.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TaintedWell.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.SetEnchantedLandType
+
+/**
+ * Tainted Well
+ * {2}{B}
+ * Enchantment — Aura
+ * Enchant land
+ * When this Aura enters, draw a card.
+ * Enchanted land is a Swamp.
+ */
+val TaintedWell = card("Tainted Well") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant land\n" +
+        "When this Aura enters, draw a card.\n" +
+        "Enchanted land is a Swamp."
+
+    auraTarget = Targets.Land
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = SetEnchantedLandType("Swamp")
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Val Mayerik"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2eec00a1-7e12-42d2-8f46-de8ab7323c2c.jpg?1562904562"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TectonicInstability.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TectonicInstability.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tectonic Instability
+ * {2}{R}
+ * Enchantment
+ * Whenever a land enters, tap all lands its controller controls.
+ *
+ * Triggers on any land entering (ANY binding). The effect taps every land controlled by the
+ * entering land's controller, resolved via [EffectTarget.ControllerOfTriggeringEntity] threaded
+ * into the group filter's controller predicate.
+ */
+val TectonicInstability = card("Tectonic Instability") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a land enters, tap all lands its controller controls."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Land,
+            binding = TriggerBinding.ANY
+        )
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter(
+                GameObjectFilter.Land.targetPlayerControls(EffectTarget.ControllerOfTriggeringEntity)
+            ),
+            effect = TapUntapEffect(target = EffectTarget.Self, tap = true)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "173"
+        artist = "Rob Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/0476cc6b-ecc6-44d6-9f44-a90d4ee85daa.jpg?1618485193"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TeferisCare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TeferisCare.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Teferi's Care
+ * {2}{W}
+ * Enchantment
+ * {W}, Sacrifice an enchantment: Destroy target enchantment.
+ * {3}{U}{U}: Counter target enchantment spell.
+ */
+val TeferisCare = card("Teferi's Care") {
+    manaCost = "{2}{W}"
+    colorIdentity = "WU"
+    typeLine = "Enchantment"
+    oracleText = "{W}, Sacrifice an enchantment: Destroy target enchantment.\n" +
+        "{3}{U}{U}: Counter target enchantment spell."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Sacrifice(GameObjectFilter.Enchantment))
+        val t = target("enchantment", Targets.Enchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{U}{U}")
+        target = TargetSpell(filter = TargetFilter(GameObjectFilter.Enchantment, zone = Zone.STACK))
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "43"
+        artist = "Scott Bailey"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/031b1cc1-4468-4bc5-85c0-c22dce131225.jpg?1562895604"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TeferisMoat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TeferisMoat.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeAttackedWithout
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Teferi's Moat
+ * {3}{W}{U}
+ * Enchantment
+ * As this enchantment enters, choose a color.
+ * Creatures of the chosen color without flying can't attack you.
+ *
+ * The chosen color is stored at ETB via [EntersWithChoice] (ChoiceType.COLOR →
+ * ChosenColorComponent). The attack restriction reuses [CantBeAttackedWithout], narrowed by
+ * an [CantBeAttackedWithout.attackerFilter] that matches only creatures sharing the chosen
+ * color (resolved with this enchantment as the predicate source).
+ */
+val TeferisMoat = card("Teferi's Moat") {
+    manaCost = "{3}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Enchantment"
+    oracleText = "As this enchantment enters, choose a color.\n" +
+        "Creatures of the chosen color without flying can't attack you."
+
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+
+    staticAbility {
+        ability = CantBeAttackedWithout(
+            requiredKeyword = Keyword.FLYING,
+            attackerFilter = GameObjectFilter.Creature.sharingChosenColorWithSource()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "279"
+        artist = "rk post"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9ed5845c-ef6d-4a7b-b725-b09d3e9bbc17.jpg?1591725011"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Tek.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Tek.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Tek
+ * {5}
+ * Artifact Creature — Dragon
+ * 2/2
+ * This creature gets +0/+2 as long as you control a Plains, has flying as long as you
+ * control an Island, gets +2/+0 as long as you control a Swamp, has first strike as long
+ * as you control a Mountain, and has trample as long as you control a Forest.
+ */
+val Tek = card("Tek") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Dragon"
+    power = 2
+    toughness = 2
+    oracleText = "This creature gets +0/+2 as long as you control a Plains, has flying as long " +
+        "as you control an Island, gets +2/+0 as long as you control a Swamp, has first strike " +
+        "as long as you control a Mountain, and has trample as long as you control a Forest."
+
+    // +0/+2 as long as you control a Plains
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 0, toughnessBonus = 2, filter = Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Plains"))
+        )
+    }
+
+    // Flying as long as you control an Island
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FLYING, Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Island"))
+        )
+    }
+
+    // +2/+0 as long as you control a Swamp
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 0, filter = Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Swamp"))
+        )
+    }
+
+    // First strike as long as you control a Mountain
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Mountain"))
+        )
+    }
+
+    // Trample as long as you control a Forest
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.TRAMPLE, Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Forest"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "313"
+        artist = "Chippy"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1f38104-a699-4bb9-930a-699f7bbc338a.jpg?1562933962"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ThunderscapeMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ThunderscapeMaster.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Thunderscape Master
+ * {2}{R}{R}
+ * Creature — Human Wizard
+ * 2/2
+ * {B}{B}, {T}: Target player loses 2 life and you gain 2 life.
+ * {G}{G}, {T}: Creatures you control get +2/+2 until end of turn.
+ */
+val ThunderscapeMaster = card("Thunderscape Master") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "RBG"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{B}{B}, {T}: Target player loses 2 life and you gain 2 life.\n" +
+        "{G}{G}, {T}: Creatures you control get +2/+2 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}{B}"), Costs.Tap)
+        val t = target("target player", TargetPlayer())
+        effect = Effects.LoseLife(2, t) then Effects.GainLife(2)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}{G}"), Costs.Tap)
+        description = "{G}{G}, {T}: Creatures you control get +2/+2 until end of turn."
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+            effect = ModifyStatsEffect(2, 2, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "175"
+        artist = "Scott M. Fischer"
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/22abdc2f-bdc8-46c4-8ce2-f06befedbc32.jpg?1562901918"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TrevasAttendant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TrevasAttendant.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Treva's Attendant
+ * {5}
+ * Artifact Creature — Golem
+ * 3/3
+ * {1}, Sacrifice this creature: Add {G}{W}{U}.
+ *
+ * One of the Invasion "Attendant" cycle — each sacrifices for the three colors of the
+ * matching dragon (Treva = Green/White/Blue). A mana ability: no targets, no stack.
+ */
+val TrevasAttendant = card("Treva's Attendant") {
+    manaCost = "{5}"
+    colorIdentity = "GWU"
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 3
+    oracleText = "{1}, Sacrifice this creature: Add {G}{W}{U}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.GREEN),
+            Effects.AddMana(Color.WHITE),
+            Effects.AddMana(Color.BLUE)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "315"
+        artist = "Christopher Moeller"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/9857af81-fb95-4dc4-b048-9ce4e96d1eca.jpg?1562925750"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TsabosDecree.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/TsabosDecree.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ChooseCreatureTypeEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Tsabo's Decree
+ * {5}{B}
+ * Instant
+ * Choose a creature type. Target player reveals their hand and discards all creature cards
+ * of that type. Then destroy all creatures of that type that player controls. They can't be
+ * regenerated.
+ *
+ * Composed entirely from existing primitives: [ChooseCreatureTypeEffect] stamps the chosen
+ * type into the pipeline (`chosenValues["chosenCreatureType"]`); the hand discard gathers the
+ * target player's creature cards and keeps only those matching the chosen type
+ * (`matchChosenCreatureType`); and the board wipe iterates creatures of that type the target
+ * player controls (`GroupFilter.chosenSubtypeKey`), destroying each without regeneration.
+ */
+val TsabosDecree = card("Tsabo's Decree") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Choose a creature type. Target player reveals their hand and discards all " +
+        "creature cards of that type. Then destroy all creatures of that type that player " +
+        "controls. They can't be regenerated."
+
+    spell {
+        val targetPlayer = target("target player", TargetPlayer())
+        effect = CompositeEffect(
+            listOf(
+                ChooseCreatureTypeEffect,
+                // Target player reveals their hand and discards all creature cards of that type.
+                RevealHandEffect(targetPlayer),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.HAND,
+                        player = Player.ContextPlayer(0),
+                        filter = GameObjectFilter.Creature,
+                    ),
+                    storeAs = "tsaboHand",
+                ),
+                SelectFromCollectionEffect(
+                    from = "tsaboHand",
+                    selection = SelectionMode.All,
+                    matchChosenCreatureType = true,
+                    storeSelected = "tsaboDiscard",
+                ),
+                MoveCollectionEffect(
+                    from = "tsaboDiscard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    moveType = MoveType.Discard,
+                ),
+                // Then destroy all creatures of that type that player controls; no regeneration.
+                ForEachInGroupEffect(
+                    filter = GroupFilter(
+                        baseFilter = GameObjectFilter.Creature.targetPlayerControls(),
+                        chosenSubtypeKey = "chosenCreatureType",
+                    ),
+                    effect = CompositeEffect(
+                        listOf(
+                            CantBeRegeneratedEffect(EffectTarget.Self),
+                            MoveToZoneEffect(EffectTarget.Self, Zone.GRAVEYARD, byDestruction = true),
+                        ),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "129"
+        artist = "Thomas M. Baxa"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c1a0ebd-1add-49e6-b5e6-5b26abb1de88.jpg?1562897461"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrborgEmissary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrborgEmissary.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+
+/**
+ * Urborg Emissary
+ * {2}{B}
+ * Creature — Human Wizard
+ * 3/1
+ * Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)
+ * When this creature enters, if it was kicked, return target permanent to its owner's hand.
+ */
+val UrborgEmissary = card("Urborg Emissary") {
+    manaCost = "{2}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Human Wizard"
+    power = 3
+    toughness = 1
+    oracleText = "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\n" +
+        "When this creature enters, if it was kicked, return target permanent to its owner's hand."
+
+    keywordAbility(KeywordAbility.kicker("{1}{U}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        val t = target("permanent", Targets.Permanent)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "131"
+        artist = "Eric Peterson"
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6912c71-1836-4e87-9a65-d577d903d03c.jpg?1562941302"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrzasFilter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrzasFilter.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Urza's Filter
+ * {4}
+ * Artifact
+ * Multicolored spells cost {2} less to cast.
+ *
+ * Affects spells cast by any player (no controller restriction in the oracle text).
+ */
+val UrzasFilter = card("Urza's Filter") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Multicolored spells cost {2} less to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.AnyCaster(GameObjectFilter.Multicolored),
+            modification = CostModification.ReduceGeneric(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "318"
+        artist = "Dave Dorman"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/680c75b1-e766-40be-84d7-2332047bb3de.jpg?1562915969"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VerduranEmissary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VerduranEmissary.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.inv.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
+
+/**
+ * Verduran Emissary
+ * {2}{G}
+ * Creature — Human Wizard
+ * 2/3
+ * Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)
+ * When this creature enters, if it was kicked, destroy target artifact. It can't be regenerated.
+ */
+val VerduranEmissary = card("Verduran Emissary") {
+    manaCost = "{2}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\n" +
+        "When this creature enters, if it was kicked, destroy target artifact. It can't be regenerated."
+
+    keywordAbility(KeywordAbility.kicker("{1}{R}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        val t = target("artifact", Targets.Artifact)
+        effect = CantBeRegeneratedEffect(t) then Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "221"
+        artist = "Alton Lawson"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55f3361b-e2e7-4297-85c2-94323f90cc90.jpg?1562912510"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -526,13 +526,35 @@ class PredicateEvaluator {
                         context.targetPlayerId?.let { controllerId == it } ?: false
                     }
                     is ControllerPredicate.ControlledByReferencedPlayer -> {
-                        context.resolvePlayerTarget(predicate.target)?.let { controllerId == it } ?: false
+                        val referenced = context.resolvePlayerTarget(predicate.target)
+                            ?: resolveReferencedPlayerFromState(state, projected, predicate.target, context)
+                        referenced?.let { controllerId == it } ?: false
                     }
                     // Already handled above
                     ControllerPredicate.OwnedByYou, ControllerPredicate.OwnedByOpponent -> true
                 }
             }
         }
+    }
+
+    /**
+     * Resolve an [EffectTarget] player reference that needs [GameState] (so it can't be
+     * answered by [PredicateContext.resolvePlayerTarget] alone). Currently covers
+     * [EffectTarget.ControllerOfTriggeringEntity] — the controller of the entity that
+     * caused the trigger (e.g. Tectonic Instability: "tap all lands its controller controls").
+     */
+    private fun resolveReferencedPlayerFromState(
+        state: GameState,
+        projected: ProjectedState,
+        target: EffectTarget,
+        context: PredicateContext,
+    ): EntityId? = when (target) {
+        EffectTarget.ControllerOfTriggeringEntity -> {
+            val triggeringId = context.triggeringEntityId ?: return null
+            projected.getController(triggeringId)
+                ?: state.getEntity(triggeringId)?.get<ControllerComponent>()?.playerId
+        }
+        else -> null
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
@@ -2,6 +2,8 @@ package com.wingedsheep.engine.mechanics.combat.rules
 
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
@@ -188,6 +190,20 @@ class CantBeAttackedWithoutDefenderRule : AttackDefenderRule {
             val cardDef = ctx.cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
             for (ability in cardDef.staticAbilities) {
                 if (ability is CantBeAttackedWithout) {
+                    // If the ability restricts only a subset of attackers, the attacker must
+                    // match the filter (resolved with this permanent as the predicate source,
+                    // so chosen-color/subtype predicates read off it).
+                    val filter = ability.attackerFilter
+                    if (filter != null) {
+                        val matches = predicateEvaluator.matches(
+                            ctx.state,
+                            ctx.projected,
+                            ctx.attackerId,
+                            filter,
+                            PredicateContext(controllerId = defendingPlayer, sourceId = permId)
+                        )
+                        if (!matches) continue
+                    }
                     if (!ctx.projected.hasKeyword(ctx.attackerId, ability.requiredKeyword)) {
                         val attackerName = ctx.state.getEntity(ctx.attackerId)?.get<CardComponent>()?.name ?: "Creature"
                         return "$attackerName can't attack: ${ability.description}"
@@ -196,6 +212,10 @@ class CantBeAttackedWithoutDefenderRule : AttackDefenderRule {
             }
         }
         return null
+    }
+
+    companion object {
+        private val predicateEvaluator = PredicateEvaluator()
     }
 }
 


### PR DESCRIPTION
Implements batch C of Invasion (INV) cards. 11 of 12 added; 1 skipped.

## Cards added
- **Tainted Well** — Aura: enchant land, ETB draw a card, enchanted land is a Swamp.
- **Tectonic Instability** — whenever a land enters, tap all lands its controller controls.
- **Teferi's Care** — `{W}`, sac an enchantment: destroy target enchantment; `{3}{U}{U}`: counter target enchantment spell.
- **Teferi's Moat** — choose a color on entry; creatures of that color without flying can't attack you.
- **Tek** — artifact Dragon `2/2` with five land-type-conditional static abilities (+0/+2 / flying / +2/+0 / first strike / trample).
- **Thunderscape Master** — `{B}{B},{T}`: drain 2; `{G}{G},{T}`: creatures you control get +2/+2.
- **Treva's Attendant** — `{1}`, sac: add `{G}{W}{U}` (mirrors Rith's Attendant).
- **Tsabo's Decree** — choose a creature type; target player reveals hand, discards all creature cards of that type, then destroy all of that type they control (no regen).
- **Urborg Emissary** — kicker `{1}{U}`; if kicked, return target permanent to hand.
- **Urza's Filter** — multicolored spells cost `{2}` less to cast (any caster).
- **Verduran Emissary** — kicker `{1}{R}`; if kicked, destroy target artifact (no regen).

## Cards skipped
- **Temporal Distortion** — requires a brand-new "hourglass" counter type wired across all five counter layers, plus a counter-gated "doesn't untap during untap step" static and a per-player upkeep counter-cleanup trigger. This is a distinct mechanic from stun counters and too large for this batch. The underlying gap is already tracked in `backlog/invasion-engine-gaps.md` ("Doesn't untap" static … Temporal Distortion via counter).

## Engine / SDK changes (general, reused)
- `CantBeAttackedWithout` gains an optional `attackerFilter`, so the restriction can apply to only a subset of attackers (evaluated with the source permanent as predicate source). Teferi's Moat uses `GameObjectFilter.Creature.sharingChosenColorWithSource()`; Form of the Dragon's existing usage is unchanged (default `null`).
- `PredicateEvaluator` now resolves `EffectTarget.ControllerOfTriggeringEntity` inside the `ControlledByReferencedPlayer` controller predicate, enabling "controlled by the triggering land's controller" filters (Tectonic Instability).
- `docs/card-sdk-language-reference.md` updated for both.

## Tests
- New scenario tests: `TeferisMoatScenarioTest` (3), `TectonicInstabilityScenarioTest` (2), `TsabosDecreeScenarioTest` (1) — all green.
- Regression: `FormOfTheDragonScenarioTest` and `ThreeTreeCityScenarioTest` still pass; full `:rules-engine:test` suite passes.
- JVM modules build clean.

INV implemented count: 298 → 309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)