### PR TITLE
Add Mobilize N keyword (Tarkir: Dragonstorm)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1347,6 +1347,11 @@ composite abilities).
 - `Renown(n)` — first combat damage to a player grants renown counters.
 - `Fabricate(n)` — ETB choose +1/+1 counters or Servo tokens.
 - `Tribute(n)` — opponent chooses ETB bonus.
+- `Mobilize(n)` — +N tapped-and-attacking 1/1 red Warrior tokens on attack (Tarkir: Dragonstorm, Mardu).
+  Display-only; wire the behavior with the `card { mobilize(n) }` builder helper, which adds this keyword
+  ability plus a "whenever this attacks" triggered `CreateTokenEffect` (`tapped = true`, `attacking = true`)
+  whose `sacrificeAtStep = Step.END` schedules one delayed `SacrificeTargetEffect` per created token at the
+  next end step (mirrors `rampage()`). `n` may be any fixed value (Mobilize 1/2/3, …).
 - `Toxic(n)` — adds poison counters on combat damage.
 - `Cycling(cost)` — pay cost, discard, draw a card.
 - `BasicLandcycling(cost)` — cycling that fetches a basic land type.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -153,6 +153,19 @@ enum class Keyword(val displayName: String) {
     FABRICATE("Fabricate"),
     TRIBUTE("Tribute"),
 
+    /**
+     * Mobilize N (Tarkir: Dragonstorm, Mardu). "Whenever this creature attacks,
+     * create N tapped and attacking 1/1 red Warrior creature tokens. Sacrifice
+     * those tokens at the beginning of the next end step."
+     *
+     * The keyword ability is display-only; the behavior lives in an attack-triggered
+     * ability wired by the `mobilize(n)` DSL helper on
+     * [com.wingedsheep.sdk.dsl.CardBuilder] — a [com.wingedsheep.sdk.scripting.effects.CreateTokenEffect]
+     * that creates the tapped-and-attacking tokens and schedules their sacrifice at
+     * the next end step via `sacrificeAtStep`.
+     */
+    MOBILIZE("Mobilize"),
+
     // ── Ability words (display prefix, no uniform mechanic) ──
     /**
      * Eerie (Duskmourn: House of Horror).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
@@ -355,6 +356,45 @@ class CardBuilder(private val name: String) {
                     toughnessModifier = perBlockerBeyondFirst,
                     target = EffectTarget.TriggeringEntity
                 )
+            )
+        )
+    }
+
+    /**
+     * Add Mobilize N (Tarkir: Dragonstorm) — keyword ability + triggered ability.
+     *
+     * "Whenever this creature attacks, create N tapped and attacking 1/1 red Warrior
+     * creature tokens. Sacrifice those tokens at the beginning of the next end step."
+     *
+     * The keyword ability is display-only (no separate Mobilize handler exists); the
+     * behavior lives entirely in the attack-triggered ability wired here. The tokens
+     * enter tapped and attacking via [CreateTokenEffect.tapped]/[CreateTokenEffect.attacking],
+     * and their end-of-turn sacrifice is scheduled via [CreateTokenEffect.sacrificeAtStep]
+     * (the sacrifice sibling of `exileAtStep`), which the executor turns into one delayed
+     * [com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect] per created token.
+     */
+    fun mobilize(n: Int) {
+        keywordAbilityList.add(KeywordAbility.mobilize(n))
+        val tokenWord = if (n == 1) "token" else "tokens"
+        val pronoun = if (n == 1) "it" else "those tokens"
+        val article = if (n == 1) "a" else "$n"
+        triggeredAbilities.add(
+            TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = CreateTokenEffect(
+                    count = DynamicAmount.Fixed(n),
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.RED),
+                    creatureTypes = setOf("Warrior"),
+                    tapped = true,
+                    attacking = true,
+                    sacrificeAtStep = Step.END
+                ),
+                descriptionOverride = "Whenever this creature attacks, create $article tapped " +
+                    "and attacking 1/1 red Warrior creature $tokenWord. Sacrifice $pronoun at the " +
+                    "beginning of the next end step."
             )
         )
     }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -718,6 +718,7 @@ sealed interface KeywordAbility {
         fun renown(n: Int): KeywordAbility = Numeric(Keyword.RENOWN, n)
         fun fabricate(n: Int): KeywordAbility = Numeric(Keyword.FABRICATE, n)
         fun tribute(n: Int): KeywordAbility = Numeric(Keyword.TRIBUTE, n)
+        fun mobilize(n: Int): KeywordAbility = Numeric(Keyword.MOBILIZE, n)
 
         /**
          * Hideaway N — display tag for the parameterized hideaway keyword. The

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
@@ -68,6 +68,10 @@ data class CreateChosenTokenEffect(
  *   Use [EffectTarget.TargetController] to give the token to the controller of a targeted permanent.
  * @property exileAtStep If set, create delayed triggers to exile the created tokens at this step.
  *   Used for "Create tokens... Exile them at the beginning of the next end step" patterns (e.g., Valduk, Kiki-Jiki).
+ * @property sacrificeAtStep If set, create delayed triggers to sacrifice the created tokens at this step.
+ *   The sacrifice sibling of [exileAtStep] — tokens go to the graveyard (firing dies/leaves and
+ *   "whenever you sacrifice" triggers) rather than being exiled. Used by Mobilize N
+ *   ("Sacrifice those tokens at the beginning of the next end step").
  */
 @SerialName("CreateToken")
 @Serializable
@@ -90,6 +94,7 @@ data class CreateTokenEffect(
     val staticAbilities: List<StaticAbility> = emptyList(),
     val triggeredAbilities: List<TriggeredAbility> = emptyList(),
     val exileAtStep: Step? = null,
+    val sacrificeAtStep: Step? = null,
     /** Counters to place on the token when it enters the battlefield. */
     val initialCounters: Map<String, Int> = emptyMap()
 ) : Effect {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ShockBrigade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ShockBrigade.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shock Brigade — Tarkir: Dragonstorm #120
+ * {1}{R} · Creature — Goblin Soldier · 1/3
+ *
+ * Menace
+ * Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior
+ * creature token. Sacrifice it at the beginning of the next end step.)
+ *
+ * Both abilities are keyword helpers: `keywords(Keyword.MENACE)` for the evasion keyword and
+ * the `mobilize(n)` builder helper, which adds the display-only "Mobilize 1" keyword ability
+ * plus the attack-triggered ability that creates the tapped-and-attacking Warrior token and
+ * schedules its sacrifice at the next end step.
+ */
+val ShockBrigade = card("Shock Brigade") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Soldier"
+    power = 1
+    toughness = 3
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)"
+
+    keywords(Keyword.MENACE)
+    mobilize(1)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "Fajareka Setiawan"
+        flavorText = "\"From Alesha to Zurgo, all Mardu khans started right here. At the front lines.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66940466-8e9d-4a85-bfb0-e92189b7a121.jpg?1743204444"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -34,6 +34,7 @@ import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import java.util.UUID
 import kotlin.reflect.KClass
@@ -185,6 +186,28 @@ class CreateTokenExecutor(
                     id = UUID.randomUUID().toString(),
                     effect = MoveToZoneEffect(EffectTarget.SpecificEntity(tokenId), Zone.EXILE),
                     fireAtStep = exileStep,
+                    sourceId = sourceId,
+                    sourceName = sourceName,
+                    controllerId = tokenControllerId
+                )
+                newState = newState.addDelayedTrigger(delayedTrigger)
+            }
+        }
+
+        // If sacrificeAtStep is set, create delayed triggers to sacrifice each created token
+        // (the sacrifice sibling of exileAtStep — used by Mobilize N). Sacrifice sends the
+        // token to the graveyard, firing dies/leaves and "whenever you sacrifice" triggers.
+        val sacrificeStep = effect.sacrificeAtStep
+        if (sacrificeStep != null) {
+            val sourceId = context.sourceId ?: context.controllerId
+            val sourceName = sourceId.let { id ->
+                state.getEntity(id)?.get<CardComponent>()?.name ?: "Unknown"
+            }
+            for (tokenId in createdTokens) {
+                val delayedTrigger = DelayedTriggeredAbility(
+                    id = UUID.randomUUID().toString(),
+                    effect = SacrificeTargetEffect(EffectTarget.SpecificEntity(tokenId)),
+                    fireAtStep = sacrificeStep,
                     sourceId = sourceId,
                     sourceName = sourceName,
                     controllerId = tokenControllerId

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MobilizeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MobilizeTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.ShockBrigade
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for the Mobilize N keyword (Tarkir: Dragonstorm, Mardu).
+ *
+ * "Whenever this creature attacks, create N tapped and attacking 1/1 red Warrior creature
+ * tokens. Sacrifice those tokens at the beginning of the next end step."
+ *
+ * The keyword is wired by the `mobilize(n)` builder helper: a display-only keyword ability
+ * plus an attack-triggered CreateTokenEffect (tapped + attacking) whose `sacrificeAtStep`
+ * schedules one delayed SacrificeTargetEffect per created token at the next end step.
+ *
+ * Shock Brigade (Mobilize 1) is the real card under test; an inline "Test Mobilizer" with
+ * Mobilize 2 covers the N>1 path.
+ */
+class MobilizeTest : FunSpec({
+
+    // Inline Mobilize 2 creature for the N>1 path.
+    val mobilizer2 = card("Test Mobilizer") {
+        manaCost = "{2}{R}"
+        typeLine = "Creature — Orc Warrior"
+        power = 2
+        toughness = 2
+        mobilize(2)
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ShockBrigade, mobilizer2))
+        return driver
+    }
+
+    fun GameTestDriver.warriorTokens(playerId: EntityId): List<EntityId> =
+        getPermanents(playerId).filter { id ->
+            val entity = state.getEntity(id)
+            entity?.has<TokenComponent>() == true &&
+                entity.get<CardComponent>()?.name == "Warrior Token"
+        }
+
+    test("Mobilize 1 creates one tapped and attacking Warrior token when the creature attacks") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val brigade = driver.putCreatureOnBattlefield(attacker, "Shock Brigade")
+        driver.removeSummoningSickness(brigade)
+
+        driver.passPriorityUntil(com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(brigade), defender)
+        driver.bothPass() // resolve the Mobilize trigger
+
+        val tokens = driver.warriorTokens(attacker)
+        tokens.size shouldBe 1
+
+        val token = tokens.first()
+        driver.state.getEntity(token)?.has<TappedComponent>() shouldBe true
+        val attacking = driver.state.getEntity(token)?.get<AttackingComponent>()
+        attacking shouldNotBe null
+        attacking!!.defenderId shouldBe defender
+
+        // One delayed sacrifice trigger should have been scheduled for the token.
+        driver.state.delayedTriggers.size shouldBe 1
+        driver.state.delayedTriggers.first().fireAtStep shouldBe com.wingedsheep.sdk.core.Step.END
+    }
+
+    test("Mobilize tokens are sacrificed at the next end step") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val brigade = driver.putCreatureOnBattlefield(attacker, "Shock Brigade")
+        driver.removeSummoningSickness(brigade)
+
+        driver.passPriorityUntil(com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(brigade), defender)
+        driver.bothPass()
+
+        driver.warriorTokens(attacker).size shouldBe 1
+
+        // Advance to the end step; the delayed trigger goes on the stack — resolve it.
+        driver.passPriorityUntil(com.wingedsheep.sdk.core.Step.END)
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // The token has been sacrificed and no longer exists on the battlefield.
+        driver.warriorTokens(attacker).size shouldBe 0
+        driver.state.delayedTriggers.size shouldBe 0
+
+        // Shock Brigade itself is unaffected.
+        driver.findPermanent(attacker, "Shock Brigade") shouldNotBe null
+    }
+
+    test("Mobilize 2 creates two Warrior tokens, both sacrificed at the next end step") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val mobilizer = driver.putCreatureOnBattlefield(attacker, "Test Mobilizer")
+        driver.removeSummoningSickness(mobilizer)
+
+        driver.passPriorityUntil(com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(mobilizer), defender)
+        driver.bothPass()
+
+        driver.warriorTokens(attacker).size shouldBe 2
+        driver.state.delayedTriggers.size shouldBe 2
+
+        driver.passPriorityUntil(com.wingedsheep.sdk.core.Step.END)
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        driver.warriorTokens(attacker).size shouldBe 0
+        driver.state.delayedTriggers.size shouldBe 0
+    }
+
+    test("Mobilize token attacks and deals combat damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val brigade = driver.putCreatureOnBattlefield(attacker, "Shock Brigade")
+        driver.removeSummoningSickness(brigade)
+
+        driver.passPriorityUntil(com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(brigade), defender)
+        driver.bothPass()
+
+        // Shock Brigade (1 power) + one 1/1 Warrior token = 2 combat damage to the defender.
+        driver.passPriorityUntil(com.wingedsheep.sdk.core.Step.POSTCOMBAT_MAIN)
+        driver.assertLifeTotal(defender, 18)
+    }
+})


### PR DESCRIPTION
## Summary

Implements the **Mobilize N** keyword (Tarkir: Dragonstorm, Mardu), the lowest-risk Tier-1 clan mechanic from `backlog/tdm-engine-gaps.md`:

> Whenever this creature attacks, create N tapped and attacking 1/1 red Warrior creature tokens. Sacrifice those tokens at the beginning of the next end step.

It is wired by composing existing primitives, mirroring the `rampage()` builder-helper pattern — no new engine subsystem.

## Changes

**SDK**
- `Keyword.MOBILIZE` + `KeywordAbility.mobilize(n)` — display-only "Mobilize N" tag.
- `CardBuilder.mobilize(n)` — adds the keyword ability plus a "whenever this attacks" triggered `CreateTokenEffect` (tapped + attacking 1/1 red Warriors) with `sacrificeAtStep = Step.END`.
- `CreateTokenEffect.sacrificeAtStep` — the **sacrifice** sibling of the existing `exileAtStep` field.

**Engine**
- `CreateTokenExecutor` schedules one delayed `SacrificeTargetEffect` per created token when `sacrificeAtStep` is set. Sacrifice (not exile) is correct for Mobilize: the tokens hit the graveyard, firing dies / "whenever you sacrifice a creature" triggers that the Mardu clan cares about.

**Content**
- **Shock Brigade** (TDM #120, `{1}{R}` Goblin Soldier 1/3, Menace + Mobilize 1) as the first user. TDM is now 20/271.

**Docs**
- `card-sdk-language-reference.md` gains the Mobilize keyword entry.

## Design note

Sacrifice scheduling reuses the per-token delayed-trigger mechanism already established by `exileAtStep` (token IDs are only known at resolution, so the scheduling is baked in the executor against the concrete entity IDs). Adding `sacrificeAtStep` alongside `exileAtStep` keeps that lifecycle handling symmetric rather than introducing a parallel collection-publish + collection-sacrifice path.

## Testing

`MobilizeTest` (all passing):
- Mobilize 1 creates one tapped-and-attacking Warrior token on attack, with one delayed sacrifice trigger at the end step.
- The token is sacrificed at the next end step; the source creature is unaffected.
- Mobilize 2 creates two tokens, both sacrificed at the next end step.
- The Warrior token attacks and deals combat damage.

Also re-ran serialization round-trip + token-related scenario tests (SiegeGangCommander, Mobilization, CentaurGlade) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)