### PR TITLE
Add Endure N keyword + 9 Abzan Endure cards (TDM)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1973,6 +1973,12 @@ Card authors rarely reference these directly; they are created/updated by the ma
 - **Evoke** — `evoke = "{U}"`; pay alt cost, sacrifice on ETB.
 - **Earthbend** — `Effects.Earthbend` composes AnimateLand + GrantKeyword + AddCounters + granted self-triggers (no fake
   keyword).
+- **Endure N** — `Effects.Endure(amount, target = EffectTarget.Self)` composes a `ModalEffect.chooseOne` of
+  AddDynamicCounters (N +1/+1 counters on the enduring permanent) and a single N/N white Spirit `CreateTokenEffect`
+  (no fake keyword — endure is always the effect of a triggered/activated ability, resolved at resolution time). `amount`
+  is `DynamicAmount.Fixed` for "endure 2" or any dynamic value for "endure X" (e.g. Warden of the Grove reads
+  `EntityProperty(Source, CounterCount(...))`); `target` defaults to `Self` ("it endures") but takes
+  `EffectTarget.TriggeringEntity` when a card endures the creature that triggered it.
 - **Forage** — `EffectPatterns.forage`; cast-from-graveyard permissions need a branch in `CastSpellHandler.validate`.
 - **Blight X** — `AdditionalCost.BlightVariable` + `DynamicAmount.AdditionalCostBlightAmount` +
   `Conditions.BlightWasPaid(n)`.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EndureScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EndureScenarioTest.kt
@@ -1,0 +1,172 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for the **Endure N** keyword action (Tarkir: Dragonstorm).
+ *
+ * "Endure N" — the enduring permanent's controller chooses one: put N +1/+1
+ * counters on it, or create an N/N white Spirit creature token. Implemented as
+ * `Effects.Endure(amount, target)` composing a [com.wingedsheep.sdk.scripting.effects.ModalEffect].
+ *
+ * These cover every branch of the mechanic:
+ * - counter mode + token mode (the binary choice),
+ * - fixed N (ETB endure) and dynamic N (Warden's "endure X = counters on me"),
+ * - self target ("it endures") and triggering-entity target (Warden endures the
+ *   creature that entered),
+ * - a non-ETB trigger source (Anafenza's "another creature dies").
+ */
+class EndureScenarioTest : ScenarioTestBase() {
+
+    /** Resolve a pending Endure modal decision, picking the counter or token mode. */
+    private fun ScenarioTestBase.TestGame.resolveEndure(chooseToken: Boolean) {
+        val decision = getPendingDecision()
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val keyword = if (chooseToken) "token" else "counter"
+        val index = decision.options.indexOfFirst { it.contains(keyword, ignoreCase = true) }
+        withClue("Endure should offer a '$keyword' mode among ${decision.options}") {
+            (index >= 0) shouldBe true
+        }
+        submitDecision(OptionChosenResponse(decision.id, index))
+        resolveStack()
+    }
+
+    private fun ScenarioTestBase.TestGame.plusOneCounters(name: String): Int =
+        state.getEntity(findPermanent(name)!!)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Endure as an enters-the-battlefield trigger") {
+
+            test("counter mode puts N +1/+1 counters on the enduring creature") {
+                // Fortress Kin-Guard ({1}{W}, 1/2): "When this creature enters, it endures 1."
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Fortress Kin-Guard")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Fortress Kin-Guard").error shouldBe null
+                game.resolveStack()
+                game.resolveEndure(chooseToken = false)
+
+                withClue("Fortress Kin-Guard should have endured into a 2/3 (one +1/+1 counter)") {
+                    game.plusOneCounters("Fortress Kin-Guard") shouldBe 1
+                }
+                withClue("Choosing counters should not create a Spirit token") {
+                    game.findPermanent("Spirit Token") shouldBe null
+                }
+            }
+
+            test("token mode creates a single N/N white Spirit token") {
+                // Dusyut Earthcarver ({5}{G}, 4/4): "When this creature enters, it endures 3."
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dusyut Earthcarver")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Dusyut Earthcarver").error shouldBe null
+                game.resolveStack()
+                game.resolveEndure(chooseToken = true)
+
+                val tokenId = game.findPermanent("Spirit Token")
+                withClue("Choosing the token mode should create a Spirit token") {
+                    tokenId.shouldNotBeNull()
+                }
+                val token = game.state.getEntity(tokenId!!)!!.get<CardComponent>()!!
+                withClue("The Spirit token should be a 3/3 (N = 3)") {
+                    token.baseStats?.basePower shouldBe 3
+                    token.baseStats?.baseToughness shouldBe 3
+                }
+                withClue("The Spirit token should be white") {
+                    token.colors shouldBe setOf(Color.WHITE)
+                }
+                withClue("Choosing the token should not put counters on Dusyut Earthcarver") {
+                    game.plusOneCounters("Dusyut Earthcarver") shouldBe 0
+                }
+            }
+        }
+
+        context("Endure with a dynamic amount on the triggering creature") {
+
+            test("Warden of the Grove endures the entering creature for X = its own counters") {
+                // Warden ({2}{G}, 2/2): "Whenever another nontoken creature you control enters,
+                // it endures X, where X is the number of counters on this creature."
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Warden of the Grove")
+                    .withCardInHand(1, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Give Warden two +1/+1 counters so X resolves to 2.
+                val warden = game.findPermanent("Warden of the Grove")!!
+                game.state = game.state.updateEntity(warden) {
+                    it.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, 2))
+                }
+
+                game.castSpell(1, "Glory Seeker").error shouldBe null
+                game.resolveStack()
+                game.resolveEndure(chooseToken = false)
+
+                withClue("The entering Glory Seeker should endure 2 (Warden's counter count)") {
+                    game.plusOneCounters("Glory Seeker") shouldBe 2
+                }
+                withClue("Warden itself should be untouched by enduring the other creature") {
+                    game.plusOneCounters("Warden of the Grove") shouldBe 2
+                }
+            }
+        }
+
+        context("Endure from a death trigger") {
+
+            test("Anafenza endures when another nontoken creature you control dies") {
+                // Anafenza, Unyielding Lineage ({2}{W}, 2/2): "Whenever another nontoken
+                // creature you control dies, Anafenza endures 2."
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Anafenza, Unyielding Lineage")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2 — Shock kills it
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glorySeeker = game.findPermanent("Glory Seeker")!!
+                game.castSpell(1, "Shock", glorySeeker).error shouldBe null
+                game.resolveStack()
+
+                withClue("Glory Seeker should have died to Shock") {
+                    game.isOnBattlefield("Glory Seeker") shouldBe false
+                }
+
+                game.resolveEndure(chooseToken = false)
+
+                withClue("Anafenza should have endured 2 (two +1/+1 counters)") {
+                    game.plusOneCounters("Anafenza, Unyielding Lineage") shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -117,6 +117,8 @@ import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfEquippedCreatureEf
 import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfSourceEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
 import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
 import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
 import com.wingedsheep.sdk.scripting.effects.CreateRoleTokenEffect
@@ -2156,6 +2158,54 @@ object Effects {
             GrantTriggeredAbilityEffect(returnTapped, target, Duration.Permanent),
         ))
     }
+
+    /**
+     * Endure N (Tarkir: Dragonstorm keyword action) — the enduring permanent's
+     * controller chooses one: put N +1/+1 counters on the enduring permanent,
+     * or create an N/N white Spirit creature token.
+     *
+     * Modeled as data — no new keyword. "Endure N" never appears in a card's
+     * keyword line; it is always the effect of a triggered or activated ability
+     * ("Whenever this attacks, endure 2"), so it composes a
+     * [ModalEffect.chooseOne] of the two existing halves: an
+     * [AddDynamicCountersEffect] on the enduring permanent and a single N/N
+     * white Spirit [CreateTokenEffect]. The mode choice is made by the ability's
+     * controller at resolution time (the modal executor's resolution-time path).
+     *
+     * @param amount N — [DynamicAmount.Fixed] for "endure 2",
+     *   [DynamicAmount.XValue] for "endures X" (Krumar Initiate), or any other
+     *   dynamic value (Warden of the Grove endures "the number of counters on
+     *   this creature").
+     * @param target the permanent that endures. Defaults to [EffectTarget.Self]
+     *   ("it"/"this creature endures"); cards like Warden of the Grove endure the
+     *   triggering creature, so pass [EffectTarget.TriggeringEntity].
+     */
+    fun Endure(
+        amount: DynamicAmount,
+        target: EffectTarget = EffectTarget.Self
+    ): Effect = ModalEffect.chooseOne(
+        Mode.noTarget(
+            AddDynamicCountersEffect(Counters.PLUS_ONE_PLUS_ONE, amount, target),
+            "Put ${amount.description} +1/+1 counter(s) on ${target.description}"
+        ),
+        Mode.noTarget(
+            CreateTokenEffect(
+                count = DynamicAmount.Fixed(1),
+                power = 0,
+                toughness = 0,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Spirit"),
+                dynamicPower = amount,
+                dynamicToughness = amount
+            ),
+            "Create a ${amount.description}/${amount.description} white Spirit creature token"
+        ),
+        countsAsModalSpell = false
+    )
+
+    /** Endure N with a fixed [amount] — sugar for `Endure(DynamicAmount.Fixed(amount), target)`. */
+    fun Endure(amount: Int, target: EffectTarget = EffectTarget.Self): Effect =
+        Endure(DynamicAmount.Fixed(amount), target)
 
     /**
      * Target permanent becomes a creature with specified characteristics.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AnafenzaUnyieldingLineage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AnafenzaUnyieldingLineage.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+
+/**
+ * Anafenza, Unyielding Lineage — Tarkir: Dragonstorm #2
+ * {2}{W} · Legendary Creature — Spirit Soldier · 2/2
+ *
+ * Flash
+ * First strike
+ * Whenever another nontoken creature you control dies, Anafenza endures 2.
+ * (Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)
+ */
+val AnafenzaUnyieldingLineage = card("Anafenza, Unyielding Lineage") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Spirit Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Flash\n" +
+        "First strike\n" +
+        "Whenever another nontoken creature you control dies, Anafenza endures 2. " +
+        "(Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)"
+
+    keywords(Keyword.FLASH, Keyword.FIRST_STRIKE)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter(
+                    cardPredicates = listOf(CardPredicate.IsCreature, CardPredicate.IsNontoken),
+                    controllerPredicate = ControllerPredicate.ControlledByYou
+                ),
+                from = Zone.BATTLEFIELD,
+                to = Zone.GRAVEYARD
+            ),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.Endure(2)
+        description = "Whenever another nontoken creature you control dies, Anafenza endures 2."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "2"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/29957f49-9a6b-42f6-b2fb-b48f653ab725.jpg?1743203958"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DescendantOfStorms.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DescendantOfStorms.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+
+/**
+ * Descendant of Storms — Tarkir: Dragonstorm #8
+ * {W} · Creature — Human Soldier · 2/1
+ *
+ * Whenever this creature attacks, you may pay {1}{W}. If you do, it endures 1.
+ * (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)
+ *
+ * The "you may pay {1}{W}" gate is an [OptionalCostEffect] (same shape as
+ * Zoraline, Cosmos Caller): if the mana is paid, the Endure 1 effect runs.
+ */
+val DescendantOfStorms = card("Descendant of Storms") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever this creature attacks, you may pay {1}{W}. If you do, it endures 1. " +
+        "(Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = OptionalCostEffect(
+            cost = PayManaCostEffect(ManaCost.parse("{1}{W}")),
+            ifPaid = Effects.Endure(1)
+        )
+        description = "Whenever this creature attacks, you may pay {1}{W}. If you do, it endures 1."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "8"
+        artist = "Lie Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f632be90-9e7f-41f8-a52e-a2952354d730.jpg?1743203984"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DusyutEarthcarver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DusyutEarthcarver.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dusyut Earthcarver — Tarkir: Dragonstorm #141
+ * {5}{G} · Creature — Elephant Druid · 4/4
+ *
+ * Reach
+ * When this creature enters, it endures 3. (Put three +1/+1 counters on it or
+ * create a 3/3 white Spirit creature token.)
+ */
+val DusyutEarthcarver = card("Dusyut Earthcarver") {
+    manaCost = "{5}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elephant Druid"
+    power = 4
+    toughness = 4
+    oracleText = "Reach\n" +
+        "When this creature enters, it endures 3. " +
+        "(Put three +1/+1 counters on it or create a 3/3 white Spirit creature token.)"
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Endure(3)
+        description = "When this creature enters, it endures 3."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "141"
+        artist = "Andrea Piparo"
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b98ecc96-f557-479a-8685-2b5487d5b407.jpg?1743204529"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FortressKinGuard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FortressKinGuard.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fortress Kin-Guard — Tarkir: Dragonstorm #12
+ * {1}{W} · Creature — Dog Soldier · 1/2
+ *
+ * When this creature enters, it endures 1. (Put a +1/+1 counter on it or
+ * create a 1/1 white Spirit creature token.)
+ */
+val FortressKinGuard = card("Fortress Kin-Guard") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog Soldier"
+    power = 1
+    toughness = 2
+    oracleText = "When this creature enters, it endures 1. " +
+        "(Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Endure(1)
+        description = "When this creature enters, it endures 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Daneen Wilkerson"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b647a018-1d70-43a1-a265-928bcd863689.jpg?1743204000"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/InspiritedVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/InspiritedVanguard.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspirited Vanguard — Tarkir: Dragonstorm #146
+ * {4}{G} · Creature — Human Soldier · 3/2
+ *
+ * Whenever this creature enters or attacks, it endures 2. (Put two +1/+1
+ * counters on it or create a 2/2 white Spirit creature token.)
+ *
+ * Modeled as the standard "enters or attacks" pair of triggers (see
+ * Sentinel of the Nameless City), each running the same Endure 2 effect.
+ */
+val InspiritedVanguard = card("Inspirited Vanguard") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever this creature enters or attacks, it endures 2. " +
+        "(Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Endure(2)
+        description = "Whenever this creature enters, it endures 2."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Endure(2)
+        description = "Whenever this creature attacks, it endures 2."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "146"
+        artist = "Carlos Palma Cruchaga"
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c642d6ac-f0f0-4b4c-a7ee-50631531f6d1.jpg?1743204549"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KinTreeNurturer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KinTreeNurturer.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kin-Tree Nurturer — Tarkir: Dragonstorm #83
+ * {2}{B} · Creature — Human Druid · 2/1
+ *
+ * Lifelink
+ * When this creature enters, it endures 1. (Put a +1/+1 counter on it or
+ * create a 1/1 white Spirit creature token.)
+ */
+val KinTreeNurturer = card("Kin-Tree Nurturer") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Druid"
+    power = 2
+    toughness = 1
+    oracleText = "Lifelink\n" +
+        "When this creature enters, it endures 1. " +
+        "(Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)"
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Endure(1)
+        description = "When this creature enters, it endures 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "83"
+        artist = "Loïc Canavaggia"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/2177ef64-28bf-4acf-b1f1-c1408f03c411.jpg?1743204295"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SandskitterOutrider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SandskitterOutrider.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sandskitter Outrider — Tarkir: Dragonstorm #89
+ * {3}{B} · Creature — Goblin Soldier · 2/1
+ *
+ * Menace
+ * When this creature enters, it endures 2. (Put two +1/+1 counters on it or
+ * create a 2/2 white Spirit creature token.)
+ */
+val SandskitterOutrider = card("Sandskitter Outrider") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "Menace\n" +
+        "When this creature enters, it endures 2. " +
+        "(Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)"
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Endure(2)
+        description = "When this creature enters, it endures 2."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Arif Wijaya"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c4bfebe-f10f-44bd-9368-33e273ba5a55.jpg?1743204318"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SinkholeSurveyor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SinkholeSurveyor.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sinkhole Surveyor — Tarkir: Dragonstorm #93
+ * {1}{B} · Creature — Bird Scout · 1/3
+ *
+ * Flying
+ * Whenever this creature attacks, you lose 1 life and this creature endures 1.
+ * (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)
+ */
+val SinkholeSurveyor = card("Sinkhole Surveyor") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bird Scout"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever this creature attacks, you lose 1 life and this creature endures 1. " +
+        "(Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = CompositeEffect(
+            listOf(
+                Effects.LoseLife(1, EffectTarget.Controller),
+                Effects.Endure(1)
+            )
+        )
+        description = "Whenever this creature attacks, you lose 1 life and this creature endures 1."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "93"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/37cb5599-7d2c-48e9-978b-902a01a74bde.jpg?1743204333"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WardenOfTheGrove.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WardenOfTheGrove.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Warden of the Grove — Tarkir: Dragonstorm #166
+ * {2}{G} · Creature — Hydra · 2/2
+ *
+ * At the beginning of your end step, put a +1/+1 counter on this creature.
+ * Whenever another nontoken creature you control enters, it endures X, where X
+ * is the number of counters on this creature. (Put X +1/+1 counters on the
+ * creature that entered or create an X/X white Spirit creature token.)
+ *
+ * The second ability endures the *entering* creature ([EffectTarget.TriggeringEntity]),
+ * not Warden itself, with N read dynamically as the number of counters on Warden
+ * ([DynamicAmount.EntityProperty] of [EntityReference.Source]).
+ */
+val WardenOfTheGrove = card("Warden of the Grove") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Hydra"
+    power = 2
+    toughness = 2
+    oracleText = "At the beginning of your end step, put a +1/+1 counter on this creature.\n" +
+        "Whenever another nontoken creature you control enters, it endures X, where X is the number of counters on this creature. " +
+        "(Put X +1/+1 counters on the creature that entered or create an X/X white Spirit creature token.)"
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "At the beginning of your end step, put a +1/+1 counter on this creature."
+    }
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter(
+                    cardPredicates = listOf(CardPredicate.IsCreature, CardPredicate.IsNontoken),
+                    controllerPredicate = ControllerPredicate.ControlledByYou
+                ),
+                to = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.Endure(
+            amount = DynamicAmount.EntityProperty(
+                EntityReference.Source,
+                EntityNumericProperty.CounterCount(CounterTypeFilter.Any)
+            ),
+            target = EffectTarget.TriggeringEntity
+        )
+        description = "Whenever another nontoken creature you control enters, it endures X, " +
+            "where X is the number of counters on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "166"
+        artist = "Alexander Ostrowski"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/2414db96-0e2b-4f7c-9b97-41f8e310b752.jpg?1743697653"
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **Endure N** clan keyword from `backlog/tdm-engine-gaps.md` (Tier 1, Abzan) plus 9 of the 10 Endure cards.

Endure N is a keyword *action*: the enduring permanent's controller chooses one — **put N +1/+1 counters on it**, or **create an N/N white Spirit creature token**.

## Approach

`Effects.Endure(amount, target = EffectTarget.Self)` composes a `ModalEffect.chooseOne` of `AddDynamicCountersEffect` + a single N/N white Spirit `CreateTokenEffect`. Following the **Earthbend** precedent, no fake `Keyword` enum entry is added — endure only ever appears as the effect of a triggered/activated ability, so the mode is picked at resolution time.

- `amount` is any `DynamicAmount` — `Fixed` for "endure 2", `EntityProperty(Source, CounterCount(...))` for Warden's "endure X".
- `target` defaults to `Self` ("it endures") but takes `TriggeringEntity` for cards that endure the creature that triggered them (Warden of the Grove).

No new engine subsystem — both halves and the modal/resolution-time-choice machinery already existed.

## Cards (TDM)

| Card | Endure wiring |
|------|---------------|
| Anafenza, Unyielding Lineage | flash, first strike; another nontoken creature you control dies → endure 2 |
| Descendant of Storms | attack trigger, may pay `{1}{W}` → endure 1 |
| Fortress Kin-Guard | ETB endure 1 |
| Kin-Tree Nurturer | lifelink; ETB endure 1 |
| Sandskitter Outrider | menace; ETB endure 2 |
| Sinkhole Surveyor | flying; attack → lose 1 life and endure 1 |
| Dusyut Earthcarver | reach; ETB endure 3 |
| Inspirited Vanguard | enters or attacks → endure 2 |
| Warden of the Grove | end-step +1/+1; another creature enters → it endures X (X = counters on Warden) |

TDM goes from 19 → 28 implemented.

## Deferred

**Krumar Initiate** (the 10th Endure card) is left out: its `{X}{B}, {T}, Pay X life` cost needs a dynamic "Pay X life" ability-cost primitive (`AbilityCost.PayLife` is fixed-`Int` only). That's orthogonal to the Endure keyword and belongs in its own change.

## Testing

`EndureScenarioTest` (all passing) covers every branch of the mechanic:
- counter mode and token mode (the binary choice),
- fixed N and dynamic N (Warden),
- self target and triggering-entity target,
- ETB and death-trigger sources.

`just test` equivalents run: `:game-server:test --tests EndureScenarioTest`, `:mtg-sdk:test`, `:mtg-sets:test` — all green. Updated `docs/card-sdk-language-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)