### PR TITLE
Add Renew keyword (Tarkir: Dragonstorm, Sultai)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1362,6 +1362,14 @@ composite abilities).
   triggered ability (gated by the same intervening-if) that removes a time counter. The engine places the N TIME counters
   when a spell cast for its impending cost resolves; casting for the normal mana cost adds no counters, so neither wiring
   fires (mirrors `prowess()` / `rampage()`).
+- `Renew(cost)` — `card { renew(cost) { effect = … } }` builder helper (Tarkir: Dragonstorm, Sultai clan keyword).
+  A graveyard-activated ability: "Renew — [cost], Exile this card from your graveyard: [effect]. Activate only as a
+  sorcery." The helper composes it entirely from existing primitives — `AbilityCost.Composite(Mana(cost), ExileSelf)`,
+  `activateFromZone = Zone.GRAVEYARD`, and `timing = TimingRule.SorcerySpeed` — so no new engine subsystem is involved.
+  The `renew { }` lambda configures the effect (and any targets via `target(name, requirement)`) exactly like
+  `activatedAbility { }`; its `cost`/`timing`/`activateFromZone` fields are ignored (fixed by Renew). The
+  `GraveyardAbilityEnumerator` surfaces the ability while the card is in the graveyard and only at sorcery speed; the
+  `ActivateAbilityHandler` pays the mana and exiles the card from the graveyard. Declares `Keyword.RENEW` for display.
 - `Morph(cost)` — cast face-down for `{3}`, flip for cost.
 - `Unmorph(cost, effect)` — turn-face-up cost + bonus effect.
 - `Equip(cost)` — Equipment attach cost.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RenewKeywordScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RenewKeywordScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * End-to-end scenario tests for the Renew keyword (Tarkir: Dragonstorm, Sultai).
+ *
+ * Renew is a graveyard-activated ability: "[cost], Exile this card from your graveyard:
+ * [effect]. Activate only as a sorcery." It is composed entirely from existing primitives —
+ * the mana cost plus [com.wingedsheep.sdk.scripting.AbilityCost.ExileSelf],
+ * `activateFromZone = GRAVEYARD`, and `timing = SorcerySpeed` — via the `renew(cost) { … }`
+ * DSL helper. These tests drive the full activate → pay → exile → resolve pipeline with an
+ * inline test card so we don't depend on any specific TDM card being implemented yet.
+ */
+class RenewKeywordScenarioTest : ScenarioTestBase() {
+
+    /** "Renew — {1}{G}, Exile this card from your graveyard: Draw a card. Activate only as a sorcery." */
+    private val renewingOoze = card("Renewing Ooze") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Ooze"
+        power = 2
+        toughness = 2
+        renew("{1}{G}") {
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    init {
+        cardRegistry.register(renewingOoze)
+
+        context("Renew — {1}{G}, Exile this card from your graveyard: Draw a card") {
+
+            test("activating from the graveyard at sorcery speed draws a card and exiles the card as a cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Renewing Ooze")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Two green covers {1}{G}: one green pays the colored pip, one pays the generic.
+                game.state = game.state.updateEntity(game.player1Id) { c ->
+                    c.with(ManaPoolComponent(green = 2))
+                }
+
+                val oozeId = game.findCardsInGraveyard(1, "Renewing Ooze").single()
+                val ability = cardRegistry.getCard("Renewing Ooze")!!.script.activatedAbilities[0]
+                val handBefore = game.handSize(1)
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = oozeId, abilityId = ability.id)
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Renew's effect resolved — drew a card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+                withClue("Card left the graveyard") {
+                    game.isInGraveyard(1, "Renewing Ooze") shouldBe false
+                }
+                withClue("Card was exiled as part of the cost") {
+                    game.state.getExile(game.player1Id).contains(oozeId) shouldBe true
+                }
+            }
+
+            test("renew is not offered as a legal action during the upkeep (\"only as a sorcery\")") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Renewing Ooze")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                    .build()
+
+                val oozeId = game.findCardsInGraveyard(1, "Renewing Ooze").single()
+                val enumerator = LegalActionEnumerator.create(cardRegistry)
+                val renewActions = enumerator.enumerate(game.state, game.player1Id)
+                    .filter { it.action is ActivateAbility && (it.action as ActivateAbility).sourceId == oozeId }
+
+                withClue("Renew must not be activatable at upkeep") {
+                    renewActions shouldBe emptyList()
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -128,6 +128,17 @@ enum class Keyword(val displayName: String) {
     PERSIST("Persist"),
 
     /**
+     * Renew (Tarkir: Dragonstorm, Sultai clan keyword).
+     * "Renew — [cost], Exile this card from your graveyard: [effect]. Activate only as a sorcery."
+     *
+     * A graveyard-activated ability composed of existing primitives: the mana cost plus
+     * [com.wingedsheep.sdk.scripting.AbilityCost.ExileSelf], `activateFromZone = GRAVEYARD`,
+     * and `timing = SorcerySpeed`. Wired in one call via the `renew(cost) { … }` helper on
+     * [com.wingedsheep.sdk.dsl.CardBuilder]; the keyword itself is display-only.
+     */
+    RENEW("Renew"),
+
+    /**
      * Ascend (Ixalan, CR 702.131). On a permanent spell, means "When this permanent
      * enters, if you control ten or more permanents, you get the city's blessing
      * for the rest of the game." Engine wires the trigger explicitly per card; the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -463,6 +463,46 @@ class CardBuilder(private val name: String) {
     }
 
     /**
+     * Add Renew (Tarkir: Dragonstorm, Sultai clan keyword).
+     *
+     * "Renew — [cost], Exile this card from your graveyard: [effect]. Activate only as a sorcery."
+     *
+     * Renew is a graveyard-activated ability. This helper composes it from existing primitives —
+     * no new engine subsystem is involved:
+     *  - the cost is the given mana [cost] plus [AbilityCost.ExileSelf] (the card exiles itself
+     *    from the graveyard as part of the cost),
+     *  - `activateFromZone = Zone.GRAVEYARD` so the engine's GraveyardAbilityEnumerator surfaces it
+     *    while the card sits in the graveyard, and
+     *  - `timing = TimingRule.SorcerySpeed` to enforce "Activate only as a sorcery".
+     *
+     * The [init] lambda configures the effect (and any targets) exactly like [activatedAbility];
+     * its `cost`, `timing`, and `activateFromZone` fields are ignored — those are fixed by Renew.
+     *
+     * ```kotlin
+     * renew("{2}{G}") {
+     *     effect = Effects.PutCounters(Counters.PLUS_ONE_PLUS_ONE, 1, target("creature", Targets.Creature))
+     * }
+     * ```
+     */
+    fun renew(cost: String, init: ActivatedAbilityBuilder.() -> Unit) {
+        val builder = ActivatedAbilityBuilder().apply(init)
+        val renewEffect = requireNotNull(builder.effect) { "renew requires an effect" }
+        activatedAbilities.add(
+            ActivatedAbility(
+                cost = AbilityCost.Composite(listOf(AbilityCost.Mana(ManaCost.parse(cost)), AbilityCost.ExileSelf)),
+                effect = renewEffect,
+                targetRequirements = builder.targetRequirements,
+                timing = TimingRule.SorcerySpeed,
+                restrictions = builder.restrictions,
+                activateFromZone = Zone.GRAVEYARD,
+                descriptionOverride = "Renew — $cost, Exile this card from your graveyard: " +
+                    "${renewEffect.description} Activate only as a sorcery."
+            )
+        )
+        keywordSet.add(Keyword.RENEW)
+    }
+
+    /**
      * Add a parameterized keyword ability.
      * Examples: ward {2}, protection from blue, annihilator 2
      */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/GraveyardAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/GraveyardAbilityEnumerator.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.TimingRule
 
 /**
  * Enumerates activated abilities on cards in the player's graveyard.
@@ -38,6 +39,12 @@ class GraveyardAbilityEnumerator : ActionEnumerator {
             }
 
             for (ability in graveyardAbilities) {
+                // "Activate only as a sorcery" — Renew and similar graveyard-activated abilities
+                // are gated to sorcery timing. Mirrors ActivatedAbilityEnumerator's battlefield
+                // check so the action is never offered at instant speed (where the handler would
+                // reject it anyway).
+                if (ability.timing == TimingRule.SorcerySpeed && !context.canPlaySorcerySpeed) continue
+
                 // Check activation restrictions
                 var restrictionsMet = true
                 for (restriction in ability.restrictions) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/RenewKeywordEnumerationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/RenewKeywordEnumerationTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.engine.legalactions.support.setupP1
+import com.wingedsheep.engine.legalactions.support.shouldContainActivatedAbilityOn
+import com.wingedsheep.engine.legalactions.support.shouldNotContainActivatedAbilityOn
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Enumeration tests for the Renew keyword (Tarkir: Dragonstorm, Sultai).
+ *
+ * Renew composes a graveyard-activated ability: "[cost], Exile this card from your
+ * graveyard: [effect]. Activate only as a sorcery." The `renew(cost) { … }` DSL helper
+ * fixes `activateFromZone = GRAVEYARD` and `timing = SorcerySpeed`; the
+ * [enumerators.GraveyardAbilityEnumerator] must surface it only at sorcery speed.
+ *
+ * These tests assert the sorcery-timing gate (the engine change) and the standard
+ * cost-affordability `continue`.
+ */
+class RenewKeywordEnumerationTest : FunSpec({
+
+    /** A {1}{G} 2/2 creature with "Renew — {1}{G}, Exile this card from your graveyard: Draw a card." */
+    val renewingOoze = card("Renewing Ooze") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Ooze"
+        power = 2
+        toughness = 2
+        renew("{1}{G}") {
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    fun entityInGraveyard(driver: com.wingedsheep.engine.legalactions.support.EnumerationTestDriver, name: String): EntityId {
+        val state = driver.game.state
+        return state.getGraveyard(driver.player1).first { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+    }
+
+    test("at precombat main with mana — renew ability is enumerated from the graveyard") {
+        val driver = setupP1(
+            battlefield = listOf("Forest", "Forest"),
+            graveyard = listOf("Renewing Ooze"),
+            extraSetCards = listOf(renewingOoze),
+            atStep = Step.PRECOMBAT_MAIN
+        )
+        val oozeId = entityInGraveyard(driver, "Renewing Ooze")
+
+        val view = driver.enumerateFor(driver.player1)
+        view shouldContainActivatedAbilityOn oozeId
+        val abilities = view.activatedAbilityActionsFor(oozeId)
+        abilities shouldHaveSize 1
+        abilities.single().description.shouldContain("Renew")
+    }
+
+    test("at upkeep — NOT enumerated (\"Activate only as a sorcery\" gate)") {
+        val driver = setupP1(
+            battlefield = listOf("Forest", "Forest"),
+            graveyard = listOf("Renewing Ooze"),
+            extraSetCards = listOf(renewingOoze),
+            atStep = Step.UPKEEP
+        )
+        val oozeId = entityInGraveyard(driver, "Renewing Ooze")
+
+        driver.enumerateFor(driver.player1) shouldNotContainActivatedAbilityOn oozeId
+    }
+
+    test("at precombat main with insufficient mana — NOT enumerated (cost unpayable)") {
+        val driver = setupP1(
+            battlefield = listOf("Forest"), // only one source; renew costs {1}{G}
+            graveyard = listOf("Renewing Ooze"),
+            extraSetCards = listOf(renewingOoze),
+            atStep = Step.PRECOMBAT_MAIN
+        )
+        val oozeId = entityInGraveyard(driver, "Renewing Ooze")
+
+        driver.enumerateFor(driver.player1) shouldNotContainActivatedAbilityOn oozeId
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Renew** from the TDM engine-gap backlog (`backlog/tdm-engine-gaps.md`, Tier 1 #4):

> Renew — [cost], Exile this card from your graveyard: [effect]. Activate only as a sorcery.

This is the Sultai clan keyword and unlocks ~12 TDM cards (Qarsi Revenant, Sage of the Fang, Kheru Goldkeeper, Naga Fleshcrafter, Lasyd Prowler, …).

## What was already there

The engine already had every building block: a per-ability `activateFromZone = GRAVEYARD` field, the `AbilityCost.ExileSelf` cost (whose payment moves the card to exile from wherever it lives), the `GraveyardAbilityEnumerator`, and the sorcery-timing gate in `ActivateAbilityHandler`. So Renew is composed, not bolted on.

## The one real gap

`GraveyardAbilityEnumerator` never honored `timing == SorcerySpeed`, so a renew-style ability would have been *offered* at instant speed (the handler would then reject it). Fixed to mirror `ActivatedAbilityEnumerator`'s existing sorcery gate.

## Changes

- **`Keyword.RENEW`** — display-only keyword enum entry.
- **`CardBuilder.renew(cost) { effect = … }`** — one-call DSL helper that composes the activated ability from existing primitives (`Composite[Mana, ExileSelf]` + `GRAVEYARD` zone + `SorcerySpeed` timing) and registers the keyword. No new `Effect` type or executor — follows the "compose, don't add params" guidance.
- **`GraveyardAbilityEnumerator`** — skips sorcery-speed abilities when the player can't act at sorcery speed.
- **Docs** — `card-sdk-language-reference.md` entry for `renew`.

## Tests

- `RenewKeywordEnumerationTest` (rules-engine) — renew surfaces at sorcery speed, is gated out at upkeep, and respects cost affordability.
- `RenewKeywordScenarioTest` (game-server) — full activate → pay mana → exile-from-graveyard → resolve-effect pipeline, plus a negative legal-action check at upkeep. Uses an inline test card so it doesn't depend on any specific TDM card being implemented yet.

All new tests pass; existing `GraveyardAbilityEnumeratorTest` and `:mtg-sdk:test` remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)