### PR TITLE
Add Flurry keyword (Tarkir: Dragonstorm) with seven Jeskai cards

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -61,11 +61,17 @@ majority of the set.
    keyword + the binary choice prompt (and the dynamic N path for "endure X").
    → Anafenza Unyielding Lineage, Descendant of Storms, Inspirited Vanguard, Krumar Initiate, …
 
-3. **Flurry** (Jeskai, 10 cards) — "Whenever you cast your **second** spell each turn, …" The
-   `spellsCastThisTurnByPlayer` tracker already exists (powers `YouCastSpellsThisTurn`), but there
-   is **no trigger that fires specifically on the 2nd cast of the turn.** Needs a new trigger type.
-   → Cori Mountain Stalwart, A-Cori-Steel Cutter, Narset Jeskai Waymaster, Voice of Victory-adjacent,
-     Taigam Master Opportunist (see Tier 3), …
+3. **Flurry** (Jeskai, 10 cards) — ✅ **DONE.** "Whenever you cast your **second** spell each turn, …"
+   The `GameEvent.NthSpellCastEvent` trigger already fired on the Nth cast of the turn (it powers the
+   EOE/BLB second-spell cards), so no new trigger type was needed — the gap note above was stale. Added
+   the display-only `Keyword.FLURRY` plus a `card { flurry { … } }` builder helper (mirrors
+   `prowess()` / `rampage()`) that forces `Triggers.NthSpellCast(2, Player.You)` and prefixes the
+   "Flurry — Whenever you cast your second spell each turn," reminder text.
+   Implemented: Cori Mountain Stalwart, Devoted Duelist, Jeskai Devotee, Poised Practitioner,
+   Wingblade Disciple, Wayspeaker Bodyguard, Equilibrium Adept.
+   Still blocked elsewhere: **Taigam, Master Opportunist** (needs Suspend, Tier 3 §14),
+   **Cori-Steel Cutter** + **A-Cori-Steel Cutter** (need "create a token, then attach this Equipment
+   to it" from a trigger — deferred).
 
 4. **Renew** (Sultai, 12 cards) — graveyard-activated ability:
    `{cost}, Exile this card from your graveyard: <effect>. Activate only as a sorcery.`

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1320,7 +1320,7 @@ activatedAbility {
 
 Flying, Menace, Intimidate, Fear, Shadow, Horsemanship, all landwalks (Plainswalk … Forestwalk), First Strike, Double
 Strike, Trample, Deathtouch, Lifelink, Vigilance, Reach, Provoke, Flanking, Defender, Indestructible, Hexproof, Shroud, Haste,
-Flash, Prowess, Changeling, Convoke, Delve, Affinity, Storm, Flashback, Evoke, Impending, Conspire, Hideaway, Cascade, Plot,
+Flash, Prowess, Flurry, Changeling, Convoke, Delve, Affinity, Storm, Flashback, Evoke, Impending, Conspire, Hideaway, Cascade, Plot,
 Offspring, Persist, Ascend, Wither, Toxic, Eerie, Vivid, Fateful Bite, … (display-only — engine effect lives in handlers or
 composite abilities).
 
@@ -1339,6 +1339,13 @@ composite abilities).
 - `Rampage(n)` — +N/+N for each blocker past the first. Display-only; wire the behavior with the
   `card { rampage(n) }` builder helper, which adds this keyword ability plus a "becomes blocked"
   triggered ability granting `+n/+n × (blockers − 1)` until end of turn (mirrors `prowess()`).
+- `Flurry` (Tarkir: Dragonstorm, Jeskai) — "Flurry — Whenever you cast your second spell each turn,
+  [effect]." Display-only `Keyword.FLURRY`; wire the behavior with the `card { flurry { … } }` builder
+  helper. Author the effect/target/optional inside the block exactly like `triggeredAbility { }` — the
+  helper forces the `Triggers.NthSpellCast(2, Player.You)` trigger, adds the FLURRY tag, and prefixes the
+  rendered text with "Flurry — Whenever you cast your second spell each turn," (mirrors `prowess()` /
+  `rampage()`). The second-spell-cast event is matched by `GameEvent.NthSpellCastEvent`; no new engine
+  subsystem is involved. Example: `flurry { effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent), damageSource = EffectTarget.Self) }`.
 - `Afflict(n)` — defender loses N when this becomes blocked.
 - `Crew(n)` — tap N power worth to animate a Vehicle.
 - `Modular(n)` — ETB with +1/+1 counters, transfer on death.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FlurryScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FlurryScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain as stringShouldContain
+
+/**
+ * Scenario tests for the Flurry keyword (Tarkir: Dragonstorm, Jeskai).
+ *
+ * "Flurry — Whenever you cast your second spell each turn, [effect]." The `flurry { }`
+ * DSL helper wires a triggered ability on the second-spell-cast event (n=2, you) plus a
+ * display-only [Keyword.FLURRY] tag. These tests exercise the trigger timing on
+ * Cori Mountain Stalwart, whose Flurry effect ("deal 2 damage to each opponent and gain
+ * 2 life") needs no player decisions, keeping the life accounting unambiguous.
+ */
+class FlurryScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Flurry — second-spell trigger") {
+
+            test("casting only the first spell does not trigger Flurry") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cori Mountain Stalwart")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shock = game.castSpellTargetingPlayer(1, "Shock", 2)
+                withClue("Shock should cast: ${shock.error}") { shock.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Only Shock resolved (2 damage) — Flurry must not have fired") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("Flurry's life gain must not have happened on the first spell") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+
+            test("casting a second spell triggers Flurry (2 damage to each opponent + gain 2 life)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cori Mountain Stalwart")
+                    .withCardInHand(1, "Shock")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // First spell of the turn — no Flurry yet.
+                val first = game.castSpellTargetingPlayer(1, "Shock", 2)
+                withClue("First Shock should cast: ${first.error}") { first.error shouldBe null }
+                game.resolveStack()
+                game.getLifeTotal(2) shouldBe 18
+                game.getLifeTotal(1) shouldBe 20
+
+                // Second spell — Flurry fires on the cast, resolving above the spell.
+                val second = game.castSpellTargetingPlayer(1, "Shock", 2)
+                withClue("Second Shock should cast: ${second.error}") { second.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Opponent: 18 − 2 (Flurry) − 2 (second Shock) = 14") {
+                    game.getLifeTotal(2) shouldBe 14
+                }
+                withClue("Controller gained 2 from Flurry — only Flurry gains life here") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+        }
+
+        context("Flurry — keyword + reminder text wiring") {
+
+            test("flurry helper tags FLURRY and prefixes the second-spell reminder text") {
+                val card = cardRegistry.getCard("Devoted Duelist")
+                    ?: error("Devoted Duelist not registered")
+
+                withClue("flurry { } adds the display-only FLURRY keyword") {
+                    card.keywords shouldContain Keyword.FLURRY
+                }
+
+                val flurryAbility = card.script.triggeredAbilities.single { ability ->
+                    ability.description.startsWith("Flurry —")
+                }
+                flurryAbility.description stringShouldContain
+                    "Flurry — Whenever you cast your second spell each turn,"
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -58,6 +58,15 @@ enum class Keyword(val displayName: String) {
 
     // ── Triggered/Static keyword abilities ───────────────────
     PROWESS("Prowess"),
+
+    /**
+     * Flurry (Tarkir: Dragonstorm, Jeskai). "Flurry — Whenever you cast your second spell
+     * each turn, [effect]." A display-only keyword tag; the behavior lives in a triggered
+     * ability on the [com.wingedsheep.sdk.scripting.GameEvent.NthSpellCastEvent] (n=2, you)
+     * event, wired by the `flurry { }` DSL helper on
+     * [com.wingedsheep.sdk.dsl.CardBuilder].
+     */
+    FLURRY("Flurry"),
     CHANGELING("Changeling"),
 
     // ── ETB modification ──────────────────────────────────────

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -21,6 +21,7 @@ import com.wingedsheep.sdk.scripting.effects.AttachEquipmentEffect
 import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetCreature
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -326,6 +327,45 @@ class CardBuilder(private val name: String) {
                     toughnessModifier = 1,
                     target = EffectTarget.Self
                 )
+            )
+        )
+    }
+
+    /**
+     * Add Flurry (Tarkir: Dragonstorm, Jeskai) — keyword tag + a "second spell each turn"
+     * triggered ability.
+     *
+     * "Flurry — Whenever you cast your second spell each turn, [effect]." The [Keyword.FLURRY]
+     * tag is display-only (the engine has no dedicated Flurry handler); the behavior lives
+     * entirely in the triggered ability wired here on the [Triggers.NthSpellCast] (n=2, you)
+     * event, which the [com.wingedsheep.sdk.scripting.GameEvent.NthSpellCastEvent] matcher
+     * already fires when its controller casts their second spell of the turn.
+     *
+     * Author the effect/target/optional inside the block exactly like [triggeredAbility]
+     * (the [TriggeredAbilityBuilder.trigger] is ignored — it is always forced to the
+     * second-spell trigger). This helper composes the rendered reminder text as
+     * "Flurry — Whenever you cast your second spell each turn, <effect>." A custom
+     * [TriggeredAbilityBuilder.description] replaces only the `<effect>` portion, keeping
+     * the "Flurry — Whenever you cast your second spell each turn," prefix.
+     */
+    fun flurry(init: TriggeredAbilityBuilder.() -> Unit) {
+        keywordSet.add(Keyword.FLURRY)
+        val builder = TriggeredAbilityBuilder()
+        builder.init()
+        builder.trigger = Triggers.NthSpellCast(2, Player.You)
+        val ability = builder.build()
+        val effectText = (builder.description ?: buildString {
+            if (ability.optional) append("you may ")
+            ability.targetRequirement?.let { append(it.description); append(" ") }
+            append(ability.effect.description.replaceFirstChar { it.lowercase() })
+            ability.elseEffect?.let {
+                append(". If you don't, ")
+                append(it.description.replaceFirstChar { c -> c.lowercase() })
+            }
+        }).trimEnd().trimEnd('.')
+        triggeredAbilities.add(
+            ability.copy(
+                descriptionOverride = "Flurry — Whenever you cast your second spell each turn, $effectText."
             )
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CoriMountainStalwart.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CoriMountainStalwart.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cori Mountain Stalwart
+ * {1}{R}{W}
+ * Creature — Human Monk
+ * 3/3
+ *
+ * Flurry — Whenever you cast your second spell each turn, this creature deals 2 damage
+ * to each opponent and you gain 2 life.
+ */
+val CoriMountainStalwart = card("Cori Mountain Stalwart") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Monk"
+    power = 3
+    toughness = 3
+    oracleText = "Flurry — Whenever you cast your second spell each turn, this creature deals 2 damage to each opponent and you gain 2 life."
+
+    flurry {
+        effect = Effects.DealDamage(2, EffectTarget.PlayerRef(Player.EachOpponent), damageSource = EffectTarget.Self)
+            .then(Effects.GainLife(2))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "175"
+        artist = "Josiah \"Jo\" Cameron"
+        flavorText = "Zhao had resolved to hold the bridge, defending the village behind him. But the villagers decided Zhao would not stand alone."
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6cbf54e-f30e-4e7b-b17c-217fa424971c.jpg?1743204677"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DevotedDuelist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DevotedDuelist.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Devoted Duelist
+ * {1}{R}
+ * Creature — Goblin Monk
+ * 2/1
+ *
+ * Haste
+ * Flurry — Whenever you cast your second spell each turn, this creature deals 1 damage
+ * to each opponent.
+ */
+val DevotedDuelist = card("Devoted Duelist") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Monk"
+    power = 2
+    toughness = 1
+    oracleText = "Haste\nFlurry — Whenever you cast your second spell each turn, this creature deals 1 damage to each opponent."
+
+    keywords(Keyword.HASTE)
+
+    flurry {
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent), damageSource = EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "104"
+        artist = "Nathaniel Himawan"
+        flavorText = "\"Arrows? Ha! Wood and feather? Toys!\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbf9c673-37b4-48ed-a9ea-13f8e3e6c47b.jpg?1743204378"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/EquilibriumAdept.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/EquilibriumAdept.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Equilibrium Adept
+ * {3}{R}
+ * Creature — Dog Monk
+ * 2/4
+ *
+ * When this creature enters, exile the top card of your library. Until the end of your
+ * next turn, you may play that card.
+ * Flurry — Whenever you cast your second spell each turn, this creature gains double
+ * strike until end of turn.
+ */
+val EquilibriumAdept = card("Equilibrium Adept") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dog Monk"
+    power = 2
+    toughness = 4
+    oracleText = "When this creature enters, exile the top card of your library. Until the end of your next turn, you may play that card.\nFlurry — Whenever you cast your second spell each turn, this creature gains double strike until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CompositeEffect(listOf(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                storeAs = "exiledCard"
+            ),
+            MoveCollectionEffect(
+                from = "exiledCard",
+                destination = CardDestination.ToZone(Zone.EXILE)
+            ),
+            GrantMayPlayFromExileEffect("exiledCard", MayPlayExpiry.UntilEndOfNextTurn)
+        ))
+    }
+
+    flurry {
+        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.Self, Duration.EndOfTurn)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "106"
+        artist = "Leroy Steinmann"
+        flavorText = "He regained balance while his opponent regained consciousness."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4ba6d74-c6be-4a5e-8859-b791bb6b8f51.jpg?1743204387"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiDevotee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiDevotee.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Jeskai Devotee
+ * {1}{R}
+ * Creature — Orc Monk
+ * 2/2
+ *
+ * Flurry — Whenever you cast your second spell each turn, this creature gets +1/+1
+ * until end of turn.
+ * {1}: Add {U}, {R}, or {W}. Activate only once each turn.
+ */
+val JeskaiDevotee = card("Jeskai Devotee") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Orc Monk"
+    power = 2
+    toughness = 2
+    oracleText = "Flurry — Whenever you cast your second spell each turn, this creature gets +1/+1 until end of turn.\n{1}: Add {U}, {R}, or {W}. Activate only once each turn."
+
+    flurry {
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        manaAbility = true
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+        effect = Effects.AddManaOfChoice(
+            ManaColorSet.Specific(setOf(Color.BLUE, Color.RED, Color.WHITE))
+        )
+        description = "{1}: Add {U}, {R}, or {W}. Activate only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "110"
+        artist = "Xavier Ribeiro"
+        flavorText = "A master of the Whirling Blade technique, he did not hesitate to leap to the monastery's defense."
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27f31f9c-7149-4608-9b18-b3530a2efd4a.jpg?1743204404"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/PoisedPractitioner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/PoisedPractitioner.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Poised Practitioner
+ * {2}{W}
+ * Creature — Human Monk
+ * 2/3
+ *
+ * Flurry — Whenever you cast your second spell each turn, put a +1/+1 counter on this
+ * creature. Scry 1.
+ */
+val PoisedPractitioner = card("Poised Practitioner") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Monk"
+    power = 2
+    toughness = 3
+    oracleText = "Flurry — Whenever you cast your second spell each turn, put a +1/+1 counter on this creature. Scry 1."
+
+    flurry {
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            .then(EffectPatterns.scry(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Alessandra Pisano"
+        flavorText = "\"Excellent form, Jun! Just keep your weight on that back foot, and you'll master this in no time.\"\n—Narset"
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bb25366d-a647-4c5e-bcc7-7e54659aacbd.jpg?1743204021"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WayspeakerBodyguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WayspeakerBodyguard.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Wayspeaker Bodyguard
+ * {3}{W}
+ * Creature — Orc Monk
+ * 3/4
+ *
+ * When this creature enters, return target nonland permanent card with mana value 2 or
+ * less from your graveyard to your hand.
+ * Flurry — Whenever you cast your second spell each turn, tap target creature an opponent
+ * controls.
+ */
+val WayspeakerBodyguard = card("Wayspeaker Bodyguard") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Orc Monk"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, return target nonland permanent card with mana value 2 or less from your graveyard to your hand.\nFlurry — Whenever you cast your second spell each turn, tap target creature an opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val card = target(
+            "card",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.NonlandPermanent.ownedByYou().manaValueAtMost(2),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.ReturnToHand(card)
+    }
+
+    flurry {
+        val creature = target("creature", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "34"
+        artist = "Inkognit"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e5b2324-69fe-4105-b6f8-14dfbe359d59.jpg?1743204097"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WingbladeDisciple.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WingbladeDisciple.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wingblade Disciple
+ * {2}{U}
+ * Creature — Human Monk
+ * 2/2
+ *
+ * Flying
+ * Flurry — Whenever you cast your second spell each turn, create a 1/1 white Bird
+ * creature token with flying.
+ */
+val WingbladeDisciple = card("Wingblade Disciple") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Monk"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\nFlurry — Whenever you cast your second spell each turn, create a 1/1 white Bird creature token with flying."
+
+    keywords(Keyword.FLYING)
+
+    flurry {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Bird"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/6/1/6105623a-ff2c-46bf-8881-e8b899d47d54.jpg?1742506584"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Julian Kok Joon Wen"
+        flavorText = "\"Our greatest teachers are those which the natural world has so thoroughly refined.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71de7dca-0231-4407-86a0-c7fc95f5aaa0.jpg?1743204222"
+    }
+}

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -177,6 +177,7 @@ export enum Keyword {
   FLASH = 'FLASH',
   // Triggered/Static keyword abilities
   PROWESS = 'PROWESS',
+  FLURRY = 'FLURRY',
   CHANGELING = 'CHANGELING',
   // Cost reduction
   CONVOKE = 'CONVOKE',
@@ -236,6 +237,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.HASTE]: 'Haste',
   [Keyword.FLASH]: 'Flash',
   [Keyword.PROWESS]: 'Prowess',
+  [Keyword.FLURRY]: 'Flurry',
   [Keyword.CHANGELING]: 'Changeling',
   [Keyword.CONVOKE]: 'Convoke',
   [Keyword.DELVE]: 'Delve',


### PR DESCRIPTION
## Summary

Implements the **Flurry** keyword (Tarkir: Dragonstorm, Jeskai) — *"Flurry — Whenever you cast your second spell each turn, [effect]."*

The `tdm-engine-gaps.md` analysis listed Flurry as needing "a new trigger type." That note was **stale**: `GameEvent.NthSpellCastEvent` already fires on the Nth spell cast each turn (it powers EOE's Sunstar Lightsmith and BLB's Hearthborn Battler). So no engine subsystem change was required — only a first-class keyword + DSL surface and the cards.

## What's in here

- **`Keyword.FLURRY`** — display-only enum entry (`mtg-sdk` + web-client `enums.ts`).
- **`card { flurry { … } }` builder helper** in `CardBuilder`, mirroring `prowess()` / `rampage()`. Author the effect/target/optional inside the block exactly like `triggeredAbility { }`; the helper forces `Triggers.NthSpellCast(2, Player.You)`, adds the `FLURRY` tag, and prefixes the rendered text with *"Flurry — Whenever you cast your second spell each turn,"*.
- **Seven cards:**
  | Card | Cost | Flurry effect |
  |---|---|---|
  | Cori Mountain Stalwart | {1}{R}{W} | 2 damage to each opponent + gain 2 life |
  | Devoted Duelist | {1}{R} | 1 damage to each opponent (Haste) |
  | Jeskai Devotee | {1}{R} | +1/+1 EOT (+ {1}: add U/R/W once/turn) |
  | Poised Practitioner | {2}{W} | +1/+1 counter + Scry 1 |
  | Wingblade Disciple | {2}{U} | create 1/1 white Bird w/ flying (Flying) |
  | Wayspeaker Bodyguard | {3}{W} | tap target creature an opponent controls (+ ETB graveyard recursion) |
  | Equilibrium Adept | {3}{R} | gains double strike EOT (+ ETB impulse draw) |
- **`FlurryScenarioTest`** — verifies the trigger fires on the 2nd cast and not the 1st (clean life accounting via Cori Mountain Stalwart), plus keyword/reminder-text wiring.
- **Docs** — `card-sdk-language-reference.md` (§11 keyword + helper) and `tdm-engine-gaps.md` (marked done).

## Deferred (noted in the gap doc)

- **Taigam, Master Opportunist** — needs Suspend (Tier 3, not yet implemented).
- **Cori-Steel Cutter** + its Alchemy **A-** variant — need "create a token, then attach this Equipment to it" from a trigger.

## Testing

- `:game-server:test --tests FlurryScenarioTest` → 3/3 pass
- `:mtg-sets:test`, `:mtg-sdk:test` → pass
- `:rules-engine`, `:game-server` compile clean (verified `Keyword` enum addition doesn't break exhaustive `when`s)
- All card + token image URIs HEAD-checked (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)