### PR TITLE
Add one-shot DoubleCounters effect (TDM gap #9)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -281,6 +281,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 - `AddCounters(type, count, target)` — add N counters of `type`.
 - `AddDynamicCounters(type, amount, target)` — count is computed at resolution.
+- `DoubleCounters(type?, target?)` — one-shot doubling of the `type` counters (default `+1/+1`) already on the
+  target: reads the current count and places that many more (so the total doubles). Distinct from the
+  `DoubleCounterPlacement` replacement (which doubles *future* placements); the added counters still trigger
+  placement replacements like Hardened Scales. No-op with zero counters. Sage of the Fang.
 - `RemoveCounters(type, count, target)` — remove N counters.
 - `RemoveAnyNumberOfCounters(target)` — player removes 0 or more.
 - `RemoveAllCounters(target)` — wipe every counter.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -869,6 +869,18 @@ object Effects {
         MoveAllLastKnownCountersEffect(target)
 
     /**
+     * Double the number of counters of [counterType] already on a target (one-shot).
+     * Reads the current count and puts that many more on the target, so the total
+     * doubles. Distinct from the [DoubleCounterPlacement] replacement, which doubles
+     * counters as they are placed in the future. Used by Sage of the Fang.
+     */
+    fun DoubleCounters(
+        counterType: String = Counters.PLUS_ONE_PLUS_ONE,
+        target: EffectTarget = EffectTarget.ContextTarget(0)
+    ): Effect =
+        com.wingedsheep.sdk.scripting.effects.DoubleCountersEffect(counterType, target)
+
+    /**
      * Remove counters of a given type from a target. No-op if the target has fewer
      * than `count` counters of that type.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
@@ -65,6 +65,32 @@ data class MoveAllLastKnownCountersEffect(
 }
 
 /**
+ * Double the number of counters of a given kind already on a target (one-shot).
+ * "Double the number of +1/+1 counters on that creature."
+ *
+ * Distinct from the `DoubleCounterPlacement` replacement effect, which doubles
+ * counters as they are *placed* in the future. This is an immediate doubling of
+ * the counters present at resolution: the executor reads the current count of
+ * [counterType] on the target and puts that many more on it (so the total
+ * doubles). Putting those counters still triggers counter-placement replacement
+ * effects (e.g., Hardened Scales), matching the rules treatment of doubling as
+ * additional counter placement.
+ *
+ * No-op when the target has no counters of [counterType].
+ */
+@SerialName("DoubleCounters")
+@Serializable
+data class DoubleCountersEffect(
+    val counterType: String = Counters.PLUS_ONE_PLUS_ONE,
+    val target: EffectTarget = EffectTarget.ContextTarget(0)
+) : Effect {
+    override val description: String =
+        "Double the number of $counterType counters on ${target.description}"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
+}
+
+/**
  * Remove counters effect.
  * "Remove X -1/-1 counters from target creature"
  */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -27,6 +27,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.counters.AddCountersToC
 import com.wingedsheep.engine.handlers.effects.permanent.counters.AddDynamicCountersExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.MoveAllLastKnownCountersExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.DistributeCountersAmongTargetsExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.counters.DoubleCountersExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.DistributeCountersFromSelfExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.ProliferateExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.RemoveAllCountersExecutor
@@ -95,6 +96,7 @@ class PermanentExecutors(
         AddDynamicCountersExecutor(),
         MoveAllLastKnownCountersExecutor(),
         AddCountersToCollectionExecutor(),
+        DoubleCountersExecutor(),
         RemoveCountersExecutor(),
         RemoveAnyNumberOfCountersExecutor(),
         RemoveAllCountersExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DoubleCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DoubleCountersExecutor.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.handlers.effects.permanent.counters
+
+import com.wingedsheep.engine.core.CountersAddedEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.scripting.effects.DoubleCountersEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [DoubleCountersEffect].
+ * "Double the number of +1/+1 counters on that creature."
+ *
+ * Reads the current count of the named counter kind on the target and puts that
+ * many more on it, so the total doubles. The added counters go through the normal
+ * counter-placement replacement path (e.g., Hardened Scales), mirroring the rules
+ * treatment of doubling as additional counter placement. No-op when the target has
+ * no counters of that kind or can't receive counters.
+ */
+class DoubleCountersExecutor : EffectExecutor<DoubleCountersEffect> {
+
+    override val effectType: KClass<DoubleCountersEffect> = DoubleCountersEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: DoubleCountersEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target, state)
+            ?: return EffectResult.error(state, "No valid target to double counters on")
+
+        if (state.projectedState.hasKeyword(targetId, AbilityFlag.CANT_RECEIVE_COUNTERS)) {
+            return EffectResult.success(state, emptyList())
+        }
+
+        val counterType = resolveCounterType(effect.counterType)
+        val current = state.getEntity(targetId)?.get<CountersComponent>() ?: CountersComponent()
+        val existing = current.getCount(counterType)
+        if (existing <= 0) {
+            return EffectResult.success(state, emptyList())
+        }
+
+        // Doubling places `existing` additional counters; honor placement replacements.
+        val added = ReplacementEffectUtils.applyCounterPlacementModifiers(
+            state, targetId, counterType, existing, placerId = context.controllerId
+        )
+
+        val newState = state.updateEntity(targetId) { container ->
+            container.with(current.withAdded(counterType, added))
+        }.let { DamageUtils.markCounterPlacedOnCreature(it, context.controllerId, targetId) }
+
+        val entityName = state.getEntity(targetId)?.get<CardComponent>()?.name ?: ""
+
+        return EffectResult.success(
+            newState,
+            listOf(CountersAddedEvent(targetId, effect.counterType, added, entityName))
+        )
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoubleCountersTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoubleCountersTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [com.wingedsheep.sdk.scripting.effects.DoubleCountersEffect] — the one-shot
+ * doubling of +1/+1 counters already on a creature (the engine gap behind Sage of the Fang).
+ *
+ * Two inline test instants exercise the primitive:
+ *  - "Counter Doubler": "Double the number of +1/+1 counters on target creature."
+ *  - "Boost and Double": "Put a +1/+1 counter on target creature, then double the number of
+ *    +1/+1 counters on that creature." — mirrors Sage of the Fang's renew ability.
+ */
+class DoubleCountersTest : FunSpec({
+
+    val counterDoubler = card("Counter Doubler") {
+        manaCost = "{G}"
+        typeLine = "Instant"
+        oracleText = "Double the number of +1/+1 counters on target creature."
+        spell {
+            val target = target("target creature", Targets.Creature)
+            effect = Effects.DoubleCounters(Counters.PLUS_ONE_PLUS_ONE, target)
+        }
+    }
+
+    val boostAndDouble = card("Boost and Double") {
+        manaCost = "{G}"
+        typeLine = "Instant"
+        oracleText =
+            "Put a +1/+1 counter on target creature, then double the number of +1/+1 counters on that creature."
+        spell {
+            val target = target("target creature", Targets.Creature)
+            effect = CompositeEffect(
+                listOf(
+                    Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, target),
+                    Effects.DoubleCounters(Counters.PLUS_ONE_PLUS_ONE, target)
+                )
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(counterDoubler, boostAndDouble))
+        return driver
+    }
+
+    fun plusCounters(driver: GameTestDriver, entityId: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("doubles the +1/+1 counters already on a creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spell = driver.putCardInHand(player1, "Counter Doubler")
+        val creature = driver.putCreatureOnBattlefield(player1, "Savannah Lions")
+        driver.addComponent(
+            creature,
+            CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 3))
+        )
+        driver.giveMana(player1, Color.GREEN, 1)
+
+        driver.castSpell(player1, spell, targets = listOf(creature))
+        driver.bothPass()
+
+        // 3 existing counters → 3 more placed → 6 total.
+        plusCounters(driver, creature) shouldBe 6
+    }
+
+    test("does nothing when the creature has no +1/+1 counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spell = driver.putCardInHand(player1, "Counter Doubler")
+        val creature = driver.putCreatureOnBattlefield(player1, "Savannah Lions")
+        driver.giveMana(player1, Color.GREEN, 1)
+
+        driver.castSpell(player1, spell, targets = listOf(creature))
+        driver.bothPass()
+
+        plusCounters(driver, creature) shouldBe 0
+    }
+
+    test("put-then-double counts the freshly-added counter (Sage of the Fang shape)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+
+        val player1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spell = driver.putCardInHand(player1, "Boost and Double")
+        val creature = driver.putCreatureOnBattlefield(player1, "Savannah Lions")
+        driver.addComponent(
+            creature,
+            CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2))
+        )
+        driver.giveMana(player1, Color.GREEN, 1)
+
+        driver.castSpell(player1, spell, targets = listOf(creature))
+        driver.bothPass()
+
+        // 2 existing + 1 added = 3, then doubled = 6.
+        plusCounters(driver, creature) shouldBe 6
+    }
+})


### PR DESCRIPTION
## What

Implements the **"Double existing +1/+1 counters (one-shot)"** engine gap from `backlog/tdm-engine-gaps.md` (Tier 2, item #9) — the primitive behind **Sage of the Fang**.

> Renew — {3}{G}, Exile this card from your graveyard: Put a +1/+1 counter on target creature, **then double the number of +1/+1 counters on that creature.** Activate only as a sorcery.

## Why a new effect

The existing `DoubleCounterPlacement` is a *replacement* that doubles counters as they're **placed in the future**. It can't express a one-shot doubling of counters **already present** at resolution. `DoubleCountersEffect` fills that gap.

## How

- **SDK** — `DoubleCountersEffect(counterType = "+1/+1", target = ContextTarget(0))` + `Effects.DoubleCounters(...)` facade.
- **Engine** — `DoubleCountersExecutor` reads the current count of the named counter kind on the target and places that many more (total doubles). The added counters route through `ReplacementEffectUtils.applyCounterPlacementModifiers`, so placement replacements (e.g. Hardened Scales) still apply — matching the rules treatment of doubling as additional counter placement. No-op when the target has no counters of that kind or can't receive counters. Registered in `PermanentExecutors`.
- **Docs** — DSL reference §4 (counter effects).

## Tests

`DoubleCountersTest` (3 cases, all green):
- doubles existing +1/+1 counters (3 → 6)
- no-op when the creature has no +1/+1 counters
- put-then-double composite counts the freshly-added counter, mirroring Sage of the Fang (2 +1 → 3 → 6)

## Scope

This is the effect primitive only. **Sage of the Fang** itself also needs the **Renew** keyword (a separate Tier-1 gap, tracked in its own worktree); once Renew lands, the card composes `AddCounters(1) → DoubleCounters()` exactly as the put-then-double test demonstrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)