### PR TITLE
Add Decayed keyword (CR 702.147)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1358,6 +1358,11 @@ composite abilities).
   ability plus a "whenever this attacks" triggered `CreateTokenEffect` (`tapped = true`, `attacking = true`)
   whose `sacrificeAtStep = Step.END` schedules one delayed `SacrificeTargetEffect` per created token at the
   next end step (mirrors `rampage()`). `n` may be any fixed value (Mobilize 1/2/3, …).
+- `Decayed` — "This creature can't block, and when it attacks, sacrifice it at end of combat" (CR 702.147,
+  Innistrad: Midnight Hunt). Display-only; wire the behavior with the `card { decayed() }` builder helper, which adds
+  the keyword plus a `CantBlock(GroupFilter.source())` static ability and a "whenever this attacks" triggered
+  `CreateDelayedTriggerEffect(step = Step.END_COMBAT, effect = Effects.SacrificeTarget(EffectTarget.Self))` (mirrors
+  Mardu Blazebringer's end-of-combat self-sacrifice). No parameter.
 - `Toxic(n)` — adds poison counters on combat damage.
 - `Cycling(cost)` — pay cost, discard, draw a card.
 - `BasicLandcycling(cost)` — cycling that fetches a basic land type.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -135,6 +135,19 @@ enum class Keyword(val displayName: String) {
      */
     ASCEND("Ascend"),
 
+    /**
+     * Decayed (CR 702.147, Innistrad: Midnight Hunt). A static ability plus a
+     * triggered ability: "This creature can't block" and "When this creature
+     * attacks, sacrifice it at end of combat."
+     *
+     * The keyword itself is display-only; the behavior is composed by the
+     * `decayed()` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder] — a
+     * [com.wingedsheep.sdk.scripting.CantBlock] static ability plus an
+     * attack-triggered [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect]
+     * that sacrifices the source at the end-of-combat step.
+     */
+    DECAYED("Decayed"),
+
     // ── Damage modification ──────────────────────────────
     WITHER("Wither"),
     TOXIC("Toxic"),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
@@ -395,6 +396,35 @@ class CardBuilder(private val name: String) {
                 descriptionOverride = "Whenever this creature attacks, create $article tapped " +
                     "and attacking 1/1 red Warrior creature $tokenWord. Sacrifice $pronoun at the " +
                     "beginning of the next end step."
+            )
+        )
+    }
+
+    /**
+     * Add Decayed (CR 702.147, Innistrad: Midnight Hunt) — keyword + static ability
+     * + triggered ability.
+     *
+     * "This creature can't block, and when it attacks, sacrifice it at end of combat."
+     *
+     * The keyword is display-only (no separate Decayed handler exists); the behavior is
+     * composed here from existing primitives: a [CantBlock] static ability on the source
+     * for "can't block", plus an attack-triggered [CreateDelayedTriggerEffect] scheduled
+     * for [Step.END_COMBAT] that sacrifices the source (mirroring Mardu Blazebringer's
+     * "sacrifice it at end of combat" wiring).
+     */
+    fun decayed() {
+        keywordSet.add(Keyword.DECAYED)
+        staticAbilities.add(CantBlock(GroupFilter.source()))
+        triggeredAbilities.add(
+            TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = CreateDelayedTriggerEffect(
+                    step = Step.END_COMBAT,
+                    effect = Effects.SacrificeTarget(EffectTarget.Self)
+                ),
+                descriptionOverride = "Decayed (This creature can't block, and when it " +
+                    "attacks, sacrifice it at end of combat.)"
             )
         )
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DecayedTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DecayedTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for the Decayed keyword (CR 702.147, Innistrad: Midnight Hunt).
+ *
+ * "This creature can't block, and when it attacks, sacrifice it at end of combat."
+ *
+ * The keyword is wired by the `decayed()` builder helper: a display-only keyword plus a
+ * `CantBlock(GroupFilter.source())` static ability and an attack-triggered
+ * `CreateDelayedTriggerEffect(step = END_COMBAT, effect = SacrificeTarget(Self))` — mirroring
+ * Mardu Blazebringer's "sacrifice it at end of combat" wiring.
+ */
+class DecayedTest : FunSpec({
+
+    val decayedZombie = card("Decayed Zombie") {
+        manaCost = "{1}{B}"
+        typeLine = "Creature — Zombie"
+        power = 3
+        toughness = 3
+        decayed()
+    }
+
+    val vanillaAttacker = card("Test Marauder") {
+        manaCost = "{2}{R}"
+        typeLine = "Creature — Human Warrior"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(decayedZombie, vanillaAttacker))
+        return driver
+    }
+
+    test("a creature with decayed can't be declared as a blocker") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        // Attacker swings with a vanilla creature; the defender holds the decayed creature.
+        val marauder = driver.putCreatureOnBattlefield(attacker, "Test Marauder")
+        driver.removeSummoningSickness(marauder)
+        val zombie = driver.putCreatureOnBattlefield(defender, "Decayed Zombie")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(marauder), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // Declaring the decayed creature as a blocker is illegal.
+        driver.submitExpectFailure(
+            DeclareBlockers(defender, mapOf(zombie to listOf(marauder)))
+        )
+    }
+
+    test("when a creature with decayed attacks, a sacrifice trigger is scheduled for end of combat") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val zombie = driver.putCreatureOnBattlefield(attacker, "Decayed Zombie")
+        driver.removeSummoningSickness(zombie)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(zombie), defender)
+        driver.bothPass() // resolve the attack trigger that creates the delayed sacrifice
+
+        driver.state.delayedTriggers.size shouldBe 1
+        driver.state.delayedTriggers.first().fireAtStep shouldBe Step.END_COMBAT
+    }
+
+    test("a decayed creature deals combat damage, then is sacrificed at end of combat") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val zombie = driver.putCreatureOnBattlefield(attacker, "Decayed Zombie")
+        driver.removeSummoningSickness(zombie)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(zombie), defender)
+        driver.bothPass()
+
+        // Combat damage is dealt before the creature is sacrificed (3/3 hits for 3).
+        driver.passPriorityUntil(Step.END_COMBAT)
+        driver.assertLifeTotal(defender, 17)
+
+        // At end of combat the delayed sacrifice trigger goes on the stack — resolve it.
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // The creature has been sacrificed and is no longer on the battlefield.
+        driver.findPermanent(attacker, "Decayed Zombie") shouldBe null
+        driver.state.delayedTriggers.size shouldBe 0
+    }
+
+    test("a creature with decayed has no requirement to attack") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val zombie = driver.putCreatureOnBattlefield(attacker, "Decayed Zombie")
+        driver.removeSummoningSickness(zombie)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        // Declaring no attackers is legal; decayed adds no attack requirement.
+        driver.declareAttackers(attacker, emptyList(), defender)
+
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        // No attack happened, so no sacrifice trigger and the creature survives.
+        driver.findPermanent(attacker, "Decayed Zombie") shouldNotBe null
+        driver.state.delayedTriggers.size shouldBe 0
+    }
+})


### PR DESCRIPTION
## What

Implements the **Decayed** keyword (Tier 1 / Tier 2 gap #6 from `backlog/tdm-engine-gaps.md`).

> Decayed (CR 702.147, Innistrad: Midnight Hunt) — "This creature can't block, and when it attacks, sacrifice it at end of combat."

## Approach

Decayed is a named MTG mechanic with no new engine behavior — it's fully composable from existing primitives, so it follows the same pattern as the other composed keywords (`rampage()`, `mobilize()`): a display-only `Keyword.DECAYED` enum entry plus a `decayed()` `CardBuilder` helper that wires:

- **`CantBlock(GroupFilter.source())`** static ability → the "can't block" half, and
- an attack-triggered **`CreateDelayedTriggerEffect(step = Step.END_COMBAT, effect = Effects.SacrificeTarget(EffectTarget.Self))`** → the end-of-combat self-sacrifice, mirroring Mardu Blazebringer's existing wiring.

No new `Effect`, handler, or engine subsystem was needed.

## Changes

- `Keyword.kt` — add display-only `DECAYED` enum entry with doc comment.
- `CardBuilder.kt` — add the `decayed()` helper (+ `CreateDelayedTriggerEffect` import).
- `card-sdk-language-reference.md` — document the keyword.
- `DecayedTest.kt` — new scenario test.

## Tests

`DecayedTest` (all passing) covers:
- a decayed creature can't be declared as a blocker,
- attacking schedules exactly one delayed sacrifice trigger for end of combat,
- combat damage lands **before** the creature is sacrificed, then it's gone at end of combat,
- decayed imposes no requirement to attack.

## Notes

The only TDM card with Decayed is **Rot-Curse Rakshasa**, which also has Renew (not yet implemented), so no card is wired up in this PR — just the reusable keyword. This was built in a worktree alongside in-flight Harmonize work on `main`; those changes are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)