### PR TITLE
Add leaves-graveyard batching trigger (TDM engine gap #8)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -926,6 +926,12 @@ in the repo today):
 - `CardsPutIntoYourGraveyard(filter?)` — when matching cards enter your yard.
 - `PermanentCardsPutIntoYourGraveyard` — only permanent cards.
 - `CreaturesPutIntoGraveyardFromLibrary` — mill-trigger shape.
+- `CardsLeaveYourGraveyard(filter?)` — batching trigger; fires once per event batch when one
+  or more matching cards **leave** your graveyard (cast/exiled/reanimated/returned to hand,
+  etc.), regardless of how many or where they went. For the common "leave your graveyard
+  **during your turn**" wording, add `triggerCondition = Conditions.IsYourTurn`; for "this
+  ability triggers only once each turn", add `oncePerTurn = true`. (Attuned Hunter, Kishla
+  Skimmer, Kheru Goldkeeper.)
 
 ### Discard
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/LeavesGraveyardTriggerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/LeavesGraveyardTriggerScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the "leave your graveyard during your turn" batching trigger
+ * (CardsLeftYourGraveyardEvent), exercised through the Tarkir: Dragonstorm cards that use it.
+ *
+ * The trigger fires once per event batch when one or more cards leave the controller's
+ * graveyard. The "during your turn" restriction is `triggerCondition = Conditions.IsYourTurn`;
+ * "only once each turn" is `oncePerTurn = true`. A card leaving the graveyard is driven here
+ * by Raise Dead ("return target creature card from your graveyard to your hand").
+ */
+class LeavesGraveyardTriggerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Attuned Hunter — put a +1/+1 counter when a card leaves your graveyard during your turn") {
+
+            test("gains a +1/+1 counter when a creature returns from your graveyard on your turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Attuned Hunter")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInHand(1, "Raise Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(1, "Raise Dead", graveyardOwnerNumber = 1, targetCardName = "Grizzly Bears")
+                game.resolveStack()
+
+                withClue("Grizzly Bears should have left the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+
+                val hunterId = game.findPermanent("Attuned Hunter")
+                hunterId shouldNotBe null
+                val hunter = game.getClientState(1).cards[hunterId!!]
+                hunter shouldNotBe null
+                withClue("Attuned Hunter should have a +1/+1 counter (3/3 -> 4/4)") {
+                    hunter!!.power shouldBe 4
+                    hunter.toughness shouldBe 4
+                }
+            }
+
+            test("does not trigger off the opponent's graveyard on the opponent's turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Attuned Hunter")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInHand(2, "Raise Dead")
+                    .withLandsOnBattlefield(2, "Swamp", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(2, "Raise Dead", graveyardOwnerNumber = 2, targetCardName = "Grizzly Bears")
+                game.resolveStack()
+
+                val hunterId = game.findPermanent("Attuned Hunter")
+                hunterId shouldNotBe null
+                val hunter = game.getClientState(1).cards[hunterId!!]
+                withClue("Attuned Hunter should stay 3/3 — the trigger watches its controller's own graveyard on their turn") {
+                    hunter!!.power shouldBe 3
+                    hunter.toughness shouldBe 3
+                }
+            }
+        }
+
+        context("Kishla Skimmer — draw a card, but only once each turn") {
+
+            test("draws once when a card leaves your graveyard, and not again on a second leave the same turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kishla Skimmer")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInHand(1, "Raise Dead")
+                    .withCardInHand(1, "Raise Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startingLibrary = game.librarySize(1)
+
+                // First leave-graveyard event: Kishla triggers and draws one card.
+                game.castSpellTargetingGraveyardCard(1, "Raise Dead", graveyardOwnerNumber = 1, targetCardName = "Grizzly Bears")
+                game.resolveStack()
+                withClue("first card leaving the graveyard should draw one card") {
+                    game.librarySize(1) shouldBe startingLibrary - 1
+                }
+
+                // Second leave-graveyard event the same turn: triggers only once each turn, so no draw.
+                game.castSpellTargetingGraveyardCard(1, "Raise Dead", graveyardOwnerNumber = 1, targetCardName = "Grizzly Bears")
+                game.resolveStack()
+                withClue("second card leaving the graveyard the same turn should NOT draw again (only once each turn)") {
+                    game.librarySize(1) shouldBe startingLibrary - 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -614,6 +614,24 @@ object Triggers {
     )
 
     // =========================================================================
+    // Leave-Graveyard Batching Triggers
+    // =========================================================================
+
+    /**
+     * Whenever one or more cards matching [filter] leave your graveyard.
+     * Batching trigger — fires at most once per event batch regardless of how many cards left,
+     * and regardless of where they went (cast/exiled/reanimated/returned to hand, etc.).
+     *
+     * Pair with `triggerCondition = Conditions.IsYourTurn` for the common
+     * "leave your graveyard during your turn" wording, and `oncePerTurn = true`
+     * for "this ability triggers only once each turn" (e.g. Kishla Skimmer).
+     */
+    fun CardsLeaveYourGraveyard(filter: GameObjectFilter = GameObjectFilter.Any): TriggerSpec = TriggerSpec(
+        event = CardsLeftYourGraveyardEvent(filter = filter),
+        binding = TriggerBinding.ANY
+    )
+
+    // =========================================================================
     // Card Drawing Triggers
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
@@ -1160,6 +1160,47 @@ sealed interface GameEvent : TextReplaceable<GameEvent> {
         }
     }
 
+    /**
+     * Whenever one or more cards matching [filter] leave your graveyard.
+     *
+     * This is a **batching trigger** — it fires at most once per event batch, regardless of
+     * how many matching cards left the graveyard. "Leave your graveyard" covers any move out
+     * of the graveyard: cast/played from it, exiled (e.g. Renew, Delve, Escape), reanimated to
+     * the battlefield, returned to hand or library, etc.
+     *
+     * Detection is handled specially by TriggerDetector: after processing individual events,
+     * it groups all from-graveyard zone changes by the owner of that graveyard and fires the
+     * trigger at most once per qualifying controller.
+     *
+     * The common "during your turn" timing restriction is expressed on the card via
+     * `triggerCondition = Conditions.IsYourTurn` rather than baked into the event, and the
+     * "this ability triggers only once each turn" restriction via `oncePerTurn = true`.
+     *
+     * Examples:
+     * - "Whenever one or more cards leave your graveyard during your turn, …"
+     *   → CardsLeftYourGraveyardEvent() + triggerCondition = Conditions.IsYourTurn
+     *   (Attuned Hunter, Kishla Skimmer, Kheru Goldkeeper)
+     */
+    @SerialName("CardsLeftYourGraveyardEvent")
+    @Serializable
+    data class CardsLeftYourGraveyardEvent(
+        val filter: GameObjectFilter = GameObjectFilter.Any
+    ) : GameEvent {
+        override val description: String = buildString {
+            append("one or more ")
+            if (filter != GameObjectFilter.Any) {
+                append(filter.cardPredicates.joinToString(" ") { it.description })
+                append(" ")
+            }
+            append("cards leave your graveyard")
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): GameEvent {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
     // =========================================================================
     // Sacrifice Triggers
     // =========================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AttunedHunter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AttunedHunter.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Attuned Hunter — Tarkir: Dragonstorm #135
+ * {2}{G} · Creature — Human Ranger · 3/3
+ *
+ * Trample
+ * Whenever one or more cards leave your graveyard during your turn, put a +1/+1 counter
+ * on this creature.
+ *
+ * "During your turn" is the trigger's timing restriction, expressed as
+ * triggerCondition = Conditions.IsYourTurn. The batching leave-graveyard trigger fires once
+ * per event batch, so it can grow this creature multiple times in a turn (one per batch).
+ */
+val AttunedHunter = card("Attuned Hunter") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Ranger"
+    power = 3
+    toughness = 3
+    oracleText = "Trample\n" +
+        "Whenever one or more cards leave your graveyard during your turn, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard()
+        triggerCondition = Conditions.IsYourTurn
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "135"
+        artist = "Scott Murphy"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1a4f502-86a9-49fb-9cb9-7918d13c5313.jpg?1743204506"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KishlaSkimmer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KishlaSkimmer.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kishla Skimmer — Tarkir: Dragonstorm #201
+ * {G}{U} · Creature — Bird Scout · 2/2
+ *
+ * Flying
+ * Whenever a card leaves your graveyard during your turn, draw a card. This ability
+ * triggers only once each turn.
+ *
+ * The leave-graveyard trigger already batches (fires once per event batch); oncePerTurn = true
+ * additionally caps it to a single fire across the whole turn, matching the "only once each
+ * turn" wording. "During your turn" is triggerCondition = Conditions.IsYourTurn.
+ */
+val KishlaSkimmer = card("Kishla Skimmer") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Bird Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever a card leaves your graveyard during your turn, draw a card. " +
+        "This ability triggers only once each turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard()
+        triggerCondition = Conditions.IsYourTurn
+        oncePerTurn = true
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "201"
+        artist = "James Ryman"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5f1acb0-d73e-4814-8158-3645daf5c4cc.jpg?1743204788"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -208,6 +208,12 @@ class TriggerDetector(
         // and fires the trigger at most once per controller.
         detectAnyToGraveyardBatchTriggers(state, events, triggers, index)
 
+        // Detect "whenever one or more cards leave your graveyard" batching triggers
+        // (e.g., Attuned Hunter, Kishla Skimmer). Groups from-graveyard zone changes by the
+        // owner of that graveyard and fires the trigger at most once per controller. The
+        // "during your turn" restriction is a triggerCondition (Conditions.IsYourTurn) on the card.
+        detectCardsLeftGraveyardBatchTriggers(state, events, triggers, index)
+
         // Detect "whenever you sacrifice one or more [permanents]" batching triggers
         // (e.g., Camellia, the Seedmiser). Groups sacrifice events per controller
         // and fires the trigger at most once per controller.
@@ -1171,34 +1177,7 @@ class TriggerDetector(
 
                 // Check if any of the moved cards match the filter
                 val hasMatch = ownerEvents.any { event ->
-                    if (trigger.filter == GameObjectFilter.Any) return@any true
-                    val entity = state.getEntity(event.entityId)
-                    val cardComponent = entity?.get<CardComponent>()
-                    if (cardComponent != null) {
-                        trigger.filter.cardPredicates.all { predicate ->
-                            when (predicate) {
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->
-                                    cardComponent.typeLine.isCreature
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact ->
-                                    cardComponent.typeLine.isArtifact
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsEnchantment ->
-                                    cardComponent.typeLine.isEnchantment
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLand ->
-                                    cardComponent.typeLine.isLand
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPlaneswalker ->
-                                    com.wingedsheep.sdk.core.CardType.PLANESWALKER in cardComponent.typeLine.cardTypes
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPermanent ->
-                                    cardComponent.typeLine.isPermanent
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonland ->
-                                    !cardComponent.typeLine.isLand
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNoncreature ->
-                                    !cardComponent.typeLine.isCreature
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
-                                    cardComponent.typeLine.hasSubtype(predicate.subtype)
-                                else -> true
-                            }
-                        }
-                    } else false
+                    cardMatchesGraveyardBatchFilter(state, event.entityId, trigger.filter)
                 }
 
                 if (hasMatch) {
@@ -1212,6 +1191,96 @@ class TriggerDetector(
                         )
                     )
                 }
+            }
+        }
+    }
+
+    /**
+     * Detect "whenever one or more cards leave your graveyard" batching triggers
+     * (e.g., Attuned Hunter, Kishla Skimmer, Kheru Goldkeeper).
+     *
+     * Groups all from-graveyard zone changes by the owner of that graveyard ("your graveyard")
+     * and fires the trigger at most once per controller, regardless of how many matching cards
+     * left or where they went (cast/exiled/reanimated/returned to hand). The "during your turn"
+     * restriction is expressed on the card as `triggerCondition = Conditions.IsYourTurn`, and
+     * "only once each turn" via `oncePerTurn = true`, both applied later in detectTriggers.
+     */
+    private fun detectCardsLeftGraveyardBatchTriggers(
+        state: GameState,
+        events: List<EngineGameEvent>,
+        triggers: MutableList<PendingTrigger>,
+        index: TriggerIndex
+    ) {
+        // Collect all zone change events leaving a graveyard, grouped by the graveyard's owner
+        val fromGravByOwner = mutableMapOf<EntityId, MutableList<ZoneChangeEvent>>()
+        for (event in events) {
+            if (event is ZoneChangeEvent && event.fromZone == Zone.GRAVEYARD && event.toZone != Zone.GRAVEYARD) {
+                fromGravByOwner.getOrPut(event.ownerId) { mutableListOf() }.add(event)
+            }
+        }
+        if (fromGravByOwner.isEmpty()) return
+
+        for (entry in index.getEntitiesForCategory(TriggerCategory.CARDS_LEFT_GRAVEYARD)) {
+            for (ability in entry.abilities) {
+                val trigger = ability.trigger
+                if (trigger !is GameEvent.CardsLeftYourGraveyardEvent) continue
+
+                val controllerId = entry.controllerId
+                val ownerEvents = fromGravByOwner[controllerId] ?: continue
+
+                // Check if any of the departed cards match the filter
+                val hasMatch = ownerEvents.any { event ->
+                    cardMatchesGraveyardBatchFilter(state, event.entityId, trigger.filter)
+                }
+
+                if (hasMatch) {
+                    triggers.add(
+                        PendingTrigger(
+                            ability = ability,
+                            sourceId = entry.entityId,
+                            sourceName = entry.cardComponent.name,
+                            controllerId = controllerId,
+                            triggerContext = TriggerContext()
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Whether the card now identified by [entityId] (which may have moved to a new zone)
+     * matches [filter] for graveyard batching triggers. Card-characteristic predicates are
+     * evaluated against the card's base [CardComponent]; [GameObjectFilter.Any] always matches.
+     */
+    private fun cardMatchesGraveyardBatchFilter(
+        state: GameState,
+        entityId: EntityId,
+        filter: GameObjectFilter
+    ): Boolean {
+        if (filter == GameObjectFilter.Any) return true
+        val cardComponent = state.getEntity(entityId)?.get<CardComponent>() ?: return false
+        return filter.cardPredicates.all { predicate ->
+            when (predicate) {
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->
+                    cardComponent.typeLine.isCreature
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact ->
+                    cardComponent.typeLine.isArtifact
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsEnchantment ->
+                    cardComponent.typeLine.isEnchantment
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLand ->
+                    cardComponent.typeLine.isLand
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPlaneswalker ->
+                    com.wingedsheep.sdk.core.CardType.PLANESWALKER in cardComponent.typeLine.cardTypes
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPermanent ->
+                    cardComponent.typeLine.isPermanent
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonland ->
+                    !cardComponent.typeLine.isLand
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNoncreature ->
+                    !cardComponent.typeLine.isCreature
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
+                    cardComponent.typeLine.hasSubtype(predicate.subtype)
+                else -> true
             }
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -59,6 +59,7 @@ enum class TriggerCategory {
     STEP,
     LIBRARY_TO_GRAVEYARD,
     ANY_TO_GRAVEYARD,
+    CARDS_LEFT_GRAVEYARD,
     SACRIFICE,
     COMBAT_DAMAGE_BATCH,
     LEAVE_WITHOUT_DYING,
@@ -178,6 +179,7 @@ class TriggerIndex(
                 is SdkGameEvent.StepEvent -> listOf(TriggerCategory.STEP)
                 is SdkGameEvent.CardsPutIntoGraveyardFromLibraryEvent -> listOf(TriggerCategory.LIBRARY_TO_GRAVEYARD)
                 is SdkGameEvent.CardsPutIntoYourGraveyardEvent -> listOf(TriggerCategory.ANY_TO_GRAVEYARD)
+                is SdkGameEvent.CardsLeftYourGraveyardEvent -> listOf(TriggerCategory.CARDS_LEFT_GRAVEYARD)
                 is SdkGameEvent.PermanentsSacrificedEvent -> listOf(TriggerCategory.SACRIFICE)
                 is SdkGameEvent.OneOrMoreDealCombatDamageToPlayerEvent -> listOf(TriggerCategory.COMBAT_DAMAGE_BATCH)
                 is SdkGameEvent.LeaveBattlefieldWithoutDyingEvent -> listOf(TriggerCategory.LEAVE_WITHOUT_DYING)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -309,6 +309,8 @@ class TriggerMatcher(
             is GameEvent.CardsPutIntoGraveyardFromLibraryEvent -> false
             // Batching trigger handled separately by detectAnyToGraveyardBatchTriggers
             is GameEvent.CardsPutIntoYourGraveyardEvent -> false
+            // Leave-graveyard batch triggers are handled by detectCardsLeftGraveyardBatchTriggers
+            is GameEvent.CardsLeftYourGraveyardEvent -> false
             // Sacrifice batch triggers are handled by detectSacrificeBatchTriggers
             is GameEvent.PermanentsSacrificedEvent -> false
             // Combat damage batch triggers are handled by detectCombatDamageBatchTriggers


### PR DESCRIPTION
## Summary

Implements the **leaves-graveyard trigger** from `backlog/tdm-engine-gaps.md` (Tier 2, gap #8): *"Whenever one or more cards leave your graveyard during your turn."* Previously the engine had only cards-*entering*-graveyard and battlefield-only LTB triggers — there was no event keyed to graveyard *exit*.

## What's new

**SDK**
- `GameEvent.CardsLeftYourGraveyardEvent(filter?)` — a batching trigger that fires at most once per event batch when one or more matching cards leave a graveyard, regardless of how many or where they went (cast/exiled/reanimated/returned to hand, …).
- `Triggers.CardsLeaveYourGraveyard(filter?)` DSL facade.

**Engine** (mirrors the existing any-to-graveyard batch path)
- `TriggerCategory.CARDS_LEFT_GRAVEYARD` + `triggerToCategories` mapping.
- `detectCardsLeftGraveyardBatchTriggers` — groups `fromZone == GRAVEYARD` zone changes by the graveyard's owner and fires once per qualifying controller.
- `TriggerMatcher` "handled separately" branch for the new event.
- Refactor: the inline card-filter match in `detectAnyToGraveyardBatchTriggers` is extracted into a shared `cardMatchesGraveyardBatchFilter` helper (now has two users).

**Design note** — "during your turn" is expressed on the card as `triggerCondition = Conditions.IsYourTurn` (the established Moonstone Harbinger precedent) and "only once each turn" via `oncePerTurn = true`, so the event itself stays atomic and composable rather than carrying timing flags.

## Cards

| Card | Status |
|------|--------|
| Attuned Hunter (#135) | ✅ implemented |
| Kishla Skimmer (#201) | ✅ implemented (`oncePerTurn`) |
| Kheru Goldkeeper | ⏭️ deferred — also needs **Renew** (separate unbuilt Tier-1 gap) |

## Tests

`LeavesGraveyardTriggerScenarioTest` (driven through Raise Dead returning a creature from a graveyard):
- Attuned Hunter gains a +1/+1 counter when a card leaves its controller's graveyard on their turn.
- Attuned Hunter does **not** fire off the opponent's graveyard on the opponent's turn (controller/turn scoping).
- Kishla Skimmer draws once on the first leave and **not** again on a second leave the same turn.

All pass. Regression suites for the shared path (`MoonshadowTest`, `DourPortMageTest`) still pass. DSL reference updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)