### PR TITLE
Add Roar of Endless Song (TDM) + reusable double-P/T-group helper

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -112,8 +112,11 @@ majority of the set.
    future placement, not a one-shot doubling of counters already present.
    → Sage of the Fang
 
-10. **Double power and toughness until end of turn (group).** No double-P/T layer-7 effect found.
-    → Roar of Endless Song
+10. ~~**Double power and toughness until end of turn (group).**~~ ✅ **Done.** Modeled as a
+    fixed +X/+Y layer-7 modification read per-entity from projected state
+    (`DynamicAmount.EntityProperty(EntityReference.IterationEntity, …)`), surfaced as the
+    reusable `EffectPatterns.doublePowerAndToughnessForAll(filter, duration)` helper.
+    → Roar of Endless Song (and Unnatural Growth, refactored onto the same helper)
 
 ---
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/EffectPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/EffectPatterns.kt
@@ -531,6 +531,10 @@ object EffectPatterns {
     fun destroyAllAndAttachedPipeline(filter: GameObjectFilter, noRegenerate: Boolean = false): CompositeEffect =
         GroupPatterns.destroyAllAndAttachedPipeline(filter, noRegenerate)
 
+    /** Double the power and toughness of every permanent matching [filter] until [duration]. */
+    fun doublePowerAndToughnessForAll(filter: GroupFilter, duration: Duration = Duration.EndOfTurn): ForEachInGroupEffect =
+        GroupPatterns.doublePowerAndToughnessForAll(filter, duration)
+
     fun grantKeywordToAll(keyword: Keyword, filter: GroupFilter, duration: Duration = Duration.EndOfTurn): ForEachInGroupEffect =
         GroupPatterns.grantKeywordToAll(keyword, filter, duration)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/GroupPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/GroupPatterns.kt
@@ -21,6 +21,8 @@ import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
 
 /**
  * Effect patterns for bulk operations on filtered groups of permanents:
@@ -137,6 +139,31 @@ object GroupPatterns {
         ForEachInGroupEffect(
             filter = filter,
             effect = ModifyStatsEffect(power, toughness, EffectTarget.Self, duration)
+        )
+
+    /**
+     * Double the power and toughness of every permanent matching [filter] until [duration].
+     *
+     * Each affected creature gets +X/+Y where X is its power and Y its toughness *as the
+     * effect begins to apply* — read per-entity from projected state via
+     * [EntityReference.IterationEntity]. Because it resolves to a fixed +X/+Y modification,
+     * the bonus is locked in when the effect resolves (it does not re-double as P/T later
+     * changes), and negative power doubles correctly (a -2/3 creature gets -2/+0). This
+     * applies as a power/toughness *modification* in layer 7 (the +N/+N sublayer), not a
+     * "set" effect, matching the standard "double its power and toughness" ruling.
+     *
+     * The reusable shape behind every "double the power and toughness" card — e.g.
+     * Roar of Endless Song, Unnatural Growth.
+     */
+    fun doublePowerAndToughnessForAll(
+        filter: GroupFilter,
+        duration: Duration = Duration.EndOfTurn
+    ): ForEachInGroupEffect =
+        modifyStatsForAll(
+            power = DynamicAmount.EntityProperty(EntityReference.IterationEntity, EntityNumericProperty.Power),
+            toughness = DynamicAmount.EntityProperty(EntityReference.IterationEntity, EntityNumericProperty.Toughness),
+            filter = filter,
+            duration = duration
         )
 
     fun dealDamageToAll(amount: Int, filter: GroupFilter): ForEachInGroupEffect =

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/UnnaturalGrowth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/UnnaturalGrowth.kt
@@ -5,9 +5,6 @@ import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
-import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
-import com.wingedsheep.sdk.scripting.values.EntityReference
 
 /**
  * Unnatural Growth
@@ -23,11 +20,7 @@ val UnnaturalGrowth = card("Unnatural Growth") {
 
     triggeredAbility {
         trigger = Triggers.EachCombat
-        effect = EffectPatterns.modifyStatsForAll(
-            power = DynamicAmount.EntityProperty(EntityReference.IterationEntity, EntityNumericProperty.Power),
-            toughness = DynamicAmount.EntityProperty(EntityReference.IterationEntity, EntityNumericProperty.Toughness),
-            filter = Filters.Group.creaturesYouControl,
-        )
+        effect = EffectPatterns.doublePowerAndToughnessForAll(Filters.Group.creaturesYouControl)
         description = "At the beginning of each combat, double the power and toughness of each creature you control until end of turn."
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RoarOfEndlessSong.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RoarOfEndlessSong.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Roar of Endless Song
+ * {2}{G}{U}{R}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I, II — Create a 5/5 green Elephant creature token.
+ * III — Double the power and toughness of each creature you control until end of turn.
+ *
+ * Chapter III composes the reusable [EffectPatterns.doublePowerAndToughnessForAll] helper
+ * (shared with Unnatural Growth) — no card-specific doubling logic.
+ */
+val RoarOfEndlessSong = card("Roar of Endless Song") {
+    manaCost = "{2}{G}{U}{R}"
+    colorIdentity = "GUR"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I, II — Create a 5/5 green Elephant creature token.\n" +
+        "III — Double the power and toughness of each creature you control until end of turn."
+
+    sagaChapter(1) {
+        effect = CreateTokenEffect(
+            power = 5,
+            toughness = 5,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elephant"),
+            name = "Elephant",
+            imageUri = "https://cards.scryfall.io/normal/front/2/4/243bcfa9-0310-4d68-9864-df46069906fa.jpg?1743176747"
+        )
+    }
+
+    sagaChapter(2) {
+        effect = CreateTokenEffect(
+            power = 5,
+            toughness = 5,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elephant"),
+            name = "Elephant",
+            imageUri = "https://cards.scryfall.io/normal/front/2/4/243bcfa9-0310-4d68-9864-df46069906fa.jpg?1743176747"
+        )
+    }
+
+    sagaChapter(3) {
+        effect = EffectPatterns.doublePowerAndToughnessForAll(Filters.Group.creaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "220"
+        artist = "Clint Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a9c3531-61a8-43f5-82a2-5166e5f5a6b9.jpg?1744577948"
+    }
+}


### PR DESCRIPTION
## What

Implements the **"Double power and toughness until end of turn (group)"** engine gap
(`backlog/tdm-engine-gaps.md` #10) and the card that uses it.

### Reusable SDK helper (the "elegant & reusable" part)
- `GroupPatterns.doublePowerAndToughnessForAll(filter, duration)` + `EffectPatterns` facade.
- Doubling is modeled as a fixed **+X/+Y layer-7 modification** read per-entity from projected
  state via `DynamicAmount.EntityProperty(EntityReference.IterationEntity, …)`. Because it
  resolves to a fixed modification, the bonus locks in at resolution (no re-doubling as P/T
  later changes) and negative power doubles correctly — matching the standard "double its
  power and toughness" ruling.
- **Refactored Unnatural Growth (MID)** onto the helper (it previously open-coded the same
  `EntityProperty` dance). Its existing scenario test now exercises the helper directly.

### Card
- **Roar of Endless Song** (TDM #220) — Enchantment — Saga `{2}{G}{U}{R}`:
  - I, II — Create a 5/5 green Elephant creature token.
  - III — Double the power and toughness of each creature you control until end of turn.
  - Pure composition of existing primitives (`sagaChapter` + `CreateTokenEffect` + the new
    helper) — no card-specific logic.

## Verification
- `:mtg-sets:compileKotlin` — **BUILD SUCCESSFUL** (card + helper compile).
- `:game-server:test --tests *UnnaturalGrowthScenarioTest*` — **3/3 PASS**, exercising the
  new `doublePowerAndToughnessForAll` helper at runtime (2/2→4/4, 1/1→2/2, each-combat,
  opponent's creatures unaffected).

## Follow-ups (blocked by an in-session tooling outage — see PR notes)
- SDK doc reference (`docs/card-sdk-language-reference.md`) entry for the new helper still
  to be added.
- A dedicated Roar saga-progression scenario test was drafted but not landed (couldn't be
  verified green this session). Doubling is already runtime-covered by Unnatural Growth, and
  saga/token primitives are independently tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
