### PR TITLE
Shiko, Paragon of the Way — copy a card in a zone, then cast the copy

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -126,9 +126,12 @@ the overwhelming majority of the set.
 
 ## Tier 3 — One-off complex cards (each needs unique new functionality)
 
-11. **Copy a card in a zone, then cast the copy.** All copy primitives operate on stack objects
-    (`CopyTargetSpellEffect`, `ChainCopyEffect`, `CopyNextSpellCast`) or make token copies of
-    permanents — none copies a card *in the graveyard* into a castable spell copy.
+11. **Copy a card in a zone, then cast the copy.** ✅ **DONE.** Added the atomic
+    `CopyCardIntoCollectionEffect` (copy a card in its zone → pipeline collection, Rule 707.12)
+    composed with the existing `CastFromCollectionWithoutPayingCostEffect` (wrapped in `MayEffect`)
+    — no bespoke executor. Uncast copies are swept by a new Rule 707.10a state-based action
+    (`PhantomCardCopiesCheck`). A resolving permanent copy becomes a token, an instant/sorcery
+    copy ceases to exist (existing Rule 707.10 paths).
     → **Shiko, Paragon of the Way**
 
 12. **Cost-linked relative mana value target.** Sacrifice a creature of MV X → return a creature of

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -409,6 +409,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CopyTargetTriggeredAbilityEffect(target)` — copy a triggered ability on the stack.
 - `CopyNextSpellCastEffect` — copy the next spell its controller casts.
 - `CopyEachSpellCastEffect` — copy every spell cast this turn.
+- `CopyCardIntoCollectionEffect(source, storeAs)` (facade `Effects.CopyCardIntoCollection(source, storeAs)`) — copy a **card in a zone** (not a spell on the stack), publishing the copy's entity id to pipeline collection `storeAs`. Per Rule 707.12 the copy is created in the card's current zone under the effect's controller and tagged as a stack-style copy, so once cast it becomes a token if it's a permanent spell and ceases to exist if it's an instant/sorcery (Rule 707.10). Pair with `CastFromCollectionWithoutPayingCostEffect(from)` (facade `Effects.CastFromCollectionWithoutPayingCost(from)`, wrap in `MayEffect` for "you may cast") to express "copy a card, then cast the copy" — e.g. **Shiko, Paragon of the Way**: `Composite(MoveToZoneEffect(target, Zone.EXILE), Effects.CopyCardIntoCollection(target, "copy"), MayEffect(Effects.CastFromCollectionWithoutPayingCost("copy")))`. A copy that is never cast is swept up by the Rule 707.10a state-based action (`PhantomCardCopiesCheck`), so no explicit cleanup step is needed.
 - `ChangeTargetEffect(spell, newTarget)` — change a spell's target.
 - `ChangeSpellTargetEffect(spell, filter)` — same, filtered.
 - `ReselectTargetRandomlyEffect(spell)` — re-choose targets at random.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ShikoParagonOfTheWayScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ShikoParagonOfTheWayScenarioTest.kt
@@ -1,0 +1,156 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.CopyOfComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Shiko, Paragon of the Way (TDM) — {2}{U}{R}{W} Legendary Spirit Dragon.
+ *
+ * "When Shiko enters, exile target nonland card with mana value 3 or less from your graveyard.
+ * Copy it, then you may cast the copy without paying its mana cost."
+ *
+ * Exercises the reusable "copy a card in a zone, then cast the copy" chain
+ * ([com.wingedsheep.sdk.scripting.effects.CopyCardIntoCollectionEffect] +
+ * `CastFromCollectionWithoutPayingCostEffect`) and the Rule 707.10a phantom-copy state-based
+ * action:
+ *  - an instant copy is cast for free and the original stays exiled (it does not return to the
+ *    graveyard);
+ *  - a permanent copy becomes a token on resolution (Rule 707.10);
+ *  - declining the cast leaves no phantom copy lingering in exile.
+ */
+class ShikoParagonOfTheWayScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Shiko, Paragon of the Way ETB") {
+
+            test("copies an instant, casts the copy for free, and leaves the original exiled") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Shiko, Paragon of the Way")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInGraveyard(1, "Shock")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shockId = graveyardCardId(game, "Shock")
+
+                game.castSpell(1, "Shiko, Paragon of the Way")
+                game.resolveStack()
+                // Shiko's ETB pauses to choose its target — the Shock in the graveyard.
+                game.selectTargets(listOf(shockId))
+                // Trigger resolves: exile Shock, copy it, prompt "you may cast the copy".
+                game.resolveStack()
+                game.answerYesNo(true)
+                // The Shock copy is "deals 2 damage to any target" — pick the opponent.
+                game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+
+                withClue("Shock copy should deal 2 damage to the opponent") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("The original Shock is exiled, not returned to the graveyard") {
+                    game.isInGraveyard(1, "Shock") shouldBe false
+                }
+                withClue("Exile holds exactly one Shock — the original, no phantom copy") {
+                    cardsInExile(game, "Shock") shouldBe 1
+                }
+            }
+
+            test("copies a creature card; the cast copy becomes a token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Shiko, Paragon of the Way")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearsId = graveyardCardId(game, "Grizzly Bears")
+
+                game.castSpell(1, "Shiko, Paragon of the Way")
+                game.resolveStack()
+                game.selectTargets(listOf(bearsId))
+                game.resolveStack()
+                game.answerYesNo(true)
+                // The Grizzly Bears copy is a creature spell (no targets) — resolve it.
+                game.resolveStack()
+
+                val tokenId = game.findPermanent("Grizzly Bears")
+                withClue("A Grizzly Bears should be on the battlefield (the cast copy)") {
+                    (tokenId != null) shouldBe true
+                }
+                withClue("Rule 707.10 — a copy of a permanent spell becomes a token") {
+                    game.state.getEntity(tokenId!!)!!.has<TokenComponent>() shouldBe true
+                }
+                withClue("The original Grizzly Bears card stays exiled (not a token)") {
+                    nonTokenCardsInExile(game, "Grizzly Bears") shouldBe 1
+                }
+            }
+
+            test("declining the cast leaves no phantom copy in exile (Rule 707.10a)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Shiko, Paragon of the Way")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearsId = graveyardCardId(game, "Grizzly Bears")
+
+                game.castSpell(1, "Shiko, Paragon of the Way")
+                game.resolveStack()
+                game.selectTargets(listOf(bearsId))
+                game.resolveStack()
+                game.answerYesNo(false)
+
+                withClue("No Grizzly Bears should hit the battlefield when the cast is declined") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("The original is exiled and the uncast copy ceased to exist (count == 1)") {
+                    cardsInExile(game, "Grizzly Bears") shouldBe 1
+                }
+            }
+        }
+    }
+
+    private fun graveyardCardId(game: TestGame, name: String) =
+        game.state.getGraveyard(game.player1Id).first { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+
+    private fun cardsInExile(game: TestGame, name: String): Int =
+        game.state.getExile(game.player1Id).count { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+
+    private fun nonTokenCardsInExile(game: TestGame, name: String): Int =
+        game.state.getExile(game.player1Id).count { id ->
+            val container = game.state.getEntity(id)
+            container?.get<CardComponent>()?.name == name &&
+                !container.has<TokenComponent>() &&
+                !container.has<CopyOfComponent>()
+        }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -47,6 +47,8 @@ import com.wingedsheep.sdk.scripting.effects.CantBlockGroupEffect
 import com.wingedsheep.sdk.scripting.effects.CantCastSpellsEffect
 import com.wingedsheep.sdk.scripting.effects.PreventLandPlaysThisTurnEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CopyCardIntoCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
 import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
@@ -1533,6 +1535,21 @@ object Effects {
      */
     fun Composite(effects: List<Effect>): Effect =
         CompositeEffect(effects)
+
+    /**
+     * Copy a card referenced by [source] into the pipeline collection [storeAs] (Rule 707.12).
+     * The copy is created in the card's current zone and becomes castable; pair with
+     * [CastFromCollectionWithoutPayingCost] reading the same key to "cast the copy".
+     */
+    fun CopyCardIntoCollection(source: EffectTarget, storeAs: String): Effect =
+        CopyCardIntoCollectionEffect(source = source, storeAs = storeAs)
+
+    /**
+     * Cast the (0..1) card stored under [from] without paying its mana cost. The card must
+     * already be in a zone where casting is legal (e.g. exile after a move/copy step).
+     */
+    fun CastFromCollectionWithoutPayingCost(from: String): Effect =
+        CastFromCollectionWithoutPayingCostEffect(from = from)
 
     /**
      * Repeat a body effect in a do-while loop controlled by a repeat condition.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CopyEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CopyEffects.kt
@@ -34,3 +34,41 @@ data class EachPermanentBecomesCopyOfTargetEffect(
         return if (newFilter !== filter) copy(filter = newFilter) else this
     }
 }
+
+/**
+ * Copy a single card referenced by [source] and store the copy's entity id in the pipeline
+ * collection [storeAs].
+ *
+ * Per Rule 707.12 the copy is created in the **same zone the original card currently is in**
+ * (under the effect's controller). The copy keeps the original's copiable characteristics
+ * (name, mana cost, type line, colors, P/T, keywords, spell effect) via a cloned
+ * `CardComponent`, and is tagged as a stack-style copy (a `CopyOfComponent` with no
+ * pre-copy snapshot) so that — once cast — it becomes a token if it's a permanent spell and
+ * ceases to exist if it's an instant/sorcery (Rule 707.10).
+ *
+ * This is the zone-side half of the "copy a card, then cast the copy" pattern: pair it with
+ * [CastFromCollectionWithoutPayingCostEffect] (wrapped in `MayEffect` for "you may cast")
+ * reading the same [storeAs] collection. A copy that is never cast is removed by the
+ * Rule 707.10a state-based action (a copy of a card outside the stack/battlefield ceases to
+ * exist), so no explicit cleanup step is needed.
+ *
+ *     // Shiko, Paragon of the Way — exile a graveyard card, copy it, then may cast the copy
+ *     CompositeEffect(listOf(
+ *         MoveToZoneEffect(target, Zone.EXILE),
+ *         CopyCardIntoCollectionEffect(target, storeAs = "copy"),
+ *         MayEffect(CastFromCollectionWithoutPayingCostEffect("copy")),
+ *     ))
+ *
+ * @property source The card to copy (e.g. `ContextTarget(0)` for a targeted graveyard card).
+ * @property storeAs Pipeline collection key under which the new copy's entity id is stored.
+ */
+@SerialName("CopyCardIntoCollection")
+@Serializable
+data class CopyCardIntoCollectionEffect(
+    val source: EffectTarget = EffectTarget.ContextTarget(0),
+    val storeAs: String,
+) : Effect {
+    override val description: String = "Copy ${source.description}"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ShikoParagonOfTheWay.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ShikoParagonOfTheWay.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Shiko, Paragon of the Way — Tarkir: Dragonstorm #223
+ * {2}{U}{R}{W} · Legendary Creature — Spirit Dragon · 4/5
+ *
+ * Flying, vigilance
+ * When Shiko enters, exile target nonland card with mana value 3 or less from your graveyard.
+ * Copy it, then you may cast the copy without paying its mana cost. (A copy of a permanent
+ * spell becomes a token.)
+ *
+ * Composed from atomic primitives rather than a bespoke executor — the "copy a card in a zone,
+ * then cast the copy" pattern (Rule 707.12) is just three chained steps:
+ *
+ *   1. **Exile** the targeted graveyard card ([MoveToZoneEffect] → exile).
+ *   2. **Copy it** in place ([Effects.CopyCardIntoCollection]) — the copy is a stack-style copy
+ *      created in exile and published to the `copy` collection.
+ *   3. **You may cast the copy** for free ([Effects.CastFromCollectionWithoutPayingCost] wrapped
+ *      in [MayEffect]). The copy is cast through the normal machinery, so it picks targets/X,
+ *      becomes a token if it's a permanent spell, and ceases to exist if it's an instant/sorcery
+ *      (Rule 707.10). A copy that's declined or can't be cast is removed by the Rule 707.10a
+ *      state-based action, leaving no phantom card in exile.
+ */
+val ShikoParagonOfTheWay = card("Shiko, Paragon of the Way") {
+    manaCost = "{2}{U}{R}{W}"
+    colorIdentity = "URW"
+    typeLine = "Legendary Creature — Spirit Dragon"
+    power = 4
+    toughness = 5
+    oracleText = "Flying, vigilance\n" +
+        "When Shiko enters, exile target nonland card with mana value 3 or less from your " +
+        "graveyard. Copy it, then you may cast the copy without paying its mana cost. " +
+        "(A copy of a permanent spell becomes a token.)"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        description = "When Shiko enters, exile target nonland card with mana value 3 or less " +
+            "from your graveyard. Copy it, then you may cast the copy without paying its mana cost."
+        val exiledCard = target(
+            "target nonland card with mana value 3 or less from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Nonland.manaValueAtMost(3).ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                )
+            )
+        )
+        effect = Effects.Composite(
+            MoveToZoneEffect(exiledCard, Zone.EXILE),
+            Effects.CopyCardIntoCollection(exiledCard, storeAs = "copy"),
+            MayEffect(
+                Effects.CastFromCollectionWithoutPayingCost("copy"),
+                descriptionOverride = "You may cast the copy without paying its mana cost.",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "223"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/8138cf10-1e3e-483f-86ad-cc399192657d.jpg?1743204881"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CopyCardIntoCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CopyCardIntoCollectionExecutor.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.CopyOfComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.scripting.effects.CopyCardIntoCollectionEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [CopyCardIntoCollectionEffect].
+ *
+ * Resolves the source card, clones its copiable characteristics onto a brand-new entity, and
+ * places that copy in the source card's current zone under the effect's controller — exactly
+ * what Rule 707.12 requires of "cast a copy of a card" effects ("the copy is created in the
+ * same zone the object is in"). The copy's id is published to the pipeline collection named by
+ * [CopyCardIntoCollectionEffect.storeAs] so a downstream
+ * [com.wingedsheep.engine.handlers.effects.library.CastFromCollectionWithoutPayingCostExecutor]
+ * can cast it.
+ *
+ * The copy carries a [CopyOfComponent] with no pre-copy snapshot (`originalCardComponent = null`),
+ * marking it a stack-style copy: when cast, [com.wingedsheep.engine.mechanics.stack.StackResolver]
+ * turns a resolving permanent copy into a token and makes an instant/sorcery copy cease to exist
+ * (Rule 707.10). A copy that is never cast is swept up by the Rule 707.10a state-based action
+ * ([com.wingedsheep.engine.mechanics.sba.zone.PhantomCardCopiesCheck]).
+ *
+ * No source / source isn't a card / source isn't in a zone → no-op with an empty collection,
+ * mirroring the gather/select primitives so the chain degrades gracefully.
+ */
+class CopyCardIntoCollectionExecutor : EffectExecutor<CopyCardIntoCollectionEffect> {
+
+    override val effectType: KClass<CopyCardIntoCollectionEffect> =
+        CopyCardIntoCollectionEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: CopyCardIntoCollectionEffect,
+        context: EffectContext,
+    ): EffectResult {
+        val emptyResult = EffectResult.success(state).copy(
+            updatedCollections = mapOf(effect.storeAs to emptyList())
+        )
+
+        val sourceId = context.resolveTarget(effect.source, state) ?: return emptyResult
+        val sourceCard = state.getEntity(sourceId)?.get<CardComponent>() ?: return emptyResult
+        val sourceZone = findEntityZone(state, sourceId) ?: return emptyResult
+
+        val controllerId = context.controllerId
+
+        // Clone the copiable characteristics (Rule 707.2). The new copy is owned and controlled
+        // by the player casting it, and is created in the same zone type the original is in.
+        val copyCard = sourceCard.copy(ownerId = controllerId)
+        val container = ComponentContainer.of(
+            copyCard,
+            OwnerComponent(controllerId),
+            ControllerComponent(controllerId),
+            CopyOfComponent(
+                originalCardDefinitionId = sourceCard.cardDefinitionId,
+                copiedCardDefinitionId = sourceCard.cardDefinitionId,
+            ),
+        )
+
+        val (copyId, stateWithId) = state.newEntity()
+        val newState = stateWithId
+            .withEntity(copyId, container)
+            .addToZone(ZoneKey(controllerId, sourceZone.zoneType), copyId)
+
+        return EffectResult.success(newState).copy(
+            updatedCollections = mapOf(effect.storeAs to listOf(copyId))
+        )
+    }
+
+    private fun findEntityZone(state: GameState, entityId: com.wingedsheep.sdk.model.EntityId): ZoneKey? {
+        for ((zoneKey, entities) in state.zones) {
+            if (entityId in entities) return zoneKey
+        }
+        return null
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -53,6 +53,7 @@ class LibraryExecutors(
         ChooseCreatureTypePipelineExecutor(),
         ChooseOptionPipelineExecutor(cardRegistry = cardRegistry),
         GatherCardsExecutor(),
+        CopyCardIntoCollectionExecutor(),
         SelectFromCollectionExecutor(),
         ChoosePileExecutor(),
         SelectTargetPipelineExecutor(targetFinder = targetFinder ?: TargetFinder()),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
@@ -17,5 +17,6 @@ object SbaOrder {
     const val SAGA_SACRIFICE = 900          // 714.4
     const val COMMANDER_ZONE_CHOICE = 950   // 903.9a (Commander format)
     const val TOKENS_IN_WRONG_ZONES = 1000  // 704.5s
+    const val PHANTOM_CARD_COPIES = 1050    // 707.10a
     const val GAME_END = 9999
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/zone/PhantomCardCopiesCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/zone/PhantomCardCopiesCheck.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.mechanics.sba.zone
+
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.mechanics.sba.SbaOrder
+import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CopyOfComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Rule 707.10a — a copy of a card in any zone other than the stack or the battlefield ceases
+ * to exist. This is a state-based action.
+ *
+ * The "copy a card, then cast the copy" pattern (e.g. Shiko, Paragon of the Way) materialises a
+ * copy in a non-stack zone before offering to cast it. When the copy is cast it moves onto the
+ * stack (and either becomes a token on the battlefield or ceases to exist on resolution per
+ * Rule 707.10) — so this check never touches a copy that is mid-cast, because state-based
+ * actions are not run while resolution is paused. It only sweeps up copies that were declined
+ * or could not be cast, leaving no phantom card lingering in the exile/graveyard/hand/library.
+ *
+ * Only stack-style copies are removed: those with [CopyOfComponent.originalCardComponent] left
+ * null. Clone-style copies (Mockingbird, "becomes a copy of") snapshot the pre-copy component
+ * and live on the battlefield as real permanents, so they are out of scope. Tokens are left to
+ * the dedicated [TokensInWrongZonesCheck] (Rule 704.5s).
+ */
+class PhantomCardCopiesCheck : StateBasedActionCheck {
+    override val name = "707.10a Phantom Card Copies"
+    override val order = SbaOrder.PHANTOM_CARD_COPIES
+
+    override fun check(state: GameState): ExecutionResult {
+        var newState = state
+        val copiesToRemove = mutableListOf<Pair<EntityId, ZoneKey>>()
+
+        for (playerId in state.turnOrder) {
+            for (zoneType in listOf(Zone.HAND, Zone.GRAVEYARD, Zone.LIBRARY, Zone.EXILE)) {
+                val zoneKey = ZoneKey(playerId, zoneType)
+                for (entityId in state.getZone(zoneKey)) {
+                    val container = state.getEntity(entityId) ?: continue
+                    if (container.has<TokenComponent>()) continue
+                    val copyOf = container.get<CopyOfComponent>() ?: continue
+                    if (copyOf.originalCardComponent == null) {
+                        copiesToRemove.add(entityId to zoneKey)
+                    }
+                }
+            }
+        }
+
+        for ((entityId, zoneKey) in copiesToRemove) {
+            newState = newState.removeFromZone(zoneKey, entityId).withoutEntity(entityId)
+        }
+
+        return ExecutionResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/zone/ZoneSbaModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/zone/ZoneSbaModule.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.mechanics.sba.StateBasedActionModule
 
 class ZoneSbaModule : StateBasedActionModule {
     override fun checks(): List<StateBasedActionCheck> = listOf(
-        TokensInWrongZonesCheck()
+        TokensInWrongZonesCheck(),
+        PhantomCardCopiesCheck()
     )
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/sba/PhantomCardCopiesCheckTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/sba/PhantomCardCopiesCheckTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.mechanics.sba
+
+import com.wingedsheep.engine.mechanics.sba.zone.PhantomCardCopiesCheck
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.CopyOfComponent
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for [PhantomCardCopiesCheck] (Rule 707.10a — a copy of a card in any zone other
+ * than the stack or the battlefield ceases to exist).
+ */
+class PhantomCardCopiesCheckTest : FunSpec({
+
+    val p1 = EntityId.generate()
+
+    fun card(name: String) = CardComponent(
+        cardDefinitionId = name,
+        name = name,
+        manaCost = ManaCost.parse("{1}"),
+        typeLine = TypeLine.parse("Instant"),
+    )
+
+    fun baseState(): GameState = GameState()
+        .withEntity(p1, ComponentContainer.of(PlayerComponent("P1", 20)))
+        .copy(turnOrder = listOf(p1))
+
+    fun stackCopy(originalSnapshot: CardComponent? = null) = ComponentContainer.of(
+        card("Phantom Bolt"),
+        CopyOfComponent("Phantom Bolt", "Phantom Bolt", originalCardComponent = originalSnapshot),
+    )
+
+    test("removes a stack-style card copy left in exile") {
+        val copyId = EntityId.generate()
+        val state = baseState()
+            .withEntity(copyId, stackCopy())
+            .addToZone(ZoneKey(p1, Zone.EXILE), copyId)
+
+        val result = PhantomCardCopiesCheck().check(state)
+
+        result.newState.getEntity(copyId) shouldBe null
+        result.newState.getZone(ZoneKey(p1, Zone.EXILE)).contains(copyId) shouldBe false
+    }
+
+    test("removes a stack-style card copy left in the graveyard") {
+        val copyId = EntityId.generate()
+        val state = baseState()
+            .withEntity(copyId, stackCopy())
+            .addToZone(ZoneKey(p1, Zone.GRAVEYARD), copyId)
+
+        PhantomCardCopiesCheck().check(state).newState.getEntity(copyId) shouldBe null
+    }
+
+    test("spares a copy on the battlefield (Rule 707.10a only sweeps off-stack/off-battlefield)") {
+        val copyId = EntityId.generate()
+        val state = baseState()
+            .withEntity(copyId, stackCopy())
+            .addToZone(ZoneKey(p1, Zone.BATTLEFIELD), copyId)
+
+        PhantomCardCopiesCheck().check(state).newState.getEntity(copyId) shouldBe state.getEntity(copyId)
+    }
+
+    test("spares a Clone-style copy in exile (it carries a pre-copy snapshot)") {
+        val copyId = EntityId.generate()
+        val state = baseState()
+            .withEntity(copyId, stackCopy(originalSnapshot = card("Clone")))
+            .addToZone(ZoneKey(p1, Zone.EXILE), copyId)
+
+        PhantomCardCopiesCheck().check(state).newState.getEntity(copyId) shouldBe state.getEntity(copyId)
+    }
+
+    test("spares a token in exile (left to the 704.5s token check)") {
+        val tokenId = EntityId.generate()
+        val state = baseState()
+            .withEntity(tokenId, stackCopy().with(TokenComponent))
+            .addToZone(ZoneKey(p1, Zone.EXILE), tokenId)
+
+        PhantomCardCopiesCheck().check(state).newState.getEntity(tokenId) shouldBe state.getEntity(tokenId)
+    }
+
+    test("leaves an ordinary (non-copy) card in the graveyard untouched") {
+        val cardId = EntityId.generate()
+        val state = baseState()
+            .withEntity(cardId, ComponentContainer.of(card("Real Bolt")))
+            .addToZone(ZoneKey(p1, Zone.GRAVEYARD), cardId)
+
+        PhantomCardCopiesCheck().check(state).newState.getEntity(cardId) shouldBe state.getEntity(cardId)
+    }
+})


### PR DESCRIPTION
Implements **TDM engine-gap #11** (`backlog/tdm-engine-gaps.md`) → **Shiko, Paragon of the Way** `{2}{U}{R}{W}` Legendary Spirit Dragon 4/5, flying/vigilance.

> When Shiko enters, exile target nonland card with mana value 3 or less from your graveyard. Copy it, then you may cast the copy without paying its mana cost. *(A copy of a permanent spell becomes a token.)*

This was the one TDM gap where no existing primitive copied a **card in a zone** into a castable spell (all copy effects operate on stack objects or make token copies of permanents).

## Approach — a chain, not a bespoke effect

Per the project's "compose atomic primitives" principle, Shiko's ETB is a three-step chain. Only one new atomic primitive was needed; the cast half reuses what `Sunbird's Invocation` already uses:

```kotlin
Composite(
    MoveToZoneEffect(target, Zone.EXILE),                       // exile the original
    Effects.CopyCardIntoCollection(target, "copy"),             // NEW — copy in place (CR 707.12)
    MayEffect(Effects.CastFromCollectionWithoutPayingCost("copy")), // existing — "you may cast"
)
```

## What's new

- **`CopyCardIntoCollectionEffect`** (SDK + executor) — clones a card's copiable characteristics into a new entity in the card's current zone, tagged as a stack-style `CopyOfComponent`, and publishes its id to a pipeline collection. Once cast, the existing `StackResolver` paths make a resolving permanent copy become a **token** and an instant/sorcery copy **cease to exist** (CR 707.10). Added `Effects.CopyCardIntoCollection` / `Effects.CastFromCollectionWithoutPayingCost` facades.
- **`PhantomCardCopiesCheck`** — a new **CR 707.10a** state-based action: a copy of a card in any zone other than the stack or battlefield ceases to exist. This sweeps up the copy when the player declines (or can't) cast it, so there's no card-specific cleanup. SBAs are skipped during *paused* resolution, so a copy that's mid-cast (waiting on a target/X/mode prompt) is never yanked out from under the cast.

## Tests

- `ShikoParagonOfTheWayScenarioTest` (game-server) — 3 cases: instant copy cast for free with the original staying exiled (not returned to graveyard); permanent copy becomes a token; declining leaves no phantom copy in exile.
- `PhantomCardCopiesCheckTest` (rules-engine) — the SBA removes off-stack/off-battlefield card copies while sparing Clone-style copies (snapshot present), tokens, battlefield permanents, and ordinary cards.
- Full `:rules-engine`, `:game-server`, and `:mtg-sets` suites pass — the always-on SBA introduces no regressions.

Rule numbers verified against yawgatog.com: **707.12** (cast a copy; created in the card's zone) and **707.10a** (copy outside stack/battlefield ceases to exist, as an SBA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)