### PR TITLE
Redesign lobby set selection: chips + searchable browser modal

### DIFF
--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1052,7 +1052,10 @@
   background-color: var(--bg-panel-light);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-xl);
-  overflow: hidden;
+  /* Stable height: the panel never grows past this — extra rows scroll inside it instead of
+     resizing (and re-centering) the whole lobby as sets/boosters are added. */
+  max-height: min(62vh, 640px);
+  overflow: hidden auto;
 }
 
 .settingsRow {
@@ -1201,6 +1204,9 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  /* Cap the per-set stepper list so picking more sets scrolls here instead of growing the row. */
+  max-height: 216px;
+  overflow-y: auto;
 }
 
 .boosterDistributionRow {
@@ -1279,56 +1285,117 @@
   color: var(--text-muted);
 }
 
-/* Set selection grid — block grouping */
-.setSelectionGrid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-1);
-  justify-content: flex-end;
-  align-items: flex-start;
-}
-
-.blockGroup {
+/* =========================================================================
+ * Set selection — selected sets as chips in the lobby; full browser is a modal
+ * ========================================================================= */
+.setSelection {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 6px 8px 6px 8px;
-  background: rgba(255, 255, 255, 0.025);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: var(--radius-md);
+  align-items: flex-end;
+  gap: var(--space-2);
+  max-width: 380px;
 }
 
-.blockLabel {
-  font-size: var(--font-xs);
-  color: var(--text-muted);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  opacity: 0.7;
-  line-height: 1;
-}
-
-.blockSets {
+.setChips {
   display: flex;
-  gap: var(--space-1);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
 }
 
-.incompleteSetsButton {
+/* Selected-set chip. Orange = sealed-shape pools, blue = draft-shape (matches the format accent). */
+.setChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 3px 3px 3px 10px;
+  font-size: var(--font-sm);
+  font-weight: var(--font-weight-medium);
+  color: #fff;
+  background: linear-gradient(180deg, #f0671b 0%, #c84a0e 100%);
+  border: 1px solid rgba(255, 165, 90, 0.55);
+  border-radius: 999px;
+  box-shadow: 0 1px 4px rgba(230, 81, 0, 0.3);
+}
+
+.setChipDraft {
+  background: linear-gradient(180deg, #2f9bf5 0%, #1769c9 100%);
+  border-color: rgba(120, 190, 255, 0.55);
+  box-shadow: 0 1px 4px rgba(33, 150, 243, 0.3);
+}
+
+.setChipPartial {
   border-style: dashed;
-  align-self: flex-start;
 }
 
-.incompleteSetsNote {
-  font-size: var(--font-xs);
+.setChipName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.setChipRemove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.18);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.setChipRemove:hover {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.setSelectionEmpty {
+  font-size: var(--font-sm);
   color: var(--text-disabled);
-  line-height: 1.4;
-  margin: 0 0 var(--space-3);
+  padding: 4px 0;
 }
 
-.incompleteSetsSearch {
+.addSetsButton {
+  align-self: flex-end;
+  padding: 6px var(--space-4);
+  font-size: var(--font-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
+}
+
+.addSetsButton:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.09);
+  border-color: var(--color-accent);
+}
+
+/* ── Set picker modal ── */
+.setPickerSelectedCount {
+  margin-left: auto;
+  margin-right: var(--space-3);
+  font-size: var(--font-sm);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.setPickerSearch {
   width: 100%;
   box-sizing: border-box;
   margin-bottom: var(--space-2);
-  padding: 8px 12px;
+  padding: 9px 12px;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid var(--border-medium);
   border-radius: var(--radius-md);
@@ -1337,36 +1404,120 @@
   outline: none;
 }
 
-.incompleteSetsSearch:focus {
+.setPickerSearch:focus {
   border-color: var(--color-accent-dark);
 }
 
-.incompleteSetsSearch::placeholder {
+.setPickerSearch::placeholder {
   color: var(--text-disabled);
 }
 
-.incompleteSetsList {
+.setPickerNote {
+  font-size: var(--font-xs);
+  color: var(--text-disabled);
+  line-height: 1.5;
+  margin: 0 0 var(--space-3);
+}
+
+.setPickerList {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
-  max-height: 48vh;
+  gap: var(--space-3);
+  max-height: 52vh;
   overflow-y: auto;
 }
 
-.incompleteSetRow {
+.setPickerGroup {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  width: 100%;
-  text-align: left;
+  flex-direction: column;
+  gap: 3px;
 }
 
-.incompleteSetRow .setButtonCardCount {
+.setPickerGroupLabel {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 4px 2px;
+  font-size: var(--font-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-tertiary);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: linear-gradient(180deg, rgba(20, 20, 30, 0.98), rgba(20, 20, 30, 0.92));
+}
+
+.setPickerRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: 8px 10px;
+  text-align: left;
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.setPickerRow:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+}
+
+.setPickerRowActive {
+  background: rgba(47, 155, 245, 0.16);
+  border-color: rgba(47, 155, 245, 0.5);
+  color: var(--text-primary);
+}
+
+.setPickerRow .setButtonCardCount {
   flex-shrink: 0;
 }
 
-.incompleteSetsEmpty {
+.setPickerCheck {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  font-size: 10px;
+  font-weight: var(--font-weight-bold);
+  color: #fff;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+}
+
+.setPickerRowActive .setPickerCheck {
+  background: var(--color-accent-dark);
+  border-color: var(--color-accent-dark);
+}
+
+.setPickerName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.setPartialBadge {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  font-size: 9px;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+  background: rgba(251, 191, 36, 0.14);
+  border: 1px solid rgba(251, 191, 36, 0.4);
+  border-radius: 999px;
+}
+
+.setPickerEmpty {
   font-size: var(--font-sm);
   color: var(--text-disabled);
   text-align: center;

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -697,8 +697,8 @@ function LobbyOverlay({
   const updateLobbySettings = useGameStore((state) => state.updateLobbySettings)
   const tournamentState = useGameStore((state) => state.tournamentState)
   const [copied, setCopied] = useState(false)
-  const [showIncompleteSets, setShowIncompleteSets] = useState(false)
-  const [incompleteSearch, setIncompleteSearch] = useState('')
+  const [showSetPicker, setShowSetPicker] = useState(false)
+  const [setSearch, setSetSearch] = useState('')
 
   // Show tournament standings when tournament is active
   if (tournamentState) {
@@ -746,25 +746,28 @@ function LobbyOverlay({
     setTimeout(() => setCopied(false), 2000)
   }
 
-  // Incomplete sets (cards not fully implemented yet) are pulled out of the main grid and offered
-  // behind a separate modal so the default picker stays focused on fully-playable sets.
+  // Unified set picker: every set (complete + incomplete) lives behind one searchable modal.
+  // The lobby itself only shows the *selected* sets as compact chips, so its footprint stays small
+  // and stable no matter how many sets exist in total or how many a host picks.
   type AvailableSet = typeof lobbyState.settings.availableSets[number]
-  const completeSets = lobbyState.settings.availableSets.filter((s) => !s.incomplete)
-  const incompleteSets = lobbyState.settings.availableSets.filter((s) => s.incomplete)
-  const selectedIncompleteCount = incompleteSets.filter((s) => lobbyState.settings.setCodes.includes(s.code)).length
-  // Searchable multi-select inside the modal — match on set name or code, like the deckbuilder picker.
-  const incompleteSearchNeedle = incompleteSearch.trim().toLowerCase()
-  const filteredIncompleteSets = incompleteSearchNeedle
-    ? incompleteSets.filter(
-        (s) =>
-          s.name.toLowerCase().includes(incompleteSearchNeedle) ||
-          s.code.toLowerCase().includes(incompleteSearchNeedle),
-      )
-    : incompleteSets
+  const allSets = lobbyState.settings.availableSets
+  const selectedSets = lobbyState.settings.setCodes
+    .map((code) => allSets.find((s) => s.code === code))
+    .filter((s): s is AvailableSet => s != null)
 
-  const closeIncompleteSets = () => {
-    setShowIncompleteSets(false)
-    setIncompleteSearch('')
+  // Searchable multi-select inside the modal — match on set name or code, like the deckbuilder picker.
+  const setSearchNeedle = setSearch.trim().toLowerCase()
+  const filteredPickerSets = setSearchNeedle
+    ? allSets.filter(
+        (s) =>
+          s.name.toLowerCase().includes(setSearchNeedle) ||
+          s.code.toLowerCase().includes(setSearchNeedle),
+      )
+    : allSets
+
+  const closeSetPicker = () => {
+    setShowSetPicker(false)
+    setSetSearch('')
   }
 
   const toggleSet = (code: string) => {
@@ -775,33 +778,20 @@ function LobbyOverlay({
     updateLobbySettings({ setCodes: newCodes })
   }
 
-  const renderSetButton = (set: AvailableSet) => {
-    const isSelected = lobbyState.settings.setCodes.includes(set.code)
-    return (
-      <button
-        key={set.code}
-        onClick={() => toggleSet(set.code)}
-        className={`${styles.settingsButton} ${isSelected ? (isAnyDraft ? `${styles.settingsButtonActive} ${styles.settingsButtonDraft}` : styles.settingsButtonActive) : ''}`}
-      >
-        <span>{set.name}</span>
-        {set.implementedCount != null && (
-          <span className={styles.setButtonCardCount}>{set.implementedCount} cards</span>
-        )}
-      </button>
-    )
-  }
-
-  // Full-width toggle row used inside the searchable incomplete-sets multi-select.
-  const renderIncompleteSetRow = (set: AvailableSet) => {
+  // One toggle row inside the picker modal. Incomplete sets get a "partial" tag so the host knows
+  // those boosters draw from a reduced pool of implemented cards.
+  const renderSetPickerRow = (set: AvailableSet) => {
     const isSelected = lobbyState.settings.setCodes.includes(set.code)
     return (
       <button
         key={set.code}
         type="button"
         onClick={() => toggleSet(set.code)}
-        className={`${styles.settingsButton} ${styles.incompleteSetRow} ${isSelected ? styles.settingsButtonActive : ''}`}
+        className={`${styles.setPickerRow} ${isSelected ? styles.setPickerRowActive : ''}`}
       >
-        <span>{set.name}</span>
+        <span className={styles.setPickerCheck} aria-hidden>{isSelected ? '✓' : ''}</span>
+        <span className={styles.setPickerName}>{set.name}</span>
+        {set.incomplete && <span className={styles.setPartialBadge}>partial</span>}
         {set.implementedCount != null && (
           <span className={styles.setButtonCardCount}>{set.implementedCount} cards</span>
         )}
@@ -809,8 +799,8 @@ function LobbyOverlay({
     )
   }
 
-  // Group sets: ungrouped first, then per-block groups (preserving first-seen order).
-  const renderGroupedSets = (sets: readonly AvailableSet[]) => {
+  // Group picker rows by block (first-seen order); ungrouped sets fall under an "Other" section.
+  const renderGroupedSetRows = (sets: readonly AvailableSet[]) => {
     const blockOrder: string[] = []
     const blockSets = new Map<string, AvailableSet[]>()
     const ungrouped: AvailableSet[] = []
@@ -825,19 +815,18 @@ function LobbyOverlay({
         ungrouped.push(set)
       }
     }
-    return (
-      <>
-        {ungrouped.map(renderSetButton)}
-        {blockOrder.map((blockName) => (
-          <div key={blockName} className={styles.blockGroup}>
-            <span className={styles.blockLabel}>{blockName} Block</span>
-            <div className={styles.blockSets}>
-              {blockSets.get(blockName)!.map(renderSetButton)}
-            </div>
-          </div>
-        ))}
-      </>
+    const groups: Array<{ key: string; label: string; sets: AvailableSet[] }> = blockOrder.map(
+      (name) => ({ key: name, label: `${name} Block`, sets: blockSets.get(name)! }),
     )
+    if (ungrouped.length > 0) {
+      groups.push({ key: '__other', label: blockOrder.length > 0 ? 'Other sets' : 'All sets', sets: ungrouped })
+    }
+    return groups.map((group) => (
+      <div key={group.key} className={styles.setPickerGroup}>
+        <div className={styles.setPickerGroupLabel}>{group.label}</div>
+        {group.sets.map(renderSetPickerRow)}
+      </div>
+    ))
   }
 
   return (
@@ -1002,24 +991,40 @@ function LobbyOverlay({
                 </div>
               )
             })()}
-            {/* Set selection — grouped by block. Skipped for Premade Decks since no boosters are generated. */}
+            {/* Set selection — selected sets shown as chips; the full searchable browser is a modal.
+                Skipped for Premade Decks since no boosters are generated. */}
             {!isPremade && (
             <div className={styles.settingsRow} style={{ alignItems: 'flex-start' }}>
-              <span className={styles.settingsLabel} style={{ paddingTop: 6 }}>Sets</span>
-              <div className={styles.setSelectionGrid}>
-                {renderGroupedSets(completeSets)}
-                {incompleteSets.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={() => setShowIncompleteSets(true)}
-                    className={`${styles.settingsButton} ${styles.incompleteSetsButton}`}
-                  >
-                    <span>Incomplete sets…</span>
-                    <span className={styles.setButtonCardCount}>
-                      {selectedIncompleteCount > 0 ? `${selectedIncompleteCount} selected` : `${incompleteSets.length} available`}
-                    </span>
-                  </button>
+              <span className={styles.settingsLabel} style={{ paddingTop: 7 }}>Sets</span>
+              <div className={styles.setSelection}>
+                {selectedSets.length > 0 ? (
+                  <div className={styles.setChips}>
+                    {selectedSets.map((set) => (
+                      <span
+                        key={set.code}
+                        className={`${styles.setChip} ${isAnyDraft ? styles.setChipDraft : ''} ${set.incomplete ? styles.setChipPartial : ''}`}
+                        title={set.incomplete ? `${set.name} — partial (reduced card pool)` : set.name}
+                      >
+                        <span className={styles.setChipName}>{set.name}</span>
+                        <button
+                          type="button"
+                          className={styles.setChipRemove}
+                          aria-label={`Remove ${set.name}`}
+                          onClick={() => toggleSet(set.code)}
+                        >×</button>
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <span className={styles.setSelectionEmpty}>No sets selected yet</span>
                 )}
+                <button
+                  type="button"
+                  onClick={() => setShowSetPicker(true)}
+                  className={styles.addSetsButton}
+                >
+                  + Add sets
+                </button>
               </div>
             </div>
             )}
@@ -1416,35 +1421,36 @@ function LobbyOverlay({
         )}
       </div>
 
-      {showIncompleteSets && (
-        <div className={styles.deckViewerBackdrop} onClick={closeIncompleteSets}>
+      {showSetPicker && (
+        <div className={styles.deckViewerBackdrop} onClick={closeSetPicker}>
           <div className={styles.deckViewerPanel} style={{ maxWidth: 560 }} onClick={(e) => e.stopPropagation()}>
             <div className={styles.deckViewerHeader}>
-              <h3 className={styles.deckViewerTitle}>Incomplete sets</h3>
-              <button className={styles.deckViewerClose} onClick={closeIncompleteSets}>×</button>
+              <h3 className={styles.deckViewerTitle}>Choose sets</h3>
+              <span className={styles.setPickerSelectedCount}>
+                {selectedSets.length} selected
+              </span>
+              <button className={styles.deckViewerClose} onClick={closeSetPicker}>×</button>
             </div>
             <div className={styles.deckViewerBody}>
-              <p className={styles.incompleteSetsNote}>
-                These sets aren't fully implemented yet — some cards are missing, so boosters draw from a
-                combined pool of the cards that exist. Pick any number to mix into your pool.
-              </p>
               <input
                 type="text"
-                className={styles.incompleteSetsSearch}
+                className={styles.setPickerSearch}
                 placeholder="Search sets by name or code…"
-                value={incompleteSearch}
+                value={setSearch}
                 spellCheck={false}
                 autoComplete="off"
                 autoFocus
-                onChange={(e) => setIncompleteSearch(e.target.value)}
+                onChange={(e) => setSetSearch(e.target.value)}
               />
-              <div className={styles.incompleteSetsList}>
-                {filteredIncompleteSets.length > 0 ? (
-                  filteredIncompleteSets.map(renderIncompleteSetRow)
+              <p className={styles.setPickerNote}>
+                Sets tagged <span className={styles.setPartialBadge}>partial</span> aren't fully
+                implemented — their boosters draw from a reduced pool of the cards that exist.
+              </p>
+              <div className={styles.setPickerList}>
+                {filteredPickerSets.length > 0 ? (
+                  renderGroupedSetRows(filteredPickerSets)
                 ) : (
-                  <div className={styles.incompleteSetsEmpty}>
-                    {incompleteSearchNeedle ? 'No sets match your search.' : 'No incomplete sets available.'}
-                  </div>
+                  <div className={styles.setPickerEmpty}>No sets match your search.</div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## What & why

The tournament/sealed lobby's set selection rendered every complete set as an inline tile grouped into block boxes. Two problems surfaced as the set count grew (~70 sets and climbing):

1. **Not scalable** — the tile wall dominated the lobby and would only get worse.
2. **The lobby jumped vertically** every time a set was selected: the per-set booster-distribution section grew a row per set, and the vertically-centered panel re-centered on every height change.

## Changes

- **Selected sets as chips.** The lobby's "Sets" row now shows only the *selected* sets as compact removable chips (orange for sealed-shape pools, blue for draft-shape, matching the format accent) plus an **`+ Add sets`** button. Footprint stays small and roughly constant regardless of how many sets exist or are picked.
- **Unified searchable picker modal.** All sets (complete **and** incomplete) now live behind one searchable, block-grouped modal with sticky section headers, a per-row check indicator, a live "N selected" count, and a small **`partial`** tag for not-fully-implemented sets. This replaces the old incomplete-sets-only modal and folds both flows into one.
- **Stable lobby height.** Capped the settings panel (`max-height` + inner scroll) and the per-set booster-distribution list so adding sets scrolls internally instead of resizing/re-centering the whole lobby.

## Notes

- Pure web-client UI change (`GameUI.tsx` + `GameUI.module.css`); no engine/server changes.
- `npm run typecheck` and `npm run build` both pass.
- Removed the now-dead inline-tile code and the previous round's tile CSS.

## Test plan

- [ ] Open a tournament/sealed lobby as host → ECL shows as a pre-selected chip.
- [ ] Click **Add sets** → search, toggle sets across blocks, see the partial tag on incomplete sets.
- [ ] Remove a chip via its ×; selection updates.
- [ ] Add several sets in Sealed → booster distribution scrolls internally; lobby panel no longer jumps/grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)