### PR TITLE
perf(engine): key components by Class.getName() instead of kotlin-reflect (perf plan step 1)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -1188,7 +1188,7 @@ object DamageUtils {
     ): Boolean {
         if (projected.hasColor(sourceId, color)) return true
         val sourceEntity = state.getEntity(sourceId) ?: return false
-        val card = sourceEntity.components[CardComponent::class.qualifiedName] as? CardComponent ?: return false
+        val card = sourceEntity.components[CardComponent::class.java.name] as? CardComponent ?: return false
         return card.colors.contains(color)
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/ComponentContainer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/ComponentContainer.kt
@@ -15,7 +15,7 @@ data class ComponentContainer(
      * Get a component by type, or null if not present.
      */
     inline fun <reified T : Component> get(): T? {
-        return components[T::class.qualifiedName] as? T
+        return components[T::class.java.name] as? T
     }
 
     /**
@@ -31,21 +31,21 @@ data class ComponentContainer(
      * Check if a component type is present.
      */
     inline fun <reified T : Component> has(): Boolean {
-        return components.containsKey(T::class.qualifiedName)
+        return components.containsKey(T::class.java.name)
     }
 
     /**
      * Add or replace a component (returns new container).
      */
     inline fun <reified T : Component> with(component: T): ComponentContainer {
-        return ComponentContainer(components + (T::class.qualifiedName!! to component))
+        return ComponentContainer(components + (T::class.java.name to component))
     }
 
     /**
      * Remove a component type (returns new container).
      */
     inline fun <reified T : Component> without(): ComponentContainer {
-        return ComponentContainer(components - T::class.qualifiedName!!)
+        return ComponentContainer(components - T::class.java.name)
     }
 
     /**
@@ -76,7 +76,7 @@ data class ComponentContainer(
      * Used by the of() factory method.
      */
     fun withComponent(component: Component): ComponentContainer {
-        val key = component::class.qualifiedName!!
+        val key = component::class.java.name
         return ComponentContainer(components + (key to component))
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolverStatePredicateTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolverStatePredicateTest.kt
@@ -113,7 +113,7 @@ class AffectsFilterResolverStatePredicateTest : FunSpec({
             .with(ControllerComponent(controller))
         extras.forEach { component ->
             @Suppress("UNCHECKED_CAST")
-            c = c.copy(components = c.components + (component::class.qualifiedName!! to component))
+            c = c.copy(components = c.components + (component::class.java.name to component))
         }
         return c
     }


### PR DESCRIPTION
## What

**Step 1** of [`backlog/engine-performance.md`](../blob/main/backlog/engine-performance.md): remove kotlin-reflect from component keys.

Every component access in the engine went through `T::class.qualifiedName`. That's a kotlin-reflect call (`KClassImpl.getQualifiedName`, backed by a `SoftReference` cache) executed on the hot legal-action enumeration path — the profile attributed ~4% of self-time to the reflection cluster (`getQualifiedName` + `SoftReference.get`).

This swaps all sites to `T::class.java.name`: a constant-pool class-literal load plus JVM-cached `Class.getName()`, with no reflection.

## Why it's safe

- The component map stays `Map<String, Component>` (default kotlinx Map serialization). Keys are written and read in the same form, so in-memory serialization round-trips are unchanged.
- `qualifiedName` and `Class.getName()` differ only for nested classes (`.` vs `$`). No JSON fixtures in the repo are keyed on component names, and the key is internal — never a persisted public contract.

## Sites changed

- `ComponentContainer` — `get` / `has` / `with` / `without` / `withComponent`
- `DamageUtils` — the one raw `CardComponent::class.qualifiedName` map lookup (must match the stored key)
- `AffectsFilterResolverStatePredicateTest` — manual container build, kept in the same key form for consistency

## Validation

- `just test-rules` — **BUILD SUCCESSFUL**, all tests pass.

Expected impact per the plan: ~5–8% total CPU, very low risk. Steps 2–5 (Class-keyed map, `getBattlefield()` memoization, scan hoisting) are independent follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)