### PR TITLE
Add Severance Priest to Tarkir: Dragonstorm

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -144,9 +144,16 @@ the overwhelming majority of the set.
     `EntityReference.Sacrificed` is unresolvable there).
     → **Sidisi, Regent of the Mire**
 
-13. **Choose-and-exile from a target opponent's revealed hand.** Existing primitives reveal /
-    look-at hands or force self-discard, but none lets the controller pick a card from the opponent's
-    hand and exile it (with a linked LTB payoff).
+13. **Choose-and-exile from a target opponent's revealed hand.** ✅ **DONE.** No new SDK was needed —
+    the card is a pure pipeline chain (mirrors Deep-Cavern Bat's hand-disruption shape):
+    `RevealHandEffect` → `GatherCards` from the opponent's hand → `SelectFromCollection`
+    (up to one nonland, `Chooser.Controller`) → `MoveCollection` to exile with `linkToSource = true`.
+    The linked LTB payoff is also composed: on `LeavesBattlefield`, re-gather the linked-exiled card
+    (it stays exiled — never returned) and create the Spirit via `CreateTokenEffect` with
+    `count = VariableReference("…_count")` (0 when nothing was exiled), `dynamicPower/Toughness =
+    StoredCardManaValue` (X = the exiled card's mana value), and `controller =
+    ControllerOfPipelineTarget` (resolves to the exiled card's owner — an exile-zone card has no
+    `ControllerComponent`, so it falls back to `ownerId`).
     → **Severance Priest**
 
 14. **Suspend.** Time counters on a card in exile + cast-when-last-counter-removed + haste payoff.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SeverancePriestScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SeverancePriestScenarioTest.kt
@@ -1,0 +1,157 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Severance Priest.
+ *
+ * Severance Priest: {W}{B}{G}
+ * Creature — Djinn Cleric (3/3)
+ * Deathtouch
+ * When this creature enters, target opponent reveals their hand. You may choose a
+ * nonland card from it. If you do, exile that card.
+ * When this creature leaves the battlefield, the exiled card's owner creates an X/X
+ * white Spirit creature token, where X is the mana value of the exiled card.
+ *
+ * The card is a pure pipeline composition — these tests pin the novel behavior:
+ * the chosen card stays exiled (it is never returned), and the LTB payoff reads the
+ * exiled card's mana value + owner to build the Spirit.
+ */
+class SeverancePriestScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Severance Priest") {
+
+            test("ETB exiles a chosen nonland card from target opponent's hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Severance Priest")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(2, "Hill Giant") // {3}{R} → mana value 4
+                    .withCardInHand(2, "Forest")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Severance Priest")
+                game.resolveStack() // priest enters → ETB triggers
+                game.selectTargets(listOf(game.player2Id))
+                game.resolveStack() // resolve ETB → reveal hand → pause for select
+
+                // Controller picks the nonland Hill Giant to exile
+                val giantId = game.findCardsInHand(2, "Hill Giant").first()
+                game.selectCards(listOf(giantId))
+
+                // Hill Giant should be in opponent's exile, linked to the priest
+                game.state.getExile(game.player2Id).any { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Hill Giant"
+                } shouldBe true
+                game.isInHand(2, "Hill Giant") shouldBe false
+
+                val priestId = game.findPermanent("Severance Priest")!!
+                val linked = game.state.getEntity(priestId)?.get<LinkedExileComponent>()
+                linked shouldNotBe null
+                linked!!.exiledIds shouldHaveSize 1
+                linked.exiledIds.first() shouldBe giantId
+
+                // Forest (a land) must stay in opponent's hand — only nonland cards are eligible
+                game.isInHand(2, "Forest") shouldBe true
+            }
+
+            test("LTB creates an X/X Spirit for the exiled card's owner, X = its mana value") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Severance Priest")
+                    .withCardInHand(1, "End Hostilities") // {3}{W}{W} board wipe to kill the priest
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(2, "Hill Giant") // {3}{R} → mana value 4
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Severance Priest")
+                game.resolveStack()
+                game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+
+                val giantId = game.findCardsInHand(2, "Hill Giant").first()
+                game.selectCards(listOf(giantId))
+                game.isInHand(2, "Hill Giant") shouldBe false
+
+                // Player1 wipes the board, killing their own priest
+                game.castSpell(1, "End Hostilities").error shouldBe null
+                game.resolveStack() // End Hostilities resolves → priest dies → LTB → create Spirit
+
+                game.isOnBattlefield("Severance Priest") shouldBe false
+
+                // The exiled card stays exiled — Severance Priest never returns it
+                game.state.getExile(game.player2Id).any { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Hill Giant"
+                } shouldBe true
+
+                // The Spirit token belongs to the exiled card's owner (the opponent)
+                val tokenId = game.findPermanent("Spirit Token")
+                tokenId.shouldNotBeNull()
+                val token = game.state.getEntity(tokenId)!!
+                val tokenCard = token.get<CardComponent>()!!
+                tokenCard.colors shouldBe setOf(Color.WHITE)
+                // X = Hill Giant's mana value (4)
+                tokenCard.baseStats?.basePower shouldBe 4
+                tokenCard.baseStats?.baseToughness shouldBe 4
+                tokenCard.ownerId shouldBe game.player2Id
+                token.get<ControllerComponent>()?.playerId shouldBe game.player2Id
+                game.state.getBattlefield(game.player2Id).contains(tokenId) shouldBe true
+            }
+
+            test("no token is created when the controller exiles nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Severance Priest")
+                    .withCardInHand(1, "End Hostilities")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(2, "Hill Giant")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Severance Priest")
+                game.resolveStack()
+                game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+
+                // Decline by exiling no card
+                game.selectCards(emptyList())
+                game.isInHand(2, "Hill Giant") shouldBe true
+                game.state.getExile(game.player2Id) shouldHaveSize 0
+
+                game.castSpell(1, "End Hostilities").error shouldBe null
+                game.resolveStack() // priest dies, but nothing was exiled
+
+                game.isOnBattlefield("Severance Priest") shouldBe false
+                game.findPermanent("Spirit Token") shouldBe null
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SeverancePriest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SeverancePriest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Severance Priest
+ * {W}{B}{G}
+ * Creature — Djinn Cleric
+ * 3/3
+ *
+ * Deathtouch
+ * When this creature enters, target opponent reveals their hand. You may choose a
+ * nonland card from it. If you do, exile that card.
+ * When this creature leaves the battlefield, the exiled card's owner creates an X/X
+ * white Spirit creature token, where X is the mana value of the exiled card.
+ *
+ * Implemented as a pure pipeline chain — no bespoke executor:
+ *  - ETB: reveal opponent's hand → gather it → controller picks up to one nonland →
+ *    move it to exile linked to this creature (`MoveCollectionEffect.linkToSource`),
+ *    so the chosen card's id lives in the priest's `LinkedExileComponent`.
+ *  - LTB: re-gather the linked-exiled card (it stays in exile — Severance Priest never
+ *    returns it) and create the Spirit. The token's count is gated on the collection
+ *    size (`VariableReference("…_count")`, 0 when nothing was exiled), its P/T reads the
+ *    exiled card's mana value (`StoredCardManaValue`), and its controller resolves to the
+ *    card's owner (`ControllerOfPipelineTarget` falls back to `ownerId` for an exile-zone
+ *    card with no controller).
+ */
+val SeverancePriest = card("Severance Priest") {
+    manaCost = "{W}{B}{G}"
+    colorIdentity = "WBG"
+    typeLine = "Creature — Djinn Cleric"
+    power = 3
+    toughness = 3
+    oracleText = "Deathtouch\n" +
+        "When this creature enters, target opponent reveals their hand. You may choose a " +
+        "nonland card from it. If you do, exile that card.\n" +
+        "When this creature leaves the battlefield, the exiled card's owner creates an X/X " +
+        "white Spirit creature token, where X is the mana value of the exiled card."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = CompositeEffect(
+            listOf(
+                RevealHandEffect(opponent),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "revealedHand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "revealedHand",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    filter = GameObjectFilter.Nonland,
+                    storeSelected = "exiledCard",
+                    prompt = "You may exile a nonland card from target opponent's hand",
+                    showAllCards = true,
+                    alwaysPrompt = true
+                ),
+                MoveCollectionEffect(
+                    from = "exiledCard",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0)),
+                    linkToSource = true
+                )
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromLinkedExile(),
+                    storeAs = "exiledCard"
+                ),
+                CreateTokenEffect(
+                    count = DynamicAmount.VariableReference("exiledCard_count"),
+                    power = 0,
+                    toughness = 0,
+                    colors = setOf(Color.WHITE),
+                    creatureTypes = setOf("Spirit"),
+                    dynamicPower = DynamicAmount.StoredCardManaValue("exiledCard"),
+                    dynamicToughness = DynamicAmount.StoredCardManaValue("exiledCard"),
+                    controller = EffectTarget.ControllerOfPipelineTarget("exiledCard", 0),
+                    imageUri = "https://cards.scryfall.io/normal/front/8/e/8ea4fc2f-95a4-49d0-b06e-b88d19637737.jpg?1743176763"
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "222"
+        artist = "Scott Murphy"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc779a1b-128c-4c74-bebd-bdb687867f68.jpg?1743204878"
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Severance Priest** ({W}{B}{G}, Creature — Djinn Cleric, 3/3, Deathtouch), the TDM Tier-3 engine gap **#13** — *"choose-and-exile from a target opponent's revealed hand"* — from `backlog/tdm-engine-gaps.md`.

The backlog flagged this as needing new functionality, but it composes entirely from existing primitives. The card is a **pure pipeline chain — no bespoke effect type or executor**.

Oracle:
> Deathtouch
> When this creature enters, target opponent reveals their hand. You may choose a nonland card from it. If you do, exile that card.
> When this creature leaves the battlefield, the exiled card's owner creates an X/X white Spirit creature token, where X is the mana value of the exiled card.

## How it composes

**ETB** (mirrors Deep-Cavern Bat's hand-disruption shape):
`RevealHandEffect` → `GatherCards` from the opponent's hand → `SelectFromCollection` (up to one nonland, `Chooser.Controller`) → `MoveCollection` to exile with `linkToSource = true` (stores the chosen card in the priest's `LinkedExileComponent`).

**LTB** (the genuinely new payoff — the card stays exiled, never returned):
`GatherCards` from linked exile → `CreateTokenEffect` where
- `count = VariableReference("…_count")` — gates on the collection size, so nothing happens if no card was exiled,
- `dynamicPower`/`dynamicToughness = StoredCardManaValue` — X = the exiled card's mana value,
- `controller = ControllerOfPipelineTarget` — resolves to the exiled card's **owner** (an exile-zone card has no `ControllerComponent`, so resolution falls back to `ownerId`).

No new SDK building blocks, so no `card-sdk-language-reference.md` change is required. Per the repo's "no single-use patterns" guidance, the chain is inlined in the card rather than extracted into an `ExilePatterns` helper.

## Tests

`SeverancePriestScenarioTest` (3 cases, all passing):
1. ETB reveals the opponent's hand and exiles a chosen nonland (linked); lands stay in hand.
2. LTB creates a **4/4** white Spirit (Hill Giant, MV 4) **owned and controlled by the opponent**, and the exiled card **stays exiled**.
3. Declining the exile creates no token on leave.

Verified canonical placement with `just check-card-printing "Severance Priest"` (canonical in TDM; promo `ptdm` printings skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)