### PR TITLE
perf(web): cut battlefield re-renders when many cards are present

### DIFF
--- a/web-client/src/components/game/card/CardStack.tsx
+++ b/web-client/src/components/game/card/CardStack.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import type { GroupedCard } from '@/store/selectors.ts'
 import { useResponsiveContext } from '../board/shared'
 import { GameCard } from './GameCard'
@@ -6,7 +7,7 @@ import { GameCard } from './GameCard'
  * Renders a group of identical cards as an overlapping stack.
  * Each card has its own data-card-id for targeting arrows.
  */
-export function CardStack({
+function CardStackImpl({
   group,
   interactive,
   isOpponentCard,
@@ -78,3 +79,8 @@ export function CardStack({
     </div>
   )
 }
+
+// Memoized: BattlefieldContent re-renders on many store changes, but a stack's
+// `group` is a content-stable reference (groupCards/toSinglesStable) so most
+// stacks can skip re-rendering when an unrelated card changes.
+export const CardStack = memo(CardStackImpl)

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -85,7 +85,7 @@ interface GameCardProps {
 /**
  * Single card display.
  */
-export function GameCard({
+function GameCardImpl({
   card,
   count = 1,
   faceDown = false,
@@ -105,7 +105,11 @@ export function GameCard({
     (state) => (state.spectatingState?.gameState ?? state.gameState)?.voidActive ?? false
   )
   const selectCard = useGameStore((state) => state.selectCard)
-  const selectedCardId = useGameStore((state) => state.selectedCardId)
+  // Subscribe to the per-card boolean, not the global selectedCardId, so that
+  // selecting a card only re-renders the two cards whose selection state flips
+  // (Zustand bails out on Object.is-equal selector results) instead of every
+  // card on the battlefield.
+  const isSelected = useGameStore((state) => state.selectedCardId === card.id)
   const hoverCard = useGameStore((state) => state.hoverCard)
   const targetingState = useGameStore((state) => state.targetingState)
   const addTarget = useGameStore((state) => state.addTarget)
@@ -212,8 +216,13 @@ export function GameCard({
   // Check if card has legal actions (is playable)
   const hasLegalActions = useHasLegalActions(card.id)
 
-  const hoveredCardId = useGameStore((state) => state.hoveredCardId)
-  const autoTapPreview = useGameStore((state) => state.autoTapPreview)
+  // Per-card boolean selectors (see isSelected above): hover and auto-tap
+  // preview change on every mouse move between cards, so subscribing to the
+  // raw global values here would re-render the entire battlefield on each
+  // hover transition. Selecting the boolean confines re-renders to the cards
+  // whose state actually changes.
+  const isHovered = useGameStore((state) => state.hoveredCardId === card.id)
+  const isInAutoTapPreview = useGameStore((state) => state.autoTapPreview?.includes(card.id) ?? false)
 
   const isTapped = suppressTapRotation ? false : (card.isTapped || forceTapped)
   const isPhasedOut = card.isPhasedOut === true
@@ -224,9 +233,6 @@ export function GameCard({
   const isRoomLandscape = !faceDown && !!battlefield && card.isRoom === true
   const totalRotateDeg = (isRoomLandscape ? 90 : 0) + (isTapped ? 90 : 0)
   const needsLandscapeContainer = Math.abs(totalRotateDeg) % 180 === 90
-  const isSelected = selectedCardId === card.id
-  const isInAutoTapPreview = autoTapPreview?.includes(card.id) ?? false
-  const isHovered = hoveredCardId === card.id
   const isInTargetingMode = targetingState !== null
   const isValidTarget = targetingState?.validTargets.includes(card.id) ?? false
   const isSelectedTarget = targetingState?.selectedTargets.includes(card.id) ?? false
@@ -2427,3 +2433,11 @@ export function GameCard({
 
   return <RenderProfiler id={profilerId}>{cardElement}</RenderProfiler>
 }
+
+// Memoized so a parent re-render (e.g. BattlefieldContent reacting to a
+// legalActions/targetingState change) only re-renders cards whose props
+// actually changed. Props from CardStack are all primitives or content-stable
+// `card` objects (see toSinglesStable/groupCards in selectors), so the default
+// shallow comparison is correct. Cards still re-render when their own store
+// subscriptions change.
+export const GameCard = React.memo(GameCardImpl)


### PR DESCRIPTION
## Problem

When many cards are on the battlefield, moving the mouse around feels laggy. `GameCard` subscribed to the **global** `hoveredCardId` / `selectedCardId` / `autoTapPreview` values and derived its per-card boolean locally:

```ts
const hoveredCardId = useGameStore((s) => s.hoveredCardId)  // global value
const isHovered     = hoveredCardId === card.id             // derived locally
```

Because the selector returns the global value, Zustand re-renders **every** subscribed card whenever it changes — so moving the mouse from one card to the next re-rendered all ~40 cards (each a large component) on every card-to-card transition.

## Fix

1. **Per-card boolean selectors** — push the equality into the selector so Zustand's `Object.is` bailout confines re-renders to the 1–2 cards whose state actually flips:
   ```ts
   const isSelected = useGameStore((s) => s.selectedCardId === card.id)
   const isHovered  = useGameStore((s) => s.hoveredCardId === card.id)
   const isInAutoTapPreview = useGameStore((s) => s.autoTapPreview?.includes(card.id) ?? false)
   ```
2. **`React.memo` on `GameCard` and `CardStack`** — stops parent-driven cascades (e.g. `BattlefieldContent` reacting to a `targetingState`/`decisionSelectionState` change re-rendering every child). Props from `CardStack` are primitives or the content-stable `card`/`group` objects (`toSinglesStable`/`groupCards` are memoized on the deep-equal-stable `useBattlefieldCards` result), so the default shallow compare is correct. No `ref` is passed to `GameCard` anywhere.

## Not included

Each `GameCard` still subscribes to the full `legalActions` array to compute its own `playableActions`, so a server state update re-renders all cards. That's user-paced (priority/turn change), not the per-mouse-move path this PR targets. Narrowing it to a per-card legal-actions selector with stable-ref memoization is a worthwhile but deeper follow-up.

## Testing

- `npm run typecheck` passes
- `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)