### PR TITLE
Add Kotis, the Fangkeeper to Tarkir: Dragonstorm

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -163,9 +163,14 @@ the overwhelming majority of the set.
     capture/forward the prevented amount.
     → **New Way Forward**
 
-17. **Free-cast-from-exile gated by a dynamic MV cap.** Exile top X of opponent's library (X =
-    combat damage) and cast any number of those with MV ≤ X for free. The free-cast-from-exile grants
-    exist, but not a dynamic MV-≤-X cap on the playable set.
+17. **Free-cast-from-exile gated by a dynamic MV cap.** ✅ **DONE.** Exile top X of the damaged
+    player's library (X = combat damage) and cast any number of those with MV ≤ X for free. No new
+    effect was needed: the dynamic cap is already expressible as
+    `CollectionFilter.ManaValueAtMost(DynamicAmount.ContextProperty(TRIGGER_DAMAGE_AMOUNT))`, and the
+    free cast reuses the existing `GrantMayPlayFromExile` + `GrantPlayWithoutPayingCost` grants — the
+    same chain as Villainous Wealth, driven by `Triggers.DealsCombatDamageToPlayer` over
+    `Player.TriggeringPlayer`'s library. Modeled as a resolution-time pipeline (gather top X → exile →
+    keep nonland → keep MV ≤ X → grant free cast).
     → **Kotis, the Fangkeeper**
 
 18. **Per-activation cost reduction by a target's color count.** Equip cost "costs {1} less to

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KotisTheFangkeeperScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KotisTheFangkeeperScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Kotis, the Fangkeeper (TDM) — {1}{B}{G}{U} Legendary Zombie Warrior, 2/1.
+ *
+ * "Indestructible. Whenever Kotis deals combat damage to a player, exile the top X cards of
+ * their library, where X is the amount of damage dealt. You may cast any number of spells with
+ * mana value X or less from among them without paying their mana costs."
+ *
+ * Exercises the reusable "exile top X, free-cast the spells with mana value ≤ X" chain
+ * (GatherCards(top of triggering player's library) → MoveCollection(exile) →
+ * FilterCollection(nonland) → FilterCollection(ManaValueAtMost(damage)) →
+ * GrantMayPlayFromExile + GrantPlayWithoutPayingCost), the same shape as Villainous Wealth but
+ * driven by a combat-damage trigger. The dynamic mana-value cap comes straight from
+ * [com.wingedsheep.sdk.scripting.effects.CollectionFilter.ManaValueAtMost] over the trigger's
+ * damage amount — no bespoke effect.
+ *
+ * Kotis is a 2/1, so X = 2 each combat: the top two cards of the defender's library are exiled,
+ * and only the nonland cards with mana value ≤ 2 among them become free-castable by Kotis's
+ * controller.
+ */
+class KotisTheFangkeeperScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Kotis, the Fangkeeper combat damage trigger") {
+
+            test("exiles top X and grants a free cast on the spell with mana value ≤ X") {
+                // Defender's top two: Grizzly Bears (MV 2, castable) and Hill Giant (MV 4, too big).
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kotis, the Fangkeeper", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Hill Giant")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Kotis, the Fangkeeper" to 2))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Kotis (2/1) deals 2 combat damage to the defender") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("X = 2 → the top two cards of the defender's library are exiled") {
+                    namesInExile(game, 2) shouldBe setOf("Grizzly Bears", "Hill Giant")
+                }
+
+                val freeCastable = freeCastableIds(game)
+                withClue("Grizzly Bears (MV 2 ≤ X) may be cast for free") {
+                    freeCastable.contains(exileId(game, 2, "Grizzly Bears")) shouldBe true
+                }
+                withClue("Hill Giant (MV 4 > X) is exiled but NOT free-castable") {
+                    freeCastable.contains(exileId(game, 2, "Hill Giant")) shouldBe false
+                }
+
+                // Player1 has no mana; a successful cast proves it is free. The card is owned by
+                // and sits in Player2's exile, but Player1 casts it via the granted permission.
+                val bearsId = exileId(game, 2, "Grizzly Bears")
+                val result = game.execute(CastSpell(game.player1Id, bearsId, emptyList()))
+                withClue("Casting Grizzly Bears from exile for free must succeed with no mana") {
+                    (result.error == null) shouldBe true
+                }
+                game.resolveStack()
+
+                withClue("The free-cast Grizzly Bears resolves onto the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("Hill Giant stays in exile — uncast cards remain exiled") {
+                    namesInExile(game, 2).contains("Hill Giant") shouldBe true
+                }
+            }
+
+            test("lands among the exiled cards can't be played this way (spells only)") {
+                // Defender's top two: Shock (MV 1, castable spell) and Forest (a land).
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kotis, the Fangkeeper", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(2, "Shock")
+                    .withCardInLibrary(2, "Forest")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Kotis, the Fangkeeper" to 2))
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Both top cards are exiled") {
+                    namesInExile(game, 2) shouldBe setOf("Shock", "Forest")
+                }
+
+                val freeCastable = freeCastableIds(game)
+                withClue("Shock (a spell with MV 1 ≤ X) is free-castable") {
+                    freeCastable.contains(exileId(game, 2, "Shock")) shouldBe true
+                }
+                withClue("Forest is a land — 'you may cast spells', so it is excluded") {
+                    freeCastable.contains(exileId(game, 2, "Forest")) shouldBe false
+                }
+            }
+        }
+    }
+
+    /** All card ids the given game's Player1 may currently cast/play via a may-play permission. */
+    private fun freeCastableIds(game: TestGame): Set<EntityId> =
+        game.state.mayPlayPermissions
+            .filter { it.controllerId == game.player1Id }
+            .flatMap { it.cardIds }
+            .toSet()
+
+    private fun exileId(game: TestGame, playerNumber: Int, name: String): EntityId {
+        val playerId = if (playerNumber == 1) game.player1Id else game.player2Id
+        return game.state.getExile(playerId).first { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+    }
+
+    private fun namesInExile(game: TestGame, playerNumber: Int): Set<String> {
+        val playerId = if (playerNumber == 1) game.player1Id else game.player2Id
+        return game.state.getExile(playerId).mapNotNull { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name
+        }.toSet()
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KotisTheFangkeeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KotisTheFangkeeper.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kotis, the Fangkeeper — Tarkir: Dragonstorm #202
+ * {1}{B}{G}{U} · Legendary Creature — Zombie Warrior · 2/1
+ *
+ * Indestructible
+ * Whenever Kotis deals combat damage to a player, exile the top X cards of their
+ * library, where X is the amount of damage dealt. You may cast any number of spells
+ * with mana value X or less from among them without paying their mana costs.
+ *
+ * This is the same "exile top X, free-cast the spells with mana value ≤ X" shape as
+ * Villainous Wealth, just driven by a combat-damage trigger instead of an {X} spell.
+ * It needs no bespoke effect — the dynamic mana-value cap the backlog flagged as a gap
+ * is already expressible via [CollectionFilter.ManaValueAtMost] over a [DynamicAmount].
+ * The ability is a resolution-time chain over existing pipeline primitives:
+ *   1. gather the top X of the damaged player's library, where X is the combat damage
+ *      read from the trigger context ([ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT]),
+ *   2. exile that whole batch ([Player.TriggeringPlayer] is the damaged player),
+ *   3. keep only nonland cards (you may cast *spells*, not play lands),
+ *   4. of those, keep only mana value ≤ X (the same X, re-read from the context),
+ *   5. grant free-cast permission on that filtered subset.
+ *
+ * Per the official ruling the spells are cast for free with type-based timing ignored;
+ * cards left uncast stay in exile. As with Villainous Wealth and Etali, Primal Storm,
+ * the free cast is modeled through the grant primitives rather than a during-resolution
+ * cast loop.
+ */
+val KotisTheFangkeeper = card("Kotis, the Fangkeeper") {
+    manaCost = "{1}{B}{G}{U}"
+    colorIdentity = "BGU"
+    typeLine = "Legendary Creature — Zombie Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "Indestructible\n" +
+        "Whenever Kotis deals combat damage to a player, exile the top X cards of their " +
+        "library, where X is the amount of damage dealt. You may cast any number of spells " +
+        "with mana value X or less from among them without paying their mana costs."
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        description = "Whenever Kotis deals combat damage to a player, exile the top X cards " +
+            "of their library, where X is the amount of damage dealt. You may cast any number " +
+            "of spells with mana value X or less from among them without paying their mana costs."
+
+        effect = CompositeEffect(
+            listOf(
+                // Exile the top X cards of the damaged player's library (X = combat damage).
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+                        player = Player.TriggeringPlayer
+                    ),
+                    storeAs = "exiled"
+                ),
+                MoveCollectionEffect(
+                    from = "exiled",
+                    destination = CardDestination.ToZone(Zone.EXILE, player = Player.TriggeringPlayer)
+                ),
+                // Narrow to spells (nonland cards) with mana value ≤ X — the free-castable set.
+                FilterCollectionEffect(
+                    from = "exiled",
+                    filter = CollectionFilter.MatchesFilter(GameObjectFilter.Nonland),
+                    storeMatching = "nonland"
+                ),
+                FilterCollectionEffect(
+                    from = "nonland",
+                    filter = CollectionFilter.ManaValueAtMost(
+                        DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+                    ),
+                    storeMatching = "castable"
+                ),
+                // You may cast any number of them without paying their mana costs.
+                GrantMayPlayFromExileEffect("castable"),
+                GrantPlayWithoutPayingCostEffect("castable")
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "202"
+        artist = "Evyn Fong"
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3736f17-f80b-4b2c-b919-2c963bc14682.jpg?1743204793"
+        ruling("2025-04-04", "If an exiled card has {X} in its mana cost, X is 0 for the purpose of determining its mana value.")
+        ruling("2025-04-04", "You cast the spells from among the exiled cards while Kotis's last ability is resolving and still on the stack. You can't wait to cast them later in the turn. Timing restrictions based on the card's type are ignored.")
+        ruling("2025-04-04", "Since you are using an alternative cost to cast the spells, you can't pay any other alternative costs. You can, however, pay additional costs, such as kicker costs. If the spells have any mandatory additional costs, you must pay those.")
+        ruling("2025-04-04", "If any of the spells you cast has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost.")
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Kotis, the Fangkeeper** (TDM #202, `{1}{B}{G}{U}` Legendary Zombie Warrior, 2/1) — closing **gap item 17** in `backlog/tdm-engine-gaps.md` ("Free-cast-from-exile gated by a dynamic MV cap").

> Indestructible
> Whenever Kotis deals combat damage to a player, exile the top X cards of their library, where X is the amount of damage dealt. You may cast any number of spells with mana value X or less from among them without paying their mana costs.

## Approach — a chain, no new engine code

The backlog flagged this as needing "a dynamic MV-≤-X cap on the playable set." It turns out **no new SDK effect is required** — this is the exact same shape as **Villainous Wealth** (identical oracle wording and rulings), just driven by a combat-damage trigger. The card is a resolution-time pipeline over existing primitives:

1. `GatherCards` — top X of the damaged player's library (`X = DynamicAmount.ContextProperty(TRIGGER_DAMAGE_AMOUNT)`, `Player.TriggeringPlayer`)
2. `MoveCollection` → exile
3. `FilterCollection` — keep nonland (you may cast *spells*, not play lands)
4. `FilterCollection` — keep `CollectionFilter.ManaValueAtMost(TRIGGER_DAMAGE_AMOUNT)` ← the dynamic cap
5. `GrantMayPlayFromExile` + `GrantPlayWithoutPayingCost` on the filtered subset

`Player.TriggeringPlayer` resolving to the *damaged* player is the same mechanism Raven Guild Master relies on.

## Tests

`KotisTheFangkeeperScenarioTest` (game-server), both passing:
- **exiles top X and grants a free cast on the spell with MV ≤ X** — Kotis (2/1) attacks → 2 damage → top two of the defender's library exiled; Grizzly Bears (MV 2) is free-castable, Hill Giant (MV 4) is exiled but not; the free cast resolves with the controller holding **zero mana** (proving it's free), and the uncast Hill Giant stays exiled.
- **lands among the exiled cards can't be played this way** — Shock (MV 1) is free-castable, Forest is excluded by the nonland filter.

`just build` is green.

## Notes

- As with Villainous Wealth and Etali, Primal Storm, the free cast is modeled through the may-play grants. The official ruling specifies the spells are cast during the ability's resolution with type-based timing ignored; matching the established codebase idiom keeps this consistent rather than introducing a bespoke during-resolution cast loop.
- Canonical printing is TDM (verified via `just check-card-printing`); the only other printings are PTDM promos, so no reprint row is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)