### PR TITLE
Add Suspend mechanic (CR 702.62) + Taigam, Master Opportunist

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1407,6 +1407,20 @@ composite abilities).
   triggered ability (gated by the same intervening-if) that removes a time counter. The engine places the N TIME counters
   when a spell cast for its impending cost resolves; casting for the normal mana cost adds no counters, so neither wiring
   fires (mirrors `prowess()` / `rampage()`).
+- `Suspend` (CR 702.62) — an **exile-zone** mechanic, unlike Impending/Vanishing which live on the battlefield.
+  A suspended card sits in exile with **time counters**; at the beginning of its **owner's** upkeep one is removed,
+  and when the last is gone its owner **may play it for free**, with **haste** if it's a creature. The lifecycle is
+  **component-driven**, not definition-driven: the engine grants `Suspend.countdownAbility` (a synthesized
+  `activeZone = EXILE` upkeep trigger — remove a counter, then a `MayEffect` that gathers the card via
+  `CardSource.Self` and casts it with `CastFromCollectionWithoutPayingCostEffect`) to **any** exiled card carrying the
+  `SuspendedComponent` marker. So an arbitrary card with no printed suspend can be suspended.
+  - **Putting a card into suspend** is a chain you compose; `Effects.Suspend(target, timeCounters)` is the reusable
+    two-step tail (`AddCounters(TIME, n)` + `GrantSuspendEffect` — the latter sets the marker **and** arms a dormant
+    permanent haste effect on the card). The caller supplies the exile step first, because it differs by source zone:
+    a spell on the stack uses `CounterSpellToExile` / `CounterEffect(counterDestination = Exile())` (it can't be lifted
+    off the stack with a zone-move); a printed `suspend N—[cost]` exiles from hand as its cast cost.
+  - **Taigam, Master Opportunist** is the first user: `Composite(CopyTargetSpell(TriggeringEntity),
+    CounterEffect(TriggeringEntity → Exile), Suspend(TriggeringEntity, 4))`.
 - `Renew(cost)` — `card { renew(cost) { effect = … } }` builder helper (Tarkir: Dragonstorm, Sultai clan keyword).
   A graveyard-activated ability: "Renew — [cost], Exile this card from your graveyard: [effect]. Activate only as a
   sorcery." The helper composes it entirely from existing primitives — `AbilityCost.Composite(Mana(cost), ExileSelf)`,

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TaigamMasterOpportunistScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TaigamMasterOpportunistScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.SuspendedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario test for Taigam, Master Opportunist (TDM) — {1}{U} Legendary Human Monk.
+ *
+ * "Flurry — Whenever you cast your second spell each turn, copy it, then exile the spell you
+ * cast with four time counters on it. If it doesn't have suspend, it gains suspend."
+ *
+ * Exercises the reusable Suspend chain ([com.wingedsheep.sdk.dsl.Effects.Suspend]): the copy
+ * resolves normally while the original spell is exiled with four time counters and the
+ * suspended marker. (The owner's-upkeep countdown that recasts it for free is covered by
+ * `SuspendMechanicTest`.)
+ */
+class TaigamMasterOpportunistScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Taigam, Master Opportunist Flurry") {
+
+            test("the second spell is copied and the original is exiled with four time counters and suspend") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Taigam, Master Opportunist")
+                    .withCardsInHand(1, "Grizzly Bears", 2)
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // First spell of the turn — resolves into a real Grizzly Bears.
+                game.castSpell(1, "Grizzly Bears")
+                game.resolveStack()
+
+                // Second spell triggers Flurry. Resolving the stack runs the trigger (copy the
+                // spell + exile the original with suspend), then the copy resolves into a token.
+                game.castSpell(1, "Grizzly Bears")
+                game.resolveStack()
+
+                val exiled = game.state.getExile(game.player1Id).filter { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                withClue("Exactly one Grizzly Bears (the original second spell) is exiled") {
+                    exiled.size shouldBe 1
+                }
+                val suspended = exiled.first()
+                withClue("The exiled spell carries the suspended marker") {
+                    game.state.getEntity(suspended)?.has<SuspendedComponent>() shouldBe true
+                }
+                withClue("The exiled spell has four time counters on it") {
+                    game.state.getEntity(suspended)?.get<CountersComponent>()
+                        ?.getCount(CounterType.TIME) shouldBe 4
+                }
+                withClue("Suspend pre-arms haste (CR 702.62g) as a dormant effect on the exiled card") {
+                    val hasteArmed = game.state.floatingEffects.any { fx ->
+                        suspended in fx.effect.affectedEntities &&
+                            (fx.effect.modification as? SerializableModification.GrantKeyword)?.keyword == Keyword.HASTE.name
+                    }
+                    hasteArmed shouldBe true
+                }
+
+                // The first Bears (real) plus the copy (a token) are on the battlefield.
+                val bears = game.state.getBattlefield().filter { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                withClue("Two Grizzly Bears on the battlefield: the first spell and the copy") {
+                    bears.size shouldBe 2
+                }
+                withClue("Rule 707.10 — the copy of a creature spell is a token") {
+                    bears.count { game.state.getEntity(it)?.has<TokenComponent>() == true } shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -194,6 +194,21 @@ enum class Keyword(val displayName: String) {
     MODULAR("Modular"),
     FADING("Fading"),
     VANISHING("Vanishing"),
+
+    /**
+     * Suspend (CR 702.62). A card with suspend can be exiled with a number of time
+     * counters on it. At the beginning of its owner's upkeep a time counter is removed,
+     * and when the last is removed its owner plays it without paying its mana cost (with
+     * haste, if it's a creature).
+     *
+     * The keyword is display-only. The exile-side behavior is component-driven, not
+     * definition-driven: any exiled card carrying the engine's suspended marker (set by
+     * [com.wingedsheep.sdk.dsl.Effects.Suspend]) gets the synthesized countdown-and-cast
+     * triggered ability ([com.wingedsheep.sdk.scripting.Suspend.countdownAbility]). This
+     * lets "exile it with N time counters; it gains suspend" effects (Taigam, Master
+     * Opportunist) suspend an arbitrary card — even a card with no printed suspend.
+     */
+    SUSPEND("Suspend"),
     RENOWN("Renown"),
     FABRICATE("Fabricate"),
     TRIBUTE("Tribute"),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -87,6 +87,7 @@ import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
 import com.wingedsheep.sdk.scripting.effects.SetLifeTotalEffect
 import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.GrantSuspendEffect
 import com.wingedsheep.sdk.scripting.effects.LibraryChoicePosition
 import com.wingedsheep.sdk.scripting.effects.PutOnLibraryPositionOfChoiceEffect
 import com.wingedsheep.sdk.scripting.effects.ExileFromTopRepeatingEffect
@@ -1550,6 +1551,26 @@ object Effects {
      */
     fun CastFromCollectionWithoutPayingCost(from: String): Effect =
         CastFromCollectionWithoutPayingCostEffect(from = from)
+
+    /**
+     * Suspend an already-exiled [target] with [timeCounters] time counters (CR 702.62) — a
+     * reusable two-step chain: put N time counters on the card, then mark it suspended. The
+     * marker is what the engine keys on to synthesize the owner's-upkeep countdown that
+     * removes a counter each turn and, when the last is gone, lets the owner play the card
+     * for free with haste (see [com.wingedsheep.sdk.scripting.Suspend]).
+     *
+     * The caller is responsible for getting the card into exile first, because that step
+     * differs by source zone: a spell on the stack is exiled with [CounterSpellToExile]
+     * (Taigam, Master Opportunist exiles "the spell you cast"); a printed `suspend N—[cost]`
+     * exiles the card from hand as its cast cost.
+     */
+    fun Suspend(target: EffectTarget, timeCounters: Int): Effect =
+        CompositeEffect(
+            listOf(
+                AddCountersEffect(Counters.TIME, timeCounters, target),
+                GrantSuspendEffect(target),
+            )
+        )
 
     /**
      * Repeat a body effect in a do-while loop controlled by a repeat condition.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Suspend.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Suspend.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.sdk.scripting
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.conditions.NotCondition
+import com.wingedsheep.sdk.scripting.conditions.SourceMatches
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Suspend (CR 702.62) as a composable, content-agnostic primitive.
+ *
+ * Suspend is an **exile-zone** mechanic, unlike Impending / Vanishing which live on the
+ * battlefield. A suspended card sits in exile with time counters; the engine drives its
+ * lifecycle off a marker component rather than the card's printed abilities, so the very
+ * same machinery works for a card with no printed suspend (Taigam, Master Opportunist
+ * exiles the spell you cast and grants it suspend).
+ *
+ * Two halves make up the mechanic:
+ *  - **Putting a card into suspend** — [com.wingedsheep.sdk.dsl.Effects.Suspend] is a chain
+ *    (move to exile → add N time counters → mark suspended). The marker is what the engine
+ *    keys on.
+ *  - **Counting down and casting** — [countdownAbility] below, a single triggered ability
+ *    the engine synthesizes for every exiled card carrying the suspend marker. It fires on
+ *    the owner's upkeep (the trigger detector already scans exile for `activeZone == EXILE`
+ *    triggers and treats exiled cards as owner-controlled), removes one time counter, and —
+ *    when that empties the pile — grants haste and plays the card for free through the
+ *    ordinary [CastFromCollectionWithoutPayingCostEffect] pipeline (which handles target / X
+ *    selection). [CardSource.Self] feeds the card itself into that collection.
+ *
+ * The intervening-if [hasTimeCounter] gate means a stale marker can never re-cast: once the
+ * counters are gone the trigger simply stops firing.
+ */
+object Suspend {
+
+    /** Pipeline collection key the countdown uses to hand the exiled card to the free-cast step. */
+    const val PLAY_COLLECTION: String = "suspend_play"
+
+    /** "this card has a time counter on it" — used as the intervening-if gate and the cast condition. */
+    private val hasTimeCounter = SourceMatches(
+        GameObjectFilter.Any.copy(statePredicates = listOf(StatePredicate.HasCounter("TIME")))
+    )
+
+    /**
+     * The synthesized triggered ability granted (by the engine) to any exiled card that
+     * carries the suspend marker. Functions only in exile.
+     */
+    val countdownAbility: TriggeredAbility = TriggeredAbility(
+        id = AbilityId("suspend_countdown"),
+        trigger = GameEvent.StepEvent(Step.UPKEEP, Player.You),
+        binding = TriggerBinding.SELF,
+        activeZone = Zone.EXILE,
+        // Only count down while counters remain; this also makes a leftover marker inert.
+        triggerCondition = hasTimeCounter,
+        effect = CompositeEffect(
+            listOf(
+                RemoveCountersEffect(Counters.TIME, 1, EffectTarget.Self),
+                ConditionalEffect(
+                    condition = NotCondition(hasTimeCounter),
+                    // CR 702.62f — "they may play it without paying its mana cost." The optional
+                    // play is wrapped in [MayEffect] (both faithful to the rule and the proven
+                    // cast-from-exile path used by Shiko, Paragon of the Way). Haste (CR 702.62g)
+                    // is pre-armed by the suspended marker, not granted here — see GrantSuspend.
+                    effect = MayEffect(
+                        CompositeEffect(
+                            listOf(
+                                GatherCardsEffect(CardSource.Self, storeAs = PLAY_COLLECTION),
+                                CastFromCollectionWithoutPayingCostEffect(from = PLAY_COLLECTION),
+                            )
+                        ),
+                        descriptionOverride = "play it without paying its mana cost",
+                    ),
+                ),
+            )
+        ),
+        descriptionOverride = "At the beginning of its owner's upkeep, they remove a time " +
+            "counter from this card. When the last is removed, they play it without paying " +
+            "its mana cost. If it's a creature, it gains haste.",
+    )
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -175,6 +175,20 @@ sealed interface CardSource {
             append("cards exiled by this permanent")
         }
     }
+
+    /**
+     * The ability's own source card ([com.wingedsheep.sdk.scripting.references] sourceId).
+     *
+     * Yields a single-element collection referencing the source, regardless of which zone
+     * it currently occupies. Lets a self-referential ability feed its own card into a
+     * pipeline that expects a collection — e.g. the suspend countdown gathering the exiled
+     * card so [CastFromCollectionWithoutPayingCostEffect] can play it.
+     */
+    @SerialName("Self")
+    @Serializable
+    data object Self : CardSource {
+        override val description: String = "this card"
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/SuspendEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/SuspendEffects.kt
@@ -1,0 +1,25 @@
+package com.wingedsheep.sdk.scripting.effects
+
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.text.TextReplacer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Mark [target] as suspended (CR 702.62) — the engine attaches the suspended marker
+ * component so the card gains the countdown-and-cast triggered ability while in exile
+ * (see [com.wingedsheep.sdk.scripting.Suspend.countdownAbility]).
+ *
+ * This is the marker step of the [com.wingedsheep.sdk.dsl.Effects.Suspend] chain; it does
+ * not move the card or add time counters itself (the chain composes those from
+ * [MoveToZoneEffect] and [AddCountersEffect]), keeping each step a reusable primitive.
+ */
+@SerialName("GrantSuspend")
+@Serializable
+data class GrantSuspendEffect(
+    val target: EffectTarget = EffectTarget.Self,
+) : Effect {
+    override val description: String = "${target.description} gains suspend"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TaigamMasterOpportunist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TaigamMasterOpportunist.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CounterDestination
+import com.wingedsheep.sdk.scripting.effects.CounterEffect
+import com.wingedsheep.sdk.scripting.effects.CounterTargetSource
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Taigam, Master Opportunist — Tarkir: Dragonstorm #60
+ * {1}{U} · Legendary Creature — Human Monk · 2/2
+ *
+ * Flurry — Whenever you cast your second spell each turn, copy it, then exile the spell you
+ * cast with four time counters on it. If it doesn't have suspend, it gains suspend. (At the
+ * beginning of its owner's upkeep, they remove a time counter. When the last is removed,
+ * they may play it without paying its mana cost. If it's a creature, it has haste.)
+ *
+ * Composed from atomic primitives rather than a bespoke executor:
+ *
+ *   1. **Copy it** — [Effects.CopyTargetSpell] on [EffectTarget.TriggeringEntity] (the spell
+ *      you cast, exactly as Alania, Divergent Storm copies its triggering spell). The copy is
+ *      created on the stack and resolves normally.
+ *   2. **Exile the spell you cast** — a [CounterEffect] to [CounterDestination.Exile] removes
+ *      the original spell from the stack into its owner's exile (a spell can't be lifted off
+ *      the stack with a zone-move effect; it must be countered/exiled).
+ *   3. **Give it suspend** — [Effects.Suspend] puts four time counters on the now-exiled card
+ *      and marks it suspended. The owner's-upkeep countdown that plays it for free is supplied
+ *      by the engine off that marker, so no card-specific cast logic lives here (see
+ *      [com.wingedsheep.sdk.scripting.Suspend]).
+ *
+ * "If it doesn't have suspend, it gains suspend" — Taigam only ever exiles freshly-cast
+ * spells, none of which have suspend, so the conditional is always the grant.
+ */
+val TaigamMasterOpportunist = card("Taigam, Master Opportunist") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Monk"
+    power = 2
+    toughness = 2
+    oracleText = "Flurry — Whenever you cast your second spell each turn, copy it, then exile " +
+        "the spell you cast with four time counters on it. If it doesn't have suspend, it " +
+        "gains suspend. (At the beginning of its owner's upkeep, they remove a time counter. " +
+        "When the last is removed, they may play it without paying its mana cost. If it's a " +
+        "creature, it has haste.)"
+
+    flurry {
+        description = "copy it, then exile the spell you cast with four time counters on it. " +
+            "If it doesn't have suspend, it gains suspend"
+        effect = Effects.Composite(
+            listOf(
+                Effects.CopyTargetSpell(EffectTarget.TriggeringEntity),
+                CounterEffect(
+                    targetSource = CounterTargetSource.TriggeringEntity,
+                    counterDestination = CounterDestination.Exile(),
+                ),
+                Effects.Suspend(EffectTarget.TriggeringEntity, timeCounters = 4),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "60"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/8693d631-05f6-414d-9e49-6385746e8960.jpg?1743204200"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -363,6 +363,7 @@ val engineSerializersModule = SerializersModule {
         subclass(WasKickedComponent::class)
         subclass(EvokedComponent::class)
         subclass(CastForImpendingComponent::class)
+        subclass(SuspendedComponent::class)
         subclass(CastRecordComponent::class)
 
         // Combat components

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SuppressesWardForGroupComponent
+import com.wingedsheep.engine.state.components.battlefield.SuspendedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.RingBearerComponent
@@ -75,7 +76,13 @@ class TriggerAbilityResolver(
 
         val ringBearerAbilities = getRingBearerAbilities(entityId, state)
 
-        val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities + wardAbilities + ringBearerAbilities
+        // A suspended card (CR 702.62) gains the owner's-upkeep countdown-and-cast ability
+        // while it carries the marker. Component-driven, so it works for an arbitrary card
+        // with no printed suspend (e.g. a spell exiled by Taigam, Master Opportunist).
+        val suspendAbilities = getSuspendTriggeredAbilities(entityId, state)
+
+        val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
+            wardAbilities + ringBearerAbilities + suspendAbilities
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         // Apply text replacement if the entity has one
@@ -86,6 +93,18 @@ class TriggerAbilityResolver(
             combined
         }
     }
+
+    /**
+     * Grant [com.wingedsheep.sdk.scripting.Suspend.countdownAbility] to any card carrying the
+     * [SuspendedComponent] marker. The ability functions only in exile (`activeZone == EXILE`),
+     * so it is inert anywhere else and harmless to return universally.
+     */
+    private fun getSuspendTriggeredAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> =
+        if (state.getEntity(entityId)?.has<SuspendedComponent>() == true) {
+            listOf(com.wingedsheep.sdk.scripting.Suspend.countdownAbility)
+        } else {
+            emptyList()
+        }
 
     /**
      * Get triggered abilities granted by static abilities on battlefield permanents.
@@ -193,7 +212,10 @@ class TriggerAbilityResolver(
         // they survive "loses all abilities" effects on the Ring-bearer (CR 701.52c).
         val ringBearerAbilities = getRingBearerAbilities(entityId, state)
 
-        val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities + wardAbilities + ringBearerAbilities
+        val suspendAbilities = getSuspendTriggeredAbilities(entityId, state)
+
+        val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
+            wardAbilities + ringBearerAbilities + suspendAbilities
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         val textReplacement = state.getEntity(entityId)?.get<TextReplacementComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -282,6 +282,7 @@ object ZoneMovementUtils {
             .without<WarpedComponent>()
             .without<EvokedComponent>()
             .without<com.wingedsheep.engine.state.components.battlefield.CastForImpendingComponent>()
+            .without<com.wingedsheep.engine.state.components.battlefield.SuspendedComponent>()
             // Note: CastRecordComponent is NOT stripped here — it needs to persist
             // for intervening-if checks on mana-spent-gated triggers that may still
             // be on the stack when the permanent leaves the battlefield (e.g., evoke).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -205,6 +205,17 @@ object ZoneTransitionService {
             if (entityContainer != null && entityContainer.has<FaceDownComponent>()) {
                 newState = newState.updateEntity(entityId) { c -> c.without<FaceDownComponent>() }
             }
+            // A suspended card that leaves exile by any non-cast path (returned to hand,
+            // shuffled in, exiled elsewhere) is no longer suspended (CR 702.62). The cast
+            // path is guarded separately by the countdown's intervening-if, so a leftover
+            // marker is inert there.
+            if (entityContainer != null &&
+                entityContainer.has<com.wingedsheep.engine.state.components.battlefield.SuspendedComponent>()
+            ) {
+                newState = newState.updateEntity(entityId) { c ->
+                    c.without<com.wingedsheep.engine.state.components.battlefield.SuspendedComponent>()
+                }
+            }
         }
 
         // 6. Remove from current zone

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -176,6 +176,12 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
                 val count = source.count
                 if (count != null) inExile.take(count) else inExile
             }
+
+            is CardSource.Self -> {
+                val sourceId = context.sourceId
+                    ?: return EffectResult.error(state, "No source entity for CardSource.Self")
+                if (state.getEntity(sourceId) != null) listOf(sourceId) else emptyList()
+            }
         }
 
         if (cards.isEmpty()) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GrantSuspendExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GrantSuspendExecutor.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.SuspendedComponent
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.GrantSuspendEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [GrantSuspendEffect] — marks the target card as suspended (CR 702.62) and
+ * pre-arms its haste.
+ *
+ * - The [SuspendedComponent] marker is what makes the engine grant the exile-side
+ *   countdown-and-cast triggered ability (see [com.wingedsheep.sdk.scripting.Suspend]).
+ * - CR 702.62g: a creature played via suspend has haste. A normal `GrantKeyword(HASTE)` can't
+ *   be used here because the card is in exile (not a projected creature), so we add a
+ *   self-sourced, permanent floating haste effect keyed to the card. It lies dormant while the
+ *   card sits in exile and takes effect once the card is played onto the battlefield (the
+ *   permanent reuses the same entity id). Harmless for a non-creature card, which never becomes
+ *   a creature on the battlefield. (Permanent duration is a deliberate simplification of
+ *   "until you lose control of it"; the effect is cleared when the permanent leaves play.)
+ *
+ * The marker step does not move the card or add time counters; the
+ * [com.wingedsheep.sdk.dsl.Effects.Suspend] chain composes those from a move/counter step.
+ */
+class GrantSuspendExecutor : EffectExecutor<GrantSuspendEffect> {
+
+    override val effectType: KClass<GrantSuspendEffect> = GrantSuspendEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: GrantSuspendEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target, state)
+            ?: return EffectResult.success(state)
+
+        var newState = state.updateEntity(targetId) { container ->
+            container.with(SuspendedComponent)
+        }
+        newState = newState.addFloatingEffect(
+            layer = Layer.ABILITY,
+            modification = SerializableModification.GrantKeyword(Keyword.HASTE.name),
+            affectedEntities = setOf(targetId),
+            duration = Duration.Permanent,
+            // Self-source the haste so it survives the granter (e.g. Taigam) leaving play
+            // during the time the card waits in exile.
+            context = context.copy(sourceId = targetId),
+        )
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -54,6 +54,7 @@ class LibraryExecutors(
         ChooseOptionPipelineExecutor(cardRegistry = cardRegistry),
         GatherCardsExecutor(),
         CopyCardIntoCollectionExecutor(),
+        GrantSuspendExecutor(),
         SelectFromCollectionExecutor(),
         ChoosePileExecutor(),
         SelectTargetPipelineExecutor(targetFinder = targetFinder ?: TargetFinder()),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2168,7 +2168,12 @@ class StackResolver(
         for (pid in state.turnOrder) {
             val exileZone = ZoneKey(pid, Zone.EXILE)
             if (cardId in state.getZone(exileZone)) {
+                // A suspended card cast out of exile is no longer suspended (CR 702.62) — drop
+                // the marker so it doesn't ride along onto the resulting permanent (which reuses
+                // this entity id). The exile-side countdown trigger is gated on time counters,
+                // so a leftover marker would be inert, but this keeps the permanent clean.
                 val removed = state.removeFromZone(exileZone, cardId)
+                    .updateEntity(cardId) { it.without<com.wingedsheep.engine.state.components.battlefield.SuspendedComponent>() }
                 return com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
                     .unlinkFromAllLinkedExiles(removed, cardId)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -100,6 +100,19 @@ data object EvokedComponent : Component
 data object CastForImpendingComponent : Component
 
 /**
+ * Marks an exiled card as suspended (CR 702.62). The marker — not the card's printed
+ * abilities — is what the engine keys on, so an arbitrary card with no printed suspend can
+ * be suspended (e.g. Taigam, Master Opportunist exiles the spell you cast and grants it
+ * suspend). While present on an exiled card, [com.wingedsheep.engine.event.TriggerAbilityResolver]
+ * grants it [com.wingedsheep.sdk.scripting.Suspend.countdownAbility] — the owner's-upkeep
+ * countdown that removes a time counter and plays the card for free when the last is gone.
+ *
+ * Stripped when the card leaves exile by a non-cast path and when it leaves the battlefield.
+ */
+@Serializable
+data object SuspendedComponent : Component
+
+/**
  * Records the mana colors spent to cast this permanent.
  * Used by mana-spent-gated trigger conditions (e.g., "if {W}{W} was spent to cast it").
  * Stripped when the permanent leaves the battlefield.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SuspendMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SuspendMechanicTest.kt
@@ -1,0 +1,167 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.FloatingEffectData
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffects
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.SuspendedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Mechanic-level tests for Suspend (CR 702.62), driven by the [SuspendedComponent] marker
+ * the engine reads off an exiled card (set by the [com.wingedsheep.sdk.dsl.Effects.Suspend]
+ * chain). Unlike Impending / Vanishing, suspend lives in **exile**: a time counter is removed
+ * at the beginning of the owner's upkeep, and when the last is gone the card is played for
+ * free — with haste if it's a creature.
+ *
+ * The setup places a creature card directly into exile with the marker + N time counters
+ * (the state a `Suspend` chain produces) and verifies the countdown-and-cast the engine
+ * synthesizes from that marker.
+ */
+class SuspendMechanicTest : FunSpec({
+
+    val suspendedBear = card("Suspended Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(suspendedBear))
+        return driver
+    }
+
+    fun timeCounters(driver: GameTestDriver, perm: EntityId): Int =
+        driver.state.getEntity(perm)?.get<CountersComponent>()?.getCount(CounterType.TIME) ?: 0
+
+    /**
+     * Put [cardName] into [owner]'s exile in the state a real [com.wingedsheep.sdk.dsl.Effects.Suspend]
+     * produces: the suspended marker, [timeCounters] time counters, and the dormant permanent
+     * haste effect (which `GrantSuspendExecutor` arms; verified independently in the Taigam
+     * scenario test). The haste effect lies inert in exile and should apply once the card is
+     * played onto the battlefield as the same entity.
+     */
+    fun suspendInExile(driver: GameTestDriver, owner: EntityId, cardName: String, timeCounters: Int): EntityId {
+        val cardId = driver.putCardInGraveyard(owner, cardName)
+        var s = driver.state
+            .removeFromZone(ZoneKey(owner, Zone.GRAVEYARD), cardId)
+            .addToZone(ZoneKey(owner, Zone.EXILE), cardId)
+            .updateEntity(cardId) { container ->
+                container
+                    .with(SuspendedComponent)
+                    .with(CountersComponent().withAdded(CounterType.TIME, timeCounters))
+            }
+        s = s.addFloatingEffects(
+            listOf(
+                ActiveFloatingEffect(
+                    id = EntityId.generate(),
+                    effect = FloatingEffectData(
+                        layer = Layer.ABILITY,
+                        modification = SerializableModification.GrantKeyword(Keyword.HASTE.name),
+                        affectedEntities = setOf(cardId),
+                    ),
+                    duration = Duration.Permanent,
+                    sourceId = cardId,
+                    sourceName = cardName,
+                    controllerId = owner,
+                    timestamp = s.timestamp,
+                )
+            )
+        )
+        driver.replaceState(s)
+        return cardId
+    }
+
+    /**
+     * Advance to the owner's next upkeep — passing through any intervening turns — and resolve
+     * the suspend countdown trigger that fires there. Steps off the current upkeep first (via
+     * the precombat main) so consecutive calls keep moving forward.
+     */
+    fun resolveNextOwnerUpkeep(driver: GameTestDriver, owner: EntityId) {
+        do {
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            driver.passPriorityUntil(Step.UPKEEP)
+        } while (driver.activePlayer != owner)
+        driver.bothPass() // resolve the suspend countdown trigger
+    }
+
+    test("a suspended card sits in exile with its time counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val cardId = suspendInExile(driver, player, "Suspended Bear", timeCounters = 2)
+
+        driver.getExile(player).contains(cardId) shouldBe true
+        timeCounters(driver, cardId) shouldBe 2
+        driver.state.getEntity(cardId)?.has<SuspendedComponent>() shouldBe true
+    }
+
+    test("a time counter is removed at the beginning of the owner's upkeep") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val cardId = suspendInExile(driver, player, "Suspended Bear", timeCounters = 2)
+
+        // Opponent's upkeep first — the owner's countdown must NOT fire on it.
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldNotBe player
+        timeCounters(driver, cardId) shouldBe 2
+
+        // The owner's next upkeep removes one.
+        resolveNextOwnerUpkeep(driver, player)
+        timeCounters(driver, cardId) shouldBe 1
+        driver.getExile(player).contains(cardId) shouldBe true
+    }
+
+    test("when the last time counter is removed the card is played for free with haste") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val cardId = suspendInExile(driver, player, "Suspended Bear", timeCounters = 2)
+
+        // First owner upkeep: 2 -> 1, still in exile.
+        resolveNextOwnerUpkeep(driver, player)
+        timeCounters(driver, cardId) shouldBe 1
+        driver.getExile(player).contains(cardId) shouldBe true
+
+        // Second owner upkeep: 1 -> 0, the suspend trigger offers to play it for free.
+        resolveNextOwnerUpkeep(driver, player)
+        // CR 702.62f — "they may play it." Accept, then resolve the cast.
+        driver.submitYesNo(player, true)
+        driver.bothPass()
+
+        driver.getExile(player).contains(cardId) shouldBe false
+        val perm = driver.findPermanent(player, "Suspended Bear")
+        perm shouldNotBe null
+        // CR 702.62g — a creature played via suspend has haste.
+        projector.project(driver.state).hasKeyword(perm!!, Keyword.HASTE) shouldBe true
+        // The marker is gone once it leaves exile.
+        driver.state.getEntity(perm)?.has<SuspendedComponent>() shouldBe false
+    }
+})


### PR DESCRIPTION
Implements **item 14 (Suspend)** from `backlog/tdm-engine-gaps.md` and the card it unblocks, **Taigam, Master Opportunist** (TDM).

## What Suspend is

Suspend (CR 702.62) is an **exile-zone** mechanic — distinct from Impending/Vanishing, which use time counters on the *battlefield*. A suspended card sits in exile with time counters; at the beginning of its **owner's** upkeep one is removed, and when the last is gone its owner **may play it without paying its mana cost** (with **haste** if it's a creature).

## Design — a reusable chain, not a monolith

The hard, reusable part (the countdown + free-cast lifecycle) is **component-driven**, so it works for an *arbitrary* card with no printed suspend — exactly what Taigam needs (it suspends a copy of whatever spell you cast):

- **`SuspendedComponent`** marks an exiled card as suspended. `TriggerAbilityResolver` grants any marked card **`Suspend.countdownAbility`** — a synthesized `activeZone = EXILE` upkeep trigger (the engine already scans exile for such triggers). It removes a time counter and, when the last is gone, wraps the optional play (CR 702.62f) in `MayEffect`, gathers the card via the new **`CardSource.Self`**, and casts it through the existing **`CastFromCollectionWithoutPayingCost`** pipeline (so targets/X are handled, and the proven Shiko cast path is reused).
- **`Effects.Suspend(target, n)`** is the reusable tail: `AddCounters(TIME, n)` + **`GrantSuspendEffect`** (sets the marker **and** arms a dormant permanent haste effect on the card, which applies once it's played onto the battlefield as the same entity — CR 702.62g). The caller composes the "get into exile" step first, since it differs by source zone.

**Taigam** then reads as a plain chain:
```kotlin
flurry {
    effect = Effects.Composite(listOf(
        Effects.CopyTargetSpell(EffectTarget.TriggeringEntity),                    // copy it
        CounterEffect(TriggeringEntity, counterDestination = Exile()),              // exile the spell you cast
        Effects.Suspend(EffectTarget.TriggeringEntity, timeCounters = 4),          // it gains suspend
    ))
}
```
(A spell can't be lifted off the stack with a zone-move effect, so "exile the spell you cast" uses counter-to-exile.)

## Lifecycle hygiene

The marker is stripped when the card leaves exile (the cast path in `StackResolver` and `ZoneTransitionService`) and on leaving the battlefield. The countdown trigger is gated on still having a time counter, so a stray marker can never re-cast.

## Tests
- `SuspendMechanicTest` (rules-engine): counter removed only on the **owner's** upkeep; at zero the card is played for free **with haste**.
- `TaigamMasterOpportunistScenarioTest` (game-server): the copy resolves normally while the original is exiled with **4 time counters**, the suspended marker, and haste armed.

Full `mtg-sdk` + `rules-engine` suites pass (no regressions); the existing Shiko scenario tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)