### PR TITLE
Add add-feature skill and contributing docs

### DIFF
--- a/.claude/skills/add-card/SKILL.md
+++ b/.claude/skills/add-card/SKILL.md
@@ -8,6 +8,27 @@ argument-hint: <card-name> [--set <set-code>]
 
 Implement the card specified in `$ARGUMENTS`. The card name is the main argument; `--set <set-code>` is optional (defaults to `por` for Portal).
 
+## Guiding principle: rules-faithful, no shortcuts
+
+The implementation must be **faithful to the actual Magic rules** — model exactly what the
+card does under the Comprehensive Rules, not a convenient approximation. No shortcuts:
+
+- **Don't fake a mechanic** that the engine doesn't yet support with a lookalike that only
+  works in the common case. If the card needs a new effect/trigger/condition/replacement,
+  build it properly (Step 4) rather than hardcoding the happy path.
+- **Don't drop edge cases** — "may" declines, fizzles, the source leaving the battlefield,
+  zero/empty inputs, simultaneous triggers, replacement-effect interactions, layer/timestamp
+  ordering. If you can't cover an interaction, say so explicitly; don't silently skip it.
+- **Don't approximate timing** — cast-time vs resolution-time choices, intervening "if"
+  clauses, last-known-information, and turn/step boundaries follow the rules (and Scryfall
+  rulings), not whatever is easiest to wire up.
+- **Honor oracle text literally** — every word maps to behavior. Don't simplify "up to N
+  target" to "N target", "you may" to "you do", or "each" to "target".
+
+When the faithful implementation is more work than a shortcut, do the work — or stop and tell
+the user what's missing. A card that looks right but resolves wrong is worse than an
+unimplemented one.
+
 ## Step 1: Look Up Card Data on Scryfall
 
 **REQUIRED**: Always fetch exact card data before implementing. Never guess card text or stats.
@@ -483,3 +504,4 @@ If `backlog/sets/{set-name}/cards.md` exists:
 11. **Verify against Scryfall before committing** — Re-check every field against the API data (Step 10)
 12. **Walkthrough new mechanics** — If new effects/engine changes, trace through all layers (Step 9)
 13. **Build/test before committing** — `just build` (simple) or `just test` (new effects)
+14. **Be rules-faithful, no shortcuts** — Model the card exactly as the Comprehensive Rules dictate; cover edge cases and timing rather than the happy path. If a faithful implementation isn't feasible, stop and tell the user what's missing (see "Guiding principle" above)

--- a/.claude/skills/add-feature/SKILL.md
+++ b/.claude/skills/add-feature/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: add-feature
+description: Adds a new feature or mechanic to the Argentum Engine (SDK primitive, effect, trigger, condition, static/replacement ability, server/client capability) following the project's architecture and SDK-elegance principles. Use when implementing engine/SDK/server/client functionality that isn't a single card — e.g. "add an effect type", "support a new keyword", "add a decision UI", "make the engine handle X".
+argument-hint: <feature description>
+---
+
+# Add Engine Feature
+
+Implement the feature described in `$ARGUMENTS`. This skill is for work that extends the
+**engine, SDK, server, or client** — a new primitive, mechanic, decision flow, or capability —
+as opposed to a single card (use `add-card` for that, and `add-card` Step 4 for the small SDK
+additions a card needs).
+
+A "feature" here is anything that adds vocabulary or behavior the rest of the system builds on:
+a new `Effect`/`Trigger`/`Condition`/`DynamicAmount`/`Filter`/`StaticAbility`/`ReplacementEffect`,
+a new component or tracker, a new decision type + UI, a new server message, a turn-structure or
+priority change, a projection/layer change. Because these are *load-bearing*, the bar for
+elegance and reuse is higher than for a card.
+
+## Guiding principle: elegance and a clean, reusable SDK
+
+Read this before touching code. It is the lens for every decision below.
+
+- **Composition over monoliths.** The strongest version of a feature is usually *not a new type
+  at all* — it's a composition of existing atoms. Before adding an `Effect`, ask whether
+  `CompositeEffect` of existing effects, an `EffectPatterns.*` recipe, or a `DynamicAmount` /
+  `GameObjectFilter` parameterization already expresses it. The Gather → Select → Move pipeline
+  (`docs/architecture-principles.md` §1.5) covers almost all zone/library manipulation with zero
+  new executors. Reach for a new type only when no composition reads the state, produces the
+  player interaction, or expresses the timing you need.
+- **Think about the SDK as a whole — and the *next* card.** Don't design for the one card or
+  situation in front of you. Ask: "what are the slight variations of this that will show up
+  later?" A feature built for "+1/+1 for each Goblin" should be the same primitive that later
+  serves "−1/−1 for each artifact" or "power equal to your life total". If a small change in
+  requirements would force a *second* new type, you've drawn the boundary wrong — generalize now.
+- **Name the mechanic, not the card.** `ReduceSpellCostEffect(filter, amount)`, not
+  `ReduceGoblinCostEffect`. A name that lies about what the type does (`CreatureTypeCount` that
+  actually counts all subtypes) is a bug — rename and document the gap.
+- **Parameterize over filter / amount / duration / target / player.** Use `GameObjectFilter`,
+  `DynamicAmount`, `Duration`, `EffectTarget`, and `Player`-parametric forms instead of baking in
+  constants, a single entity type, or a hardcoded "until end of turn". One type, many cards. See
+  `add-card` Step 4 reusability rules and `review-changes` §2 — this skill is held to the same bar.
+- **Keep effects pure data; logic lives in executors.** SDK types are serializable data bags with
+  no behavior (`docs/architecture-principles.md` §1.1). This is what makes state projection safe,
+  networking trivial, and replay deterministic. Never put a lambda or engine reference in an SDK
+  type.
+- **When the elegant version is more work, do the work.** A one-off type that "works for this
+  case" is technical debt that every future card pays interest on. If you genuinely can't find a
+  reusable shape, say so explicitly and explain why — don't silently ship the monolith.
+
+If you're unsure whether a new type is justified, apply the `review-changes` §2 test to your own
+design: *Could a card compose existing primitives? Is it genuinely novel? Is it parameterized for
+the next card? Does the name match the semantics?*
+
+## Step 1: Understand the feature and find the seam
+
+1. **Read the architecture.** [`docs/architecture-principles.md`](../../../docs/architecture-principles.md)
+   — especially §1 (SDK data contract: AST values, composable filters, late-binding targets,
+   atomic pipelines, DSL) and the §2 subsection for the layer you're touching (projection §2.3,
+   continuations §2.4, events §2.5, registries §2.6, replacements §2.7, SBAs §2.8, turn/priority
+   §2.9, mana §2.10, copies §2.11).
+2. **Read the SDK catalog.** [`docs/card-sdk-language-reference.md`](../../../docs/card-sdk-language-reference.md)
+   — the full inventory of existing effects, triggers, conditions, filters, costs, keywords,
+   dynamic amounts, modal/choice shapes, and replacement effects. **Most features are 80% already
+   built.** Find the closest existing primitive before designing a new one.
+3. **Search for prior art.** `grep -r "<mechanic-or-effect>" mtg-sdk/ rules-engine/` and look at how
+   the nearest analogous feature is wired end-to-end. Mirror its structure; don't invent a new one.
+4. **State the boundary in one sentence.** Write down what the new vocabulary *is* and what it is
+   deliberately *not* — this is the contract the rest of the system depends on. If you can't state
+   it crisply, the design isn't ready.
+
+## Step 2: Composition-first — try hard not to add a type
+
+Before adding any new SDK type, attempt the composition. Concretely:
+
+- **Behavior** → `CompositeEffect(listOf(...))` of existing `Effects.*`, or a new recipe in
+  `EffectPatterns.kt` composing existing atoms (see [feedback: no single-use patterns] — only add
+  an `EffectPatterns.*` helper when a *second* user appears, or it's a named MTG mechanic; inline
+  with explicit flags otherwise).
+- **A number that changes with game state** → a `DynamicAmount` composition
+  (`Add`, `Subtract`, `Multiply`, `Min`, `Max`, `EntityProperty`, counts over a filter), not a new
+  amount node. Add a new `DynamicAmount` variant only when it must *read state no existing node can
+  read*.
+- **"Which objects"** → a `GameObjectFilter` composition of `CardPredicate` / `StatePredicate` /
+  `ControllerPredicate`, not a new filter type.
+- **A continuous stat/keyword/type change** → an existing static ability
+  (`GrantDynamicStatsEffect`, `ModifyStatsForCreatureGroup`, etc.) fed a `DynamicAmount` /
+  `GameObjectFilter`, not a bespoke static ability.
+
+If a composition expresses it: stop. Add the card/recipe and go to tests. **Don't extend an
+existing effect with a new optional parameter to cover a variation** — compose instead
+(see [feedback: atomic effects]). Document the composition in the SDK reference if it's a reusable
+recipe.
+
+## Step 3: If a new type is genuinely needed — design it for reuse
+
+Apply the four reusability principles from `add-card` Step 4 (target generality, duration/removal
+generality, parameterized filters/amounts, name-the-mechanic). Then add it in the right place:
+
+| New vocabulary | SDK home | Engine wiring |
+|---|---|---|
+| Effect | `mtg-sdk/.../scripting/effect/{Category}Effects.kt` + facade in `dsl/Effects.kt` | Executor in `rules-engine/.../handlers/effects/{category}/` + register in `{Category}Executors.kt` |
+| Trigger | `mtg-sdk/.../scripting/trigger/` + facade in `dsl/Triggers.kt` | `TriggerDetector` detection path + `TriggerIndex` registration |
+| Condition | `mtg-sdk/.../scripting/condition/` + facade in `dsl/Conditions.kt` | `ConditionEvaluator` (must work in *both* resolution and projection via `ConditionEvaluationContext`) |
+| Static ability | `mtg-sdk/.../scripting/StaticAbility.kt` | `StateProjector` layer application (correct Rule 613 layer) |
+| Replacement effect | `mtg-sdk/.../scripting/ReplacementEffect.kt` (declarative `appliesTo` pattern) | engine interception point |
+| DynamicAmount variant | `mtg-sdk/.../scripting/DynamicAmount.kt` | `DynamicAmountEvaluator` |
+| Filter predicate | `mtg-sdk/.../model/` predicate types | `PredicateEvaluator` |
+| Keyword | `mtg-sdk/.../core/Keyword.kt` | `web-client/src/types/enums.ts` (enum + display name) + icon index |
+| Counter type | `core/CounterType.kt` | spans **5 layers** — see `add-card` Step 4.5b (CounterType, StateProjector KEYWORD_COUNTER_MAP, enums.ts, icon index, 3 frontend badge files) |
+| Component / tracker | `mtg-sdk/.../component/` or engine component | reader in projection/handlers; cleanup if it has a duration |
+| Decision type | `mtg-sdk` decision model | `PendingDecision` + continuation frame + client UI (Step 6) |
+
+Hard rules while writing it (from `CLAUDE.md` "Load-bearing rules" and the engine's recurring bug
+classes — `review-changes` §3):
+
+- **Immutability** — never mutate components/state in place; return new instances.
+- **Projected state for battlefield reads** — type/subtype/color/keywords/P/T/controller on
+  battlefield permanents MUST go through `predicateEvaluator.matchesWithProjection(...)` /
+  `projected.isCreature(...)` / `state.projectedState.getController(...)`, never base
+  `ControllerComponent` or `cardComponent.typeLine.isCreature`. Non-battlefield zones can use base
+  state.
+- **Events, not silent mutations** — every state change emits a `GameEvent` so triggers and
+  animations can react.
+- **One condition, both contexts** — conditions must evaluate identically at resolution and during
+  projection (no separate `*ProjectionCondition` types; use `ConditionEvaluationContext`).
+- **Continuations carry targets** — any frame wrapping `EffectTarget.ContextTarget(n)` must
+  propagate `targets` / `namedTargets` / `outerTargets` into the rebuilt `EffectContext`.
+- **Last-known information** — dies/leaves triggers read `triggerLastKnownPower`,
+  `lastKnownCardDefinitionId`, `lastKnownCounters` off the `ZoneChangeEvent` (the entity is gone by
+  the time the trigger resolves).
+- **Layer 613.8 dependency** — new continuous-effect families sort by trial application before
+  timestamp; never `toMutableSet()` a `ContinuousEffect` list (it dedupes equal lord effects).
+
+## Step 4: Trace the feature through every layer it touches
+
+This is the analogue of `add-card` Step 9, and it is mandatory for engine features. A feature is
+done only when every layer below either handles it or is verified not to need changes. Walk **at
+least the happy path plus one edge case** (fizzle, "may" declined, source leaves before resolution,
+empty/zero input, simultaneous instances, replacement interaction):
+
+| Layer | What to verify |
+|---|---|
+| **SDK (data)** | Pure, serializable, fully parameterized? Round-trips through serialization? |
+| **Engine (handler/executor)** | Right handler/executor picks it up; emits the right `GameEvent`s; returns correct new `GameState`. Registered in the right registry. |
+| **TriggerDetector** | New trigger detected from emitted events; registered in `TriggerIndex`; correct detection path (battlefield `detectTriggers` vs phase/step `detectPhaseStepTriggers` vs `detectLeavesBattlefieldTriggers`). |
+| **StateProjector** | New continuous effect/static ability applied in the correct Rule 613 layer; projected state reflects it; dependency ordering holds. |
+| **Continuations** | Player-input features pause with a `PendingDecision` and resume correctly, carrying targets/collections. |
+| **Cleanup** | Duration-bounded state removed at the right time (end of turn/combat, source leaves). |
+| **Server DTO / masking** | New `GameEvent` → branch in `ClientEvent.kt` exhaustive `when`. New client-visible state → `ClientStateTransformer`. Private info masked by `StateMasker`. |
+| **Legal actions** | New player action enumerated by an `ActionEnumerator`; never computed client-side. |
+| **Frontend** | New decision/UX → component in `web-client/src/components/decisions/`; new keyword/icon → `enums.ts`, display names, icon index. |
+
+Write a short trace per scenario (SDK → engine → triggers → continuations → DTO → frontend, each
+✅ or a noted gap). Fix every gap before proceeding.
+
+## Step 5: Performance
+
+The engine runs full state projection and legal-action enumeration constantly (every priority
+pass, every AI/MCTS node). Cheap-looking work in a primitive multiplies.
+
+- **Don't recompute projection.** Projected state is cached per immutable `GameState`; read
+  `state.projectedState`, don't re-run `StateProjector` yourself. Inside executors that already
+  have a projected state in context, reuse it.
+- **Keep `DynamicAmount` / filter evaluation allocation-light.** They run inside projection and
+  enumeration hot paths. Avoid building large intermediate collections per entity; prefer counting
+  over a filtered view to materializing lists.
+- **Respect immutability without copying the world.** Use the `with`/`without` component helpers
+  and `copy(...)` of the changed slice — don't rebuild whole maps. Local `mutableListOf`
+  accumulation inside a pure function is fine (the SBA loop does this); leaking mutation across
+  calls is not.
+- **Watch the client too.** New per-card fields in `ClientCard` or frequent `StateDeltaUpdate`
+  churn can cause battlefield re-renders. If the feature adds card-visible state, confirm it only
+  changes when it actually changes (see the recent battlefield re-render perf work).
+- **Benchmarks** — the AI `*Benchmark` classes are too slow for routine validation; run `*Test`
+  classes during development (see [feedback: skip benchmarks]).
+
+## Step 6: UX / UI
+
+The client is a dumb terminal (`docs/architecture-principles.md` §4): it renders what the server
+sends and captures intent. Server-side feature design *is* the UX.
+
+- **Server-authoritative interactivity.** The feature becomes clickable only because it appears in
+  the server's legal actions / `PendingDecision`. Make sure the new action/decision is enumerated;
+  never add client-side rules to make something interactive.
+- **Route decisions to the right component.** Map each player choice to an existing component in
+  `web-client/src/components/decisions/` (battlefield selection, graveyard/library/zone overlays,
+  yes/no, choose color/number/option, modal/budget). Prefer **on-battlefield selection** over a
+  card-list overlay when choosing among permanents in play — overlays hide counters/effects/board
+  context (see [feedback: UX review] and `add-card` Step 6).
+- **Extend before creating.** Prefer extending an existing decision component over a new one. Add a
+  new decision type/component only when an existing one genuinely can't express the interaction.
+- **Clear labels.** Any `description` on a mode/ability becomes button/label text — write it from
+  the player's perspective.
+- **Suppress stale UI at the handler**, not just at render time, if a sticky store field drives a
+  UI element (see [feedback: suppress stale UI state]).
+- **Trace the player flow** end to end for the feature, exactly as `add-card` Step 6.1 prescribes.
+
+## Step 7: Tests — match the pyramid
+
+Pick the layer that proves the feature, per `docs/architecture-principles.md` §5:
+
+- **SDK round-trip / unit** (`mtg-sdk`) — new data type serializes and composes as intended.
+- **Engine unit/integration** (`rules-engine`) — the executor/projector/detector behaves in
+  isolation; construct `GameState` directly and assert on the result.
+- **Scenario** (`ScenarioTestBase`) — the feature works in a realistic board state, exercised
+  through a card that uses it. **Every rule the implementation cites must have a paired test**
+  (`review-changes` §5). Cover the edge cases you traced in Step 4. Put these in `rules-engine` by
+  default; only use `game-server` when the feature is genuinely a game-server concern (state masking,
+  DTO transformation, session/tournament orchestration) rather than an engine feature.
+- **`ScenarioTestBase` scope** — only registered sets load; define inline test cards via
+  `CardDefinition.creature(...)` + `cardRegistry.register(...)` in `init { }` for anything else.
+
+Run them yourself: `just test` / `just test-rules` / `just test-class <Name>` (or the direct
+gradle module command). Don't trust a description — confirm green. If a registry/executor/evaluator
+signature changed, run the broader module suite.
+
+## Step 8: Update the docs in the same change
+
+- **`docs/card-sdk-language-reference.md` is the canonical SDK catalog.** Any new effect, trigger,
+  condition, filter, cost, keyword, dynamic amount, modal shape, or replacement effect MUST be
+  documented in the appropriate section in this same change (this is a `CLAUDE.md` standing rule).
+- **`docs/architecture-principles.md`** — update only if the feature introduces or changes an
+  *architectural* concept (a new layer of the engine, a new cross-cutting pattern), not for a
+  routine new primitive.
+- Update any other doc the feature contradicts (`engine-server-interface.md`, `data-contracts.md`,
+  `player-input.md`, `web-client-architecture.md`, `continuous-effect-dependency-system.md`).
+
+## Step 9: Build, verify, commit
+
+1. `just build` (no new behavior to exercise) or `just test` (new effects/engine changes). Fix only
+   failures your change caused; if a pre-existing/other-agent test fails, report it and stop
+   (`CLAUDE.md` collaboration rules — never revert or stash others' work).
+2. **Verify CR rule numbers** you cite in code/comments/commit at
+   <https://yawgatog.com/resources/magic-rules/> before committing — they're easy to misremember.
+   Describe the rule by name if you can't confirm the number.
+3. Commit with a message describing the capability (e.g. `Add <mechanic> support to the engine`).
+   End the message with the project's `Co-Authored-By` trailer. Commit to the current branch; don't
+   push unless asked.
+
+## Anti-patterns to reject in your own design
+
+- A new `Effect`/`StaticAbility` whose executor converts it 1:1 into an existing `Modification` /
+  effect with a literal formula → use the existing type fed a `DynamicAmount`.
+- A new optional parameter bolted onto an existing effect to cover a variation → compose instead.
+- Constants baked into a type (`bonusPerType = 1`, hardcoded subtype, `count = 20` for "any
+  number") → parameterize (`DynamicAmount`, `GameObjectFilter`, `unlimited`/`dynamicMaxCount`
+  flags).
+- A type named for the card that motivated it.
+- Battlefield reads against base state instead of projected state.
+- A new `GameEvent` without a `ClientEvent.kt` branch; client-visible state without a transformer.
+- Game logic creeping into `web-client`.
+- A single-use `EffectPatterns.*` helper with no second caller (inline it).
+
+## Important rules
+
+1. **Compose first** — a new SDK type is the last resort, not the first move.
+2. **Design for the next card, not this one** — parameterize over filter/amount/duration/target.
+3. **Name the mechanic, not the card.**
+4. **Keep SDK types pure serializable data**; logic lives in executors.
+5. **Immutability + projected-state reads** are non-negotiable on battlefield code.
+6. **Trace every layer** (Step 4) before declaring done.
+7. **Mind performance** on projection/enumeration hot paths and client re-renders.
+8. **Server-authoritative UX**; the client only renders and captures intent.
+9. **Update `card-sdk-language-reference.md`** for every SDK addition, same change.
+10. **Verify CR rule numbers**; test every cited rule.
+11. **Be elegant — no monolithic one-off shortcuts.** If you can't find the reusable shape, say so
+    and explain why rather than shipping the monolith.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,9 @@ Guidance for Claude Code working in this repository.
   revert, stash, or discard others' changes — that's likely another agent's in-flight work. Pause until the user
   confirms it is safe to continue.
 - **Implementing a card from a backlog file** (e.g., `backlog/sets/scourge/cards.md`) → always use the `add-card` skill.
+- **Adding an engine/SDK/server/client feature** (a new effect, trigger, condition, keyword, decision flow, or any
+  capability that isn't a single card) → always use the `add-feature` skill. It enforces composition-over-monoliths,
+  designing each new SDK type for reuse, full cross-layer tracing, and performance + UX review.
 - **Verify MTG rule numbers before citing them.** Rule numbers are easy to misremember (613.8 vs 613.7, 704.5 vs
   704.6, etc.). Whenever you reference a specific rule number in code comments, commit messages, PR descriptions,
   or chat, look it up first at <https://yawgatog.com/resources/magic-rules/> to confirm the number matches the
@@ -83,6 +86,10 @@ anti-corruption layer between engine and clients.
   scenario test).
 - **Adding a mechanic** → prefer composing in `EffectPatterns.kt` first; only add a new `Effect` type + executor in
   `rules-engine/handlers/effects/` when atomic primitives don't suffice.
+- **Adding an engine/SDK/server/client feature** (a new primitive, mechanic, decision flow, or capability that isn't a
+  single card) → use the `add-feature` skill. It enforces composition-over-monoliths, designing each new SDK type for
+  the *next* card (not just the one in front of you), full cross-layer tracing (SDK → engine → projection/triggers →
+  continuations → server DTO → client), and performance + UX/UI review.
 
 Detailed DSL reference: [`docs/card-sdk-language-reference.md`](docs/card-sdk-language-reference.md) — a complete
 catalog of every building block (effects, triggers, conditions, filters, costs, keywords, dynamic amounts, etc.).

--- a/README.md
+++ b/README.md
@@ -259,6 +259,68 @@ For AlphaZero-shaped projects that want tree search in the JVM and only use Pyth
 
 See [`gym-trainer/README.md`](gym-trainer/README.md) for the full design write-up and a 30-line hello-world.
 
+## Contributing
+
+Contributions are very welcome, and I'm genuinely grateful for every PR. To keep the project
+healthy, there's one rule above all others:
+
+> **No slop PRs.** A reviewer's time is the scarcest resource here. Please open a PR only when
+> you've built and tested it yourself, kept the change focused, and made it faithful to the actual
+> Magic rules (no shortcuts). A polished small PR is worth far more than a large unverified one.
+
+### Using AI to implement cards
+
+Using AI to implement cards is encouraged — most of the card catalog is data, and the project ships
+[Claude Code](https://claude.com/claude-code) skills that automate the workflow correctly (Scryfall
+lookup, oracle errata, set registration, scenario tests, reprint handling):
+
+- **`add-card <CARD_NAME> <SET_CODE>`** — implement a specific card.
+- **`add-random-card <SET_CODE>`** — pick a random unimplemented card from a set and implement it.
+
+**If a card adds a new UI / UX element, test it manually** before opening the PR — AI can build the
+flow, but a human needs to confirm it actually feels right in the client. Run the app (`just server`
++ `just client`), set up the situation (the `generate-scenario` skill can inject a board state), and
+click through the decision yourself.
+
+### Implementing a whole set
+
+When bringing up an entire set, this flow has proven much faster than implementing cards one at a
+time (it's how Invasion was done):
+
+1. **Gap analysis.** Diff the set against the SDK/engine: which effects, triggers, conditions,
+   keywords, costs, or mechanics are *missing* that you need before any card can be implemented
+   cleanly? Produce the full list up front. (Invasion needed roughly 25 new features.)
+2. **Plan each missing feature for elegance and reuse.** For every gap, design the implementation so
+   it composes complex effects from small reusable atoms rather than a one-off type per card — think
+   about the SDK as a whole and the *next* card, not just the one in front of you. Use the
+   **`add-feature`** skill, which encodes these principles end to end.
+3. **Implement the features one by one, with care.** This is the step that pays off later, so give it
+   attention: write tests, and **manually test the UX** for anything that touches the client. Some
+   features are deep — Invasion's banding required rewriting the whole combat system — so don't rush
+   them.
+4. **Then fan out the cards.** Once the building blocks exist, most cards need no engine changes. Add
+   them in parallel — e.g. spawn a few agents, each using the `add-card` skill to implement a handful
+   of cards, and have each open a PR when its batch is done.
+5. **Review engine changes.** Cards will occasionally still need a small engine tweak. When a PR adds
+   or changes engine/SDK code, run **`review-changes <PR_URL>`** on it — this checks for elegance and
+   correctness and keeps the engine/SDK clean. (Card-only PRs with no engine changes don't need it.)
+
+### Guidelines
+
+- Read [`CLAUDE.md`](CLAUDE.md) and [`docs/architecture-principles.md`](docs/architecture-principles.md)
+  first — they describe the load-bearing rules (immutability, projected state, events-not-mutations,
+  server-authoritative client) that PRs are reviewed against.
+- Prefer composing existing primitives over adding new SDK types; when you do add a type, parameterize
+  it and name the mechanic, not the card.
+- Update [`docs/card-sdk-language-reference.md`](docs/card-sdk-language-reference.md) in the same
+  change whenever you add or change anything in the SDK.
+- Verify Comprehensive Rules numbers at <https://yawgatog.com/resources/magic-rules/> before citing
+  them in code, comments, or commit messages.
+- Run `just build` (simple changes) or `just test` (new effects/engine changes) and confirm green
+  before opening the PR.
+
+Questions or ideas? [Join the Discord](https://discord.gg/dy6eSRPWzu).
+
 ## Why "Argentum"?
 
 Argentum was a plane of mathematical perfection, created by the planeswalker Karn. Every angle intentional, every law


### PR DESCRIPTION
## Summary

Adds tooling and docs to make contributions (especially AI-assisted ones) follow the project's architecture and SDK-elegance principles.

- **New `add-feature` skill** (`.claude/skills/add-feature/SKILL.md`) — a composition-first workflow for adding engine/SDK/server/client features (not single cards). Enforces composition-over-monoliths, designing each new SDK type for the *next* card, full cross-layer tracing (SDK → engine → projection/triggers → continuations → server DTO → client), and performance + UX/UI review. Grounded in `docs/architecture-principles.md` and aligned with the `add-card` and `review-changes` skills.
- **`add-card` skill** — adds a "rules-faithful, no shortcuts" guiding principle so card implementations model the actual Comprehensive Rules (edge cases, timing, literal oracle text) rather than the happy path.
- **`CLAUDE.md`** — links `add-feature` from both the collaboration rules and the card/effect authoring section.
- **`README.md`** — new Contributing section: the no-slop-PR expectation, the AI card workflow (`add-card` / `add-random-card`, manual UX testing for new UI), the whole-set flow (gap analysis → plan reusable features → implement with care → fan out cards via subagents → `review-changes` on engine PRs), and general guidelines.

Docs/tooling only — no engine or card code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)