### PR TITLE
perf(engine): key components by Class<*> instead of String (perf plan Step 2)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -1188,7 +1188,7 @@ object DamageUtils {
     ): Boolean {
         if (projected.hasColor(sourceId, color)) return true
         val sourceEntity = state.getEntity(sourceId) ?: return false
-        val card = sourceEntity.components[CardComponent::class.java.name] as? CardComponent ?: return false
+        val card = sourceEntity.components[CardComponent::class.java] as? CardComponent ?: return false
         return card.colors.contains(color)
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/ComponentContainer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/ComponentContainer.kt
@@ -1,21 +1,32 @@
 package com.wingedsheep.engine.state
 
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.Serializable
-import kotlin.reflect.KClass
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 /**
  * Immutable container for an entity's components.
  * Components are accessed by their type.
+ *
+ * Components are keyed in-memory by their [Class] (identity hashCode — no string
+ * hashing on the hot path). For serialization, [ComponentContainerSerializer] writes
+ * the map with class-name string keys so the on-disk form stays human-readable and
+ * stable across runs.
  */
-@Serializable
+@Serializable(with = ComponentContainerSerializer::class)
 data class ComponentContainer(
-    @PublishedApi internal val components: Map<String, Component> = emptyMap()
+    @PublishedApi internal val components: Map<Class<*>, Component> = emptyMap()
 ) {
     /**
      * Get a component by type, or null if not present.
      */
     inline fun <reified T : Component> get(): T? {
-        return components[T::class.java.name] as? T
+        return components[T::class.java] as? T
     }
 
     /**
@@ -31,21 +42,21 @@ data class ComponentContainer(
      * Check if a component type is present.
      */
     inline fun <reified T : Component> has(): Boolean {
-        return components.containsKey(T::class.java.name)
+        return components.containsKey(T::class.java)
     }
 
     /**
      * Add or replace a component (returns new container).
      */
     inline fun <reified T : Component> with(component: T): ComponentContainer {
-        return ComponentContainer(components + (T::class.java.name to component))
+        return ComponentContainer(components + (T::class.java to component))
     }
 
     /**
      * Remove a component type (returns new container).
      */
     inline fun <reified T : Component> without(): ComponentContainer {
-        return ComponentContainer(components - T::class.java.name)
+        return ComponentContainer(components - T::class.java)
     }
 
     /**
@@ -76,7 +87,32 @@ data class ComponentContainer(
      * Used by the of() factory method.
      */
     fun withComponent(component: Component): ComponentContainer {
-        val key = component::class.java.name
+        val key = component::class.java
         return ComponentContainer(components + (key to component))
+    }
+}
+
+/**
+ * Serializes [ComponentContainer] as a plain map of class-name → component
+ * (`{"<class-name>": <component>, ...}`). The in-memory map is keyed by [Class] for
+ * identity-hash lookups on the hot path; the serialized form uses the class name so it
+ * stays readable and independent of JVM object identity.
+ *
+ * On deserialize each key is recovered from the polymorphically-decoded component's own
+ * runtime class — no `Class.forName` lookup, and robust to whatever name was stored.
+ */
+object ComponentContainerSerializer : KSerializer<ComponentContainer> {
+    private val delegate = MapSerializer(String.serializer(), PolymorphicSerializer(Component::class))
+
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun serialize(encoder: Encoder, value: ComponentContainer) {
+        val byName = value.components.entries.associate { (cls, component) -> cls.name to component }
+        encoder.encodeSerializableValue(delegate, byName)
+    }
+
+    override fun deserialize(decoder: Decoder): ComponentContainer {
+        val byName = decoder.decodeSerializableValue(delegate)
+        return ComponentContainer(byName.values.associateBy { it::class.java })
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/ComponentContainerSerializationRoundTripTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/ComponentContainerSerializationRoundTripTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.hygiene
+
+import com.wingedsheep.engine.core.engineSerializersModule
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.serialization.json.Json
+
+/**
+ * Step 2 of `backlog/engine-performance.md`: [ComponentContainer] now keys its map by
+ * [Class] for identity-hash lookups, with a custom [com.wingedsheep.engine.state.ComponentContainerSerializer].
+ * These tests pin the serializer's behaviour — that a live container survives a JSON
+ * round-trip (the components, and their type-keyed accessibility, are preserved) and
+ * that the on-disk form still uses class-name string keys.
+ */
+class ComponentContainerSerializationRoundTripTest : FunSpec({
+
+    val json = Json {
+        serializersModule = engineSerializersModule
+        encodeDefaults = true
+    }
+
+    test("container round-trips: components recovered and accessible by type") {
+        val original = ComponentContainer()
+            .with(TappedComponent)
+            .with(SummoningSicknessComponent)
+            .with(LifeTotalComponent(37))
+
+        val encoded = json.encodeToString(ComponentContainer.serializer(), original)
+        val decoded = json.decodeFromString(ComponentContainer.serializer(), encoded)
+
+        decoded shouldBe original
+        decoded.has<TappedComponent>() shouldBe true
+        decoded.has<SummoningSicknessComponent>() shouldBe true
+        decoded.get<LifeTotalComponent>() shouldBe LifeTotalComponent(37)
+    }
+
+    test("wire format keys the map by fully-qualified class name") {
+        val encoded = json.encodeToString(
+            ComponentContainer.serializer(),
+            ComponentContainer().with(LifeTotalComponent(20))
+        )
+        encoded shouldContain LifeTotalComponent::class.java.name
+    }
+
+    test("empty container round-trips") {
+        val decoded = json.decodeFromString(
+            ComponentContainer.serializer(),
+            json.encodeToString(ComponentContainer.serializer(), ComponentContainer.EMPTY)
+        )
+        decoded.isEmpty() shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolverStatePredicateTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolverStatePredicateTest.kt
@@ -113,7 +113,7 @@ class AffectsFilterResolverStatePredicateTest : FunSpec({
             .with(ControllerComponent(controller))
         extras.forEach { component ->
             @Suppress("UNCHECKED_CAST")
-            c = c.copy(components = c.components + (component::class.java.name to component))
+            c = c.copy(components = c.components + (component::class.java to component))
         }
         return c
     }


### PR DESCRIPTION
## What

Step 2 of [`backlog/engine-performance.md`](backlog/engine-performance.md). `ComponentContainer`'s internal map was `Map<String, Component>`, so every `get`/`has`/`with`/`without` paid String `hashCode` + `equals` — a large share of `HashMap.getNode` (~7.5% self-time) and String hashing (~3%) in the engine profile.

This switches the in-memory map to `Map<Class<*>, Component>` keyed by `T::class.java`: `Class` uses identity hashCode (no string hashing), and `T::class.java` compiles to a constant-pool class-literal load (no reflection).

This is the previously-unmerged commit from the `engine-perf-step2-class-keys` worktree, cherry-picked onto current `main` (Steps 1 and 3 are already merged).

## Serialization

`Class<*>` isn't natively serializable, so `ComponentContainer` gets a custom `ComponentContainerSerializer` that writes the map as `class-name → component` and, on decode, recovers each key from the polymorphically-decoded component's own runtime class (no `Class.forName`). The on-disk form stays human-readable and stable across runs. This drops the previous `{"components": {...}}` wrapper — the container now serializes as the map directly. No fixtures/tests asserted the old shape; `GameState` round-trips are symmetric.

## Changes

- `ComponentContainer.get/has/with/without/withComponent` → `Class<*>` keys
- `ComponentContainerSerializer` (new) — name↔Class at the wire boundary
- `DamageUtils` raw map lookup → `Class<*>` key
- `AffectsFilterResolverStatePredicateTest` manual build → `Class<*>` key
- New `ComponentContainerSerializationRoundTripTest` pins serializer behaviour

## Testing

- `just test-rules` — BUILD SUCCESSFUL (green)
- Benchmark with all three perf steps in (`just benchmark-random 200 BLB`) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)