### PR TITLE
Suspend haste: end on loss of control (CR 702.62g), not permanent

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1416,7 +1416,8 @@ composite abilities).
   `SuspendedComponent` marker. So an arbitrary card with no printed suspend can be suspended.
   - **Putting a card into suspend** is a chain you compose; `Effects.Suspend(target, timeCounters)` is the reusable
     two-step tail (`AddCounters(TIME, n)` + `GrantSuspendEffect` — the latter sets the marker **and** arms a dormant
-    permanent haste effect on the card). The caller supplies the exile step first, because it differs by source zone:
+    haste effect on the card with duration `WhileControlledByController`, so the haste ends the moment the player who
+    played it loses control of the permanent — CR 702.62g). The caller supplies the exile step first, because it differs by source zone:
     a spell on the stack uses `CounterSpellToExile` / `CounterEffect(counterDestination = Exile())` (it can't be lifted
     off the stack with a zone-move); a printed `suspend N—[cost]` exiles from hand as its cast cost.
   - **Taigam, Master Opportunist** is the first user: `Composite(CopyTargetSpell(TriggeringEntity),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Duration.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Duration.kt
@@ -131,6 +131,22 @@ sealed interface Duration {
     ) : Duration {
         override val description = "for as long as $sourceDescription remains tapped"
     }
+
+    /**
+     * Effect lasts for as long as the effect's controller controls the affected object —
+     * it ends the moment that object's controller becomes a different player ("for as long
+     * as you control it"). Evaluated against the *projected* controller, so it responds to
+     * every kind of control-changing effect (one-shot steals, Threaten, and static control
+     * Auras alike).
+     *
+     * Example: Suspend (CR 702.62g) — a creature played via suspend "gains haste until you
+     * lose control of the spell or the permanent it becomes."
+     */
+    @SerialName("WhileControlledByController")
+    @Serializable
+    data object WhileControlledByController : Duration {
+        override val description = "for as long as you control it"
+    }
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -268,6 +268,7 @@ class CleanupPhaseManager(
                     sourceId != null && newState.getBattlefield().contains(sourceId) &&
                         newState.getEntity(sourceId)?.has<TappedComponent>() == true
                 }
+                is Duration.WhileControlledByController -> true  // Gated at projection by controller; cleared on leaving play
                 is Duration.UntilAfterAffectedControllersNextUntap -> true  // Expires after affected entity's controller's untap
                 is Duration.UntilPhase -> true  // Handle in phase transitions
                 is Duration.UntilCondition -> true  // Handle condition checking elsewhere

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GrantSuspendExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GrantSuspendExecutor.kt
@@ -19,13 +19,17 @@ import kotlin.reflect.KClass
  *
  * - The [SuspendedComponent] marker is what makes the engine grant the exile-side
  *   countdown-and-cast triggered ability (see [com.wingedsheep.sdk.scripting.Suspend]).
- * - CR 702.62g: a creature played via suspend has haste. A normal `GrantKeyword(HASTE)` can't
- *   be used here because the card is in exile (not a projected creature), so we add a
- *   self-sourced, permanent floating haste effect keyed to the card. It lies dormant while the
- *   card sits in exile and takes effect once the card is played onto the battlefield (the
- *   permanent reuses the same entity id). Harmless for a non-creature card, which never becomes
- *   a creature on the battlefield. (Permanent duration is a deliberate simplification of
- *   "until you lose control of it"; the effect is cleared when the permanent leaves play.)
+ * - CR 702.62g: a creature played via suspend "gains haste until you lose control of the spell
+ *   or the permanent it becomes." A normal `GrantKeyword(HASTE)` can't be used here because the
+ *   card is in exile (not a projected creature), so we add a self-sourced floating haste effect
+ *   keyed to the card. It lies dormant while the card sits in exile and takes effect once the
+ *   card is played onto the battlefield (the permanent reuses the same entity id). Harmless for
+ *   a non-creature card, which never becomes a creature on the battlefield.
+ *
+ *   The duration is [Duration.WhileControlledByController], not `Permanent`: the projector drops
+ *   the haste the instant the permanent's projected controller stops being the player who played
+ *   it (the card's owner — only the owner ever plays a suspended card, per CR 702.62a), faithfully
+ *   modeling "until you lose control of it." It's still cleared outright when the card leaves play.
  *
  * The marker step does not move the card or add time counters; the
  * [com.wingedsheep.sdk.dsl.Effects.Suspend] chain composes those from a move/counter step.
@@ -49,9 +53,12 @@ class GrantSuspendExecutor : EffectExecutor<GrantSuspendEffect> {
             layer = Layer.ABILITY,
             modification = SerializableModification.GrantKeyword(Keyword.HASTE.name),
             affectedEntities = setOf(targetId),
-            duration = Duration.Permanent,
+            // CR 702.62g — haste lasts "until you lose control" of the permanent it becomes.
+            duration = Duration.WhileControlledByController,
             // Self-source the haste so it survives the granter (e.g. Taigam) leaving play
-            // during the time the card waits in exile.
+            // during the time the card waits in exile. context.controllerId — the player who
+            // suspended/will play the card — is captured as the floating effect's controller
+            // and becomes the gate the projector checks against.
             context = context.copy(sourceId = targetId),
         )
         return EffectResult.success(newState)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
@@ -182,7 +182,13 @@ data class ContinuousEffect(
     val modification: Modification,
     val affectedEntities: Set<EntityId> = emptySet(),
     val sourceCondition: Condition? = null,
-    val affectsFilter: AffectsFilter? = null
+    val affectsFilter: AffectsFilter? = null,
+    /**
+     * When non-null, this effect applies only to affected entities whose *projected* controller
+     * is this player (a "for as long as you control it" gate, e.g. suspend haste — CR 702.62g).
+     * Evaluated after Layer 2 control is established, so it tracks control-changing effects.
+     */
+    val controllerGate: EntityId? = null
 ) {
     val layer: Layer get() = modification.layer
     val sublayer: Sublayer? get() = modification.sublayer

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -149,6 +149,7 @@ class StateProjector(
 
         // Re-resolve controller-dependent filters for layers 3-6 now that control is established
         val nonControlNonPTEffects = sortedEffects.filter { it.layer != Layer.CONTROL && it.layer != Layer.POWER_TOUGHNESS }
+            .map { effect -> applyControllerGate(effect, projectedValues) }
             .map { effect ->
                 if (effect.affectsFilter != null && filterResolver.isControllerDependentFilter(effect.affectsFilter)) {
                     effect.copy(affectedEntities = filterResolver.resolveAffectedEntities(state, effect.sourceId, effect.affectsFilter, projectedValues))
@@ -227,7 +228,8 @@ class StateProjector(
         // removing a lord's abilities means its continuous effects no longer apply in Layer 7).
         // Exception: sources that themselves generate RemoveAllAbilities are exempt — their effects
         // are self-sustaining (e.g., Humility's own P/T-setting effect persists).
-        val resolvedLayer7Effects = sortedEffects.mapNotNull { effect ->
+        val resolvedLayer7Effects = sortedEffects.mapNotNull { rawEffect ->
+            val effect = applyControllerGate(rawEffect, projectedValues)
             if (effect.layer != Layer.POWER_TOUGHNESS) return@mapNotNull effect
 
             // Suppress effects from sources that lost all abilities (e.g., a lord under Humility),
@@ -373,6 +375,27 @@ class StateProjector(
         return types
     }
 
+    /**
+     * Enforce a [ContinuousEffect.controllerGate] ("for as long as you control it"): drop any
+     * affected entity whose projected controller is no longer the gating player. Called after
+     * Layer 2 control is resolved, so it reflects every control-changing effect (steals,
+     * Threaten, static control Auras). A no-op for effects without a gate.
+     */
+    private fun applyControllerGate(
+        effect: ContinuousEffect,
+        projectedValues: Map<EntityId, MutableProjectedValues>
+    ): ContinuousEffect {
+        val gate = effect.controllerGate ?: return effect
+        val stillControlled = effect.affectedEntities.filterTo(mutableSetOf()) { entityId ->
+            projectedValues[entityId]?.controllerId == gate
+        }
+        return if (stillControlled.size == effect.affectedEntities.size) {
+            effect
+        } else {
+            effect.copy(affectedEntities = stillControlled)
+        }
+    }
+
     private fun collectContinuousEffects(
         state: GameState,
         projectedValues: Map<EntityId, MutableProjectedValues>
@@ -444,7 +467,15 @@ class StateProjector(
                         sourceId = floating.sourceId ?: EntityId("floating-${floating.id}"),
                         timestamp = floating.timestamp,
                         modification = floating.effect.modification.toModification(),
-                        affectedEntities = validAffectedEntities
+                        affectedEntities = validAffectedEntities,
+                        // "for as long as you control it" (e.g. suspend haste — CR 702.62g):
+                        // the gate is applied after Layer 2, against the projected controller,
+                        // so the effect drops the instant another player gains control.
+                        controllerGate = if (floating.duration is Duration.WhileControlledByController) {
+                            floating.controllerId
+                        } else {
+                            null
+                        }
                     )
                 )
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SuspendMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SuspendMechanicTest.kt
@@ -80,7 +80,9 @@ class SuspendMechanicTest : FunSpec({
                         modification = SerializableModification.GrantKeyword(Keyword.HASTE.name),
                         affectedEntities = setOf(cardId),
                     ),
-                    duration = Duration.Permanent,
+                    // Mirrors GrantSuspendExecutor: haste lasts "until you lose control" (CR 702.62g),
+                    // gated by the projector against the owner who plays the suspended card.
+                    duration = Duration.WhileControlledByController,
                     sourceId = cardId,
                     sourceName = cardName,
                     controllerId = owner,
@@ -163,5 +165,53 @@ class SuspendMechanicTest : FunSpec({
         projector.project(driver.state).hasKeyword(perm!!, Keyword.HASTE) shouldBe true
         // The marker is gone once it leaves exile.
         driver.state.getEntity(perm)?.has<SuspendedComponent>() shouldBe false
+    }
+
+    test("suspend haste ends when you lose control of the permanent it became") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val opponent = if (player == driver.player1) driver.player2 else driver.player1
+        val cardId = suspendInExile(driver, player, "Suspended Bear", timeCounters = 1)
+
+        // Owner's upkeep: 1 -> 0, play it for free; it enters under the owner's control with haste.
+        resolveNextOwnerUpkeep(driver, player)
+        driver.submitYesNo(player, true)
+        driver.bothPass()
+
+        val perm = driver.findPermanent(player, "Suspended Bear")
+        perm shouldNotBe null
+        projector.project(driver.state).hasKeyword(perm!!, Keyword.HASTE) shouldBe true
+
+        // An opponent steals it (CR 702.62g: haste lasts only "until you lose control of ...
+        // the permanent it becomes"). Model the steal exactly as GainControlExecutor does —
+        // a Layer 2 control-changing floating effect.
+        driver.replaceState(
+            driver.state.addFloatingEffects(
+                listOf(
+                    ActiveFloatingEffect(
+                        id = EntityId.generate(),
+                        effect = FloatingEffectData(
+                            layer = Layer.CONTROL,
+                            modification = SerializableModification.ChangeController(opponent),
+                            affectedEntities = setOf(perm),
+                        ),
+                        duration = Duration.Permanent,
+                        sourceId = perm,
+                        sourceName = "Steal Effect",
+                        controllerId = opponent,
+                        timestamp = driver.state.timestamp,
+                    )
+                )
+            )
+        )
+
+        val projected = projector.project(driver.state)
+        // Control actually moved to the opponent...
+        projected.getController(perm) shouldBe opponent
+        // ...so the suspend haste is gone — it was "for as long as you control it".
+        projected.hasKeyword(perm, Keyword.HASTE) shouldBe false
     }
 })


### PR DESCRIPTION
Follow-up to #324. That PR armed the suspend-granted haste as a `Duration.Permanent` floating effect — a deliberate simplification noted in the code (*"Permanent duration is a deliberate simplification of 'until you lose control of it'"*). This implements it properly.

## The rule

CR 702.62g: a creature played via suspend *"gains haste until you lose control of the spell or the permanent it becomes."* With a permanent duration, a suspended creature kept haste even after an opponent gained control of it.

## The fix — a reusable duration, not a one-off

- **`Duration.WhileControlledByController`** ("for as long as you control it"). Evaluated against the **projected** controller, so it responds to *every* kind of control change uniformly — one-shot steals (`GainControl`/`Threaten`) **and** static control Auras (`ControlEnchantedPermanent`, which emits no event). This is why a projection-time gate is the right mechanism rather than reacting to `ControlChangedEvent` (static Auras never fire one).
- **`StateProjector`** threads the gate through a new `ContinuousEffect.controllerGate` field and applies it **after Layer 2 (control) is resolved**, dropping the effect from any affected entity whose projected controller is no longer the gating player. It's a no-op for effects without a gate, so the projection hot path is unaffected. Consistent with how `WhileSourceTapped` / `WhileSourceOnBattlefield` are re-evaluated each projection.
- **`GrantSuspendExecutor`** arms the haste with `WhileControlledByController` instead of `Permanent`. The floating effect's controller is the player who suspended/plays the card — the owner, since only the owner ever plays a suspended card (CR 702.62a) — which becomes the gate.

## Tests (`SuspendMechanicTest`)

- Updated the in-exile setup helper so it mirrors the executor's new duration.
- **New — "suspend haste ends when you lose control of the permanent it became"**: the card is played for free and has haste; an opponent then steals it via a Layer 2 control-changing effect (modeled exactly as `GainControlExecutor` does); the projector reports the new controller **and** that haste is gone.

Full `mtg-sdk` + `rules-engine` suites pass; the `TaigamMasterOpportunistScenarioTest` and control/projection regression tests (`*Control*`, `ProjectedControllerInReplacementsTest`, `LayerSystemTest`, Annex) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)