### PR TITLE
Add OpponentsCantCastSpells static ability + Voice of Victory (TDM gap #19)

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -193,9 +193,14 @@ the overwhelming majority of the set.
     activated (equip) cost by the chosen target's color count.
     → **Dragonfire Blade**
 
-19. **Opponent-scoped continuous cast prohibition.** "Your opponents can't cast spells during your
-    turn." Current cast restrictions are self-controller-scoped (`RestrictSpellsCastPerTurn`); needs a
-    player-group prohibition gated on your turn.
+19. **Opponent-scoped continuous cast prohibition.** ✅ **DONE.** "Your opponents can't cast spells
+    during your turn." Added the `OpponentsCantCastSpells(onlyDuringYourTurn)` static ability —
+    modeled on Mana Maze's `CantCastSpellsSharingColorWithLastCast` (a continuous restriction read at
+    cast-legality time, never on the stack). Enforced via one `CastPermissionUtils` helper OR'd into
+    the central `cantCastSpells` gate, so it covers every casting zone (hand, flashback/harmonize,
+    exile, top of library) uniformly; control is read from projected state. `onlyDuringYourTurn = true`
+    gives Voice of Victory; `false` covers Grand Abolisher's cast clause. Deliberately not filtered —
+    a "can't cast spells with even mana value" (Void Winnower) prohibition is left as a future sibling.
     → **Voice of Victory**
 
 20. **Sacrifice-a-token as a cost** (minor — verify a token-only sacrifice-cost filter exists).

--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -4,10 +4,10 @@ Cross-reference of the **252 remaining (unimplemented) TDM cards** against the e
 capabilities (SDK reference + source verification, May 2026). Generated to scope what must be
 built before the set can be completed.
 
-**Status:** 19 / 271 implemented (7%). All 19 implemented are reprints (taplands, Evolving Wilds,
-Snakeskin Veil) plus two simple spells (Awaken the Honored Dead, Strategic Betrayal). **No
-new-mechanic card is implemented yet.** Card list comes from `scripts/card-status --list --set TDM`.
-Oracle text pulled from Scryfall (`set:tdm`, 277 printings → 271 unique cards).
+**Status:** 49 / 271 implemented (18%). All five wedge clan keywords (Tier 1), every Tier-2
+primitive, and all but three Tier-3 one-offs are now built — only items 15, 18, and 20 remain.
+Card list comes from `scripts/card-status --list --set TDM`. Oracle text pulled from Scryfall
+(`set:tdm`, 277 printings → 271 unique cards).
 
 ## Bottom line
 
@@ -42,8 +42,8 @@ work. Once the Tier-1 keywords land, the large majority of remaining cards are b
 What follows are the **genuine gaps** — elements no current SDK primitive expresses.
 
 > **Update (May 2026):** Tier 1 (all five clan keywords + Decayed) and Tier 2 (keyword counters,
-> leaves-graveyard trigger, one-shot counter doubling, group P/T doubling) are now **complete**.
-> Only the Tier-3 one-off complex cards (items 11–20) remain.
+> leaves-graveyard trigger, one-shot counter doubling, group P/T doubling) are **complete**, as are
+> Tier-3 items 11–14, 16, 17, and 19. Only **items 15, 18, and 20** remain.
 
 ---
 
@@ -156,8 +156,14 @@ the overwhelming majority of the set.
     `ControllerComponent`, so it falls back to `ownerId`).
     → **Severance Priest**
 
-14. **Suspend.** Time counters on a card in exile + cast-when-last-counter-removed + haste payoff.
-    Impending/Vanishing use time counters on the battlefield, not the Suspend exile-cast flow.
+14. **Suspend.** ✅ **DONE.** Time counters on a card in exile + cast-when-last-counter-removed + haste
+    payoff. Modeled content-agnostically (CR 702.62): `Effects.Suspend` moves the card to exile, adds N
+    time counters, and sets a suspend marker; the engine synthesizes a single owner's-upkeep countdown
+    triggered ability (`Suspend.countdownAbility`) for any exiled card carrying that marker, so the same
+    machinery serves a card with no printed suspend. The countdown removes a time counter and, when the
+    pile empties, grants haste and plays the card for free through the existing
+    `CastFromCollectionWithoutPayingCostEffect` pipeline; an intervening-if "has a time counter" gate
+    prevents a stale marker from re-casting. Composed from atomics, no bespoke executor.
     → **Taigam, Master Opportunist** (Flurry copies a spell, exiles it with 4 time counters + Suspend)
 
 15. **Event-based "when you next attack this turn" delayed trigger.** Current delayed triggers are
@@ -214,7 +220,7 @@ the overwhelming majority of the set.
    modest. Unlocks ~30 cards quickly.
 2. ✅ **Renew** (enumerator extension) + **Harmonize** (new alt-cost) — bigger lifts, ~22 cards.
 3. ✅ **Keyword counters + Decayed + leaves-graveyard trigger** (Tier 2) — small, scattered unlocks.
-4. **Tier-3 one-offs** as the relevant legendaries / rares come up. *(remaining work — items 11–20)*
+4. **Tier-3 one-offs** as the relevant legendaries / rares come up. *(remaining work — items 15, 18, 20)*
 
 The clan keywords (Tier 1) cover the bulk of the remaining cards. Behold and Omen already being done
 means Temur spells and the 13 DFC dragons are essentially ready once the shared supporting effects

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1247,6 +1247,15 @@ of "type" to count.
   colors of the last spell cast, cleared each turn). Never blocks the first spell of the turn; a
   colorless spell shares no color, so it is always castable and casting one lifts the restriction
   until the next colored spell. (Mana Maze)
+- `OpponentsCantCastSpells(onlyDuringYourTurn = false)` — opponent-scoped continuous cast
+  *prohibition*: every player other than the source's controller can't cast any spell. With
+  `onlyDuringYourTurn = true` the lock applies only while the controller is the active player (Voice
+  of Victory: "Your opponents can't cast spells during your turn."); with `false` it applies on every
+  turn (Grand Abolisher's cast clause). Read at cast-legality time and OR'd into the central
+  `cantCastSpells` gate, so it covers every casting zone (hand, flashback/harmonize, exile, top of
+  library) uniformly; control is read from projected state so a control-changing effect flips who is
+  restricted. Deliberately *not* filtered — a "can't cast spells with even mana value" (Void
+  Winnower) prohibition needs a per-spell filter and should be a sibling ability.
 
 **Tapped-for-mana mana statics** (extra mana / replaced mana when a land is tapped for mana — resolve
 inline as triggered mana abilities, off the stack per CR 605). These fire on the *manual* mana-ability

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -256,3 +256,38 @@ data object CantCastSpellsSharingColorWithLastCast : StaticAbility {
         "Players can't cast a spell that shares a color with the spell most recently cast this turn"
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
 }
+
+/**
+ * Your opponents can't cast spells — either unconditionally, or (when [onlyDuringYourTurn] is
+ * true) only while this permanent's controller is the active player.
+ *
+ * An opponent-scoped continuous cast *prohibition*: every player other than the source's
+ * controller is forbidden from casting any spell from any zone. The engine reads it during
+ * cast-legality checks (it never uses the stack), so it composes with every casting path —
+ * hand, graveyard flashback/harmonize, exile, top of library — without per-zone wiring. Control
+ * is read from projected state, so a control-changing effect flips which player is restricted.
+ *
+ * - Voice of Victory (TDM): `OpponentsCantCastSpells(onlyDuringYourTurn = true)` —
+ *   "Your opponents can't cast spells during your turn."
+ * - Grand Abolisher's cast clause is the same shape (its "can't activate abilities" clause is a
+ *   separate ability).
+ *
+ * Deliberately **not** a filtered prohibition: "can't cast spells with even mana value"
+ * (Void Winnower) needs a per-spell [GameObjectFilter] check at a different enforcement point —
+ * add a sibling ability when such a card arrives rather than overloading this one.
+ *
+ * @property onlyDuringYourTurn When true, the restriction applies only while the source's
+ *   controller is the active player; when false, it applies on every turn.
+ */
+@SerialName("OpponentsCantCastSpells")
+@Serializable
+data class OpponentsCantCastSpells(
+    val onlyDuringYourTurn: Boolean = false
+) : StaticAbility {
+    override val description: String = if (onlyDuringYourTurn) {
+        "Your opponents can't cast spells during your turn"
+    } else {
+        "Your opponents can't cast spells"
+    }
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/VoiceOfVictory.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/VoiceOfVictory.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.OpponentsCantCastSpells
+
+/**
+ * Voice of Victory — Tarkir: Dragonstorm #33
+ * {1}{W} · Creature — Human Bard · 1/3
+ *
+ * Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior
+ * creature tokens. Sacrifice them at the beginning of the next end step.)
+ * Your opponents can't cast spells during your turn.
+ *
+ * Mobilize is the `mobilize(n)` builder helper. The lock clause is the reusable
+ * [OpponentsCantCastSpells] static ability — an opponent-scoped continuous cast prohibition the
+ * engine reads at cast-legality time, so it blocks every casting zone during this card's
+ * controller's turn without any per-zone wiring.
+ */
+val VoiceOfVictory = card("Voice of Victory") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Bard"
+    power = 1
+    toughness = 3
+    oracleText = "Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)\n" +
+        "Your opponents can't cast spells during your turn."
+
+    mobilize(2)
+
+    staticAbility {
+        ability = OpponentsCantCastSpells(onlyDuringYourTurn = true)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "33"
+        artist = "Joshua Cairos"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec3de5f4-bb55-4ab9-995f-f3e0dc22c1bb.jpg?1758215927"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -179,6 +179,12 @@ class CastSpellHandler(
             return "You can't cast a spell that shares a color with the spell most recently cast this turn"
         }
 
+        // Voice of Victory: an opponent's static ability forbids you from casting spells
+        // (optionally only during that opponent's turn).
+        if (castPermissionUtils.cantCastSpellsDueToOpponentRestriction(state, action.playerId)) {
+            return "An opponent's effect prevents you from casting spells right now"
+        }
+
         if (hasForageFromGraveyard) {
             if (!costHandler.canPayAdditionalCost(state, AdditionalCost.Forage, action.playerId)) {
                 return "Cannot forage: need 3 other cards in graveyard or a Food"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -83,7 +83,8 @@ class EnumerationContext(
     // Cast restrictions
     val cantCastSpells: Boolean by lazy {
         state.getEntity(playerId)?.has<CantCastSpellsComponent>() == true ||
-            castPermissionUtils.hasReachedSpellCastLimit(state, playerId)
+            castPermissionUtils.hasReachedSpellCastLimit(state, playerId) ||
+            castPermissionUtils.cantCastSpellsDueToOpponentRestriction(state, playerId)
     }
 
     // Alternative casting costs from battlefield permanents (e.g., Jodah)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
 import com.wingedsheep.sdk.scripting.MayPlayLandsFromGraveyard
 import com.wingedsheep.sdk.scripting.MayPlayPermanentsFromGraveyard
+import com.wingedsheep.sdk.scripting.OpponentsCantCastSpells
 import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
@@ -164,6 +165,35 @@ class CastPermissionUtils(
 
         val spellColors = state.getEntity(spellCardId)?.get<CardComponent>()?.colors ?: return false
         return spellColors.any { it in lastColors }
+    }
+
+    /**
+     * Voice of Victory (CR via [OpponentsCantCastSpells]): true when [playerId] is forbidden from
+     * casting any spell because an *opponent* controls a permanent with that static ability — and,
+     * for the [OpponentsCantCastSpells.onlyDuringYourTurn] form, that opponent is the active player.
+     *
+     * Scans the battlefield once. Control is read from projected state, so a control-changing
+     * effect flips which player is restricted (gaining control of Voice of Victory turns the lock
+     * onto its original controller). Face-down permanents have no abilities and are skipped. This
+     * is OR'd into the central `cantCastSpells` gate, so it covers every casting zone uniformly.
+     */
+    fun cantCastSpellsDueToOpponentRestriction(state: GameState, playerId: EntityId): Boolean {
+        for (permanentId in state.getBattlefield()) {
+            val container = state.getEntity(permanentId) ?: continue
+            if (container.has<com.wingedsheep.engine.state.components.identity.FaceDownComponent>()) continue
+            val card = container.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            for (sa in cardDef.script.staticAbilities) {
+                if (sa !is OpponentsCantCastSpells) continue
+                val controller = state.projectedState.getController(permanentId)
+                    ?: container.get<ControllerComponent>()?.playerId
+                    ?: continue
+                if (controller == playerId) continue
+                if (sa.onlyDuringYourTurn && state.activePlayerId != controller) continue
+                return true
+            }
+        }
+        return false
     }
 
     fun hasPlayFromTopOfLibrary(state: GameState, playerId: EntityId): Boolean {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OpponentsCantCastSpellsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OpponentsCantCastSpellsTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.VoiceOfVictory
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the [com.wingedsheep.sdk.scripting.OpponentsCantCastSpells] static ability — an
+ * opponent-scoped continuous cast prohibition (Tarkir: Dragonstorm Tier-3 gap #19).
+ *
+ * Voice of Victory ({1}{W} 1/3): "Your opponents can't cast spells during your turn." Modeled as
+ * `OpponentsCantCastSpells(onlyDuringYourTurn = true)`, read at cast-legality time and OR'd into
+ * the central `cantCastSpells` gate so it covers every casting zone.
+ *
+ * The probe spell is Lightning Bolt (an instant targeting any target). Using an instant avoids the
+ * sorcery-speed timing confound: a creature/sorcery already wouldn't enumerate on an opponent's
+ * turn for unrelated reasons. `LegalActionEnumerator.enumerate` returns actions regardless of
+ * priority or affordability, so presence/absence of the CastSpell action isolates the restriction.
+ */
+class OpponentsCantCastSpellsTest : FunSpec({
+
+    fun createDriver(startingPlayer: Int = 0): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(VoiceOfVictory))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20, startingPlayer = startingPlayer)
+        return driver
+    }
+
+    fun GameTestDriver.boltActionsFor(playerId: EntityId, cardId: EntityId): List<CastSpell> {
+        val enumerator = LegalActionEnumerator.create(cardRegistry)
+        return enumerator.enumerate(state, playerId)
+            .mapNotNull { it.action as? CastSpell }
+            .filter { it.cardId == cardId }
+    }
+
+    test("opponents can't cast spells during the controller's turn") {
+        val driver = createDriver(startingPlayer = 0)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.putCreatureOnBattlefield(controller, "Voice of Victory")
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+
+        driver.boltActionsFor(opponent, bolt) shouldHaveSize 0
+    }
+
+    test("the controller can still cast their own spells during their turn") {
+        val driver = createDriver(startingPlayer = 0)
+        val controller = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(controller, "Voice of Victory")
+        val bolt = driver.putCardInHand(controller, "Lightning Bolt")
+        driver.giveMana(controller, Color.RED, 1)
+
+        driver.boltActionsFor(controller, bolt).isNotEmpty() shouldBe true
+    }
+
+    test("opponents can cast spells on their own turn (the restriction is your-turn-only)") {
+        // player2 is the active player; Voice of Victory's controller (player1) is not active,
+        // so the onlyDuringYourTurn restriction does not apply.
+        val driver = createDriver(startingPlayer = 1)
+        val activeOpponent = driver.activePlayer!!
+        val voiceController = driver.getOpponent(activeOpponent)
+
+        driver.putCreatureOnBattlefield(voiceController, "Voice of Victory")
+        val bolt = driver.putCardInHand(activeOpponent, "Lightning Bolt")
+        driver.giveMana(activeOpponent, Color.RED, 1)
+
+        driver.boltActionsFor(activeOpponent, bolt).isNotEmpty() shouldBe true
+    }
+
+    test("the handler rejects an opponent's cast attempt during the controller's turn") {
+        val driver = createDriver(startingPlayer = 0)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.putCreatureOnBattlefield(controller, "Voice of Victory")
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        // Hand priority to the opponent so the only barrier to casting is the static restriction.
+        driver.passPriority(controller)
+
+        driver.submitExpectFailure(
+            CastSpell(opponent, bolt, targets = listOf(ChosenTarget.Player(controller)))
+        )
+    }
+})


### PR DESCRIPTION
## What

Implements **TDM engine-gap Tier-3 item #19** — an opponent-scoped continuous cast prohibition — and the card that needs it, **Voice of Victory**.

> Tier-3 items #14 (Suspend) and #16/#17 are already merged; the backlog doc was stale. #15 and #18 have in-flight branches owned by other agents, so this PR takes the next *unclaimed* item, #19.

## The mechanic

`OpponentsCantCastSpells(onlyDuringYourTurn)` — a new `StaticAbility` modeled on Mana Maze's `CantCastSpellsSharingColorWithLastCast`: a **continuous cast restriction read at cast-legality time** (it never uses the stack). Every player other than the source's controller is forbidden from casting any spell.

- `onlyDuringYourTurn = true` → Voice of Victory: *"Your opponents can't cast spells during your turn."*
- `onlyDuringYourTurn = false` → Grand Abolisher's cast clause (every turn).

### Elegance / reuse

- **One enforcement seam.** A single `CastPermissionUtils.cantCastSpellsDueToOpponentRestriction` helper is OR'd into the central `cantCastSpells` gate, so it covers **every** casting zone (hand, flashback/harmonize, exile, top of library) with no per-zone wiring, plus a defensive mirror in `CastSpellHandler.validate`.
- **Projected control.** Control is read from projected state, so a control-changing effect flips which player is restricted. Face-down permanents (no abilities) are skipped.
- **Named for the mechanic, parameterized for the next card.** Deliberately *not* a filtered prohibition — "can't cast spells with even mana value" (Void Winnower) needs a per-spell filter and is left as a future sibling; this is documented in the type's KDoc.

## Cross-layer trace

- **SDK** — `OpponentsCantCastSpells` data class (`@Serializable` sealed-interface subtype, auto-registered).
- **Engine** — helper + central-gate OR + handler validation. No `StateProjector`/trigger/continuation/event changes (rules-modifying static, not a continuous P/T/type effect).
- **Server DTO / client** — none needed: purely server-authoritative legal-action filtering; no new `GameEvent`, keyword, or client state.

## Tests

`OpponentsCantCastSpellsTest` (all green), probing with an instant (Lightning Bolt) to avoid the sorcery-timing confound:
- opponents can't cast during the controller's turn
- the controller can still cast their own spells
- opponents *can* cast on their own turn (your-turn-only)
- the handler rejects an opponent's cast attempt during the controller's turn

Regression: `CastSpellEnumeratorTest`, `MobilizeTest` pass.

## Docs

- `docs/card-sdk-language-reference.md` — new static ability documented.
- `backlog/tdm-engine-gaps.md` — item #19 marked done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
