### PR TITLE
Add modal DFC support (CR 712) + Flamescroll Celebrant // Revel in Silence

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -68,15 +68,21 @@ section; do not let SDK additions land without a corresponding doc update.
   half (Room) carries triggered/activated/static abilities instead.
 - `ADVENTURE` — primary face is a creature, `cardFaces[0]` is an instant/sorcery Adventure (CR 715). Resolving the
   Adventure exiles the card and grants permission to cast the creature from exile.
+- `MODAL_DFC` — primary characteristics are the front face, `cardFaces[0]` is the back face (CR 712). Cast **one**
+  face from hand (front via primary characteristics, back via `CastSpell.faceIndex = 0`), never both. Unlike
+  ADVENTURE there is no exile-then-recast linkage — a spell back resolves as an ordinary spell (graveyard, or exile
+  when its script sets `selfExileOnResolve` via `spell { selfExile() }`). DSL: `card { modalBack("Name") { spell { … } } }`.
 
-**`CardFace` (SPLIT / ADVENTURE)**
+**`CardFace` (SPLIT / ADVENTURE / MODAL_DFC)**
 
 - `name` — face name.
 - `manaCost` — face mana cost.
 - `typeLine` — face type line.
-- `script { ... }` — that face's abilities; for instant/sorcery SPLIT halves and Adventures this includes a
-  `spell { effect = …; target(...) }` block holding the face's effect and target requirements.
+- `script { ... }` — that face's abilities; for instant/sorcery SPLIT halves, Adventures, and modal DFC spell
+  faces this includes a `spell { effect = …; target(...) }` block holding the face's effect and target
+  requirements (plus `selfExile()` for faces that exile themselves on resolution).
 - `keywords` — face-local keywords.
+- `imageUri` — face art when it differs from the front (MODAL_DFC backs have their own Scryfall image).
 
 **`metadata { ... }`**
 
@@ -384,10 +390,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `Effects.SkipNextDrawStep(target = Controller)` (`SkipNextDrawStepEffect`) — target skips their next draw step. Adds a one-shot `SkipDrawStepComponent` marker consumed by `DrawPhaseManager.performDrawStep` (Elfhame Sanctuary's "you skip your draw step this turn").
 - `HijackNextTurnEffect(target)` — you control target's next turn.
 - `GrantCantBeBlockedByChosenColorEffect(target, duration)` — unblockable except by chosen color.
-- `CantCastSpellsEffect(target, until?)` — target can't cast spells.
+- `CantCastSpellsEffect(target, until?)` — target can't cast spells. Facade: `Effects.CantCastSpells(target, duration)`.
 - `Effects.CantPlayLandsThisTurn(target = Controller)` (`PreventLandPlaysThisTurnEffect`) — the target player can't
   play lands for the rest of this turn (sets remaining land drops to 0). Defaults to the controller (Rock Jockey);
   pass `EffectTarget.ContextTarget(n)` for "target player can't play lands this turn" cards like Turf Wound.
+- `CantActivateLoyaltyAbilitiesEffect(target, duration)` — target can't activate planeswalkers' loyalty abilities.
+  Facade: `Effects.CantActivateLoyaltyAbilities(target, duration)`. Sibling of `CantCastSpells`; compose the two for
+  cards that forbid both (e.g. Revel in Silence).
 
 ### Forced sacrifice / discard
 
@@ -979,6 +988,10 @@ Named sugar for the common type-primitive cases; reach for `youCastSpell(...)` p
 - `YouCastHistoric` — artifact / legendary / Saga.
 - `YouCastSubtype(subtype)` — tribal helper: spell with matching subtype.
 - `AnySpellOrAbilityOnStack` — any object hits the stack.
+- `OpponentActivatesAbility` — an opponent activates an ability that **isn't a mana ability** (CR 605/606). Mana
+  abilities don't use the stack, so they never fire this; loyalty abilities (which are activated abilities) do. Pair
+  with `Effects.DealDamage(n, EffectTarget.PlayerRef(Player.TriggeringPlayer))` to punish the activator (Flamescroll
+  Celebrant). Backed by `GameEvent.AbilityActivatedEvent(player)`.
 
 **Other casters.** The same shape, scoped to a different caster via the runtime
 `Player.Each` / `Player.Opponent` matching on `SpellCastEvent`. Bind the payoff to the
@@ -2038,6 +2051,11 @@ Card authors rarely reference these directly; they are created/updated by the ma
   keeps the grant alive across end-of-turn cleanup. Emits `CardPlottedEvent` / `ClientEvent.CardPlotted`.
 - **Adventure (CR 715)** — `layout = ADVENTURE` + `cardFaces[0]` Adventure spell; DSL:
   `card { adventure("Name") { spell { … } } }`.
+- **Modal DFC (CR 712)** — `layout = MODAL_DFC` + `cardFaces[0]` back face; DSL:
+  `card { modalBack("Name") { imageUri = …; spell { selfExile(); … } } }`. Cast either face from hand (back via
+  `CastSpell.faceIndex = 0`); reuses the Adventure cast/enumeration path (`enumerateSecondaryFace`) but with no
+  exile-then-recast linkage at resolution. `StackResolver` reads the cast face's `selfExileOnResolve`, and the back
+  art rides on `CardFace.imageUri` → `CardComponent.backFaceImageUri`. First user: Flamescroll Celebrant.
 - **Hideaway N** — `KeywordAbility.hideaway(n)` (display, "Hideaway N") + `MoveCollectionEffect(faceDown = true,
   linkToSource = true)` + `CardSource.FromLinkedExile()`; no special engine plumbing needed.
 - **Ascend / City's Blessing** — `Keyword.ASCEND` + `Effects.GainCitysBlessing()` + `Conditions.YouHaveCitysBlessing` /

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -46,6 +46,7 @@ import com.wingedsheep.mtg.sets.definitions.roe.RiseOfTheEldraziSet
 import com.wingedsheep.mtg.sets.definitions.scg.ScourgeSet
 import com.wingedsheep.mtg.sets.definitions.soi.ShadowsOverInnistradSet
 import com.wingedsheep.mtg.sets.definitions.spm.SpiderManSet
+import com.wingedsheep.mtg.sets.definitions.stx.StrixhavenSchoolOfMagesSet
 import com.wingedsheep.mtg.sets.definitions.tdm.TarkirDragonstormSet
 import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
 import com.wingedsheep.mtg.sets.definitions.tmp.TempestSet
@@ -145,6 +146,7 @@ abstract class ScenarioTestBase : FunSpec() {
         register(ScourgeSet.cards)
         register(ShadowsOverInnistradSet.cards)
         register(SpiderManSet.cards)
+        register(StrixhavenSchoolOfMagesSet.cards)
         register(TarkirDragonstormSet.cards)
         register(TempestSet.cards); register(TempestSet.basicLands)
         register(UrzasSagaSet.cards); register(UrzasSagaSet.basicLands)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FlamescrollCelebrantScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FlamescrollCelebrantScenarioTest.kt
@@ -1,0 +1,236 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbilitiesComponent
+import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Scenario tests for Flamescroll Celebrant // Revel in Silence — a modal double-faced card.
+ *
+ * Front — Flamescroll Celebrant ({1}{R}, 2/1 Human Shaman):
+ *   - "Whenever an opponent activates an ability that isn't a mana ability, this creature deals
+ *     1 damage to that player."
+ *   - "{1}{R}: This creature gets +2/+0 until end of turn."
+ * Back — Revel in Silence ({W}{W} Instant):
+ *   - "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.
+ *     Exile Revel in Silence."
+ *
+ * Exercises the new MODAL_DFC layout, the OpponentActivatesAbility trigger, and the
+ * CantActivateLoyaltyAbilities restriction.
+ */
+class FlamescrollCelebrantScenarioTest : ScenarioTestBase() {
+
+    // A creature with a cheap, non-mana activated ability the opponent can activate.
+    private val testActivator = card("Test Activator") {
+        manaCost = "{1}"
+        typeLine = "Creature — Construct"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            cost = Costs.Mana("{0}")
+            effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        }
+    }
+
+    // A minimal planeswalker with one loyalty ability, for the loyalty-restriction tests.
+    private val testWalker = card("Test Walker") {
+        manaCost = "{2}"
+        typeLine = "Legendary Planeswalker — Tester"
+        startingLoyalty = 3
+        loyaltyAbility(1) {
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    init {
+        cardRegistry.register(testActivator)
+        cardRegistry.register(testWalker)
+
+        context("Front face — Flamescroll Celebrant (creature)") {
+            test("casting the primary face resolves a 2/1 creature") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Flamescroll Celebrant")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Flamescroll Celebrant")
+                withClue("Casting the creature face should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val flamescroll = game.findPermanent("Flamescroll Celebrant")
+                withClue("Flamescroll Celebrant should be on the battlefield") {
+                    flamescroll shouldNotBe null
+                }
+                val info = game.getClientState(1).cards[flamescroll]
+                withClue("Flamescroll Celebrant is a 2/1") {
+                    info!!.power shouldBe 2
+                    info.toughness shouldBe 1
+                }
+            }
+
+            test("the {1}{R} ability gives +2/+0 until end of turn") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Flamescroll Celebrant")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val flamescroll = game.findPermanent("Flamescroll Celebrant")!!
+                val pump = cardRegistry.getCard("Flamescroll Celebrant")!!.script.activatedAbilities[0]
+
+                val result = game.execute(ActivateAbility(game.player1Id, flamescroll, pump.id))
+                withClue("Activating the pump should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                val info = game.getClientState(1).cards[flamescroll]
+                withClue("Flamescroll Celebrant should be 4/1 after +2/+0") {
+                    info!!.power shouldBe 4
+                    info.toughness shouldBe 1
+                }
+            }
+        }
+
+        context("Trigger — opponent activates a non-mana ability") {
+            test("deals 1 damage to the opponent who activated the ability") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Flamescroll Celebrant")
+                    .withCardOnBattlefield(2, "Test Activator")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val activator = game.findPermanent("Test Activator")!!
+                val ability = cardRegistry.getCard("Test Activator")!!.script.activatedAbilities[0]
+
+                val result = game.execute(ActivateAbility(game.player2Id, activator, ability.id))
+                withClue("Opponent activating their ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Flamescroll should have dealt 1 damage to the activating opponent (20 -> 19)") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("Flamescroll's controller takes no damage") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+
+            test("does NOT trigger off the controller's own ability activation") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Flamescroll Celebrant")
+                    .withCardOnBattlefield(1, "Test Activator")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val activator = game.findPermanent("Test Activator")!!
+                val ability = cardRegistry.getCard("Test Activator")!!.script.activatedAbilities[0]
+
+                game.execute(ActivateAbility(game.player1Id, activator, ability.id))
+                game.resolveStack()
+
+                withClue("No self-ping when the controller activates their own ability") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+
+        context("Back face — Revel in Silence (instant)") {
+            test("casting the back face restricts opponents and exiles itself") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Flamescroll Celebrant")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.findCardsInHand(1, "Flamescroll Celebrant").first()
+
+                // faceIndex = 0 casts the back face (Revel in Silence).
+                val cast = game.execute(CastSpell(game.player1Id, cardId, faceIndex = 0))
+                withClue("Casting Revel in Silence should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Revel in Silence exiles itself, not into the graveyard") {
+                    game.state.getExile(game.player1Id).contains(cardId) shouldBe true
+                    game.state.getGraveyard(game.player1Id).contains(cardId) shouldBe false
+                }
+                withClue("The opponent can't cast spells this turn") {
+                    game.state.getEntity(game.player2Id)?.has<CantCastSpellsComponent>() shouldBe true
+                }
+                withClue("The opponent can't activate loyalty abilities this turn") {
+                    game.state.getEntity(game.player2Id)?.has<CantActivateLoyaltyAbilitiesComponent>() shouldBe true
+                }
+            }
+        }
+
+        context("Loyalty restriction enforcement") {
+            test("a loyalty ability is activatable without the restriction") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(2, "Test Walker")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val walker = game.findPermanent("Test Walker")!!
+                val loyalty = cardRegistry.getCard("Test Walker")!!.script.activatedAbilities[0]
+
+                val result = game.execute(ActivateAbility(game.player2Id, walker, loyalty.id))
+                withClue("Loyalty ability should activate normally with no restriction: ${result.error}") {
+                    result.error shouldBe null
+                }
+            }
+
+            test("the restriction blocks loyalty-ability activation") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(2, "Test Walker")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Apply the restriction the way Revel in Silence would.
+                game.state = game.state.updateEntity(game.player2Id) { c ->
+                    c.with(CantActivateLoyaltyAbilitiesComponent())
+                }
+
+                val walker = game.findPermanent("Test Walker")!!
+                val loyalty = cardRegistry.getCard("Test Walker")!!.script.activatedAbilities[0]
+
+                val result = game.execute(ActivateAbility(game.player2Id, walker, loyalty.id))
+                withClue("Loyalty activation should be rejected while restricted") {
+                    result.error shouldNotBe null
+                    result.error!! shouldContain "loyalty"
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -807,6 +807,19 @@ class CardBuilder(private val name: String) {
         face(name, init)
     }
 
+    /**
+     * Declare the back face of a modal double-faced card (CR 712). Sets [layout] to
+     * [CardLayout.MODAL_DFC] and registers the named back face. The front face is described by
+     * the surrounding [CardBuilder]'s top-level fields; the owner casts one face or the other,
+     * never both. Inside the block, declare the back face's `manaCost`, `typeLine`, `oracleText`,
+     * its own art via `imageUri`, and — for a spell back — a `spell { … }` block (use
+     * `spell { selfExile() }` for backs that say "Exile <name>.").
+     */
+    fun modalBack(name: String, init: CardFaceBuilder.() -> Unit) {
+        layout = CardLayout.MODAL_DFC
+        face(name, init)
+    }
+
     // =========================================================================
     // Metadata
     // =========================================================================
@@ -853,6 +866,14 @@ class CardBuilder(private val name: String) {
             val adventureFace = cardFaceList.first()
             require(adventureFace.script.spellEffect != null) {
                 "Adventure face '${adventureFace.name}' must declare a spell { } effect"
+            }
+        }
+
+        // MODAL_DFC layout (CR 712): the surrounding CardBuilder fields describe the front face;
+        // cardFaces[0] is the back face. Both faces are independently castable from hand.
+        if (layout == CardLayout.MODAL_DFC) {
+            require(cardFaceList.size == 1) {
+                "MODAL_DFC layout requires exactly one back face: $name"
             }
         }
 
@@ -1582,6 +1603,9 @@ class CardFaceBuilder(private val name: String) {
     var typeLine: String = ""
     var oracleText: String = ""
 
+    /** Art for this face when it differs from the front (e.g. a MODAL_DFC back). */
+    var imageUri: String? = null
+
     private val keywordSet: MutableSet<Keyword> = mutableSetOf()
     private val triggeredAbilities: MutableList<TriggeredAbility> = mutableListOf()
     private val activatedAbilities: MutableList<ActivatedAbility> = mutableListOf()
@@ -1641,6 +1665,7 @@ class CardFaceBuilder(private val name: String) {
             activatedAbilities = activatedAbilities.toList(),
             staticAbilities = staticAbilities.toList(),
             additionalCosts = additionalCostsList.toList(),
+            selfExileOnResolve = spellBuilder?.exilesOnResolve ?: false,
         )
         return CardFace(
             name = name,
@@ -1649,6 +1674,7 @@ class CardFaceBuilder(private val name: String) {
             oracleText = oracleText,
             keywords = keywordSet.toSet(),
             script = script,
+            imageUri = imageUri,
         )
     }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -44,6 +44,7 @@ import com.wingedsheep.sdk.scripting.effects.CantAttackEffect
 import com.wingedsheep.sdk.scripting.effects.CantBlockEffect
 import com.wingedsheep.sdk.scripting.effects.SetSuspectedEffect
 import com.wingedsheep.sdk.scripting.effects.CantBlockGroupEffect
+import com.wingedsheep.sdk.scripting.effects.CantActivateLoyaltyAbilitiesEffect
 import com.wingedsheep.sdk.scripting.effects.CantCastSpellsEffect
 import com.wingedsheep.sdk.scripting.effects.PreventLandPlaysThisTurnEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
@@ -1940,6 +1941,13 @@ object Effects {
      */
     fun CantPlayLandsThisTurn(target: EffectTarget = EffectTarget.Controller): Effect =
         PreventLandPlaysThisTurnEffect(target)
+
+    /**
+     * Target player can't activate planeswalkers' loyalty abilities for the duration.
+     * Compose with [CantCastSpells] for cards that forbid both (e.g. Revel in Silence).
+     */
+    fun CantActivateLoyaltyAbilities(target: EffectTarget = EffectTarget.PlayerRef(Player.Opponent), duration: Duration = Duration.EndOfTurn): Effect =
+        CantActivateLoyaltyAbilitiesEffect(target, duration)
 
     /**
      * Target player skips their next turn.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -889,6 +889,16 @@ object Triggers {
         binding = TriggerBinding.ANY
     )
 
+    /**
+     * Whenever an opponent activates an ability that isn't a mana ability (CR 605 / 606).
+     * Mana abilities don't use the stack, so they never fire this; loyalty abilities (which are
+     * activated abilities) do. Used for Flamescroll Celebrant.
+     */
+    val OpponentActivatesAbility: TriggerSpec = TriggerSpec(
+        event = AbilityActivatedEvent(player = Player.Opponent),
+        binding = TriggerBinding.ANY
+    )
+
     // =========================================================================
     // Counter Triggers
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
@@ -78,6 +78,19 @@ enum class CardLayout {
      * caster gains permission to cast the creature face from exile (CR 715.4-5).
      */
     ADVENTURE,
+
+    /**
+     * Modal double-faced card (CR 712). The front face is described by the primary
+     * [CardDefinition] characteristics; [CardDefinition.cardFaces] holds the single back face
+     * (its own name, mana cost, type line, oracle text, and — for a spell back — a `spell { }`
+     * script). Unlike a transforming DFC, the two faces are unrelated: from hand the owner casts
+     * **one** face (front via primary characteristics, back signalled by [CastSpell.faceIndex] = 0)
+     * and never both. There is no exile-then-recast linkage like [ADVENTURE]; a spell back resolves
+     * as an ordinary spell (going to the graveyard, or to exile when its script sets
+     * `selfExileOnResolve`). Faces share one physical card, so each face carries its own art
+     * ([CardFace.imageUri]).
+     */
+    MODAL_DFC,
 }
 
 /**
@@ -101,6 +114,13 @@ data class CardFace(
     val oracleText: String = "",
     val keywords: Set<Keyword> = emptySet(),
     val script: CardScript = CardScript.EMPTY,
+    /**
+     * Art for this face, when it differs from the primary characteristics' art. Only meaningful
+     * for layouts whose faces are printed on separate sides — i.e. [CardLayout.MODAL_DFC], where
+     * the back face has its own Scryfall image. SPLIT/ADVENTURE faces share the front art and
+     * leave this null.
+     */
+    val imageUri: String? = null,
 )
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
@@ -1081,6 +1081,29 @@ sealed interface GameEvent : TextReplaceable<GameEvent> {
     }
 
     /**
+     * When a player activates an activated ability that isn't a mana ability.
+     *
+     * Mana abilities resolve without using the stack (CR 605.3), so the engine only emits its
+     * `AbilityActivatedEvent` for non-mana activated abilities — including planeswalker loyalty
+     * abilities (CR 606), which are activated abilities. This template therefore matches exactly
+     * "activates an ability that isn't a mana ability"; [player] scopes whose activations count
+     * ([Player.Opponent] for "an opponent activates …", [Player.You] for your own, etc.).
+     *
+     * Used by Flamescroll Celebrant: "Whenever an opponent activates an ability that isn't a mana
+     * ability, this creature deals 1 damage to that player."
+     */
+    @SerialName("AbilityActivatedEvent")
+    @Serializable
+    data class AbilityActivatedEvent(
+        val player: Player = Player.You
+    ) : GameEvent {
+        override val description: String =
+            "${player.description} activates an ability that isn't a mana ability"
+
+        override fun applyTextReplacement(replacer: TextReplacer): GameEvent = this
+    }
+
+    /**
      * When a card is revealed from the first draw of a turn.
      * Triggered by the RevealFirstDrawEachTurn static ability.
      *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -269,6 +269,26 @@ data class CantCastSpellsEffect(
 }
 
 /**
+ * Target player can't activate planeswalkers' loyalty abilities for the specified duration.
+ * Sibling restriction to [CantCastSpellsEffect]; compose the two for cards that forbid both
+ * (e.g. Revel in Silence: "Your opponents can't cast spells or activate planeswalkers' loyalty
+ * abilities this turn.").
+ *
+ * @param target The player who can't activate loyalty abilities
+ * @param duration How long the restriction lasts (default: EndOfTurn)
+ */
+@SerialName("CantActivateLoyaltyAbilities")
+@Serializable
+data class CantActivateLoyaltyAbilitiesEffect(
+    val target: EffectTarget = EffectTarget.PlayerRef(Player.Opponent),
+    val duration: Duration = Duration.EndOfTurn
+) : Effect {
+    override val description: String = "${target.description.replaceFirstChar { it.uppercase() }} can't activate planeswalkers' loyalty abilities ${duration.description}"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
+}
+
+/**
  * Target player loses the game.
  * Used for cards like Phage the Untouchable: "that player loses the game."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -58,6 +58,7 @@ import com.wingedsheep.mtg.sets.definitions.xln.IxalanSet
 import com.wingedsheep.mtg.sets.definitions.roe.RiseOfTheEldraziSet
 import com.wingedsheep.mtg.sets.definitions.scg.ScourgeSet
 import com.wingedsheep.mtg.sets.definitions.soi.ShadowsOverInnistradSet
+import com.wingedsheep.mtg.sets.definitions.stx.StrixhavenSchoolOfMagesSet
 import com.wingedsheep.mtg.sets.definitions.tmp.TempestSet
 import com.wingedsheep.mtg.sets.definitions.usg.UrzasSagaSet
 import com.wingedsheep.mtg.sets.definitions.vis.VisionsSet
@@ -150,6 +151,7 @@ object MtgSetCatalog {
         ShadowsOverInnistradSet,
         WorldwakeSet,
         LordOfTheRingsSet,
+        StrixhavenSchoolOfMagesSet,
     )
 
     private val byCode: Map<String, MtgSet> = all.associateBy { it.code }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/StrixhavenSchoolOfMagesSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/StrixhavenSchoolOfMagesSet.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.stx
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Strixhaven: School of Mages (2021)
+ *
+ * The set built around the five mage colleges of Strixhaven University, featuring
+ * the Learn / Lesson mechanic, Magecraft, and the Mystical Archive reprints.
+ *
+ * Set Code: STX
+ * Release Date: April 23, 2021
+ */
+object StrixhavenSchoolOfMagesSet : MtgSet {
+
+    override val code = "STX"
+    override val displayName = "Strixhaven: School of Mages"
+    override val releaseDate = "2021-04-23"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.stx.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FlamescrollCelebrant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FlamescrollCelebrant.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Flamescroll Celebrant // Revel in Silence
+ *
+ * Modal double-faced card (CR 712). Cast either face from hand, never both.
+ *
+ * Front — Flamescroll Celebrant ({1}{R}, Creature — Human Shaman, 2/1):
+ *   "Whenever an opponent activates an ability that isn't a mana ability, this creature deals
+ *    1 damage to that player."  (the engine emits AbilityActivatedEvent only for non-mana
+ *    abilities, since mana abilities resolve without the stack — loyalty abilities qualify.)
+ *   "{1}{R}: This creature gets +2/+0 until end of turn."
+ *
+ * Back — Revel in Silence ({W}{W}, Instant):
+ *   "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.
+ *    Exile Revel in Silence."
+ *   (Per Scryfall ruling, this is not countermagic — casting it in response to a spell or ability
+ *    doesn't affect that spell or ability.)
+ */
+val FlamescrollCelebrant = card("Flamescroll Celebrant") {
+    manaCost = "{1}{R}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Shaman"
+    oracleText = "Whenever an opponent activates an ability that isn't a mana ability, " +
+        "this creature deals 1 damage to that player.\n" +
+        "{1}{R}: This creature gets +2/+0 until end of turn."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.OpponentActivatesAbility
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    modalBack("Revel in Silence") {
+        manaCost = "{W}{W}"
+        typeLine = "Instant"
+        oracleText = "Your opponents can't cast spells or activate planeswalkers' loyalty " +
+            "abilities this turn.\nExile Revel in Silence."
+        imageUri = "https://cards.scryfall.io/normal/back/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg?1739656768"
+        spell {
+            selfExile()
+            effect = Effects.Composite(
+                Effects.CantCastSpells(EffectTarget.PlayerRef(Player.Opponent)),
+                Effects.CantActivateLoyaltyAbilities(EffectTarget.PlayerRef(Player.Opponent)),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "150"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg?1739656768"
+        ruling("4/16/2021", "An activated ability that costs mana to activate is not a “mana ability” unless it could also produce mana and has no targets.")
+        ruling("4/16/2021", "Loyalty abilities of planeswalkers are activated abilities, so activating one causes Flamescroll Celebrant's ability to trigger.")
+        ruling("4/16/2021", "Casting Revel in Silence in response to a spell or ability won't affect that spell or ability. That is, it's not countermagic.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -21,6 +21,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
 import com.wingedsheep.engine.state.components.player.AdditionalCombatPhasesComponent
+import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbilitiesComponent
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
 import com.wingedsheep.engine.state.components.player.DamageBonusComponent
 import com.wingedsheep.engine.state.components.player.DamageReceivedThisTurnComponent
@@ -327,6 +328,10 @@ class CleanupPhaseManager(
                 val cantCast = result.get<CantCastSpellsComponent>()
                 if (cantCast?.removeOn == PlayerEffectRemoval.EndOfTurn) {
                     result = result.without<CantCastSpellsComponent>()
+                }
+                val cantLoyalty = result.get<CantActivateLoyaltyAbilitiesComponent>()
+                if (cantLoyalty?.removeOn == PlayerEffectRemoval.EndOfTurn) {
+                    result = result.without<CantActivateLoyaltyAbilitiesComponent>()
                 }
                 val spellsUncounterable = result.get<SpellsCantBeCounteredComponent>()
                 if (spellsUncounterable?.removeOn == PlayerEffectRemoval.EndOfTurn) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -350,7 +350,10 @@ class GameInitializer(
                 ownerId = ownerId,
                 spellEffect = cardDef.spellEffect,
                 imageUri = printing?.imageUri ?: cardDef.metadata.imageUri,
-                backFaceImageUri = printing?.backFaceImageUri ?: cardDef.backFace?.metadata?.imageUri,
+                backFaceImageUri = printing?.backFaceImageUri
+                    ?: cardDef.backFace?.metadata?.imageUri
+                    // Modal DFC backs aren't a separate CardDefinition; their art rides on the face.
+                    ?: cardDef.cardFaces.firstOrNull { it.imageUri != null }?.imageUri,
                 hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             ),
             OwnerComponent(ownerId),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -396,6 +396,7 @@ val engineSerializersModule = SerializersModule {
         subclass(WasDealtCombatDamageThisTurnComponent::class)
         subclass(AdditionalCombatPhasesComponent::class)
         subclass(CantCastSpellsComponent::class)
+        subclass(CantActivateLoyaltyAbilitiesComponent::class)
         subclass(CardsLeftGraveyardThisTurnComponent::class)
         subclass(CreaturesDiedThisTurnComponent::class)
         subclass(DamageBonusComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -167,6 +167,7 @@ class TriggerIndex(
                 is SdkGameEvent.NthSpellCastEvent -> listOf(TriggerCategory.SPELL_CAST)
                 is SdkGameEvent.ExpendEvent -> listOf(TriggerCategory.SPELL_CAST)
                 is SdkGameEvent.SpellOrAbilityOnStackEvent -> listOf(TriggerCategory.SPELL_OR_ABILITY)
+                is SdkGameEvent.AbilityActivatedEvent -> listOf(TriggerCategory.SPELL_OR_ABILITY)
                 is SdkGameEvent.CycleEvent -> listOf(TriggerCategory.CARD_CYCLED)
                 is SdkGameEvent.TapEvent -> listOf(TriggerCategory.TAPPED)
                 is SdkGameEvent.UntapEvent -> listOf(TriggerCategory.UNTAPPED)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -195,6 +195,13 @@ class TriggerMatcher(
                     ?.get<TargetsComponent>()?.targets
                 targets != null && targets.size == 1
             }
+            is GameEvent.AbilityActivatedEvent -> {
+                // The engine only emits AbilityActivatedEvent for non-mana activated abilities
+                // (mana abilities resolve without the stack), so this naturally matches
+                // "activates an ability that isn't a mana ability". Loyalty abilities qualify.
+                event is AbilityActivatedEvent &&
+                    matchesPlayer(trigger.player, event.controllerId, controllerId)
+            }
             is GameEvent.CycleEvent -> {
                 event is CardCycledEvent &&
                     matchesPlayer(trigger.player, event.playerId, controllerId) &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -37,6 +37,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
+import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbilitiesComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.capturePermanentSnapshots
@@ -189,6 +190,10 @@ class ActivateAbilityHandler(
 
         // Check timing for planeswalker abilities
         if (ability.isPlaneswalkerAbility) {
+            // Revel in Silence etc.: "can't activate planeswalkers' loyalty abilities this turn"
+            if (state.getEntity(action.playerId)?.has<CantActivateLoyaltyAbilitiesComponent>() == true) {
+                return "You can't activate loyalty abilities this turn"
+            }
             if (!turnManager.canPlaySorcerySpeed(state, action.playerId)) {
                 return "Loyalty abilities can only be activated at sorcery speed"
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CantActivateLoyaltyAbilitiesExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CantActivateLoyaltyAbilitiesExecutor.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbilitiesComponent
+import com.wingedsheep.engine.state.components.player.PlayerEffectRemoval
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.CantActivateLoyaltyAbilitiesEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [CantActivateLoyaltyAbilitiesEffect].
+ * Adds [CantActivateLoyaltyAbilitiesComponent] to the target player, preventing them from
+ * activating planeswalkers' loyalty abilities for the effect's duration.
+ */
+class CantActivateLoyaltyAbilitiesExecutor : EffectExecutor<CantActivateLoyaltyAbilitiesEffect> {
+
+    override val effectType: KClass<CantActivateLoyaltyAbilitiesEffect> = CantActivateLoyaltyAbilitiesEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: CantActivateLoyaltyAbilitiesEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolvePlayerTarget(effect.target)
+            ?: return EffectResult.error(state, "No valid target for can't-activate-loyalty effect")
+
+        if (!state.turnOrder.contains(targetId)) {
+            return EffectResult.error(state, "Target is not a player")
+        }
+
+        val removeOn = when (effect.duration) {
+            is Duration.Permanent -> PlayerEffectRemoval.Permanent
+            else -> PlayerEffectRemoval.EndOfTurn
+        }
+
+        val newState = state.updateEntity(targetId) { container ->
+            container.with(CantActivateLoyaltyAbilitiesComponent(removeOn = removeOn))
+        }
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -41,6 +41,7 @@ class PlayerExecutors(
         AmassExecutor(effectExecutor),
         AddCombatPhaseExecutor(),
         AnyPlayerMayPayExecutor(executeEffect = effectExecutor),
+        CantActivateLoyaltyAbilitiesExecutor(),
         CantCastSpellsExecutor(),
         CreateGlobalTriggeredAbilityUntilEndOfTurnExecutor(),
         CreateGlobalTriggeredAbilityWithDurationExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.engine.mechanics.mana.ManaSource
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbilitiesComponent
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.sdk.model.EntityId
@@ -84,6 +85,11 @@ class EnumerationContext(
     val cantCastSpells: Boolean by lazy {
         state.getEntity(playerId)?.has<CantCastSpellsComponent>() == true ||
             castPermissionUtils.hasReachedSpellCastLimit(state, playerId)
+    }
+
+    // Loyalty-activation restriction (Revel in Silence etc.)
+    val cantActivateLoyaltyAbilities: Boolean by lazy {
+        state.getEntity(playerId)?.has<CantActivateLoyaltyAbilitiesComponent>() == true
     }
 
     // Alternative casting costs from battlefield permanents (e.g., Jodah)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -115,6 +115,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
 
                 // Planeswalker loyalty abilities: sorcery speed + once per turn + loyalty cost check
                 if (ability.isPlaneswalkerAbility) {
+                    if (context.cantActivateLoyaltyAbilities) continue
                     if (!context.canPlaySorcerySpeed) continue
                     val tracker = container.get<AbilityActivatedThisTurnComponent>()
                     if (tracker != null && tracker.loyaltyActivationCount > 0) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -74,13 +74,19 @@ class CastSpellEnumerator : ActionEnumerator {
             // Pain // Suffering, Stand // Deliver, Wax // Wane — read their face's
             // `targetRequirements` in CastSpellHandler). Modal effects, alternative costs, blight,
             // behold, kicker, and convoke on a split half are not yet wired up.
-            // Adventure layout (CR 715) — emit one cast option for the Adventure face, then fall
-            // through so the surrounding code also enumerates the creature face. The Adventure
-            // face has its own mana cost, type line (instant/sorcery — Adventure), target
-            // requirements, and spell effect; the creature face uses the card's primary fields.
-            if (cardDef.layout == com.wingedsheep.sdk.model.CardLayout.ADVENTURE && cardDef.cardFaces.isNotEmpty()) {
-                enumerateAdventureFace(context, cardId, cardDef, result)
-                // Don't `continue` — let the surrounding loop also enumerate the creature face.
+            // Adventure (CR 715) and modal DFC (CR 712) both expose a secondary spell face that
+            // is castable from hand alongside the primary characteristics. Emit one cast option
+            // for that face, then fall through so the surrounding code also enumerates the
+            // primary (creature) face. The secondary face carries its own mana cost, type line,
+            // target requirements, and spell effect; the primary face uses the card's top-level
+            // fields. (MODAL_DFC differs from ADVENTURE only at resolution — no exile-then-recast
+            // linkage — which is handled in StackResolver, not here.)
+            if ((cardDef.layout == com.wingedsheep.sdk.model.CardLayout.ADVENTURE ||
+                    cardDef.layout == com.wingedsheep.sdk.model.CardLayout.MODAL_DFC) &&
+                cardDef.cardFaces.isNotEmpty()
+            ) {
+                enumerateSecondaryFace(context, cardId, cardDef, result)
+                // Don't `continue` — let the surrounding loop also enumerate the primary face.
             }
 
             if (cardDef.layout == com.wingedsheep.sdk.model.CardLayout.SPLIT && cardDef.cardFaces.isNotEmpty()) {
@@ -1729,20 +1735,21 @@ class CastSpellEnumerator : ActionEnumerator {
     }
 
     // =========================================================================
-    // Adventure face (CR 715)
+    // Secondary spell face (Adventure CR 715 / modal DFC CR 712)
     // =========================================================================
 
     /**
-     * Emit a [LegalAction] for casting the Adventure face of an adventurer card from hand.
-     * The card's creature face is enumerated by the surrounding loop's normal cast path; this
-     * method only adds the alternative-characteristics cast that uses [CastSpell.faceIndex] = 0.
+     * Emit a [LegalAction] for casting the secondary spell face of an Adventure or modal DFC card
+     * from hand. The card's primary (creature) face is enumerated by the surrounding loop's normal
+     * cast path; this method only adds the alternative-characteristics cast that uses
+     * [CastSpell.faceIndex] = 0.
      *
      * Supports mana cost, instant/sorcery timing, and per-face target requirements. Additional
-     * costs declared on the Adventure face's script are honoured for affordability but the full
-     * additional-cost UX (sacrifice picker, blight, etc.) is not yet wired for Adventure faces —
+     * costs declared on the face's script are honoured for affordability but the full
+     * additional-cost UX (sacrifice picker, blight, etc.) is not yet wired for these faces —
      * cards that need that can extend this method later.
      */
-    private fun enumerateAdventureFace(
+    private fun enumerateSecondaryFace(
         context: EnumerationContext,
         cardId: EntityId,
         cardDef: CardDefinition,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1300,7 +1300,10 @@ class StackResolver(
 
                 val ownerId = cardComponent?.ownerId ?: spellComponent.casterId
                 val pausedCardDef = cardComponent?.let { cardRegistry.getCard(it.name) }
-                val pausedSelfExile = pausedCardDef?.script?.selfExileOnResolve == true
+                // For a cast face (Adventure / modal DFC), "Exile <name>." lives on the face's script.
+                val pausedResolvedScript = spellComponent.faceIndex?.let { pausedCardDef?.cardFaces?.getOrNull(it)?.script }
+                    ?: pausedCardDef?.script
+                val pausedSelfExile = pausedResolvedScript?.selfExileOnResolve == true
                 // Flashback and Harmonize both cast from the graveyard and exile on resolution.
                 val pausedFlashbackExile = spellComponent.castFromZone == Zone.GRAVEYARD &&
                     pausedCardDef?.keywordAbilities?.any {
@@ -1385,7 +1388,10 @@ class StackResolver(
         // Move to graveyard (or exile if selfExileOnResolve, flashback, or ExileAfterResolveComponent)
         val ownerId = cardComponent?.ownerId ?: spellComponent.casterId
         val cardDef = cardComponent?.let { cardRegistry.getCard(it.name) }
-        val selfExile = cardDef?.script?.selfExileOnResolve == true
+        // For a cast face (Adventure / modal DFC), "Exile <name>." lives on the face's script.
+        val resolvedScript = spellComponent.faceIndex?.let { cardDef?.cardFaces?.getOrNull(it)?.script }
+            ?: cardDef?.script
+        val selfExile = resolvedScript?.selfExileOnResolve == true
         // Flashback and Harmonize both cast from the graveyard and exile on resolution.
         val flashbackExile = spellComponent.castFromZone == Zone.GRAVEYARD &&
             cardDef?.keywordAbilities?.any {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -387,6 +387,22 @@ data class CantCastSpellsComponent(
 ) : Component
 
 /**
+ * Component indicating that a player cannot activate planeswalkers' loyalty abilities for the
+ * rest of this turn. Applied by effects like Revel in Silence. Sibling of [CantCastSpellsComponent].
+ *
+ * When present on a player entity, that player's loyalty-ability activations are suppressed in
+ * ActivatedAbilityEnumerator and rejected by ActivateAbilityHandler.validate.
+ *
+ * @param removeOn When this component should be removed:
+ *   - [PlayerEffectRemoval.EndOfTurn] — removed during end-of-turn cleanup (default)
+ *   - [PlayerEffectRemoval.Permanent] — stays until explicitly removed
+ */
+@Serializable
+data class CantActivateLoyaltyAbilitiesComponent(
+    val removeOn: PlayerEffectRemoval = PlayerEffectRemoval.EndOfTurn
+) : Component
+
+/**
  * Grants permission to cast creature spells from graveyard by paying the forage
  * additional cost (exile 3 cards from graveyard or sacrifice a Food).
  * Creatures cast this way enter with a finality counter.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -997,6 +997,11 @@ class ClientStateTransformer(
             }
         }
 
+        // Modal DFC (CR 712) back face for display/flip preview (it lives in `cardFaces`, not `backFace`).
+        val modalBackFace = if (cardDef?.layout == com.wingedsheep.sdk.model.CardLayout.MODAL_DFC) {
+            cardDef.cardFaces.firstOrNull()
+        } else null
+
         return ClientCard(
             id = entityId,
             name = cardComponent.name,
@@ -1078,13 +1083,16 @@ class ClientStateTransformer(
             } else null,
             chosenModeDescriptions = chosenModeDescriptions,
             perModeTargets = perModeTargets,
-            isDoubleFaced = container.has<com.wingedsheep.engine.state.components.identity.DoubleFacedComponent>() || cardDef?.isDoubleFaced == true,
+            // Modal DFCs (CR 712) keep their back face in `cardFaces`, not `backFace`, so the
+            // SDK `isDoubleFaced` (transform machinery) stays false; surface them to the client
+            // as double-faced for display/flip-preview only.
+            isDoubleFaced = container.has<com.wingedsheep.engine.state.components.identity.DoubleFacedComponent>() || cardDef?.isDoubleFaced == true || modalBackFace != null,
             currentFace = container.get<com.wingedsheep.engine.state.components.identity.DoubleFacedComponent>()?.currentFace?.name
-                ?: if (cardDef?.isDoubleFaced == true) "FRONT" else null,
-            backFaceName = dfcBackFace(container, cardDef)?.name,
-            backFaceTypeLine = dfcBackFace(container, cardDef)?.typeLine?.toString(),
-            backFaceOracleText = dfcBackFace(container, cardDef)?.oracleText,
-            backFaceImageUri = cardComponent.backFaceImageUri ?: dfcBackFace(container, cardDef)?.metadata?.imageUri,
+                ?: if (cardDef?.isDoubleFaced == true || modalBackFace != null) "FRONT" else null,
+            backFaceName = dfcBackFace(container, cardDef)?.name ?: modalBackFace?.name,
+            backFaceTypeLine = dfcBackFace(container, cardDef)?.typeLine?.toString() ?: modalBackFace?.typeLine?.toString(),
+            backFaceOracleText = dfcBackFace(container, cardDef)?.oracleText ?: modalBackFace?.oracleText,
+            backFaceImageUri = cardComponent.backFaceImageUri ?: dfcBackFace(container, cardDef)?.metadata?.imageUri ?: modalBackFace?.imageUri,
             planeswalkerAbilities = buildPlaneswalkerAbilities(cardDef, zoneKey),
             isRoom = cardDef?.isRoom == true,
             cardFaces = buildClientCardFaces(container, cardDef),


### PR DESCRIPTION
## What

Adds reusable **modal double-faced card** support (CR 712) to the engine and ships the first user, **Flamescroll Celebrant // Revel in Silence** (STX). Also introduces a new `StrixhavenSchoolOfMagesSet` shell to register the card.

## Engine feature (the reusable part)

- New `CardLayout.MODAL_DFC` + `modalBack("Name") { spell { … } }` DSL for declaring the back spell face.
- Cast enumeration: generalized `enumerateAdventureFace` → **`enumerateSecondaryFace`**, now shared by both `ADVENTURE` (CR 715) and `MODAL_DFC` (CR 712) — both expose a secondary spell face castable from hand alongside the primary characteristics via `CastSpell.faceIndex`.
- Resolution: `StackResolver` reads `selfExileOnResolve` from the *cast face's* script (`resolvedScript`), so a back face that says "Exile this" self-exiles correctly. MODAL_DFC differs from ADVENTURE only here — no exile-then-recast linkage.
- Per-face back art: `backFaceImageUri` falls back to the face's own `imageUri` (MDFC backs aren't a separate `CardDefinition`).

## Supporting SDK additions (used by Revel in Silence)

- `OpponentActivatesAbility` trigger — fires when an opponent activates a non-mana ability (incl. loyalty).
- `Effects.CantActivateLoyaltyAbilities(target, duration)` — sibling of `CantCastSpells`; compose the two for cards that forbid both.

## Tests

`FlamescrollCelebrantScenarioTest` (7 tests, all passing): front-face creature + its pump ability; the opponent-activates-ability trigger (and that it does *not* fire on the controller's own activations); back-face cast applying both restrictions + self-exile; and loyalty-restriction enforcement with/without the effect.

## Validation

Rebased onto current `main` (resolved 8 mechanical conflicts — DSL/list insertions + the `enumerateSecondaryFace` rename). Full regression green:
- `rules-engine`: 2121 tests, 0 failures
- `game-server`: 94 tests, 0 failures
- Existing Adventure + Invasion split-card paths verified unaffected by the rename/generalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)