### PR TITLE
Gym: register all catalogued sets + self-play manual-testing doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,8 @@ continuations, layer system, mana, priority): [`docs/architecture-principles.md`
 - **Unit / integration / scenario tests** — Kotest in `rules-engine` and `game-server`.
 - **E2E tests** — Playwright in `e2e-scenarios/`, run against full stack. Patterns, scenario config, and `GamePage`
   helper reference: [`docs/e2e-test-patterns.md`](docs/e2e-test-patterns.md).
+- **Manual self-play** — drive a full game over the gym server's HTTP step loop to shake out new-set cards that
+  don't behave as printed: [`docs/gym-self-play-testing.md`](docs/gym-self-play-testing.md).
 - Run: `just test` · `just test-rules` · `just test-class <Name>`.
 
 ## Documentation index
@@ -119,3 +121,4 @@ continuations, layer system, mana, priority): [`docs/architecture-principles.md`
 | [`web-client-architecture.md`](docs/web-client-architecture.md) | Frontend architecture, WebSocket API |
 | [`e2e-test-patterns.md`](docs/e2e-test-patterns.md) | Playwright fixtures, GamePage helpers, scenario config |
 | [`gym-deckbuild-env.md`](docs/gym-deckbuild-env.md) | Sealed deckbuild gym env (build → play pipeline) + how to supply your own win-rate reward |
+| [`gym-self-play-testing.md`](docs/gym-self-play-testing.md) | Driving the gym server over HTTP to manually self-play and surface broken cards |

--- a/docs/gym-self-play-testing.md
+++ b/docs/gym-self-play-testing.md
@@ -1,0 +1,218 @@
+# Playing the gym server against itself (manual set testing)
+
+A way for **Claude Code (or any human/agent) to drive a full game of Magic over HTTP**, making
+every decision for both players, to shake out cards in a new set that don't behave as printed.
+
+This is *exploratory* testing, not a replacement for scenario tests. A scenario test asserts one
+known interaction; a self-play session walks an entire game and surfaces the things you didn't think
+to write a test for — a card that produces no legal action, an oracle effect that never fires, a
+trigger that crashes the engine, a board state that can't legally exist.
+
+The engine never picks moves. The `gym-server` exposes a stateless step loop: it answers *"what are
+the legal actions?"* and *"what's the state after this action?"*, and the caller chooses. That makes
+the engine perfectly inspectable from the outside — which is exactly what we want for finding bugs.
+
+> Endpoint and payload reference is in this doc; the source of truth is
+> [`gym-server/.../EnvController.kt`](../gym-server/src/main/kotlin/com/wingedsheep/gym/server/controller/EnvController.kt)
+> and [`gym/.../TrainingObservation.kt`](../gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt).
+> Live, try-it-out docs are at `http://localhost:8081/swagger-ui.html` once the server is up.
+
+---
+
+## 1. Start the server
+
+```bash
+just gym-server        # ./gradlew :gym-server:bootRun — listens on :8081
+```
+
+Wait for it to come up, then sanity-check:
+
+```bash
+curl -s localhost:8081/health        # -> {"status":"ok"}
+```
+
+The server is in-memory and unauthenticated — bind to localhost, and remember a restart wipes every
+env.
+
+---
+
+## 2. Create a game
+
+`POST /envs` with an `EnvConfig`. Build a deck that **concentrates the cards under test** — a small
+toolbox of the new set's cards plus enough basics to actually cast them. The point is to maximise the
+chance each card you care about gets drawn and played, not to build a good deck.
+
+```bash
+curl -s -X POST localhost:8081/envs -H 'Content-Type: application/json' -d '{
+  "players": [
+    { "name": "A", "deck": { "type": "Explicit", "cards": {
+        "Mountain": 14, "Raging Goblin": 4, "Some New Set Card": 4, "Another New Card": 4
+    } } },
+    { "name": "B", "deck": { "type": "Explicit", "cards": {
+        "Mountain": 14, "Raging Goblin": 4, "Some New Set Card": 4, "Another New Card": 4
+    } } }
+  ],
+  "skipMulligans": true,
+  "startingPlayerIndex": 0,
+  "revealAll": true
+}'
+```
+
+Key config fields:
+
+- **`deck`** — `{"type":"Explicit","cards":{"Name":count}}` (recommended for testing), or
+  `{"type":"RandomSealed","setCode":"BLB","boosterCount":8}` (needs the set's basic-land variants
+  registered).
+- **`revealAll: true`** — set this for self-play. Normally observations hide the opponent's hand and
+  libraries; since one agent is playing *both* seats, you want to see everything. (Never use it for
+  real RL self-play — it leaks information.)
+- **`skipMulligans: true`** — skip the mulligan back-and-forth.
+- `startingPlayerIndex` — pin it for reproducibility (null = random).
+
+The response is `{ "envId": "...", "observation": { ... } }`. Keep the `envId`.
+
+---
+
+## 3. The decision loop
+
+```
+loop:
+  read observation
+  if observation.terminated  -> done (winnerId)
+  if observation.pendingDecision != null and pendingDecision.requiresStructuredResponse:
+        POST /envs/{id}/decision  with a typed DecisionResponse   (section 5)
+  else:
+        pick an actionId from observation.legalActions
+        POST /envs/{id}/step  { "actionId": N }
+  -> response is the next observation; repeat
+```
+
+```bash
+curl -s -X POST localhost:8081/envs/$ENV/step \
+  -H 'Content-Type: application/json' -d '{"actionId": 3}'
+```
+
+**Action IDs are per-step.** They are regenerated on every step/decision. Always pick from the
+*latest* observation; a stale id returns `400`.
+
+### Reading an observation
+
+The fields that matter most for spotting bugs:
+
+- `agentToAct` — whose decision this is. (With `revealAll` you make moves for both.)
+- `legalActions[]` — each has `actionId`, `kind` (`PLAY_CARD`, `ACTIVATE_ABILITY`, `PASS`,
+  `DECISION`, …), `description`, `affordable`, `manaCost`, target counts.
+- `zones[]` → `cards[]` → `EntityFeatures` — the projected (post-layers) truth about each object:
+  `oracleText`, `power`/`toughness`, `types`/`subtypes`/`keywords`/`colors`, `tapped`, `counters`,
+  `attachedTo`. **`oracleText` is your oracle**: read what the card *says*, then watch whether the
+  game state changes the way it says.
+- `stack[]` — what's resolving, with `oracleText` and `targets`.
+- `players[]` — life, hand/library/graveyard sizes, mana pool.
+- `stateDigest` — a hash of the observable state; if it doesn't change across a full round of passes,
+  you're in a loop (see section 6).
+
+---
+
+## 4. How to reason through moves (and what to look for)
+
+Play *purposefully toward exercising the cards under test*, not to win:
+
+1. **Develop mana**, then **cast the new-set cards** as soon as they're castable. Prefer the action
+   whose `description`/`sourceEntityId` matches a card you want to test.
+2. When a spell or ability resolves, **diff the before/after observation against its `oracleText`**:
+   - Did the stated effect happen (counters added, cards drawn, creature destroyed, life changed)?
+   - Did the *right* objects change? (Use `entityId`s — projection means types/P-T can differ from
+     the printed card.)
+   - Did a triggered ability that should have fired appear on the `stack`?
+3. **Drive combat** to exercise attack/block/damage triggers and keywords (flying, trample, first
+   strike, deathtouch).
+4. **Pass priority** (`kind: "PASS"`) when there's nothing to test, to advance the turn.
+
+Red flags that mean a card is probably broken — note them, don't just play around them:
+
+- A card in hand that should be castable but produces **no `PLAY_CARD` action** (or one with
+  `affordable: false` when you can clearly pay).
+- A resolved spell whose **oracle effect didn't change the state** (silent fizzle).
+- A trigger condition that's met but **nothing lands on the stack**.
+- An **HTTP 500** (engine exception) or **409** on a decision — capture the request that caused it.
+- `EntityFeatures` that contradict the card: missing/extra keywords, wrong P/T after a pump, a
+  type-changing effect not reflected, counters not applied.
+- A board state that **can't legally exist** (e.g., an Aura on the battlefield attached to nothing).
+- The game **stalls** — same `stateDigest` cycling forever (often a never-ending trigger loop).
+
+When you find one, record: the `envId`, the card, the action/decision posted, the observation before
+and after, and what oracle text predicted. That reproduction is what becomes a scenario test or bug
+report.
+
+---
+
+## 5. Structured decisions
+
+Simple decisions (yes/no, choose-a-number, choose-a-mode, single-select) are **folded into
+`legalActions`** as entries with `kind: "DECISION"` — just `step` the chosen `actionId`.
+
+Complex decisions set `pendingDecision.requiresStructuredResponse = true` and leave `legalActions`
+empty. Post a typed `DecisionResponse` to `POST /envs/{id}/decision`. The JSON discriminator key is
+`"type"` and its value is the response's `@SerialName`. Match the response to
+`pendingDecision.kind`:
+
+| `pendingDecision.kind` | `type` (SerialName) | Payload fields |
+|---|---|---|
+| `CHOOSE_TARGETS` | `TargetsResponse` | `selectedTargets: { "<reqIndex>": ["<entityId>", …] }` |
+| `SELECT_CARDS` | `CardsSelectedResponse` | `selectedCards: ["<entityId>", …]` |
+| `YES_NO` | `YesNoResponse` | `choice: true\|false` |
+| `CHOOSE_MODE` | `ModesChosenResponse` | `selectedModes: [int, …]` |
+| `CHOOSE_COLOR` | `ColorChosenResponse` | `color: "RED"` |
+| `CHOOSE_NUMBER` | `NumberChosenResponse` | `number: int` |
+| `DISTRIBUTE` | `DistributionResponse` | `distribution: { "<entityId>": int }` |
+| `ORDER_OBJECTS` | `OrderedResponse` | `orderedObjects: ["<entityId>", …]` |
+| `SPLIT_PILES` | `PilesSplitResponse` | `piles: [["<id>",…], ["<id>",…]]` |
+| `CHOOSE_OPTION` | `OptionChosenResponse` | `optionIndex: int` |
+| `CHOOSE_REPLACEMENT` | `ReplacementChosenResponse` | `fromIndex: int, toIndex: int` |
+| `ASSIGN_DAMAGE` | `DamageAssignmentResponse` | `assignments: { "<entityId>": int }` |
+| `SELECT_MANA_SOURCES` | `ManaSourcesSelectedResponse` | `selectedSources: ["<id>",…]` or `autoPay: true` |
+| `BUDGET_MODAL` | `BudgetModalResponse` | `selectedModeIndices: [int, …]` |
+
+Every response also needs `decisionId` (copy it from `pendingDecision.decisionId`). The
+`pendingDecision.shape` field carries the constraints (`minSelections`, `maxSelections`,
+`numericMin/Max`, `availableColors`, `totalToDistribute`, `budget`).
+
+```bash
+# Choose targets for a pending ChooseTargets decision (requirement 0 -> one creature)
+curl -s -X POST localhost:8081/envs/$ENV/decision -H 'Content-Type: application/json' -d '{
+  "type": "TargetsResponse",
+  "decisionId": "'"$DID"'",
+  "selectedTargets": { "0": ["'"$TARGET"'"] }
+}'
+```
+
+Source of truth for these shapes:
+[`PendingDecision.kt`](../rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt)
+(the `sealed interface DecisionResponse`).
+
+---
+
+## 6. Practical guardrails
+
+- **Cap the loop.** A real game is hundreds of priority passes. Set a max-step budget (e.g. 1500) and
+  abort if exceeded — a runaway count is itself a finding (probably a trigger loop).
+- **Detect stalls** via `stateDigest`: if a full round-trip of passes by both players doesn't change
+  it and the game isn't over, you're looping.
+- **Reproducibility:** pin `startingPlayerIndex` and keep the exact decklist. The engine's own
+  randomness (draws) isn't seedable here, so capture the full action transcript to replay a bug.
+- **Snapshot/fork** before a risky line: `POST /envs/{id}/snapshot` → `{handle}`, then
+  `POST /envs/{id}/restore {"handle": …}` to retry a different decision from the same point. Useful
+  for testing both branches of a modal/choice without replaying the whole game.
+- **Clean up:** `curl -X DELETE localhost:8081/envs -d '{"envIds":["'"$ENV"'"]}'`.
+
+---
+
+## 7. Turning a finding into a regression test
+
+A self-play bug is only worth as much as its reproduction. Once you isolate one:
+
+1. Note the minimal board state right before the broken action (from the observation).
+2. Reproduce it as a Kotest **scenario test** (`ScenarioTestBase`) or a **manual scenario JSON**, not
+   another self-play run — see [`add-card`](../.claude/skills) conventions and existing
+   `rules-engine` scenario tests.
+3. Fix the card/engine, and leave the scenario test behind so it can't regress.

--- a/gym-server/src/main/kotlin/com/wingedsheep/gym/server/config/GymBeansConfig.kt
+++ b/gym-server/src/main/kotlin/com/wingedsheep/gym/server/config/GymBeansConfig.kt
@@ -4,52 +4,52 @@ import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.gym.service.MultiEnvService
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.registry.PrintingRegistry
-import com.wingedsheep.mtg.sets.definitions.blb.BloomburrowSet
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
+import com.wingedsheep.mtg.sets.MtgSetCatalog
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 /**
  * Wires a default [CardRegistry] and [MultiEnvService] as Spring singletons.
  *
- * The chosen set catalogue here is deliberately small (Portal + Bloomburrow)
- * — enough to exercise the full service surface (constructed decks + sealed
- * pools). Extend via the `gym.sets` property once a richer set catalogue is
- * agreed on; sets are merged into both the card registry (for casting) and
- * the booster generator (for sealed).
+ * The catalogue is [MtgSetCatalog.all] — every set the engine knows about — so a
+ * constructed deck can name any implemented card and a [DeckSpec.RandomSealed] can
+ * draw from any sealed-supported set. This mirrors `game-server`'s `GameBeansConfig`;
+ * `MtgSetCatalog` is the single registration point, so newly-added sets show up here
+ * automatically with no edit to this file.
  */
 @Configuration
 class GymBeansConfig {
 
     @Bean
     fun cardRegistry(): CardRegistry = CardRegistry().apply {
-        register(PortalSet.cards)
-        register(BloomburrowSet.cards)
-        // Basic-land variants are needed for the RandomSealed path so that
-        // variant names like "Swamp#BLB-270" resolve during GameInitializer.
-        register(BloomburrowSet.basicLands)
+        for (set in MtgSetCatalog.all) {
+            register(set.cards.stampSetCode(set.code))
+            // Basic-land variants are needed for the RandomSealed path so that
+            // variant names like "Swamp#BLB-270" resolve during GameInitializer.
+            register(set.basicLands)
+            set.basicLandsFallback?.let { register(it.basicLands) }
+        }
     }
 
     @Bean
     fun printingRegistry(cardRegistry: CardRegistry): PrintingRegistry = PrintingRegistry().apply {
+        // One synthesised printing per registered card (its canonical printing)...
         for (name in cardRegistry.allCardNames()) {
             cardRegistry.getCardsByName(name).forEach(::registerSynthesizedDefault)
         }
-        // Each set may contribute reprint rows for cards canonically defined elsewhere.
-        register(PortalSet.printings)
-        register(BloomburrowSet.printings)
+        // ...then explicit reprint rows, which overwrite synthesised entries sharing a key.
+        for (set in MtgSetCatalog.all) {
+            register(set.printings)
+        }
     }
 
     @Bean
     fun boosterGenerator(): BoosterGenerator = BoosterGenerator(
-        mapOf(
-            BloomburrowSet.code to BoosterGenerator.SetConfig(
-                setCode = BloomburrowSet.code,
-                setName = BloomburrowSet.displayName,
-                cards = BloomburrowSet.cards,
-                basicLands = BloomburrowSet.basicLands
-            )
-        )
+        MtgSetCatalog.all
+            .filter { it.sealedSupported }
+            .associate { it.code to it.toBoosterSetConfig() }
     )
 
     @Bean
@@ -58,3 +58,18 @@ class GymBeansConfig {
         boosterGenerator: BoosterGenerator
     ): MultiEnvService = MultiEnvService(cardRegistry, boosterGenerator)
 }
+
+/** Stamp a set code onto any card that doesn't already carry one, so printing synthesis keys correctly. */
+private fun List<CardDefinition>.stampSetCode(setCode: String): List<CardDefinition> =
+    map { if (it.setCode == null) it.copy(setCode = setCode) else it }
+
+private fun MtgSet.toBoosterSetConfig(): BoosterGenerator.SetConfig =
+    BoosterGenerator.SetConfig(
+        setCode = code,
+        setName = displayName,
+        cards = cards,
+        basicLands = (basicLandsFallback ?: this).basicLands,
+        incomplete = incomplete,
+        block = block,
+        boosterStrategy = boosterStrategy,
+    )


### PR DESCRIPTION
## What

Two related gym improvements:

1. **Register all catalogued sets in the gym server.** `GymBeansConfig` previously hardcoded only Portal + Bloomburrow for both the card registry and booster generator. It now derives from `MtgSetCatalog.all` (the same source `game-server`'s `GameBeansConfig` already uses), so newly-added sets are automatically available in the gym with zero further edits.

2. **Add `docs/gym-self-play-testing.md`** — a manual-testing guide for driving the gym server over HTTP to self-play games and surface broken cards: endpoint reference, the decision loop, worked examples, red flags to watch for, and how to turn a finding into a regression scenario test.

## Why

Manually exercising new cards through the gym was blocked on hand-editing `GymBeansConfig` for every set. Sourcing from `MtgSetCatalog.all` removes that maintenance burden and keeps gym/game-server set coverage in sync.

## Validation

Rebased onto current `main` (one trivial doc-index conflict in CLAUDE.md). `:gym-server` compiles and all gym-server tests pass, including the `create → observe → step → dispose` HTTP round-trip and unknown-set-code handling that exercise set registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)