### PR TITLE
Show set release dates in the tournament picker, sorted newest-first

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
@@ -103,5 +103,6 @@ private fun MtgSet.toBoosterSetConfig(): BoosterGenerator.SetConfig =
         basicLands = (basicLandsFallback ?: this).basicLands,
         incomplete = incomplete,
         block = block,
+        releaseDate = releaseDate,
         boosterStrategy = boosterStrategy,
     )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -35,7 +35,8 @@ class ConnectionHandler(
             name = config.setName,
             incomplete = config.incomplete,
             block = config.block,
-            implementedCount = config.cards.size
+            implementedCount = config.cards.size,
+            releaseDate = config.releaseDate
         )
     }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -1391,7 +1391,8 @@ class TournamentLobby(
                 name = config.setName,
                 incomplete = config.incomplete,
                 block = config.block,
-                implementedCount = config.cards.size
+                implementedCount = config.cards.size,
+                releaseDate = config.releaseDate
             )
         }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -377,7 +377,8 @@ sealed interface ServerMessage {
         val name: String,
         val incomplete: Boolean = false,
         val block: String? = null,
-        val implementedCount: Int? = null
+        val implementedCount: Int? = null,
+        val releaseDate: String? = null
     )
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
@@ -37,6 +37,8 @@ class BoosterGenerator(
         val basicLands: List<CardDefinition>,
         val incomplete: Boolean = false,
         val block: String? = null,
+        /** Set release date in ISO `YYYY-MM-DD` form, or null if unknown. Used by clients to sort sets chronologically. */
+        val releaseDate: String? = null,
         val boosterStrategy: BoosterStrategy = StandardBooster(),
     )
 

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1504,6 +1504,14 @@
   white-space: nowrap;
 }
 
+.setReleaseDate {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-disabled);
+  white-space: nowrap;
+}
+
 .setPartialBadge {
   flex-shrink: 0;
   padding: 1px 6px;

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -778,10 +778,34 @@ function LobbyOverlay({
     updateLobbySettings({ setCodes: newCodes })
   }
 
+  // Format an ISO `YYYY-MM-DD` release date as e.g. "Oct 2002". Parsed manually to avoid timezone shifts.
+  const MONTH_ABBREVS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  const formatReleaseDate = (releaseDate?: string): string | null => {
+    if (!releaseDate) return null
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(releaseDate)
+    if (!match) return null
+    const [, year, month] = match
+    if (!year) return null
+    const monthName = MONTH_ABBREVS[Number(month) - 1]
+    return monthName ? `${monthName} ${year}` : year
+  }
+
+  // Newest-first comparator on ISO `YYYY-MM-DD` keys; sets/blocks with no known release date sort last.
+  const UNKNOWN_RELEASE = ''
+  const releaseSortKey = (releaseDate?: string): string => releaseDate ?? UNKNOWN_RELEASE
+  const byNewestFirst = (a: string, b: string): number => {
+    if (a === UNKNOWN_RELEASE || b === UNKNOWN_RELEASE) {
+      if (a === b) return 0
+      return a === UNKNOWN_RELEASE ? 1 : -1 // unknowns always last
+    }
+    return b.localeCompare(a) // later date first
+  }
+
   // One toggle row inside the picker modal. Incomplete sets get a "partial" tag so the host knows
   // those boosters draw from a reduced pool of implemented cards.
   const renderSetPickerRow = (set: AvailableSet) => {
     const isSelected = lobbyState.settings.setCodes.includes(set.code)
+    const released = formatReleaseDate(set.releaseDate)
     return (
       <button
         key={set.code}
@@ -792,6 +816,7 @@ function LobbyOverlay({
         <span className={styles.setPickerCheck} aria-hidden>{isSelected ? '✓' : ''}</span>
         <span className={styles.setPickerName}>{set.name}</span>
         {set.incomplete && <span className={styles.setPartialBadge}>partial</span>}
+        {released && <span className={styles.setReleaseDate}>{released}</span>}
         {set.implementedCount != null && (
           <span className={styles.setButtonCardCount}>{set.implementedCount} cards</span>
         )}
@@ -799,7 +824,9 @@ function LobbyOverlay({
     )
   }
 
-  // Group picker rows by block (first-seen order); ungrouped sets fall under an "Other" section.
+  // Order sets newest-first while keeping blocks grouped: each block is a single unit positioned by
+  // its newest set's release date, and each blockless set is its own unit. Units are sorted by date
+  // (newest on top), and sets within a block are sorted newest-first too.
   const renderGroupedSetRows = (sets: readonly AvailableSet[]) => {
     const blockOrder: string[] = []
     const blockSets = new Map<string, AvailableSet[]>()
@@ -815,18 +842,40 @@ function LobbyOverlay({
         ungrouped.push(set)
       }
     }
-    const groups: Array<{ key: string; label: string; sets: AvailableSet[] }> = blockOrder.map(
-      (name) => ({ key: name, label: `${name} Block`, sets: blockSets.get(name)! }),
-    )
-    if (ungrouped.length > 0) {
-      groups.push({ key: '__other', label: blockOrder.length > 0 ? 'Other sets' : 'All sets', sets: ungrouped })
+
+    type Unit =
+      | { kind: 'block'; key: string; label: string; sets: AvailableSet[]; sortKey: string }
+      | { kind: 'set'; key: string; set: AvailableSet; sortKey: string }
+
+    const units: Unit[] = []
+    for (const name of blockOrder) {
+      const blockMembers = blockSets
+        .get(name)!
+        .slice()
+        .sort((a, b) => byNewestFirst(releaseSortKey(a.releaseDate), releaseSortKey(b.releaseDate)))
+      units.push({
+        kind: 'block',
+        key: name,
+        label: `${name} Block`,
+        sets: blockMembers,
+        sortKey: releaseSortKey(blockMembers[0]?.releaseDate), // newest in block, after sort above
+      })
     }
-    return groups.map((group) => (
-      <div key={group.key} className={styles.setPickerGroup}>
-        <div className={styles.setPickerGroupLabel}>{group.label}</div>
-        {group.sets.map(renderSetPickerRow)}
-      </div>
-    ))
+    for (const set of ungrouped) {
+      units.push({ kind: 'set', key: set.code, set, sortKey: releaseSortKey(set.releaseDate) })
+    }
+    units.sort((a, b) => byNewestFirst(a.sortKey, b.sortKey))
+
+    return units.map((unit) =>
+      unit.kind === 'block' ? (
+        <div key={`block:${unit.key}`} className={styles.setPickerGroup}>
+          <div className={styles.setPickerGroupLabel}>{unit.label}</div>
+          {unit.sets.map(renderSetPickerRow)}
+        </div>
+      ) : (
+        renderSetPickerRow(unit.set)
+      ),
+    )
   }
 
   return (

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1032,6 +1032,8 @@ export interface AvailableSet {
   readonly incomplete?: boolean
   readonly block?: string
   readonly implementedCount?: number
+  /** Set release date in ISO `YYYY-MM-DD` form, or undefined if unknown. */
+  readonly releaseDate?: string
 }
 
 export interface LobbySettings {


### PR DESCRIPTION
## What

Surfaces each set's release date in the tournament set picker and sorts the sets newest-first (within their block grouping), so recent sets are easy to find.

- **Backend:** thread an optional `releaseDate` through `BoosterGenerator` set config → `ConnectionHandler` → `TournamentLobby` → the `ServerMessage` protocol → the client's `AvailableSet` type.
- **Frontend:** format the ISO `YYYY-MM-DD` date as e.g. "Oct 2002" in the picker, sort sets newest-first within each block (unknown dates sort last), and style the date label.

## Note on the branch

The original local branch was misleadingly named `perf-battlefield-card-rerenders` — but that perf work already shipped separately (PR #322). The only unmerged commit on it was this tournament-picker feature, so this PR is filed under an accurate branch name (`feat/tournament-picker-release-dates`).

## Validation

Rebased cleanly onto current `main`. Backend (`:rules-engine`, `:game-server`) compiles; web-client `tsc --noEmit` typecheck passes. UI-only feature — no automated tests (matches existing picker code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)