### PR TITLE
Delete DynamicAmount.CreaturesSharingTypeWithEntity, compose via AggregateBattlefield

### DIFF
--- a/backlog/sdk-quality-audit.md
+++ b/backlog/sdk-quality-audit.md
@@ -57,7 +57,13 @@ User counts are caller _files_ in `mtg-sets/src/main` (worktree copies excluded)
   so card call sites are unchanged. Preserve `CreatePermanentGlobalTriggeredAbilityEffect`'s
   `descriptionOverride` field.
 
-### 3. `DynamicAmount.CreaturesSharingTypeWithEntity` — pure composition
+### 3. `DynamicAmount.CreaturesSharingTypeWithEntity` — pure composition ✅ DONE
+- **Resolution:** Deleted the variant + evaluator branch. Alpha Status now uses
+  `AggregateBattlefield(Player.Each, GameObjectFilter.Creature.sharingCreatureTypeWith(EntityReference.AffectedEntity), excludeSelf = true)`.
+  Two supporting generalizations: `EntityReference.AffectedEntity` now resolves inside predicate
+  filters during projection (threaded through `PredicateContext`), and `AggregateBattlefield`'s
+  `excludeSelf` excludes the affected entity (not just the source) so granted "for each OTHER …"
+  effects exclude the right permanent.
 - **Location:** `scripting/values/DynamicAmount.kt:738`
 - **Standards:** #4, #5 (a `DynamicAmount` variant should only exist when it reads state no node can)
 - **Why:** The SDK already has `CardPredicate.SharesCreatureTypeWith(entity)` (evaluator-backed)

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -674,6 +674,12 @@ Every `TargetRequirement` carries count semantics (defaults shown):
 - `.withChosenColor()` — `CardPredicate.HasChosenColor`: matches the color chosen during the current
   effect's resolution (read from `EffectContext.chosenColor`, set by `Effects.ChooseColorThen`). Use with
   `AggregateBattlefield(Player.Each, …)` for "for each permanent of that color" (Coalition Dragon cycle).
+- `.sharingCreatureTypeWith(entity)` — `CardPredicate.SharesCreatureTypeWith(entity)`: shares ≥1 (projected)
+  creature subtype with a referenced entity. `entity` may be `EntityReference.AffectedEntity`, which resolves
+  to the creature a continuous effect is being applied to during projection — combine with
+  `AggregateBattlefield(Player.Each, GameObjectFilter.Creature.sharingCreatureTypeWith(EntityReference.AffectedEntity), excludeSelf = true)`
+  for "+X/+X for each OTHER creature that shares a creature type with it" (Alpha Status). In a granted
+  context `excludeSelf` excludes the affected (enchanted) creature, not the granting source.
 - `.sharingColorWith(entity)` — `CardPredicate.SharesColorWith(entity)`: shares ≥1 (projected) color with
   a referenced entity (e.g. `EntityReference.Triggering`). Mirror of `.sharingCreatureTypeWith(entity)`.
   Colorless entities share no color (never match). Used by Spreading Plague ("destroy all other creatures

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -731,15 +731,4 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
     }
 
-    /**
-     * Count other creatures on the battlefield that share a creature type with the referenced entity.
-     * Used for Alpha Status: "+2/+2 for each other creature that shares a creature type with it."
-     */
-    @SerialName("CreaturesSharingTypeWithEntity")
-    @Serializable
-    data class CreaturesSharingTypeWithEntity(val entity: EntityReference) : DynamicAmount {
-        override val description: String = "the number of other creatures that share a creature type with ${entity.description}"
-        override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
-    }
-
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/AlphaStatus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/AlphaStatus.kt
@@ -1,10 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.scg.cards
 
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityReference
 
@@ -25,7 +27,15 @@ val AlphaStatus = card("Alpha Status") {
     auraTarget = Targets.Creature
 
     staticAbility {
-        val sharedTypeCount = DynamicAmount.CreaturesSharingTypeWithEntity(EntityReference.AffectedEntity)
+        // "each OTHER creature that shares a creature type with the enchanted creature" — count
+        // every battlefield creature sharing a type with the affected (enchanted) creature, then
+        // exclude that creature itself. excludeSelf resolves "self" to the affected entity here,
+        // since the bonus is granted to the enchanted creature rather than to the Aura source.
+        val sharedTypeCount = DynamicAmount.AggregateBattlefield(
+            player = Player.Each,
+            filter = GameObjectFilter.Creature.sharingCreatureTypeWith(EntityReference.AffectedEntity),
+            excludeSelf = true,
+        )
         ability = GrantDynamicStatsEffect(
             filter = GroupFilter.attachedCreature(),
             powerBonus = DynamicAmount.Multiply(sharedTypeCount, 2),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -326,30 +326,6 @@ class DynamicAmountEvaluator(
                 }
             }
 
-            is DynamicAmount.CreaturesSharingTypeWithEntity -> {
-                val entityId = resolveEntityId(amount.entity, context, state) ?: return 0
-                val projection = resolveProjection(state, projectedState)
-
-                // Projection has no entry off the battlefield — fall back to base CardComponent.
-                val entitySubtypes = projection.getSubtypes(entityId).ifEmpty {
-                    state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.subtypes?.map { it.value }?.toSet()
-                        ?: return 0
-                }
-                if (entitySubtypes.isEmpty()) return 0
-
-                state.getBattlefield().count { otherId ->
-                    if (otherId == entityId) return@count false
-                    val isCreature = projection.getTypes(otherId).contains("CREATURE")
-                        || state.getEntity(otherId)?.get<CardComponent>()?.typeLine?.isCreature == true
-                    if (!isCreature) return@count false
-                    val subtypes = projection.getSubtypes(otherId).ifEmpty {
-                        state.getEntity(otherId)?.get<CardComponent>()?.typeLine?.subtypes?.map { it.value }?.toSet()
-                            ?: emptySet()
-                    }
-                    subtypes.any { it in entitySubtypes }
-                }
-            }
-
         }
     }
 
@@ -466,11 +442,17 @@ class DynamicAmountEvaluator(
         val predicateContext = PredicateContext.fromEffectContext(context)
         val projection = resolveProjection(state, explicitProjection)
 
+        // "Self" is the affected entity when this aggregate is evaluated for a granted effect
+        // (e.g. an Aura's "for each OTHER creature that shares a type with the enchanted creature":
+        // self is the enchanted creature, not the Aura source). For a creature's own CDA there is
+        // no affected entity, so it falls back to the source — the creature itself.
+        val selfId = context.affectedEntityId ?: context.sourceId
+
         val matchingEntities = playerIds.flatMap { playerId ->
             state.getBattlefield()
                 .filter { entityId ->
                     // Exclude self if requested (e.g., "other creatures you control")
-                    if (amount.excludeSelf && entityId == context.sourceId) return@filter false
+                    if (amount.excludeSelf && entityId == selfId) return@filter false
                     controllerOf(state, projection, entityId) == playerId
                 }
                 .filter { entityId ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -588,7 +588,7 @@ class PredicateEvaluator {
             is EntityReference.Target -> null // Not available in predicate context
             is EntityReference.Sacrificed -> null
             is EntityReference.TappedAsCost -> null
-            is EntityReference.AffectedEntity -> null // Only available during projection
+            is EntityReference.AffectedEntity -> context?.affectedEntityId
             is EntityReference.IterationEntity -> null // Only available during ForEachInGroup iteration
             is EntityReference.FromCostStorage -> null // Cost-pipeline state is not threaded into PredicateContext
             is EntityReference.EnchantedCreature -> null // Attachment lookup needs state, not threaded here
@@ -865,6 +865,13 @@ data class PredicateContext(
     val ownerId: EntityId? = null,
     /** The entity that caused the trigger to fire (for SharesCreatureTypeWithTriggeringEntity) */
     val triggeringEntityId: EntityId? = null,
+    /**
+     * The entity a continuous effect is being applied to during projection (e.g. the creature an
+     * Aura is enchanting). Lets filters resolve [EntityReference.AffectedEntity] — needed by
+     * `AggregateBattlefield(filter = ...sharingCreatureTypeWith(AffectedEntity))` for Alpha Status.
+     * Only set during projection-time evaluation; null otherwise.
+     */
+    val affectedEntityId: EntityId? = null,
     /** Named values chosen by the player during pipeline execution (e.g., creature type, color). */
     val chosenValues: Map<String, String> = emptyMap(),
     /** Named string lists stored by pipeline effects (e.g., chosen creature types). */
@@ -933,6 +940,7 @@ data class PredicateContext(
                 targetPlayerId = chosenPlayerTarget ?: context.opponentId,
                 sourceId = context.sourceId,
                 triggeringEntityId = context.triggeringEntityId,
+                affectedEntityId = context.affectedEntityId,
                 chosenValues = context.pipeline.chosenValues,
                 storedStringLists = context.pipeline.storedStringLists,
                 storedSubtypeGroups = context.pipeline.storedSubtypeGroups,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlphaStatusTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlphaStatusTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Alpha Status: "Enchanted creature gets +2/+2 for each OTHER creature on the battlefield that
+ * shares a creature type with it."
+ *
+ * Exercises the composition that replaced the bespoke `DynamicAmount.CreaturesSharingTypeWithEntity`
+ * variant: `AggregateBattlefield(Player.Each, Creature.sharingCreatureTypeWith(AffectedEntity),
+ * excludeSelf = true)`. Two engine behaviours are under test:
+ *   - `EntityReference.AffectedEntity` resolves inside an `AggregateBattlefield` filter predicate
+ *     during projection (so the filter knows which creature "it" refers to).
+ *   - `excludeSelf` excludes the *affected* (enchanted) creature, not the Aura source — otherwise
+ *     the enchanted creature would count itself (it trivially shares all its own types).
+ */
+class AlphaStatusTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // Mirror of the real Alpha Status static ability, defined inline because rules-engine tests
+    // cannot depend on mtg-sets.
+    val AlphaStatus = card("Alpha Status") {
+        manaCost = "{2}{G}"
+        typeLine = "Enchantment — Aura"
+        auraTarget = Targets.Creature
+
+        staticAbility {
+            val sharedTypeCount = DynamicAmount.AggregateBattlefield(
+                player = Player.Each,
+                filter = GameObjectFilter.Creature.sharingCreatureTypeWith(EntityReference.AffectedEntity),
+                excludeSelf = true,
+            )
+            ability = GrantDynamicStatsEffect(
+                filter = GroupFilter.attachedCreature(),
+                powerBonus = DynamicAmount.Multiply(sharedTypeCount, 2),
+                toughnessBonus = DynamicAmount.Multiply(sharedTypeCount, 2),
+            )
+        }
+    }
+
+    fun goblin(name: String) = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse("{1}{R}"),
+        subtypes = setOf(Subtype("Goblin")),
+        power = 2,
+        toughness = 2,
+    )
+
+    val Elf = CardDefinition.creature(
+        name = "Test Elf",
+        manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Elf")),
+        power = 1,
+        toughness = 1,
+    )
+
+    val Typeless = CardDefinition.creature(
+        name = "Test Typeless",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = emptySet(),
+        power = 3,
+        toughness = 3,
+    )
+
+    fun GameTestDriver.attachAura(auraId: EntityId, targetId: EntityId) {
+        replaceState(state.updateEntity(auraId) { container ->
+            container.with(AttachedToComponent(targetId))
+        })
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AlphaStatus)
+        driver.registerCard(goblin("Test Goblin A"))
+        driver.registerCard(goblin("Test Goblin B"))
+        driver.registerCard(goblin("Test Goblin C"))
+        driver.registerCard(Elf)
+        driver.registerCard(Typeless)
+        return driver
+    }
+
+    test("counts other creatures sharing a type, excluding the enchanted creature and unrelated types") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Enchanted Goblin (2/2) + two more Goblins (one on each side) + an Elf + a typeless creature.
+        val enchanted = driver.putCreatureOnBattlefield(p1, "Test Goblin A")
+        driver.putCreatureOnBattlefield(p1, "Test Goblin B")
+        driver.putCreatureOnBattlefield(p2, "Test Goblin C") // shared types count across all players
+        driver.putCreatureOnBattlefield(p1, "Test Elf")
+        driver.putCreatureOnBattlefield(p1, "Test Typeless")
+
+        val aura = driver.putPermanentOnBattlefield(p1, "Alpha Status")
+        driver.attachAura(aura, enchanted)
+
+        // 2 OTHER Goblins share the type → +2/+2 each = +4/+4 on a 2/2 base → 6/6.
+        // The enchanted Goblin itself, the Elf, and the typeless creature are not counted.
+        val projected = projector.project(driver.state)
+        projected.getPower(enchanted) shouldBe 6
+        projected.getToughness(enchanted) shouldBe 6
+    }
+
+    test("enchanted creature with no creature subtypes gets no bonus") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val enchanted = driver.putCreatureOnBattlefield(p1, "Test Typeless")
+        driver.putCreatureOnBattlefield(p1, "Test Goblin A")
+        driver.putCreatureOnBattlefield(p1, "Test Goblin B")
+
+        val aura = driver.putPermanentOnBattlefield(p1, "Alpha Status")
+        driver.attachAura(aura, enchanted)
+
+        // Shares no creature type with anything → +0/+0, stays 3/3.
+        val projected = projector.project(driver.state)
+        projected.getPower(enchanted) shouldBe 3
+        projected.getToughness(enchanted) shouldBe 3
+    }
+})


### PR DESCRIPTION
Resolves **item #3** of the [SDK quality audit](../blob/main/backlog/sdk-quality-audit.md): `DynamicAmount.CreaturesSharingTypeWithEntity` — pure composition.

## What

The bespoke `CreaturesSharingTypeWithEntity` variant (and its hand-rolled evaluator loop in `DynamicAmountEvaluator.kt`) re-implemented what existing primitives already express: counting battlefield creatures matched by `CardPredicate.SharesCreatureTypeWith` via `AggregateBattlefield`. Deleted the variant + its evaluator branch.

Alpha Status — the only user — now composes:

```kotlin
DynamicAmount.AggregateBattlefield(
    player = Player.Each,
    filter = GameObjectFilter.Creature.sharingCreatureTypeWith(EntityReference.AffectedEntity),
    excludeSelf = true,
)
```

This also gives the previously-unused `SharesCreatureTypeWith` predicate its first real user.

## Two supporting generalizations

The audit's suggested one-liner didn't work as-written; two small, well-contained engine fixes were needed to make the composition correct:

1. **`EntityReference.AffectedEntity` now resolves inside predicate filters during projection.** It was previously dropped (`-> null`) in `PredicateEvaluator.resolveEntityReference`, so the filter couldn't know which creature "it" refers to. Now threaded through `PredicateContext` (set only during projection-time evaluation).

2. **`AggregateBattlefield.excludeSelf` now excludes the affected entity when present** (`affectedEntityId ?: sourceId`), not just the source. For a granted "for each OTHER creature …" effect, "self" is the enchanted creature, not the granting Aura. CDAs — where there is no affected entity — fall back to the source and are unchanged. `affectedEntityId` is only ever populated by the dynamic P/T projection path, so no other caller is affected.

## Tests

- New `AlphaStatusTest`: shared-type count (+2/+2 per other sharer), self-exclusion of the enchanted creature, cross-player counting (`Player.Each`), and the no-subtype edge case (no bonus).
- Full `:rules-engine:test` suite green; `:mtg-sdk:test` and `:mtg-sets:test` green.

## Docs

Updated `card-sdk-language-reference.md` with a `.sharingCreatureTypeWith(entity)` entry documenting the `AffectedEntity`-in-projection + `excludeSelf` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)