### PR TITLE
Skip attack combat simulation when opponent has no creatures

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
@@ -169,8 +169,15 @@ class CombatAdvisor(
         }
 
         // ── Local search: try add/remove mutations via simulation ──
-        // Only run if we're at DECLARE_ATTACKERS (simulation needs to submit DeclareAttackers)
-        if (state.step == Step.DECLARE_ATTACKERS) {
+        // Only run if we're at DECLARE_ATTACKERS (simulation needs to submit DeclareAttackers).
+        // Skip entirely when no opponent controls a creature: nothing can block, so combat is
+        // deterministic, and with zero enemy creatures there's no crack-back to weigh — the
+        // heuristic seed (attack with everything) is already optimal. Running a full-combat
+        // simulation here only burns time without ever changing the plan.
+        val enemyControlsCreature = state.turnOrder.any { other ->
+            other != playerId && projected.getBattlefieldControlledBy(other).any { projected.isCreature(it) }
+        }
+        if (state.step == Step.DECLARE_ATTACKERS && enemyControlsCreature) {
             val deadline = System.currentTimeMillis() + 1000
             improveAttackViaLocalSearch(
                 state, playerId, opponentId, validAttackers, mandatory.toSet(), seedMap, deadline


### PR DESCRIPTION
## Problem

The engine AI was running a full combat simulation when declaring attackers even in situations where the outcome was already determined.

The genuinely-empty cases were already covered:
- The engine auto-skips `DECLARE_ATTACKERS`/`DECLARE_BLOCKERS` when there are no valid attackers / no attacking creatures (`TurnManager.kt:294-308`).
- `CombatAdvisor.chooseAttackers`/`chooseBlockers` early-return on empty valid-attacker/blocker lists.

The remaining gap: when the AI declares attackers and **the opponent controls no creatures**, the code still ran `improveAttackViaLocalSearch` → `simulateFullAttack` (a full declare → block → damage simulation, up to ~1s of add/remove mutations). With nothing able to block, combat is deterministic, the heuristic seed already attacks with everything, and there's no crack-back to weigh — so those simulations could never change the plan.

## Fix

Guard the attack local search behind an `enemyControlsCreature` check. If no opposing player controls any creature, skip the simulation and return the heuristic seed directly.

The check counts **any** enemy creature, including tapped ones — a tapped enemy creature can't block now but untaps to crack back next turn, so the local search's hold-back reasoning still runs in that case. It only short-circuits when the enemy board is truly empty.

## Testing

- `:ai:compileKotlin` clean
- `CombatAdvisorTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)