### PR TITLE
Replace IsFirstSpellOfTypeCastThisTurn with a composable primitive + facade

### DIFF
--- a/backlog/sdk-quality-audit.md
+++ b/backlog/sdk-quality-audit.md
@@ -77,16 +77,23 @@ User counts are caller _files_ in `mtg-sets/src/main` (worktree copies excluded)
   Delete the variant + its evaluator branch. (Bonus: gives the unused `SharesCreatureTypeWith`
   predicate its first real user.)
 
-### 4. `IsFirstSpellOfTypeCastThisTurn` — duplicate of `PlayerCastSpellsThisTurn`, no facade
+### 4. `IsFirstSpellOfTypeCastThisTurn` — duplicate of `PlayerCastSpellsThisTurn`, no facade ✅ RESOLVED
 - **Location:** `scripting/conditions/TurnConditions.kt:136`
 - **Standards:** #3, #4, plus the "use the facades" load-bearing rule (card builds the raw type)
 - **Why:** Means "exactly one matching spell cast by you this turn." Expressible as
   `All(YouCastSpellsThisTurn(1, filter), Not(YouCastSpellsThisTurn(2, filter)))` over the existing
   `PlayerCastSpellsThisTurn` primitive. Has **no `Conditions.*` facade entry**.
 - **Users:** 1 (`AlaniaDivergentStorm.kt`).
-- **Fix:** Delete the type; express Alania via the `PlayerCastSpellsThisTurn`-backed
-  `Conditions.YouCastSpellsThisTurn` composed with `Conditions.Not`. If "first of type" is worth
-  keeping, add a facade helper re-implemented on top of `PlayerCastSpellsThisTurn`.
+- **Resolution:** Type deleted. The count-only decomposition above was **rejected as buggy** — it
+  drops the evaluator's guard that *the triggering spell itself matches the filter*, so casting a
+  non-matching spell after one matching spell would wrongly fire (an instant cast earlier this turn
+  would satisfy `YouCastSpellsThisTurn(1, Instant)` even while a creature is the spell being cast).
+  Instead added a small, genuinely-general primitive `TriggeringSpellMatchesFilter(filter)` (facade
+  `Conditions.TriggeringSpellMatches`) and a composing facade
+  `Conditions.YouCastFirstSpellOfTypeThisTurn(filter)` =
+  `All(TriggeringSpellMatches(filter), Not(YouCastSpellsThisTurn(2, filter)))` — reusing the
+  `PlayerCastSpellsThisTurn` count instead of a bespoke loop. Alania now uses the facade. Covered by
+  `AlaniaDivergentStormTest` (incl. the guard case). See `card-sdk-language-reference.md`.
 
 ---
 
@@ -212,7 +219,7 @@ Each touches shared SDK types with cross-layer wiring, so route through the **`a
 1. #1 `TapTargetCreaturesEffect` (kills the `20` sentinel)
 2. #2 `CreateGlobalTriggeredAbility*` 3→1 collapse
 3. #3 `CreaturesSharingTypeWithEntity` delete
-4. #4 `IsFirstSpellOfTypeCastThisTurn` delete
+4. #4 `IsFirstSpellOfTypeCastThisTurn` delete ✅ done
 5. #5 delete zero-user protection-Group variant; then MEDIUM batch
 6. #9 inline single-card `EffectPatterns` helpers
 7. LOW cleanup

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1566,6 +1566,16 @@ default to "you" so card authors don't need to pass it explicitly.
   `PlayerAttackedWithCreaturesThisTurn(Player.You, filter, atLeast)`.
 - `YouCastSpellsThisTurn(atLeast, filter)` — Prowess/Magecraft shape. Backed by
   `PlayerCastSpellsThisTurn(Player.You, filter, atLeast)`.
+- `TriggeringSpellMatches(filter)` — intervening-if guard: the spell that triggered this ability
+  matches `filter`. Reads the triggering entity's static card characteristics (so it stays correct
+  after the spell leaves the stack). General "whenever you cast a spell, if it's a/an X ..." gate.
+  Backed by `TriggeringSpellMatchesFilter(filter)`.
+- `YouCastFirstSpellOfTypeThisTurn(filter)` — true when the triggering spell is the *first* spell
+  matching `filter` you've cast this turn. Pure composition, no bespoke counting:
+  `All(TriggeringSpellMatches(filter), Not(YouCastSpellsThisTurn(atLeast = 2, filter)))`. The
+  `TriggeringSpellMatches` half is load-bearing — it stops a later non-matching cast from satisfying
+  the count once one matching spell exists. Used by Alania, Divergent Storm (first instant / first
+  sorcery / first Otter).
 - `YouHaveCitysBlessing` — Ascend gate. Backed by `PlayerHasCitysBlessing(Player.You)`.
 - `IsFirstSpellPaidWithTreasureManaCastThisTurn` — gates a triggered ability to fire only
   on the first spell each turn that mana from a Treasure was spent to cast (Rain of

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -733,6 +733,27 @@ object Conditions {
     val TriggeringSpellHasSingleTarget: ConditionInterface =
         com.wingedsheep.sdk.scripting.conditions.TriggeringSpellHasSingleTarget
 
+    /**
+     * If the spell that triggered this ability matches [filter].
+     * General intervening-if guard for "whenever you cast a spell, if it's a/an X ..." cards.
+     */
+    fun TriggeringSpellMatches(filter: com.wingedsheep.sdk.scripting.GameObjectFilter): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TriggeringSpellMatchesFilter(filter)
+
+    /**
+     * If the spell that triggered this ability is the first spell matching [filter] you've cast
+     * this turn. True iff the triggering spell matches [filter] and no second matching spell has
+     * been cast yet. Composed from [TriggeringSpellMatches] + the [YouCastSpellsThisTurn] count
+     * primitive (no bespoke counting logic). Used by Alania, Divergent Storm.
+     */
+    fun YouCastFirstSpellOfTypeThisTurn(
+        filter: com.wingedsheep.sdk.scripting.GameObjectFilter
+    ): ConditionInterface =
+        All(
+            TriggeringSpellMatches(filter),
+            Not(YouCastSpellsThisTurn(atLeast = 2, filter = filter))
+        )
+
     // =========================================================================
     // Collection Conditions (pipeline-based)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -152,6 +152,29 @@ data object TriggeringSpellHasSingleTarget : Condition {
 }
 
 /**
+ * Condition: "if it's a/an [filter] spell" — true iff the spell that triggered this ability
+ * matches [filter]. Reads the triggering entity (the spell of a "whenever you cast a spell"
+ * trigger) by its static card characteristics, so it stays correct even after the spell has
+ * left the stack. Resolution-only.
+ *
+ * General intervening-if guard for "whenever you cast a spell, if it's a/an X ..." cards. Compose
+ * with [PlayerCastSpellsThisTurn] for "first X spell this turn" payoffs — see
+ * `Conditions.YouCastFirstSpellOfTypeThisTurn`, which ANDs this with
+ * `Not(PlayerCastSpellsThisTurn(filter, atLeast = 2))` so the count machinery isn't duplicated.
+ */
+@SerialName("TriggeringSpellMatchesFilter")
+@Serializable
+data class TriggeringSpellMatchesFilter(
+    val filter: GameObjectFilter
+) : Condition {
+    override val description: String = "if it's ${filter.description.ifEmpty { "a matching" }} spell"
+    override fun applyTextReplacement(replacer: TextReplacer): Condition {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Condition: "if [target] is [filter]"
  * Checks whether a context target matches a GameObjectFilter.
  * Used for cards like Blessing of Belzenlok: "If it's legendary, it also gains lifelink."

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
@@ -129,20 +129,6 @@ data class PlayerCastSpellsThisTurn(
 }
 
 /**
- * Condition: "if this is the first spell matching the given filter cast by you this turn"
- * Checks the per-player spell record tracker. The condition is true if exactly one spell
- * matching the filter has been cast (just this spell). Used for Alania, Divergent Storm.
- */
-@SerialName("IsFirstSpellOfTypeCastThisTurn")
-@Serializable
-data class IsFirstSpellOfTypeCastThisTurn(
-    val spellFilter: GameObjectFilter
-) : Condition {
-    override val description: String = "if it's the first ${spellFilter.description} spell you've cast this turn"
-    override fun applyTextReplacement(replacer: TextReplacer): Condition = this
-}
-
-/**
  * Condition: "if this is the first spell you've cast this turn that mana from a Treasure
  * was spent to cast." Used by Rain of Riches.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/AlaniaDivergentStorm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/AlaniaDivergentStorm.kt
@@ -1,12 +1,11 @@
 package com.wingedsheep.mtg.sets.definitions.blb.cards
 
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.conditions.AnyCondition
-import com.wingedsheep.sdk.scripting.conditions.IsFirstSpellOfTypeCastThisTurn
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CopyTargetSpellEffect
 import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
@@ -33,12 +32,10 @@ val AlaniaDivergentStorm = card("Alania, Divergent Storm") {
 
     triggeredAbility {
         trigger = Triggers.YouCastSpell
-        triggerCondition = AnyCondition(
-            listOf(
-                IsFirstSpellOfTypeCastThisTurn(GameObjectFilter.Instant),
-                IsFirstSpellOfTypeCastThisTurn(GameObjectFilter.Sorcery),
-                IsFirstSpellOfTypeCastThisTurn(GameObjectFilter.Any.withSubtype(com.wingedsheep.sdk.core.Subtype("Otter")))
-            )
+        triggerCondition = Conditions.Any(
+            Conditions.YouCastFirstSpellOfTypeThisTurn(GameObjectFilter.Instant),
+            Conditions.YouCastFirstSpellOfTypeThisTurn(GameObjectFilter.Sorcery),
+            Conditions.YouCastFirstSpellOfTypeThisTurn(GameObjectFilter.Any.withSubtype(com.wingedsheep.sdk.core.Subtype("Otter")))
         )
         val opponent = target("opponent", Targets.Opponent)
         effect = ReflexiveTriggerEffect(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -71,8 +71,8 @@ import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadMinusOneMinus
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityWasHistoric
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityWasNotPutByThisSource
 import com.wingedsheep.sdk.scripting.conditions.TriggeringSpellHasSingleTarget
+import com.wingedsheep.sdk.scripting.conditions.TriggeringSpellMatchesFilter
 import com.wingedsheep.sdk.scripting.conditions.CollectionContainsMatch
-import com.wingedsheep.sdk.scripting.conditions.IsFirstSpellOfTypeCastThisTurn
 import com.wingedsheep.sdk.scripting.conditions.IsFirstSpellPaidWithTreasureManaCastThisTurn
 import com.wingedsheep.sdk.scripting.conditions.SourceAbilityResolvedNTimesThisTurn
 import com.wingedsheep.sdk.scripting.conditions.ManaSpentToCastIncludes
@@ -216,13 +216,13 @@ class ConditionEvaluator {
             is TriggeringEntityWasNotPutByThisSource ->
                 ifResolution { evaluateTriggeringEntityWasNotPutByThisSource(state, it) }
             is TriggeringSpellHasSingleTarget -> ifResolution { evaluateTriggeringSpellHasSingleTarget(state, it) }
+            is TriggeringSpellMatchesFilter -> ifResolution { evaluateTriggeringSpellMatchesFilter(state, condition, it) }
             is TargetMatchesFilter -> ifResolution { evaluateTargetMatchesFilter(state, condition, it) }
             is TargetSharesMostCommonColor -> ifResolution { evaluateTargetSharesMostCommonColor(state, condition, it) }
             is AnotherPermanentWithSameNameAsTarget ->
                 ifResolution { evaluateAnotherPermanentWithSameNameAsTarget(state, condition, it) }
             is IsInPhase -> ifResolution { evaluateIsInPhase(state, condition, it) }
             is YouWereAttackedThisStep -> ifResolution { evaluateYouWereAttackedThisStep(state, it) }
-            is IsFirstSpellOfTypeCastThisTurn -> ifResolution { evaluateFirstSpellOfType(state, condition, it) }
             is IsFirstSpellPaidWithTreasureManaCastThisTurn ->
                 ifResolution { evaluateFirstSpellPaidWithTreasureMana(state, it) }
             is SourceAbilityResolvedNTimesThisTurn -> ifResolution { evaluateSourceAbilityResolvedNTimes(state, condition, it) }
@@ -745,13 +745,15 @@ class ConditionEvaluator {
         return colorCounts.filterValues { it == maxCount }.keys
     }
 
-    private fun evaluateFirstSpellOfType(
+    private fun evaluateTriggeringSpellMatchesFilter(
         state: GameState,
-        condition: IsFirstSpellOfTypeCastThisTurn,
+        condition: TriggeringSpellMatchesFilter,
         context: EffectContext
     ): Boolean {
-        // The triggering spell itself must match the filter — otherwise casting an artifact
-        // when one instant was already cast this turn would incorrectly match the Instant filter.
+        // Match the triggering spell by its static card characteristics so the check stays correct
+        // even after the spell has left the stack. Composes with PlayerCastSpellsThisTurn (via
+        // Conditions.YouCastFirstSpellOfTypeThisTurn) to express "first X spell this turn" — this
+        // guard is what stops a non-matching cast from satisfying that count-based payoff.
         val triggeringId = context.triggeringEntityId ?: return false
         val entity = state.getEntity(triggeringId) ?: return false
         val card = entity.get<CardComponent>() ?: return false
@@ -761,12 +763,7 @@ class ConditionEvaluator {
             colors = card.colors,
             isFaceDown = entity.has<com.wingedsheep.engine.state.components.identity.FaceDownComponent>()
         )
-        val evaluator = PredicateEvaluator()
-        if (!evaluator.matchesFilter(triggeringRecord, condition.spellFilter)) return false
-
-        val records = state.spellsCastThisTurnByPlayer[context.controllerId] ?: return false
-        val count = records.count { evaluator.matchesFilter(it, condition.spellFilter) }
-        return count == 1
+        return PredicateEvaluator().matchesFilter(triggeringRecord, condition.filter)
     }
 
     private fun evaluateFirstSpellPaidWithTreasureMana(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlaniaDivergentStormTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlaniaDivergentStormTest.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.AlaniaDivergentStorm
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Alania, Divergent Storm {3}{U}{R} — Otter Wizard 3/5.
+ * "Whenever you cast a spell, if it's the first instant spell, the first sorcery spell,
+ *  or the first Otter spell other than Alania you've cast this turn, you may have target
+ *  opponent draw a card. If you do, copy that spell."
+ *
+ * The intervening-if is built from `Conditions.YouCastFirstSpellOfTypeThisTurn(filter)`,
+ * which composes `TriggeringSpellMatches(filter)` with `Not(YouCastSpellsThisTurn(2, filter))`
+ * on top of the shared `PlayerCastSpellsThisTurn` count primitive (no bespoke counting).
+ *
+ * These tests pin the load-bearing part of that composition: the `TriggeringSpellMatches`
+ * guard. Without it, casting a *non-matching* spell after one matching spell would wrongly
+ * satisfy the count-based half and fire the ability — the exact bug a count-only
+ * decomposition would introduce.
+ */
+class AlaniaDivergentStormTest : FunSpec({
+
+    // Inline Otter creature for the "first Otter spell" branch — avoids depending on
+    // set-specific Otters and keeps the cast cheap.
+    val TestOtter = CardDefinition.creature(
+        name = "Test Otter",
+        manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Otter")),
+        power = 1,
+        toughness = 1
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AlaniaDivergentStorm, TestOtter))
+        return driver
+    }
+
+    /**
+     * Resolve the entire stack after a cast, declining Alania's optional "may have target
+     * opponent draw a card" prompt so the board stays clean for the next cast. Returns
+     * whether that prompt was ever offered — i.e. whether Alania's ability triggered.
+     */
+    fun GameTestDriver.castAndDidAlaniaFire(controller: EntityId, cast: () -> Unit): Boolean {
+        cast()
+        var fired = false
+        var guard = 0
+        while (stackSize > 0 && guard++ < 60) {
+            val decision = pendingDecision
+            when {
+                decision is YesNoDecision -> {
+                    fired = true
+                    submitYesNo(controller, false) // decline the optional draw+copy
+                }
+                decision != null -> autoResolveDecision() // e.g. Careful Study's discard
+                else -> bothPass()
+            }
+        }
+        return fired
+    }
+
+    fun GameTestDriver.setup(): Pair<EntityId, EntityId> {
+        initMirrorMatch(deck = Deck.of("Island" to 40))
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = activePlayer!!
+        val opponent = getOpponent(you)
+        // Put Alania directly on the battlefield so casting it doesn't count toward the turn.
+        putCreatureOnBattlefield(you, "Alania, Divergent Storm")
+        return you to opponent
+    }
+
+    test("fires on the first instant spell of the turn") {
+        val driver = createDriver()
+        val (you, opponent) = driver.setup()
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+
+        val fired = driver.castAndDidAlaniaFire(you) {
+            driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+        }
+        fired shouldBe true
+    }
+
+    test("fires on the first sorcery spell of the turn") {
+        val driver = createDriver()
+        val (you, _) = driver.setup()
+
+        driver.giveMana(you, Color.BLACK, 1)
+        val study = driver.putCardInHand(you, "Careful Study")
+
+        val fired = driver.castAndDidAlaniaFire(you) {
+            driver.castSpell(you, study, emptyList()).error shouldBe null
+        }
+        fired shouldBe true
+    }
+
+    test("fires on the first Otter spell of the turn") {
+        val driver = createDriver()
+        val (you, _) = driver.setup()
+
+        driver.giveMana(you, Color.BLUE, 1)
+        val otter = driver.putCardInHand(you, "Test Otter")
+
+        val fired = driver.castAndDidAlaniaFire(you) {
+            driver.castSpell(you, otter, emptyList()).error shouldBe null
+        }
+        fired shouldBe true
+    }
+
+    test("does NOT fire on a second instant cast the same turn") {
+        val driver = createDriver()
+        val (you, opponent) = driver.setup()
+
+        driver.giveMana(you, Color.RED, 2)
+        val bolt1 = driver.putCardInHand(you, "Lightning Bolt")
+        val bolt2 = driver.putCardInHand(you, "Lightning Bolt")
+
+        driver.castAndDidAlaniaFire(you) {
+            driver.castSpellWithTargets(you, bolt1, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+        } shouldBe true
+
+        // Second instant this turn — the count half (Not(>= 2 instants)) is now false.
+        driver.castAndDidAlaniaFire(you) {
+            driver.castSpellWithTargets(you, bolt2, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+        } shouldBe false
+    }
+
+    test("guard: does NOT fire on a non-matching spell cast after one matching spell") {
+        val driver = createDriver()
+        val (you, opponent) = driver.setup()
+
+        // First an instant — fires.
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castAndDidAlaniaFire(you) {
+            driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+        } shouldBe true
+
+        // Then a vanilla (non-instant, non-sorcery, non-Otter) creature. One instant has been
+        // cast this turn, so a count-only decomposition would wrongly fire the instant branch.
+        // The TriggeringSpellMatches guard keeps it correct: the creature matches no branch.
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveColorlessMana(you, 2)
+        val courser = driver.putCardInHand(you, "Centaur Courser")
+        driver.castAndDidAlaniaFire(you) {
+            driver.castSpell(you, courser, emptyList()).error shouldBe null
+        } shouldBe false
+    }
+})


### PR DESCRIPTION
Fixes **SDK quality audit item #4** (`backlog/sdk-quality-audit.md`):
`IsFirstSpellOfTypeCastThisTurn` — duplicate of `PlayerCastSpellsThisTurn`, no facade.

## Problem
The card-shaped `IsFirstSpellOfTypeCastThisTurn` condition re-implemented the spell-counting
loop that `PlayerCastSpellsThisTurn` already owns, and had no `Conditions.*` facade — Alania,
Divergent Storm constructed the raw type directly (violating the "use the facades" rule).

## Why the audit's suggested fix wasn't applied verbatim
The audit proposed deleting the type and expressing it as
`All(YouCastSpellsThisTurn(1, filter), Not(YouCastSpellsThisTurn(2, filter)))`. That decomposition
is **subtly buggy**: it drops the evaluator's guard that *the triggering spell itself must match the
filter*. Without it, casting a non-matching spell after one matching spell would wrongly satisfy the
count and fire the ability (e.g. one instant cast earlier this turn would fire the "first instant"
branch even when the spell being cast is a creature).

## What this does instead
- Adds **`TriggeringSpellMatchesFilter(filter)`** — a small, genuinely-general intervening-if
  primitive ("the spell that triggered this ability matches X"), facade
  `Conditions.TriggeringSpellMatches`. Reads the triggering spell's static characteristics, so it
  stays correct after the spell leaves the stack.
- Adds facade **`Conditions.YouCastFirstSpellOfTypeThisTurn(filter)`** =
  `All(TriggeringSpellMatches(filter), Not(YouCastSpellsThisTurn(2, filter)))` — reuses the shared
  `PlayerCastSpellsThisTurn` count instead of a bespoke loop.
- Deletes `IsFirstSpellOfTypeCastThisTurn` and its `ConditionEvaluator` branch.
- Repoints **Alania, Divergent Storm** at the facade.
- Documents both conditions in `card-sdk-language-reference.md`.

## Tests
New `AlaniaDivergentStormTest` covers:
- fires on the first instant / sorcery / Otter spell of the turn,
- does **not** fire on a second instant the same turn (the count half),
- **guard:** does **not** fire on a non-matching creature cast after one matching instant — the case
  the count-only decomposition would have gotten wrong.

`just build` + full `:mtg-sdk:test` and `:rules-engine:test` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)