### PR TITLE
Sacrifice-a-token cost (TDM gap item 20) + Hardened Tactician

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -5,7 +5,7 @@ capabilities (SDK reference + source verification, May 2026). Generated to scope
 built before the set can be completed.
 
 **Status:** 49 / 271 implemented (18%). All five wedge clan keywords (Tier 1), every Tier-2
-primitive, and all but three Tier-3 one-offs are now built — only items 15, 18, and 20 remain.
+primitive, and all but two Tier-3 one-offs are now built — only items 15 and 18 remain.
 Card list comes from `scripts/card-status --list --set TDM`. Oracle text pulled from Scryfall
 (`set:tdm`, 277 printings → 271 unique cards).
 
@@ -43,7 +43,7 @@ What follows are the **genuine gaps** — elements no current SDK primitive expr
 
 > **Update (May 2026):** Tier 1 (all five clan keywords + Decayed) and Tier 2 (keyword counters,
 > leaves-graveyard trigger, one-shot counter doubling, group P/T doubling) are **complete**, as are
-> Tier-3 items 11–14, 16, 17, and 19. Only **items 15, 18, and 20** remain.
+> Tier-3 items 11–14, 16, 17, 19, and 20. Only **items 15 and 18** remain.
 
 ---
 
@@ -211,7 +211,14 @@ the overwhelming majority of the set.
     a "can't cast spells with even mana value" (Void Winnower) prohibition is left as a future sibling.
     → **Voice of Victory**
 
-20. **Sacrifice-a-token as a cost** (minor — verify a token-only sacrifice-cost filter exists).
+20. **Sacrifice-a-token as a cost.** ✅ **DONE.** No new SDK was needed — "Sacrifice a token" is the
+    existing generic sacrifice cost narrowed by the `GameObjectFilter.Token` filter (`IsToken` →
+    `has<TokenComponent>`). `Costs.Sacrifice(GameObjectFilter.Token)` already renders as "Sacrifice a
+    token" and is gated by `canPayAbilityCost`, so the ability is only offered (and only payable) when
+    a token is on the battlefield; a nontoken permanent can't satisfy it. Fountainport
+    (`{2}, {T}, Sacrifice a token: Draw a card`) was already a user. Locked in by
+    `HardenedTacticianScenarioTest`, plus a reusable `isToken` flag on the scenario builder's
+    `withCardOnBattlefield` so tests can place real tokens.
     → **Hardened Tactician**
 
 ---
@@ -222,7 +229,7 @@ the overwhelming majority of the set.
    modest. Unlocks ~30 cards quickly.
 2. ✅ **Renew** (enumerator extension) + **Harmonize** (new alt-cost) — bigger lifts, ~22 cards.
 3. ✅ **Keyword counters + Decayed + leaves-graveyard trigger** (Tier 2) — small, scattered unlocks.
-4. **Tier-3 one-offs** as the relevant legendaries / rares come up. *(remaining work — items 15, 18, 20)*
+4. **Tier-3 one-offs** as the relevant legendaries / rares come up. *(remaining work — items 15, 18)*
 
 The clan keywords (Tier 1) cover the bulk of the remaining cards. Behold and Omen already being done
 means Temur spells and the 13 DFC dragons are essentially ready once the shared supporting effects

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -72,6 +72,7 @@ import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.identity.HexproofFromColorComponent
 import com.wingedsheep.engine.state.components.identity.ToxicComponent
 import com.wingedsheep.engine.state.components.identity.ProtectionComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
 import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombatComponent
@@ -240,13 +241,19 @@ abstract class ScenarioTestBase : FunSpec() {
         /**
          * Add a card to the battlefield under a player's control.
          * By default, removes summoning sickness (as if it's been there).
+         *
+         * Set [isToken] to mark the permanent as a token (adds [TokenComponent]) — needed so
+         * `IsToken` / `IsNontoken` filters and token-only sacrifice costs evaluate correctly.
+         * The permanent's stats/types still come from the named (token) card definition, e.g.
+         * a predefined token like "Treasure" or a creature-token script.
          */
         fun withCardOnBattlefield(
             playerNumber: Int,
             cardName: String,
             tapped: Boolean = false,
             summoningSickness: Boolean = false,
-            classLevel: Int? = null
+            classLevel: Int? = null,
+            isToken: Boolean = false
         ): ScenarioBuilder {
             val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
             val cardId = createCard(cardName, playerId)
@@ -264,6 +271,10 @@ abstract class ScenarioTestBase : FunSpec() {
 
             if (summoningSickness) {
                 container = container.with(SummoningSicknessComponent)
+            }
+
+            if (isToken) {
+                container = container.with(TokenComponent)
             }
 
             // Add continuous effects from static abilities (e.g., "Other creatures you control have...")

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HardenedTacticianScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HardenedTacticianScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.session.GameSession
+import com.wingedsheep.gameserver.session.PlayerSession
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
+
+/**
+ * Scenario tests for Hardened Tactician (Tarkir: Dragonstorm #191).
+ *
+ * Card reference:
+ * - Hardened Tactician ({1}{W}{B}): Creature — Human Warrior, 2/4
+ *   "{1}, Sacrifice a token: Draw a card."
+ *
+ * These tests verify the token-only sacrifice cost (engine gap item 20): the cost is the
+ * existing generic sacrifice cost narrowed by `GameObjectFilter.Token`, so only a token can
+ * pay it. A nontoken permanent must not satisfy the cost.
+ */
+class HardenedTacticianScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hardened Tactician — {1}, Sacrifice a token: Draw a card") {
+
+            test("sacrificing a token pays the cost and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hardened Tactician")
+                    .withCardOnBattlefield(1, "Treasure", isToken = true)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tactician = game.findPermanent("Hardened Tactician")!!
+                val token = game.findPermanent("Treasure")!!
+                val abilityId = cardRegistry.getCard("Hardened Tactician")!!
+                    .script.activatedAbilities.first().id
+
+                val handBefore = game.handSize(1)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tactician,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(token))
+                    )
+                )
+                withClue("Activating the draw ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                // Sacrifice is paid immediately as a cost; the draw resolves off the stack.
+                withClue("The sacrificed token should be gone from the battlefield") {
+                    game.findPermanent("Treasure") shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Player should have drawn exactly one card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("the ability cannot be activated without a token to sacrifice") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hardened Tactician")
+                    // A nontoken creature is present, but the cost demands a *token*.
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tactician = game.findPermanent("Hardened Tactician")!!
+
+                val session = GameSession(cardRegistry = cardRegistry)
+                val mockWs1 = mockk<WebSocketSession>(relaxed = true) { every { id } returns "ws1" }
+                val mockWs2 = mockk<WebSocketSession>(relaxed = true) { every { id } returns "ws2" }
+                val player1Session = PlayerSession(mockWs1, game.player1Id, "Player1")
+                val player2Session = PlayerSession(mockWs2, game.player2Id, "Player2")
+                session.injectStateForTesting(
+                    game.state,
+                    mapOf(game.player1Id to player1Session, game.player2Id to player2Session)
+                )
+
+                val drawAction = session.getLegalActions(game.player1Id).find {
+                    it.actionType == "ActivateAbility" &&
+                        (it.action as? ActivateAbility)?.sourceId == tactician
+                }
+                // The engine still surfaces the ability so the player can see it, but it must be
+                // greyed-out (unaffordable) — there's no token to pay the sacrifice cost (CR 602.2b).
+                withClue("Hardened Tactician's draw ability must not be affordable with no token to sacrifice") {
+                    drawAction?.isAffordable shouldBe false
+                }
+            }
+
+            test("a nontoken creature cannot be used to pay the token sacrifice cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hardened Tactician")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tactician = game.findPermanent("Hardened Tactician")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val abilityId = cardRegistry.getCard("Hardened Tactician")!!
+                    .script.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tactician,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(bears))
+                    )
+                )
+                withClue("Sacrificing a nontoken creature must not satisfy 'Sacrifice a token'") {
+                    result.error shouldNotBe null
+                }
+                withClue("Grizzly Bears should still be on the battlefield (cost rejected)") {
+                    game.findPermanent("Grizzly Bears") shouldBe bears
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HardenedTactician.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HardenedTactician.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Hardened Tactician — Tarkir: Dragonstorm #191
+ * {1}{W}{B} · Creature — Human Warrior · 2/4
+ *
+ * {1}, Sacrifice a token: Draw a card.
+ *
+ * The token-only sacrifice cost is the existing [GameObjectFilter.Token] filter on the
+ * generic sacrifice cost — no new SDK primitive is needed (cf. Fountainport).
+ */
+val HardenedTactician = card("Hardened Tactician") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 4
+    oracleText = "{1}, Sacrifice a token: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Sacrifice(GameObjectFilter.Token))
+        effect = Effects.DrawCards(1)
+        description = "{1}, Sacrifice a token: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "191"
+        artist = "Milivoj Ćeran"
+        flavorText = "\"Life is full of tough calls. We honor the dead today to make better decisions tomorrow.\"\n—Uruna, Mardu lieutenant"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86b225cb-5c45-4da1-a64e-b04091e483e8.jpg?1743204747"
+    }
+}


### PR DESCRIPTION
## What & why

Resolves **item 20** of `backlog/tdm-engine-gaps.md` — *"Sacrifice-a-token as a cost (minor — verify a token-only sacrifice-cost filter exists)"* — and ships the card that motivated it, **Hardened Tactician**.

The verification result: **no new SDK is needed.** "Sacrifice a token" is the existing generic sacrifice cost narrowed by the existing `GameObjectFilter.Token` filter (`IsToken` → `has<TokenComponent>`):

```kotlin
Costs.Sacrifice(GameObjectFilter.Token)   // renders as "Sacrifice a token"
```

- It's gated by `canPayAbilityCost`, so the legal-action enumerator marks the ability **unaffordable** (greyed-out, CR 602.2b) whenever the controller has no token, and `CostHandler` rejects payment with a nontoken permanent.
- Fountainport (`{2}, {T}, Sacrifice a token: Draw a card`) was already a user — so this composes an established, reusable primitive rather than adding a redundant alias.

## Changes

- **`HardenedTactician.kt`** — `{1}{W}{B}` 2/4 Human Warrior, `{1}, Sacrifice a token: Draw a card.` (TDM #191). Uses `Costs.Composite(Costs.Mana("{1}"), Costs.Sacrifice(GameObjectFilter.Token))`.
- **`ScenarioTestBase.withCardOnBattlefield`** — adds a reusable `isToken: Boolean = false` flag (mirrors the existing `tapped`/`summoningSickness`/`classLevel` flags) so scenario tests can place a *real* token (`TokenComponent`) on the battlefield. Previously there was no way to do this, so token-filter / token-sacrifice behavior couldn't be exercised in game-server scenarios.
- **`HardenedTacticianScenarioTest`** — locks in the behavior:
  1. sacrificing a token pays the cost and draws a card (token leaves the battlefield);
  2. with no token present the ability is surfaced but **unaffordable**;
  3. a nontoken creature is **rejected** as payment.
- **`backlog/tdm-engine-gaps.md`** — item 20 marked ✅ DONE; remaining work is now items 15 and 18.

## Testing

`./gradlew :game-server:test --tests "*HardenedTacticianScenarioTest"` — 3/3 pass. Card metadata verified against Scryfall (`set=tdm`, #191), image returns HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)