### PR TITLE
Add four Dragons of Tarkir commons (Anticipate, Colossodon Yearling, Dromoka Warrior, Defeat)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AnticipateReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AnticipateReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Anticipate reprint in Battle for Zendikar. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Dragons of Tarkir (`dtk`) `cards/` package; this file contributes only
+ * presentation data.
+ */
+val AnticipateReprint = Printing(
+    oracleId = "a97da5a9-17fc-4367-81e1-17ff81601a63",
+    name = "Anticipate",
+    setCode = "BFZ",
+    collectorNumber = "69",
+    scryfallId = "871c1931-06b4-4c69-9c2f-0dee3543c632",
+    artist = "Tyler Jacobson",
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/871c1931-06b4-4c69-9c2f-0dee3543c632.jpg?1562926891",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Anticipate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Anticipate.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Anticipate
+ * {1}{U}
+ * Instant
+ * Look at the top three cards of your library. Put one of them into your hand
+ * and the rest on the bottom of your library in any order.
+ */
+val Anticipate = card("Anticipate") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order."
+
+    spell {
+        // Look at top 3, keep one in hand, rest to bottom of library in chosen order.
+        effect = EffectPatterns.lookAtTopAndKeep(
+            count = DynamicAmount.Fixed(3),
+            keepCount = DynamicAmount.Fixed(1),
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.ControllerChooses
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Lake Hurwitz"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/7028d9e8-002f-43a1-bdce-0db0b6a642b0.jpg?1562788114"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ColossodonYearling.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ColossodonYearling.kt
@@ -1,0 +1,26 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Colossodon Yearling
+ * {2}{G}
+ * Creature — Beast
+ * 2/4 vanilla
+ */
+val ColossodonYearling = card("Colossodon Yearling") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Yeong-Hao Han"
+        flavorText = "The colossodon's hard outer shell stops many predators, but with a gentle flip from a dragon, it quickly becomes a meal in a bowl."
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2c60e63-0b86-4100-a932-bb9e9b197610.jpg?1562795540"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Defeat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Defeat.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Defeat
+ * {1}{B}
+ * Sorcery
+ * Destroy target creature with power 2 or less.
+ */
+val Defeat = card("Defeat") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature with power 2 or less."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtMost(2)))
+        effect = MoveToZoneEffect(t, Zone.GRAVEYARD, byDestruction = true)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Dave Kendall"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60473300-0bdc-4e89-87d9-28c8d7b4d83d.jpg?1562787158"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DromokaWarrior.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DromokaWarrior.kt
@@ -1,0 +1,26 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dromoka Warrior
+ * {1}{W}
+ * Creature — Human Warrior
+ * 3/1 vanilla
+ */
+val DromokaWarrior = card("Dromoka Warrior") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Warrior"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Zack Stella"
+        flavorText = "Dromoka has regard for the humans who serve under her. In return for her protection, they obey with steadfast loyalty, acting as weapons for her and her scalelords against the other clans."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13ae001b-556f-4576-8cf4-0b8902997bb1.jpg?1562782782"
+    }
+}


### PR DESCRIPTION
## Summary

Implements four Dragons of Tarkir (DTK) commons, all using existing SDK primitives — no new effects, triggers, or conditions were needed.

| Card | Cost | Type | Implementation |
|------|------|------|----------------|
| **Anticipate** | {1}{U} | Instant | `EffectPatterns.lookAtTopAndKeep(3, keep 1 → hand, rest → bottom in chosen order)` |
| **Colossodon Yearling** | {2}{G} | Creature — Beast (2/4) | Vanilla |
| **Dromoka Warrior** | {1}{W} | Creature — Human Warrior (3/1) | Vanilla |
| **Defeat** | {1}{B} | Sorcery | `TargetCreature(powerAtMost(2))` + `MoveToZoneEffect(byDestruction = true)` |

## Notes

- **Reuse over new code:** Anticipate mirrors Invasion's Worldly Counsel; Defeat mirrors Onslaught's Swat (minus cycling). No new SDK building blocks introduced, so no scenario tests are required by the add-card skill.
- **Canonical printing:** Anticipate's `CardDefinition` lives in DTK (its earliest real expansion printing — the f15 FNM promo is skipped). Since BFZ is also scaffolded and reprinted Anticipate, added an `AnticipateReprint` `Printing` row to BFZ. `just check-card-printing` is clean for all four.
- All image URIs verified HTTP 200 against Scryfall; all fields cross-checked against the DTK Scryfall API data.

## Testing

- `./gradlew :mtg-sets:compileKotlin` — passes
- `./gradlew :mtg-sets:test` — passes
- `just check-card-printing` for all four cards — clean
- `scripts/card-status --set DTK` — DTK now shows 5 implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)