### PR TITLE
Add Ancient Carp, Aerie Bowmasters, Dragon Fodder, Death Wind (DTK)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets
 
 import com.wingedsheep.mtg.sets.definitions.akh.AmonkhetSet
+import com.wingedsheep.mtg.sets.definitions.ala.ShardsOfAlaraSet
 import com.wingedsheep.mtg.sets.definitions.arn.ArabianNightsSet
 import com.wingedsheep.mtg.sets.definitions.avr.AvacynRestoredSet
 import com.wingedsheep.mtg.sets.definitions.bfz.BattleForZendikarSet
@@ -142,6 +143,7 @@ object MtgSetCatalog {
         GuildpactSet,
         TimeSpiralSet,
         ConfluxSet,
+        ShardsOfAlaraSet,
         Magic2010Set,
         Magic2012Set,
         Magic2014Set,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/ShardsOfAlaraSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/ShardsOfAlaraSet.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ala
+
+import com.wingedsheep.mtg.sets.definitions.por.PortalSet
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Shards of Alara Set (2008)
+ *
+ * Shards of Alara is the first set in the Alara block. The plane of Alara is
+ * split into five shards, each tied to three allied colors of mana. It
+ * introduced devour, exalted, unearth, and the cycling of three-color shards.
+ *
+ * Set Code: ALA
+ * Release Date: October 3, 2008
+ * Card Count: 250
+ */
+object ShardsOfAlaraSet : MtgSet {
+
+    override val code = "ALA"
+    override val displayName = "Shards of Alara"
+    override val releaseDate = "2008-10-03"
+    override val block = "Alara"
+    override val basicLandsFallback = PortalSet
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.ala.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DragonFodder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DragonFodder.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Dragon Fodder
+ * {1}{R}
+ * Sorcery
+ * Create two 1/1 red Goblin creature tokens.
+ *
+ * Canonical definition lives in Shards of Alara (earliest real printing).
+ * Reprinted in Dragons of Tarkir — see DTK `DragonFodderReprint`.
+ */
+val DragonFodder = card("Dragon Fodder") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create two 1/1 red Goblin creature tokens."
+
+    spell {
+        effect = CreateTokenEffect(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Goblin"),
+            imageUri = "https://cards.scryfall.io/normal/front/e/d/ed418a8b-f158-492d-a323-6265b3175292.jpg?1562640121"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Jaime Jones"
+        flavorText = "Goblins journey to the sacrificial peaks in pairs so that the rare survivor might be able to relate the details of the other's grisly demise."
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9eab4120-e7d8-4132-a304-30b88e3175e2.jpg?1562707210"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/DeathWind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/DeathWind.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Death Wind
+ * {X}{B}
+ * Instant
+ * Target creature gets -X/-X until end of turn.
+ *
+ * Canonical definition lives in Avacyn Restored (earliest real printing).
+ * Reprinted in Dragons of Tarkir — see DTK `DeathWindReprint`.
+ */
+val DeathWind = card("Death Wind") {
+    manaCost = "{X}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -X/-X until end of turn."
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        val negX = DynamicAmount.Multiply(DynamicAmount.XValue, -1)
+        effect = Effects.ModifyStats(negX, negX, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "93"
+        artist = "Tomasz Jedruszek"
+        flavorText = "Leukin stared at the smoldering angel feathers. \"Run!\" he screamed to his patrol. \"We don't stand a chance!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/462a0961-cca5-4d63-867f-7426dbef8639.jpg?1592708809"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/AerieBowmasters.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/AerieBowmasters.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Aerie Bowmasters
+ * {2}{G}{G}
+ * Creature — Dog Archer
+ * 3/4
+ * Reach
+ * Megamorph {5}{G}
+ *
+ * Megamorph is modeled as the Morph keyword with a face-up effect that puts a
+ * +1/+1 counter on the creature when it is turned face up (CR 702.37 / 702.36).
+ * The card may be cast face down as a 2/2 for {3}; turning it face up for the
+ * megamorph cost executes the face-up effect.
+ */
+val AerieBowmasters = card("Aerie Bowmasters") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dog Archer"
+    power = 3
+    toughness = 4
+    oracleText = "Reach (This creature can block creatures with flying.)\n" +
+        "Megamorph {5}{G} (You may cast this card face down as a 2/2 creature for {3}. " +
+        "Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)"
+
+    keywords(Keyword.REACH)
+
+    // Megamorph {5}{G}: turn face up for the cost, then put a +1/+1 counter on it.
+    morph = "{5}{G}"
+    morphFaceUpEffect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6db26b5-d28c-4524-9347-eec412d584bc.jpg?1562791100"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/AncientCarp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/AncientCarp.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ancient Carp
+ * {4}{U}
+ * Creature — Fish
+ * 2/5
+ *
+ * Vanilla creature — no abilities.
+ */
+val AncientCarp = card("Ancient Carp") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Fish"
+    power = 2
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Christopher Burdett"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1fef6e95-e7f1-4646-be5e-130c8b5a3ca6.jpg?1562783481"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DeathWindReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DeathWindReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Death Wind reprint in Dragons of Tarkir. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Avacyn Restored's `cards/`
+ * package; this file contributes only presentation data.
+ */
+val DeathWindReprint = Printing(
+    oracleId = "a636b62a-340b-444d-9161-f6d3367b745c",
+    name = "Death Wind",
+    setCode = "DTK",
+    collectorNumber = "95",
+    scryfallId = "87ed0a14-1a98-4190-b195-f84fa42d4364",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/87ed0a14-1a98-4190-b195-f84fa42d4364.jpg?1562789406",
+    releaseDate = "2015-03-27",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonFodderReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonFodderReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon Fodder reprint in Dragons of Tarkir. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shards of Alara's `cards/`
+ * package; this file contributes only presentation data.
+ */
+val DragonFodderReprint = Printing(
+    oracleId = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617",
+    name = "Dragon Fodder",
+    setCode = "DTK",
+    collectorNumber = "135",
+    scryfallId = "5220e572-7386-4f2f-905f-ba4a2d222f83",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/5220e572-7386-4f2f-905f-ba4a2d222f83.jpg?1562786231",
+    releaseDate = "2015-03-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DragonFodderReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DragonFodderReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon Fodder reprint in Foundations. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shards of Alara's `cards/`
+ * package; this file contributes only presentation data.
+ */
+val DragonFodderReprint = Printing(
+    oracleId = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617",
+    name = "Dragon Fodder",
+    setCode = "FDN",
+    collectorNumber = "535",
+    scryfallId = "f9abe517-f601-4784-8d62-2350bd755146",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/f/9/f9abe517-f601-4784-8d62-2350bd755146.jpg?1730490630",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AerieBowmastersTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AerieBowmastersTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dtk.cards.AerieBowmasters
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Aerie Bowmasters.
+ *
+ * Aerie Bowmasters: {2}{G}{G}
+ * Creature — Dog Archer
+ * 3/4
+ * Reach
+ * Megamorph {5}{G}
+ *
+ * Megamorph is modeled as the Morph keyword with a face-up effect that puts a
+ * +1/+1 counter on the creature when it is turned face up.
+ */
+class AerieBowmastersTest : FunSpec({
+
+    val allCards = TestCards.all + listOf(AerieBowmasters)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    fun GameTestDriver.putFaceDownCreature(playerId: EntityId, cardName: String): EntityId {
+        val creatureId = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = allCards.first { it.name == cardName }
+        val morphAbility = cardDef.keywordAbilities
+            .filterIsInstance<KeywordAbility.Morph>()
+            .first()
+        replaceState(state.updateEntity(creatureId) { container ->
+            container
+                .with(FaceDownComponent)
+                .with(MorphDataComponent(morphAbility.morphCost, cardDef.name, morphAbility.faceUpEffect))
+        })
+        return creatureId
+    }
+
+    test("megamorph: turning face up puts a +1/+1 counter on the creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val activePlayer = driver.activePlayer!!
+
+        // Put Aerie Bowmasters face-down (a 2/2 morph) on the battlefield.
+        val bowmasters = driver.putFaceDownCreature(activePlayer, "Aerie Bowmasters")
+        driver.removeSummoningSickness(bowmasters)
+
+        // Pay the megamorph cost {5}{G}.
+        driver.giveColorlessMana(activePlayer, 5)
+        driver.giveMana(activePlayer, Color.GREEN, 1)
+
+        val result = driver.submit(
+            TurnFaceUp(
+                playerId = activePlayer,
+                sourceId = bowmasters,
+                costTargetIds = emptyList()
+            )
+        )
+        (result.error == null) shouldBe true
+
+        // It should now be face up as Aerie Bowmasters.
+        driver.state.getEntity(bowmasters)?.get<FaceDownComponent>() shouldBe null
+        driver.state.getEntity(bowmasters)?.get<CardComponent>()?.name shouldBe "Aerie Bowmasters"
+
+        // Megamorph face-up effect: exactly one +1/+1 counter.
+        val counters = driver.state.getEntity(bowmasters)?.get<CountersComponent>()
+        (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeathWindTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeathWindTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.DeathWind
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Death Wind.
+ *
+ * Death Wind: {X}{B}
+ * Instant
+ * Target creature gets -X/-X until end of turn.
+ */
+class DeathWindTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DeathWind))
+        return driver
+    }
+
+    test("X=3 kills a 3/3 creature (-3/-3)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        // 3/3 Centaur Courser controlled by the opponent.
+        val courser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val deathWind = driver.putCardInHand(activePlayer, "Death Wind")
+        driver.giveColorlessMana(activePlayer, 3) // for X=3
+        driver.giveMana(activePlayer, com.wingedsheep.sdk.core.Color.BLACK, 1) // for {B}
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = deathWind,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                xValue = 3,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        (result.error == null) shouldBe true
+
+        driver.bothPass()
+
+        // -3/-3 makes it 0/0 — it dies to a state-based action.
+        driver.assertInGraveyard(opponent, "Centaur Courser")
+    }
+
+    test("X=1 leaves a 3/3 alive as a 2/2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        val courser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val deathWind = driver.putCardInHand(activePlayer, "Death Wind")
+        driver.giveColorlessMana(activePlayer, 1) // for X=1
+        driver.giveMana(activePlayer, com.wingedsheep.sdk.core.Color.BLACK, 1) // for {B}
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = deathWind,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                xValue = 1,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        (result.error == null) shouldBe true
+
+        driver.bothPass()
+
+        // -1/-1 makes the 3/3 a 2/2 — still on the battlefield.
+        val projected = projector.project(driver.state)
+        projected.getPower(courser) shouldBe 2
+        projected.getToughness(courser) shouldBe 2
+    }
+})


### PR DESCRIPTION
Implements four Dragons of Tarkir cards.

## Cards

| Card | Cost | Type | Canonical set | Notes |
|------|------|------|---------------|-------|
| **Ancient Carp** | `{4}{U}` | Creature — Fish 2/5 | DTK | Vanilla |
| **Aerie Bowmasters** | `{2}{G}{G}` | Creature — Dog Archer 3/4 | DTK | Reach + Megamorph `{5}{G}` |
| **Dragon Fodder** | `{1}{R}` | Sorcery | ALA (new) | Two 1/1 red Goblin tokens; reprints in DTK + FDN |
| **Death Wind** | `{X}{B}` | Instant | AVR | Target creature gets -X/-X EOT; reprint in DTK |

## Reprint wiring

Per the Printing/Reprints mechanism, each canonical `CardDefinition` is registered once in its **earliest real printing**, with reprinting sets contributing only per-printing metadata (set code, collector number, art):

- **Dragon Fodder** — canonical in **Shards of Alara** (newly scaffolded `ShardsOfAlaraSet`, registered in `MtgSetCatalog`); `Printing` rows in DTK (#135) and Foundations (#535).
- **Death Wind** — canonical in **Avacyn Restored**; `Printing` row in DTK (#95).

## Megamorph

Aerie Bowmasters' Megamorph is modeled as the `Morph` keyword with a face-up effect (`Effects.AddCounters(PLUS_ONE_PLUS_ONE, 1, Self)`) that runs when the card is turned face up — the same pattern as Hooded Hydra. No new SDK type needed.

## Tests
- `AerieBowmastersTest` — turning face up for the megamorph cost adds exactly one +1/+1 counter.
- `DeathWindTest` — X=3 kills a 3/3 (-3/-3 → 0/0 SBA death); X=1 leaves it a 2/2.

## Verification
- All card data, oracle IDs, and image URIs (all HTTP 200) checked against Scryfall.
- `check-card-printing` passes with **no drift** for all four cards.
- `scripts/card-status --set DTK` shows the new cards as implemented.
- `:mtg-sets:test` and the two scenario tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)