### PR TITLE
Add four Dragons of Tarkir cards (Atarka Monument, Aven Tactician, Dragonlord's Servant, Dragon's Eye Sentry)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -555,6 +555,10 @@ Composed pipelines (`GatherCards → SelectFromCollection → MoveCollection` sh
 - `mayPay(cost, effect)` — optionally pay cost to trigger an effect.
 - `mayPayOrElse(cost, ifPaid, ifNotPaid)` — pay-or-else fork.
 - `blight(amount, player?)` — Blight X additional cost glue.
+- `bolster(amount)` — Bolster N (CR 701.36): controller chooses a creature with the least toughness among
+  creatures they control and puts N +1/+1 counters on it. Non-targeting; no-op with no creatures. Composes
+  Gather → `FilterCollection(CollectionFilter.LeastToughness)` → `SelectFromCollection(ChooseExactly 1)` →
+  `AddCountersToCollection(+1/+1)`. Toughness is read from projected state for the least-toughness comparison.
 - `forage(afterEffect?)` — Forage cost; choose card-from-hand to play.
 - `loot(draw?, discard?)` — "draw N, discard M" loop.
 - `rummage(count?)` — discard then draw.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.mtg.sets.definitions.dft.AetherdriftSet
 import com.wingedsheep.mtg.sets.definitions.dmu.DominariaUnitedSet
 import com.wingedsheep.mtg.sets.definitions.dom.DominariaSet
 import com.wingedsheep.mtg.sets.definitions.dsk.DuskmournSet
+import com.wingedsheep.mtg.sets.definitions.dtk.DragonsOfTarkirSet
 import com.wingedsheep.mtg.sets.definitions.ecl.LorwynEclipsedSet
 import com.wingedsheep.mtg.sets.definitions.eoe.EdgeOfEternitiesSet
 import com.wingedsheep.mtg.sets.definitions.exo.ExodusSet
@@ -113,6 +114,7 @@ abstract class ScenarioTestBase : FunSpec() {
         register(Commander2015Set.cards)
         register(DominariaSet.cards); register(DominariaSet.basicLands)
         register(DominariaUnitedSet.cards)
+        register(DragonsOfTarkirSet.cards)
         register(DuskmournSet.cards)
         register(EdgeOfEternitiesSet.cards); register(EdgeOfEternitiesSet.basicLands)
         register(ExodusSet.cards)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AvenTacticianBolsterScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AvenTacticianBolsterScenarioTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Aven Tactician's Bolster 1 (CR 701.36).
+ *
+ * Aven Tactician: {4}{W} Creature — Bird Soldier 2/3, Flying.
+ * "When this creature enters, bolster 1." — the controller puts a +1/+1 counter on
+ * a creature with the least toughness among creatures they control (the controller
+ * breaks ties). Bolster is non-targeting.
+ */
+class AvenTacticianBolsterScenarioTest : ScenarioTestBase() {
+
+    // A 1/1 vanilla creature — strictly lower toughness than the entering 2/3 Tactician,
+    // so bolster has a single unambiguous least-toughness target.
+    private val tinyGoblin = card("Tiny Test Goblin") {
+        manaCost = "{R}"
+        typeLine = "Creature — Goblin"
+        power = 1
+        toughness = 1
+    }
+
+    init {
+        cardRegistry.register(tinyGoblin)
+
+        context("Aven Tactician — bolster 1 on enter") {
+
+            test("bolster puts a +1/+1 counter on the least-toughness creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    // A 1/1 is strictly the least toughness on board: smaller than the
+                    // entering 2/3 Tactician, so no tie / no ambiguity.
+                    .withCardOnBattlefield(1, "Tiny Test Goblin", summoningSickness = false)
+                    .withCardInHand(1, "Aven Tactician")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goblinId = game.findPermanent("Tiny Test Goblin")!!
+
+                val cast = game.castSpell(1, "Aven Tactician")
+                withClue("Casting Aven Tactician should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Bolster resolves as a choice; with a single least-toughness creature the
+                // selection is unambiguous. Answer it if the engine surfaces a decision.
+                if (game.state.pendingDecision != null) {
+                    game.selectCards(listOf(goblinId))
+                    game.resolveStack()
+                }
+
+                withClue("Aven Tactician should have resolved onto the battlefield") {
+                    game.isOnBattlefield("Aven Tactician") shouldBe true
+                }
+
+                val counters = game.state.getEntity(goblinId)?.get<CountersComponent>()
+                val plusOne = counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                withClue("Tiny Test Goblin (least toughness) should have the bolster +1/+1 counter, had $plusOne") {
+                    plusOne shouldBe 1
+                }
+
+                // The entering Tactician (toughness 3) must NOT be bolstered.
+                val tacticianId = game.findPermanent("Aven Tactician")!!
+                tacticianId shouldNotBe goblinId
+                val tacCounters = game.state.getEntity(tacticianId)?.get<CountersComponent>()
+                withClue("The entering Tactician is not the least toughness and should not be bolstered") {
+                    (tacCounters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/EffectPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/EffectPatterns.kt
@@ -65,6 +65,14 @@ object EffectPatterns {
     fun blight(amount: Int, player: Player = Player.You): CompositeEffect =
         MiscPatterns.blight(amount, player)
 
+    /**
+     * Bolster N (CR 701.36) — the controller chooses a creature with the least toughness
+     * among creatures they control and puts N +1/+1 counters on it. Non-targeting; does
+     * nothing if the controller has no creatures. See [MiscPatterns.bolster].
+     */
+    fun bolster(amount: Int): CompositeEffect =
+        MiscPatterns.bolster(amount)
+
     // =========================================================================
     // Forage Patterns (MiscPatterns)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MiscPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MiscPatterns.kt
@@ -8,11 +8,13 @@ import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.Chooser
 import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.EffectChoice
 import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
 import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
@@ -81,6 +83,44 @@ object MiscPatterns {
             )
         )
     }
+
+    /**
+     * Bolster N (CR 701.36) — "Choose a creature with the least toughness among creatures
+     * you control and put N +1/+1 counters on it."
+     *
+     * Non-targeting keyword action (the reminder text never says "target", so
+     * shroud/hexproof do not interact). The controller chooses among creatures they
+     * control, restricted to those tied for the least toughness; a single tie-break
+     * choice is made via [SelectionMode.ChooseExactly]. If the controller has no
+     * creatures, the gather yields nothing and the counter placement is a silent no-op.
+     *
+     * Toughness is read from projected state in the executor, so continuous effects and
+     * counters already in play are respected when determining "least toughness".
+     *
+     * @param amount Number of +1/+1 counters to place
+     */
+    fun bolster(amount: Int): CompositeEffect = CompositeEffect(
+        listOf(
+            GatherCardsEffect(
+                source = CardSource.ControlledPermanents(Player.You, GameObjectFilter.Creature),
+                storeAs = "bolsterCreatures"
+            ),
+            FilterCollectionEffect(
+                from = "bolsterCreatures",
+                filter = CollectionFilter.LeastToughness,
+                storeMatching = "bolsterLeastToughness"
+            ),
+            SelectFromCollectionEffect(
+                from = "bolsterLeastToughness",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                storeSelected = "bolstered",
+                prompt = "Bolster $amount — choose a creature with the least toughness",
+                useTargetingUI = true
+            ),
+            AddCountersToCollectionEffect("bolstered", Counters.PLUS_ONE_PLUS_ONE, amount)
+        )
+    )
 
     fun sacrificeFor(
         filter: GameObjectFilter,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -1155,6 +1155,19 @@ sealed interface CollectionFilter {
     data object GreatestPower : CollectionFilter
 
     /**
+     * Keep only creatures with the least toughness in the collection.
+     * Uses projected state to determine toughness (respects continuous effects).
+     * If multiple creatures are tied for the least toughness, all of them are kept
+     * (so a downstream "exactly one" consumer lets the controller break the tie).
+     *
+     * Used for the Bolster keyword action (CR 701.36): "Choose a creature with the least
+     * toughness among creatures you control and put N +1/+1 counters on it."
+     */
+    @SerialName("LeastToughness")
+    @Serializable
+    data object LeastToughness : CollectionFilter
+
+    /**
      * Keep only the cards with the greatest mana value in the collection. If multiple cards are
      * tied for the greatest mana value, all of them are kept (so a downstream "exactly one" consumer
      * can detect a tie).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/DragonlordsServantReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/DragonlordsServantReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonlord's Servant reprint in Commander 2017. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in DTK.
+ */
+val DragonlordsServantReprint = Printing(
+    oracleId = "faf81ae0-0b35-45ef-a50d-6cecf0c0eeeb",
+    name = "Dragonlord's Servant",
+    setCode = "C17",
+    collectorNumber = "135",
+    scryfallId = "39e9bfcb-af85-4c4c-95e3-e6460d69719e",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/39e9bfcb-af85-4c4c-95e3-e6460d69719e.jpg?1562605300",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/AtarkaMonument.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/AtarkaMonument.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Atarka Monument
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {R} or {G}.
+ * {4}{R}{G}: This artifact becomes a 4/4 red and green Dragon artifact creature with
+ * flying until end of turn.
+ */
+val AtarkaMonument = card("Atarka Monument") {
+    manaCost = "{3}"
+    colorIdentity = "RG"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {R} or {G}.\n" +
+        "{4}{R}{G}: This artifact becomes a 4/4 red and green Dragon artifact creature with flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{R}{G}")
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = 4,
+            toughness = 4,
+            keywords = setOf(Keyword.FLYING),
+            creatureTypes = setOf("Dragon"),
+            colors = setOf("RED", "GREEN"),
+            duration = Duration.EndOfTurn
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "235"
+        artist = "Daniel Ljunggren"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63d52217-a340-4567-9b07-28092a7dc561.jpg?1562787370"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/AvenTactician.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/AvenTactician.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aven Tactician
+ * {4}{W}
+ * Creature — Bird Soldier
+ * 2/3
+ *
+ * Flying
+ * When this creature enters, bolster 1. (Choose a creature with the least toughness
+ * among creatures you control and put a +1/+1 counter on it.)
+ */
+val AvenTactician = card("Aven Tactician") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, bolster 1. (Choose a creature with the least toughness " +
+        "among creatures you control and put a +1/+1 counter on it.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.bolster(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "Christopher Moeller"
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9dfc3ec-ca06-40a6-b77c-c2432af9802f.jpg?1562792120"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonlordsServant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonlordsServant.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Dragonlord's Servant
+ * {1}{R}
+ * Creature — Goblin Shaman
+ * 1/3
+ * Dragon spells you cast cost {1} less to cast.
+ */
+val DragonlordsServant = card("Dragonlord's Servant") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Shaman"
+    power = 1
+    toughness = 3
+    oracleText = "Dragon spells you cast cost {1} less to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withSubtype("Dragon")),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "138"
+        artist = "Steve Prescott"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0ffcdd54-b6be-4d42-82c0-ae927037e859.jpg?1562782618"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonsEyeSentry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonsEyeSentry.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon's Eye Sentry
+ * {W}
+ * Creature — Human Monk
+ * 1/3
+ * Defender, first strike
+ */
+val DragonsEyeSentry = card("Dragon's Eye Sentry") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Monk"
+    power = 1
+    toughness = 3
+    oracleText = "Defender, first strike"
+
+    keywords(Keyword.DEFENDER, Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Anastasia Ovchinnikova"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/750880cd-59bf-4b67-a2d5-9b66e4d05665.jpg?1562788403"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DragonlordsServantReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DragonlordsServantReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonlord's Servant reprint in Foundations. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in DTK.
+ */
+val DragonlordsServantReprint = Printing(
+    oracleId = "faf81ae0-0b35-45ef-a50d-6cecf0c0eeeb",
+    name = "Dragonlord's Servant",
+    setCode = "FDN",
+    collectorNumber = "536",
+    scryfallId = "37e35f88-a580-4b55-9c11-0b58e2f752d1",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37e35f88-a580-4b55-9c11-0b58e2f752d1.jpg?1730490630",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/FilterCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/FilterCollectionExecutor.kt
@@ -85,6 +85,15 @@ class FilterCollectionExecutor : EffectExecutor<FilterCollectionEffect> {
                 }
             }
 
+            is CollectionFilter.LeastToughness -> {
+                val minToughness = cards.minOfOrNull { projected.getToughness(it) ?: Int.MAX_VALUE }
+                if (minToughness == null || minToughness == Int.MAX_VALUE) {
+                    emptyList<EntityId>() to cards
+                } else {
+                    cards.partition { (projected.getToughness(it) ?: Int.MAX_VALUE) == minToughness }
+                }
+            }
+
             is CollectionFilter.GreatestManaValue -> {
                 fun manaValueOf(cardId: EntityId): Int =
                     state.getEntity(cardId)?.get<CardComponent>()?.manaValue ?: Int.MIN_VALUE


### PR DESCRIPTION
Implements four Dragons of Tarkir (DTK) cards. Card texts verified against Scryfall (DTK printings); all four are auto-discovered via `CardDiscovery`.

## Cards

- **Atarka Monument** — `{3}` Artifact. `{T}: Add {R} or {G}`; `{4}{R}{G}: becomes a 4/4 red and green Dragon artifact creature with flying until end of turn.` Composes two mana abilities + `Effects.BecomeCreature`. No new SDK.
- **Aven Tactician** — `{4}{W}` 2/3 Bird Soldier, Flying. *"When this creature enters, bolster 1."* Introduces the **Bolster** keyword action (CR 701.36).
- **Dragonlord's Servant** — `{1}{R}` 1/3 Goblin Shaman. *"Dragon spells you cast cost {1} less to cast."* `ModifySpellCost` static ability. No new SDK.
- **Dragon's Eye Sentry** — `{W}` 1/3 Human Monk. Defender, first strike. Vanilla keywords only.

## SDK change kept: Bolster (minimal, reusable)

The interrupted agent's SDK edits were all for **Bolster**, which Aven Tactician genuinely needs (the card really does have bolster 1 — not "just a white creature"). After review the implementation was kept because it is minimal, correct, and composes existing primitives rather than introducing a monolithic executor:

`EffectPatterns.bolster(N)` → `MiscPatterns.bolster` composes
`GatherCards(ControlledPermanents, Creature)` → `FilterCollection(CollectionFilter.LeastToughness)` → `SelectFromCollection(ChooseExactly 1, Chooser.Controller)` → `AddCountersToCollection(+1/+1)`.

The only new primitive is `CollectionFilter.LeastToughness`, mirroring the existing `GreatestPower` / `GreatestManaValue` filters and reading toughness from **projected** state (respects continuous effects/counters). No new effect type, executor, continuation, or DTO was needed. Bolster is a named MTG mechanic that recurs across DTK, so a reusable pattern is warranted per project guidance (named mechanics are the documented exception to the no-single-use-pattern rule).

`docs/card-sdk-language-reference.md` updated with the bolster pattern.

## Reprints

Dragonlord's Servant predates DTK reprints in the scaffolded sets **C17** and **FDN**. Wired via `Printing` rows (`DragonlordsServantReprint` in each set's `cards` package) rather than duplicate `CardDefinition`s. `just check-card-printing "Dragonlord's Servant"` passes.

## Tests

- `AvenTacticianBolsterScenarioTest` — verifies bolster places the +1/+1 counter on the least-toughness creature and not on the entering, higher-toughness source.
- `ScenarioTestBase` registers the DTK set.
- Green: `:mtg-sets:test`, `:rules-engine:test`, `:game-server:test --tests "...scenarios.*"`, full compile.
- `scripts/card-status --set DTK` shows all four implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)