### PR TITLE
Per-activation cost reduction by a target's color count (Dragonfire Blade)

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -4,8 +4,8 @@ Cross-reference of the **252 remaining (unimplemented) TDM cards** against the e
 capabilities (SDK reference + source verification, May 2026). Generated to scope what must be
 built before the set can be completed.
 
-**Status:** 49 / 271 implemented (18%). All five wedge clan keywords (Tier 1), every Tier-2
-primitive, and all but one Tier-3 one-off are now built — only item 18 remains.
+**Status:** 50 / 271 implemented (18%). All five wedge clan keywords (Tier 1), every Tier-2
+primitive, and every Tier-3 one-off are now built — all engine gaps are closed.
 Card list comes from `scripts/card-status --list --set TDM`. Oracle text pulled from Scryfall
 (`set:tdm`, 277 printings → 271 unique cards).
 
@@ -43,7 +43,7 @@ What follows are the **genuine gaps** — elements no current SDK primitive expr
 
 > **Update (May 2026):** Tier 1 (all five clan keywords + Decayed) and Tier 2 (keyword counters,
 > leaves-graveyard trigger, one-shot counter doubling, group P/T doubling) are **complete**, as are
-> Tier-3 items 11–17, 19, and 20. Only **item 18** remains.
+> all Tier-3 items 11–20. Every identified engine gap is now closed.
 
 ---
 
@@ -201,9 +201,20 @@ the overwhelming majority of the set.
     nonland → keep MV ≤ X → cast any number for free.
     → **Kotis, the Fangkeeper**
 
-18. **Per-activation cost reduction by a target's color count.** Equip cost "costs {1} less to
-    activate for each color of the creature it targets." Cost statics target spells; none reduces an
-    activated (equip) cost by the chosen target's color count.
+18. **Per-activation cost reduction by a target's color count.** ✅ **DONE.** Equip cost "costs {1}
+    less to activate for each color of the creature it targets." No new cost-reduction machinery was
+    needed: `ActivatedAbility.genericCostReduction` already reduces an activated ability's generic
+    cost by a `DynamicAmount` evaluated at activation. The gap was that it was evaluated without the
+    chosen target. Added the `EntityNumericProperty.ColorCount` numeric property (read off projected
+    colors, mirroring `SubtypeCount`) so `DynamicAmounts.targetColorCount()` reads the equip target's
+    color count, and threaded `action.targets` into `ActivateAbilityHandler.applyGenericCostReduction`
+    so the reduction resolves against the picked target. The legal-action enumerator gates
+    affordability on the cheapest reachable cost (largest reduction over the currently-legal targets)
+    since no target is chosen at enumeration time, and the handler re-derives the exact per-target cost
+    at activation. The `equipAbility(cost, genericCostReduction = …)` DSL form wires it on the card.
+    Also added "hexproof from monocolored" (`GrantHexproofFromMonocoloredToGroup` static +
+    `HEXPROOF_FROM_MONOCOLORED` projected keyword + a CR-105.2 monocolored-source targeting check) for
+    the equipped-creature half of the card.
     → **Dragonfire Blade**
 
 19. **Opponent-scoped continuous cast prohibition.** ✅ **DONE.** "Your opponents can't cast spells
@@ -234,7 +245,7 @@ the overwhelming majority of the set.
    modest. Unlocks ~30 cards quickly.
 2. ✅ **Renew** (enumerator extension) + **Harmonize** (new alt-cost) — bigger lifts, ~22 cards.
 3. ✅ **Keyword counters + Decayed + leaves-graveyard trigger** (Tier 2) — small, scattered unlocks.
-4. **Tier-3 one-offs** as the relevant legendaries / rares come up. *(remaining work — item 18)*
+4. ✅ **Tier-3 one-offs** as the relevant legendaries / rares come up. *(complete)*
 
 The clan keywords (Tier 1) cover the bulk of the remaining cards. Behold and Omen already being done
 means Temur spells and the 13 DFC dragons are essentially ready once the shared supporting effects

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1203,6 +1203,11 @@ staticAbility {
   among the permanents the source's controller controls, recomputed at projection (Layer 6, after
   Layer 5 colors) so it tracks the board in real time. Colorless permanents add no color. (Pledge of
   Loyalty)
+- `GrantHexproofFromMonocoloredToGroup(filter = attachedCreature())` — "[filter] have hexproof from
+  monocolored" — adds the projected keyword `HEXPROOF_FROM_MONOCOLORED`, which blocks targeting by
+  monocolored (exactly one color, CR 105.2) spells and abilities opponents control. Colorless and
+  multicolored sources are unaffected; the controller can still target their own creatures. (Dragonfire
+  Blade)
 - `GrantCardType(cardType, filter)` / `RemoveCardType(cardType, filter)` — Layer 4 type-changing statics that add or
   remove a card type (e.g. `"CREATURE"`). `RemoveCardType` backs Impending's "isn't a creature while it has a time
   counter" (wrapped in a `ConditionalStaticAbility`); reuse it for any "it's no longer a [type]" effect.
@@ -1482,7 +1487,14 @@ composite abilities).
   `ActivateAbilityHandler` pays the mana and exiles the card from the graveyard. Declares `Keyword.RENEW` for display.
 - `Morph(cost)` — cast face-down for `{3}`, flip for cost.
 - `Unmorph(cost, effect)` — turn-face-up cost + bonus effect.
-- `Equip(cost)` — Equipment attach cost.
+- `Equip(cost)` — Equipment attach cost. The `equipAbility(cost, genericCostReduction = …)` DSL
+  form optionally reduces the generic portion of the equip cost by a `DynamicAmount` evaluated at
+  activation. Reductions that read the chosen equip target (e.g. `DynamicAmounts.targetColorCount()`
+  for "costs {1} less to activate for each color of the creature it targets" — Dragonfire Blade)
+  resolve against the picked target. Backed by `ActivatedAbility.genericCostReduction`: the
+  `ActivateAbilityHandler` locks the per-target reduction in before paying; the legal-action
+  enumerator gates affordability on the cheapest reachable cost (largest reduction over the
+  currently-legal targets) since the target isn't chosen until activation.
 - `Fortify(cost)` — Aura-like attach cost on lands.
 
 ```kotlin
@@ -1696,6 +1708,11 @@ Numbers computed at resolution time.
   mana spent to cast that spell was less than its mana value" gates (Unravel).
   Desugars to `EntityProperty(EntityReference.Target(index), EntityNumericProperty.ManaSpent)`.
   Returns 0 if the target isn't a spell on the stack.
+- `DynamicAmounts.targetColorCount(index)` / `DynamicAmounts.colorCountOf(entity)` — number of
+  distinct colors of the indexed cast-time target / any `EntityReference`. Desugars to
+  `EntityProperty(entity, EntityNumericProperty.ColorCount)`. Read from projected state for
+  battlefield permanents (honors layer-5 color-changing — a creature turned colorless counts 0).
+  Powers "for each color of [it]" amounts, e.g. Dragonfire Blade's equip cost reduction.
 - `CardNumericProperty(card, property)` — generic numeric property accessor.
 
 ### Triggering-entity shortcuts (`DynamicAmounts.*` facades)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -700,8 +700,14 @@ class CardBuilder(private val name: String) {
      * Add an equip ability with the specified cost.
      * This sets the equipCost metadata and generates the activated ability
      * (Equip: attach to target creature you control, sorcery speed).
+     *
+     * [genericCostReduction] optionally reduces the generic portion of the equip cost by a
+     * dynamic amount evaluated when the ability is activated. Reductions that read the chosen
+     * equip target (e.g. `DynamicAmounts.targetColorCount()` for "costs {1} less to activate
+     * for each color of the creature it targets" — Dragonfire Blade) resolve against the
+     * selected target creature; the engine locks the reduction in before the cost is paid.
      */
-    fun equipAbility(cost: String) {
+    fun equipAbility(cost: String, genericCostReduction: DynamicAmount? = null) {
         equipCost = ManaCost.parse(cost)
         activatedAbilities.add(
             ActivatedAbility(
@@ -713,6 +719,7 @@ class CardBuilder(private val name: String) {
                 ),
                 isManaAbility = false,
                 timing = TimingRule.SorcerySpeed,
+                genericCostReduction = genericCostReduction,
             )
         )
     }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -284,6 +284,14 @@ object DynamicAmounts {
     fun targetManaSpent(index: Int = 0): DynamicAmount =
         DynamicAmount.EntityProperty(EntityReference.Target(index), EntityNumericProperty.ManaSpent)
 
+    /** Number of distinct colors of the indexed cast-time target ("for each color of the creature it targets"). */
+    fun targetColorCount(index: Int = 0): DynamicAmount =
+        DynamicAmount.EntityProperty(EntityReference.Target(index), EntityNumericProperty.ColorCount)
+
+    /** Number of distinct colors of any referenced entity. */
+    fun colorCountOf(entity: EntityReference): DynamicAmount =
+        DynamicAmount.EntityProperty(entity, EntityNumericProperty.ColorCount)
+
     fun sacrificedPower(index: Int = 0): DynamicAmount =
         DynamicAmount.EntityProperty(EntityReference.Sacrificed(index), EntityNumericProperty.Power)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
@@ -72,6 +72,29 @@ data class GrantHexproofFromOwnColorsToGroup(
 }
 
 /**
+ * Grants each affected creature "hexproof from monocolored" — they can't be the targets of
+ * monocolored (exactly one color, CR 105.2) spells or abilities opponents control. Colorless
+ * and multicolored sources are unaffected.
+ *
+ * Used by Dragonfire Blade ("Equipped creature ... has hexproof from monocolored."). The
+ * default filter applies it to the attached creature; pass a wider [GroupFilter] for cards that
+ * blanket a group.
+ *
+ * @property filter The group of creatures that gain the hexproof
+ */
+@SerialName("GrantHexproofFromMonocoloredToGroup")
+@Serializable
+data class GrantHexproofFromMonocoloredToGroup(
+    val filter: GroupFilter = GroupFilter.attachedCreature()
+) : StaticAbility {
+    override val description: String = "${filter.description} have hexproof from monocolored"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Grants each affected creature protection from the colors of permanents the source's
  * controller currently controls. The protection set is board-derived and re-evaluated at
  * projection (after Layer 5), so it tracks the controller's permanents in real time; a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
@@ -82,4 +82,19 @@ sealed interface EntityNumericProperty {
     data object SubtypeCount : EntityNumericProperty {
         override val description: String = "the number of its subtypes"
     }
+
+    /**
+     * The number of distinct colors this entity has, read from projected state when
+     * available (so layer-5 color-changing effects are honored). A colorless entity
+     * counts 0; a monocolored entity 1; a five-color entity 5 (CR 105.2 — there are
+     * five colors).
+     *
+     * Powers "for each color of [entity]" amounts — e.g. Dragonfire Blade's equip cost
+     * reduction reads `EntityProperty(EntityReference.Target(0), ColorCount)`.
+     */
+    @SerialName("ColorCount")
+    @Serializable
+    data object ColorCount : EntityNumericProperty {
+        override val description: String = "the number of its colors"
+    }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonfireBlade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonfireBlade.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantHexproofFromMonocoloredToGroup
+
+/**
+ * Dragonfire Blade
+ * {1}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +2/+2 and has hexproof from monocolored.
+ * Equip {4}. This ability costs {1} less to activate for each color of the creature it targets.
+ *
+ * The equip cost reduction is modeled with the engine's per-activation generic cost reduction
+ * (`ActivatedAbility.genericCostReduction`) fed a dynamic amount that reads the chosen target's
+ * color count — `DynamicAmounts.targetColorCount()`. The reduction resolves against the target
+ * creature the player picks when activating Equip.
+ */
+val DragonfireBlade = card("Dragonfire Blade") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+2 and has hexproof from monocolored.\n" +
+        "Equip {4}. This ability costs {1} less to activate for each color of the creature it targets."
+
+    staticAbility {
+        effect = Effects.ModifyStats(+2, +2)
+        filter = Filters.EquippedCreature
+    }
+
+    staticAbility {
+        ability = GrantHexproofFromMonocoloredToGroup()
+    }
+
+    equipAbility("{4}", genericCostReduction = DynamicAmounts.targetColorCount())
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "240"
+        artist = "Clint Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/031afea3-fbfb-4663-a8cc-9b7eb7b16020.jpg?1743204949"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -740,6 +740,11 @@ class DynamicAmountEvaluator(
             // (including Changeling) are honored. Falls back to base subtypes off the battlefield.
             is EntityNumericProperty.SubtypeCount ->
                 resolveSubtypeCount(state, entityId, useProjected, explicitProjected)
+
+            // Read from projected state when available so layer-5 color-changing effects are
+            // honored. Falls back to the printed colors off the battlefield.
+            is EntityNumericProperty.ColorCount ->
+                resolveColorCount(state, entityId, useProjected, explicitProjected)
         }
     }
 
@@ -754,6 +759,21 @@ class DynamicAmountEvaluator(
             if (projectedSubtypes.isNotEmpty()) return projectedSubtypes.size
         }
         return state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.subtypes?.size ?: 0
+    }
+
+    private fun resolveColorCount(
+        state: GameState,
+        entityId: EntityId,
+        useProjected: Boolean,
+        explicitProjected: ProjectedState?
+    ): Int {
+        // For battlefield permanents the projected color set is authoritative even when empty —
+        // a creature turned colorless by a layer-5 effect must count 0, not fall back to its
+        // printed colors. Off the battlefield (or when projection isn't requested) use base colors.
+        if (useProjected && entityId in state.getBattlefield()) {
+            return resolveProjection(state, explicitProjected).getColors(entityId).size
+        }
+        return state.getEntity(entityId)?.get<CardComponent>()?.colors?.size ?: 0
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -526,9 +526,11 @@ class TargetFinder(
             sourceColors = state.getEntity(sourceId)?.get<CardComponent>()
                 ?.colors?.map { it.name }?.toSet() ?: emptySet()
         }
-        return sourceColors.any { colorName ->
-            projected.hasKeyword(entityId, "HEXPROOF_FROM_$colorName")
+        if (sourceColors.any { colorName -> projected.hasKeyword(entityId, "HEXPROOF_FROM_$colorName") }) {
+            return true
         }
+        // Hexproof from monocolored: a source with exactly one color can't target (CR 105.2).
+        return sourceColors.size == 1 && projected.hasKeyword(entityId, "HEXPROOF_FROM_MONOCOLORED")
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -71,6 +71,7 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.CostPaymentChoices
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.Zone
 import kotlin.reflect.KClass
 
@@ -181,7 +182,7 @@ class ActivateAbilityHandler(
         // Apply ability-specific generic cost reduction (e.g., The Dominion Bracelet's
         // "{X} less, where X is this creature's power"). Per Scryfall ruling, the reduced
         // cost is locked in here, before costs are paid.
-        val effectiveCost = applyGenericCostReduction(rawCost, ability, state, action.sourceId, action.playerId)
+        val effectiveCost = applyGenericCostReduction(rawCost, ability, state, action.sourceId, action.playerId, action.targets)
         val effectiveTargetReqs = if (textReplacement != null) {
             ability.targetRequirements.map { it.applyTextReplacement(textReplacement) }
         } else {
@@ -361,7 +362,7 @@ class ActivateAbilityHandler(
         }
         // Apply ability-specific generic cost reduction (e.g., The Dominion Bracelet's
         // "{X} less, where X is this creature's power"). Locked in before payment.
-        val effectiveCost = applyGenericCostReduction(rawCost, ability, state, action.sourceId, action.playerId)
+        val effectiveCost = applyGenericCostReduction(rawCost, ability, state, action.sourceId, action.playerId, action.targets)
 
         val executeAbilityContext = buildAbilityPaymentContext(cardComponent, state.projectedState, action.sourceId)
 
@@ -998,21 +999,26 @@ class ActivateAbilityHandler(
     /**
      * Apply [ActivatedAbility.genericCostReduction] to the mana portion of [cost].
      * The reduction is evaluated against the activating entity (e.g., the equipped creature
-     * for The Dominion Bracelet, whose granted ability reduces by the creature's power).
-     * Per Scryfall ruling, this is locked in before costs are paid.
+     * for The Dominion Bracelet, whose granted ability reduces by the creature's power) and,
+     * when present, the chosen [targets] — so reductions that read the target the player picked
+     * (e.g. Dragonfire Blade's "costs {1} less to activate for each color of the creature it
+     * targets") resolve against that target. Per Scryfall ruling, this is locked in before costs
+     * are paid.
      */
     private fun applyGenericCostReduction(
         cost: AbilityCost,
         ability: ActivatedAbility,
         state: GameState,
         sourceId: EntityId,
-        controllerId: EntityId
+        controllerId: EntityId,
+        targets: List<ChosenTarget>
     ): AbilityCost {
         val reduction = ability.genericCostReduction ?: return cost
         val reductionContext = EffectContext(
             sourceId = sourceId,
             controllerId = controllerId,
-            opponentId = null
+            opponentId = null,
+            targets = targets
         )
         val amount = DynamicAmountEvaluator().evaluate(state, reduction, reductionContext)
         if (amount <= 0) return cost

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -140,7 +140,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 // Apply ability-specific generic cost reduction so payability is checked against
                 // the locked-in cost (e.g., The Dominion Bracelet — "{X} less, where X is this
                 // creature's power").
-                val effectiveCost = applyAbilityGenericCostReduction(rawCost, ability, state, entityId, playerId)
+                val effectiveCost = applyAbilityGenericCostReduction(rawCost, ability, state, entityId, playerId, context)
 
                 // Description shown to the player. When the ability has a generic cost reduction
                 // that's currently active, rebuild the prefix from [effectiveCost] so the menu
@@ -947,24 +947,70 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
      * Apply [ActivatedAbility.genericCostReduction] to the mana portion of [cost].
      * The reduction is evaluated against the activating entity (e.g., the equipped creature
      * for The Dominion Bracelet, where X = the creature's power).
+     *
+     * When the ability requires a target, the player hasn't chosen one yet at enumeration time,
+     * so a reduction that reads the chosen target (e.g. Dragonfire Blade — "costs {1} less to
+     * activate for each color of the creature it targets") can't resolve a specific target here.
+     * We gate affordability on the *cheapest* reachable cost — the largest reduction over the
+     * currently-legal targets — so the ability is offered (and its displayed cost shown) whenever
+     * it's payable for at least one target. The handler re-derives the exact reduction from the
+     * target the player actually chose (ActivateAbilityHandler.applyGenericCostReduction), and in
+     * auto-tap mode pays that exact per-target cost. The reduction only ever lowers the cost, so a
+     * best-case preview never causes the client to under-tap for the chosen target in auto-tap mode.
      */
     private fun applyAbilityGenericCostReduction(
         cost: AbilityCost,
         ability: ActivatedAbility,
         state: com.wingedsheep.engine.state.GameState,
         sourceId: EntityId,
-        controllerId: EntityId
+        controllerId: EntityId,
+        enumerationContext: EnumerationContext
     ): AbilityCost {
         val reduction = ability.genericCostReduction ?: return cost
-        val context = com.wingedsheep.engine.handlers.EffectContext(
+        val evaluator = com.wingedsheep.engine.handlers.DynamicAmountEvaluator()
+        val baseContext = com.wingedsheep.engine.handlers.EffectContext(
             sourceId = sourceId,
             controllerId = controllerId,
             opponentId = null
         )
-        val amount = com.wingedsheep.engine.handlers.DynamicAmountEvaluator()
-            .evaluate(state, reduction, context)
+        val amount = if (ability.targetRequirements.isNotEmpty()) {
+            maxReductionOverLegalTargets(reduction, ability, state, sourceId, controllerId, enumerationContext, evaluator)
+        } else {
+            evaluator.evaluate(state, reduction, baseContext)
+        }
         if (amount <= 0) return cost
         return reduceGenericInAbilityCost(cost, amount)
+    }
+
+    /**
+     * Largest [reduction] achievable across the ability's currently-legal first-requirement
+     * targets. Evaluates the reduction once per legal target (as if that target were chosen) and
+     * keeps the maximum. For a reduction that doesn't read the target this collapses to a constant,
+     * so it stays correct for non-target-dependent reductions on targeted abilities too. Returns 0
+     * when there are no legal targets (the ability won't be offered anyway).
+     */
+    private fun maxReductionOverLegalTargets(
+        reduction: com.wingedsheep.sdk.scripting.values.DynamicAmount,
+        ability: ActivatedAbility,
+        state: com.wingedsheep.engine.state.GameState,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        enumerationContext: EnumerationContext,
+        evaluator: com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+    ): Int {
+        val validTargets = enumerationContext.targetUtils
+            .buildTargetInfos(state, controllerId, ability.targetRequirements, sourceId = sourceId)
+            .firstOrNull()?.validTargets ?: emptyList()
+        if (validTargets.isEmpty()) return 0
+        return validTargets.maxOf { targetId ->
+            val targetContext = com.wingedsheep.engine.handlers.EffectContext(
+                sourceId = sourceId,
+                controllerId = controllerId,
+                opponentId = null,
+                targets = listOf(ChosenTarget.Permanent(targetId))
+            )
+            evaluator.evaluate(state, reduction, targetContext)
+        }
     }
 
     private fun reduceGenericInAbilityCost(cost: AbilityCost, amount: Int): AbilityCost = when (cost) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -180,6 +180,9 @@ internal class EffectApplicator(
                         values.keywords.add("HEXPROOF_FROM_$colorName")
                     }
                 }
+                is Modification.GrantHexproofFromMonocolored -> {
+                    values.keywords.add("HEXPROOF_FROM_MONOCOLORED")
+                }
                 is Modification.GrantProtectionFromControlledColors -> {
                     // Protection from the colors of permanents the source's controller controls
                     // (e.g., Pledge of Loyalty). Read the projected controller + projected colors

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
@@ -415,6 +415,16 @@ sealed interface Modification {
     }
 
     /**
+     * Grants "hexproof from monocolored" to each affected entity — adds the keyword
+     * `HEXPROOF_FROM_MONOCOLORED`, which blocks targeting by monocolored (exactly one color)
+     * spells and abilities opponents control. Used for Dragonfire Blade.
+     */
+    @Serializable
+    data object GrantHexproofFromMonocolored : Modification {
+        override val layer get() = Layer.ABILITY
+    }
+
+    /**
      * Grants each affected entity "protection from the colors of permanents the source's
      * controller controls". Read at apply-time: collects the projected colors of every
      * battlefield permanent controlled by the source's (projected) controller, then adds

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -43,6 +43,7 @@ import com.wingedsheep.sdk.scripting.GrantSupertype
 import com.wingedsheep.sdk.scripting.GrantProtectionFromChosenColorToGroup
 import com.wingedsheep.sdk.scripting.GrantProtectionFromControlledColors
 import com.wingedsheep.sdk.scripting.GrantHexproofFromOwnColorsToGroup
+import com.wingedsheep.sdk.scripting.GrantHexproofFromMonocoloredToGroup
 import com.wingedsheep.sdk.scripting.AnimateLandGroup
 import com.wingedsheep.sdk.scripting.GrantAdditionalTypesToGroup
 import com.wingedsheep.sdk.scripting.GrantColor
@@ -339,6 +340,12 @@ class StaticAbilityHandler(
             is GrantHexproofFromOwnColorsToGroup -> {
                 ContinuousEffectData(
                     modification = Modification.GrantHexproofFromOwnColors,
+                    affectsFilter = convertGroupFilter(ability.filter)
+                )
+            }
+            is GrantHexproofFromMonocoloredToGroup -> {
+                ContinuousEffectData(
+                    modification = Modification.GrantHexproofFromMonocolored,
                     affectsFilter = convertGroupFilter(ability.filter)
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -263,6 +263,11 @@ class TargetValidator {
                     return "$cardName has hexproof from ${color.displayName.lowercase()}"
                 }
             }
+            // Hexproof from monocolored: a source with exactly one color can't target (CR 105.2).
+            if (sourceColors.size == 1 && projected.hasKeyword(entityId, "HEXPROOF_FROM_MONOCOLORED")) {
+                val cardName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: "target"
+                return "$cardName has hexproof from monocolored"
+            }
         }
         return null
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -145,6 +145,9 @@ data class ClientCard(
     /** Hexproof-from-color colors (for colored hexproof shield icons) */
     val hexproofFromColors: List<Color> = emptyList(),
 
+    /** Hexproof from monocolored (CR 105.2) — shows an uncolored hexproof shield chip */
+    val hexproofFromMonocolored: Boolean = false,
+
     /** Counters on the card */
     val counters: Map<CounterType, Int>,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -675,6 +675,9 @@ class ClientStateTransformer(
             ?.distinct()
             ?: emptyList()
 
+        // Hexproof from monocolored (CR 105.2) — a quality, not a color, so it rides its own flag.
+        val hexproofFromMonocolored = projectedValues?.keywords?.contains("HEXPROOF_FROM_MONOCOLORED") ?: false
+
         // Add PROTECTION keyword when protections are present
         val keywords = if (protections.isNotEmpty()) rawKeywords + Keyword.PROTECTION else rawKeywords
 
@@ -1021,6 +1024,7 @@ class ClientStateTransformer(
             abilityFlags = abilityFlags,
             protections = protections,
             hexproofFromColors = hexproofFromColors,
+            hexproofFromMonocolored = hexproofFromMonocolored,
             counters = counters,
             isTapped = isTapped,
             hasSummoningSickness = hasSummoningSickness,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragonfireBladeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragonfireBladeTest.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.mechanics.targeting.TargetValidator
+import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
@@ -144,5 +145,9 @@ class DragonfireBladeTest : FunSpec({
         // The controller can still target their own creature with a monocolored source.
         validator.validateTargets(driver.state, target, req, casterId = player, sourceColors = setOf(Color.RED))
             .shouldBeNull()
+
+        // The client DTO surfaces the quality so the FE can render the hexproof-from-monocolored chip.
+        val view = ClientStateTransformer(cardRegistry = driver.cardRegistry).transform(driver.state, viewingPlayerId = opponent)
+        view.cards[beast]?.hexproofFromMonocolored shouldBe true
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragonfireBladeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragonfireBladeTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.targeting.TargetValidator
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.DragonfireBlade
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+/**
+ * Tests for Dragonfire Blade (TDM) — exercises gap item 18:
+ * "Equip {4}. This ability costs {1} less to activate for each color of the creature it targets."
+ * plus the granted "hexproof from monocolored".
+ *
+ * The cost reduction is the engine's per-activation [com.wingedsheep.sdk.scripting.ActivatedAbility.genericCostReduction]
+ * fed `DynamicAmounts.targetColorCount()`, which reads the chosen equip target's color count.
+ */
+class DragonfireBladeTest : FunSpec({
+
+    val equipAbilityId = DragonfireBlade.activatedAbilities.first().id
+
+    // Vanilla test creatures of varying color counts (colors derive from the mana cost).
+    val triColorBeast = CardDefinition.creature("Test Trio Beast", ManaCost.parse("{W}{U}{B}"), emptySet(), 3, 3)
+    val gruulBeast = CardDefinition.creature("Test Gruul Beast", ManaCost.parse("{R}{G}"), emptySet(), 2, 2)
+    val monoBear = CardDefinition.creature("Test Mono Bear", ManaCost.parse("{G}"), emptySet(), 2, 2)
+    val colorlessGolem = CardDefinition.creature("Test Golem", ManaCost.parse("{2}"), emptySet(), 2, 2)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DragonfireBlade)
+        driver.registerCard(triColorBeast)
+        driver.registerCard(gruulBeast)
+        driver.registerCard(monoBear)
+        driver.registerCard(colorlessGolem)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("equip costs {1} less per color of the target — three-color creature pays {1}") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val blade = driver.putPermanentOnBattlefield(player, "Dragonfire Blade")
+        val beast = driver.putCreatureOnBattlefield(player, "Test Trio Beast")
+
+        // Equip {4} reduced by 3 colors = {1}. One mana is exactly enough.
+        driver.giveColorlessMana(player, 1)
+        val result = driver.submit(
+            ActivateAbility(player, blade, equipAbilityId, targets = listOf(ChosenTarget.Permanent(beast)))
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.getEntity(blade)?.get<AttachedToComponent>()?.targetId shouldBe beast
+    }
+
+    test("equip onto a two-color creature pays {2}") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val blade = driver.putPermanentOnBattlefield(player, "Dragonfire Blade")
+        val beast = driver.putCreatureOnBattlefield(player, "Test Gruul Beast")
+
+        // {4} - 2 colors = {2}. One mana is not enough...
+        driver.giveColorlessMana(player, 1)
+        driver.submitExpectFailure(
+            ActivateAbility(player, blade, equipAbilityId, targets = listOf(ChosenTarget.Permanent(beast)))
+        )
+        driver.state.getEntity(blade)?.get<AttachedToComponent>().shouldBeNull()
+
+        // ...but two mana is.
+        driver.giveColorlessMana(player, 1)
+        driver.submit(
+            ActivateAbility(player, blade, equipAbilityId, targets = listOf(ChosenTarget.Permanent(beast)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getEntity(blade)?.get<AttachedToComponent>()?.targetId shouldBe beast
+    }
+
+    test("equip onto a colorless creature gets no reduction — pays the full {4}") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val blade = driver.putPermanentOnBattlefield(player, "Dragonfire Blade")
+        val golem = driver.putCreatureOnBattlefield(player, "Test Golem")
+
+        // Three mana is short of the unreduced {4}.
+        driver.giveColorlessMana(player, 3)
+        driver.submitExpectFailure(
+            ActivateAbility(player, blade, equipAbilityId, targets = listOf(ChosenTarget.Permanent(golem)))
+        )
+
+        // The fourth mana covers it.
+        driver.giveColorlessMana(player, 1)
+        driver.submit(
+            ActivateAbility(player, blade, equipAbilityId, targets = listOf(ChosenTarget.Permanent(golem)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getEntity(blade)?.get<AttachedToComponent>()?.targetId shouldBe golem
+    }
+
+    test("equipped creature has hexproof from monocolored — blocks monocolored opponents only") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val blade = driver.putPermanentOnBattlefield(player, "Dragonfire Blade")
+        val beast = driver.putCreatureOnBattlefield(player, "Test Trio Beast")
+        driver.giveColorlessMana(player, 1)
+        driver.submit(
+            ActivateAbility(player, blade, equipAbilityId, targets = listOf(ChosenTarget.Permanent(beast)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        val validator = TargetValidator()
+        val target = listOf<ChosenTarget>(ChosenTarget.Permanent(beast))
+        val req = listOf(TargetCreature())
+
+        // A monocolored opponent's source can't target it.
+        validator.validateTargets(driver.state, target, req, casterId = opponent, sourceColors = setOf(Color.RED))
+            .shouldNotBeNull()
+
+        // A multicolored opponent's source can.
+        validator.validateTargets(driver.state, target, req, casterId = opponent, sourceColors = setOf(Color.RED, Color.WHITE))
+            .shouldBeNull()
+
+        // A colorless opponent's source can (colorless is not monocolored).
+        validator.validateTargets(driver.state, target, req, casterId = opponent, sourceColors = emptySet())
+            .shouldBeNull()
+
+        // The controller can still target their own creature with a monocolored source.
+        validator.validateTargets(driver.state, target, req, casterId = player, sourceColors = setOf(Color.RED))
+            .shouldBeNull()
+    }
+})

--- a/web-client/src/components/game/card/CardOverlays.tsx
+++ b/web-client/src/components/game/card/CardOverlays.tsx
@@ -22,6 +22,9 @@ const COLOR_TINTS: Record<string, string> = {
   GREEN: '#40a050',
 }
 
+/** Neutral tint for quality-scoped hexproof shields (e.g. "from monocolored") — no single color fits. */
+const HEXPROOF_QUALITY_TINT = '#c8b86a'
+
 /**
  * Renders a single keyword glyph: prefer a local SVG when mapped (for keywords
  * the mana-font Arena set lacks, e.g. PERSIST), otherwise fall back to mana-font.
@@ -53,6 +56,7 @@ export function KeywordIcons({
   abilityFlags,
   protections,
   hexproofFromColors,
+  hexproofFromMonocolored,
   isSuspected,
   size,
 }: {
@@ -60,6 +64,8 @@ export function KeywordIcons({
   abilityFlags?: readonly AbilityFlag[]
   protections: readonly Color[]
   hexproofFromColors?: readonly Color[]
+  /** Hexproof from monocolored (CR 105.2) — an uncolored hexproof-quality shield. */
+  hexproofFromMonocolored?: boolean
   /** Whether the permanent currently has the suspected status (CR 701.60). */
   isSuspected?: boolean
   size: number
@@ -68,17 +74,20 @@ export function KeywordIcons({
   // Also drop generic HEXPROOF when the creature only has per-color hexproof — the colored shields below
   // already convey the protection set, and showing an uncolored shield alongside misleads the player.
   const hexproofFromList = hexproofFromColors ?? []
+  const hasHexproofFromMonocolored = hexproofFromMonocolored === true
+  // Any "hexproof from [quality]" — per-color or monocolored — that conveys the protection set.
+  const hasScopedHexproof = hexproofFromList.length > 0 || hasHexproofFromMonocolored
   const hasFullHexproof = keywords.includes('HEXPROOF' as Keyword)
   const hasDoubleStrike = keywords.includes('DOUBLE_STRIKE' as Keyword)
   const filteredKeywords = keywords.filter(k =>
     displayableKeywords.has(k)
     && k !== 'PROTECTION'
     && !(k === 'FIRST_STRIKE' && hasDoubleStrike)
-    && !(k === 'HEXPROOF' && !hasFullHexproof && hexproofFromList.length > 0)
+    && !(k === 'HEXPROOF' && !hasFullHexproof && hasScopedHexproof)
   )
   const displayableFlags = (abilityFlags ?? []).filter(f => displayableKeywords.has(f))
   const hasProtections = protections.length > 0
-  const hasHexproofFrom = hexproofFromList.length > 0
+  const hasHexproofFrom = hasScopedHexproof
   const hasKeywords = filteredKeywords.length > 0 || displayableFlags.length > 0
   const hasSuspected = isSuspected === true
 
@@ -140,6 +149,28 @@ export function KeywordIcons({
           />
         </div>
       ))}
+      {hasHexproofFromMonocolored && (
+        <div
+          key="hexproof-monocolored"
+          style={{
+            ...styles.keywordIconWrapper,
+            // Neutral grey ring distinguishes the quality shield from the per-color ones.
+            border: `1px solid ${HEXPROOF_QUALITY_TINT}`,
+            boxShadow: `0 0 4px ${HEXPROOF_QUALITY_TINT}`,
+          }}
+          title="Hexproof from monocolored"
+        >
+          <i
+            className="ms ms-ability-hexproof"
+            style={{
+              fontSize: size,
+              color: HEXPROOF_QUALITY_TINT,
+              display: 'block',
+              lineHeight: 1,
+            }}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1735,7 +1735,7 @@ function GameCardImpl({
 
       {/* Keyword ability icons (shown for face-up cards, and for face-down cards with granted keywords) */}
       {battlefield && !hideKeywordIcons && (card.keywords.length > 0 || (card.abilityFlags && card.abilityFlags.length > 0) || (card.protections && card.protections.length > 0) || (card.hexproofFromColors && card.hexproofFromColors.length > 0) || card.isSuspected) && (
-        <KeywordIcons keywords={card.keywords} abilityFlags={card.abilityFlags ?? []} protections={card.protections ?? []} hexproofFromColors={card.hexproofFromColors ?? []} isSuspected={card.isSuspected ?? false} size={responsive.badges.keywordIconSize} />
+        <KeywordIcons keywords={card.keywords} abilityFlags={card.abilityFlags ?? []} protections={card.protections ?? []} hexproofFromColors={card.hexproofFromColors ?? []} hexproofFromMonocolored={card.hexproofFromMonocolored ?? false} isSuspected={card.isSuspected ?? false} size={responsive.badges.keywordIconSize} />
       )}
 
       {/* Revealed face-down eye icon (e.g., peeked via Spy Network) */}

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -124,6 +124,9 @@ export interface ClientCard {
   /** Hexproof-from-color colors (for colored hexproof shield icons) */
   readonly hexproofFromColors?: readonly Color[]
 
+  /** Hexproof from monocolored (CR 105.2) — shows an uncolored hexproof shield chip */
+  readonly hexproofFromMonocolored?: boolean
+
   /** Counters on the card */
   readonly counters: Partial<Record<CounterType, number>>
 


### PR DESCRIPTION
Closes the last **TDM engine gap (item 18)**: an activated (equip) ability whose cost *"costs {1} less to activate for each color of the creature it targets."* → **Dragonfire Blade**.

## The feature (item 18)

No new cost-reduction machinery was needed. `ActivatedAbility.genericCostReduction` already reduces an activated ability's generic cost by a `DynamicAmount` evaluated at activation (The Dominion Bracelet uses it). The only gap was that it was evaluated *without* the chosen target. This PR:

- **Adds the reusable `EntityNumericProperty.ColorCount`** — distinct colors of any referenced entity, read off projected colors (so layer-5 color-changing is honored; a creature turned colorless counts 0), mirroring the existing `SubtypeCount`. Plus `DynamicAmounts.targetColorCount()` / `colorCountOf(entity)` facades.
- **Threads `action.targets` into `ActivateAbilityHandler.applyGenericCostReduction`**, so a reduction reading `EntityReference.Target(0)` resolves against the picked equip target.
- **Makes the enumerator target-aware for affordability.** No target is chosen at enumeration time, so the legal-action enumerator gates affordability (and the displayed cost) on the *cheapest reachable* cost — the largest reduction over the currently-legal targets — and the handler re-derives the exact per-target cost at activation. The reduction only ever lowers the cost, so in auto-tap mode (the default) the server pays the correct per-target amount and a best-case preview never under-taps.
- **Extends the `equipAbility(cost, genericCostReduction = …)` DSL form.**

Named for the mechanic, parameterized over the entity reference and dynamic amount — the same `EntityProperty(…, ColorCount)` serves any future "for each color of X".

## Card completeness: "hexproof from monocolored"

Dragonfire Blade also grants *"hexproof from monocolored"* to the equipped creature. Implemented as a `GrantHexproofFromMonocoloredToGroup` static ability (mirroring `GrantHexproofFromOwnColorsToGroup`) projected to a `HEXPROOF_FROM_MONOCOLORED` keyword, with a CR-105.2 monocolored-source (`sourceColors.size == 1`) check added to both the target validator and the target enumerator. Consistent with the existing keyword-string protection model; the client conveys it via oracle text like other non-color protection scopes.

## Tests

`DragonfireBladeTest` (all green) covers:
- 3-color target → equip pays {1}; 2-color → {2}; colorless → full {4} (with negative cases for insufficient mana).
- Attachment succeeds with the reduced cost.
- Hexproof from monocolored: blocks a monocolored opponent source, allows multicolored and colorless sources, and never blocks the controller.

Regression batches run green: SDK card validation/DSL, equipment/hexproof/protection scenarios, and the full `legalactions` + `targeting` packages (shared enumerator/validator changes).

Docs (`card-sdk-language-reference.md`) and the TDM gap backlog updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)