### PR TITLE
Resolve LOW cleanup items from SDK quality audit

### DIFF
--- a/backlog/sdk-quality-audit.md
+++ b/backlog/sdk-quality-audit.md
@@ -197,24 +197,31 @@ User counts are caller _files_ in `mtg-sets/src/main` (worktree copies excluded)
 
 ## LOW — opportunistic / cleanup
 
-- **Dead facade entries (0 callers):** `readTheRunes`, `destroyAllSharingTypeWithSacrificed`,
-  `takeFromLinkedExile`, `eachPlayerReturnsPermanentToHand`, `chooseCreatureTypeGainControl`, plus
-  redundant `EffectPatterns.connive` / `EffectPatterns.drain` aliases (cards reach the mechanics via
-  `Effects.*`). Remove after confirming no out-of-module references.
-- **`Int` amounts that should be `DynamicAmount`** (convert when a 2nd user lands):
-  `GrantDamageBonusEffect.bonusAmount` (`PlayerEffects.kt:389`, Flame of Keld);
-  `BudgetModalEffect.budget` (`CompositeEffects.kt:1021`); `TakeExtraTurnEffect.loseAtEndStep`
-  (`PlayerEffects.kt:116`) → generic `endOfExtraTurnEffect: Effect?`.
-- **`AmassEffect.subtype` defaults to `"Orc"`** (`AmassEffect.kt:22`) — bakes one set's flavor into a
-  generic primitive (Amass is a real keyword, CR 701.47). Make `subtype` required.
-- **`GainControlByActivePlayerEffect` vs `GiveControlToTargetPlayerEffect`**
-  (`ControlEffects.kt:46, 120`) — converge on one player-parametric
-  `GiveControl(permanent, newController, duration)`; the ActivePlayer variant is also missing a
-  `duration` field.
+- **Dead facade entries — claim was stale; only `drain` was actually dead. ✅ DONE.** Re-checking
+  callers showed the original "0 callers" list was wrong: `readTheRunes` (Read the Runes),
+  `destroyAllSharingTypeWithSacrificed` (Endemic Plague), `takeFromLinkedExile` (Parallel Thoughts),
+  `eachPlayerReturnsPermanentToHand` (Words of Wind), and `chooseCreatureTypeGainControl` (Peer
+  Pressure) are all **live** — each reached by a real card through its `Effects.*` wrapper. Deleting
+  them would break those cards, so they were kept. `EffectPatterns.connive` is likewise live
+  (`Effects.Connive`); kept as a consistent sibling of the ~40 other `EffectPatterns` delegations
+  rather than singled out. The only genuinely dead entry was **`drain`** (no `Effects.Drain` wrapper,
+  zero callers) — `EffectPatterns.drain` + `MiscPatterns.drain` + its DSL-reference line deleted.
+- **`Int` amounts that should be `DynamicAmount`** (convert when a 2nd user lands — deliberately left
+  per the no-premature-generalization rule): `GrantDamageBonusEffect.bonusAmount`
+  (`PlayerEffects.kt:389`, Flame of Keld); `BudgetModalEffect.budget` (`CompositeEffects.kt:1021`);
+  `TakeExtraTurnEffect.loseAtEndStep` (`PlayerEffects.kt:116`) → generic `endOfExtraTurnEffect: Effect?`.
+- **`AmassEffect.subtype` defaulted to `"Orc"` ✅ DONE.** Default removed from `AmassEffect` and both
+  `Effects.Amass` overloads; the keyword's subtype is now required (Amass is CR 701.47 and the Army's
+  type is printed on each card). All 19 LTR call sites updated to pass `"Orc"` explicitly.
+- **`GainControlByActivePlayerEffect` vs `GiveControlToTargetPlayerEffect`** (`ControlEffects.kt:46, 120`)
+  — converge on one player-parametric `GiveControl(permanent, newController, duration)`. **Deferred:**
+  the merge needs a new `Player.ActivePlayer` reference (none exists today) whose addition ripples
+  through every exhaustive `when (player)` in the SDK + engine and reworks the hardcoded "target
+  opponent gains control" description — feature-sized blast radius, not opportunistic cleanup.
 - **`ForceExileMultiZoneEffect`** (`RemovalEffects.kt:448`) — zone set hardcoded in name/behavior;
-  1 user. Parameterize `zones: Set<Zone>` if a second multi-zone-exile card appears.
-- **Cosmetic:** `SourceAbilityResolvedNTimesThisTurn` ordinal produces "21th"/"22th"
-  (`TurnConditions.kt:199`) — only special-cases 1–3.
+  1 user. Parameterize `zones: Set<Zone>` if a second multi-zone-exile card appears. (Deferred to 2nd user.)
+- **Cosmetic:** `SourceAbilityResolvedNTimesThisTurn` ordinal produced "21th"/"22th" ✅ DONE — added an
+  `ordinalSuffix` helper (21st/22nd/23rd/24th, with the 11–13 exceptions) in `TurnConditions.kt`.
 
 ---
 
@@ -250,4 +257,6 @@ Each touches shared SDK types with cross-layer wiring, so route through the **`a
 5. #5 protection combinator ✅ done · #6 `OpenLifeBidEffect` rename ✅ done · #7 shared tally ⚠️ partial (types not yet merged)
 6. Remaining MEDIUM: #8 `CopyNextSpellCast` spellFilter (not done)
 7. #9 inline single-card `EffectPatterns` helpers (not done — all 15 still present)
-8. LOW cleanup (not done; ordinal still emits "21th"/"22th")
+8. LOW cleanup ✅ actionable items done — dead `drain` removed (the rest of the "dead facade" list
+   was stale: all live), `AmassEffect.subtype` made required, ordinal fixed. Convergence + the two
+   "wait for 2nd user" items deliberately deferred (see LOW section for rationale).

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -560,7 +560,6 @@ Composed pipelines (`GatherCards → SelectFromCollection → MoveCollection` sh
 - `rummage(count?)` — discard then draw.
 - `connive(target?)` — draw 1, discard 1, then put a +1/+1 counter on `target` if the discard was a nonland (CR 702.166). Also exposed as `Effects.Connive(target)`.
 - `readTheRunes()` — "draw X cards; for each, discard a card unless you sacrifice a permanent." Composes `RepeatDynamicTimesEffect(XValue, ChooseActionEffect(...))` with feasibility guards. Exposed as `Effects.ReadTheRunes()`.
-- `drain(amount, target)` — deal N damage, gain N life.
 - `eachOpponentMayPutFromHand(filter?)` — each opponent may dump a matching card.
 - `putFromHand(filter?, count?, entersTapped?)` — you may put N from hand onto battlefield.
 - `incubate(n)` — make an Incubator token with N counters.
@@ -2134,8 +2133,9 @@ Card authors rarely reference these directly; they are created/updated by the ma
   `RingBearerCantBeBlockedByGreaterPowerRule`; the ≥2/≥3/≥4 triggered abilities are appended to the bearer by
   `TriggerAbilityResolver` (see `TheRingAbilities`). For card triggers/checks use `Triggers.RingTemptsYou`
   ("Whenever the Ring tempts you") and `Conditions.SourceIsRingBearer` ("if this is your Ring-bearer").
-- **Amass [subtype] N (CR 701.47)** — `Effects.Amass(count, subtype = "Orc")` (fixed) or
-  `Effects.Amass(amount, subtype)` (a `DynamicAmount`, for "amass Orcs X"). If the controller controls no Army
+- **Amass [subtype] N (CR 701.47)** — `Effects.Amass(count, subtype)` (fixed) or
+  `Effects.Amass(amount, subtype)` (a `DynamicAmount`, for "amass Orcs X"). `subtype` is required (no default) —
+  the amassed Army's type is printed on each card (Orcs for the LTR cards). If the controller controls no Army
   creature, a 0/0 black `[subtype]` Army token is created first (composing `CreateTokenEffect`); then they put N
   +1/+1 counters on an Army they control (a `SelectCardsDecision` resolved by `AmassContinuation` picks which one
   when they control several) and that Army becomes the subtype if it isn't already. The counter/subtype back half

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/EffectPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/EffectPatterns.kt
@@ -107,13 +107,6 @@ object EffectPatterns {
         MiscPatterns.sequence(*effects)
 
     // =========================================================================
-    // Drain (MiscPatterns)
-    // =========================================================================
-
-    fun drain(amount: Int, target: EffectTarget): CompositeEffect =
-        MiscPatterns.drain(amount, target)
-
-    // =========================================================================
     // Gift Pattern (Bloomburrow)
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -567,11 +567,11 @@ object Effects {
      * control, creating a 0/0 black [subtype] Army token first if they control no Army, and the
      * chosen Army becomes that subtype in addition to its other types.
      */
-    fun Amass(count: Int, subtype: String = "Orc"): Effect =
+    fun Amass(count: Int, subtype: String): Effect =
         com.wingedsheep.sdk.scripting.effects.AmassEffect(DynamicAmount.Fixed(count), subtype)
 
     /** "Amass [subtype] X" with a dynamic amount (e.g. Fall of Cair Andros, The Mouth of Sauron). */
-    fun Amass(amount: DynamicAmount, subtype: String = "Orc"): Effect =
+    fun Amass(amount: DynamicAmount, subtype: String): Effect =
         com.wingedsheep.sdk.scripting.effects.AmassEffect(amount, subtype)
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MiscPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MiscPatterns.kt
@@ -9,12 +9,10 @@ import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.Chooser
 import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
-import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.EffectChoice
 import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
 import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
-import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
@@ -33,7 +31,7 @@ import com.wingedsheep.sdk.scripting.values.EffectVariable
 /**
  * Small utility effect patterns that don't fit a larger domain category:
  * optional costs, sacrifice, reflexive triggers, store/reference, sequence,
- * drain, and multi-player utility effects.
+ * and multi-player utility effects.
  */
 object MiscPatterns {
 
@@ -121,13 +119,6 @@ object MiscPatterns {
 
     fun sequence(vararg effects: Effect): CompositeEffect =
         CompositeEffect(effects.toList())
-
-    fun drain(amount: Int, target: EffectTarget): CompositeEffect = CompositeEffect(
-        listOf(
-            DealDamageEffect(amount, target),
-            GainLifeEffect(amount, EffectTarget.Controller)
-        )
-    )
 
     fun eachPlayerReturnsPermanentToHand(): ForEachPlayerEffect = ForEachPlayerEffect(
         players = Player.ActivePlayerFirst,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
@@ -186,8 +186,17 @@ data class SourceAbilityResolvedNTimesThisTurn(val count: Int) : Condition {
         1 -> "first"
         2 -> "second"
         3 -> "third"
-        else -> "${n}th"
+        else -> "$n${ordinalSuffix(n)}"
     }
+
+    /** English ordinal suffix: 21st, 22nd, 23rd, 24th, with the 11th/12th/13th exceptions. */
+    private fun ordinalSuffix(n: Int): String =
+        if (n % 100 in 11..13) "th" else when (n % 10) {
+            1 -> "st"
+            2 -> "nd"
+            3 -> "rd"
+            else -> "th"
+        }
 }
 
 // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/AmassEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/AmassEffect.kt
@@ -12,6 +12,9 @@ import kotlinx.serialization.Serializable
  * [subtype] Army creature token. Then they choose an Army they control, put N +1/+1 counters on it,
  * and — if it isn't already that subtype — it becomes that subtype in addition to its other types.
  *
+ * [subtype] is required — the amassed Army's type is part of each card's printed text (Orcs for the
+ * LTR cards, Zombies / Phyrexians elsewhere), so it must never default to one set's flavor.
+ *
  * The amount is a [DynamicAmount] so the keyword supports both the fixed printings ("amass Orcs 2")
  * and the variable ones ("amass Orcs X", e.g. Fall of Cair Andros, The Mouth of Sauron, Shagrat).
  */
@@ -19,7 +22,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AmassEffect(
     val amount: DynamicAmount = DynamicAmount.Fixed(1),
-    val subtype: String = "Orc"
+    val subtype: String
 ) : Effect {
     override val description: String = "amass ${subtype}s ${amount.description}"
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AssaultOnOsgiliath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/AssaultOnOsgiliath.kt
@@ -27,7 +27,7 @@ val AssaultOnOsgiliath = card("Assault on Osgiliath") {
         "an Army, create a 0/0 black Orc Army creature token first.)"
 
     spell {
-        effect = Effects.Amass(DynamicAmount.XValue)
+        effect = Effects.Amass(DynamicAmount.XValue, "Orc")
             .then(
                 ForEachInGroupEffect(
                     filter = GroupFilter(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BookOfMazarbul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BookOfMazarbul.kt
@@ -27,10 +27,10 @@ val BookOfMazarbul = card("Book of Mazarbul") {
         "III — Creatures you control get +1/+0 and gain menace until end of turn."
 
     sagaChapter(1) {
-        effect = Effects.Amass(1)
+        effect = Effects.Amass(1, "Orc")
     }
     sagaChapter(2) {
-        effect = Effects.Amass(2)
+        effect = Effects.Amass(2, "Orc")
     }
     sagaChapter(3) {
         effect = EffectPatterns.modifyStatsForAll(1, 0, GroupFilter.AllCreaturesYouControl)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DeceiveTheMessenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DeceiveTheMessenger.kt
@@ -24,7 +24,7 @@ val DeceiveTheMessenger = card("Deceive the Messenger") {
     spell {
         val creature = target("target creature", Targets.Creature)
         effect = Effects.ModifyStats(-3, 0, creature)
-            .then(Effects.Amass(1))
+            .then(Effects.Amass(1, "Orc"))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunlandCrebain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/DunlandCrebain.kt
@@ -30,7 +30,7 @@ val DunlandCrebain = card("Dunland Crebain") {
 
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = Effects.Amass(2)
+        effect = Effects.Amass(2, "Orc")
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/EasterlingVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/EasterlingVanguard.kt
@@ -24,7 +24,7 @@ val EasterlingVanguard = card("Easterling Vanguard") {
 
     triggeredAbility {
         trigger = Triggers.Dies
-        effect = Effects.Amass(1)
+        effect = Effects.Amass(1, "Orc")
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GothmogMorgulLieutenant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GothmogMorgulLieutenant.kt
@@ -30,7 +30,7 @@ val GothmogMorgulLieutenant = card("Gothmog, Morgul Lieutenant") {
 
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = Effects.Amass(1)
+        effect = Effects.Amass(1, "Orc")
     }
 
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MarchFromTheBlackGate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MarchFromTheBlackGate.kt
@@ -23,14 +23,14 @@ val MarchFromTheBlackGate = card("March from the Black Gate") {
 
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = Effects.Amass(1)
+        effect = Effects.Amass(1, "Orc")
     }
 
     triggeredAbility {
         trigger = Triggers.YouAttackWithFilter(
             GameObjectFilter.Creature.withSubtype("Army").youControl()
         )
-        effect = Effects.Amass(1)
+        effect = Effects.Amass(1, "Orc")
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MordorMuster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MordorMuster.kt
@@ -25,7 +25,7 @@ val MordorMuster = card("Mordor Muster") {
     spell {
         effect = Effects.DrawCards(1)
             .then(Effects.LoseLife(1, EffectTarget.Controller))
-            .then(Effects.Amass(1))
+            .then(Effects.Amass(1, "Orc"))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/OrcishMedicine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/OrcishMedicine.kt
@@ -30,12 +30,12 @@ val OrcishMedicine = card("Orcish Medicine") {
             mode("Target creature gains lifelink until end of turn") {
                 val creature = target("target creature", Targets.Creature)
                 effect = Effects.GrantKeyword(Keyword.LIFELINK, creature)
-                    .then(Effects.Amass(1))
+                    .then(Effects.Amass(1, "Orc"))
             }
             mode("Target creature gains indestructible until end of turn") {
                 val creature = target("target creature", Targets.Creature)
                 effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature)
-                    .then(Effects.Amass(1))
+                    .then(Effects.Amass(1, "Orc"))
             }
         }
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumanTheWhite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumanTheWhite.kt
@@ -30,7 +30,7 @@ val SarumanTheWhite = card("Saruman the White") {
 
     triggeredAbility {
         trigger = Triggers.NthSpellCast(2, Player.You)
-        effect = Effects.Amass(2)
+        effect = Effects.Amass(2, "Orc")
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumansTrickery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SarumansTrickery.kt
@@ -24,7 +24,7 @@ val SarumansTrickery = card("Saruman's Trickery") {
     spell {
         target("target spell", Targets.Spell)
         effect = Effects.CounterSpell()
-            .then(Effects.Amass(1))
+            .then(Effects.Amass(1, "Orc"))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SwarmingOfMoria.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SwarmingOfMoria.kt
@@ -22,7 +22,7 @@ val SwarmingOfMoria = card("Swarming of Moria") {
 
     spell {
         effect = Effects.CreateTreasure()
-            .then(Effects.Amass(2))
+            .then(Effects.Amass(2, "Orc"))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheTormentOfGollum.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheTormentOfGollum.kt
@@ -58,7 +58,7 @@ val TheTormentOfGollum = card("The Torment of Gollum") {
                     destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
                     moveType = MoveType.Discard
                 ),
-                Effects.Amass(2)
+                Effects.Amass(2, "Orc")
             )
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TreasonOfIsengard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TreasonOfIsengard.kt
@@ -33,7 +33,7 @@ val TreasonOfIsengard = card("Treason of Isengard") {
             )
         )
         effect = Effects.PutOnTopOfLibrary(card)
-            .then(Effects.Amass(2))
+            .then(Effects.Amass(2, "Orc"))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WarbeastOfGorgoroth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WarbeastOfGorgoroth.kt
@@ -32,7 +32,7 @@ val WarbeastOfGorgoroth = card("Warbeast of Gorgoroth") {
             to = Zone.GRAVEYARD,
             binding = TriggerBinding.ANY
         )
-        effect = Effects.Amass(2)
+        effect = Effects.Amass(2, "Orc")
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WargRider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/WargRider.kt
@@ -44,7 +44,7 @@ val WargRider = card("Warg Rider") {
 
     triggeredAbility {
         trigger = Triggers.BeginCombat
-        effect = Effects.Amass(2)
+        effect = Effects.Amass(2, "Orc")
     }
 
     metadata {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmassScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmassScenarioTest.kt
@@ -38,13 +38,13 @@ class AmassScenarioTest : FunSpec({
         manaCost = "{0}"
         typeLine = "Sorcery"
         oracleText = "Amass Orcs 2."
-        spell { effect = Effects.Amass(2) }
+        spell { effect = Effects.Amass(2, "Orc") }
     }
     val AmassOne = card("Amass One") {
         manaCost = "{0}"
         typeLine = "Sorcery"
         oracleText = "Amass Orcs 1."
-        spell { effect = Effects.Amass(1) }
+        spell { effect = Effects.Amass(1, "Orc") }
     }
 
     // Pre-existing Armies for the multi-Army choice. Base 2/2 so they survive state-based actions.
@@ -67,7 +67,7 @@ class AmassScenarioTest : FunSpec({
         keywords(Keyword.FLYING)
         triggeredAbility {
             trigger = Triggers.EntersBattlefield
-            effect = Effects.Amass(2)
+            effect = Effects.Amass(2, "Orc")
         }
     }
 
@@ -84,7 +84,7 @@ class AmassScenarioTest : FunSpec({
                 to = Zone.GRAVEYARD,
                 binding = TriggerBinding.ANY
             )
-            effect = Effects.Amass(2)
+            effect = Effects.Amass(2, "Orc")
         }
     }
 


### PR DESCRIPTION
Addresses the actionable **LOW — opportunistic / cleanup** items from [`backlog/sdk-quality-audit.md`](backlog/sdk-quality-audit.md).

## What changed

### Dead facade entries — the audit's claim was stale
Re-checking callers showed the original "0 callers" list was **wrong**. These are all **live**, each reached by a real card through its `Effects.*` wrapper, so deleting them would have broken cards:

| Facade | Live card caller |
|---|---|
| `readTheRunes` | Read the Runes |
| `destroyAllSharingTypeWithSacrificed` | Endemic Plague |
| `takeFromLinkedExile` | Parallel Thoughts |
| `eachPlayerReturnsPermanentToHand` | Words of Wind |
| `chooseCreatureTypeGainControl` | Peer Pressure |

`EffectPatterns.connive` is likewise live (`Effects.Connive`) — kept as a consistent sibling of the ~40 other `EffectPatterns` delegations rather than singled out.

The **only** genuinely dead entry was **`drain`** (no `Effects.Drain` wrapper, zero callers). Removed `EffectPatterns.drain` + `MiscPatterns.drain` + the DSL-reference line.

### `AmassEffect.subtype` made required
Dropped the `"Orc"` default that baked one set's flavor into a generic CR 701.47 keyword. Both `Effects.Amass` overloads and all **19 LTR call sites** (+ the Amass scenario test) now pass `"Orc"` explicitly.

### Ordinal cosmetic fix
`SourceAbilityResolvedNTimesThisTurn` produced `"21th"`/`"22th"`. Added an `ordinalSuffix` helper → `21st`/`22nd`/`23rd`/`24th`, handling the 11–13 exceptions.

## Deliberately deferred (documented in the audit)
- **`GainControlByActivePlayer` / `GiveControlToTargetPlayer` convergence** — needs a new `Player.ActivePlayer` reference that doesn't exist today; adding it ripples through every exhaustive `when (player)` in the SDK + engine and reworks a hardcoded description. Feature-sized blast radius, not opportunistic cleanup.
- **`Int` → `DynamicAmount`** items and **`ForceExileMultiZoneEffect`** — the audit marks these "convert when a 2nd user lands"; left per the project's no-premature-generalization rule.

## Testing
- `./gradlew :mtg-sdk:test` ✅
- `./gradlew :rules-engine:test --tests "*AmassScenarioTest*"` ✅ (6/6)
- `:mtg-sdk` + `:mtg-sets` compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
