### PR TITLE
Add basic lands to Tarkir: Dragonstorm

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/TarkirDragonstormSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/TarkirDragonstormSet.kt
@@ -22,6 +22,10 @@ object TarkirDragonstormSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TarkirDragonstormBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TarkirDragonstormBasicLands.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Tarkir: Dragonstorm Basic Lands
+ *
+ * Tarkir: Dragonstorm contains 4 art variants of each basic land type.
+ * Cards 272-291.
+ */
+
+// =============================================================================
+// Plains (Cards 272, 277, 278, 287)
+// =============================================================================
+
+val TdmPlains272 = basicLand("Plains") {
+    collectorNumber = "272"
+    artist = "Sergey Glushakov"
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0d0f1dd6-9564-4adc-af7d-f83252e8581a.jpg?1743205074"
+}
+
+val TdmPlains277 = basicLand("Plains") {
+    collectorNumber = "277"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/12cff32a-a365-43ee-a196-8ce32b3bb9fd.jpg?1743205092"
+}
+
+val TdmPlains278 = basicLand("Plains") {
+    collectorNumber = "278"
+    artist = "Valera Lutfullina"
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b8c391f2-b340-43c7-89e6-afac5b70491f.jpg?1743205099"
+}
+
+val TdmPlains287 = basicLand("Plains") {
+    collectorNumber = "287"
+    artist = "Ron Spencer"
+    imageUri = "https://cards.scryfall.io/normal/front/3/e/3e8c67e5-587a-43b2-af47-bbad1f8b52e9.jpg?1743205132"
+}
+
+// =============================================================================
+// Island (Cards 273, 279, 280, 288)
+// =============================================================================
+
+val TdmIsland273 = basicLand("Island") {
+    collectorNumber = "273"
+    artist = "Sergey Glushakov"
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/4208e66c-8c98-4c48-ab07-8523c0b26ca4.jpg?1743205078"
+}
+
+val TdmIsland279 = basicLand("Island") {
+    collectorNumber = "279"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/1/f/1ff6acc9-581c-468f-894d-41f725da7f33.jpg?1743205101"
+}
+
+val TdmIsland280 = basicLand("Island") {
+    collectorNumber = "280"
+    artist = "Constantin Marin"
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/15be7923-6efc-4650-b8d1-f61cb33ef81d.jpg?1743205106"
+}
+
+val TdmIsland288 = basicLand("Island") {
+    collectorNumber = "288"
+    artist = "Ron Spencer"
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b300be80-6618-4284-b5c3-95c1ab373e6f.jpg?1743205137"
+}
+
+// =============================================================================
+// Swamp (Cards 274, 281, 282, 289)
+// =============================================================================
+
+val TdmSwamp274 = basicLand("Swamp") {
+    collectorNumber = "274"
+    artist = "Sergey Glushakov"
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef235170-8276-4ef0-bdfd-ba68d5b218ec.jpg?1743205082"
+}
+
+val TdmSwamp281 = basicLand("Swamp") {
+    collectorNumber = "281"
+    artist = "Alexander Ostrowski"
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f0bfdb9e-318f-4acd-9fbd-41b98a8875d6.jpg?1743205109"
+}
+
+val TdmSwamp282 = basicLand("Swamp") {
+    collectorNumber = "282"
+    artist = "Arthur Yuan"
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac885eb7-9dae-4c48-b45c-97ef9c62c99e.jpg?1743205112"
+}
+
+val TdmSwamp289 = basicLand("Swamp") {
+    collectorNumber = "289"
+    artist = "Ron Spencer"
+    imageUri = "https://cards.scryfall.io/normal/front/5/7/57da24a0-89a7-4756-b4ca-4dea132e8f67.jpg?1743205139"
+}
+
+// =============================================================================
+// Mountain (Cards 275, 283, 284, 290)
+// =============================================================================
+
+val TdmMountain275 = basicLand("Mountain") {
+    collectorNumber = "275"
+    artist = "Sergey Glushakov"
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe0865ba-47c0-40bc-b0c6-e1ea5ae08a98.jpg?1743205085"
+}
+
+val TdmMountain283 = basicLand("Mountain") {
+    collectorNumber = "283"
+    artist = "Ralph Horsley"
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bfa10a88-12e0-4b79-80bb-6f4620277e20.jpg?1743205117"
+}
+
+val TdmMountain284 = basicLand("Mountain") {
+    collectorNumber = "284"
+    artist = "Josu Solano"
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3df7c206-97b6-49d7-ba01-7a35fd8c61d9.jpg?1743205118"
+}
+
+val TdmMountain290 = basicLand("Mountain") {
+    collectorNumber = "290"
+    artist = "Ron Spencer"
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a4db1b7a-93f2-40a5-b649-80a099ddeb62.jpg?1743205146"
+}
+
+// =============================================================================
+// Forest (Cards 276, 285, 286, 291)
+// =============================================================================
+
+val TdmForest276 = basicLand("Forest") {
+    collectorNumber = "276"
+    artist = "Sergey Glushakov"
+    imageUri = "https://cards.scryfall.io/normal/front/4/8/48811e13-5774-4da1-95ec-6ea5dc4976ad.jpg?1743205092"
+}
+
+val TdmForest285 = basicLand("Forest") {
+    collectorNumber = "285"
+    artist = "Jesper Ejsing"
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/8100bceb-ffba-487a-bb45-4fe2a156a8dc.jpg?1743205126"
+}
+
+val TdmForest286 = basicLand("Forest") {
+    collectorNumber = "286"
+    artist = "Valera Lutfullina"
+    imageUri = "https://cards.scryfall.io/normal/front/8/e/8e3e83d2-96ba-4d5c-a1ed-6c08a90b339c.jpg?1743205126"
+}
+
+val TdmForest291 = basicLand("Forest") {
+    collectorNumber = "291"
+    artist = "Ron Spencer"
+    imageUri = "https://cards.scryfall.io/normal/front/7/e/7e33e540-2828-46ad-a441-366552843d9c.jpg?1743205146"
+}
+
+/**
+ * All Tarkir: Dragonstorm basic land variants.
+ */
+val TarkirDragonstormBasicLands = listOf(
+    TdmPlains272, TdmPlains277, TdmPlains278, TdmPlains287,
+    TdmIsland273, TdmIsland279, TdmIsland280, TdmIsland288,
+    TdmSwamp274, TdmSwamp281, TdmSwamp282, TdmSwamp289,
+    TdmMountain275, TdmMountain283, TdmMountain284, TdmMountain290,
+    TdmForest276, TdmForest285, TdmForest286, TdmForest291
+)


### PR DESCRIPTION
## Summary
- Adds all 20 basic land variants for Tarkir: Dragonstorm (TDM) — Plains, Island, Swamp, Mountain, and Forest, with the 4 art variants each (collector numbers 272–291).
- Lands are defined via the `basicLand(...)` DSL in `TarkirDragonstormBasicLands.kt`, mirroring the Edge of Eternities pattern.
- Wires `TarkirDragonstormSet.basicLands` through `CardDiscovery.findBasicLandsIn`, stamping the `TDM` set code.

All artist credits and `image_uris.normal` URLs were pulled directly from the Scryfall API (verified HTTP 200).

## Test plan
- `./gradlew :mtg-sets:compileKotlin` — compiles clean.
- `./gradlew :mtg-sets:test --tests CardDiscoveryEquivalenceTest` — passes (confirms discovery still classifies the package correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)