### PR TITLE
Add Twin Bolt, Rebellious Strike, and Skirmish Rhino (TDM)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/TwinBolt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/TwinBolt.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Twin Bolt
+ * {1}{R}
+ * Instant
+ * Twin Bolt deals 2 damage divided as you choose among one or two targets.
+ *
+ * Canonical definition lives in DTK (earliest real-expansion printing). TDM (and CN2)
+ * are reprints that add only a [com.wingedsheep.sdk.model.Printing] row.
+ */
+val TwinBolt = card("Twin Bolt") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Twin Bolt deals 2 damage divided as you choose among one or two targets."
+
+    spell {
+        target = AnyTarget(count = 2, minCount = 1)
+        effect = DividedDamageEffect(
+            totalDamage = 2,
+            minTargets = 1,
+            maxTargets = 2
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Kolaghan archers are trained in Dakla, the way of the bow. They utilize their dragonlord's lightning to strike their target, no matter how small, how fast, or how far away.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5bd58ec4-34a9-4fc2-b057-438492e2e06e.jpg?1562786902"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RebelliousStrike.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RebelliousStrike.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Rebellious Strike
+ * {1}{W}
+ * Instant
+ * Target creature gets +3/+0 until end of turn.
+ * Draw a card.
+ */
+val RebelliousStrike = card("Rebellious Strike") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+0 until end of turn.\nDraw a card."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(power = 3, toughness = 0, target = t)
+            .then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Evyn Fong"
+        flavorText = "\"Even if you battle unseen, even if there is no one to witness your sacrifice—strike! Strike true. Strike from the heart. Let that be your legacy.\"\n—Shiko"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9bafe19-3bd6-4da0-b3e5-e0b89262504c.jpg?1743204030"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SkirmishRhino.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SkirmishRhino.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Skirmish Rhino
+ * {W}{B}{G}
+ * Creature — Rhino
+ * 3/4
+ *
+ * Trample
+ * When this creature enters, each opponent loses 2 life and you gain 2 life.
+ */
+val SkirmishRhino = card("Skirmish Rhino") {
+    manaCost = "{W}{B}{G}"
+    colorIdentity = "WBG"
+    typeLine = "Creature — Rhino"
+    power = 3
+    toughness = 4
+    oracleText = "Trample\nWhen this creature enters, each opponent loses 2 life and you gain 2 life."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CompositeEffect(
+            listOf(
+                LoseLifeEffect(DynamicAmount.Fixed(2), EffectTarget.PlayerRef(Player.EachOpponent)),
+                GainLifeEffect(DynamicAmount.Fixed(2), EffectTarget.Controller)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "224"
+        artist = "James Bousema"
+        flavorText = "Slowly, the clans have begun to recover and adapt long-forgotten tactics."
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a2e9ba1-c254-41e3-9845-4e81f9fec38d.jpg?1743204887"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TwinBoltReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TwinBoltReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Twin Bolt reprint in TDM.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (spell script) lives in the DTK
+ * `cards/` package — DTK is the card's earliest real-expansion printing. This file
+ * contributes only the TDM-specific presentation row, picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val TwinBoltReprint = Printing(
+    oracleId = "970dc070-3668-4584-9904-2897b27bb806",
+    name = "Twin Bolt",
+    setCode = "TDM",
+    collectorNumber = "128",
+    scryfallId = "688d8e93-d071-4089-9ef9-565ac4ae9ae0",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/688d8e93-d071-4089-9ef9-565ac4ae9ae0.jpg?1743204476",
+    releaseDate = "2025-04-11",
+    rarity = Rarity.COMMON,
+)


### PR DESCRIPTION
Implements three Tarkir: Dragonstorm cards. All use existing, already-tested SDK effects — no new engine code.

## Cards

- **Twin Bolt** `{1}{R}` Instant — "2 damage divided as you choose among one or two targets." Canonical `CardDefinition` placed in **DTK** (the card's earliest real-expansion printing, 2015) via the existing `DividedDamageEffect` (same as Arc Lightning); TDM and CN2 are reprints. TDM gets a `Printing` row.
- **Rebellious Strike** `{1}{W}` Instant — "Target creature gets +3/+0 until end of turn. Draw a card." `ModifyStats(+3/+0).then(DrawCards(1))`, the Aggressive Urge idiom. TDM-only, canonical in TDM.
- **Skirmish Rhino** `{W}{B}{G}` 3/4 Rhino — Trample + ETB "each opponent loses 2 life and you gain 2 life." Mirrors Glidedive Duo. TDM-only, canonical in TDM.

`just check-card-printing` passes for all three (canonical in earliest printing, reprint rows present).

## Skipped: Gurmag Nightwatch

`{2/B}{2/G}{2/U}` requires **monocolored hybrid mana** ("pay two generic OR one of a color"), which the engine does not model:
- `ManaSymbol` has `Hybrid` (two-color), `Phyrexian`, `Generic`, etc., but **no two-generic-or-color variant**.
- `ManaCost.parse` throws `IllegalArgumentException` on `{2/B}` (it splits on `/` and `Color.fromSymbol('2')` is null).
- `ManaSolver`/auto-tap would also need the generic-vs-colored payment choice, plus client symbol rendering.

That is a cross-layer SDK/engine feature (the kind the `add-feature` skill owns), not a single card, so it was skipped per instructions. Its ETB library effect (look at top 3, keep one on top, mill the rest) is already supported and would work once the cost is modeled.

## Testing

`just build` (full build + all rules-engine and game-server test suites) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)