### PR TITLE
Add four Tarkir: Dragonstorm cards

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TarkirDragonstormCommonsScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TarkirDragonstormCommonsScenarioTest.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for four Tarkir: Dragonstorm commons/uncommons that compose existing
+ * SDK primitives:
+ *
+ * - Ainok Wayfarer — ETB mill 3, may take a land into hand, else +1/+1 counter
+ * - Snowmelt Stag — "during your turn" base power/toughness 5/2 conditional static
+ * - Iridescent Tiger — ETB "if you cast it, add {W}{U}{B}{R}{G}"
+ * - Salt Road Packbeast — Affinity for creatures + ETB draw
+ */
+class TarkirDragonstormCommonsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Ainok Wayfarer") {
+
+            test("mills three and takes a land into hand when one is available") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Ainok Wayfarer")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    // Top three of library: two nonland + a Mountain to grab.
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Ainok Wayfarer")
+                game.resolveStack() // enters → ETB → mill 3 → pause to choose a land
+
+                val mountainId = game.findCardsInGraveyard(1, "Mountain").first()
+                game.selectCards(listOf(mountainId))
+
+                // The Mountain is now in hand; the other two milled cards stay in the graveyard.
+                game.isInHand(1, "Mountain") shouldBe true
+                game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 2
+
+                // No +1/+1 counter, since a land was taken.
+                val wayfarer = game.findPermanent("Ainok Wayfarer")!!
+                val counters = game.state.getEntity(wayfarer)?.get<CountersComponent>()
+                (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+            }
+
+            test("gets a +1/+1 counter when no land is taken") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Ainok Wayfarer")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    // No lands among the top three → "if you don't" branch fires.
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Ainok Wayfarer")
+                game.resolveStack() // enters → mill 3 → no land to take
+
+                // All three milled cards are in the graveyard.
+                game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 3
+
+                val wayfarer = game.findPermanent("Ainok Wayfarer")!!
+                val counters = game.state.getEntity(wayfarer)?.get<CountersComponent>()
+                (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+            }
+        }
+
+        context("Snowmelt Stag") {
+
+            test("has base 5/2 during its controller's turn and base 2/5 otherwise") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardOnBattlefield(1, "Snowmelt Stag")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stag = game.findPermanent("Snowmelt Stag")!!
+
+                // During your turn: base power/toughness 5/2.
+                game.state.projectedState.getPower(stag) shouldBe 5
+                game.state.projectedState.getToughness(stag) shouldBe 2
+
+                // Advance past player 1's main phase, then into the opponent's turn —
+                // base reverts to the printed 2/5 once it's no longer the controller's turn.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.state.activePlayerId shouldBe game.player2Id
+                game.state.projectedState.getPower(stag) shouldBe 2
+                game.state.projectedState.getToughness(stag) shouldBe 5
+            }
+        }
+
+        context("Iridescent Tiger") {
+
+            test("adds {W}{U}{B}{R}{G} when cast") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Iridescent Tiger")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Iridescent Tiger").error shouldBe null
+                game.resolveStack() // enters → ETB adds WUBRG
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()!!
+                pool.white shouldBe 1
+                pool.blue shouldBe 1
+                pool.black shouldBe 1
+                pool.red shouldBe 1
+                pool.green shouldBe 1
+            }
+        }
+
+        context("Salt Road Packbeast") {
+
+            test("affinity for creatures reduces the generic cost and ETB draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Salt Road Packbeast")
+                    // Three creatures → affinity shaves {3} off {5}{W}, so {2}{W} = 3 lands.
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.findCardsInHand(1, "Mountain").size
+
+                game.castSpell(1, "Salt Road Packbeast").error shouldBe null
+                game.resolveStack() // enters → ETB draw a card
+
+                game.isOnBattlefield("Salt Road Packbeast") shouldBe true
+                // The top-of-library Mountain was drawn by the ETB.
+                game.findCardsInHand(1, "Mountain").size shouldBe handBefore + 1
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AinokWayfarer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AinokWayfarer.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ainok Wayfarer — Tarkir: Dragonstorm #134
+ * {1}{G} · Creature — Dog Scout · 1/1
+ *
+ * When this creature enters, mill three cards. You may put a land card from among
+ * them into your hand. If you don't, put a +1/+1 counter on this creature.
+ *
+ * Modeled as the atomic gather → mill → (IfYouDo select-land-into-hand else
+ * +1/+1 counter) pipeline:
+ *   1. Gather the top three cards as "milled".
+ *   2. Move all three into the graveyard — this is the actual mill (emits the mill /
+ *      put-into-graveyard events the Mill keyword and graveyard triggers care about).
+ *   3. IfYouDo: optionally select a land from among the milled three and put it into
+ *      hand. Success is gated on the "chosen" collection becoming non-empty
+ *      ([SuccessCriterion.CollectionNonEmpty]); if no land is taken (declined or none
+ *      present), the "if you don't" branch adds a +1/+1 counter to this creature.
+ */
+val AinokWayfarer = card("Ainok Wayfarer") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dog Scout"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, mill three cards. You may put a land card from among them into your hand. If you don't, put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CompositeEffect(
+            listOf(
+                // Mill three: gather the top three, then move them to the graveyard.
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(3)),
+                    storeAs = "milled"
+                ),
+                MoveCollectionEffect(
+                    from = "milled",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD)
+                ),
+                // You may put a land card from among them into your hand.
+                // If you don't, put a +1/+1 counter on this creature.
+                // Success is gated on whether a land actually reached your hand:
+                // SuccessCriterion.Auto probes the terminal hand move's destination
+                // zone, so the "if you don't" counter only fires when the player
+                // declines or no land is among the milled cards. There is no "if you do"
+                // payoff, so that branch is an empty composite.
+                Effects.IfYouDo(
+                    action = CompositeEffect(
+                        listOf(
+                            SelectFromCollectionEffect(
+                                from = "milled",
+                                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                                filter = GameObjectFilter.Land,
+                                storeSelected = "chosen",
+                                storeRemainder = "leftInGraveyard",
+                                selectedLabel = "Put in hand"
+                            ),
+                            MoveCollectionEffect(
+                                from = "chosen",
+                                destination = CardDestination.ToZone(Zone.HAND),
+                                revealed = true
+                            )
+                        )
+                    ),
+                    ifYouDo = Effects.Composite(),
+                    ifYouDont = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Filipe Pagliuso"
+        flavorText = "\"There has to be a faster route through Sagu Jungle. Give me a week.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57695a9b-8f72-4ccc-a946-5d5037b09b8f.jpg?1743204503"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/IridescentTiger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/IridescentTiger.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Iridescent Tiger — Tarkir: Dragonstorm #109
+ * {4}{R} · Creature — Cat · 3/4
+ *
+ * When this creature enters, if you cast it, add {W}{U}{B}{R}{G}.
+ *
+ * The "if you cast it" clause is an intervening-if on the enters trigger, modeled as
+ * [Conditions.WasCast] on the EntersBattlefield trigger — so the mana is only produced
+ * when the creature was cast (not when put onto the battlefield by another effect). The
+ * five-color mana is a composite of five single-color [Effects.AddMana] additions.
+ */
+val IridescentTiger = card("Iridescent Tiger") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cat"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, if you cast it, add {W}{U}{B}{R}{G}."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        effect = Effects.Composite(
+            Effects.AddMana(Color.WHITE),
+            Effects.AddMana(Color.BLUE),
+            Effects.AddMana(Color.BLACK),
+            Effects.AddMana(Color.RED),
+            Effects.AddMana(Color.GREEN)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "109"
+        artist = "Fajareka Setiawan"
+        flavorText = "The power of the dragonstorms transformed not only the land but many of the creatures within it."
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3abbc8b-2bf8-478e-a541-f8019d150054.jpg?1743213469"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SaltRoadPackbeast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SaltRoadPackbeast.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Salt Road Packbeast — Tarkir: Dragonstorm #23
+ * {5}{W} · Creature — Beast · 4/3
+ *
+ * Affinity for creatures (This spell costs {1} less to cast for each creature you control.)
+ * When this creature enters, draw a card.
+ *
+ * Affinity is modeled with the existing [KeywordAbility.Affinity] keyword (CardType
+ * granularity); the cost calculator already reduces generic cost by the number of
+ * permanents of the named type the caster controls.
+ */
+val SaltRoadPackbeast = card("Salt Road Packbeast") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 3
+    oracleText = "Affinity for creatures (This spell costs {1} less to cast for each creature you control.)\n" +
+        "When this creature enters, draw a card."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.CREATURE))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Ben Wootten"
+        flavorText = "\"She huffs like she's Queen Hellkite of the Scour, but we've been together for many journeys and she's never let me down.\"\n—Mandakh, Mardu scout"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98d548c9-42bc-4155-8211-0aea801c3724.jpg?1763487067"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SnowmeltStag.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SnowmeltStag.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Snowmelt Stag — Tarkir: Dragonstorm #57
+ * {3}{U} · Creature — Elemental Elk · 2/5
+ *
+ * Vigilance
+ * During your turn, this creature has base power and toughness 5/2.
+ * {5}{U}{U}: This creature can't be blocked this turn.
+ *
+ * The "during your turn" base P/T swap is a [SetBasePowerToughnessStatic] on this
+ * creature itself (Layer 7b — set base power/toughness), gated behind
+ * [Conditions.IsYourTurn] via a conditional static ability so it only applies on the
+ * controller's turn. The printed 2/5 is the off-turn base; the static overrides it to
+ * 5/2 during your turn.
+ */
+val SnowmeltStag = card("Snowmelt Stag") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental Elk"
+    power = 2
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "During your turn, this creature has base power and toughness 5/2.\n" +
+        "{5}{U}{U}: This creature can't be blocked this turn."
+
+    keywords(Keyword.VIGILANCE)
+
+    // During your turn: base power/toughness 5/2.
+    staticAbility {
+        ability = SetBasePowerToughnessStatic(power = 5, toughness = 2, filter = GroupFilter.source())
+        condition = Conditions.IsYourTurn
+    }
+
+    // {5}{U}{U}: This creature can't be blocked this turn.
+    activatedAbility {
+        cost = Costs.Mana("{5}{U}{U}")
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "Elementals conjured by Temur mages are forever watchful and swift."
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6b3b131-704a-4586-84f8-db465cd4a277.jpg?1743204189"
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) cards, one per the add-card workflow. All four compose existing SDK primitives — no engine/SDK changes were needed.

## Cards

| Card | Cost | P/T | Mechanic |
|------|------|-----|----------|
| Ainok Wayfarer | {1}{G} | 1/1 | ETB mill 3, may take a land into hand, else +1/+1 counter |
| Snowmelt Stag | {3}{U} | 2/5 | Vigilance; base 5/2 during your turn; {5}{U}{U}: can't be blocked this turn |
| Iridescent Tiger | {4}{R} | 3/4 | ETB "if you cast it, add {W}{U}{B}{R}{G}" |
| Salt Road Packbeast | {5}{W} | 4/3 | Affinity for creatures; ETB draw a card |

## Implementation notes

- **Ainok Wayfarer** — gather top 3 → mill all 3 to graveyard → `Effects.IfYouDo(select a land from the milled cards into hand, ifYouDont = +1/+1 counter)`. Success is gated on the terminal hand move (`SuccessCriterion.Auto`), so the counter only fires when the player declines or no land was milled.
- **Snowmelt Stag** — conditional `SetBasePowerToughnessStatic(5, 2, source())` gated behind `Conditions.IsYourTurn`; the printed 2/5 is the off-turn base. `{5}{U}{U}` grants `AbilityFlag.CANT_BE_BLOCKED` until end of turn.
- **Iridescent Tiger** — EntersBattlefield trigger with `triggerCondition = Conditions.WasCast` (intervening "if you cast it") producing five single-color `Effects.AddMana`.
- **Salt Road Packbeast** — existing `KeywordAbility.Affinity(CardType.CREATURE)` (already wired into the cost calculator) + ETB `Effects.DrawCards(1)`.

## Tests

`TarkirDragonstormCommonsScenarioTest` (5 tests, all passing) covers: Ainok's land-taken vs +1/+1-counter branches, Snowmelt's on-turn 5/2 vs off-turn 2/5 reversion, Iridescent's five-color mana pool, and Salt Road's affinity cost reduction + ETB draw. `:rules-engine:test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)