### PR TITLE
Add Mountain to Arabian Nights

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 50 / 78
+**Implemented:** 51 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -91,5 +91,5 @@
 - [x] Elephant Graveyard
 - [x] Island of Wak-Wak
 - [x] Library of Alexandria
-- [ ] Mountain
+- [x] Mountain
 - [x] Oasis

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Mountain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Mountain.kt
@@ -1,0 +1,9 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+val ArnMountain = basicLand("Mountain") {
+    collectorNumber = "77"
+    artist = "Douglas Shuler"
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c321d0e1-ff30-4424-979b-25e1a33e45d5.jpg?1562931505"
+}


### PR DESCRIPTION
ARN-art basic land variant (collector #77, Douglas Shuler). Until now it was implicitly served by `basicLandsFallback = PortalSet`; this adds the distinct ARN printing.