### PR TITLE
Add TDM cards (batch 2)

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CausticExhaleScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CausticExhaleScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Caustic Exhale (TDM) — {B} Instant.
+ *
+ * "As an additional cost to cast this spell, behold a Dragon or pay {1}.
+ *  Target creature gets -3/-3 until end of turn."
+ *
+ * Exercises the `AdditionalCost.BeholdOrPay` cost (Dragon filter) plus the {1}-mana
+ * alternative, with the -3/-3 spell effect on a targeted creature.
+ */
+class CausticExhaleScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Caustic Exhale behold-or-pay cost") {
+
+            test("behold a Dragon in hand to cast for just {B}, target gets -3/-3") {
+                // Player 1 has Caustic Exhale + a Dragon to behold, and only one Swamp ({B}).
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Caustic Exhale")
+                    .withCardInHand(1, "Kilnmouth Dragon")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Hill Giant")!!
+
+                // Behold the Dragon (reveal from hand) — cost is just {B}, with target on Hill Giant.
+                val hand = game.state.getHand(game.player1Id)
+                val cardId = hand.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Caustic Exhale"
+                }
+                val dragonId = hand.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Kilnmouth Dragon"
+                }
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(target)),
+                        additionalCostPayment = AdditionalCostPayment(beheldCards = listOf(dragonId))
+                    )
+                )
+                withClue("Cast via behold should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+                withClue("Hill Giant (3/3) gets -3/-3 → 0/0 and dies") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+            }
+
+            test("pay {1} instead of beholding") {
+                // No Dragon — pay the {1} alternative. Needs {B} + {1} = 2 mana.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Caustic Exhale")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Caustic Exhale", target)
+                withClue("Cast paying {1} should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears (2/2) gets -3/-3 → -1/-1 and dies") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/GurmagRakshasaScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/GurmagRakshasaScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Gurmag Rakshasa (TDM) — {4}{B}{B} Creature — Demon, 5/5.
+ *
+ * "Menace
+ *  When this creature enters, target creature an opponent controls gets -2/-2 until end of
+ *  turn and target creature you control gets +2/+2 until end of turn."
+ *
+ * Exercises the two-target ETB trigger: one target on an opponent's creature (-2/-2) and one on
+ * a creature you control (+2/+2), each its own `Effects.ModifyStats` until end of turn.
+ */
+class GurmagRakshasaScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Gurmag Rakshasa enters-the-battlefield trigger") {
+
+            test("shrinks an opponent's creature and pumps one of yours") {
+                // Player 1 controls Grizzly Bears (2/2) to pump; Player 2 controls Hill Giant (3/3) to shrink.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gurmag Rakshasa")
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ownBears = game.findPermanent("Grizzly Bears")!!
+                val oppGiant = game.findPermanent("Hill Giant")!!
+
+                val cast = game.castSpell(1, "Gurmag Rakshasa")
+                withClue("Cast should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // ETB trigger goes on the stack and asks for both targets in one decision:
+                // slot 0 = opponent's creature (-2/-2), slot 1 = your creature (+2/+2).
+                val decisionId = game.getPendingDecision()?.id
+                    ?: error("expected a target-selection decision for the ETB trigger")
+                game.submitDecision(
+                    com.wingedsheep.engine.core.TargetsResponse(
+                        decisionId,
+                        mapOf(0 to listOf(oppGiant), 1 to listOf(ownBears))
+                    )
+                )
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+                withClue("Hill Giant (3/3) gets -2/-2 → 1/1") {
+                    projected.getPower(oppGiant) shouldBe 1
+                    projected.getToughness(oppGiant) shouldBe 1
+                }
+                withClue("Grizzly Bears (2/2) gets +2/+2 → 4/4") {
+                    projected.getPower(ownBears) shouldBe 4
+                    projected.getToughness(ownBears) shouldBe 4
+                }
+                withClue("Gurmag Rakshasa itself resolves onto the battlefield") {
+                    game.isOnBattlefield("Gurmag Rakshasa") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BearerOfGlory.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BearerOfGlory.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bearer of Glory
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2/1
+ *
+ * During your turn, this creature has first strike.
+ * {4}{W}: Creatures you control get +1/+1 until end of turn.
+ */
+val BearerOfGlory = card("Bearer of Glory") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "During your turn, this creature has first strike.\n{4}{W}: Creatures you control get +1/+1 until end of turn."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.Self),
+            condition = Conditions.IsYourTurn
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{W}")
+        effect = EffectPatterns.modifyStatsForAll(1, 1, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Joshua Cairos"
+        flavorText = "Morale stands so long as he does."
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6d91e42-43db-428d-a4dd-ef9d40306314.jpg?1743203967"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CausticExhale.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CausticExhale.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalCost
+
+/**
+ * Caustic Exhale
+ * {B}
+ * Instant
+ *
+ * As an additional cost to cast this spell, behold a Dragon or pay {1}.
+ * (To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)
+ * Target creature gets -3/-3 until end of turn.
+ */
+val CausticExhale = card("Caustic Exhale") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, behold a Dragon or pay {1}. " +
+        "(To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)\n" +
+        "Target creature gets -3/-3 until end of turn."
+
+    additionalCost(
+        AdditionalCost.BeholdOrPay(
+            filter = Filters.WithSubtype("Dragon"),
+            alternativeManaCost = "{1}"
+        )
+    )
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-3, -3, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Camille Alquier"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/488152ce-2048-4ccb-b2d6-b9628958286f.jpg?1743204258"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CruelTruths.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CruelTruths.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cruel Truths
+ * {3}{B}
+ * Instant
+ *
+ * Surveil 2, then draw two cards. You lose 2 life.
+ */
+val CruelTruths = card("Cruel Truths") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Surveil 2, then draw two cards. You lose 2 life. " +
+        "(To surveil 2, look at the top two cards of your library, then put any number of " +
+        "them into your graveyard and the rest on top of your library in any order.)"
+
+    spell {
+        effect = EffectPatterns.surveil(2)
+            .then(Effects.DrawCards(2))
+            .then(Effects.LoseLife(2, EffectTarget.PlayerRef(Player.You)))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Fajareka Setiawan"
+        flavorText = "\"Who are you to defy me? In my time, the sibsig knew their place.\"\n—Sidisi, to Nishang"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/6852b4d5-74e0-44ba-ba44-20aa91e3c4c8.jpg?1743204266"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonSniper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonSniper.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon Sniper
+ * {G}
+ * Creature — Human Archer
+ * 1/1
+ *
+ * Vigilance, reach, deathtouch
+ */
+val DragonSniper = card("Dragon Sniper") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Archer"
+    power = 1
+    toughness = 1
+    oracleText = "Vigilance, reach, deathtouch"
+
+    keywords(Keyword.VIGILANCE, Keyword.REACH, Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "David Auden Nash"
+        flavorText = "During Dromoka's reign, Qatros Karst City was a haven for the Abzan rebellion. " +
+            "Its current residents have not lost their proficiency against their former foes."
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/074b1e00-45bb-4436-8f5e-058512b2d08a.jpg?1743204520"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GurmagRakshasa.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GurmagRakshasa.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gurmag Rakshasa
+ * {4}{B}{B}
+ * Creature — Demon
+ * 5/5
+ *
+ * Menace
+ * When this creature enters, target creature an opponent controls gets -2/-2 until end of turn
+ * and target creature you control gets +2/+2 until end of turn.
+ */
+val GurmagRakshasa = card("Gurmag Rakshasa") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 5
+    toughness = 5
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "When this creature enters, target creature an opponent controls gets -2/-2 until end of turn " +
+        "and target creature you control gets +2/+2 until end of turn."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponentCreature = target("creature an opponent controls", Targets.CreatureOpponentControls)
+        val yourCreature = target("creature you control", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(-2, -2, opponentCreature)
+            .then(Effects.ModifyStats(2, 2, yourCreature))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "81"
+        artist = "Johan Grenier"
+        flavorText = "\"It's a pity to hoard life essence in a form so weak. Give it to me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f05ad909-8860-473b-9a30-a322f7670b32.jpg?1743204286"
+    }
+}


### PR DESCRIPTION
Implements five Tarkir: Dragonstorm (TDM) cards. All use existing SDK primitives — no new engine code was needed.

## Implemented
- **Bearer of Glory** ({1}{W} Human Soldier 2/1) — "During your turn, this creature has first strike" via `ConditionalStaticAbility(GrantKeyword(FIRST_STRIKE), IsYourTurn)`; plus `{4}{W}: Creatures you control get +1/+1 until end of turn` via `EffectPatterns.modifyStatsForAll`.
- **Cruel Truths** ({3}{B} Instant) — Surveil 2, draw two cards, lose 2 life. Composes `EffectPatterns.surveil(2) → DrawCards(2) → LoseLife(2)` (identical shape to Bloomburrow's Diresight).
- **Caustic Exhale** ({B} Instant) — "behold a Dragon or pay {1}" additional cost via `AdditionalCost.BeholdOrPay(filter = Dragon, alternativeManaCost = {1})`; target creature gets -3/-3.
- **Dragon Sniper** ({G} Human Archer 1/1) — vanilla vigilance, reach, deathtouch.
- **Gurmag Rakshasa** ({4}{B}{B} Demon 5/5) — menace; ETB trigger with two targets: opponent's creature gets -2/-2 and your creature gets +2/+2 until end of turn.

## Tests
- `GurmagRakshasaScenarioTest` — two-target ETB trigger (shrink opponent / pump own).
- `CausticExhaleScenarioTest` — behold-a-Dragon path and pay-{1} path, both confirming the -3/-3 kill.
- All cards covered by `:mtg-sets:test` (image-URI + discovery + legality). All green.

## Skipped
None — all five cards were feasible with existing primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)