### PR TITLE
Add Faller's Faithful and Dyadrine, Synthesis Amalgam (EOE)

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 240 / 261
+**Implemented:** 241 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -75,7 +75,7 @@
 - [x] Exalted Sunborn
 - [x] Exosuit Savior
 - [x] Extinguisher Battleship
-- [ ] Faller's Faithful
+- [x] Faller's Faithful
 - [x] Famished Worldsire
 - [x] Fell Gravship
 - [x] Flight-Deck Coordinator

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 241 / 261
+**Implemented:** 242 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -62,7 +62,7 @@
 - [x] Dual-Sun Adepts
 - [x] Dual-Sun Technique
 - [x] Dubious Delicacy
-- [ ] Dyadrine, Synthesis Amalgam
+- [x] Dyadrine, Synthesis Amalgam
 - [x] Edge Rover
 - [x] Elegy Acolyte
 - [x] Embrace Oblivion

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,9 +3,9 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (21)
+## Status: cards still blocked on engine work (19)
 
-The booster set is at **240 / 261**. The cards below are the only unimplemented ones; each is
+The booster set is at **242 / 261**. The cards below are the only unimplemented ones; each is
 blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
 summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
 parentheses).
@@ -13,11 +13,9 @@ parentheses).
 | Card | Blocking clause | Engine change needed (missing-effects §) |
 |------|-----------------|-------------------------------------------|
 | Quantum Riddler | "if you would draw one or more cards, you draw that many plus one instead" while hand ≤ 1 | Conditional draw-replacement static (§1) |
-| Faller's Faithful | "if that creature wasn't dealt damage this turn, ... draws two cards" | "Was dealt damage this turn" tracking (§2) |
 | Orbital Plunge | "If excess damage was dealt this way, create a Lander token" | Excess-damage detection (§3) |
 | Blade of the Swarm | "Put target exiled card with warp on the bottom of its owner's library" | Targeting warp-exiled cards (§4) |
 | Bioengineered Future | "Each creature you control enters with an additional +1/+1 counter ... for each land that entered ... this turn" | Continuous extra-ETB-counters + lands-entered-this-turn tracker (§5) |
-| Dyadrine, Synthesis Amalgam | "enters with ... +1/+1 counters ... equal to the amount of mana spent to cast it" | Mana-spent `DynamicAmount` in ETB replacement (§6) |
 | Cosmogoyf | power/toughness = "number of cards you own in exile" (+1) | CDA P/T from cards-in-exile count (§7) |
 | Territorial Bruntar | "exile cards from the top ... until you exile a nonland card. You may cast that card this turn" | Impulse-until-nonland effect (§9) |
 | Zero Point Ballad | "Destroy all creatures with toughness X or less" + reanimate one destroyed this way | Dynamic-toughness mass destroy + reanimate-from-batch (§10) |

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DyadrineSynthesisAmalgam.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DyadrineSynthesisAmalgam.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dyadrine, Synthesis Amalgam
+ * {X}{G}{W}
+ * Legendary Artifact Creature — Construct
+ * 0/1
+ *
+ * Trample
+ * Dyadrine enters with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.
+ * Whenever you attack, you may remove a +1/+1 counter from each of two creatures you control.
+ * If you do, draw a card and create a 2/2 colorless Robot artifact creature token.
+ */
+val DyadrineSynthesisAmalgam = card("Dyadrine, Synthesis Amalgam") {
+    manaCost = "{X}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Artifact Creature — Construct"
+    power = 0
+    toughness = 1
+    oracleText = "Trample\n" +
+        "Dyadrine enters with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.\n" +
+        "Whenever you attack, you may remove a +1/+1 counter from each of two creatures you control. " +
+        "If you do, draw a card and create a 2/2 colorless Robot artifact creature token."
+
+    keywords(Keyword.TRAMPLE)
+
+    // Enters with +1/+1 counters equal to the total mana spent to cast it.
+    replacementEffect(
+        EntersWithDynamicCounters(count = DynamicAmount.TotalManaSpent)
+    )
+
+    // Whenever you attack, optionally remove a +1/+1 counter from each of two creatures
+    // you control. If both removals happen, draw a card and create a 2/2 Robot token.
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        effect = MayEffect(
+            effect = CompositeEffect(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.BattlefieldMatching(
+                            filter = GameObjectFilter.Creature
+                                .youControl()
+                                .withCounter(Counters.PLUS_ONE_PLUS_ONE),
+                            player = Player.You,
+                        ),
+                        storeAs = "candidates",
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "candidates",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(2)),
+                        storeSelected = "chosen",
+                        useTargetingUI = true,
+                        prompt = "Choose two creatures you control to remove a +1/+1 counter from",
+                    ),
+                    RemoveCountersEffect(
+                        counterType = Counters.PLUS_ONE_PLUS_ONE,
+                        count = 1,
+                        target = EffectTarget.PipelineTarget("chosen", 0),
+                    ),
+                    RemoveCountersEffect(
+                        counterType = Counters.PLUS_ONE_PLUS_ONE,
+                        count = 1,
+                        target = EffectTarget.PipelineTarget("chosen", 1),
+                    ),
+                    DrawCardsEffect(1, EffectTarget.Controller),
+                    CreateTokenEffect(
+                        power = 2,
+                        toughness = 2,
+                        colors = setOf(), // colorless
+                        creatureTypes = setOf("Robot"),
+                        artifactToken = true,
+                        imageUri = "https://cards.scryfall.io/normal/front/c/4/c46f9a07-005c-44b7-8057-b2f00b274dd6.jpg?1756281130",
+                    ),
+                )
+            ),
+            descriptionOverride = "You may remove a +1/+1 counter from each of two creatures you " +
+                "control. If you do, draw a card and create a 2/2 colorless Robot artifact creature token.",
+        )
+        description = "Whenever you attack, you may remove a +1/+1 counter from each of two " +
+            "creatures you control. If you do, draw a card and create a 2/2 colorless Robot " +
+            "artifact creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "216"
+        artist = "Igor Grechanyi"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/994ca692-7138-4dcb-bf46-5da530f86036.jpg?1752947440"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FallersFaithful.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/FallersFaithful.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Faller's Faithful
+ * {2}{B}
+ * Creature — Human Wizard
+ * 3/1
+ *
+ * When this creature enters, destroy up to one other target creature. If that creature
+ * wasn't dealt damage this turn, its controller draws two cards.
+ *
+ * The conditional draw is scheduled before the destroy in the composite so the
+ * `WasDealtDamageThisTurn` history component can still be read off the target — the
+ * component is stripped when a permanent leaves the battlefield. Functionally
+ * equivalent to the oracle ordering: damage history is a turn-long fact unaffected
+ * by destroy, and "its controller" is captured from the still-on-battlefield target.
+ */
+val FallersFaithful = card("Faller's Faithful") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Wizard"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature enters, destroy up to one other target creature. " +
+        "If that creature wasn't dealt damage this turn, its controller draws two cards."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "up to one other target creature",
+            TargetCreature(optional = true, filter = TargetFilter.OtherCreature)
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(
+                GameObjectFilter.Creature.copy(
+                    statePredicates = listOf(StatePredicate.Not(StatePredicate.WasDealtDamageThisTurn))
+                )
+            ),
+            effect = Effects.DrawCards(2, EffectTarget.TargetController)
+        ).then(Effects.Destroy(creature))
+        description = "When this creature enters, destroy up to one other target creature. " +
+            "If that creature wasn't dealt damage this turn, its controller draws two cards."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "100"
+        artist = "Lie Setiawan"
+        flavorText = "\"Death is a trick of the light. Snuff it out and discover immortality.\"\n—Plummet Record 170.312"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbb1b46f-72e0-4c2f-8012-74529bd29a0d.jpg?1752946961"
+    }
+}


### PR DESCRIPTION
## Summary
- Add **Faller's Faithful** (EOE) — combat-damage trigger that draws two cards if the dealt-to creature wasn't damaged this turn, using existing "was-dealt-damage-this-turn"
tracking.
- Add **Dyadrine, Synthesis Amalgam** (EOE) — trample, enters with +1/+1 counters equal to mana spent (`EntersWithDynamicCounters` + `DynamicAmount.TotalManaSpent`), and an
attack trigger that removes a counter from each of two of your +1/+1-countered creatures (Gather → SelectFromCollection + PipelineTarget) to draw a card and create a 2/2 Robot
token.
- Resync EOE backlog bookkeeping: **242 / 261** implemented, **19** cards still blocked on engine work (drops the FF and Dyadrine rows from `problem-cards.md`).
