### PR TITLE
Add TDM cards (batch 3)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -108,6 +108,9 @@ the `CardDefinition`.
 - `Costs.Untap` — `{Q}`; untap this permanent.
 - `Costs.Mana("{2}{U}")` — pay the given mana cost (string or `ManaCost`).
 - `Costs.PayLife(amount)` — pay N life.
+- `Costs.PayXLife` — pay X life, where X is the value chosen for the ability's `{X}` mana cost
+  (e.g. "{X}{B}, {T}, Pay X life: …" on Krumar Initiate). The X-linked counterpart to
+  `Costs.PayLife`; `calculateMaxAffordableX` caps X by the controller's life total.
 - `Costs.Sacrifice(filter)` — sacrifice a permanent matching the filter (may include self).
 - `Costs.SacrificeAnother(filter)` — sacrifice a *different* permanent matching the filter.
 - `Costs.DiscardCard` — discard a card you choose (any card).
@@ -385,6 +388,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CantBlockGroupEffect(filter, condition?)` — group-scoped can't-block.
 - `Effects.Suspect(target)` — target becomes Suspected (MKM keyword). Composite: `SetSuspectedEffect` (named status, CR 701.60d dedup) + `GrantKeywordEffect(MENACE)` + `CantBlockEffect`.
 - `RemoveFromCombatEffect(target)` — yank target out of combat.
+- `Effects.CanAttackThisTurn(target = Self)` (`CanAttackThisTurnEffect`) — target can attack this
+  turn as though it didn't have defender. Adds a transient `CanAttackDespiteDefenderThisTurnComponent`
+  honored by the defender attack-restriction rule and cleaned up at end of turn. The
+  activated/temporary counterpart to the static `CanAttackDespiteDefender` ability (Krotiq Nestguard).
 - `SkipNextTurnEffect(target)` — target skips their next turn.
 - `Effects.SkipNextDrawStep(target = Controller)` (`SkipNextDrawStepEffect`) — target skips their next draw step. Adds a one-shot `SkipDrawStepComponent` marker consumed by `DrawPhaseManager.performDrawStep` (Elfhame Sanctuary's "you skip your draw step this turn").
 - `HijackNextTurnEffect(target)` — you control target's next turn.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -388,7 +388,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CantBlockGroupEffect(filter, condition?)` — group-scoped can't-block.
 - `Effects.Suspect(target)` — target becomes Suspected (MKM keyword). Composite: `SetSuspectedEffect` (named status, CR 701.60d dedup) + `GrantKeywordEffect(MENACE)` + `CantBlockEffect`.
 - `RemoveFromCombatEffect(target)` — yank target out of combat.
-- `Effects.CanAttackThisTurn(target = Self)` (`CanAttackThisTurnEffect`) — target can attack this
+- `Effects.CanAttackDespiteDefenderThisTurn(target = Self)` (`CanAttackDespiteDefenderThisTurnEffect`) — target can attack this
   turn as though it didn't have defender. Adds a transient `CanAttackDespiteDefenderThisTurnComponent`
   honored by the defender attack-restriction rule and cleaned up at end of turn. The
   activated/temporary counterpart to the static `CanAttackDespiteDefender` ability (Krotiq Nestguard).

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KrotiqNestguardScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KrotiqNestguardScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Krotiq Nestguard (TDM) — {2}{G} Insect, 4/4 with Defender.
+ *
+ * "{2}{G}: This creature can attack this turn as though it didn't have defender."
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.effects.CanAttackThisTurnEffect]: a creature
+ * with Defender can't normally attack, but after activating the ability it gains a transient
+ * marker letting it attack this turn. The marker is removed at end of turn.
+ */
+class KrotiqNestguardScenarioTest : ScenarioTestBase() {
+
+    private val krotiqAbilityId =
+        cardRegistry.getCard("Krotiq Nestguard")!!.activatedAbilities.first().id
+
+    init {
+        context("Krotiq Nestguard can-attack-despite-defender ability") {
+
+            test("cannot attack with defender before activating the ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krotiq Nestguard", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val result = game.declareAttackers(mapOf("Krotiq Nestguard" to 2))
+                withClue("Krotiq has Defender and cannot attack without the ability") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("attacks after activating '{2}{G}: can attack as though it didn't have defender'") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krotiq Nestguard", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val krotiq = game.findPermanent("Krotiq Nestguard")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = krotiq,
+                        abilityId = krotiqAbilityId
+                    )
+                )
+                withClue("Activating the ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Krotiq Nestguard" to 2))
+                withClue("After activation Krotiq can attack despite Defender: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Krotiq is now an attacker") {
+                    game.state.getEntity(krotiq)?.get<AttackingComponent>().shouldNotBeNull()
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KrotiqNestguardScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KrotiqNestguardScenarioTest.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.gameserver.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
 import com.wingedsheep.gameserver.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
@@ -14,7 +15,7 @@ import io.kotest.matchers.shouldBe
  *
  * "{2}{G}: This creature can attack this turn as though it didn't have defender."
  *
- * Exercises the new [com.wingedsheep.sdk.scripting.effects.CanAttackThisTurnEffect]: a creature
+ * Exercises the new [com.wingedsheep.sdk.scripting.effects.CanAttackDespiteDefenderThisTurnEffect]: a creature
  * with Defender can't normally attack, but after activating the ability it gains a transient
  * marker letting it attack this turn. The marker is removed at end of turn.
  */
@@ -71,6 +72,44 @@ class KrotiqNestguardScenarioTest : ScenarioTestBase() {
                 }
                 withClue("Krotiq is now an attacker") {
                     game.state.getEntity(krotiq)?.get<AttackingComponent>().shouldNotBeNull()
+                }
+            }
+
+            test("the grant expires at end of turn — Krotiq can't attack the following turn without reactivating") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krotiq Nestguard", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val krotiq = game.findPermanent("Krotiq Nestguard")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = krotiq,
+                        abilityId = krotiqAbilityId
+                    )
+                )
+                game.resolveStack()
+
+                withClue("The marker is present immediately after activating") {
+                    game.state.getEntity(krotiq)?.get<CanAttackDespiteDefenderThisTurnComponent>().shouldNotBeNull()
+                }
+
+                // Pass through the rest of Player 1's turn (cleanup removes the marker) and
+                // into Player 2's turn, exercising the end-of-turn cleanup.
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                withClue("The 'can attack despite defender' marker is removed at end of turn") {
+                    (game.state.getEntity(krotiq)?.get<CanAttackDespiteDefenderThisTurnComponent>() == null) shouldBe true
                 }
             }
         }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KrumarInitiateScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KrumarInitiateScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Krumar Initiate (TDM) — {1}{B} Human Cleric, 2/2.
+ *
+ * "{X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery."
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.AbilityCost.PayXLife] cost — the X-linked life
+ * payment must equal the X chosen for the `{X}{B}` mana cost — and that the endure amount reads
+ * the same X. Both endure modes are checked (counters and Spirit token).
+ */
+class KrumarInitiateScenarioTest : ScenarioTestBase() {
+
+    private val krumarAbilityId =
+        cardRegistry.getCard("Krumar Initiate")!!.activatedAbilities.first().id
+
+    init {
+        context("Krumar Initiate endure-X activated ability") {
+
+            test("endure X (counter mode) puts X +1/+1 counters on Krumar and pays X life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krumar Initiate", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 4) // pays {3}{B} → X up to 3
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val krumar = game.findPermanent("Krumar Initiate")!!
+
+                // {X}{B} with X = 3 → spend {3}{B} (4 mana), pay 3 life, endure 3.
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = krumar,
+                        abilityId = krumarAbilityId,
+                        xValue = 3
+                    )
+                )
+                withClue("Activating endure-3 should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Pay X life consumed exactly X = 3 life") {
+                    game.getLifeTotal(1) shouldBe 17
+                }
+
+                // Resolve the ability off the stack; endure pauses mid-resolution for the
+                // choose-one (counters vs token). Pick counters (option 0).
+                game.resolveStack()
+                val decision = game.getPendingDecision()
+                decision.shouldNotBeNull()
+                decision.shouldBeInstanceOf<ChooseOptionDecision>()
+                game.submitDecision(OptionChosenResponse(decision.id, 0))
+                game.resolveStack()
+
+                val counters = game.state.getEntity(krumar)?.get<CountersComponent>()
+                withClue("Endure 3 in counter mode adds three +1/+1 counters") {
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 3
+                }
+            }
+
+            test("endure X (token mode) creates an X/X white Spirit token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krumar Initiate", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 3) // pays {2}{B} → X up to 2
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val krumar = game.findPermanent("Krumar Initiate")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = krumar,
+                        abilityId = krumarAbilityId,
+                        xValue = 2
+                    )
+                )
+                withClue("Activating endure-2 should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Pay X life consumed exactly X = 2 life") {
+                    game.getLifeTotal(1) shouldBe 18
+                }
+
+                // Resolve the ability; endure pauses for the choose-one. Choose token mode (option 1).
+                game.resolveStack()
+                val decision = game.getPendingDecision()
+                decision.shouldNotBeNull()
+                decision.shouldBeInstanceOf<ChooseOptionDecision>()
+                game.submitDecision(OptionChosenResponse(decision.id, 1))
+                game.resolveStack()
+
+                val spirit = game.findPermanent("Spirit Token")
+                withClue("Endure 2 in token mode creates a 2/2 white Spirit token") {
+                    spirit.shouldNotBeNull()
+                    val tokenCard = game.state.getEntity(spirit)!!.get<CardComponent>()!!
+                    tokenCard.colors shouldBe setOf(Color.WHITE)
+                    tokenCard.baseStats?.basePower shouldBe 2
+                    tokenCard.baseStats?.baseToughness shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -62,6 +62,12 @@ object Costs {
     fun PayLife(amount: Int): AbilityCost =
         AbilityCost.PayLife(amount)
 
+    /**
+     * Pay X life, where X is the value chosen for the ability's `{X}` mana cost
+     * (e.g. "{X}{B}, {T}, Pay X life: ..." on Krumar Initiate).
+     */
+    val PayXLife: AbilityCost = AbilityCost.PayXLife
+
     // =========================================================================
     // Sacrifice Costs
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2162,6 +2162,13 @@ object Effects {
         RemoveFromCombatEffect(target)
 
     /**
+     * Let a creature attack this turn as though it didn't have defender (Krotiq Nestguard).
+     * The activated/temporary counterpart to the static [com.wingedsheep.sdk.scripting.CanAttackDespiteDefender].
+     */
+    fun CanAttackThisTurn(target: EffectTarget = EffectTarget.Self): Effect =
+        com.wingedsheep.sdk.scripting.effects.CanAttackThisTurnEffect(target)
+
+    /**
      * Grant a creature "can't attack or block unless its controller pays {X} for each [creature type]
      * on the battlefield" until end of turn.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2165,8 +2165,8 @@ object Effects {
      * Let a creature attack this turn as though it didn't have defender (Krotiq Nestguard).
      * The activated/temporary counterpart to the static [com.wingedsheep.sdk.scripting.CanAttackDespiteDefender].
      */
-    fun CanAttackThisTurn(target: EffectTarget = EffectTarget.Self): Effect =
-        com.wingedsheep.sdk.scripting.effects.CanAttackThisTurnEffect(target)
+    fun CanAttackDespiteDefenderThisTurn(target: EffectTarget = EffectTarget.Self): Effect =
+        com.wingedsheep.sdk.scripting.effects.CanAttackDespiteDefenderThisTurnEffect(target)
 
     /**
      * Grant a creature "can't attack or block unless its controller pays {X} for each [creature type]

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -142,6 +142,23 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
     }
 
     /**
+     * Pay X life, where X is the value chosen for the ability's `{X}` mana cost.
+     *
+     * Mirrors [ExileXFromGraveyard]: an X-linked variable cost that reads the chosen
+     * X (`CostPaymentChoices.xValue`) at payment time. Used by abilities like
+     * "{X}{B}, {T}, Pay X life: ..." (Krumar Initiate) where the life payment must
+     * equal the X paid for the mana cost. The legal-action enumerator caps the
+     * affordable X by the controller's life total (you can't pay more life than you
+     * have, and must survive at 1+).
+     */
+    @SerialName("CostPayXLife")
+    @Serializable
+    data object PayXLife : AbilityCost {
+        override val description: String = "Pay X life"
+        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost = this
+    }
+
+    /**
      * Sacrifice a permanent
      *
      * @property filter Which permanents can be sacrificed

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
@@ -422,6 +422,28 @@ data class MarkMustAttackThisTurnEffect(
 }
 
 /**
+ * Let a creature attack this turn as though it didn't have defender.
+ * Adds a transient marker the attack-restriction rules honor, cleaned up at end of turn.
+ *
+ * This is the activated/temporary counterpart to the static [CanAttackDespiteDefender]
+ * ability: cards like Krotiq Nestguard ("{2}{G}: This creature can attack this turn as
+ * though it didn't have defender.") grant the permission for one turn rather than
+ * permanently.
+ *
+ * @property target The creature gaining the permission (typically EffectTarget.Self).
+ */
+@SerialName("CanAttackThisTurn")
+@Serializable
+data class CanAttackThisTurnEffect(
+    val target: EffectTarget = EffectTarget.Self
+) : Effect {
+    override val description: String =
+        "${target.description} can attack this turn as though it didn't have defender"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
+}
+
+/**
  * Redirect the next time damage would be dealt to the protected targets this turn.
  * "The next time damage would be dealt to [protected targets] this turn,
  *  that damage is dealt to [redirectTo] instead."

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
@@ -432,9 +432,9 @@ data class MarkMustAttackThisTurnEffect(
  *
  * @property target The creature gaining the permission (typically EffectTarget.Self).
  */
-@SerialName("CanAttackThisTurn")
+@SerialName("CanAttackDespiteDefenderThisTurn")
 @Serializable
-data class CanAttackThisTurnEffect(
+data class CanAttackDespiteDefenderThisTurnEffect(
     val target: EffectTarget = EffectTarget.Self
 ) : Effect {
     override val description: String =

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HumblingElder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HumblingElder.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Humbling Elder — Tarkir: Dragonstorm #48
+ * {U} · Creature — Human Monk · 1/2
+ *
+ * Flash
+ * When this creature enters, target creature an opponent controls gets -2/-0
+ * until end of turn.
+ */
+val HumblingElder = card("Humbling Elder") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Monk"
+    power = 1
+    toughness = 2
+    oracleText = "Flash\n" +
+        "When this creature enters, target creature an opponent controls gets -2/-0 until end of turn."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature", Targets.CreatureOpponentControls)
+        effect = Effects.ModifyStats(-2, 0, creature)
+        description = "When this creature enters, target creature an opponent controls gets -2/-0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Yohann Schepacz"
+        flavorText = "\"There is no better way to measure a person's true character than to let them think they're above you.\"\n—Master Xian"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a84c3f8-0030-4653-880e-b2d19272f5fa.jpg?1743697602"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/IceridgeSerpent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/IceridgeSerpent.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Iceridge Serpent — Tarkir: Dragonstorm #49
+ * {4}{U} · Creature — Serpent · 3/3
+ *
+ * When this creature enters, return target creature an opponent controls to its
+ * owner's hand.
+ */
+val IceridgeSerpent = card("Iceridge Serpent") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Serpent"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, return target creature an opponent controls to its owner's hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature", Targets.CreatureOpponentControls)
+        effect = Effects.ReturnToHand(creature)
+        description = "When this creature enters, return target creature an opponent controls to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Brian Valeza"
+        flavorText = "\"Even dragons avoid Glintglaze Lake in this season. Which of you youngsters can tell me why?\"\n—Teacher Eliam"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d13f117b-b8e4-48db-8ce9-5da9c7ce23a5.jpg?1743204156"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KrotiqNestguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KrotiqNestguard.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Krotiq Nestguard — Tarkir: Dragonstorm #148
+ * {2}{G} · Creature — Insect · 4/4
+ *
+ * Defender
+ * {2}{G}: This creature can attack this turn as though it didn't have defender.
+ */
+val KrotiqNestguard = card("Krotiq Nestguard") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 4
+    toughness = 4
+    oracleText = "Defender\n" +
+        "{2}{G}: This creature can attack this turn as though it didn't have defender."
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = Effects.CanAttackThisTurn()
+        description = "{2}{G}: This creature can attack this turn as though it didn't have defender."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Loïc Canavaggia"
+        flavorText = "The bushwhacker's machete glanced off the root with a sickening crack. Slowly, the entire undergrowth turned to face him."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5d0a9fb-1068-478d-a78c-6fd77cc313f0.jpg?1743204557"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KrotiqNestguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KrotiqNestguard.kt
@@ -26,7 +26,7 @@ val KrotiqNestguard = card("Krotiq Nestguard") {
 
     activatedAbility {
         cost = Costs.Mana("{2}{G}")
-        effect = Effects.CanAttackThisTurn()
+        effect = Effects.CanAttackDespiteDefenderThisTurn()
         description = "{2}{G}: This creature can attack this turn as though it didn't have defender."
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KrumarInitiate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KrumarInitiate.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Krumar Initiate — Tarkir: Dragonstorm #84
+ * {1}{B} · Creature — Human Cleric · 2/2
+ *
+ * {X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery.
+ * (Put X +1/+1 counters on it or create an X/X white Spirit creature token.)
+ *
+ * The {X} mana cost drives X; [Costs.PayXLife] consumes the same chosen X in life,
+ * and the endure amount reads [DynamicAmount.XValue]. The activation is gated to
+ * sorcery speed via [TimingRule.SorcerySpeed].
+ */
+val KrumarInitiate = card("Krumar Initiate") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "{X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery. " +
+        "(Put X +1/+1 counters on it or create an X/X white Spirit creature token.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}{B}"), Costs.Tap, Costs.PayXLife)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Endure(DynamicAmount.XValue)
+        description = "{X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Josu Solano"
+        flavorText = "\"Welcome,\" the spirits of House Emesh whispered to Cemal. \"Welcome, newest sprout of our Kin-Tree.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc66680f-24ab-433a-8197-feac3a174075.jpg?1743204296"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LasydProwler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LasydProwler.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lasyd Prowler — Tarkir: Dragonstorm #149
+ * {2}{G}{G} · Creature — Snake Ranger · 5/5
+ *
+ * When this creature enters, you may mill cards equal to the number of lands you control.
+ * Renew — {1}{G}, Exile this card from your graveyard: Put X +1/+1 counters on target
+ * creature, where X is the number of land cards in your graveyard. Activate only as a sorcery.
+ *
+ * The Renew ability counts land cards in the graveyard at resolution. Lasyd Prowler itself
+ * is exiled as a cost (it is not a land), so it never contributes to X.
+ */
+val LasydProwler = card("Lasyd Prowler") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Snake Ranger"
+    power = 5
+    toughness = 5
+    oracleText = "When this creature enters, you may mill cards equal to the number of lands you control.\n" +
+        "Renew — {1}{G}, Exile this card from your graveyard: Put X +1/+1 counters on target creature, " +
+        "where X is the number of land cards in your graveyard. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            EffectPatterns.mill(DynamicAmount.Count(Player.You, Zone.BATTLEFIELD, Filters.Land)),
+            descriptionOverride = "You may mill cards equal to the number of lands you control."
+        )
+        description = "When this creature enters, you may mill cards equal to the number of lands you control."
+    }
+
+    renew("{1}{G}") {
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.Count(Player.You, Zone.GRAVEYARD, Filters.Land),
+            target("creature", Targets.Creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "149"
+        artist = "Anna Pavleeva"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7f5c8ef-8e9e-4264-a7d2-126a30a5d341.jpg?1743204564"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -14,6 +14,7 @@ import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFired
 import com.wingedsheep.engine.state.components.battlefield.GraveyardPlayPermissionUsedComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.battlefield.TokenReplacementOfferedThisTurnComponent
+import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
 import com.wingedsheep.engine.state.components.combat.MustAttackThisTurnComponent
 import com.wingedsheep.engine.state.components.combat.PlayerAttackedThisTurnComponent
 import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent
@@ -129,6 +130,15 @@ class CleanupPhaseManager(
         }.keys
         for (entityId in creaturesWithMustAttack) {
             newState = newState.updateEntity(entityId) { it.without<MustAttackThisTurnComponent>() }
+        }
+
+        // Remove CanAttackDespiteDefenderThisTurnComponent (Krotiq Nestguard's "can attack
+        // this turn as though it didn't have defender" activated ability).
+        val creaturesWithCanAttackDespiteDefender = newState.entities.filter { (_, container) ->
+            container.has<CanAttackDespiteDefenderThisTurnComponent>()
+        }.keys
+        for (entityId in creaturesWithCanAttackDespiteDefender) {
+            newState = newState.updateEntity(entityId) { it.without<CanAttackDespiteDefenderThisTurnComponent>() }
         }
 
         // No priority during cleanup (normally)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -379,6 +379,7 @@ val engineSerializersModule = SerializersModule {
         subclass(BlockersDeclaredThisCombatComponent::class)
         subclass(MustAttackPlayerComponent::class)
         subclass(MustAttackThisTurnComponent::class)
+        subclass(CanAttackDespiteDefenderThisTurnComponent::class)
         subclass(PlayerAttackedThisTurnComponent::class)
         subclass(PlayerAttackersThisTurnComponent::class)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -86,6 +86,11 @@ class CostHandler(
                 val life = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life ?: 0
                 life > cost.amount // Can pay if life is > cost (not <= 0 after)
             }
+            is AbilityCost.PayXLife -> {
+                // X can be 0, so this is always payable as long as the player has a life total.
+                // maxAffordableX is capped by life total in calculateMaxAffordableX.
+                state.getEntity(controllerId)?.has<LifeTotalComponent>() == true
+            }
             is AbilityCost.Sacrifice -> {
                 val candidates = findMatchingPermanentsUnified(state, controllerId, cost.filter)
                 val eligible = if (cost.excludeSelf) candidates.filter { it != sourceId } else candidates
@@ -257,6 +262,24 @@ class CostHandler(
                     newState, manaPool,
                     events = listOf(LifeChangedEvent(controllerId, currentLife, newLife, LifeChangeReason.PAYMENT))
                 )
+            }
+            is AbilityCost.PayXLife -> {
+                val amount = choices.xValue
+                if (amount == 0) {
+                    CostPaymentResult.success(state, manaPool)
+                } else {
+                    val currentLife = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life
+                        ?: return CostPaymentResult.failure("Player has no life total")
+                    val newLife = currentLife - amount
+                    var newState = state.updateEntity(controllerId) { container ->
+                        container.with(LifeTotalComponent(newLife))
+                    }
+                    newState = DamageUtils.markLifeLostThisTurn(newState, controllerId)
+                    CostPaymentResult.success(
+                        newState, manaPool,
+                        events = listOf(LifeChangedEvent(controllerId, currentLife, newLife, LifeChangeReason.PAYMENT))
+                    )
+                }
             }
             is AbilityCost.Sacrifice, is AbilityCost.SacrificeChosenCreatureType -> {
                 val requiredCount = when (cost) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CanAttackDespiteDefenderThisTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CanAttackDespiteDefenderThisTurnExecutor.kt
@@ -5,23 +5,23 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
-import com.wingedsheep.sdk.scripting.effects.CanAttackThisTurnEffect
+import com.wingedsheep.sdk.scripting.effects.CanAttackDespiteDefenderThisTurnEffect
 import kotlin.reflect.KClass
 
 /**
- * Executor for [CanAttackThisTurnEffect].
+ * Executor for [CanAttackDespiteDefenderThisTurnEffect].
  *
  * Adds [CanAttackDespiteDefenderThisTurnComponent] to the target creature, letting it
  * attack this turn as though it didn't have defender. The marker is honored by the
  * defender attack-restriction rule and removed at end of turn during cleanup.
  */
-class CanAttackThisTurnExecutor : EffectExecutor<CanAttackThisTurnEffect> {
+class CanAttackDespiteDefenderThisTurnExecutor : EffectExecutor<CanAttackDespiteDefenderThisTurnEffect> {
 
-    override val effectType: KClass<CanAttackThisTurnEffect> = CanAttackThisTurnEffect::class
+    override val effectType: KClass<CanAttackDespiteDefenderThisTurnEffect> = CanAttackDespiteDefenderThisTurnEffect::class
 
     override fun execute(
         state: GameState,
-        effect: CanAttackThisTurnEffect,
+        effect: CanAttackDespiteDefenderThisTurnEffect,
         context: EffectContext
     ): EffectResult {
         val targetId = context.resolveTarget(effect.target)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CanAttackThisTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CanAttackThisTurnExecutor.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.engine.handlers.effects.combat
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
+import com.wingedsheep.sdk.scripting.effects.CanAttackThisTurnEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [CanAttackThisTurnEffect].
+ *
+ * Adds [CanAttackDespiteDefenderThisTurnComponent] to the target creature, letting it
+ * attack this turn as though it didn't have defender. The marker is honored by the
+ * defender attack-restriction rule and removed at end of turn during cleanup.
+ */
+class CanAttackThisTurnExecutor : EffectExecutor<CanAttackThisTurnEffect> {
+
+    override val effectType: KClass<CanAttackThisTurnEffect> = CanAttackThisTurnEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: CanAttackThisTurnEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target)
+            ?: return EffectResult.success(state)
+
+        if (targetId !in state.getBattlefield()) {
+            return EffectResult.success(state)
+        }
+
+        val newState = state.updateEntity(targetId) { it.with(CanAttackDespiteDefenderThisTurnComponent) }
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CombatExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CombatExecutors.kt
@@ -24,6 +24,7 @@ class CombatExecutors(
         CantBlockExecutor(),
         RemoveFromCombatExecutor(),
         MarkMustAttackThisTurnExecutor(),
+        CanAttackThisTurnExecutor(),
         RedirectNextDamageExecutor(),
         RedirectCombatDamageToControllerExecutor(),
         GrantAttackBlockTaxPerCreatureTypeExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CombatExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CombatExecutors.kt
@@ -24,7 +24,7 @@ class CombatExecutors(
         CantBlockExecutor(),
         RemoveFromCombatExecutor(),
         MarkMustAttackThisTurnExecutor(),
-        CanAttackThisTurnExecutor(),
+        CanAttackDespiteDefenderThisTurnExecutor(),
         RedirectNextDamageExecutor(),
         RedirectCombatDamageToControllerExecutor(),
         GrantAttackBlockTaxPerCreatureTypeExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ChosenCreatureTypeComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
@@ -478,6 +479,18 @@ class CostEnumerationUtils(
         }
         if (tapXCost != null) {
             maxX = minOf(maxX, findAbilityTapTargets(state, playerId, tapXCost.filter).size)
+        }
+
+        // Cap by life total if PayXLife — you can't pay more life than you have, and
+        // (mirroring AbilityCost.PayLife affordability) must keep at least 1 life.
+        val hasPayXLife = when (abilityCost) {
+            is AbilityCost.PayXLife -> true
+            is AbilityCost.Composite -> abilityCost.costs.any { it is AbilityCost.PayXLife }
+            else -> false
+        }
+        if (hasPayXLife) {
+            val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+            maxX = minOf(maxX, (life - 1).coerceAtLeast(0))
         }
 
         return maxX

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
@@ -86,6 +87,11 @@ class DefenderAttackRule : AttackRestrictionRule {
         if (!ctx.projected.hasKeyword(ctx.attackerId, Keyword.DEFENDER)) return null
 
         val container = ctx.state.getEntity(ctx.attackerId) ?: return errorMsg(ctx)
+
+        // Temporary "can attack this turn as though it didn't have defender" grant
+        // (e.g. Krotiq Nestguard's activated ability). The marker is removed at end of turn.
+        if (container.has<CanAttackDespiteDefenderThisTurnComponent>()) return null
+
         val cardComp = container.get<CardComponent>() ?: return errorMsg(ctx)
         val cardDef = ctx.cardRegistry.getCard(cardComp.cardDefinitionId) ?: return errorMsg(ctx)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/combat/CombatComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/combat/CombatComponents.kt
@@ -148,6 +148,16 @@ data class MustAttackPlayerComponent(
 data object MustAttackThisTurnComponent : Component
 
 /**
+ * Marker component letting a creature attack this turn as though it didn't have defender.
+ *
+ * Added by [com.wingedsheep.sdk.scripting.effects.CanAttackThisTurnEffect] (e.g. Krotiq
+ * Nestguard's "{2}{G}: This creature can attack this turn as though it didn't have defender").
+ * The defender attack-restriction rule honors it, and it is removed at end of turn during cleanup.
+ */
+@Serializable
+data object CanAttackDespiteDefenderThisTurnComponent : Component
+
+/**
  * Marker component added to a player when they have declared at least one attacker this turn.
  * Used for Raid abilities and similar "if you attacked this turn" checks.
  * Persists past END_COMBAT; removed at end of turn during cleanup.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/combat/CombatComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/combat/CombatComponents.kt
@@ -150,7 +150,7 @@ data object MustAttackThisTurnComponent : Component
 /**
  * Marker component letting a creature attack this turn as though it didn't have defender.
  *
- * Added by [com.wingedsheep.sdk.scripting.effects.CanAttackThisTurnEffect] (e.g. Krotiq
+ * Added by [com.wingedsheep.sdk.scripting.effects.CanAttackDespiteDefenderThisTurnEffect] (e.g. Krotiq
  * Nestguard's "{2}{G}: This creature can attack this turn as though it didn't have defender").
  * The defender attack-restriction rule honors it, and it is removed at end of turn during cleanup.
  */


### PR DESCRIPTION
Implements five Tarkir: Dragonstorm (TDM) cards using the add-card skill.

## Cards implemented
- **Iceridge Serpent** ({4}{U}, 3/3 Serpent) — ETB return target opponent creature to hand. Existing primitives.
- **Humbling Elder** ({U}, 1/2 Human Monk) — Flash; ETB target opponent creature gets -2/-0 until end of turn. Existing primitives.
- **Lasyd Prowler** ({2}{G}{G}, 5/5 Snake Ranger) — ETB "you may mill cards equal to lands you control"; Renew — {1}{G}, exile from graveyard: put X +1/+1 counters on target creature, X = land cards in your graveyard. Existing `renew` helper + `DynamicAmount.Count`.
- **Krumar Initiate** ({1}{B}, 2/2 Human Cleric) — "{X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery."
- **Krotiq Nestguard** ({2}{G}, 4/4 Insect) — Defender; "{2}{G}: This creature can attack this turn as though it didn't have defender."

## New SDK / engine building blocks
- `AbilityCost.PayXLife` (`Costs.PayXLife`) — an X-linked life cost that pays life equal to the chosen `{X}` mana value, mirroring `ExileXFromGraveyard`. `calculateMaxAffordableX` now caps X by the controller's life total. Used by Krumar Initiate.
- `Effects.CanAttackThisTurn` (`CanAttackThisTurnEffect`) — temporary/activated counterpart to the static `CanAttackDespiteDefender`. Adds a transient `CanAttackDespiteDefenderThisTurnComponent` honored by `DefenderAttackRule` and cleaned up at end of turn. Used by Krotiq Nestguard.

Both new building blocks are documented in `docs/card-sdk-language-reference.md`.

## Tests
- `KrumarInitiateScenarioTest` — endure-X in both counter and token modes; verifies X life is paid equal to chosen X.
- `KrotiqNestguardScenarioTest` — can't attack with Defender before activation; can after.
- Full `:rules-engine`, `:mtg-sdk`, `:mtg-sets` (catalog/discovery), and `:game-server` scenario suites pass.

## Skipped
None — all five cards implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)