### PR TITLE
Add TDM cards (batch C: Sultai/BG)

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/GurmagNightwatchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/GurmagNightwatchScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Gurmag Nightwatch (TDM) — {2/B}{2/G}{2/U} Creature — Human Ranger, 3/3.
+ *
+ * "When this creature enters, look at the top three cards of your library. You may put one of
+ *  those cards back on top of your library. Put the rest into your graveyard."
+ *
+ * Exercises the look-at-top / select-one / bin-the-rest pipeline: of the three cards looked at,
+ * the chosen one stays on top of the library and the other two go to the graveyard.
+ */
+class GurmagNightwatchScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Gurmag Nightwatch enters-the-battlefield trigger") {
+
+            test("keeps one of the top three on top and bins the rest") {
+                // 6 lands pays the twobrid cost as generic. Three known cards seed the top of the library.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gurmag Nightwatch")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Bog Imp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libraryBefore = game.librarySize(1)
+                val topThree = game.state.getLibrary(game.player1Id).take(3)
+                val keep = topThree.first()
+
+                val cast = game.castSpell(1, "Gurmag Nightwatch")
+                withClue("Cast should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // ETB look-3 pauses for a "choose up to one to keep on top" selection.
+                game.getPendingDecision() ?: error("expected a selection decision for the look-three trigger")
+                game.selectCards(listOf(keep))
+                game.resolveStack()
+
+                withClue("Two of the three looked-at cards are binned to the graveyard") {
+                    game.graveyardSize(1) shouldBe 2
+                }
+                withClue("Net library loss is three (the three looked at), one of which returns to top") {
+                    game.librarySize(1) shouldBe libraryBefore - 2
+                }
+                withClue("The kept card is back on top of the library") {
+                    game.state.getLibrary(game.player1Id).first() shouldBe keep
+                }
+                withClue("Gurmag Nightwatch resolves onto the battlefield") {
+                    game.isOnBattlefield("Gurmag Nightwatch") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ConstrictorSage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ConstrictorSage.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Constrictor Sage — Tarkir: Dragonstorm #39
+ * {4}{U} · Creature — Snake Wizard · 4/4
+ *
+ * When this creature enters, tap target creature an opponent controls and put a stun
+ * counter on it.
+ * Renew — {2}{U}, Exile this card from your graveyard: Tap target creature an opponent
+ * controls and put a stun counter on it. Activate only as a sorcery.
+ *
+ * Both the ETB and the Renew ability are the same tap + stun-counter shape, composed from
+ * [Effects.Tap] and [Effects.AddCounters]. A stun counter makes the next untap removal-only
+ * (CR 122.1c / the stun counter replacement), keeping the creature tapped one extra cycle.
+ */
+val ConstrictorSage = card("Constrictor Sage") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Snake Wizard"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, tap target creature an opponent controls and " +
+        "put a stun counter on it. (If a permanent with a stun counter would become untapped, " +
+        "remove one from it instead.)\n" +
+        "Renew — {2}{U}, Exile this card from your graveyard: Tap target creature an opponent " +
+        "controls and put a stun counter on it. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(creature)
+            .then(Effects.AddCounters(Counters.STUN, 1, creature))
+        description = "When this creature enters, tap target creature an opponent controls " +
+            "and put a stun counter on it."
+    }
+
+    renew("{2}{U}") {
+        val creature = target("creature", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(creature)
+            .then(Effects.AddCounters(Counters.STUN, 1, creature))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Nereida"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2f160d7-c832-4b83-8f2e-aaeb190add3f.jpg?1743233749"
+        ruling("2025-04-04", "If a card with a renew ability is put into your graveyard during your turn, you can activate that ability if it's legal to do so before any other player can take any actions.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GurmagNightwatch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GurmagNightwatch.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gurmag Nightwatch — Tarkir: Dragonstorm #190
+ * {2/B}{2/G}{2/U} · Creature — Human Ranger · 3/3
+ *
+ * When this creature enters, look at the top three cards of your library. You may put
+ * one of those cards back on top of your library. Put the rest into your graveyard.
+ *
+ * Composed from the look-at-top / select / bin pipeline:
+ *   1. gather the top three cards into a private collection ("looked"),
+ *   2. let the controller choose up to one to keep on top of the library,
+ *   3. the kept card returns to the top, the remainder is put into the graveyard.
+ *
+ * The mana cost is monocolored hybrid ("twobrid"): each symbol can be paid with 2 generic
+ * or one mana of the listed color, so the card is castable in any of B/G/U decks.
+ */
+val GurmagNightwatch = card("Gurmag Nightwatch") {
+    manaCost = "{2/B}{2/G}{2/U}"
+    colorIdentity = "BGU"
+    typeLine = "Creature — Human Ranger"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, look at the top three cards of your library. " +
+        "You may put one of those cards back on top of your library. Put the rest into your graveyard."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CompositeEffect(listOf(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(3)),
+                storeAs = "looked"
+            ),
+            SelectFromCollectionEffect(
+                from = "looked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "keptOnTop",
+                storeRemainder = "toGraveyard",
+                selectedLabel = "Put back on top of your library",
+                remainderLabel = "Put into your graveyard"
+            ),
+            MoveCollectionEffect(
+                from = "keptOnTop",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Top)
+            ),
+            MoveCollectionEffect(
+                from = "toGraveyard",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD)
+            )
+        ))
+        description = "When this creature enters, look at the top three cards of your library. " +
+            "You may put one of those cards back on top of your library. Put the rest into your graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "190"
+        artist = "Nereida"
+        flavorText = "\"The fishers were probably exaggerating the size of the crocodile they spotted, " +
+            "but maybe they weren't. Let's check it out.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de731430-6bbf-4782-953e-b69c46353959.jpg?1743204741"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HerdHeirloom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HerdHeirloom.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+
+/**
+ * Herd Heirloom — Tarkir: Dragonstorm #144
+ * {1}{G} · Artifact
+ *
+ * {T}: Add one mana of any color. Spend this mana only to cast a creature spell.
+ * {T}: Until end of turn, target creature you control with power 4 or greater gains
+ *   trample and "Whenever this creature deals combat damage to a player, draw a card."
+ *
+ * The first ability is a restricted mana ability ([ManaRestriction.CreatureSpellsOnly]).
+ * The second taps for a temporary grant: trample plus a granted combat-damage trigger
+ * ([GrantTriggeredAbilityEffect] over `DealsCombatDamageToPlayer`, bound to SELF so it
+ * fires for the buffed creature). The target filter is creature-you-control with power ≥ 4.
+ */
+val HerdHeirloom = card("Herd Heirloom") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add one mana of any color. Spend this mana only to cast a creature spell.\n" +
+        "{T}: Until end of turn, target creature you control with power 4 or greater gains trample " +
+        "and \"Whenever this creature deals combat damage to a player, draw a card.\""
+
+    // {T}: Add one mana of any color, spendable only on creature spells.
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddAnyColorMana(1, ManaRestriction.CreatureSpellsOnly)
+    }
+
+    // {T}: temporary trample + draw-on-combat-damage grant to a power-4+ creature you control.
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target(
+            "creature",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.powerAtLeast(4))
+        )
+        effect = CompositeEffect(listOf(
+            Effects.GrantKeyword(Keyword.TRAMPLE, creature, Duration.EndOfTurn),
+            GrantTriggeredAbilityEffect(
+                ability = TriggeredAbility.create(
+                    trigger = Triggers.DealsCombatDamageToPlayer.event,
+                    binding = Triggers.DealsCombatDamageToPlayer.binding,
+                    effect = Effects.DrawCards(1),
+                    descriptionOverride = "Whenever this creature deals combat damage to a player, draw a card."
+                ),
+                target = creature,
+                duration = Duration.EndOfTurn
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "144"
+        artist = "Allen Morris"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a88c7713-b3a9-4685-b1d3-623d35b62365.jpg?1743204542"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/QarsiRevenant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/QarsiRevenant.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+
+/**
+ * Qarsi Revenant — Tarkir: Dragonstorm #86
+ * {1}{B}{B} · Creature — Vampire · 3/3
+ *
+ * Flying, deathtouch, lifelink
+ * Renew — {2}{B}, Exile this card from your graveyard: Put a flying counter, a deathtouch
+ * counter, and a lifelink counter on target creature. Activate only as a sorcery.
+ *
+ * Flying / deathtouch / lifelink are keyword counters (CR 122.1d): the [StateProjector]'s
+ * KEYWORD_COUNTER_MAP grants the matching keyword to any creature carrying the counter, so
+ * the Renew ability simply stacks three [Effects.AddCounters] on one target.
+ */
+val QarsiRevenant = card("Qarsi Revenant") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, deathtouch, lifelink\n" +
+        "Renew — {2}{B}, Exile this card from your graveyard: Put a flying counter, a deathtouch " +
+        "counter, and a lifelink counter on target creature. Activate only as a sorcery."
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH, Keyword.LIFELINK)
+
+    renew("{2}{B}") {
+        val creature = target("creature", Targets.Creature)
+        effect = CompositeEffect(listOf(
+            Effects.AddCounters(Counters.FLYING, 1, creature),
+            Effects.AddCounters(Counters.DEATHTOUCH, 1, creature),
+            Effects.AddCounters(Counters.LIFELINK, 1, creature)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "86"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "\"Evil wears many faces. Keep your windows closed at night, or it might wear yours.\"\n—Sultai warning"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c93a0f6-5e50-4dda-9ff6-da741fb839ff.jpg?1743204304"
+    }
+}


### PR DESCRIPTION
Implements the Sultai / green-black batch of missing Tarkir: Dragonstorm (TDM) cards via the add-card workflow. All implemented cards compose existing SDK primitives — no new engine/SDK mechanics were introduced.

## Cards

- **Gurmag Nightwatch** — Implemented. `{2/B}{2/G}{2/U}` 3/3 Human Ranger. ETB: look at top 3, keep up to one on top, bin the rest (gather → select → move pipeline). Monocolored-hybrid (twobrid) mana cost.
- **Constrictor Sage** — Implemented. `{4}{U}` 4/4 Snake Wizard. ETB and Renew (`{2}{U}`) both tap an opponent's creature and put a stun counter on it.
- **Herd Heirloom** — Implemented. `{1}{G}` Artifact. Creature-spell-only any-color mana ability; second `{T}` ability grants a power-4+ creature you control trample and a temporary "deals combat damage to a player → draw a card" trigger until end of turn.
- **Qarsi Revenant** — Implemented. `{1}{B}{B}` 3/3 Vampire with flying/deathtouch/lifelink; Renew (`{2}{B}`) puts a flying counter, a deathtouch counter, and a lifelink counter on target creature (keyword counters).
- **Feral Deathgorger // Dusk Sight** — **Skipped.** This is an Omen card. Scryfall labels it `layout: adventure`, but Omen differs from Adventure at resolution: the Omen spell face shuffles into its owner's library and the creature is later cast normally from hand, whereas Adventure exiles the face and grants cast-from-exile (CR 715.3d), which the engine's resolver hardcodes. A faithful Omen needs a new layout / resolution path (add-feature scope), so it was left unimplemented rather than shipped as an incorrect Adventure lookalike.

## Tests

- Added `GurmagNightwatchScenarioTest` covering the look-3 / keep-1-on-top / bin-2 ETB flow.
- The other three reuse already-tested mechanics (Renew, stun counters, keyword counters, restricted mana, granted triggers), matching how the sibling TDM Renew cards (Lasyd Prowler, Adorned Crocodile) ship without dedicated scenario tests.

`mtg-sets` + `game-server` test sources compile; the Gurmag scenario test passes. `scripts/card-status --set TDM` shows the four as implemented and Feral Deathgorger as still missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)