### PR TITLE
Add TDM cards (batch B: Jeskai/UR)

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ScenarioTestBase.kt
@@ -1167,6 +1167,16 @@ abstract class ScenarioTestBase : FunSpec() {
         }
 
         /**
+         * Find all cards in a player's library matching the given name.
+         */
+        fun findCardsInLibrary(playerNumber: Int, cardName: String): List<EntityId> {
+            val playerId = if (playerNumber == 1) player1Id else player2Id
+            return state.getLibrary(playerId).filter { entityId ->
+                state.getEntity(entityId)?.get<CardComponent>()?.name == cardName
+            }
+        }
+
+        /**
          * Submit a target selection for a triggered ability (e.g., Gravedigger's ETB).
          * @param targets List of entity IDs to select as targets
          */

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BewilderingBlizzardScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BewilderingBlizzardScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Bewildering Blizzard (TDM #38).
+ *
+ * "Draw three cards. Creatures your opponents control get -3/-0 until end of turn."
+ *
+ * Verifies the caster draws three and only opponents' creatures get the -3/-0,
+ * while the caster's own creature is unaffected. The caster's 2/2 Grizzly Bears
+ * and the opponent's 3/3 Hill Giant are distinct names so each is identifiable.
+ */
+class BewilderingBlizzardScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bewildering Blizzard") {
+
+            test("draws three and shrinks opponents' creatures by -3/-0") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Bewildering Blizzard")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    // Library cards so the draw-three actually has cards to pull.
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val myBear = game.findPermanent("Grizzly Bears")!!
+                val theirGiant = game.findPermanent("Hill Giant")!!
+
+                val cast = game.castSpell(1, "Bewildering Blizzard")
+                withClue("Casting Bewildering Blizzard should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Casting drew three (hand had Blizzard, cast it, drew 3 → +2 net)") {
+                    game.handSize(1) shouldBe handBefore - 1 + 3
+                }
+                withClue("Opponent's Hill Giant should be 0/3 with -3/-0 (3/3 base)") {
+                    game.state.projectedState.getPower(theirGiant) shouldBe 0
+                    game.state.projectedState.getToughness(theirGiant) shouldBe 3
+                }
+                withClue("Caster's own Grizzly Bears should be unaffected (2/2)") {
+                    game.state.projectedState.getPower(myBear) shouldBe 2
+                    game.state.projectedState.getToughness(myBear) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EmbermouthSentinelScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EmbermouthSentinelScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Embermouth Sentinel (TDM #242).
+ *
+ * "When this creature enters, you may search your library for a basic land card, reveal it,
+ *  then shuffle and put that card on top. If you control a Dragon, put that card onto the
+ *  battlefield tapped instead."
+ *
+ * Verifies both branches of the conditional ETB search:
+ *  - no Dragon controlled → the found basic land returns to the library,
+ *  - a Dragon controlled → the found basic land enters the battlefield tapped.
+ */
+class EmbermouthSentinelScenarioTest : ScenarioTestBase() {
+
+    init {
+        // A simple Dragon to satisfy "If you control a Dragon".
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Dragon",
+                manaCost = ManaCost.parse("{4}{R}"),
+                subtypes = setOf(Subtype("Dragon")),
+                power = 4,
+                toughness = 4
+            )
+        )
+
+        context("Embermouth Sentinel") {
+
+            test("no Dragon: searched basic land goes on top of library") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Embermouth Sentinel")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Embermouth Sentinel")
+                withClue("Casting Embermouth Sentinel should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // ETB prompts to search for a basic land; pick the Island.
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision()!!
+                    val options = (decision as? com.wingedsheep.engine.core.SelectCardsDecision)?.options
+                        ?: emptyList()
+                    if (options.isNotEmpty()) {
+                        game.selectCards(listOf(options.first()))
+                    } else {
+                        game.skipSelection()
+                    }
+                    game.resolveStack()
+                }
+
+                withClue("Embermouth Sentinel should be on the battlefield") {
+                    game.isOnBattlefield("Embermouth Sentinel") shouldBe true
+                }
+                withClue("Without a Dragon, the Island should not be on the battlefield") {
+                    game.findPermanents("Island").isEmpty() shouldBe true
+                }
+                withClue("Without a Dragon, the Island returns to the library") {
+                    game.findCardsInLibrary(1, "Island").size shouldBe 1
+                }
+            }
+
+            test("with a Dragon: searched basic land enters the battlefield tapped") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Embermouth Sentinel")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Test Dragon")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Embermouth Sentinel")
+                withClue("Casting Embermouth Sentinel should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision()!!
+                    val options = (decision as? com.wingedsheep.engine.core.SelectCardsDecision)?.options
+                        ?: emptyList()
+                    if (options.isNotEmpty()) {
+                        game.selectCards(listOf(options.first()))
+                    } else {
+                        game.skipSelection()
+                    }
+                    game.resolveStack()
+                }
+
+                withClue("Embermouth Sentinel should be on the battlefield") {
+                    game.isOnBattlefield("Embermouth Sentinel") shouldBe true
+                }
+                val islandId = game.findPermanents("Island").singleOrNull()
+                withClue("With a Dragon, the Island should be on the battlefield") {
+                    (islandId != null) shouldBe true
+                }
+                withClue("The Island should enter tapped") {
+                    (game.state.getEntity(islandId!!)?.get<TappedComponent>() != null) shouldBe true
+                }
+                withClue("The Island should no longer be in the library") {
+                    game.findCardsInLibrary(1, "Island").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FlameholdGrapplerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FlameholdGrapplerScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Flamehold Grappler (TDM #185).
+ *
+ * "First strike
+ *  When this creature enters, copy the next spell you cast this turn when you cast it.
+ *  You may choose new targets for the copy."
+ *
+ * Verifies the ETB arms a pending spell copy and that the next spell cast is copied.
+ * Divination (draw two, no targets) is used so the copy needs no retargeting decision:
+ * drawing two twice nets four cards.
+ */
+class FlameholdGrapplerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Flamehold Grappler") {
+
+            test("casting Grappler from hand then Divination draws four") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Flamehold Grappler")
+                    .withCardInHand(1, "Divination")
+                    // {U}{R}{W} for Grappler + {2}{U} for Divination.
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .also { b -> repeat(10) { b.withCardInLibrary(1, "Island") } }
+                    .build()
+
+                val castGrappler = game.castSpell(1, "Flamehold Grappler")
+                withClue("Casting Flamehold Grappler should succeed: ${castGrappler.error}") {
+                    castGrappler.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grappler's ETB should arm exactly one pending spell copy") {
+                    game.state.pendingSpellCopies.size shouldBe 1
+                }
+
+                val handBefore = game.handSize(1)
+                val castDivination = game.castSpell(1, "Divination")
+                withClue("Casting Divination should succeed: ${castDivination.error}") {
+                    castDivination.error shouldBe null
+                }
+
+                withClue("The pending copy should be consumed by Divination") {
+                    game.state.pendingSpellCopies.size shouldBe 0
+                }
+
+                game.resolveStack()
+
+                // hand before casting Divination minus Divination (cast) plus 4 drawn (2 + copy 2).
+                withClue("Divination + its copy should draw four cards total") {
+                    game.handSize(1) shouldBe handBefore - 1 + 4
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BewilderingBlizzard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BewilderingBlizzard.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bewildering Blizzard
+ * {4}{U}{U}
+ * Instant
+ *
+ * Draw three cards. Creatures your opponents control get -3/-0 until end of turn.
+ */
+val BewilderingBlizzard = card("Bewildering Blizzard") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Draw three cards. Creatures your opponents control get -3/-0 until end of turn."
+
+    spell {
+        effect = Effects.DrawCards(3).then(
+            EffectPatterns.modifyStatsForAll(
+                power = -3,
+                toughness = 0,
+                filter = GroupFilter.AllCreaturesOpponentsControl
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "38"
+        artist = "Milivoj Ćeran"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/91b25843-1aa0-484a-b6c7-0c284fe7214a.jpg?1743204112"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/EmbermouthSentinel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/EmbermouthSentinel.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Embermouth Sentinel
+ * {2}
+ * Artifact Creature — Chimera
+ * 2/1
+ *
+ * When this creature enters, you may search your library for a basic land card, reveal it,
+ * then shuffle and put that card on top. If you control a Dragon, put that card onto the
+ * battlefield tapped instead.
+ *
+ * Modeled as a [ConditionalEffect] on "you control a Dragon", checked at resolution. The
+ * search is a single optional library search (ChooseUpTo via [EffectPatterns.searchLibrary]);
+ * only one destination branch runs:
+ *  - Control a Dragon → put the basic land onto the battlefield tapped, then shuffle.
+ *  - Otherwise → shuffle, then put the basic land on top of the library.
+ * Both branches reveal the found card per the oracle text.
+ */
+val EmbermouthSentinel = card("Embermouth Sentinel") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Chimera"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, you may search your library for a basic land card, " +
+        "reveal it, then shuffle and put that card on top. If you control a Dragon, put that " +
+        "card onto the battlefield tapped instead."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ConditionalEffect(
+            condition = Conditions.ControlCreatureOfType(Subtype.DRAGON),
+            // Control a Dragon: put the basic land onto the battlefield tapped instead.
+            effect = EffectPatterns.searchLibrary(
+                filter = Filters.BasicLand,
+                count = 1,
+                destination = SearchDestination.BATTLEFIELD,
+                entersTapped = true,
+                shuffleAfter = true,
+                reveal = true
+            ),
+            // Otherwise: shuffle and put the basic land on top of the library.
+            elseEffect = EffectPatterns.searchLibrary(
+                filter = Filters.BasicLand,
+                count = 1,
+                destination = SearchDestination.TOP_OF_LIBRARY,
+                shuffleAfter = true,
+                reveal = true
+            )
+        )
+        description = "you may search your library for a basic land card, reveal it, then shuffle and " +
+            "put that card on top. If you control a Dragon, put that card onto the battlefield tapped instead."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "242"
+        artist = "Stephanie Cheung"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/485f75d5-da5b-4605-885a-561ccd999cc6.jpg?1743204957"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FlameholdGrappler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FlameholdGrappler.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Flamehold Grappler
+ * {U}{R}{W}
+ * Creature — Human Monk
+ * 3/3
+ *
+ * First strike
+ * When this creature enters, copy the next spell you cast this turn when you cast it.
+ * You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)
+ *
+ * The "copy the next spell" clause copies *any* spell — not just instants and sorceries —
+ * so the pending copy uses [GameObjectFilter.Any]. The shared Storm copy infrastructure
+ * already handles choosing new targets for the copy and turning a copied permanent spell
+ * into a token.
+ */
+val FlameholdGrappler = card("Flamehold Grappler") {
+    manaCost = "{U}{R}{W}"
+    colorIdentity = "URW"
+    typeLine = "Creature — Human Monk"
+    power = 3
+    toughness = 3
+    oracleText = "First strike\n" +
+        "When this creature enters, copy the next spell you cast this turn when you cast it. " +
+        "You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)"
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CopyNextSpellCast(copies = 1, spellFilter = GameObjectFilter.Any)
+        description = "copy the next spell you cast this turn when you cast it. You may choose new targets for the copy."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "185"
+        artist = "Wayne Wu"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc8443a6-282f-4218-9dc8-144b5570d891.jpg?1743204722"
+    }
+}


### PR DESCRIPTION
Adds three Tarkir: Dragonstorm (TDM) blue/red/Jeskai cards using existing SDK primitives, each with a scenario test.

## Implemented

- **Bewildering Blizzard** ✅ — `{4}{U}{U}` Instant. "Draw three cards. Creatures your opponents control get -3/-0 until end of turn." Composes `Effects.DrawCards(3)` + `EffectPatterns.modifyStatsForAll(-3, 0, AllCreaturesOpponentsControl)`.
- **Embermouth Sentinel** ✅ — `{2}` Artifact Creature — Chimera, 2/1. ETB: optional search for a basic land → top of library, or onto the battlefield tapped if you control a Dragon. Modeled as a `ConditionalEffect` on `ControlCreatureOfType(Dragon)` over two `EffectPatterns.searchLibrary` branches.
- **Flamehold Grappler** ✅ — `{U}{R}{W}` Creature — Human Monk, 3/3. First strike + ETB "copy the next spell you cast this turn." Uses `Effects.CopyNextSpellCast(1, spellFilter = GameObjectFilter.Any)` so it copies any spell (permanent spells become tokens), reusing the existing Storm copy infrastructure (new-targets handling included).

## Skipped (require `add-feature`, not single cards)

- **Dirgur Island Dragon // Skimming Strike** ⏭️ — Omen mechanic. The card uses the Adventure layout, but Adventure resolution exiles the spell and grants play-from-exile, whereas Omen **shuffles the spell back into its owner's library** on resolution. That distinct resolution behavior isn't modeled yet; implementing it faithfully needs an engine/SDK feature, not a card hand-roll.
- **Molten Exhale** ⏭️ — "You may cast this spell as though it had flash if you behold a Dragon as an additional cost." The damage half (`4 damage to target creature or planeswalker`) is fully supported, but `OptionalAdditionalCost.grantsFlashTiming` only supports a *mana* cost today. Granting flash timing by *beholding* is a new cost/flash-unlock that requires the `add-feature` skill; implementing it half-way (dropping the behold-flash clause) would violate rules-faithfulness.

## Tests

- `BewilderingBlizzardScenarioTest`, `EmbermouthSentinelScenarioTest` (both branches), `FlameholdGrapplerScenarioTest` — all passing.
- Added a small `findCardsInLibrary` helper to `ScenarioTestBase` (mirrors the existing `findCardsInGraveyard`).

`just check-card-printing` confirms all three canonicals sit in their earliest real printing (TDM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)