### PR TITLE
Add TDM cards (batch A: Abzan/white)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -656,6 +656,13 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   controlled by the same player**"). Enforced cross-target by `TargetValidator` at cast time using
   projected control; a no-op for single-target requirements. E.g.
   `TargetCreature(count = 2, sameController = true)` (Barrin's Spite).
+- `sameOwner = false` — on `TargetObject`; when `true` and the requirement picks more than one target,
+  every chosen **card** target must share an owner ("**exile up to two target cards from a single
+  graveyard**"). Enforced cross-target both at cast time (`TargetValidator`) and on triggered-ability
+  target decisions (`DecisionValidators` reads each card's `OwnerComponent`); a no-op for single-target
+  requirements and for non-card targets. E.g.
+  `TargetObject(count = 2, optional = true, filter = TargetFilter.CardInGraveyard, sameOwner = true)`
+  (Arashin Sunshield).
 
 ---
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ArashinSunshieldScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ArashinSunshieldScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Arashin Sunshield ({3}{W}, 3/4 Human Warrior).
+ *
+ * "When this creature enters, exile up to two target cards from a single graveyard.
+ *  {W}, {T}: Tap target creature."
+ *
+ * Exercises the new `TargetObject.sameOwner` cross-target constraint: the two chosen
+ * cards must come from one graveyard ("a single graveyard").
+ */
+class ArashinSunshieldScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Arashin Sunshield") {
+
+            test("ETB exiles two cards from a single graveyard") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Arashin Sunshield")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInGraveyard(2, "Glory Seeker")
+                    .withCardInGraveyard(2, "Hill Giant")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Arashin Sunshield").error shouldBe null
+                game.resolveStack() // creature enters → ETB trigger on stack, asks for targets
+
+                val target1 = game.findCardsInGraveyard(2, "Glory Seeker").first()
+                val target2 = game.findCardsInGraveyard(2, "Hill Giant").first()
+                val result = game.selectTargets(listOf(target1, target2))
+                withClue("Two cards from the same graveyard is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                game.graveyardSize(2) shouldBe 0
+                game.state.getExile(game.player2Id).size shouldBe 2
+            }
+
+            test("ETB cannot exile cards from two different graveyards") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Arashin Sunshield")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInGraveyard(1, "Glory Seeker")
+                    .withCardInGraveyard(2, "Hill Giant")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Arashin Sunshield").error shouldBe null
+                game.resolveStack()
+
+                val mine = game.findCardsInGraveyard(1, "Glory Seeker").first()
+                val theirs = game.findCardsInGraveyard(2, "Hill Giant").first()
+                val result = game.selectTargets(listOf(mine, theirs))
+                withClue("Targets from two graveyards must be rejected") {
+                    result.error shouldNotBe null
+                }
+            }
+
+            test("ETB may exile zero cards (up to two)") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Arashin Sunshield")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInGraveyard(2, "Glory Seeker")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Arashin Sunshield").error shouldBe null
+                game.resolveStack()
+
+                // "up to two" — decline by selecting nothing.
+                game.skipTargets().error shouldBe null
+                game.resolveStack()
+
+                game.graveyardSize(2) shouldBe 1
+                game.isOnBattlefield("Arashin Sunshield") shouldBe true
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmAbzanBatchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmAbzanBatchScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the white-leaning Tarkir: Dragonstorm batch:
+ * Loxodon Battle Priest (begin-combat +1/+1 counter) and Marshal of the Lost
+ * (attack-triggered +X/+X where X is the number of attacking creatures).
+ */
+class TdmAbzanBatchScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Loxodon Battle Priest") {
+
+            test("begin-combat trigger puts a +1/+1 counter on another creature you control") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Loxodon Battle Priest")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                val seeker = game.findPermanent("Glory Seeker")!!
+                game.selectTargets(listOf(seeker))
+                game.resolveStack()
+
+                val clientState = game.getClientState(1)
+                val seekerCard = clientState.cards.values.find { it.name == "Glory Seeker" }
+                withClue("Glory Seeker should be 3/3 after the +1/+1 counter") {
+                    seekerCard shouldNotBe null
+                    seekerCard!!.power shouldBe 3
+                    seekerCard.toughness shouldBe 3
+                }
+            }
+
+            test("trigger cannot target the Battle Priest itself (another target creature)") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Loxodon Battle Priest")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                val priest = game.findPermanent("Loxodon Battle Priest")!!
+                val decision = game.getPendingDecision()
+                withClue("There should be a target decision for the begin-combat trigger") {
+                    decision shouldNotBe null
+                }
+                val result = game.selectTargets(listOf(priest))
+                withClue("Targeting the Priest itself is illegal ('another target creature')") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+
+        context("Marshal of the Lost") {
+
+            test("attack trigger pumps target by the number of attacking creatures") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Marshal of the Lost") // 3/3
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                // Attack with both creatures → 2 attacking creatures → +2/+2.
+                game.declareAttackers(mapOf("Marshal of the Lost" to 2, "Glory Seeker" to 2))
+
+                val seeker = game.findPermanent("Glory Seeker")!!
+                game.selectTargets(listOf(seeker))
+                game.resolveStack()
+
+                val clientState = game.getClientState(1)
+                val seekerCard = clientState.cards.values.find { it.name == "Glory Seeker" }
+                withClue("Glory Seeker should be 4/4 (2/2 base + 2 attacking creatures)") {
+                    seekerCard shouldNotBe null
+                    seekerCard!!.power shouldBe 4
+                    seekerCard.toughness shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -302,7 +302,15 @@ data class TargetObject(
      * the same player"). Enforced cross-target by `TargetValidator` at cast time; a no-op
      * for single-target requirements. Defaults to false.
      */
-    val sameController: Boolean = false
+    val sameController: Boolean = false,
+    /**
+     * When true and more than one target is chosen for this requirement, every chosen
+     * card target must be owned by the same player — i.e. drawn "from a single graveyard"
+     * (Arashin Sunshield: "exile up to two target cards from a single graveyard").
+     * Enforced cross-target by `TargetValidator` against each `ChosenTarget.Card`'s owner;
+     * a no-op for single-target requirements and for non-card targets. Defaults to false.
+     */
+    val sameOwner: Boolean = false
 ) : TargetRequirement {
     override val description: String = run {
         val base = if (id != null) {
@@ -327,7 +335,11 @@ data class TargetObject(
                 }
             }
         }
-        if (sameController) "$base controlled by the same player" else base
+        when {
+            sameController -> "$base controlled by the same player"
+            sameOwner -> "$base from a single graveyard"
+            else -> base
+        }
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): TargetRequirement {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ArashinSunshield.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ArashinSunshield.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Arashin Sunshield
+ * {3}{W}
+ * Creature — Human Warrior
+ * 3/4
+ *
+ * When this creature enters, exile up to two target cards from a single graveyard.
+ * {W}, {T}: Tap target creature.
+ */
+val ArashinSunshield = card("Arashin Sunshield") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Warrior"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, exile up to two target cards from a single graveyard.\n" +
+        "{W}, {T}: Tap target creature."
+
+    // ETB: exile up to two target cards, both from the same graveyard (sameOwner).
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to two target cards from a single graveyard",
+            TargetObject(
+                count = 2,
+                optional = true,
+                filter = TargetFilter.CardInGraveyard,
+                sameOwner = true,
+            )
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(MoveToZoneEffect(EffectTarget.ContextTarget(0), Zone.EXILE))
+        )
+    }
+
+    // {W}, {T}: Tap target creature.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target("target creature", TargetCreature())
+        effect = TapUntapEffect(target = t, tap = true)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Inkognit"
+        flavorText = "\"The best way to protect the citizens is to defend Arashin, not hunt dragonstorms across Tarkir.\"\n—Sadesh of House Mevak"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd7102d8-90b3-45a1-b66d-dcca469b1fb6.jpg?1743697519"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HighspireBellRinger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HighspireBellRinger.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Highspire Bell-Ringer
+ * {2}{U}
+ * Creature — Djinn Monk
+ * 1/4
+ *
+ * Flying
+ * The second spell you cast each turn costs {1} less to cast.
+ */
+val HighspireBellRinger = card("Highspire Bell-Ringer") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Djinn Monk"
+    power = 1
+    toughness = 4
+    oracleText = "Flying\nThe second spell you cast each turn costs {1} less to cast."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.NthOfTypePerTurn(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Zoltan Boros"
+        flavorText = "The sequence of chimes rang out a specific alarm: dragonstorm, half a day, southwest."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e75dccf7-2894-4c4a-b516-3eee73acddd3.jpg?1743204148"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LoxodonBattlePriest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LoxodonBattlePriest.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Loxodon Battle Priest
+ * {4}{W}
+ * Creature — Elephant Cleric
+ * 3/5
+ *
+ * At the beginning of combat on your turn, put a +1/+1 counter on another
+ * target creature you control.
+ */
+val LoxodonBattlePriest = card("Loxodon Battle Priest") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Cleric"
+    power = 3
+    toughness = 5
+    oracleText = "At the beginning of combat on your turn, put a +1/+1 counter on another target creature you control."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val t = target(
+            "another target creature you control",
+            TargetCreature(filter = TargetFilter.OtherCreatureYouControl)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "15"
+        artist = "Yeong-Hao Han"
+        flavorText = "\"I grant you the strength of Qatros's walls and the tenacity of Arashin's oasis.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a527cdb0-f54a-4b53-83a0-6b3e8cafa45e.jpg?1743204012"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarduDevotee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarduDevotee.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Mardu Devotee
+ * {W}
+ * Creature — Human Scout
+ * 1/2
+ *
+ * When this creature enters, scry 2.
+ * {1}: Add {R}, {W}, or {B}. Activate only once each turn.
+ */
+val MarduDevotee = card("Mardu Devotee") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    power = 1
+    toughness = 2
+    oracleText = "When this creature enters, scry 2. (Look at the top two cards of your library, " +
+        "then put any number of them on the bottom and the rest on top in any order.)\n" +
+        "{1}: Add {R}, {W}, or {B}. Activate only once each turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.scry(2)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        manaAbility = true
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+        effect = Effects.AddManaOfChoice(
+            ManaColorSet.Specific(setOf(Color.RED, Color.WHITE, Color.BLACK))
+        )
+        description = "{1}: Add {R}, {W}, or {B}. Activate only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "16"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "Eskeg and his companion stood watch, the sights of the steppe a constant inspiration."
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/da45e9b0-a4f6-413b-9e62-666c511eb5b0.jpg?1743204014"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarshalOfTheLost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarshalOfTheLost.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Marshal of the Lost
+ * {2}{W}{B}
+ * Creature — Orc Warrior
+ * 3/3
+ *
+ * Deathtouch
+ * Whenever you attack, target creature gets +X/+X until end of turn, where X is
+ * the number of attacking creatures.
+ */
+val MarshalOfTheLost = card("Marshal of the Lost") {
+    manaCost = "{2}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Orc Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Deathtouch\nWhenever you attack, target creature gets +X/+X until end of turn, where X is the number of attacking creatures."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    // X is the number of attacking creatures. Only one player attacks per combat, and
+    // "whenever you attack" fires for this card's controller, so the attacking creatures
+    // are exactly the ones controlled by that player.
+    val attackerCount = DynamicAmounts.attackingCreaturesYouControl()
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(
+            power = attackerCount,
+            toughness = attackerCount,
+            target = t
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "207"
+        artist = "Andreas Zafiratos"
+        flavorText = "Gvar carved his way through the Ancestral Maelstrom, seeking to restore the withered Kin-Tree and soothe the raging spirits."
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64fbaa16-67c3-4ed2-9545-39abbbde61dc.jpg?1743204817"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -104,7 +104,13 @@ data class TargetRequirementInfo(
     val index: Int,
     val description: String,
     val minTargets: Int = 1,
-    val maxTargets: Int = 1
+    val maxTargets: Int = 1,
+    /**
+     * When true, every chosen card target for this requirement must be owned by the same
+     * player — "from a single graveyard" (Arashin Sunshield). Enforced against each
+     * selected card's owner in [DecisionValidators.validateTargets].
+     */
+    val sameOwner: Boolean = false
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -397,7 +397,8 @@ class TriggerProcessor(
                 index = index,
                 description = req.description,
                 minTargets = effectiveMinTargets,
-                maxTargets = req.count
+                maxTargets = req.count,
+                sameOwner = (req as? com.wingedsheep.sdk.scripting.targets.TargetObject)?.sameOwner == true
             )
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
@@ -37,6 +37,8 @@ import com.wingedsheep.engine.core.SplitPilesDecision
 import com.wingedsheep.engine.core.TargetsResponse
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.model.EntityId
 
 /**
@@ -54,9 +56,9 @@ object DecisionValidators {
      * @param response The player's response
      * @return An error message if invalid, null if valid
      */
-    fun validate(decision: PendingDecision, response: DecisionResponse): String? {
+    fun validate(decision: PendingDecision, response: DecisionResponse, state: GameState? = null): String? {
         return when (decision) {
-            is ChooseTargetsDecision -> validateTargets(decision, response)
+            is ChooseTargetsDecision -> validateTargets(decision, response, state)
             is SelectCardsDecision -> validateSelectCards(decision, response)
             is YesNoDecision -> validateYesNo(response)
             is ChooseModeDecision -> validateModes(decision, response)
@@ -163,7 +165,11 @@ object DecisionValidators {
         return null
     }
 
-    private fun validateTargets(decision: ChooseTargetsDecision, response: DecisionResponse): String? {
+    private fun validateTargets(
+        decision: ChooseTargetsDecision,
+        response: DecisionResponse,
+        state: GameState? = null
+    ): String? {
         if (response is CancelDecisionResponse) {
             return if (decision.canCancel) null else "This decision cannot be cancelled"
         }
@@ -186,6 +192,15 @@ object DecisionValidators {
                 }
                 if (selectedIds.size > req.maxTargets) {
                     return "Too many targets for requirement $reqIndex: maximum is ${req.maxTargets}"
+                }
+                // "... from a single graveyard" — every chosen card target must share an owner.
+                if (req.sameOwner && selectedIds.size > 1 && state != null) {
+                    val owners = selectedIds.mapNotNull { id ->
+                        state.getEntity(id)?.get<OwnerComponent>()?.playerId
+                    }
+                    if (owners.toSet().size > 1) {
+                        return "Targets for requirement $reqIndex must be from a single graveyard"
+                    }
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
@@ -39,7 +39,7 @@ class SubmitDecisionHandler(
             return "Decision ID mismatch: expected ${pending.id}, got ${action.response.decisionId}"
         }
 
-        return DecisionValidators.validate(pending, action.response)
+        return DecisionValidators.validate(pending, action.response, state)
     }
 
     override fun execute(state: GameState, action: SubmitDecision): ExecutionResult {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -119,6 +119,18 @@ class TargetValidator {
                     return "Targets must be controlled by the same player"
                 }
             }
+
+            // "... from a single graveyard" — every chosen card target for this requirement
+            // must share an owner (CR uses the graveyard's owner). No-op for single-target
+            // requirements and for non-card targets.
+            if (requirement is TargetObject && requirement.sameOwner && targetsForReq.size > 1) {
+                val owners = targetsForReq.mapNotNull { target ->
+                    (target as? ChosenTarget.Card)?.ownerId
+                }
+                if (owners.toSet().size > 1) {
+                    return "Targets must be from a single graveyard"
+                }
+            }
         }
 
         return null


### PR DESCRIPTION
Implements five white-leaning Tarkir: Dragonstorm (TDM) cards via the add-card workflow.

## Cards

| Card | Status | Notes |
|------|--------|-------|
| Arashin Sunshield | ✅ Implemented | `{3}{W}` 3/4. ETB: exile up to two target cards **from a single graveyard**; `{W}, {T}`: tap target creature. Required a small, general SDK addition (`TargetObject.sameOwner`) for the "single graveyard" cross-target constraint — composed from existing exile/tap primitives otherwise. |
| Loxodon Battle Priest | ✅ Implemented | `{4}{W}` 3/5. Begin-combat trigger puts a +1/+1 counter on **another** target creature you control (`TargetFilter.OtherCreatureYouControl`). |
| Mardu Devotee | ✅ Implemented | `{W}` 1/2. ETB scry 2 + once-per-turn `{1}: Add {R}, {W}, or {B}` mana ability. Mirrors Abzan Devotee + `EffectPatterns.scry`. |
| Marshal of the Lost | ✅ Implemented | `{2}{W}{B}` 3/3. Deathtouch + "whenever you attack, target creature gets +X/+X" where X is the number of attacking creatures (`DynamicAmounts.attackingCreaturesYouControl`). |
| Highspire Bell-Ringer | ✅ Implemented | `{2}{U}` 1/4. Flying + "second spell you cast each turn costs {1} less" via `ModifySpellCost` + `CostGating.NthOfTypePerTurn(2)` (same shape as Uthros Psionicist). |

All five implemented; none skipped.

## SDK change

`TargetObject.sameOwner` — when set and more than one card target is chosen, every chosen card must share an owner ("from a single graveyard"). Enforced cross-target at cast time (`TargetValidator`) and on triggered-ability target decisions (`DecisionValidators`, reading each card's `OwnerComponent`; plumbed through `TargetRequirementInfo` + `TriggerProcessor`). Documented in `docs/card-sdk-language-reference.md`.

## Tests

- `ArashinSunshieldScenarioTest` — two cards from one graveyard (legal), two graveyards (rejected), zero-target decline.
- `TdmAbzanBatchScenarioTest` — Loxodon begin-combat counter + "another target" self-exclusion; Marshal attacking-creature pump.

Mardu Devotee and Highspire Bell-Ringer reuse fully-tested mechanics (scry / `AddManaOfChoice` / `ModifySpellCost`), so no new scenario tests were added for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)