### PR TITLE
Add TDM cards: Abzan Monument, Aegis Sculptor, Auroral Procession, Rescue Leopard

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AbzanMonumentScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AbzanMonumentScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Abzan Monument (TDM #238).
+ *
+ * "{2} Artifact — When this artifact enters, search your library for a basic Plains, Swamp,
+ *  or Forest card, reveal it, put it into your hand, then shuffle.
+ *  {1}{W}{B}{G}, {T}, Sacrifice this artifact: Create an X/X white Spirit creature token,
+ *  where X is the greatest toughness among creatures you control. Activate only as a sorcery."
+ */
+class AbzanMonumentScenarioTest : ScenarioTestBase() {
+
+    // A vanilla 0/5 wall whose toughness drives X for the token ability.
+    private val sturdyWall = card("Sturdy Test Wall") {
+        manaCost = "{2}"
+        typeLine = "Creature — Wall"
+        power = 0
+        toughness = 5
+    }
+
+    private val stateProjector = StateProjector()
+
+    init {
+        cardRegistry.register(sturdyWall)
+
+        context("Abzan Monument") {
+
+            test("ETB searches for a basic Plains/Swamp/Forest and puts it into hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Abzan Monument")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Abzan Monument")
+                withClue("Casting Abzan Monument should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // ETB search surfaces a selection; the only eligible basic is the Forest.
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<SelectCardsDecision>()
+                game.selectCards(listOf(decision.options.first()))
+                game.resolveStack()
+
+                withClue("The searched Forest should be in hand") {
+                    game.state.getHand(game.player1Id).count { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                    } shouldBe 1
+                }
+            }
+
+            test("sacrifice ability makes an X/X white Spirit where X is greatest toughness") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Abzan Monument")
+                    // A 0/5 wall → greatest toughness among creatures you control is 5.
+                    .withCardOnBattlefield(1, "Sturdy Test Wall", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val monumentId = game.findPermanent("Abzan Monument")!!
+                val cardDef = cardRegistry.getCard("Abzan Monument")!!
+                val tokenAbility = cardDef.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monumentId,
+                        abilityId = tokenAbility.id
+                    )
+                )
+                withClue("Activating the Spirit ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Abzan Monument should be sacrificed") {
+                    game.isOnBattlefield("Abzan Monument") shouldBe false
+                }
+
+                val spirit = game.findPermanent("Spirit Token")
+                withClue("A 5/5 white Spirit token should exist (X = greatest toughness 5)") {
+                    val id = spirit!!
+                    val projected = stateProjector.project(game.state)
+                    projected.getPower(id) shouldBe 5
+                    projected.getToughness(id) shouldBe 5
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AegisSculptorScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AegisSculptorScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Aegis Sculptor (TDM #35).
+ *
+ * "{3}{U} Creature — Bird Wizard 2/3. Flying, Ward {2}.
+ *  At the beginning of your upkeep, you may exile two cards from your graveyard. If you do,
+ *  put a +1/+1 counter on this creature."
+ *
+ * The test advances from player 2's turn into player 1's upkeep so the "your upkeep" trigger
+ * fires for the Sculptor's controller. Verifies: with two graveyard cards, exiling both adds a
+ * +1/+1 counter; with fewer than two, declining adds no counter.
+ */
+class AegisSculptorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Aegis Sculptor upkeep") {
+
+            test("exiling two cards from graveyard puts a +1/+1 counter on it") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Aegis Sculptor", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Library fuel so neither player decks during the step advances.
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                // Advance to player 1's upkeep so the "your upkeep" trigger fires.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                // MayEffect: accept, then choose exactly two graveyard cards to exile.
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(true)
+                    game.resolveStack()
+                }
+                if (game.hasPendingDecision()) {
+                    val gy = game.state.getGraveyard(game.player1Id)
+                    game.selectCards(gy.take(2))
+                    game.resolveStack()
+                }
+
+                withClue("Both graveyard cards should have been exiled") {
+                    game.state.getGraveyard(game.player1Id).size shouldBe 0
+                }
+
+                val sculptorId = game.findPermanent("Aegis Sculptor")!!
+                val counters = game.state.getEntity(sculptorId)?.get<CountersComponent>()
+                withClue("Aegis Sculptor should have a +1/+1 counter after exiling two cards") {
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+                }
+            }
+
+            test("declining the upkeep ability adds no counter") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Aegis Sculptor", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(false)
+                    game.resolveStack()
+                }
+
+                withClue("Declining should leave the graveyard intact") {
+                    game.state.getGraveyard(game.player1Id).size shouldBe 2
+                }
+
+                val sculptorId = game.findPermanent("Aegis Sculptor")!!
+                val counters = game.state.getEntity(sculptorId)?.get<CountersComponent>()
+                withClue("Aegis Sculptor should have no counter when declining") {
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AuroralProcessionScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AuroralProcessionScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Auroral Procession (TDM #169).
+ *
+ * "{G}{U} Instant — Return target card from your graveyard to your hand."
+ *
+ * Verifies the regrowth-style return from your own graveyard. Non-creature cards are
+ * valid targets (the filter is "any card you own in your graveyard").
+ */
+class AuroralProcessionScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Auroral Procession") {
+
+            test("returns a target card from your graveyard to your hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Auroral Procession")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellTargetingGraveyardCard(
+                    playerNumber = 1,
+                    spellName = "Auroral Procession",
+                    graveyardOwnerNumber = 1,
+                    targetCardName = "Grizzly Bears"
+                )
+                withClue("Casting Auroral Procession should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears should no longer be in the graveyard") {
+                    game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 0
+                }
+                withClue("Grizzly Bears should be back in hand") {
+                    game.state.getHand(game.player1Id).count { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    } shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RescueLeopardScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RescueLeopardScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rescue Leopard (TDM #116).
+ *
+ * "Whenever this creature becomes tapped, you may discard a card. If you do, draw a card."
+ *
+ * Attacking taps the Leopard, firing the becomes-tapped loot trigger. Verifies the optional
+ * discard-then-draw (a card is discarded and a card drawn) and the decline path (no change).
+ */
+class RescueLeopardScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rescue Leopard") {
+
+            test("tapping to attack loots: discard a card then draw a card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Rescue Leopard", tapped = false, summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Rescue Leopard" to 2))
+                game.resolveStack()
+
+                // The trigger is a MayEffect: answer yes, then choose the card to discard.
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(true)
+                    game.resolveStack()
+                }
+                if (game.hasPendingDecision()) {
+                    val grizzly = game.state.getHand(game.player1Id).first { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    }
+                    game.selectCards(listOf(grizzly))
+                    game.resolveStack()
+                }
+
+                withClue("Grizzly Bears should have been discarded to the graveyard") {
+                    game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("The drawn Forest should be in hand") {
+                    game.state.getHand(game.player1Id).count { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                    } shouldBe 1
+                }
+            }
+
+            test("declining the loot leaves hand and graveyard unchanged") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Rescue Leopard", tapped = false, summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Rescue Leopard" to 2))
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(false)
+                    game.resolveStack()
+                }
+
+                withClue("Nothing discarded when declining") {
+                    game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 0
+                }
+                withClue("Hand still holds just Grizzly Bears (no draw)") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AbzanMonument.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AbzanMonument.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Abzan Monument — Tarkir: Dragonstorm #238
+ * {2} · Artifact
+ *
+ * When this artifact enters, search your library for a basic Plains, Swamp, or Forest card,
+ * reveal it, put it into your hand, then shuffle.
+ * {1}{W}{B}{G}, {T}, Sacrifice this artifact: Create an X/X white Spirit creature token, where
+ * X is the greatest toughness among creatures you control. Activate only as a sorcery.
+ *
+ * The ETB is a mandatory single-card library search restricted to basic lands carrying one of
+ * the three Abzan basic subtypes, revealed and placed into hand then shuffled (atomic
+ * [EffectPatterns.searchLibrary]). The sacrifice ability mirrors Kin-Tree Invocation: an X/X
+ * token whose P/T are read at resolution as the greatest toughness among creatures you control
+ * ([DynamicAmounts.battlefield] MAX toughness).
+ */
+val AbzanMonument = card("Abzan Monument") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, search your library for a basic Plains, Swamp, or Forest card, " +
+        "reveal it, put it into your hand, then shuffle.\n" +
+        "{1}{W}{B}{G}, {T}, Sacrifice this artifact: Create an X/X white Spirit creature token, where X " +
+        "is the greatest toughness among creatures you control. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.BasicLand.withAnyOfSubtypes(
+                listOf(Subtype.PLAINS, Subtype.SWAMP, Subtype.FOREST)
+            ),
+            count = 1,
+            destination = SearchDestination.HAND,
+            shuffleAfter = true,
+            reveal = true
+        )
+        description = "When this artifact enters, search your library for a basic Plains, Swamp, or Forest card, " +
+            "reveal it, put it into your hand, then shuffle."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}{B}{G}"), Costs.Tap, Costs.SacrificeSelf)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.CreateDynamicToken(
+            dynamicPower = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature).maxToughness(),
+            dynamicToughness = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature).maxToughness(),
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            imageUri = "https://cards.scryfall.io/normal/front/8/e/8ea4fc2f-95a4-49d0-b06e-b88d19637737.jpg?1743176763"
+        )
+        description = "{1}{W}{B}{G}, {T}, Sacrifice this artifact: Create an X/X white Spirit creature token, " +
+            "where X is the greatest toughness among creatures you control. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "238"
+        artist = "Jorge Jacinto"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2da9024-3b58-4a57-8f7d-4094c193daee.jpg?1743204940"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AegisSculptor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AegisSculptor.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aegis Sculptor — Tarkir: Dragonstorm #35
+ * {3}{U} · Creature — Bird Wizard · 2/3
+ *
+ * Flying
+ * Ward {2}
+ * At the beginning of your upkeep, you may exile two cards from your graveyard. If you do,
+ * put a +1/+1 counter on this creature.
+ *
+ * The upkeep ability is an optional "exile exactly two" pipeline gated by [IfYouDoEffect]: gather
+ * your graveyard, let the player choose exactly two cards, move them to exile, and only add the
+ * counter when both cards were actually exiled ([SuccessCriterion.CollectionNonEmpty] with
+ * `min = 2`). With fewer than two cards in the graveyard the player can decline / cannot complete
+ * the exile, so the counter is not put on.
+ */
+val AegisSculptor = card("Aegis Sculptor") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, " +
+        "counter it unless that player pays {2}.)\n" +
+        "At the beginning of your upkeep, you may exile two cards from your graveyard. If you do, " +
+        "put a +1/+1 counter on this creature."
+
+    keywords(Keyword.FLYING, Keyword.WARD)
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = MayEffect(
+            IfYouDoEffect(
+                action = CompositeEffect(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(zone = Zone.GRAVEYARD),
+                            storeAs = "graveyardCards"
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "graveyardCards",
+                            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(2)),
+                            storeSelected = "toExile",
+                            selectedLabel = "Exile"
+                        ),
+                        MoveCollectionEffect(
+                            from = "toExile",
+                            destination = CardDestination.ToZone(Zone.EXILE)
+                        )
+                    )
+                ),
+                ifYouDo = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                successCriterion = SuccessCriterion.CollectionNonEmpty("toExile", min = 2)
+            )
+        )
+        description = "At the beginning of your upkeep, you may exile two cards from your graveyard. " +
+            "If you do, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "35"
+        artist = "Michele Giorgi"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19c1417a-9719-46f6-8749-d92b93ce0529.jpg?1743204100"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AuroralProcession.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AuroralProcession.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Auroral Procession — Tarkir: Dragonstorm #169
+ * {G}{U} · Instant
+ *
+ * Return target card from your graveyard to your hand.
+ */
+val AuroralProcession = card("Auroral Procession") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Instant"
+    oracleText = "Return target card from your graveyard to your hand."
+
+    spell {
+        target = TargetObject(
+            filter = TargetFilter(GameObjectFilter.Any.ownedByYou(), zone = Zone.GRAVEYARD)
+        )
+        effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "169"
+        artist = "Marco Gorlei"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/672f94ad-65d6-4c7d-925d-165ef264626f.jpg?1743204647"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RescueLeopard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RescueLeopard.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Rescue Leopard — Tarkir: Dragonstorm #116
+ * {2}{R} · Creature — Cat · 4/2
+ *
+ * Whenever this creature becomes tapped, you may discard a card. If you do, draw a card.
+ */
+val RescueLeopard = card("Rescue Leopard") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cat"
+    power = 4
+    toughness = 2
+    oracleText = "Whenever this creature becomes tapped, you may discard a card. If you do, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.BecomesTapped
+        effect = MayEffect(
+            IfYouDoEffect(
+                action = Effects.Discard(1),
+                ifYouDo = Effects.DrawCards(1)
+            )
+        )
+        description = "Whenever this creature becomes tapped, you may discard a card. If you do, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Hector Ortiz"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/056136a8-84be-477c-b654-63238fb8236e.jpg?1743204430"
+    }
+}


### PR DESCRIPTION
Adds four Tarkir: Dragonstorm cards. All compose existing SDK primitives — no new engine/SDK code.

## Cards

- **Abzan Monument** ({2} Artifact, #238) — ETB tutors a basic Plains/Swamp/Forest into hand (`EffectPatterns.searchLibrary`). `{1}{W}{B}{G}, {T}, Sacrifice` creates an X/X white Spirit token where X is the greatest toughness among creatures you control (`CreateDynamicToken` + `DynamicAmounts.battlefield(...).maxToughness()`), sorcery-speed via `TimingRule.SorcerySpeed`.
- **Aegis Sculptor** ({3}{U} Bird Wizard 2/3, #35) — Flying, Ward {2}. Upkeep `MayEffect(IfYouDo)`: gather your graveyard → choose exactly two → exile; counter is gated on actually exiling two (`SuccessCriterion.CollectionNonEmpty(min = 2)`).
- **Auroral Procession** ({G}{U} Instant, #169) — return any target card from your graveyard to your hand.
- **Rescue Leopard** ({2}{R} Cat 4/2, #116) — becomes-tapped `MayEffect(IfYouDo)` loot: discard a card, then draw a card.

## Tests

Scenario tests for each card, covering both branches of every "may" / "if you do" choice (loot taken vs declined, exile-two vs decline, ETB tutor, token P/T). All pass; full `just test-rules` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)