### PR TITLE
Add TDM cards: Jeskai Monument, Formation Breaker

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1221,6 +1221,12 @@ staticAbility {
   remove a card type (e.g. `"CREATURE"`). `RemoveCardType` backs Impending's "isn't a creature while it has a time
   counter" (wrapped in a `ConditionalStaticAbility`); reuse it for any "it's no longer a [type]" effect.
 - `ConditionalStaticAbility` — static gated by a runtime `Condition`.
+- `CantBlockCreaturesWithGreaterPower(filter = source())` — blocker-side evasion (Spitfire Handler): this
+  creature can't block creatures whose projected power exceeds its own.
+- `CantBeBlockedByCreaturesWithLessPower(filter = source())` — attacker-side dual (Formation Breaker): this
+  creature can't be blocked by creatures whose projected power is less than its own. Resolved by
+  `CantBeBlockedByCreaturesWithLessPowerRule`; both sides use projected power, so a P/T buff raises the
+  threshold.
 - `Effects.CreatePermanentEmblem(...)` — emblem with static abilities (planeswalker ultimates).
 - `AttackTax(amountPerAttacker: DynamicAmount)` — Propaganda / Ghostly Prison / Windborn Muse /
   Collective Restraint. Per-attacker generic-mana tax for attacking the source's controller; the

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FormationBreakerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FormationBreakerScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Formation Breaker (TDM #143).
+ *
+ * "Creatures with power less than this creature's power can't block it.
+ *  As long as you control a creature with a counter on it, this creature gets +1/+2."
+ *
+ * Exercises the new attacker-side [com.wingedsheep.sdk.scripting.CantBeBlockedByCreaturesWithLessPower]
+ * static (the dual of Spitfire Handler) and its interaction with the conditional +1/+2 buff:
+ *  - A lower-power blocker can't legally block Formation Breaker.
+ *  - An equal/greater-power blocker can.
+ *  - When you control a creature with a counter, the buff raises Formation Breaker's power, which in
+ *    turn raises the evasion threshold (a blocker that could block the 2/1 can no longer block the 3/3).
+ */
+class FormationBreakerScenarioTest : ScenarioTestBase() {
+
+    init {
+        // Plain vanilla blockers of various sizes (TestCards aren't in the scenario registry).
+        cardRegistry.register(
+            CardDefinition.creature("Small Blocker", ManaCost.parse("{1}"), emptySet(), power = 1, toughness = 1)
+        )
+        cardRegistry.register(
+            CardDefinition.creature("Equal Blocker", ManaCost.parse("{2}"), emptySet(), power = 2, toughness = 2)
+        )
+        cardRegistry.register(
+            CardDefinition.creature("Big Blocker", ManaCost.parse("{3}"), emptySet(), power = 3, toughness = 3)
+        )
+
+        context("Formation Breaker") {
+
+            test("a creature with less power can't block it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Formation Breaker")
+                    .withCardOnBattlefield(2, "Small Blocker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Formation Breaker" to 2))
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Small Blocker" to listOf("Formation Breaker")))
+                withClue("A power-1 blocker can't block a power-2 Formation Breaker") {
+                    block.error shouldNotBe null
+                }
+            }
+
+            test("a creature with equal power can block it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Formation Breaker")
+                    .withCardOnBattlefield(2, "Equal Blocker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Formation Breaker" to 2))
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Equal Blocker" to listOf("Formation Breaker")))
+                withClue("A power-2 blocker can legally block a power-2 Formation Breaker: ${block.error}") {
+                    block.error shouldBe null
+                }
+            }
+
+            test("counter buff raises the evasion threshold: a power-2 blocker can no longer block") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Formation Breaker")
+                    .withCardOnBattlefield(1, "Small Blocker") // a creature you control to carry a counter
+                    .withCardOnBattlefield(2, "Equal Blocker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                // Put a +1/+1 counter on a creature you control to switch on Formation Breaker's +1/+2.
+                val counterHolder = game.findPermanent("Small Blocker")!!
+                game.state = game.state.updateEntity(counterHolder) {
+                    it.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+                }
+
+                game.declareAttackers(mapOf("Formation Breaker" to 2))
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Equal Blocker" to listOf("Formation Breaker")))
+                withClue("With the +1/+2 buff, Formation Breaker is a 3/3; a power-2 blocker can't block it") {
+                    block.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/JeskaiMonumentScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/JeskaiMonumentScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Jeskai Monument (TDM #244).
+ *
+ * "When this artifact enters, search your library for a basic Island, Mountain, or Plains card,
+ *  reveal it, put it into your hand, then shuffle."
+ *
+ * Verifies the ETB search filter: a basic Island / Mountain / Plains is a legal choice and lands in
+ * hand, while a basic Forest (not one of the three named types) is not offered.
+ */
+class JeskaiMonumentScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Jeskai Monument") {
+
+            test("ETB search fetches a basic Island, Mountain, or Plains into hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Jeskai Monument")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Jeskai Monument")
+                withClue("Casting Jeskai Monument should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("ETB should prompt a library search") {
+                    (decision is SelectCardsDecision) shouldBe true
+                }
+                val options = (decision as SelectCardsDecision).options
+                withClue("Only the basic Island should be a legal choice (Forest is excluded)") {
+                    options.mapNotNull { game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name }
+                        .toSet() shouldBe setOf("Island")
+                }
+
+                game.selectCards(listOf(options.first()))
+                game.resolveStack()
+
+                withClue("Jeskai Monument should be on the battlefield") {
+                    game.isOnBattlefield("Jeskai Monument") shouldBe true
+                }
+                withClue("The Island should now be in hand") {
+                    game.findCardsInHand(1, "Island").size shouldBe 1
+                }
+                withClue("The Island should no longer be in the library") {
+                    game.findCardsInLibrary(1, "Island").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/BlockingStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/BlockingStaticAbilities.kt
@@ -104,6 +104,25 @@ data class CantBlockCreaturesWithGreaterPower(
 }
 
 /**
+ * This creature can't be blocked by creatures with power less than this creature's power.
+ * Used for cards like Formation Breaker. The attacker-side dual of
+ * [CantBlockCreaturesWithGreaterPower].
+ *
+ * The comparison uses projected power for both the attacker (source) and each potential
+ * blocker, so it accounts for buffs/debuffs that change power.
+ *
+ * @property filter What this ability applies to (typically [GroupFilter.source])
+ */
+@SerialName("CantBeBlockedByCreaturesWithLessPower")
+@Serializable
+data class CantBeBlockedByCreaturesWithLessPower(
+    val filter: GroupFilter = GroupFilter.source()
+) : StaticAbility {
+    override val description: String = "can't be blocked by creatures with power less than this creature's power"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility = this
+}
+
+/**
  * This creature can't be blocked by more than N creatures.
  * Used for Charging Rhino: "can't be blocked by more than one creature."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FormationBreaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FormationBreaker.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByCreaturesWithLessPower
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Formation Breaker
+ * {1}{G}
+ * Creature — Beast
+ * 2/1
+ *
+ * Creatures with power less than this creature's power can't block it.
+ * As long as you control a creature with a counter on it, this creature gets +1/+2.
+ *
+ * The first ability is a new attacker-side static [CantBeBlockedByCreaturesWithLessPower]
+ * (the dual of Spitfire Handler's CantBlockCreaturesWithGreaterPower). The second is a
+ * [ConditionalStaticAbility] wrapping a self [ModifyStats] (+1/+2), gated on
+ * "you control a creature with a counter" via [Exists] + [GameObjectFilter.withAnyCounter].
+ * Both comparisons use projected power, so the +1/+2 buff feeds into the evasion threshold.
+ */
+val FormationBreaker = card("Formation Breaker") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 1
+    oracleText = "Creatures with power less than this creature's power can't block it.\n" +
+        "As long as you control a creature with a counter on it, this creature gets +1/+2."
+
+    staticAbility {
+        ability = CantBeBlockedByCreaturesWithLessPower()
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(1, 2, GroupFilter.source()),
+            condition = Exists(
+                Player.You,
+                Zone.BATTLEFIELD,
+                GameObjectFilter.Creature.withAnyCounter()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "143"
+        artist = "Eelis Kyttanen"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67ab8e8f-3ef6-4339-8c66-68c5aca4867a.jpg?1743207531"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiMonument.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiMonument.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Jeskai Monument
+ * {2}
+ * Artifact
+ *
+ * When this artifact enters, search your library for a basic Island, Mountain, or Plains card,
+ * reveal it, put it into your hand, then shuffle.
+ * {1}{U}{R}{W}, {T}, Sacrifice this artifact: Create two 1/1 white Bird creature tokens with
+ * flying. Activate only as a sorcery.
+ *
+ * The ETB search is a single (non-optional) library search restricted to basic Island /
+ * Mountain / Plains cards via [GameObjectFilter.BasicLand.withAnyOfSubtypes]; it reveals the
+ * found card, moves it to hand, then shuffles. The activated ability pays {1}{U}{R}{W} + tap +
+ * sacrifice-self at sorcery speed ([TimingRule.SorcerySpeed]) and makes two flying Bird tokens.
+ */
+val JeskaiMonument = card("Jeskai Monument") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, search your library for a basic Island, Mountain, or Plains card, " +
+        "reveal it, put it into your hand, then shuffle.\n" +
+        "{1}{U}{R}{W}, {T}, Sacrifice this artifact: Create two 1/1 white Bird creature tokens with flying. " +
+        "Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.BasicLand.withAnyOfSubtypes(
+                listOf(Subtype.ISLAND, Subtype.MOUNTAIN, Subtype.PLAINS)
+            ),
+            count = 1,
+            destination = SearchDestination.HAND,
+            shuffleAfter = true,
+            reveal = true
+        )
+        description = "search your library for a basic Island, Mountain, or Plains card, reveal it, " +
+            "put it into your hand, then shuffle."
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Composite(
+            listOf(
+                AbilityCost.Mana(ManaCost.parse("{1}{U}{R}{W}")),
+                AbilityCost.Tap,
+                AbilityCost.SacrificeSelf
+            )
+        )
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Bird"),
+            keywords = setOf(com.wingedsheep.sdk.core.Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/6/1/6105623a-ff2c-46bf-8881-e8b899d47d54.jpg?1742506584"
+        )
+        description = "Create two 1/1 white Bird creature tokens with flying. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "244"
+        artist = "Julian Kok Joon Wen"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0193ad6-39b7-4558-bd3e-36f809332ea2.jpg?1743204966"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
@@ -418,6 +418,34 @@ class CantBlockCreaturesWithGreaterPowerRule : BlockEvasionRule {
 }
 
 /**
+ * CantBeBlockedByCreaturesWithLessPower: Attacker can't be blocked by creatures whose power is
+ * less than the attacker's power (e.g. Formation Breaker). The attacker-side dual of
+ * [CantBlockCreaturesWithGreaterPowerRule].
+ */
+class CantBeBlockedByCreaturesWithLessPowerRule : BlockEvasionRule {
+    override fun check(ctx: BlockCheckContext): String? {
+        // Face-down creatures have no abilities — restriction doesn't apply
+        if (ctx.state.getEntity(ctx.attackerId)?.has<FaceDownComponent>() == true) return null
+        val attackerCard = ctx.state.getEntity(ctx.attackerId)?.get<CardComponent>() ?: return null
+        val cardDef = ctx.cardRegistry.getCard(attackerCard.cardDefinitionId) ?: return null
+        val restriction = cardDef.staticAbilities
+            .filterIsInstance<com.wingedsheep.sdk.scripting.CantBeBlockedByCreaturesWithLessPower>().firstOrNull()
+            ?: return null
+
+        if (restriction.filter.scope !is com.wingedsheep.sdk.scripting.filters.unified.Scope.Self) return null
+
+        val attackerPower = ctx.projected.getPower(ctx.attackerId) ?: 0
+        val blockerPower = ctx.projected.getPower(ctx.blockerId) ?: 0
+
+        if (blockerPower < attackerPower) {
+            val blockerName = ctx.state.getEntity(ctx.blockerId)?.get<CardComponent>()?.name ?: "Creature"
+            return "$blockerName can't block ${attackerCard.name} (power $blockerPower is less than ${attackerCard.name}'s power $attackerPower)"
+        }
+        return null
+    }
+}
+
+/**
  * GrantCantBeBlockedToSmallCreatures: Attacker can't be blocked if it has power or toughness
  * at most N and its controller controls a permanent with this static ability
  * (e.g., Tetsuko Umezawa, Fugitive).
@@ -517,5 +545,6 @@ fun defaultBlockEvasionRules(
     ProtectionFromEachOpponentRule(),
     CanOnlyBlockCreaturesWithRule(predicateEvaluator),
     CantBlockCreaturesWithGreaterPowerRule(),
+    CantBeBlockedByCreaturesWithLessPowerRule(),
     RingBearerCantBeBlockedByGreaterPowerRule()
 )


### PR DESCRIPTION
Adds two cards from Tarkir: Dragonstorm (TDM).

## Cards
- **Jeskai Monument** (#244, uncommon) — {2} Artifact. ETB: search your library for a basic Island, Mountain, or Plains card, reveal it, put it into hand, then shuffle. `{1}{U}{R}{W}, {T}, Sacrifice` at sorcery speed: create two 1/1 white flying Bird tokens. Composed entirely from existing primitives (`EffectPatterns.searchLibrary` + `withAnyOfSubtypes`, `Effects.CreateToken`, `AbilityCost.SacrificeSelf` + `TimingRule.SorcerySpeed`).
- **Formation Breaker** (#143, uncommon) — {1}{G} 2/1 Beast. "Creatures with power less than this creature's power can't block it" + "As long as you control a creature with a counter on it, this creature gets +1/+2."

## New engine SDK
- `CantBeBlockedByCreaturesWithLessPower` static ability — the attacker-side dual of `CantBlockCreaturesWithGreaterPower` (Spitfire Handler). Resolved by the new `CantBeBlockedByCreaturesWithLessPowerRule` block-evasion rule. Both sides use projected power, so Formation Breaker's conditional +1/+2 correctly raises the evasion threshold.
- The +1/+2 buff reuses `ConditionalStaticAbility` + `ModifyStats(GroupFilter.source())` + `Exists(... Creature.withAnyCounter())`.
- Doc updated in `card-sdk-language-reference.md`.

## Tests
- `FormationBreakerScenarioTest` — lower-power blocker rejected, equal-power blocker allowed, and the +1/+2 buff raising the threshold so a power-2 blocker can no longer block the 3/3.
- `JeskaiMonumentScenarioTest` — ETB search offers only basic Island/Mountain/Plains (Forest excluded) and lands the choice in hand.
- `just test-rules` green; combat/block rules-engine tests green; `mtg-sets` tests green.

## Skipped
- **Molten Exhale** and **Piercing Exhale** — both depend on the "behold a Dragon" mechanic used as an **optional** additional cost, which the engine doesn't support today: the kicker enumerator only wires `SacrificePermanent` as an optional additional cost, and `grantsFlashTiming` requires a mana cost (Molten Exhale unlocks flash via a *behold*, and Piercing Exhale needs a "if a Dragon was beheld, surveil 2" branch). Implementing these faithfully is an `add-feature` task (optional-behold cost + behold-granted flash timing + beheld-branch condition), not a single-card change, so they were skipped rather than shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)