### PR TITLE
Add Omen mechanic support to the engine

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -56,7 +56,7 @@ section; do not let SDK additions land without a corresponding doc update.
 - `loyaltyAbility(±N) { ... }` — planeswalker loyalty abilities.
 - `replacementEffect { ... }` — "instead/if … would" replacement.
 - `keywords(...)` / `keywordAbility(...)` / `keywordAbilities(...)` — add keyword abilities.
-- `spell { ... }` — define the spell payload for instants/sorceries and Adventure faces.
+- `spell { ... }` — define the spell payload for instants/sorceries and Adventure / Omen faces.
 
 ---
 
@@ -72,12 +72,16 @@ section; do not let SDK additions land without a corresponding doc update.
   half (Room) carries triggered/activated/static abilities instead.
 - `ADVENTURE` — primary face is a creature, `cardFaces[0]` is an instant/sorcery Adventure (CR 715). Resolving the
   Adventure exiles the card and grants permission to cast the creature from exile.
+- `OMEN` — primary face is a permanent (creature), `cardFaces[0]` is an instant/sorcery Omen (Tarkir: Dragonstorm).
+  Casts exactly like an Adventure (creature face, or Omen via `CastSpell.faceIndex = 0`), but resolving the Omen
+  **shuffles the card into its owner's library** instead of exiling it — no cast-from-exile linkage. DSL:
+  `card { omen("Name") { spell { … } } }`.
 - `MODAL_DFC` — primary characteristics are the front face, `cardFaces[0]` is the back face (CR 712). Cast **one**
   face from hand (front via primary characteristics, back via `CastSpell.faceIndex = 0`), never both. Unlike
   ADVENTURE there is no exile-then-recast linkage — a spell back resolves as an ordinary spell (graveyard, or exile
   when its script sets `selfExileOnResolve` via `spell { selfExile() }`). DSL: `card { modalBack("Name") { spell { … } } }`.
 
-**`CardFace` (SPLIT / ADVENTURE / MODAL_DFC)**
+**`CardFace` (SPLIT / ADVENTURE / OMEN / MODAL_DFC)**
 
 - `name` — face name.
 - `manaCost` — face mana cost.
@@ -2122,6 +2126,12 @@ Card authors rarely reference these directly; they are created/updated by the ma
   keeps the grant alive across end-of-turn cleanup. Emits `CardPlottedEvent` / `ClientEvent.CardPlotted`.
 - **Adventure (CR 715)** — `layout = ADVENTURE` + `cardFaces[0]` Adventure spell; DSL:
   `card { adventure("Name") { spell { … } } }`.
+- **Omen (Tarkir: Dragonstorm)** — `layout = OMEN` + `cardFaces[0]` Omen spell; DSL:
+  `card { omen("Name") { spell { … } } }`. Reuses the Adventure cast/enumeration path (`enumerateSecondaryFace`,
+  cast via `CastSpell.faceIndex = 0`), but `StackResolver` routes the resolving Omen to `Zone.LIBRARY` and shuffles
+  the owner's library (`shuffleOwnerLibrary` + `LibraryShuffledEvent`) instead of exiling with a `MayPlayPermission`.
+  No new effect/component — the layout enum drives the resolution fork. First user: Dirgur Island Dragon //
+  Skimming Strike.
 - **Modal DFC (CR 712)** — `layout = MODAL_DFC` + `cardFaces[0]` back face; DSL:
   `card { modalBack("Name") { imageUri = …; spell { selfExile(); … } } }`. Cast either face from hand (back via
   `CastSpell.faceIndex = 0`); reuses the Adventure cast/enumeration path (`enumerateSecondaryFace`) but with no

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -815,6 +815,22 @@ class CardBuilder(private val name: String) {
     }
 
     /**
+     * Declare the Omen face of an Omen card (Tarkir: Dragonstorm). Sets [layout] to
+     * [CardLayout.OMEN] and registers the named face. Inside the block, declare the Omen's
+     * `manaCost`, `typeLine` (e.g. `"Instant — Omen"`), `oracleText`, and a `spell { … }` block
+     * for its effect / targets.
+     *
+     * Structurally identical to [adventure]: the permanent (creature) face is described by the
+     * surrounding [CardBuilder]'s top-level fields. The difference is at resolution — an Omen
+     * shuffles its card into its owner's library instead of exiling itself with a cast-from-exile
+     * permission.
+     */
+    fun omen(name: String, init: CardFaceBuilder.() -> Unit) {
+        layout = CardLayout.OMEN
+        face(name, init)
+    }
+
+    /**
      * Declare the back face of a modal double-faced card (CR 712). Sets [layout] to
      * [CardLayout.MODAL_DFC] and registers the named back face. The front face is described by
      * the surrounding [CardBuilder]'s top-level fields; the owner casts one face or the other,
@@ -873,6 +889,19 @@ class CardBuilder(private val name: String) {
             val adventureFace = cardFaceList.first()
             require(adventureFace.script.spellEffect != null) {
                 "Adventure face '${adventureFace.name}' must declare a spell { } effect"
+            }
+        }
+
+        // OMEN layout (Tarkir: Dragonstorm): the surrounding CardBuilder fields describe the
+        // permanent face; cardFaces[0] is the Omen spell, which shuffles the card into its
+        // owner's library on resolution rather than exiling like an Adventure.
+        if (layout == CardLayout.OMEN) {
+            require(cardFaceList.size == 1) {
+                "OMEN layout requires exactly one face (the Omen): $name"
+            }
+            val omenFace = cardFaceList.first()
+            require(omenFace.script.spellEffect != null) {
+                "Omen face '${omenFace.name}' must declare a spell { } effect"
             }
         }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
@@ -80,6 +80,22 @@ enum class CardLayout {
     ADVENTURE,
 
     /**
+     * Omen card (Tarkir: Dragonstorm). Structurally a sibling of [ADVENTURE]: the primary
+     * characteristics describe a permanent (a creature), and [CardDefinition.cardFaces] holds
+     * the single Omen face — an instant or sorcery with its own name, mana cost, type line,
+     * oracle text, target requirements, and spell effect.
+     *
+     * Casting flow is identical to [ADVENTURE]: from hand the owner may cast either the permanent
+     * (primary characteristics) or the Omen (face[0]'s alternative characteristics, signalled by
+     * [CastSpell.faceIndex]). The difference is at resolution — when an Omen resolves, instead of
+     * exiling itself and granting a cast-from-exile permission, the card is **shuffled into its
+     * owner's library** ("then shuffle this card into its owner's library"). From every zone other
+     * than the stack (and on the stack when not cast as the Omen) the card has only the permanent's
+     * characteristics, exactly like an adventurer.
+     */
+    OMEN,
+
+    /**
      * Modal double-faced card (CR 712). The front face is described by the primary
      * [CardDefinition] characteristics; [CardDefinition.cardFaces] holds the single back face
      * (its own name, mana cost, type line, oracle text, and — for a spell back — a `spell { }`
@@ -239,6 +255,7 @@ data class CardDefinition(
     val isDoubleFaced: Boolean get() = backFace != null
     val isSplit: Boolean get() = layout == CardLayout.SPLIT
     val isAdventure: Boolean get() = layout == CardLayout.ADVENTURE
+    val isOmen: Boolean get() = layout == CardLayout.OMEN
 
     /**
      * True if this card is a Room (CR 709.5 + 205.3h). A Room is a split-layout enchantment whose

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DirgurIslandDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DirgurIslandDragon.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+
+/**
+ * Dirgur Island Dragon // Skimming Strike — Tarkir: Dragonstorm #40
+ * {5}{U} · Creature — Dragon · 4/4
+ *
+ * Flying
+ * Ward {2}
+ *
+ * Omen: Skimming Strike — {1}{U}, Instant — Omen
+ * Tap up to one target creature. Draw a card.
+ *
+ * (Omen, Tarkir: Dragonstorm: casting the Omen face shuffles this card into its owner's
+ * library on resolution instead of putting it in the graveyard. From every zone other than
+ * the stack the card is just the Dragon — see [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ */
+val DirgurIslandDragon = card("Dirgur Island Dragon") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\nWard {2} (Whenever this creature becomes the target of a spell or " +
+        "ability an opponent controls, counter it unless that player pays {2}.)"
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+
+    // Omen: Skimming Strike — Instant. Tap up to one target creature. Draw a card.
+    omen("Skimming Strike") {
+        manaCost = "{1}{U}"
+        typeLine = "Instant — Omen"
+        oracleText = "Tap up to one target creature. Draw a card. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            val creature = target("creature", Targets.UpToCreatures(1))
+            effect = Effects.Tap(creature).then(Effects.DrawCards(1))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Daniel Ljunggren"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1d21a9a-6b0c-4fbc-a427-81be885d326b.jpg?1743204119"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -77,9 +77,11 @@ class CastSpellEnumerator : ActionEnumerator {
             // for that face, then fall through so the surrounding code also enumerates the
             // primary (creature) face. The secondary face carries its own mana cost, type line,
             // target requirements, and spell effect; the primary face uses the card's top-level
-            // fields. (MODAL_DFC differs from ADVENTURE only at resolution — no exile-then-recast
-            // linkage — which is handled in StackResolver, not here.)
+            // fields. (MODAL_DFC, ADVENTURE, and OMEN differ only at resolution — exile-then-recast
+            // for Adventure, shuffle-into-library for Omen, plain graveyard for modal DFC — which
+            // is handled in StackResolver, not here.)
             if ((cardDef.layout == com.wingedsheep.sdk.model.CardLayout.ADVENTURE ||
+                    cardDef.layout == com.wingedsheep.sdk.model.CardLayout.OMEN ||
                     cardDef.layout == com.wingedsheep.sdk.model.CardLayout.MODAL_DFC) &&
                 cardDef.cardFaces.isNotEmpty()
             ) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1313,7 +1313,13 @@ class StackResolver(
                 val pausedExileAfterResolve = pausedExileAfterResolveComp != null
                 val pausedAdventureFaceExile = pausedCardDef?.layout == com.wingedsheep.sdk.model.CardLayout.ADVENTURE &&
                     spellComponent.faceIndex != null
-                val pausedIntended = if (pausedSelfExile || pausedFlashbackExile || pausedExileAfterResolve || pausedAdventureFaceExile) Zone.EXILE else Zone.GRAVEYARD
+                val pausedOmenFaceShuffle = pausedCardDef?.layout == com.wingedsheep.sdk.model.CardLayout.OMEN &&
+                    spellComponent.faceIndex != null
+                val pausedIntended = when {
+                    pausedSelfExile || pausedFlashbackExile || pausedExileAfterResolve || pausedAdventureFaceExile -> Zone.EXILE
+                    pausedOmenFaceShuffle -> Zone.LIBRARY
+                    else -> Zone.GRAVEYARD
+                }
 
                 // Apply RedirectZoneChange replacement effects (e.g., Festival of Embers).
                 val pausedRedirect = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.checkZoneChangeRedirect(
@@ -1345,6 +1351,12 @@ class StackResolver(
                 val pausedCounterEvents = mutableListOf<GameEvent>()
                 if (pausedDestZone == Zone.EXILE && pausedExileAfterResolveComp != null && pausedExileAfterResolveComp.withCounters.isNotEmpty()) {
                     pausedState = applyExileCounters(pausedState, spellId, pausedExileAfterResolveComp.withCounters, pausedCounterEvents)
+                }
+
+                // Omen (Tarkir: Dragonstorm): shuffle the just-added card into its owner's library.
+                if (pausedOmenFaceShuffle && pausedDestZone == Zone.LIBRARY) {
+                    pausedState = shuffleOwnerLibrary(pausedState, ownerId)
+                    pausedCounterEvents.add(LibraryShuffledEvent(ownerId))
                 }
 
                 pausedRedirect.additionalEffect?.let { extra ->
@@ -1404,7 +1416,15 @@ class StackResolver(
         // creature spell while it remains exiled.
         val adventureFaceExile = cardDef?.layout == com.wingedsheep.sdk.model.CardLayout.ADVENTURE &&
             spellComponent.faceIndex != null
-        val intendedDestination = if (selfExile || flashbackExile || exileAfterResolve || adventureFaceExile) Zone.EXILE else Zone.GRAVEYARD
+        // Omen face (Tarkir: Dragonstorm): when an Omen resolves, shuffle it into its owner's
+        // library instead of putting it in the graveyard. No cast-from-exile linkage.
+        val omenFaceShuffle = cardDef?.layout == com.wingedsheep.sdk.model.CardLayout.OMEN &&
+            spellComponent.faceIndex != null
+        val intendedDestination = when {
+            selfExile || flashbackExile || exileAfterResolve || adventureFaceExile -> Zone.EXILE
+            omenFaceShuffle -> Zone.LIBRARY
+            else -> Zone.GRAVEYARD
+        }
 
         // Apply RedirectZoneChange replacement effects (e.g., Festival of Embers
         // exiles cards that would go to your graveyard from anywhere).
@@ -1439,6 +1459,13 @@ class StackResolver(
                     timestamp = state.timestamp,
                 )
             )
+        }
+
+        // Omen (Tarkir: Dragonstorm): the card was just added to the bottom of its owner's
+        // library above — now shuffle that library and announce it.
+        if (omenFaceShuffle && destinationZone == Zone.LIBRARY) {
+            newState = shuffleOwnerLibrary(newState, ownerId)
+            events.add(LibraryShuffledEvent(ownerId))
         }
 
         // Add counters granted by ExileAfterResolveComponent (e.g., Goliath Daydreamer's dream counter).
@@ -1477,6 +1504,21 @@ class StackResolver(
         )
 
         return ExecutionResult.success(newState, events)
+    }
+
+    /**
+     * Shuffle [ownerId]'s library after an Omen spell has been added to it on resolution
+     * (Tarkir: Dragonstorm — "then shuffle this card into its owner's library"). Mirrors
+     * [com.wingedsheep.engine.handlers.effects.library.ShuffleLibraryExecutor]: clears any
+     * known top-of-library positions before shuffling, then advances the deterministic RNG.
+     * The caller is responsible for emitting the [LibraryShuffledEvent].
+     */
+    private fun shuffleOwnerLibrary(state: GameState, ownerId: EntityId): GameState {
+        val libraryZone = ZoneKey(ownerId, Zone.LIBRARY)
+        val cleared = com.wingedsheep.engine.handlers.effects.library.LibraryRevealUtils
+            .clearLibraryReveals(state, ownerId)
+        val (library, advanced) = cleared.nextRandom { shuffle(cleared.getZone(libraryZone)) }
+        return advanced.copy(zones = advanced.zones + (libraryZone to library))
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmenMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmenMechanicTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsDrawnEvent
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.LibraryShuffledEvent
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the Omen mechanic (Tarkir: Dragonstorm).
+ *
+ * An Omen card is a permanent (here a creature) whose [com.wingedsheep.sdk.model.CardLayout.OMEN]
+ * `cardFaces[0]` is an instant/sorcery spell. Casting the Omen face (via [CastSpell.faceIndex] = 0)
+ * is identical to casting an Adventure, but on resolution the card is **shuffled into its owner's
+ * library** instead of being exiled with a cast-from-exile permission, and instead of going to the
+ * graveyard like a normal spell.
+ *
+ * Modeled on Dirgur Island Dragon // Skimming Strike — the Omen draws a card and shuffles itself
+ * back in. Here the Omen face is reduced to a plain "Draw a card" so the resolution behavior is
+ * isolated from target selection.
+ *
+ * ## Covered scenarios
+ * - Casting the Omen resolves the spell effect, then shuffles the card into the library.
+ * - The card lands in the library (not graveyard, not exile).
+ * - A [LibraryShuffledEvent] is emitted.
+ * - The permanent (creature) face still casts normally to the battlefield.
+ */
+class OmenMechanicTest : FunSpec({
+
+    // Inline Omen test card: {5}{U} Dragon 4/4 with Omen "Skimming Strike" — {1}{U}, Instant — Omen,
+    // "Draw a card."
+    val islandDragon = card("Island Dragon") {
+        manaCost = "{5}{U}"
+        typeLine = "Creature — Dragon"
+        power = 4
+        toughness = 4
+        keywords(Keyword.FLYING)
+        omen("Skimming Strike") {
+            manaCost = "{1}{U}"
+            typeLine = "Instant — Omen"
+            oracleText = "Draw a card. (Then shuffle this card into its owner's library.)"
+            spell {
+                effect = Effects.DrawCards(1)
+            }
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(islandDragon)
+        return driver
+    }
+
+    test("Casting the Omen face shuffles the card into its owner's library on resolution") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 40, "Forest" to 20),
+            startingLife = 20
+        )
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val omen = driver.putCardInHand(player, "Island Dragon")
+        driver.giveMana(player, Color.BLUE, 2) // {1}{U}
+
+        // Cast the Omen face (faceIndex = 0), not the creature.
+        val cast = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = omen,
+                faceIndex = 0,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        cast.isSuccess shouldBe true
+
+        // Resolve the spell.
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        // The card shuffled into the library — not graveyard, not exile.
+        driver.state.getZone(ZoneKey(player, Zone.LIBRARY)) shouldContain omen
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)) shouldNotContain omen
+        driver.state.getZone(ZoneKey(player, Zone.EXILE)) shouldNotContain omen
+        driver.state.getZone(ZoneKey(player, Zone.STACK)) shouldNotContain omen
+
+        // The library was shuffled and the Omen's "Draw a card" resolved.
+        driver.events.filterIsInstance<LibraryShuffledEvent>()
+            .any { it.playerId == player } shouldBe true
+        driver.events.filterIsInstance<CardsDrawnEvent>()
+            .any { it.playerId == player } shouldBe true
+    }
+
+    test("The permanent face of an Omen card casts normally to the battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 40, "Forest" to 20),
+            startingLife = 20
+        )
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val dragon = driver.putCardInHand(player, "Island Dragon")
+        driver.giveMana(player, Color.BLUE, 6) // {5}{U}
+
+        // Cast the creature face (no faceIndex).
+        val cast = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = dragon,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        cast.isSuccess shouldBe true
+
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        // The Dragon resolved onto the battlefield — not shuffled away.
+        driver.getPermanents(player) shouldContain dragon
+        driver.state.getZone(ZoneKey(player, Zone.LIBRARY)) shouldNotContain dragon
+    }
+})


### PR DESCRIPTION
## What

Adds engine/SDK support for the **Omen** mechanic (Tarkir: Dragonstorm). Omen is structurally a sibling of Adventure — a permanent (creature) card whose `cardFaces[0]` is an instant/sorcery castable from hand — but it differs at *resolution*: an Omen spell **shuffles its card into its owner's library** instead of exiling itself and granting a cast-from-exile permission.

Motivating card: **Dirgur Island Dragon // Skimming Strike** (TDM #40), which the previous Adventure layout couldn't model faithfully (Adventure exiles + grants recast-from-exile; Omen shuffles back into the library).

## How

- **SDK** — new `CardLayout.OMEN` (+ `isOmen`) and an `omen("Name") { spell { … } }` DSL builder mirroring `adventure()`, with build-time validation that the single Omen face declares a `spell { }` effect. The layout enum drives the resolution fork — no new `Effect`/component was needed.
- **Engine** —
  - `CastSpellEnumerator` includes `OMEN` in the secondary-face enumeration (reuses `enumerateSecondaryFace`, cast via `CastSpell.faceIndex = 0`).
  - `StackResolver` forks **both** resolution sites (normal completion + mid-resolution pause): the resolving Omen is routed to `Zone.LIBRARY` and the owner's library is shuffled via a shared `shuffleOwnerLibrary` helper (mirrors `ShuffleLibraryExecutor` — clears known top-of-library positions, advances the deterministic RNG) which emits `LibraryShuffledEvent`.
  - A **countered/fizzled** Omen still goes to the graveyard (it only shuffles "as it resolves"), matching the existing Adventure precedent — `fizzleSpell` is intentionally left unchanged.
- **Content** — `Dirgur Island Dragon // Skimming Strike` as the first user (Flying, Ward {2}; Omen "Tap up to one target creature. Draw a card.").
- **Docs** — `docs/card-sdk-language-reference.md` documents the `OMEN` layout and mechanic alongside Adventure / Modal DFC.

## Layer trace

SDK ✅ (pure serializable enum + DSL) · enumerator ✅ · StackResolver resolution ✅ (both paths) · projection ✅ (off-stack the card is just the creature — same as Adventure, no change) · server DTO ✅ (reuses existing `LibraryShuffledEvent` / `ClientEvent`, no new `GameEvent`) · frontend ✅ (server-authoritative secondary-face cast, identical to Adventure — no client change).

## Tests

`OmenMechanicTest` (rules-engine):
- Casting the Omen face shuffles the card into its owner's library on resolution (in library, not graveyard/exile/stack; `LibraryShuffledEvent` + `CardsDrawnEvent` emitted).
- The permanent (creature) face still casts normally to the battlefield.

Full `:rules-engine`, `:mtg-sdk`, and `:mtg-sets` `*Test` suites pass; `:game-server` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)