### PR TITLE
TDM: Add Tempest Hawk, Watcher of the Wayside, Stadium Headliner

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StadiumHeadlinerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StadiumHeadlinerScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Stadium Headliner (TDM #122) — {R} Goblin Warrior, 1/1, Mobilize 1.
+ *
+ * "{1}{R}, Sacrifice this creature: It deals damage equal to the number of creatures you control
+ *  to target creature."
+ *
+ * Stadium Headliner is sacrificed as a cost, so it is no longer a creature you control when the
+ * ability resolves. With Stadium Headliner plus two other creatures, the count at resolution is 2,
+ * so it deals 2 damage to the target — enough to kill a 2-toughness creature.
+ */
+class StadiumHeadlinerScenarioTest : ScenarioTestBase() {
+
+    private val sacAbilityId =
+        cardRegistry.getCard("Stadium Headliner")!!.activatedAbilities.first().id
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Goblin A",
+                manaCost = ManaCost.parse("{R}"),
+                subtypes = setOf(Subtype("Goblin")),
+                power = 1,
+                toughness = 1
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Goblin B",
+                manaCost = ManaCost.parse("{R}"),
+                subtypes = setOf(Subtype("Goblin")),
+                power = 1,
+                toughness = 1
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Enemy Bear",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Stadium Headliner sacrifice ability") {
+
+            test("deals damage equal to creatures you control (after the sacrifice) to a target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Stadium Headliner", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Test Goblin A", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Test Goblin B", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "Enemy Bear", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val headliner = game.findPermanent("Stadium Headliner")!!
+                val bear = game.findPermanent("Enemy Bear")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = headliner,
+                        abilityId = sacAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bear))
+                    )
+                )
+                withClue("Activating the sacrifice ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Stadium Headliner was sacrificed as a cost and left the battlefield") {
+                    game.isOnBattlefield("Stadium Headliner") shouldBe false
+                }
+                withClue("Two creatures remained at resolution, so 2 damage kills the 2/2 Enemy Bear") {
+                    game.isOnBattlefield("Enemy Bear") shouldBe false
+                }
+            }
+
+            test("with more creatures the damage scales up") {
+                // Stadium Headliner + three others = 4 creatures; after sacrifice, 3 remain → 3 damage.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Stadium Headliner", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Test Goblin A", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Test Goblin B", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Stadium Headliner", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "Enemy Bear", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val headliners = game.findPermanents("Stadium Headliner")
+                val bear = game.findPermanent("Enemy Bear")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = headliners.first(),
+                        abilityId = sacAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bear))
+                    )
+                )
+                withClue("Activating the sacrifice ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Three creatures remain (other Headliner + two Goblins) → 3 damage to the 2/2 bear.
+                withClue("Enemy Bear (2/2) should be dead from 3 damage") {
+                    game.isOnBattlefield("Enemy Bear") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TempestHawkScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TempestHawkScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Tempest Hawk (TDM #31) — {2}{W} Bird, 2/2, Flying.
+ *
+ * "Whenever this creature deals combat damage to a player, you may search your library for a card
+ *  named Tempest Hawk, reveal it, put it into your hand, then shuffle."
+ *
+ * Verifies the combat-damage trigger's optional library search filtered to the card's own name:
+ *  - finding a second Tempest Hawk in the library and putting it into hand, and
+ *  - declining (the "may") leaves the library copy untouched.
+ */
+class TempestHawkScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Tempest Hawk combat damage trigger") {
+
+            test("dealing combat damage lets the controller fetch another Tempest Hawk to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tempest Hawk", summoningSickness = false)
+                    .withCardInLibrary(1, "Tempest Hawk")
+                    .withCardInLibrary(1, "Mountain")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Tempest Hawk" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                var iterations = 0
+                while (!game.hasPendingDecision() && game.state.step != Step.POSTCOMBAT_MAIN && iterations++ < 20) {
+                    game.passPriority()
+                }
+
+                withClue("Tempest Hawk (2/2) deals 2 combat damage to the defender") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+
+                val decision = game.getPendingDecision()
+                withClue("The combat damage trigger should pause for the optional name search") {
+                    (decision is SelectCardsDecision) shouldBe true
+                }
+                decision as SelectCardsDecision
+                withClue("Only the second Tempest Hawk should be offered — the Mountain is not 'named Tempest Hawk'") {
+                    decision.options.size shouldBe 1
+                }
+
+                game.selectCards(listOf(decision.options.first()))
+                game.resolveStack()
+
+                withClue("The fetched Tempest Hawk should be in hand") {
+                    game.findCardsInHand(1, "Tempest Hawk").size shouldBe 1
+                }
+                withClue("The fetched Tempest Hawk should have left the library") {
+                    game.findCardsInLibrary(1, "Tempest Hawk").size shouldBe 0
+                }
+            }
+
+            test("declining the optional search leaves the library copy in place") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tempest Hawk", summoningSickness = false)
+                    .withCardInLibrary(1, "Tempest Hawk")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Tempest Hawk" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                var iterations = 0
+                while (!game.hasPendingDecision() && game.state.step != Step.POSTCOMBAT_MAIN && iterations++ < 20) {
+                    game.passPriority()
+                }
+
+                // Decline the optional search (select nothing).
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+
+                withClue("Declining leaves the Tempest Hawk in the library") {
+                    game.findCardsInLibrary(1, "Tempest Hawk").size shouldBe 1
+                }
+                withClue("Nothing was added to hand") {
+                    game.findCardsInHand(1, "Tempest Hawk").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/WatcherOfTheWaysideScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/WatcherOfTheWaysideScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Watcher of the Wayside (TDM #249) — {3} Artifact Creature — Golem, 3/2.
+ *
+ * "When this creature enters, target player mills two cards. You gain 2 life."
+ *
+ * Verifies the enters trigger: the targeted player mills two, and the controller gains 2 life
+ * unconditionally (the life gain is a separate clause, independent of the mill).
+ */
+class WatcherOfTheWaysideScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Watcher of the Wayside enters trigger") {
+
+            test("target player mills two cards and the controller gains 2 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Watcher of the Wayside")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(2, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Island")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Watcher of the Wayside")
+                withClue("Casting Watcher of the Wayside should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // The enters trigger targets a player; choose Player2 to mill.
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(game.player2Id))
+                }
+                game.resolveStack()
+
+                withClue("Watcher of the Wayside should be on the battlefield") {
+                    game.isOnBattlefield("Watcher of the Wayside") shouldBe true
+                }
+                withClue("Target player (Player2) milled exactly two cards") {
+                    game.graveyardSize(2) shouldBe 2
+                }
+                withClue("Controller gains 2 life (20 -> 22)") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StadiumHeadliner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StadiumHeadliner.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Stadium Headliner — Tarkir: Dragonstorm #122
+ * {R} · Creature — Goblin Warrior · 1/1
+ *
+ * Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior
+ * creature token. Sacrifice it at the beginning of the next end step.)
+ * {1}{R}, Sacrifice this creature: It deals damage equal to the number of creatures you control
+ * to target creature.
+ *
+ * Mobilize is the `mobilize(n)` builder helper (display keyword + attack-triggered token ability).
+ *
+ * The activated ability sacrifices Stadium Headliner as a cost, so it is no longer a creature you
+ * control when the ability resolves — the `DynamicAmount.Count(creatures you control)` is evaluated
+ * at resolution and does not include the (already sacrificed) source. Damage is attributed to
+ * Stadium Headliner via the ability's source (last-known information), so no `damageSource` override
+ * is needed.
+ */
+val StadiumHeadliner = card("Stadium Headliner") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior " +
+        "creature token. Sacrifice it at the beginning of the next end step.)\n" +
+        "{1}{R}, Sacrifice this creature: It deals damage equal to the number of creatures you control to target creature."
+
+    mobilize(1)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.SacrificeSelf)
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(
+            DynamicAmount.Count(Player.You, Zone.BATTLEFIELD, Filters.Creature),
+            t
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "122"
+        artist = "Ralph Horsley"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/37d4ab2a-a06a-4768-b5e1-e1def957d7f4.jpg?1743204451"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TempestHawk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TempestHawk.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * Tempest Hawk — Tarkir: Dragonstorm #31
+ * {2}{W} · Creature — Bird · 2/2
+ *
+ * Flying
+ * Whenever this creature deals combat damage to a player, you may search your library for a card
+ * named Tempest Hawk, reveal it, put it into your hand, then shuffle.
+ * A deck can have any number of cards named Tempest Hawk.
+ *
+ * The combat-damage trigger reuses [Triggers.DealsCombatDamageToPlayer] + the
+ * `EffectPatterns.searchLibrary` Gather→Select→Move pipeline, filtered to the card's own name via
+ * `CardPredicate.NameEquals`. The search is `ChooseUpTo(1)`, so selecting zero cards is the "you may"
+ * decline (no separate yes/no needed) — the same idiom as Embermouth Sentinel's optional ETB search.
+ *
+ * The final line ("A deck can have any number...") is a deck-construction allowance (CR 100.4-style
+ * exemption from the four-copy rule). The engine does not enforce singleton/four-copy deck limits at
+ * gameplay time, so this clause has no in-game behavior to model; it is preserved in [oracleText] only.
+ */
+val TempestHawk = card("Tempest Hawk") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever this creature deals combat damage to a player, you may search your library for a " +
+        "card named Tempest Hawk, reveal it, put it into your hand, then shuffle.\n" +
+        "A deck can have any number of cards named Tempest Hawk."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter(cardPredicates = listOf(CardPredicate.NameEquals("Tempest Hawk"))),
+            count = 1,
+            destination = SearchDestination.HAND,
+            shuffleAfter = true,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Abz J Harding"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/422f9453-ab12-4e3c-8c51-be87391395a1.jpg?1743204081"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WatcherOfTheWayside.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WatcherOfTheWayside.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Watcher of the Wayside — Tarkir: Dragonstorm #249
+ * {3} · Artifact Creature — Golem · 3/2
+ *
+ * When this creature enters, target player mills two cards. You gain 2 life.
+ *
+ * A single enters trigger with a player target. The mill is directed at the chosen target player
+ * (`EffectTarget.ContextTarget(0)`); the life gain is unconditional and goes to the controller
+ * (`EffectTarget.Controller`), so it happens whether or not the target had cards to mill. Composed
+ * from the `EffectPatterns.mill` Gather→Move pipeline + `Effects.GainLife`.
+ */
+val WatcherOfTheWayside = card("Watcher of the Wayside") {
+    manaCost = "{3}"
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, target player mills two cards. You gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target player", Targets.Player)
+        effect = Effects.Composite(
+            EffectPatterns.mill(2, EffectTarget.ContextTarget(0)),
+            Effects.GainLife(2, EffectTarget.Controller)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "249"
+        artist = "Brian Valeza"
+        flavorText = "Against dragonlords, khans, and Ugin himself, the golem survived. Original purpose forgotten, it awaits orders that will never come, from a world that has moved on without it."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2dcafdac-a293-4adc-a540-3b3f469cf6f3.jpg?1743204983"
+    }
+}


### PR DESCRIPTION
Adds three Tarkir: Dragonstorm cards, each implemented via the `add-card` workflow (Scryfall lookup, canonical-printing check, composed from existing SDK facades) with a Kotest scenario test.

## Cards
- **Tempest Hawk** — optional self-name library fetch on combat damage (`searchLibrary` `ChooseUpTo(1)` + `CardPredicate.NameEquals`, same idiom as Embermouth Sentinel).
- **Watcher of the Wayside** — implemented + tested.
- **Stadium Headliner** — damage counts creatures you control at resolution, after the source is sacrificed as a cost (correctly excludes itself).

No new engine/SDK mechanics were required — all three compose existing primitives. All scenario tests pass; `mtg-sets` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)