### PR TITLE
TDM: Add Trade Route Envoy, Reputable Merchant, Veteran Ice Climber

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ReputableMerchantScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ReputableMerchantScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Reputable Merchant (TDM #217).
+ *
+ * "{2/W}{2/B}{2/G} Creature — Human Citizen 2/2.
+ *  When this creature enters or dies, put a +1/+1 counter on target creature you control."
+ *
+ * Covers both halves of the "enters or dies" pair of triggered abilities:
+ *  - On enter, the controller targets a creature they control and places a +1/+1 counter.
+ *  - On death, the controller's death trigger fires and again places a +1/+1 counter on a
+ *    targeted creature they control.
+ */
+class ReputableMerchantScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Reputable Merchant") {
+
+            test("ETB puts a +1/+1 counter on a target creature you control") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Reputable Merchant")
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(3) { builder = builder.withCardInLibrary(1, "Forest") }
+                val game = builder.build()
+
+                val cast = game.castSpell(1, "Reputable Merchant")
+                withClue("Casting Reputable Merchant should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack() // Merchant enters → ETB trigger on stack, asks for a target.
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("ETB trigger should be waiting for a target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                val counters = game.state.getEntity(bears)?.get<CountersComponent>()
+                withClue("Grizzly Bears should have a +1/+1 counter from the ETB trigger") {
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+                }
+            }
+
+            test("dies trigger puts a +1/+1 counter on a target creature you control") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Reputable Merchant", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(2, "Bring Low")
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(3) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(3) { builder = builder.withCardInLibrary(2, "Mountain") }
+                val game = builder.build()
+
+                val merchant = game.findPermanent("Reputable Merchant")!!
+                // Opponent burns the Merchant for 3 (it's a 2/2) → it dies.
+                val cast = game.castSpell(2, "Bring Low", merchant)
+                withClue("Casting Bring Low should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack() // Bring Low resolves, Merchant dies, dies trigger on stack.
+
+                withClue("Reputable Merchant should be gone from the battlefield") {
+                    game.isOnBattlefield("Reputable Merchant") shouldBe false
+                }
+                withClue("Dies trigger should be waiting for a target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                val counters = game.state.getEntity(bears)?.get<CountersComponent>()
+                withClue("Grizzly Bears should have a +1/+1 counter from the dies trigger") {
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TradeRouteEnvoyScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TradeRouteEnvoyScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Trade Route Envoy (TDM #163).
+ *
+ * "{3}{G} Creature — Dog Soldier 4/3.
+ *  When this creature enters, draw a card if you control a creature with a counter on it.
+ *  If you don't draw a card this way, put a +1/+1 counter on this creature."
+ *
+ * Exercises both branches of the ETB [com.wingedsheep.sdk.scripting.effects.ConditionalEffect]:
+ *  - With a counter-bearing creature already in play, the controller draws a card and the Envoy
+ *    gains no counter.
+ *  - With no counter-bearing creature, the controller draws nothing and the Envoy gains a +1/+1
+ *    counter instead.
+ */
+class TradeRouteEnvoyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Trade Route Envoy ETB") {
+
+            test("draws a card when you control a creature with a counter") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Trade Route Envoy")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(3) { builder = builder.withCardInLibrary(1, "Forest") }
+                val game = builder.build()
+
+                // Give the Grizzly Bears a +1/+1 counter so the draw branch is satisfied.
+                val bearsId = game.findPermanent("Grizzly Bears")!!
+                game.state = game.state.updateEntity(bearsId) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, 1))
+                }
+
+                val handBefore = game.handSize(1)
+
+                val cast = game.castSpell(1, "Trade Route Envoy")
+                withClue("Casting Trade Route Envoy should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Trade Route Envoy should be on the battlefield") {
+                    game.isOnBattlefield("Trade Route Envoy") shouldBe true
+                }
+                // Casting moved the Envoy out of hand (-1); drawing a card adds it back (+1) => net unchanged.
+                withClue("Controller should have drawn a card from the ETB") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                val envoyId = game.findPermanent("Trade Route Envoy")!!
+                val counters = game.state.getEntity(envoyId)?.get<CountersComponent>()
+                withClue("Envoy should have NO +1/+1 counter when it drew a card") {
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+                }
+            }
+
+            test("adds a +1/+1 counter to itself when no counter-bearing creature is controlled") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Trade Route Envoy")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(3) { builder = builder.withCardInLibrary(1, "Forest") }
+                val game = builder.build()
+
+                // Bears has no counter, so no controlled creature satisfies the draw condition.
+                val handBefore = game.handSize(1)
+
+                val cast = game.castSpell(1, "Trade Route Envoy")
+                withClue("Casting Trade Route Envoy should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Trade Route Envoy should be on the battlefield") {
+                    game.isOnBattlefield("Trade Route Envoy") shouldBe true
+                }
+                // Casting removed the Envoy from hand (-1) and no draw occurred => hand shrinks by one.
+                withClue("Controller should NOT have drawn a card") {
+                    game.handSize(1) shouldBe handBefore - 1
+                }
+                val envoyId = game.findPermanent("Trade Route Envoy")!!
+                val counters = game.state.getEntity(envoyId)?.get<CountersComponent>()
+                withClue("Envoy should have a +1/+1 counter since it didn't draw") {
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VeteranIceClimberScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VeteranIceClimberScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Veteran Ice Climber (TDM #64).
+ *
+ * "{1}{U} Creature — Human Scout 1/3.
+ *  Vigilance. This creature can't be blocked.
+ *  Whenever this creature attacks, up to one target player mills cards equal to this
+ *  creature's power."
+ *
+ * Verifies the attack-trigger mill scales with the creature's power: a base 1/3 mills one
+ * card from the chosen player, and a pumped (+1/+1 counter) 2/3 mills two. The mill amount
+ * is read at resolution via DynamicAmounts.sourcePower().
+ */
+class VeteranIceClimberScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Veteran Ice Climber attack trigger") {
+
+            test("mills the targeted player a number of cards equal to its power (1)") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Veteran Ice Climber", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.declareAttackers(mapOf("Veteran Ice Climber" to 2))
+                game.resolveStack()
+
+                // "up to one target player" — choose the opponent if prompted.
+                if (game.hasPendingDecision() && game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.selectTargets(listOf(game.player2Id))
+                }
+                game.resolveStack()
+
+                withClue("A 1-power Veteran Ice Climber mills exactly one card") {
+                    game.findCardsInGraveyard(2, "Forest").size shouldBe 1
+                }
+                withClue("Library should have shrunk by one (5 -> 4)") {
+                    game.findCardsInLibrary(2, "Forest").size shouldBe 4
+                }
+            }
+
+            test("mill amount scales with power (a +1/+1 counter makes it mill two)") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Veteran Ice Climber", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                // Pump to 2/4 with a +1/+1 counter so the mill should be 2.
+                val climber = game.findPermanent("Veteran Ice Climber")!!
+                game.state = game.state.updateEntity(climber) { c ->
+                    c.with(
+                        com.wingedsheep.engine.state.components.battlefield.CountersComponent()
+                            .withAdded(com.wingedsheep.sdk.core.CounterType.PLUS_ONE_PLUS_ONE, 1)
+                    )
+                }
+
+                game.declareAttackers(mapOf("Veteran Ice Climber" to 2))
+                game.resolveStack()
+
+                if (game.hasPendingDecision() && game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.selectTargets(listOf(game.player2Id))
+                }
+                game.resolveStack()
+
+                withClue("A 2-power Veteran Ice Climber mills two cards") {
+                    game.findCardsInGraveyard(2, "Forest").size shouldBe 2
+                }
+                withClue("Library should have shrunk by two (5 -> 3)") {
+                    game.findCardsInLibrary(2, "Forest").size shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -110,6 +110,15 @@ object Conditions {
         Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature)
 
     /**
+     * If you control at least one permanent matching [filter].
+     * General-purpose battlefield existence check — pass any [GameObjectFilter]
+     * (e.g. `GameObjectFilter.Creature.copy(statePredicates = listOf(StatePredicate.HasAnyCounter))`
+     * for "a creature with a counter on it").
+     */
+    fun YouControl(filter: GameObjectFilter): ConditionInterface =
+        Exists(Player.You, Zone.BATTLEFIELD, filter)
+
+    /**
      * If you control an enchantment.
      */
     val ControlEnchantment: ConditionInterface =

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ReputableMerchant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ReputableMerchant.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Reputable Merchant — Tarkir: Dragonstorm #217
+ * {2/W}{2/B}{2/G} · Creature — Human Citizen · 2/2
+ *
+ * When this creature enters or dies, put a +1/+1 counter on target creature you control.
+ *
+ * Two separate triggered abilities (enters; dies) since "enters or dies" is two distinct
+ * trigger events (CR 603.2). Each targets a creature you control and places one +1/+1
+ * counter on it via [EffectTarget.ContextTarget]. On death, last-known information determines
+ * the controller for "you control"; if you control no creature at that point the trigger has
+ * no legal target and is removed.
+ *
+ * The hybrid {2/W}{2/B}{2/G} cost lets each pip be paid with either two generic mana or one
+ * mana of the listed color, so the card is castable in any of those three colors' decks.
+ */
+val ReputableMerchant = card("Reputable Merchant") {
+    manaCost = "{2/W}{2/B}{2/G}"
+    colorIdentity = "WBG"
+    typeLine = "Creature — Human Citizen"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters or dies, put a +1/+1 counter on target creature you control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0))
+        description = "When this creature enters, put a +1/+1 counter on target creature you control."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0))
+        description = "When this creature dies, put a +1/+1 counter on target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "217"
+        artist = "Craig J Spearing"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7d0591e-7fb7-40ea-ba2a-cfe544d40216.jpg?1743204858"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TradeRouteEnvoy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TradeRouteEnvoy.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trade Route Envoy — Tarkir: Dragonstorm #163
+ * {3}{G} · Creature — Dog Soldier · 4/3
+ *
+ * When this creature enters, draw a card if you control a creature with a counter on it.
+ * If you don't draw a card this way, put a +1/+1 counter on this creature.
+ *
+ * Modeled as a single ETB [ConditionalEffect]: if you control a creature with any counter
+ * ([Conditions.YouControl] over a creature filter carrying [StatePredicate.HasAnyCounter]),
+ * draw a card; otherwise put a +1/+1 counter on Trade Route Envoy itself. The condition is
+ * checked at resolution, so this creature's own counter (e.g. one it gained earlier) counts.
+ */
+val TradeRouteEnvoy = card("Trade Route Envoy") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dog Soldier"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature enters, draw a card if you control a creature with a counter on it. " +
+        "If you don't draw a card this way, put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ConditionalEffect(
+            condition = Conditions.YouControl(
+                GameObjectFilter.Creature.copy(
+                    statePredicates = listOf(StatePredicate.HasAnyCounter)
+                )
+            ),
+            effect = Effects.DrawCards(1),
+            elseEffect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+        description = "When this creature enters, draw a card if you control a creature with a counter on it. " +
+            "If you don't draw a card this way, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "163"
+        artist = "Gaboleps"
+        flavorText = "The Abzan pride themselves on the safety of their roads. " +
+            "To reject their escorts invites storm and sorrow."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0c89d95-d697-4cfa-9dfa-52d7adb96176.jpg?1743204618"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/VeteranIceClimber.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/VeteranIceClimber.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Veteran Ice Climber — Tarkir: Dragonstorm #64
+ * {1}{U} · Creature — Human Scout · 1/3
+ *
+ * Vigilance
+ * This creature can't be blocked.
+ * Whenever this creature attacks, up to one target player mills cards equal to this
+ * creature's power.
+ *
+ * Vigilance is a keyword; "can't be blocked" is the static [AbilityFlag.CANT_BE_BLOCKED].
+ * The attack trigger declares an optional ("up to one") [TargetPlayer], and mills that
+ * player a number of cards equal to this creature's current power
+ * ([DynamicAmounts.sourcePower], read at resolution). With no target chosen the trigger
+ * simply does nothing.
+ */
+val VeteranIceClimber = card("Veteran Ice Climber") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Scout"
+    power = 1
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "This creature can't be blocked.\n" +
+        "Whenever this creature attacks, up to one target player mills cards equal to this creature's power. " +
+        "(They put that many cards from the top of their library into their graveyard.)"
+
+    keywords(Keyword.VIGILANCE)
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        target("up to one target player", TargetPlayer(optional = true))
+        effect = EffectPatterns.mill(DynamicAmounts.sourcePower(), EffectTarget.ContextTarget(0))
+        description = "Whenever this creature attacks, up to one target player mills cards equal to this creature's power."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "64"
+        artist = "Néstor Ossandón Leal"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bcccfd7b-2846-4552-a89a-2b868bc9ab20.jpg?1743204215"
+    }
+}


### PR DESCRIPTION
Adds three Tarkir: Dragonstorm cards, each implemented via the `add-card` workflow with a Kotest scenario test covering both behavioral branches.

## Cards
- **Trade Route Envoy** — {3}{G} 4/3; ETB conditional draw-or-+1/+1 via `ConditionalEffect` + new `Conditions.YouControl(filter)` facade.
- **Reputable Merchant** — {2/W}{2/B}{2/G} 2/2; "enters or dies" pair of triggers, each placing a +1/+1 counter on a target creature you control.
- **Veteran Ice Climber** — {1}{U} 1/3; Vigilance + can't-be-blocked + attack trigger milling up to one target player equal to its power.

One small SDK addition: `Conditions.YouControl(filter)` (a thin `Exists(Player.You, BATTLEFIELD, filter)` wrapper that was already documented in the SDK reference but missing from code). `mtg-sdk`, `mtg-sets`, and `rules-engine` compile clean; tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)