### PR TITLE
Fix Recoil: the bounced permanent's owner discards (not the caster)

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RecoilScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RecoilScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Recoil ({1}{U}{B} instant): "Return target permanent to its owner's hand. Then that player
+ * discards a card."
+ *
+ * Regression: the discard step must be made by the permanent's owner (the discarding player),
+ * choosing from their own hand — not by the spell's controller. The owner is referenced via
+ * [com.wingedsheep.sdk.scripting.references.Player.OwnerOf], which previously fell through to the
+ * controller in `effectTargetToChooser`.
+ */
+class RecoilScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Recoil") {
+
+            test("the bounced permanent's owner chooses which card to discard") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Recoil")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    // Player 2 owns the targeted permanent and holds cards to choose from.
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(2, "Forest")
+                    .withCardInHand(2, "Mountain")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearsId = game.findPermanent("Grizzly Bears")!!
+
+                val castResult = game.castSpell(1, "Recoil", targetId = bearsId)
+                withClue("Casting Recoil should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                // The bounce returns Grizzly Bears to player 2's hand before the discard.
+                withClue("Grizzly Bears should be back in player 2's hand") {
+                    game.isInHand(2, "Grizzly Bears") shouldBe true
+                }
+
+                // The discard must be a choice made BY the owner (player 2), not the caster.
+                val decision = game.getPendingDecision()
+                withClue("Resolving Recoil should pause for the owner to choose a card to discard") {
+                    decision.shouldNotBeNull()
+                }
+                val selectDecision = decision.shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("Player 2 (the permanent's owner) must be the one choosing the discard") {
+                    selectDecision.playerId shouldBe game.player2Id
+                }
+
+                // Player 2 chooses Mountain; the caster does not get to pick.
+                val mountainId = game.findCardsInHand(2, "Mountain").single()
+                val discardResult = game.selectCards(listOf(mountainId))
+                withClue("Submitting the discard should succeed: ${discardResult.error}") {
+                    discardResult.error shouldBe null
+                }
+
+                withClue("The card player 2 chose should be in their graveyard") {
+                    game.isInGraveyard(2, "Mountain") shouldBe true
+                }
+                withClue("The card player 2 kept should remain in hand") {
+                    game.isInHand(2, "Forest") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PatternUtils.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PatternUtils.kt
@@ -27,6 +27,11 @@ internal fun effectTargetToChooser(target: EffectTarget): Chooser = when (target
         is Player.You -> Chooser.Controller
         is Player.Opponent, is Player.TargetOpponent, is Player.EachOpponent -> Chooser.Opponent
         is Player.TriggeringPlayer -> Chooser.TriggeringPlayer
+        // "Its owner" (e.g. Recoil: "Return target permanent to its owner's hand. Then that
+        // player discards a card.") resolves to whoever owns the targeted permanent, which may be
+        // the controller or an opponent. The discarding player chooses from their own hand, so
+        // derive the chooser from the gathered cards rather than the spell's controller.
+        is Player.OwnerOf -> Chooser.ControllerOfSelection
         else -> Chooser.Controller
     }
     else -> Chooser.Controller


### PR DESCRIPTION
## Problem

**Recoil** ({1}{U}{B} instant) reads *"Return target permanent to its owner's hand. Then that player discards a card."* The discard must be chosen by the permanent's owner from their own hand. Currently the **caster** chose which card the opponent discarded.

## Root cause

Recoil models the discarding player as `EffectTarget.PlayerRef(Player.OwnerOf("target permanent"))`. In `effectTargetToChooser` (`PatternUtils.kt`), the `Player.OwnerOf` case had no branch and fell through to `else -> Chooser.Controller`, so the spell's controller made the selection.

## Fix

Map `Player.OwnerOf` to `Chooser.ControllerOfSelection`. The discard pipeline gathers cards from the owner's hand (`CardSource.FromZone(Zone.HAND, owner)`), so deriving the chooser from the controller of the gathered cards correctly resolves to the discarding player — whether the owner is an opponent or the caster themselves (when bouncing their own permanent). Empty-hand is handled before the chooser resolves, so there's no edge-case error.

`DrawCards` (Oblation — the only other `Player.OwnerOf` user) draws deterministically and does not route through `effectTargetToChooser`, so it is unaffected.

## Test

`RecoilScenarioTest` casts Recoil targeting an opponent's permanent and asserts the resulting `SelectCardsDecision.playerId` is the **owner** (player 2), then that the owner's chosen card lands in their graveyard while the kept card stays in hand. Verified the test fails on the pre-fix code (asserts caster instead of owner) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)