### PR TITLE
Add TDM cards (group C): Temur Devotee, Sultai Devotee, Mardu Monument, Nightblade Brigade

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -357,7 +357,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 - `CreateToken(name, p, t, colors?, subtypes?, keywords?, count?, tapped?)` — make N tokens. `count` accepts an
   `Int` or a `DynamicAmount` (the latter for "create X tokens" wording — e.g. Verdeloth the Ancient passes
-  `count = DynamicAmount.XValue` to make X Saprolings when kicked).
+  `count = DynamicAmount.XValue` to make X Saprolings when kicked). Publishes the created token entity IDs to the
+  `CREATED_TOKENS` pipeline collection, so a sibling effect in a `CompositeEffect` can address each token via
+  `EffectTarget.PipelineTarget(CREATED_TOKENS, index)` — e.g. Mardu Monument grants menace and haste until end of
+  turn to each of its three freshly-created Warriors with one `GrantKeyword` per token.
 - `CreateDynamicToken(dynamicPower, dynamicToughness, colors?, creatureTypes, keywords?, count?, controller?, imageUri?)` —
   tokens whose P/T is computed at resolution (e.g. Pure Reflection's X/X Reflection where X = the cast spell's mana
   value, via `DynamicAmounts.triggeringManaValue()`). `controller` directs who gets the token (e.g.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MarduMonumentScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MarduMonumentScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Mardu Monument (TDM #245).
+ *
+ * "{2} Artifact — When this artifact enters, search your library for a basic Mountain, Plains,
+ *  or Swamp card, reveal it, put it into your hand, then shuffle.
+ *  {2}{R}{W}{B}, {T}, Sacrifice this artifact: Create three 1/1 red Warrior creature tokens.
+ *  They gain menace and haste until end of turn. Activate only as a sorcery."
+ */
+class MarduMonumentScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Mardu Monument") {
+
+            test("ETB searches for a basic Mountain/Plains/Swamp and puts it into hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Mardu Monument")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Mardu Monument")
+                withClue("Casting Mardu Monument should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // ETB search surfaces a selection; the only eligible basic is the Swamp.
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("Only the basic Swamp should be a legal choice (Forest is excluded)") {
+                    decision.options.mapNotNull {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name
+                    }.toSet() shouldBe setOf("Swamp")
+                }
+                game.selectCards(listOf(decision.options.first()))
+                game.resolveStack()
+
+                withClue("The searched Swamp should be in hand") {
+                    game.state.getHand(game.player1Id).count { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Swamp"
+                    } shouldBe 1
+                }
+            }
+
+            test("sacrifice ability makes three Warrior tokens with menace and haste") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Mardu Monument")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val monumentId = game.findPermanent("Mardu Monument")!!
+                val cardDef = cardRegistry.getCard("Mardu Monument")!!
+                val tokenAbility = cardDef.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monumentId,
+                        abilityId = tokenAbility.id
+                    )
+                )
+                withClue("Activating the token ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Mardu Monument should be sacrificed") {
+                    game.isOnBattlefield("Mardu Monument") shouldBe false
+                }
+
+                val tokens = game.findPermanents("Warrior Token")
+                withClue("Three 1/1 red Warrior tokens should exist") {
+                    tokens.size shouldBe 3
+                }
+
+                val projected = stateProjector.project(game.state)
+                tokens.forEach { id ->
+                    withClue("Each token should be 1/1") {
+                        projected.getPower(id) shouldBe 1
+                        projected.getToughness(id) shouldBe 1
+                    }
+                    withClue("Each token should have menace until end of turn") {
+                        projected.hasKeyword(id, Keyword.MENACE) shouldBe true
+                    }
+                    withClue("Each token should have haste until end of turn") {
+                        projected.hasKeyword(id, Keyword.HASTE) shouldBe true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarduMonument.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarduMonument.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mardu Monument — Tarkir: Dragonstorm #245
+ * {2} · Artifact
+ *
+ * When this artifact enters, search your library for a basic Mountain, Plains, or Swamp card,
+ * reveal it, put it into your hand, then shuffle.
+ * {2}{R}{W}{B}, {T}, Sacrifice this artifact: Create three 1/1 red Warrior creature tokens. They
+ * gain menace and haste until end of turn. Activate only as a sorcery.
+ *
+ * The ETB is a mandatory single-card library search restricted to basic lands carrying one of the
+ * three Mardu basic subtypes, revealed and placed into hand then shuffled (atomic
+ * [EffectPatterns.searchLibrary]). The sacrifice ability creates three Warrior tokens, then grants
+ * each menace and haste until end of turn via the [CREATED_TOKENS] pipeline — the keywords are a
+ * temporary grant (not intrinsic) so menace does not wrongly persist if a token survives the turn.
+ */
+val MarduMonument = card("Mardu Monument") {
+    manaCost = "{2}"
+    colorIdentity = "RWB"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, search your library for a basic Mountain, Plains, or Swamp card, " +
+        "reveal it, put it into your hand, then shuffle.\n" +
+        "{2}{R}{W}{B}, {T}, Sacrifice this artifact: Create three 1/1 red Warrior creature tokens. They " +
+        "gain menace and haste until end of turn. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.BasicLand.withAnyOfSubtypes(
+                listOf(Subtype.MOUNTAIN, Subtype.PLAINS, Subtype.SWAMP)
+            ),
+            count = 1,
+            destination = SearchDestination.HAND,
+            shuffleAfter = true,
+            reveal = true
+        )
+        description = "When this artifact enters, search your library for a basic Mountain, Plains, or Swamp card, " +
+            "reveal it, put it into your hand, then shuffle."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}{W}{B}"), Costs.Tap, Costs.SacrificeSelf)
+        timing = TimingRule.SorcerySpeed
+        effect = CompositeEffect(
+            buildList {
+                add(
+                    CreateTokenEffect(
+                        count = 3,
+                        power = 1,
+                        toughness = 1,
+                        colors = setOf(Color.RED),
+                        creatureTypes = setOf("Warrior"),
+                        imageUri = "https://cards.scryfall.io/normal/front/7/e/7edc0515-a130-45a7-aa09-0e23bba41587.jpg?1742506712"
+                    )
+                )
+                // Grant menace and haste until end of turn to each freshly-created token.
+                for (index in 0 until 3) {
+                    add(
+                        Effects.GrantKeyword(
+                            Keyword.MENACE,
+                            EffectTarget.PipelineTarget(CREATED_TOKENS, index),
+                            Duration.EndOfTurn
+                        )
+                    )
+                    add(
+                        Effects.GrantKeyword(
+                            Keyword.HASTE,
+                            EffectTarget.PipelineTarget(CREATED_TOKENS, index),
+                            Duration.EndOfTurn
+                        )
+                    )
+                }
+            }
+        )
+        description = "{2}{R}{W}{B}, {T}, Sacrifice this artifact: Create three 1/1 red Warrior creature tokens. " +
+            "They gain menace and haste until end of turn. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "245"
+        artist = "Salvatorre Zee Yazzie"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9bd0c794-77bc-4d4a-a769-3829e2ce4bdf.jpg?1743204968"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarduMonument.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarduMonument.kt
@@ -13,7 +13,6 @@ import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
-import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
 import com.wingedsheep.sdk.scripting.effects.SearchDestination
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -63,12 +62,12 @@ val MarduMonument = card("Mardu Monument") {
         effect = CompositeEffect(
             buildList {
                 add(
-                    CreateTokenEffect(
-                        count = 3,
+                    Effects.CreateToken(
                         power = 1,
                         toughness = 1,
                         colors = setOf(Color.RED),
                         creatureTypes = setOf("Warrior"),
+                        count = 3,
                         imageUri = "https://cards.scryfall.io/normal/front/7/e/7edc0515-a130-45a7-aa09-0e23bba41587.jpg?1742506712"
                     )
                 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NightbladeBrigade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NightbladeBrigade.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nightblade Brigade — Tarkir: Dragonstorm #85
+ * {2}{B} · Creature — Goblin Soldier · 1/3
+ *
+ * Deathtouch
+ * Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior
+ * creature token. Sacrifice it at the beginning of the next end step.)
+ * When this creature enters, surveil 1.
+ *
+ * Deathtouch and Mobilize 1 are keyword helpers (`mobilize(n)` adds the display keyword plus the
+ * attack-triggered tapped-and-attacking Warrior token that's sacrificed at the next end step). The
+ * enters-the-battlefield surveil 1 uses the atomic [EffectPatterns.surveil] composition.
+ */
+val NightbladeBrigade = card("Nightblade Brigade") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Soldier"
+    power = 1
+    toughness = 3
+    oracleText = "Deathtouch\n" +
+        "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\n" +
+        "When this creature enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+
+    keywords(Keyword.DEATHTOUCH)
+    mobilize(1)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.surveil(1)
+        description = "When this creature enters, surveil 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "Gary Laib"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/648debd9-d4cf-4788-8882-f1601a3d87f5.jpg?1743204303"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SultaiDevotee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SultaiDevotee.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Sultai Devotee
+ * {1}{G}
+ * Creature — Zombie Snake Druid
+ * 2/1
+ *
+ * Deathtouch
+ * {1}: Add {B}, {G}, or {U}. Activate only once each turn.
+ */
+val SultaiDevotee = card("Sultai Devotee") {
+    manaCost = "{1}{G}"
+    colorIdentity = "BGU"
+    typeLine = "Creature — Zombie Snake Druid"
+    power = 2
+    toughness = 1
+    oracleText = "Deathtouch\n{1}: Add {B}, {G}, or {U}. Activate only once each turn."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        manaAbility = true
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+        effect = Effects.AddManaOfChoice(
+            ManaColorSet.Specific(setOf(Color.BLACK, Color.GREEN, Color.BLUE))
+        )
+        description = "{1}: Add {B}, {G}, or {U}. Activate only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Bastien L. Deharme"
+        flavorText = "Many Sultai villages are protected by naga who weave magics to bless or curse as needed."
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c32487e9-f3ac-472e-b6ea-81bd9254770c.jpg?1743204608"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TemurDevotee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TemurDevotee.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Temur Devotee
+ * {1}{U}
+ * Creature — Human Druid
+ * 3/3
+ *
+ * Defender
+ * {1}: Add {G}, {U}, or {R}. Activate only once each turn.
+ */
+val TemurDevotee = card("Temur Devotee") {
+    manaCost = "{1}{U}"
+    colorIdentity = "GUR"
+    typeLine = "Creature — Human Druid"
+    power = 3
+    toughness = 3
+    oracleText = "Defender\n{1}: Add {G}, {U}, or {R}. Activate only once each turn."
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        manaAbility = true
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+        effect = Effects.AddManaOfChoice(
+            ManaColorSet.Specific(setOf(Color.GREEN, Color.BLUE, Color.RED))
+        )
+        description = "{1}: Add {G}, {U}, or {R}. Activate only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "61"
+        artist = "Marina Ortega Lorente"
+        flavorText = "Whisperers are conduits to the spirits of the land. They provide healing, " +
+            "guidance, and support to the Temur people."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2ef698e-5466-43bd-985d-020f2e5d8205.jpg?1743204205"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -31,6 +31,7 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
@@ -268,6 +269,15 @@ class CreateTokenExecutor(
             )
         }
 
-        return EffectResult.success(newState, events + counterEvents)
+        // Publish the freshly-created token entity IDs to the pipeline so sibling effects in a
+        // CompositeEffect can address them via EffectTarget.PipelineTarget(CREATED_TOKENS, index).
+        // Mirrors CreatePredefinedTokenExecutor — lets a composite grant keywords/counters to the
+        // tokens it just made (e.g. Mardu Monument's "create three Warriors; they gain menace and
+        // haste until end of turn").
+        return EffectResult(
+            state = newState,
+            events = events + counterEvents,
+            updatedCollections = mapOf(CREATED_TOKENS to createdTokens)
+        )
     }
 }


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) cards.

## Cards
- **Temur Devotee** ({1}{U} 3/3 Human Druid) — Defender; `{1}: Add {G}, {U}, or {R}. Activate only once each turn.` Uses the `keywords(DEFENDER)` helper plus the standard once-per-turn `AddManaOfChoice` mana ability (same shape as the other Devotees in the set).
- **Sultai Devotee** ({1}{G} 2/1 Zombie Snake Druid) — Deathtouch; `{1}: Add {B}, {G}, or {U}. Activate only once each turn.`
- **Mardu Monument** ({2} Artifact) — ETB searches the library for a basic Mountain/Plains/Swamp to hand then shuffles (atomic `EffectPatterns.searchLibrary`). `{2}{R}{W}{B}, {T}, Sacrifice this artifact:` create three 1/1 red Warrior tokens that gain menace and haste until end of turn (sorcery speed).
- **Nightblade Brigade** ({2}{B} 1/3 Goblin Soldier) — Deathtouch, Mobilize 1, and ETB surveil 1 (`EffectPatterns.surveil`).

## Engine change
Mardu Monument's "they gain menace and haste until end of turn" composes `CreateToken` with per-token `GrantKeyword` (duration EndOfTurn) addressed via `EffectTarget.PipelineTarget(CREATED_TOKENS, index)`. `CreateTokenExecutor` previously did not publish its created tokens to the `CREATED_TOKENS` pipeline (only `CreatePredefinedTokenExecutor` did), so this PR makes `CreateTokenExecutor` publish them too — a small, additive, reusable change letting any composite address freshly-created tokens. The SDK reference is updated accordingly.

## Tests
- Added `MarduMonumentScenarioTest` covering the ETB land search and verifying all three tokens are 1/1 with menace and haste.
- Full `:rules-engine` suite and the TDM Monument/Devotee scenario tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)