### PR TITLE
Add TDM cards (group A): Alchemist's Assistant, Dragonologist, Monastery Messenger, Venerated Stormsinger

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AlchemistsAssistantScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AlchemistsAssistantScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Alchemist's Assistant (TDM #71) — {1}{B} Monkey, 2/1, Lifelink.
+ *
+ * "Renew — {1}{B}, Exile this card from your graveyard: Put a lifelink counter on target
+ *  creature. Activate only as a sorcery."
+ *
+ * The lifelink counter grants the Lifelink keyword via projected state (KEYWORD_COUNTER_MAP),
+ * and the card is exiled from the graveyard as part of the cost.
+ */
+class AlchemistsAssistantScenarioTest : ScenarioTestBase() {
+
+    private val renewAbilityId =
+        cardRegistry.getCard("Alchemist's Assistant")!!.activatedAbilities.first().id
+
+    init {
+        context("Alchemist's Assistant renew") {
+
+            test("puts a lifelink counter (granting Lifelink) on a target creature and exiles itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Alchemist's Assistant")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2, no lifelink
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val assistant = game.findCardsInGraveyard(1, "Alchemist's Assistant").first()
+                val creature = game.findPermanent("Glory Seeker")!!
+
+                withClue("Glory Seeker has no Lifelink before the counter is placed") {
+                    game.state.projectedState.hasKeyword(creature, Keyword.LIFELINK) shouldBe false
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = assistant,
+                        abilityId = renewAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(creature)),
+                    )
+                )
+                withClue("Activating renew should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                val counters = game.state.getEntity(creature)?.get<CountersComponent>()
+                withClue("Glory Seeker gets one lifelink counter") {
+                    (counters?.counters?.get(CounterType.LIFELINK) ?: 0) shouldBe 1
+                }
+                withClue("The lifelink counter grants the Lifelink keyword via projection") {
+                    game.state.projectedState.hasKeyword(creature, Keyword.LIFELINK) shouldBe true
+                }
+                withClue("Alchemist's Assistant is exiled from the graveyard as part of the cost") {
+                    game.findCardsInGraveyard(1, "Alchemist's Assistant").size shouldBe 0
+                    game.state.getExile(game.player1Id).contains(assistant) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DragonologistScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DragonologistScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Dragonologist (TDM #42) — {2}{U} Human Wizard, 1/3.
+ *
+ * "When this creature enters, look at the top six cards of your library. You may reveal an
+ *  instant, sorcery, or Dragon card from among them and put it into your hand. Put the rest on
+ *  the bottom of your library in a random order."
+ * "Untapped Dragons you control have hexproof."
+ */
+class DragonologistScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dragonologist enters-the-battlefield dig") {
+
+            test("reveals an instant from the top six and puts it into hand, bottoming the rest") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dragonologist")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    // Six cards on top: one instant (eligible) among five lands (ineligible).
+                    .withCardInLibrary(1, "Rebellious Strike") // instant — eligible
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val strike = game.findCardsInLibrary(1, "Rebellious Strike").first()
+
+                game.castSpell(1, "Dragonologist").error shouldBe null
+                game.resolveStack() // creature enters → ETB look-six pauses for a selection
+
+                game.getPendingDecision() ?: error("expected a selection decision for the look-six trigger")
+                game.selectCards(listOf(strike))
+                game.resolveStack()
+
+                withClue("The revealed instant is now in hand") {
+                    game.findCardsInHand(1, "Rebellious Strike").size shouldBe 1
+                }
+                withClue("The other five looked-at cards are on the bottom of the library (none kept)") {
+                    game.findCardsInLibrary(1, "Rebellious Strike").size shouldBe 0
+                }
+                withClue("Dragonologist resolves onto the battlefield") {
+                    game.isOnBattlefield("Dragonologist") shouldBe true
+                }
+            }
+
+            test("may decline to keep any of the looked-at cards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dragonologist")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Dragonologist").error shouldBe null
+                game.resolveStack()
+
+                // Only lands are visible (ineligible) — decline by selecting nothing.
+                game.getPendingDecision() ?: error("expected a selection decision for the look-six trigger")
+                game.selectCards(emptyList())
+                game.resolveStack()
+
+                withClue("Nothing was put into hand") {
+                    game.findCardsInHand(1, "Island").size shouldBe 0
+                }
+                withClue("Dragonologist resolves onto the battlefield") {
+                    game.isOnBattlefield("Dragonologist") shouldBe true
+                }
+            }
+        }
+
+        context("Dragonologist static — untapped Dragons you control have hexproof") {
+
+            test("an untapped Dragon you control has hexproof, a tapped one does not") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dragonologist")
+                    .withCardOnBattlefield(1, "Kilnmouth Dragon", tapped = false)
+                    .withCardOnBattlefield(2, "Kilnmouth Dragon", tapped = false) // opponent's Dragon
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myDragon = game.findPermanents("Kilnmouth Dragon")
+                    .first { game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()?.playerId == game.player1Id }
+                val theirDragon = game.findPermanents("Kilnmouth Dragon")
+                    .first { game.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()?.playerId == game.player2Id }
+
+                withClue("Untapped Dragon you control gains hexproof from Dragonologist") {
+                    game.state.projectedState.hasKeyword(myDragon, Keyword.HEXPROOF) shouldBe true
+                }
+                withClue("Opponent's Dragon is not affected (only Dragons you control)") {
+                    game.state.projectedState.hasKeyword(theirDragon, Keyword.HEXPROOF) shouldBe false
+                }
+            }
+
+            test("a tapped Dragon you control does not have hexproof") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dragonologist")
+                    .withCardOnBattlefield(1, "Kilnmouth Dragon", tapped = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tappedDragon = game.findPermanent("Kilnmouth Dragon")!!
+                withClue("Tapped Dragon does not have hexproof (static only grants to untapped Dragons)") {
+                    game.state.projectedState.hasKeyword(tappedDragon, Keyword.HEXPROOF) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MonasteryMessengerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/MonasteryMessengerScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Monastery Messenger (TDM #208) — {2/U}{2/R}{2/W} Bird Scout, 2/3,
+ * Flying, vigilance.
+ *
+ * "When this creature enters, put up to one target noncreature, nonland card from your
+ *  graveyard on top of your library."
+ *
+ * Exercises the optional (up to one) graveyard target restricted to noncreature, nonland
+ * cards, moved to the top of the owner's library.
+ */
+class MonasteryMessengerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Monastery Messenger enters-the-battlefield trigger") {
+
+            test("puts a noncreature, nonland card from your graveyard on top of your library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Monastery Messenger")
+                    .withLandsOnBattlefield(1, "Island", 6) // pay the twobrid cost as generic
+                    .withCardInGraveyard(1, "Rebellious Strike") // an instant — a legal target
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Monastery Messenger").error shouldBe null
+                game.resolveStack() // creature enters → ETB trigger on stack, asks for a target
+
+                val strike = game.findCardsInGraveyard(1, "Rebellious Strike").first()
+                val result = game.selectTargets(listOf(strike))
+                withClue("An instant in your graveyard is a legal target: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Rebellious Strike leaves the graveyard") {
+                    game.findCardsInGraveyard(1, "Rebellious Strike").size shouldBe 0
+                }
+                withClue("Rebellious Strike is on top of the library") {
+                    game.state.getLibrary(game.player1Id).first() shouldBe strike
+                }
+                withClue("Monastery Messenger resolves onto the battlefield") {
+                    game.isOnBattlefield("Monastery Messenger") shouldBe true
+                }
+            }
+
+            test("may decline (up to one) when only ineligible cards are present") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Monastery Messenger")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardInGraveyard(1, "Grizzly Bears") // a creature — not a legal target
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Monastery Messenger").error shouldBe null
+                game.resolveStack()
+
+                // "up to one" — decline by selecting nothing.
+                game.skipTargets().error shouldBe null
+                game.resolveStack()
+
+                withClue("The creature card stays in the graveyard (never a legal target)") {
+                    game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("Monastery Messenger resolves onto the battlefield") {
+                    game.isOnBattlefield("Monastery Messenger") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VeneratedStormsingerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/VeneratedStormsingerScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Venerated Stormsinger (TDM #97) — {3}{B} Orc Cleric, 3/3.
+ *
+ * "Whenever this creature or another creature you control dies, each opponent loses 1 life and
+ *  you gain 1 life."
+ *
+ * Uses Caustic Exhale (-3/-3) to kill a creature the controller owns and verifies the drain
+ * triggers once per death (opponent loses 1, controller gains 1). Also verifies it fires when
+ * the Stormsinger itself dies.
+ */
+class VeneratedStormsingerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Venerated Stormsinger dies-drain") {
+
+            test("another creature you control dying drains 1 / gains 1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Venerated Stormsinger")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withCardInHand(1, "Caustic Exhale")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Caustic Exhale", bears)
+                withClue("Casting Caustic Exhale on Grizzly Bears should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears dies to -3/-3") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("Each opponent loses 1 life from the dies trigger") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("Controller gains 1 life from the dies trigger") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+            }
+
+            test("the Stormsinger dying also triggers its own drain") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Venerated Stormsinger")
+                    .withCardInHand(1, "Caustic Exhale")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stormsinger = game.findPermanent("Venerated Stormsinger")!!
+                val cast = game.castSpell(1, "Caustic Exhale", stormsinger)
+                withClue("Casting Caustic Exhale on the Stormsinger should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Venerated Stormsinger dies to -3/-3") {
+                    game.isOnBattlefield("Venerated Stormsinger") shouldBe false
+                }
+                withClue("Its own death triggers the drain: opponent loses 1") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("Its own death triggers the drain: controller gains 1") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AlchemistsAssistant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AlchemistsAssistant.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alchemist's Assistant — Tarkir: Dragonstorm #71
+ * {1}{B} · Creature — Monkey · 2/1
+ *
+ * Lifelink
+ * Renew — {1}{B}, Exile this card from your graveyard: Put a lifelink counter on target
+ * creature. Activate only as a sorcery.
+ *
+ * Lifelink is a keyword counter (CR 122.1d): the [StateProjector]'s KEYWORD_COUNTER_MAP grants
+ * the keyword to any creature carrying a lifelink counter, so the Renew ability is a single
+ * [Effects.AddCounters] on one target.
+ */
+val AlchemistsAssistant = card("Alchemist's Assistant") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Monkey"
+    power = 2
+    toughness = 1
+    oracleText = "Lifelink\n" +
+        "Renew — {1}{B}, Exile this card from your graveyard: Put a lifelink counter on target " +
+        "creature. Activate only as a sorcery."
+
+    keywords(Keyword.LIFELINK)
+
+    renew("{1}{B}") {
+        effect = Effects.AddCounters(Counters.LIFELINK, 1, target("creature", Targets.Creature))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "71"
+        artist = "Eelis Kyttanen"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d305609-64f8-4f3f-bf67-cd5257f0d01e.jpg?1743204244"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/Dragonologist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/Dragonologist.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dragonologist — Tarkir: Dragonstorm #42
+ * {2}{U} · Creature — Human Wizard · 1/3
+ *
+ * When this creature enters, look at the top six cards of your library. You may reveal an
+ * instant, sorcery, or Dragon card from among them and put it into your hand. Put the rest on
+ * the bottom of your library in a random order.
+ * Untapped Dragons you control have hexproof.
+ *
+ * The ETB is the standard "look at top N, may keep one matching, bottom the rest in random
+ * order" pipeline (Gather top six → SelectUpTo(1) filtered to instant/sorcery/Dragon → move
+ * the kept card revealed to hand → bottom the remainder randomly). The "you may reveal" is
+ * `ChooseUpTo(1)`. The static grants hexproof to the group of untapped Dragons you control
+ * via [GrantKeyword] with a [GroupFilter].
+ */
+val Dragonologist = card("Dragonologist") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 3
+    oracleText = "When this creature enters, look at the top six cards of your library. You may reveal " +
+        "an instant, sorcery, or Dragon card from among them and put it into your hand. Put the rest on " +
+        "the bottom of your library in a random order.\n" +
+        "Untapped Dragons you control have hexproof."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CompositeEffect(listOf(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(count = DynamicAmount.Fixed(6), player = Player.You),
+                storeAs = "looked"
+            ),
+            SelectFromCollectionEffect(
+                from = "looked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                filter = GameObjectFilter.InstantOrSorcery or
+                    GameObjectFilter.Any.withSubtype(Subtype.DRAGON),
+                storeSelected = "kept",
+                storeRemainder = "toBottom",
+                showAllCards = true,
+                prompt = "You may reveal an instant, sorcery, or Dragon card to put into your hand.",
+                selectedLabel = "Put into hand",
+                remainderLabel = "Put on bottom"
+            ),
+            MoveCollectionEffect(
+                from = "kept",
+                destination = CardDestination.ToZone(Zone.HAND),
+                revealed = true
+            ),
+            MoveCollectionEffect(
+                from = "toBottom",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random
+            )
+        ))
+        description = "When this creature enters, look at the top six cards of your library. You may reveal " +
+            "an instant, sorcery, or Dragon card from among them and put it into your hand. Put the rest on " +
+            "the bottom of your library in a random order."
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.HEXPROOF,
+            GroupFilter.AllCreaturesYouControl.untapped().withSubtype(Subtype.DRAGON)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "42"
+        artist = "Mila Pesic"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/8810ebb4-9e51-46f0-a54a-a0b4d77b762a.jpg?1743204126"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MonasteryMessenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MonasteryMessenger.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Monastery Messenger — Tarkir: Dragonstorm #208
+ * {2/U}{2/R}{2/W} · Creature — Bird Scout · 2/3
+ *
+ * Flying, vigilance
+ * When this creature enters, put up to one target noncreature, nonland card from your
+ * graveyard on top of your library.
+ *
+ * "Up to one target" is `optional = true` on the [TargetObject]; the graveyard filter is a
+ * noncreature, nonland card owned by you. The card is moved to the top of the library via
+ * [Effects.PutOnTopOfLibrary].
+ */
+val MonasteryMessenger = card("Monastery Messenger") {
+    manaCost = "{2/U}{2/R}{2/W}"
+    colorIdentity = "URW"
+    typeLine = "Creature — Bird Scout"
+    power = 2
+    toughness = 3
+    oracleText = "Flying, vigilance\n" +
+        "When this creature enters, put up to one target noncreature, nonland card from your graveyard on top of your library."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val card = target(
+            "noncreature, nonland card from your graveyard",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Nonland and GameObjectFilter.Noncreature.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.PutOnTopOfLibrary(card)
+        description = "When this creature enters, put up to one target noncreature, nonland card from your graveyard on top of your library."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "208"
+        artist = "Forrest Imel"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c9eeced-6464-41f0-bbea-05b3af4cc005.jpg?1743204819"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/VeneratedStormsinger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/VeneratedStormsinger.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Venerated Stormsinger — Tarkir: Dragonstorm #97
+ * {3}{B} · Creature — Orc Cleric · 3/3
+ *
+ * Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior
+ * creature token. Sacrifice it at the beginning of the next end step.)
+ * Whenever this creature or another creature you control dies, each opponent loses 1 life and
+ * you gain 1 life.
+ *
+ * "This creature or another creature you control dies" is exactly "a creature you control
+ * dies", so the trigger is [Triggers.YourCreatureDies] (ANY binding + Creature.youControl
+ * filter), which also fires when the source itself dies via last-known control information.
+ */
+val VeneratedStormsinger = card("Venerated Stormsinger") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Orc Cleric"
+    power = 3
+    toughness = 3
+    oracleText = "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\n" +
+        "Whenever this creature or another creature you control dies, each opponent loses 1 life and you gain 1 life."
+
+    mobilize(1)
+
+    triggeredAbility {
+        trigger = Triggers.YourCreatureDies
+        effect = CompositeEffect(
+            listOf(
+                LoseLifeEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                GainLifeEffect(1, EffectTarget.Controller)
+            )
+        )
+        description = "Whenever this creature or another creature you control dies, each opponent loses 1 life and you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "97"
+        artist = "Elizabeth Peiró"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4a4e985-facd-47e6-b680-3023c82c2957.jpg?1743204350"
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm cards, each composed from existing SDK primitives (no new engine mechanics).

- **Alchemist's Assistant** — {1}{B} Monkey 2/1. Lifelink. Renew — {1}{B}, Exile from graveyard: put a lifelink counter on target creature (sorcery speed). Lifelink counter grants the keyword via the existing KEYWORD_COUNTER_MAP projection.
- **Dragonologist** — {2}{U} Human Wizard 1/3. ETB: look at the top six cards, may reveal an instant, sorcery, or Dragon and put it into hand, bottom the rest in a random order (Gather → SelectUpTo(1) filtered → move to hand revealed → bottom random). Static: untapped Dragons you control have hexproof (GrantKeyword on a GroupFilter).
- **Monastery Messenger** — {2/U}{2/R}{2/W} Bird Scout 2/3. Flying, vigilance. ETB: put up to one target noncreature, nonland card from your graveyard on top of your library (optional TargetObject + PutOnTopOfLibrary).
- **Venerated Stormsinger** — {3}{B} Orc Cleric 3/3. Mobilize 1 (existing helper). Whenever this or another creature you control dies, each opponent loses 1 life and you gain 1 life (YourCreatureDies drain).

Scenario tests added for all four (renew counter + self-exile, ETB dig keep/decline, static hexproof tapped/untapped/opponent, graveyard-to-top with optional target, dies-drain including self-death). Card-loading + serialization tests and all four scenario tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)