### PR TITLE
Add TDM cards (group B): Sage of the Fang, Sibsig Appraiser, Stalwart Successor, Meticulous Artisan

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -308,6 +308,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `RemoveAllCountersOfType(type, target)` — wipe one kind.
 - `MoveAllLastKnownCounters(target)` — Hooded Hydra / Essence Channeler — move every counter kind from source's
   last-known state.
+- `Counters.ANY` — wildcard counter-type string for "counters of any type" triggers/events (e.g.
+  `Triggers.countersPlacedOn`); not a real placeable counter, only a matcher sentinel.
 - `DistributeCountersFromSelf(type?, count?)` — split source's counters among creatures you control.
 - `DistributeCountersAmongTargets(total, type?, minPerTarget?)` — divvy N counters among chosen targets.
 - `Proliferate()` — add one counter of each kind already present on chosen permanents/players (CR 701.27).
@@ -1127,7 +1129,12 @@ Triggers.youCastSpell(
 
 - `YouSacrificeOneOrMore(filter?)` — you sac ≥1 matching.
 - `Sacrificed` — source is sacrificed.
-- `PlusOneCountersPlacedOnYourCreature` — Hardened Scales shape.
+- `PlusOneCountersPlacedOnYourCreature` — Hardened Scales shape (+1/+1 only).
+- `countersPlacedOn(filter = Creature.youControl(), counterType = Counters.ANY, firstTimeEachTurn = true)`
+  — fires when counters of any type (`Counters.ANY` wildcard) land on a matching permanent;
+  `firstTimeEachTurn` gates it to the first counter placement on *that* permanent this turn
+  (engine-tracked via `ReceivedCountersThisTurnComponent`). Triggering permanent is
+  `EffectTarget.TriggeringEntity`. Stalwart Successor shape.
 - `OneOrMorePermanentsEnter(filter?)` — batched ETB trigger.
 - `OneOrMoreLeaveWithoutDying(...)` — batched LTB-without-dying.
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SageOfTheFangScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SageOfTheFangScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sage of the Fang (Tarkir: Dragonstorm #155).
+ *
+ * Sage of the Fang ({2}{G}, 2/2):
+ *   ETB: put a +1/+1 counter on target creature.
+ *   Renew — {3}{G}, Exile from graveyard: put a +1/+1 counter on target creature, then double
+ *   the number of +1/+1 counters on that creature. Sorcery speed.
+ */
+class SageOfTheFangScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Sage of the Fang") {
+
+            test("ETB puts a +1/+1 counter on the targeted creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Sage of the Fang")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpell(1, "Sage of the Fang")
+                withClue("Casting Sage of the Fang should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears should have one +1/+1 counter") {
+                    plusOneCounters(game, bears) shouldBe 1
+                }
+            }
+
+            test("Renew from graveyard adds a counter then doubles the total") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    // Bears already carries two +1/+1 counters; Renew adds one (→3) then doubles (→6).
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Sage of the Fang")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                // Seed two existing counters directly.
+                game.state = game.state.updateEntity(bears) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, 2))
+                }
+
+                val sage = game.state.getGraveyard(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Sage of the Fang"
+                }
+                val renewAbility = cardRegistry.getCard("Sage of the Fang")!!
+                    .script.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = sage,
+                        abilityId = renewAbility,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("Activating Renew should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                // Renew targets a creature.
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(bears))
+                }
+                game.resolveStack()
+
+                withClue("Bears should have 6 +1/+1 counters: (2 existing + 1) doubled") {
+                    plusOneCounters(game, bears) shouldBe 6
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StalwartSuccessorScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StalwartSuccessorScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Scenario tests for Stalwart Successor (Tarkir: Dragonstorm #227).
+ *
+ * Stalwart Successor ({1}{B}{G}, 3/2, Menace):
+ *   "Whenever one or more counters are put on a creature you control, if it's the first time
+ *    counters have been put on that creature this turn, put a +1/+1 counter on that creature."
+ *
+ * Exercises the engine's new `Triggers.countersPlacedOn` (any counter type, first-time-per-turn
+ * gate via `ReceivedCountersThisTurnComponent`). Sage of the Fang's ETB ("put a +1/+1 counter on
+ * target creature") is the counter source.
+ */
+class StalwartSuccessorScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Stalwart Successor — first counters on a creature you control") {
+
+            test("first +1/+1 counter this turn triggers Stalwart for an extra counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stalwart Successor")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Sage of the Fang")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpell(1, "Sage of the Fang")
+                withClue("Casting Sage of the Fang should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Sage's ETB asks for a target — choose our Grizzly Bears.
+                withClue("Sage ETB should prompt for a counter target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                // Sage places the first +1/+1 (first counters this turn) → Stalwart adds one more.
+                withClue("Grizzly Bears should have 2 +1/+1 counters (Sage's + Stalwart's)") {
+                    plusOneCounters(game, bears) shouldBe 2
+                }
+            }
+
+            test("a second counter the same turn does not re-trigger Stalwart") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stalwart Successor")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Sage of the Fang")
+                    .withCardInHand(1, "Sage of the Fang")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // First Sage: 1 (Sage) + 1 (Stalwart) = 2 counters.
+                game.castSpell(1, "Sage of the Fang")
+                game.resolveStack()
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+                withClue("After first Sage, Grizzly Bears has 2 counters") {
+                    plusOneCounters(game, bears) shouldBe 2
+                }
+
+                // Second Sage same turn: Sage adds 1 (now 3), but counters were already put on
+                // Grizzly Bears this turn, so Stalwart does NOT trigger again.
+                game.castSpell(1, "Sage of the Fang")
+                game.resolveStack()
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+                withClue("Second counter source must not re-trigger Stalwart (3, not 4)") {
+                    plusOneCounters(game, bears) shouldBe 3
+                }
+            }
+
+            test("counters on a creature an opponent controls do not trigger Stalwart") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stalwart Successor")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Sage of the Fang")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val opponentBears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Sage of the Fang")
+                game.resolveStack()
+                game.selectTargets(listOf(opponentBears))
+                game.resolveStack()
+
+                withClue("Opponent's Grizzly Bears should have only Sage's 1 counter") {
+                    plusOneCounters(game, opponentBears) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StalwartSuccessorScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StalwartSuccessorScenarioTest.kt
@@ -94,6 +94,32 @@ class StalwartSuccessorScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("a creature you control entering with counters triggers Stalwart") {
+                // CR: a permanent entering with counters has those counters "put on" it (the
+                // controller is the one putting them), so Stalwart's "first time counters this
+                // turn" trigger fires. Dockworker Drone enters with one +1/+1 counter; Stalwart
+                // adds a second.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stalwart Successor")
+                    .withCardInHand(1, "Dockworker Drone")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Dockworker Drone")
+                withClue("Casting Dockworker Drone should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val drone = game.findPermanent("Dockworker Drone")!!
+                withClue("Dockworker Drone should have 2 +1/+1 counters (enters-with + Stalwart)") {
+                    plusOneCounters(game, drone) shouldBe 2
+                }
+            }
+
             test("counters on a creature an opponent controls do not trigger Stalwart") {
                 val game = scenario()
                     .withPlayers("Player", "Opponent")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -86,4 +86,12 @@ object Counters {
     const val TIME = "time"
     const val FEATHER = "feather"
     const val HOURGLASS = "hourglass"
+
+    /**
+     * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.
+     * "whenever one or more counters are put on a creature you control" (Stalwart Successor).
+     * A [com.wingedsheep.sdk.scripting.GameEvent.CountersPlacedEvent] with this `counterType`
+     * matches every counter-placement event regardless of the counter kind.
+     */
+    const val ANY = "any"
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -914,6 +914,28 @@ object Triggers {
         binding = TriggerBinding.ANY
     )
 
+    /**
+     * Whenever one or more counters of any type are put on a permanent matching [filter],
+     * optionally only the first time counters land on that permanent this turn.
+     *
+     * Defaults to "a creature you control … for the first time this turn" — the Stalwart
+     * Successor shape. Pass a different [filter] or `firstTimeEachTurn = false` to reuse for
+     * other "counters placed" payoffs. The triggering permanent is available via
+     * [com.wingedsheep.sdk.scripting.targets.EffectTarget.TriggeringEntity].
+     */
+    fun countersPlacedOn(
+        filter: GameObjectFilter = GameObjectFilter.Creature.youControl(),
+        counterType: String = Counters.ANY,
+        firstTimeEachTurn: Boolean = true,
+    ): TriggerSpec = TriggerSpec(
+        event = CountersPlacedEvent(
+            counterType = counterType,
+            filter = filter,
+            firstTimeEachTurn = firstTimeEachTurn,
+        ),
+        binding = TriggerBinding.ANY
+    )
+
     // =========================================================================
     // Damage Received (incoming)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
@@ -1054,11 +1054,21 @@ sealed interface GameEvent : TextReplaceable<GameEvent> {
     @Serializable
     data class CountersPlacedEvent(
         val counterType: String,
-        val filter: GameObjectFilter = GameObjectFilter.Any
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        /**
+         * When true, the trigger fires only the first time counters are put on the affected
+         * permanent this turn (per CR intervening-if "if it's the first time counters have been
+         * put on that creature this turn", e.g. Stalwart Successor). Matched against the engine
+         * event's own "first counters this turn" flag, mirroring how Valiant uses
+         * `firstTimeEachTurn` on [BecomesTargetEvent].
+         */
+        val firstTimeEachTurn: Boolean = false
     ) : GameEvent {
         override val description: String = buildString {
-            append("one or more $counterType counters are placed on ")
+            val typeLabel = if (counterType == com.wingedsheep.sdk.core.Counters.ANY) "" else "$counterType "
+            append("one or more ${typeLabel}counters are placed on ")
             append(describeObjectForEvent(filter))
+            if (firstTimeEachTurn) append(" for the first time this turn")
         }
 
         override fun applyTextReplacement(replacer: TextReplacer): GameEvent = this

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MeticulousArtisan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MeticulousArtisan.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meticulous Artisan — Tarkir: Dragonstorm #112
+ * {3}{R} · Creature — Djinn Artificer · 3/3
+ *
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ * When this creature enters, create a Treasure token.
+ *
+ * Prowess via the [prowess] keyword helper; ETB creates a single predefined Treasure token via
+ * [Effects.CreateTreasure].
+ */
+val MeticulousArtisan = card("Meticulous Artisan") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Djinn Artificer"
+    power = 3
+    toughness = 3
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until " +
+        "end of turn.)\n" +
+        "When this creature enters, create a Treasure token. (It's an artifact with \"{T}, " +
+        "Sacrifice this token: Add one mana of any color.\")"
+
+    prowess()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateTreasure(1)
+        description = "When this creature enters, create a Treasure token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "112"
+        artist = "Anna Pavleeva"
+        flavorText = "\"It isn't about expression or results. Doing the thing is itself the point.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/baf4c9dd-0546-41ac-a7ba-0bc312fef31e.jpg?1743204413"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SageOfTheFang.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SageOfTheFang.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sage of the Fang — Tarkir: Dragonstorm #155
+ * {2}{G} · Creature — Human Druid · 2/2
+ *
+ * When this creature enters, put a +1/+1 counter on target creature.
+ * Renew — {3}{G}, Exile this card from your graveyard: Put a +1/+1 counter on target creature,
+ * then double the number of +1/+1 counters on that creature. Activate only as a sorcery.
+ *
+ * ETB is a plain [Effects.AddCounters]. The Renew ability adds one +1/+1 counter and then
+ * doubles the resulting total via [Effects.DoubleCounters] (reads the post-add count, so the
+ * creature ends with 2×(existing+1) counters). Both target the same creature; the doubling
+ * runs on the same [Targets.Creature] reference, so "that creature" resolves to the one that
+ * received the new counter.
+ */
+val SageOfTheFang = card("Sage of the Fang") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, put a +1/+1 counter on target creature.\n" +
+        "Renew — {3}{G}, Exile this card from your graveyard: Put a +1/+1 counter on target " +
+        "creature, then double the number of +1/+1 counters on that creature. Activate only as " +
+        "a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        description = "When this creature enters, put a +1/+1 counter on target creature."
+    }
+
+    renew("{3}{G}") {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+            .then(Effects.DoubleCounters(Counters.PLUS_ONE_PLUS_ONE, creature))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "155"
+        artist = "Ioannis Fiore"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1ebf4a9d-d90c-4017-9f00-fca89899f301.jpg?1743403231"
+        ruling("2025-04-04", "If a card with a renew ability is put into your graveyard during your turn, you can activate that ability if it's legal to do so before any other player can take any actions.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SibsigAppraiser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SibsigAppraiser.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sibsig Appraiser — Tarkir: Dragonstorm #56
+ * {2}{U} · Creature — Zombie Advisor · 2/1
+ *
+ * When this creature enters, look at the top two cards of your library. Put one of them into
+ * your hand and the other into your graveyard.
+ *
+ * Exactly the [EffectPatterns.lookAtTopAndKeep] shape: count = 2, keepCount = 1. The kept card
+ * goes to HAND and the remainder to the GRAVEYARD (the pattern defaults), matching oracle text.
+ */
+val SibsigAppraiser = card("Sibsig Appraiser") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Advisor"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, look at the top two cards of your library. Put one " +
+        "of them into your hand and the other into your graveyard."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.lookAtTopAndKeep(count = 2, keepCount = 1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Ina Wong"
+        flavorText = "\"Oh, I can absolutely verify its authenticity,\" chuckled Sarnai. " +
+            "\"I was there when it was made.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/670c5b96-bac6-449b-a2bd-cb43750d3911.jpg?1743204185"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StalwartSuccessor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StalwartSuccessor.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stalwart Successor — Tarkir: Dragonstorm #227
+ * {1}{B}{G} · Creature — Human Warrior · 3/2
+ *
+ * Menace.
+ * Whenever one or more counters are put on a creature you control, if it's the first time
+ * counters have been put on that creature this turn, put a +1/+1 counter on that creature.
+ *
+ * Uses [Triggers.countersPlacedOn] — fires on counters of any type ([Counters.ANY]) put on a
+ * creature you control, gated by the engine's per-creature "first counters this turn" flag.
+ * The reward goes on the triggering creature via [EffectTarget.TriggeringEntity]. The +1/+1
+ * counter Stalwart itself adds is *not* the first counter of the turn for that creature (the
+ * triggering placement already set the marker), so it does not re-trigger — matching the
+ * intervening-if once-per-creature-per-turn behavior.
+ */
+val StalwartSuccessor = card("Stalwart Successor") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Human Warrior"
+    power = 3
+    toughness = 2
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Whenever one or more counters are put on a creature you control, if it's the first " +
+        "time counters have been put on that creature this turn, put a +1/+1 counter on that " +
+        "creature."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.countersPlacedOn()
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.TriggeringEntity)
+        description = "Whenever one or more counters are put on a creature you control, if it's " +
+            "the first time counters have been put on that creature this turn, put a +1/+1 " +
+            "counter on that creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "227"
+        artist = "Bastien L. Deharme"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a7b206f-8190-46e6-bb9e-44763d3eb4ac.jpg?1743204896"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.engine.state.components.battlefield.DamageDealtByPlayersT
 import com.wingedsheep.engine.state.components.battlefield.DamageDealtToCreaturesThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.TargetedByControllerThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.ReceivedCountersThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.GraveyardPlayPermissionUsedComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
@@ -407,6 +408,9 @@ class CleanupPhaseManager(
             if (container.has<TargetedByControllerThisTurnComponent>()) {
                 needsUpdate = true
             }
+            if (container.has<ReceivedCountersThisTurnComponent>()) {
+                needsUpdate = true
+            }
             if (container.has<PlayerAttackedThisTurnComponent>()) {
                 needsUpdate = true
             }
@@ -436,6 +440,7 @@ class CleanupPhaseManager(
                     c.without<AbilityActivatedThisTurnComponent>()
                         .without<DamageDealtToCreaturesThisTurnComponent>()
                         .without<TargetedByControllerThisTurnComponent>()
+                        .without<ReceivedCountersThisTurnComponent>()
                         .without<PlayerAttackedThisTurnComponent>()
                         .without<PlayerAttackersThisTurnComponent>()
                         .without<GraveyardPlayPermissionUsedComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -593,7 +593,14 @@ data class CountersAddedEvent(
     val entityId: EntityId,
     val counterType: String,
     val amount: Int,
-    val entityName: String = ""
+    val entityName: String = "",
+    /**
+     * True when this is the first counter placement on [entityId] this turn. Drives
+     * "first time counters have been put on that creature this turn" intervening-if triggers
+     * (Stalwart Successor). Computed against the target's [ReceivedCountersThisTurnComponent]
+     * before that marker is set; defaults to false for emitters that don't track it.
+     */
+    val firstThisTurn: Boolean = false
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -358,6 +358,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ReplacementEffectSourceComponent::class)
         subclass(SagaComponent::class)
         subclass(TargetedByControllerThisTurnComponent::class)
+        subclass(ReceivedCountersThisTurnComponent::class)
         subclass(TriggeredAbilityFiredThisTurnComponent::class)
         subclass(WarpedComponent::class)
         subclass(WasKickedComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -343,7 +343,11 @@ class TriggerMatcher(
             is GameEvent.PermanentsEnteredEvent -> false
             is GameEvent.CountersPlacedEvent -> {
                 if (event !is CountersAddedEvent) return false
-                if (!counterTypesMatch(trigger.counterType, event.counterType)) return false
+                // Counters.ANY is the wildcard "counters of any type" sentinel.
+                if (trigger.counterType != com.wingedsheep.sdk.core.Counters.ANY &&
+                    !counterTypesMatch(trigger.counterType, event.counterType)) return false
+                // "First time counters this turn" intervening-if (Stalwart Successor).
+                if (trigger.firstTimeEachTurn && !event.firstThisTurn) return false
                 // Check filter: the permanent receiving counters must match
                 if (trigger.filter != GameObjectFilter.Any) {
                     val projected = state.projectedState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -629,16 +629,21 @@ class CostHandler(
                     return CostPaymentResult.failure("Blight target must be a creature you control")
                 }
                 val counters = targetContainer.get<CountersComponent>() ?: CountersComponent()
-                val newState = state.updateEntity(targetId) { c ->
+                val firstThisTurn = com.wingedsheep.engine.handlers.effects.DamageUtils
+                    .isFirstCounterThisTurn(state, targetId)
+                val withCounters = state.updateEntity(targetId) { c ->
                     c.with(counters.withAdded(CounterType.MINUS_ONE_MINUS_ONE, cost.amount))
                 }
+                val newState = com.wingedsheep.engine.handlers.effects.DamageUtils
+                    .markCounterPlacedOnCreature(withCounters, controllerId, targetId)
                 val targetName = targetContainer.get<CardComponent>()?.name ?: "Creature"
                 val events = listOf<GameEvent>(
                     CountersAddedEvent(
                         entityId = targetId,
                         counterType = Counters.MINUS_ONE_MINUS_ONE,
                         amount = cost.amount,
-                        entityName = targetName
+                        entityName = targetName,
+                        firstThisTurn = firstThisTurn
                     )
                 )
                 CostPaymentResult.success(newState, manaPool, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1663,6 +1663,7 @@ class CastSpellHandler(
                             val targetContainer = currentState.getEntity(targetId)
                             if (targetContainer != null) {
                                 val counters = targetContainer.get<CountersComponent>() ?: CountersComponent()
+                                val firstThisTurn = DamageUtils.isFirstCounterThisTurn(currentState, targetId)
                                 currentState = currentState.updateEntity(targetId) { c ->
                                     c.with(counters.withAdded(CounterType.MINUS_ONE_MINUS_ONE, additionalCost.blightAmount))
                                 }
@@ -1676,7 +1677,8 @@ class CastSpellHandler(
                                     entityId = targetId,
                                     counterType = Counters.MINUS_ONE_MINUS_ONE,
                                     amount = additionalCost.blightAmount,
-                                    entityName = targetName
+                                    entityName = targetName,
+                                    firstThisTurn = firstThisTurn
                                 ))
                             }
                         }
@@ -1689,6 +1691,7 @@ class CastSpellHandler(
                             val targetContainer = targetId?.let { currentState.getEntity(it) }
                             if (targetId != null && targetContainer != null) {
                                 val counters = targetContainer.get<CountersComponent>() ?: CountersComponent()
+                                val firstThisTurn = DamageUtils.isFirstCounterThisTurn(currentState, targetId)
                                 currentState = currentState.updateEntity(targetId) { c ->
                                     c.with(counters.withAdded(CounterType.MINUS_ONE_MINUS_ONE, amount))
                                 }
@@ -1702,7 +1705,8 @@ class CastSpellHandler(
                                     entityId = targetId,
                                     counterType = Counters.MINUS_ONE_MINUS_ONE,
                                     amount = amount,
-                                    entityName = targetName
+                                    entityName = targetName,
+                                    firstThisTurn = firstThisTurn
                                 ))
                             }
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
@@ -379,10 +379,13 @@ class MiscContinuationResumer(
                 newState = newState.updateEntity(targetId) { container ->
                     container.with(targetCounters.withAdded(counterType, modifiedAmount))
                 }
+                val (afterMark, firstThisTurn) = com.wingedsheep.engine.handlers.effects.DamageUtils
+                    .recordCounterPlacement(newState, targetId)
+                newState = afterMark
 
                 val targetName = newState.getEntity(targetId)
                     ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name ?: ""
-                events.add(CountersAddedEvent(targetId, continuation.counterType, modifiedAmount, targetName))
+                events.add(CountersAddedEvent(targetId, continuation.counterType, modifiedAmount, targetName, firstThisTurn))
             }
         }
 
@@ -547,12 +550,16 @@ class MiscContinuationResumer(
                 newState = newState.updateEntity(entityId) { container ->
                     container.with(before.withAdded(counterType, modifiedAmount))
                 }
+                val (afterMark, firstThisTurn) = com.wingedsheep.engine.handlers.effects.DamageUtils
+                    .recordCounterPlacement(newState, entityId)
+                newState = afterMark
                 events.add(
                     CountersAddedEvent(
                         entityId,
                         com.wingedsheep.engine.handlers.effects.permanent.counters.counterTypeToString(counterType),
                         modifiedAmount,
-                        entityName
+                        entityName,
+                        firstThisTurn
                     )
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -1097,10 +1097,13 @@ class ModalAndCloneContinuationResumer(
             newState = newState.updateEntity(spellId) { c ->
                 c.with(current.withAdded(resolvedCounterType, counterCount))
             }
+            val (afterMark, firstThisTurn) = com.wingedsheep.engine.handlers.effects.DamageUtils
+                .recordCounterPlacement(newState, spellId)
+            newState = afterMark
             val spellName = newState.getEntity(spellId)?.get<CardComponent>()?.name ?: ""
             events.add(
                 com.wingedsheep.engine.core.CountersAddedEvent(
-                    spellId, continuation.counterType, counterCount, spellName
+                    spellId, continuation.counterType, counterCount, spellName, firstThisTurn
                 )
             )
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -328,16 +328,35 @@ object DamageUtils {
     }
 
     /**
+     * Whether [targetId] has not yet had counters put on it this turn — i.e. the placement about
+     * to happen is the first this turn. Read *before* [markCounterPlacedOnCreature] sets the
+     * marker, to stamp [com.wingedsheep.engine.core.CountersAddedEvent.firstThisTurn] for
+     * "the first time counters have been put on that creature this turn" triggers (Stalwart
+     * Successor). Only meaningful for creatures; non-creature targets return false.
+     */
+    fun isFirstCounterThisTurn(state: GameState, targetId: EntityId): Boolean {
+        if (!state.projectedState.isCreature(targetId)) return false
+        return state.getEntity(targetId)
+            ?.has<com.wingedsheep.engine.state.components.battlefield.ReceivedCountersThisTurnComponent>() != true
+    }
+
+    /**
      * Mark that [placerId] put one or more counters on the creature [targetId] this turn.
      * Only marks when [targetId] is a creature in the projected state.
-     * Sets the PutCounterOnCreatureThisTurnComponent on the placing player's entity.
-     * Used for conditions like "if you put a counter on a creature this turn" (Lasting Tarfire).
+     * Sets the PutCounterOnCreatureThisTurnComponent on the placing player's entity (for
+     * "if you put a counter on a creature this turn", Lasting Tarfire) and the per-creature
+     * [com.wingedsheep.engine.state.components.battlefield.ReceivedCountersThisTurnComponent]
+     * marker (for "first time counters this turn" triggers, Stalwart Successor).
      */
     fun markCounterPlacedOnCreature(state: GameState, placerId: EntityId, targetId: EntityId): GameState {
         if (!state.projectedState.isCreature(targetId)) return state
-        return state.updateEntity(placerId) { container ->
-            container.with(com.wingedsheep.engine.state.components.player.PutCounterOnCreatureThisTurnComponent)
-        }
+        return state
+            .updateEntity(placerId) { container ->
+                container.with(com.wingedsheep.engine.state.components.player.PutCounterOnCreatureThisTurnComponent)
+            }
+            .updateEntity(targetId) { container ->
+                container.with(com.wingedsheep.engine.state.components.battlefield.ReceivedCountersThisTurnComponent)
+            }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -360,6 +360,29 @@ object DamageUtils {
     }
 
     /**
+     * Stamp the per-permanent [com.wingedsheep.engine.state.components.battlefield.ReceivedCountersThisTurnComponent]
+     * marker on [targetId] and report whether this is the first counter placement on it this turn
+     * (read *before* the marker is set), so the caller can populate
+     * [com.wingedsheep.engine.core.CountersAddedEvent.firstThisTurn] for "first time counters this
+     * turn" intervening-if triggers (Stalwart Successor).
+     *
+     * Unlike [isFirstCounterThisTurn] + [markCounterPlacedOnCreature], this performs no
+     * projected creature/zone check, so it also covers the enters-with-counters path where the
+     * permanent is not yet on the battlefield (CR confirms a permanent entering with counters has
+     * those counters "put on" it). Stamping the marker on a non-creature is harmless: the trigger's
+     * own "creature you control" filter re-checks type. This intentionally does *not* set the
+     * placer's "you put a counter on a creature this turn" marker — that path stays as it was.
+     */
+    fun recordCounterPlacement(state: GameState, targetId: EntityId): Pair<GameState, Boolean> {
+        val first = state.getEntity(targetId)
+            ?.has<com.wingedsheep.engine.state.components.battlefield.ReceivedCountersThisTurnComponent>() != true
+        val newState = state.updateEntity(targetId) { container ->
+            container.with(com.wingedsheep.engine.state.components.battlefield.ReceivedCountersThisTurnComponent)
+        }
+        return newState to first
+    }
+
+    /**
      * Track that [sourceId] dealt damage to [targetCreatureId] this turn.
      * Updates the DamageDealtToCreaturesThisTurnComponent on the source entity.
      * Used for triggers like Soul Collector's "whenever a creature dealt damage by this creature this turn dies".

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithCountersHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithCountersHelper.kt
@@ -79,7 +79,9 @@ object EntersWithCountersHelper {
                     newState = newState.updateEntity(enteringEntityId) { c ->
                         c.with(current.withAdded(counterType, modifiedCount))
                     }
-                    events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName))
+                    val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, enteringEntityId)
+                    newState = afterMark
+                    events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn))
                 }
                 is EntersWithDynamicCounters -> {
                     if (effect.otherOnly) continue
@@ -99,7 +101,9 @@ object EntersWithCountersHelper {
                         newState = newState.updateEntity(enteringEntityId) { c ->
                             c.with(current.withAdded(counterType, modifiedCount))
                         }
-                        events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName))
+                        val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, enteringEntityId)
+                        newState = afterMark
+                        events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn))
                     }
                 }
                 else -> { /* Other replacement effects handled elsewhere */ }
@@ -159,7 +163,9 @@ object EntersWithCountersHelper {
                         newState = newState.updateEntity(enteringEntityId) { c ->
                             c.with(current.withAdded(counterType, modifiedCount))
                         }
-                        events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName))
+                        val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, enteringEntityId)
+                        newState = afterMark
+                        events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn))
                     }
                     is EntersWithDynamicCounters -> {
                         if (!effect.otherOnly) continue
@@ -179,7 +185,9 @@ object EntersWithCountersHelper {
                             newState = newState.updateEntity(enteringEntityId) { c ->
                                 c.with(current.withAdded(counterType, modifiedCount))
                             }
-                            events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName))
+                            val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, enteringEntityId)
+                            newState = afterMark
+                            events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn))
                         }
                     }
                     else -> { /* Other replacement effects handled elsewhere */ }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/ExploreEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/ExploreEffectExecutor.kt
@@ -141,10 +141,12 @@ class ExploreEffectExecutor : EffectExecutor<ExploreEffect> {
         val count = ReplacementEffectUtils.applyCounterPlacementModifiers(
             state, creatureId, CounterType.PLUS_ONE_PLUS_ONE, 1, placerId = context.controllerId
         )
-        val newState = state.updateEntity(creatureId) {
+        val updated = state.updateEntity(creatureId) {
             it.with(current.withAdded(CounterType.PLUS_ONE_PLUS_ONE, count))
         }
+        val (newState, firstThisTurn) =
+            com.wingedsheep.engine.handlers.effects.DamageUtils.recordCounterPlacement(updated, creatureId)
         val name = state.getEntity(creatureId)?.get<CardComponent>()?.name ?: ""
-        return newState to listOf(CountersAddedEvent(creatureId, "PLUS_ONE_PLUS_ONE", count, name))
+        return newState to listOf(CountersAddedEvent(creatureId, "PLUS_ONE_PLUS_ONE", count, name, firstThisTurn))
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersExecutor.kt
@@ -43,6 +43,8 @@ class AddCountersExecutor : EffectExecutor<AddCountersEffect> {
             state, targetId, counterType, effect.count, placerId = context.controllerId
         )
 
+        val firstThisTurn = DamageUtils.isFirstCounterThisTurn(state, targetId)
+
         val newState = state.updateEntity(targetId) { container ->
             container.with(current.withAdded(counterType, modifiedCount))
         }.let { DamageUtils.markCounterPlacedOnCreature(it, context.controllerId, targetId) }
@@ -51,7 +53,7 @@ class AddCountersExecutor : EffectExecutor<AddCountersEffect> {
 
         return EffectResult.success(
             newState,
-            listOf(CountersAddedEvent(targetId, effect.counterType, modifiedCount, entityName))
+            listOf(CountersAddedEvent(targetId, effect.counterType, modifiedCount, entityName, firstThisTurn))
         )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersToCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersToCollectionExecutor.kt
@@ -43,13 +43,14 @@ class AddCountersToCollectionExecutor : EffectExecutor<AddCountersToCollectionEf
                 currentState, entityId, counterType, effect.count, placerId = context.controllerId
             )
 
+            val firstThisTurn = DamageUtils.isFirstCounterThisTurn(currentState, entityId)
             currentState = currentState.updateEntity(entityId) { container ->
                 container.with(current.withAdded(counterType, modifiedCount))
             }
             currentState = DamageUtils.markCounterPlacedOnCreature(currentState, context.controllerId, entityId)
 
             val entityName = currentState.getEntity(entityId)?.get<CardComponent>()?.name ?: ""
-            events.add(CountersAddedEvent(entityId, effect.counterType, modifiedCount, entityName))
+            events.add(CountersAddedEvent(entityId, effect.counterType, modifiedCount, entityName, firstThisTurn))
         }
 
         return EffectResult.success(currentState, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddDynamicCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddDynamicCountersExecutor.kt
@@ -44,6 +44,8 @@ class AddDynamicCountersExecutor : EffectExecutor<AddDynamicCountersEffect> {
             state, targetId, counterType, count, placerId = context.controllerId
         )
 
+        val firstThisTurn = DamageUtils.isFirstCounterThisTurn(state, targetId)
+
         val newState = state.updateEntity(targetId) { container ->
             container.with(current.withAdded(counterType, modifiedCount))
         }.let { DamageUtils.markCounterPlacedOnCreature(it, context.controllerId, targetId) }
@@ -52,7 +54,7 @@ class AddDynamicCountersExecutor : EffectExecutor<AddDynamicCountersEffect> {
 
         return EffectResult.success(
             newState,
-            listOf(CountersAddedEvent(targetId, effect.counterType, modifiedCount, entityName))
+            listOf(CountersAddedEvent(targetId, effect.counterType, modifiedCount, entityName, firstThisTurn))
         )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DistributeCountersAmongTargetsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DistributeCountersAmongTargetsExecutor.kt
@@ -59,13 +59,14 @@ class DistributeCountersAmongTargetsExecutor : EffectExecutor<DistributeCounters
             )
 
             val current = currentState.getEntity(targetId)?.get<CountersComponent>() ?: CountersComponent()
+            val firstThisTurn = DamageUtils.isFirstCounterThisTurn(currentState, targetId)
             currentState = currentState.updateEntity(targetId) { container ->
                 container.with(current.withAdded(counterType, modifiedCount))
             }
             currentState = DamageUtils.markCounterPlacedOnCreature(currentState, context.controllerId, targetId)
 
             val entityName = state.getEntity(targetId)?.get<CardComponent>()?.name ?: ""
-            events.add(CountersAddedEvent(targetId, effect.counterType, modifiedCount, entityName))
+            events.add(CountersAddedEvent(targetId, effect.counterType, modifiedCount, entityName, firstThisTurn))
         }
 
         return EffectResult.success(currentState, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DoubleCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DoubleCountersExecutor.kt
@@ -51,6 +51,8 @@ class DoubleCountersExecutor : EffectExecutor<DoubleCountersEffect> {
             state, targetId, counterType, existing, placerId = context.controllerId
         )
 
+        val firstThisTurn = DamageUtils.isFirstCounterThisTurn(state, targetId)
+
         val newState = state.updateEntity(targetId) { container ->
             container.with(current.withAdded(counterType, added))
         }.let { DamageUtils.markCounterPlacedOnCreature(it, context.controllerId, targetId) }
@@ -59,7 +61,7 @@ class DoubleCountersExecutor : EffectExecutor<DoubleCountersEffect> {
 
         return EffectResult.success(
             newState,
-            listOf(CountersAddedEvent(targetId, effect.counterType, added, entityName))
+            listOf(CountersAddedEvent(targetId, effect.counterType, added, entityName, firstThisTurn))
         )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/MoveAllLastKnownCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/MoveAllLastKnownCountersExecutor.kt
@@ -48,6 +48,9 @@ class MoveAllLastKnownCountersExecutor : EffectExecutor<MoveAllLastKnownCounters
         var newState = state
         val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
         val targetName = state.getEntity(targetId)?.get<CardComponent>()?.name ?: ""
+        // One "put counters" event batch on a single creature ⇒ one "first this turn" flag,
+        // carried on the first emitted event so it fires the intervening-if trigger once.
+        var firstThisTurn = DamageUtils.isFirstCounterThisTurn(state, targetId)
 
         for ((counterTypeString, count) in lastKnown) {
             if (count <= 0) continue
@@ -62,7 +65,8 @@ class MoveAllLastKnownCountersExecutor : EffectExecutor<MoveAllLastKnownCounters
             newState = newState.updateEntity(targetId) { container ->
                 container.with(current.withAdded(counterType, modifiedCount))
             }
-            events.add(CountersAddedEvent(targetId, counterTypeString, modifiedCount, targetName))
+            events.add(CountersAddedEvent(targetId, counterTypeString, modifiedCount, targetName, firstThisTurn))
+            firstThisTurn = false
         }
 
         if (events.isNotEmpty()) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -1059,8 +1059,11 @@ internal class CombatDamageManager(
                 newState = newState.updateEntity(targetId) { container ->
                     container.with(counters.withAdded(com.wingedsheep.sdk.core.CounterType.MINUS_ONE_MINUS_ONE, amount))
                 }
+                val (afterMark, firstThisTurn) =
+                    com.wingedsheep.engine.handlers.effects.DamageUtils.recordCounterPlacement(newState, targetId)
+                newState = afterMark
                 events.add(CountersAddedEvent(targetId, com.wingedsheep.sdk.core.CounterType.MINUS_ONE_MINUS_ONE.name, amount,
-                    newState.getEntity(targetId)?.get<CardComponent>()?.name ?: "Creature"))
+                    newState.getEntity(targetId)?.get<CardComponent>()?.name ?: "Creature", firstThisTurn))
             } else {
                 val existingDamage = newState.getEntity(targetId)?.get<DamageComponent>()
                 val currentDamage = existingDamage?.amount ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -47,6 +47,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.EntersAsCopy
 import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.EntersWithChoice
@@ -1816,7 +1817,9 @@ class StackResolver(
                     newState = newState.updateEntity(entityId) { c ->
                         c.with(current.withAdded(counterType, modifiedCount))
                     }
-                    events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName))
+                    val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
+                    newState = afterMark
+                    events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn))
                 }
                 is EntersWithDynamicCounters -> {
                     // Skip "other only" effects when applying to self (e.g., Gev)
@@ -1837,7 +1840,9 @@ class StackResolver(
                         newState = newState.updateEntity(entityId) { c ->
                             c.with(current.withAdded(counterType, modifiedCount))
                         }
-                        events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName))
+                        val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
+                        newState = afterMark
+                        events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn))
                     }
                 }
                 else -> { /* Other replacement effects handled elsewhere */ }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -360,6 +360,16 @@ data class TargetedByControllerThisTurnComponent(
 }
 
 /**
+ * Marks a permanent that has had one or more counters put on it already this turn.
+ * Used for "the first time counters have been put on that creature this turn" intervening-if
+ * triggers (e.g. Stalwart Successor). Set the first time any counter lands on the permanent
+ * (see DamageUtils.markCounterPlacedOnCreature), read to compute the per-event "first this turn"
+ * flag, and cleared at end of turn by CleanupPhaseManager.
+ */
+@Serializable
+data object ReceivedCountersThisTurnComponent : Component
+
+/**
  * Tracks which creatures this entity dealt damage to this turn.
  * Used for triggers like Soul Collector: "Whenever a creature dealt damage by Soul Collector this turn dies..."
  * Cleared at end of turn by TurnManager.


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm cards, plus the engine support Stalwart Successor needs.

## Cards

- **Sage of the Fang** ({2}{G}, 2/2 Human Druid) — ETB puts a +1/+1 counter on target creature. Renew {3}{G} (exile from graveyard, sorcery speed): add a +1/+1 counter on target creature, then double the number of +1/+1 counters on it. Composed from `Effects.AddCounters` + `Effects.DoubleCounters`.
- **Sibsig Appraiser** ({2}{U}, 2/1 Zombie Advisor) — ETB look at the top two cards, one to hand and the other to graveyard (`EffectPatterns.lookAtTopAndKeep(count = 2, keepCount = 1)`).
- **Stalwart Successor** ({1}{B}{G}, 3/2 Human Warrior, Menace) — whenever one or more counters of any type are put on a creature you control, if it's the first time counters have been put on that creature this turn, put a +1/+1 counter on that creature.
- **Meticulous Artisan** ({3}{R}, 3/3 Djinn Artificer) — Prowess; ETB create a Treasure token.

## Engine feature (for Stalwart Successor)

A reusable "first time counters this turn, any counter type" triggered-ability shape, mirroring the existing Valiant first-time-each-turn pattern:

- `Counters.ANY` wildcard sentinel + `Triggers.countersPlacedOn(filter, counterType, firstTimeEachTurn)`.
- `CountersPlacedEvent.firstTimeEachTurn` gate; engine `CountersAddedEvent.firstThisTurn` flag.
- `ReceivedCountersThisTurnComponent` per-creature marker set in the shared `DamageUtils.markCounterPlacedOnCreature` funnel (read before marking to stamp the per-event flag), cleared at end of turn by `CleanupPhaseManager`.
- `TriggerMatcher` matches the wildcard counter type and the first-this-turn flag.

## Tests

Scenario tests for Sage of the Fang (ETB counter + Renew add-then-double, 2→3→6) and Stalwart Successor (triggers once on the first counter; not on a second same-turn counter; not on opponents' creatures). SDK reference doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)