### PR TITLE
Add TDM cards (group A)

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroupABatchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroupABatchScenarioTest.kt
@@ -1,0 +1,221 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the "group A" Tarkir: Dragonstorm batch:
+ * Coordinated Maneuver, Frontline Rush, Salt Road Skirmish, Kin-Tree Severance, Duty Beyond Death.
+ *
+ * Every card composes existing primitives (modal choose-one, dynamic damage/pump scaled by
+ * creatures you control, destroy/exile targeting, temporary haste tokens that sacrifice at the
+ * next end step, additional sacrifice cost + group indestructible/counter buff).
+ */
+class TdmGroupABatchScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Coordinated Maneuver") {
+
+            test("damage mode deals damage equal to the number of creatures you control") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Coordinated Maneuver")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2 — two creatures you control
+                    .withCardOnBattlefield(2, "Glory Seeker") // 2/2 enemy target (will take 2)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val enemy = game.findPermanents("Glory Seeker")
+                    .first { game.state.getEntity(it)?.get<ControllerComponent>()?.playerId == game.player2Id }
+
+                // Mode 0 = damage to creature/planeswalker. 2 creatures controlled → 2 damage → kills the 2/2.
+                game.castSpellWithMode(1, "Coordinated Maneuver", modeIndex = 0, targetId = enemy)
+                game.resolveStack()
+
+                withClue("Enemy 2/2 should be dead after taking 2 damage (2 creatures you control)") {
+                    game.findPermanents("Glory Seeker")
+                        .none { game.state.getEntity(it)?.get<ControllerComponent>()?.playerId == game.player2Id } shouldBe true
+                }
+            }
+
+            test("destroy-enchantment mode destroys target enchantment") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Coordinated Maneuver")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(2, "Grand Melee") // enchantment
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val melee = game.findPermanent("Grand Melee")!!
+                game.castSpellWithMode(1, "Coordinated Maneuver", modeIndex = 1, targetId = melee)
+                game.resolveStack()
+
+                withClue("Grand Melee should be destroyed") {
+                    game.findPermanent("Grand Melee") shouldBe null
+                }
+            }
+        }
+
+        context("Frontline Rush") {
+
+            test("token mode creates two 1/1 red Goblins") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Frontline Rush")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellWithMode(1, "Frontline Rush", modeIndex = 0)
+                game.resolveStack()
+
+                withClue("Two Goblin tokens should exist") {
+                    game.findPermanents("Goblin Token").size shouldBe 2
+                }
+            }
+
+            test("pump mode gives +X/+X where X is the number of creatures you control") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Frontline Rush")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2 — X = 2
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanents("Glory Seeker").first()
+                game.castSpellWithMode(1, "Frontline Rush", modeIndex = 1, targetId = target)
+                game.resolveStack()
+
+                val clientState = game.getClientState(1)
+                val pumped = clientState.cards[target]
+                withClue("Targeted Glory Seeker should be 4/4 (2/2 + 2 creatures you control)") {
+                    pumped shouldNotBe null
+                    pumped!!.power shouldBe 4
+                    pumped.toughness shouldBe 4
+                }
+            }
+        }
+
+        context("Salt Road Skirmish") {
+
+            test("destroys target creature and creates two hasty Warriors") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Salt Road Skirmish")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardOnBattlefield(2, "Glory Seeker") // target to destroy
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val victim = game.findPermanent("Glory Seeker")!!
+                game.castSpell(1, "Salt Road Skirmish", targetId = victim)
+                game.resolveStack()
+
+                withClue("Target creature should be destroyed") {
+                    game.findPermanent("Glory Seeker") shouldBe null
+                }
+                val warriors = game.findPermanents("Warrior Token")
+                withClue("Two Warrior tokens should be created with haste") {
+                    warriors.size shouldBe 2
+                    warriors.all {
+                        game.getClientState(1).cards[it]?.keywords?.contains(Keyword.HASTE) == true
+                    } shouldBe true
+                }
+
+                // They are sacrificed at the beginning of the next end step.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                withClue("Warriors should be sacrificed at the next end step") {
+                    game.findPermanents("Warrior Token").size shouldBe 0
+                }
+            }
+        }
+
+        context("Kin-Tree Severance") {
+
+            test("exiles target permanent with mana value 3 or greater") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Kin-Tree Severance")
+                    .withLandsOnBattlefield(1, "Plains", 6) // pay {2/W}{2/B}{2/G} as all-generic
+                    .withCardOnBattlefield(2, "Marshal of the Lost") // MV 4 creature
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Marshal of the Lost")!!
+                game.castSpell(1, "Kin-Tree Severance", targetId = target)
+                game.resolveStack()
+
+                withClue("Target should be exiled") {
+                    game.findPermanent("Marshal of the Lost") shouldBe null
+                    game.state.getExile(game.player2Id).contains(target) shouldBe true
+                }
+            }
+        }
+
+        context("Duty Beyond Death") {
+
+            test("sacrifice cost, grants indestructible and a +1/+1 counter to each creature you control") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Duty Beyond Death")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Glory Seeker") // sacrifice fodder
+                    .withCardOnBattlefield(1, "Marshal of the Lost") // survivor
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellWithAdditionalSacrifice(1, "Duty Beyond Death", sacrificeCreatureName = "Glory Seeker")
+                game.resolveStack()
+
+                val marshal = game.findPermanent("Marshal of the Lost")!!
+                val counters = game.state.getEntity(marshal)?.get<CountersComponent>()
+                withClue("Surviving creature should have a +1/+1 counter") {
+                    (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+                }
+                withClue("Surviving creature should have indestructible until end of turn") {
+                    game.getClientState(1).cards[marshal]?.keywords?.contains(Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+                withClue("Glory Seeker was sacrificed as a cost") {
+                    game.findPermanent("Glory Seeker") shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CoordinatedManeuver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CoordinatedManeuver.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Coordinated Maneuver — Tarkir: Dragonstorm #6
+ * {1}{W} · Instant · Common
+ *
+ * Choose one —
+ * • Coordinated Maneuver deals damage equal to the number of creatures you control to
+ *   target creature or planeswalker.
+ * • Destroy target enchantment.
+ */
+val CoordinatedManeuver = card("Coordinated Maneuver") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Coordinated Maneuver deals damage equal to the number of creatures you control to " +
+        "target creature or planeswalker.\n" +
+        "• Destroy target enchantment."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Deal damage equal to the number of creatures you control to target creature or planeswalker") {
+                val t = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+                effect = Effects.DealDamage(DynamicAmounts.creaturesYouControl(), t)
+            }
+            mode("Destroy target enchantment") {
+                val t = target("target enchantment", TargetPermanent(filter = TargetFilter.Enchantment))
+                effect = MoveToZoneEffect(t, Zone.GRAVEYARD, byDestruction = true)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "Wisnu Tan"
+        flavorText = "\"We follow the dragonstorms, and we take down any threats that emerge from them!\"\n" +
+            "—Zurgo, khan of the Mardu"
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6569487-53c5-4b91-877d-e4e31bfa90c0.jpg?1743203976"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DutyBeyondDeath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DutyBeyondDeath.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Duty Beyond Death — Tarkir: Dragonstorm #10
+ * {1}{W} · Instant · Uncommon
+ *
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Creatures you control gain indestructible until end of turn. Put a +1/+1 counter on each
+ * creature you control.
+ *
+ * Both clauses apply to "creatures you control" — they affect the same group of creatures
+ * present as the spell resolves (the sacrificed creature is already gone, paid as a cast cost).
+ */
+val DutyBeyondDeath = card("Duty Beyond Death") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\n" +
+        "Creatures you control gain indestructible until end of turn. Put a +1/+1 counter on " +
+        "each creature you control."
+
+    additionalCost(AdditionalCost.SacrificePermanent(GameObjectFilter.Creature))
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                // Creatures you control gain indestructible until end of turn.
+                ForEachInGroupEffect(
+                    filter = GroupFilter.AllCreaturesYouControl,
+                    effect = GrantKeywordEffect(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+                ),
+                // Put a +1/+1 counter on each creature you control.
+                ForEachInGroupEffect(
+                    filter = GroupFilter.AllCreaturesYouControl,
+                    effect = AddCountersEffect(
+                        counterType = Counters.PLUS_ONE_PLUS_ONE,
+                        count = 1,
+                        target = EffectTarget.Self
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "10"
+        artist = "Kev Fang"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e92640d-768b-4357-905f-bea017d351cc.jpg?1743203993"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FrontlineRush.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FrontlineRush.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frontline Rush — Tarkir: Dragonstorm #186
+ * {R}{W} · Instant · Uncommon
+ *
+ * Choose one —
+ * • Create two 1/1 red Goblin creature tokens.
+ * • Target creature gets +X/+X until end of turn, where X is the number of creatures you control.
+ */
+val FrontlineRush = card("Frontline Rush") {
+    manaCost = "{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Create two 1/1 red Goblin creature tokens.\n" +
+        "• Target creature gets +X/+X until end of turn, where X is the number of creatures you control."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Create two 1/1 red Goblin creature tokens") {
+                effect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.RED),
+                    creatureTypes = setOf("Goblin"),
+                    count = 2,
+                    imageUri = "https://cards.scryfall.io/normal/front/e/2/e265ca24-96c0-4654-a8f3-bbffe288970a.jpg?1742506636"
+                )
+            }
+            mode("Target creature gets +X/+X until end of turn, where X is the number of creatures you control") {
+                val t = target("target creature", Targets.Creature)
+                effect = Effects.ModifyStats(
+                    DynamicAmounts.creaturesYouControl(),
+                    DynamicAmounts.creaturesYouControl(),
+                    t
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "186"
+        artist = "Filipe Pagliuso"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2ce8a205-99d6-4a9c-83a7-18b7220177d3.jpg?1743204723"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KinTreeSeverance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KinTreeSeverance.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Kin-Tree Severance — Tarkir: Dragonstorm #200
+ * {2/W}{2/B}{2/G} · Instant · Uncommon
+ *
+ * Exile target permanent with mana value 3 or greater.
+ */
+val KinTreeSeverance = card("Kin-Tree Severance") {
+    manaCost = "{2/W}{2/B}{2/G}"
+    colorIdentity = "WBG"
+    typeLine = "Instant"
+    oracleText = "Exile target permanent with mana value 3 or greater."
+
+    spell {
+        val t = target(
+            "target permanent with mana value 3 or greater",
+            TargetPermanent(filter = TargetFilter.Permanent.manaValueAtLeast(3))
+        )
+        effect = MoveToZoneEffect(t, Zone.EXILE)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "200"
+        artist = "Zack Stella"
+        flavorText = "\"For his crimes—burn his blood and cut him from his ancestors. Perennation is only for family.\"\n" +
+            "—Dictate of House Mevak in the banishment of Oret"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b577e246-3377-42aa-856e-b9fa89f3603a.jpg?1743204786"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SaltRoadSkirmish.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SaltRoadSkirmish.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Salt Road Skirmish — Tarkir: Dragonstorm #88
+ * {3}{B} · Sorcery · Uncommon
+ *
+ * Destroy target creature. Create two 1/1 red Warrior creature tokens. They gain haste until
+ * end of turn. Sacrifice them at the beginning of the next end step.
+ *
+ * The created tokens are modeled with built-in haste plus `sacrificeAtStep = Step.END`, which
+ * schedules the sacrifice at the next end step — exactly the "haste now, gone at end of turn"
+ * temporary-attacker shape used by Valduk's elementals.
+ */
+val SaltRoadSkirmish = card("Salt Road Skirmish") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature. Create two 1/1 red Warrior creature tokens. They gain " +
+        "haste until end of turn. Sacrifice them at the beginning of the next end step."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = MoveToZoneEffect(t, Zone.GRAVEYARD, byDestruction = true)
+            .then(
+                CreateTokenEffect(
+                    count = DynamicAmount.Fixed(2),
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.RED),
+                    creatureTypes = setOf("Warrior"),
+                    keywords = setOf(Keyword.HASTE),
+                    sacrificeAtStep = Step.END,
+                    imageUri = "https://cards.scryfall.io/normal/front/7/e/7edc0515-a130-45a7-aa09-0e23bba41587.jpg?1742506712"
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "88"
+        artist = "Arif Wijaya"
+        flavorText = "Dariya's first mistake was thinking they could short the Mardu trader on a deal. " +
+            "Their last was not considering the trader would bring backup."
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f529a2e-5102-492e-84ab-68541d83b5a3.jpg?1743204314"
+    }
+}


### PR DESCRIPTION
Implements five Tarkir: Dragonstorm cards, all composing existing SDK primitives — no engine/SDK changes were needed.

## Cards added
- **Coordinated Maneuver** ({1}{W} instant) — modal choose-one: deal damage equal to the number of creatures you control to target creature or planeswalker; or destroy target enchantment.
- **Frontline Rush** ({R}{W} instant) — modal choose-one: create two 1/1 red Goblin tokens; or target creature gets +X/+X until end of turn where X = creatures you control.
- **Salt Road Skirmish** ({3}{B} sorcery) — destroy target creature, then create two 1/1 red Warrior tokens with haste that sacrifice at the beginning of the next end step (`CreateTokenEffect.sacrificeAtStep = Step.END`).
- **Kin-Tree Severance** ({2/W}{2/B}{2/G} instant) — exile target permanent with mana value 3 or greater.
- **Duty Beyond Death** ({1}{W} instant) — additional cost: sacrifice a creature; creatures you control gain indestructible until end of turn and get a +1/+1 counter each.

## Skipped
None — all five compose existing primitives (modal choose-one, `DynamicAmounts.creaturesYouControl()`, destroy/exile targeting, temporary-token sacrifice step, additional sacrifice cost + group buffs).

## Tests
`TdmGroupABatchScenarioTest` — 7 cases covering every mode/branch (both modes of the two modal spells, token haste + next-end-step sacrifice, exile-by-mana-value, sacrifice cost + group indestructible/counter). All passing. Per project rule, no JSON serialization test resources were added.

Note: an unrelated `feat/tdm-cards-group-a` branch already exists (different cards from another agent), so this PR uses `feat/tdm-cards-group-a-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)