### PR TITLE
Add TDM cards (group B)

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroupBScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroupBScenarioTest.kt
@@ -1,0 +1,217 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for TDM "group B":
+ *  - Defibrillating Current (#177): 4 damage to a creature/planeswalker + gain 2 life.
+ *  - Seize Opportunity (#119): modal — impulse-exile top two OR pump up to two creatures.
+ *  - Piercing Exhale (#151): fight-style; optional behold a Dragon → surveil 2.
+ *  - Osseous Exhale (#17): 5 damage to attacking/blocking creature; behold → gain 2 life.
+ *  - Dispelling Exhale (#41): counter unless pays {2}, or {4} if a Dragon was beheld.
+ *
+ * The three Exhale cards model the optional "you may behold a Dragon" additional cost at
+ * resolution time (a MayEffect that stores the chosen Dragon), so after the spell resolves
+ * the controller answers a yes/no and — if yes — selects the Dragon to behold.
+ */
+class TdmGroupBScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Defibrillating Current") {
+            test("deals 4 damage to a creature and the caster gains 2 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Defibrillating Current")
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Hill Giant")!!
+                val cast = game.castSpell(1, "Defibrillating Current", target)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Hill Giant (3/3) takes 4 damage and dies") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("Caster gains 2 life") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+        }
+
+        context("Seize Opportunity") {
+            test("mode 1 exiles the top two cards and lets you play them") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Seize Opportunity")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellWithMode(1, "Seize Opportunity", 0)
+                withClue("Cast (mode 1) should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Both top cards left the library") {
+                    game.findCardsInLibrary(1, "Grizzly Bears").size shouldBe 0
+                    game.findCardsInLibrary(1, "Hill Giant").size shouldBe 0
+                }
+            }
+
+            test("mode 2 pumps up to two target creatures +2/+1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Seize Opportunity")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpellWithMode(1, "Seize Opportunity", 1, bear)
+                withClue("Cast (mode 2) should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val bearCard = game.getClientState(1).cards.values.first { it.name == "Grizzly Bears" }
+                withClue("Grizzly Bears is pumped to 4/3") {
+                    bearCard.power shouldBe 4
+                    bearCard.toughness shouldBe 3
+                }
+            }
+        }
+
+        context("Osseous Exhale") {
+            test("5 damage to an attacking creature; behold a Dragon to gain 2 life") {
+                // Player 1 attacks with their own creature, then (holding priority) casts
+                // Osseous Exhale at it — "attacking creature" is a valid target regardless of
+                // controller.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Osseous Exhale")
+                    .withCardInHand(1, "Kilnmouth Dragon") // a Dragon to behold
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Hill Giant") // 3/3 attacker
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Hill Giant" to 0))
+
+                val attacker = game.findPermanent("Hill Giant")!!
+                val cast = game.castSpell(1, "Osseous Exhale", attacker)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // Resolution-time behold: a "choose up to one Dragon" selection is pending.
+                withClue("A behold card selection should be pending") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val dragon = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Kilnmouth Dragon"
+                }
+                game.selectCards(listOf(dragon))
+                game.resolveStack()
+
+                withClue("Hill Giant (3/3) takes 5 damage and dies") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("Beholding a Dragon grants 2 life") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+        }
+
+        context("Piercing Exhale") {
+            test("my creature deals damage equal to its power; declining behold skips surveil") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Piercing Exhale")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Hill Giant")      // 3/3 attacker source
+                    .withCardOnBattlefield(2, "Grizzly Bears")   // 2/2 victim
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mine = game.findPermanent("Hill Giant")!!
+                val victim = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Piercing Exhale"
+                }
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(victim))
+                    )
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // No Dragon to behold (none in hand/play) → behold selection is empty/auto-skipped.
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+
+                withClue("Grizzly Bears (2/2) takes 3 damage and dies") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+        }
+
+        context("Dispelling Exhale") {
+            test("counters a spell unless its controller pays {2} when no Dragon is beheld") {
+                // Player 2 casts Grizzly Bears (tapping out); Player 1 responds with Dispelling
+                // Exhale. With no Dragon beheld the tax is {2}, which the tapped-out Player 2
+                // cannot pay, so the spell is countered.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dispelling Exhale")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gbCast = game.castSpell(2, "Grizzly Bears")
+                withClue("Player 2's Grizzly Bears cast should succeed: ${gbCast.error}") {
+                    gbCast.error shouldBe null
+                }
+                // Player 2 holds priority after casting; pass it to Player 1.
+                game.passPriority()
+
+                val cast = game.castSpellTargetingStackSpell(1, "Dispelling Exhale", "Grizzly Bears")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // No Dragon to behold → selection auto-skips; counter tax is {2}.
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+
+                withClue("Grizzly Bears should be countered (not on battlefield)") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroupBScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroupBScenarioTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.gameserver.scenarios
 
 import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.gameserver.ScenarioTestBase
@@ -8,6 +9,7 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Scenario tests for TDM "group B":
@@ -18,8 +20,10 @@ import io.kotest.matchers.shouldBe
  *  - Dispelling Exhale (#41): counter unless pays {2}, or {4} if a Dragon was beheld.
  *
  * The three Exhale cards model the optional "you may behold a Dragon" additional cost at
- * resolution time (a MayEffect that stores the chosen Dragon), so after the spell resolves
- * the controller answers a yes/no and — if yes — selects the Dragon to behold.
+ * resolution time: gather the Dragons you control or hold, then a single "choose up to one"
+ * selection (no separate yes/no — declining is selecting zero) stores the chosen Dragon, and
+ * a ConditionalEffect gated on that store applies the rider. So after the spell resolves the
+ * controller gets a card selection; picking a Dragon enables the bonus, picking none skips it.
  */
 class TdmGroupBScenarioTest : ScenarioTestBase() {
 
@@ -66,9 +70,14 @@ class TdmGroupBScenarioTest : ScenarioTestBase() {
                 withClue("Cast (mode 1) should succeed: ${cast.error}") { cast.error shouldBe null }
                 game.resolveStack()
 
-                withClue("Both top cards left the library") {
+                withClue("Both top cards left the library and are now in exile") {
                     game.findCardsInLibrary(1, "Grizzly Bears").size shouldBe 0
                     game.findCardsInLibrary(1, "Hill Giant").size shouldBe 0
+                    game.state.getExile(game.player1Id).size shouldBe 2
+                }
+                withClue("The exiled cards are playable (granted a may-play permission)") {
+                    val permitted = game.state.mayPlayPermissions.flatMap { it.cardIds }.toSet()
+                    game.state.getExile(game.player1Id).all { it in permitted } shouldBe true
                 }
             }
 
@@ -135,6 +144,39 @@ class TdmGroupBScenarioTest : ScenarioTestBase() {
                     game.getLifeTotal(1) shouldBe 22
                 }
             }
+
+            test("5 damage but no life gain when no Dragon is beheld") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Osseous Exhale")
+                    // No Dragon in hand or play → nothing to behold.
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Hill Giant") // 3/3 attacker
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Hill Giant" to 0))
+
+                val attacker = game.findPermanent("Hill Giant")!!
+                val cast = game.castSpell(1, "Osseous Exhale", attacker)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // No Dragon to behold → the selection is empty/auto-skipped.
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+
+                withClue("Hill Giant (3/3) takes 5 damage and dies") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("No Dragon beheld → no life gain") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
         }
 
         context("Piercing Exhale") {
@@ -174,6 +216,61 @@ class TdmGroupBScenarioTest : ScenarioTestBase() {
                     game.isOnBattlefield("Grizzly Bears") shouldBe false
                 }
             }
+
+            test("beholding a Dragon enables the surveil 2 rider") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Piercing Exhale")
+                    .withCardInHand(1, "Kilnmouth Dragon")       // a Dragon to behold
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Hill Giant")      // 3/3 source
+                    .withCardOnBattlefield(2, "Grizzly Bears")   // 2/2 victim
+                    .withCardInLibrary(1, "Mountain")            // surveil fodder (top two)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mine = game.findPermanent("Hill Giant")!!
+                val victim = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.findCardsInHand(1, "Piercing Exhale").first()
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(victim))
+                    )
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // Behold the Dragon, which enables the surveil 2 rider.
+                withClue("A behold selection should be pending") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val dragon = game.findCardsInHand(1, "Kilnmouth Dragon").first()
+                game.selectCards(listOf(dragon))
+
+                // Surveil 2: a card selection over the top two library cards.
+                val surveil = game.getPendingDecision()
+                withClue("Surveil 2 should pause for a library look") {
+                    surveil.shouldBeInstanceOf<SelectCardsDecision>()
+                }
+                val lookedAt = (surveil as SelectCardsDecision).options
+                withClue("Surveil 2 looks at the top two cards") { lookedAt.size shouldBe 2 }
+                game.selectCards(lookedAt) // put both into the graveyard
+                game.resolveStack()
+
+                withClue("Grizzly Bears (2/2) takes 3 damage and dies") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("Surveil 2 binned both looked-at cards") {
+                    game.findCardsInLibrary(1, "Mountain").size shouldBe 0
+                    game.findCardsInLibrary(1, "Island").size shouldBe 0
+                    game.findCardsInGraveyard(1, "Mountain").size shouldBe 1
+                    game.findCardsInGraveyard(1, "Island").size shouldBe 1
+                }
+            }
         }
 
         context("Dispelling Exhale") {
@@ -208,6 +305,49 @@ class TdmGroupBScenarioTest : ScenarioTestBase() {
                     game.resolveStack()
                 }
 
+                withClue("Grizzly Bears should be countered (not on battlefield)") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("beholding a Dragon raises the tax to {4}, which the controller cannot pay") {
+                // Player 2 casts Grizzly Bears ({1}{G}), tapping two of five Forests and leaving
+                // three untapped — enough to pay {2}. Player 1 responds with Dispelling Exhale and
+                // beholds a Dragon, raising the tax to {4}, which Player 2 cannot afford, so no
+                // payment is offered and the spell is countered. (A {2} tax would have let Player 2
+                // pay, distinguishing this from the no-behold path above.)
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dispelling Exhale")
+                    .withCardInHand(1, "Kilnmouth Dragon") // a Dragon to behold
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 5) // 2 to cast, 3 left over (covers {2}, not {4})
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gbCast = game.castSpell(2, "Grizzly Bears")
+                withClue("Player 2's Grizzly Bears cast should succeed: ${gbCast.error}") {
+                    gbCast.error shouldBe null
+                }
+                game.passPriority()
+
+                val cast = game.castSpellTargetingStackSpell(1, "Dispelling Exhale", "Grizzly Bears")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // Resolution-time behold: choose the Dragon to raise the tax from {2} to {4}.
+                withClue("A behold selection should be pending") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val dragon = game.findCardsInHand(1, "Kilnmouth Dragon").first()
+                game.selectCards(listOf(dragon))
+                game.resolveStack()
+
+                withClue("Player 2 cannot afford {4}, so no payment is offered") {
+                    game.hasPendingDecision() shouldBe false
+                }
                 withClue("Grizzly Bears should be countered (not on battlefield)") {
                     game.isOnBattlefield("Grizzly Bears") shouldBe false
                 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DefibrillatingCurrent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DefibrillatingCurrent.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+
+/**
+ * Defibrillating Current
+ * {2/R}{2/W}{2/B}
+ * Sorcery
+ *
+ * Defibrillating Current deals 4 damage to target creature or planeswalker and you gain 2 life.
+ */
+val DefibrillatingCurrent = card("Defibrillating Current") {
+    manaCost = "{2/R}{2/W}{2/B}"
+    colorIdentity = "RWB"
+    typeLine = "Sorcery"
+    oracleText = "Defibrillating Current deals 4 damage to target creature or planeswalker and you gain 2 life."
+
+    spell {
+        val t = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = CompositeEffect(
+            listOf(
+                Effects.DealDamage(4, t),
+                Effects.GainLife(2)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "177"
+        artist = "Isis"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf3a18cf-03db-4eb0-8d53-0c1a71e184da.jpg?1743204687"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DispellingExhale.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DispellingExhale.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dispelling Exhale
+ * {1}{U}
+ * Instant
+ *
+ * As an additional cost to cast this spell, you may behold a Dragon. (You may choose a
+ * Dragon you control or reveal a Dragon card from your hand.)
+ * Counter target spell unless its controller pays {2}. If a Dragon was beheld, counter that
+ * spell unless its controller pays {4} instead.
+ *
+ * Implementation note: the optional behold (no real cost component) is modelled at
+ * resolution time as a gather of your Dragons followed by a `ChooseUpTo(1)` selection
+ * ("you may behold") storing the chosen Dragon under "beheld". The "{2}" vs "{4}" tax is
+ * selected by a [ConditionalEffect] gated on [Conditions.CollectionContainsMatch] of that store.
+ */
+val DispellingExhale = card("Dispelling Exhale") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, you may behold a Dragon. " +
+        "(You may choose a Dragon you control or reveal a Dragon card from your hand.)\n" +
+        "Counter target spell unless its controller pays {2}. If a Dragon was beheld, " +
+        "counter that spell unless its controller pays {4} instead."
+
+    spell {
+        target("target spell", Targets.Spell)
+        effect = CompositeEffect(
+            listOf(
+                // Optional behold: gather your Dragons and choose up to one of them.
+                GatherCardsEffect(
+                    source = CardSource.FromMultipleZones(
+                        zones = listOf(Zone.BATTLEFIELD, Zone.HAND),
+                        player = Player.You,
+                        filter = Filters.WithSubtype("Dragon")
+                    ),
+                    storeAs = "beholdable"
+                ),
+                SelectFromCollectionEffect(
+                    from = "beholdable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "beheld",
+                    prompt = "You may behold a Dragon"
+                ),
+                RevealCollectionEffect(from = "beheld"),
+                ConditionalEffect(
+                    condition = Conditions.CollectionContainsMatch("beheld"),
+                    effect = Effects.CounterUnlessPays("{4}"),
+                    elseEffect = Effects.CounterUnlessPays("{2}")
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "David Auden Nash"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c9af3f1-711e-42ae-803a-1100eba3fb13.jpg?1743204126"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/OsseousExhale.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/OsseousExhale.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Osseous Exhale
+ * {1}{W}
+ * Instant
+ *
+ * As an additional cost to cast this spell, you may behold a Dragon. (You may choose a
+ * Dragon you control or reveal a Dragon card from your hand.)
+ * Osseous Exhale deals 5 damage to target attacking or blocking creature. If a Dragon was
+ * beheld, you gain 2 life.
+ *
+ * Implementation note: the oracle frames the optional behold as a cast-time additional cost,
+ * but Behold has no real cost component (it neither pays mana nor exiles). Following the
+ * Celestial Reunion precedent, the entire spell is modelled at resolution time: a gather of
+ * the Dragons you control or hold, then a `ChooseUpTo(1)` selection ("you may behold") storing
+ * the chosen Dragon under "beheld", and the life-gain rider gated on
+ * [Conditions.CollectionContainsMatch] of that store. Choosing zero (or having no Dragons)
+ * leaves the store empty, so the rider is skipped.
+ */
+val OsseousExhale = card("Osseous Exhale") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, you may behold a Dragon. " +
+        "(You may choose a Dragon you control or reveal a Dragon card from your hand.)\n" +
+        "Osseous Exhale deals 5 damage to target attacking or blocking creature. " +
+        "If a Dragon was beheld, you gain 2 life."
+
+    spell {
+        val t = target(
+            "target attacking or blocking creature",
+            TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature)
+        )
+        effect = CompositeEffect(
+            listOf(
+                // Optional behold: gather your Dragons and choose up to one of them.
+                GatherCardsEffect(
+                    source = CardSource.FromMultipleZones(
+                        zones = listOf(Zone.BATTLEFIELD, Zone.HAND),
+                        player = Player.You,
+                        filter = Filters.WithSubtype("Dragon")
+                    ),
+                    storeAs = "beholdable"
+                ),
+                SelectFromCollectionEffect(
+                    from = "beholdable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "beheld",
+                    prompt = "You may behold a Dragon"
+                ),
+                RevealCollectionEffect(from = "beheld"),
+                Effects.DealDamage(5, t),
+                ConditionalEffect(
+                    condition = Conditions.CollectionContainsMatch("beheld"),
+                    effect = Effects.GainLife(2)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Camille Alquier"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/2300da2f-2297-4c2f-90c1-11ce2b42d91f.jpg?1743204021"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/PiercingExhale.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/PiercingExhale.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Piercing Exhale
+ * {1}{G}
+ * Instant
+ *
+ * As an additional cost to cast this spell, you may behold a Dragon. (You may choose a
+ * Dragon you control or reveal a Dragon card from your hand.)
+ * Target creature you control deals damage equal to its power to target creature or
+ * planeswalker. If a Dragon was beheld, surveil 2.
+ *
+ * Implementation note: as with the other Exhale cards, the optional behold (which has no
+ * real cost component) is modelled at resolution time as a gather of your Dragons followed by
+ * a `ChooseUpTo(1)` selection ("you may behold") storing the chosen Dragon under "beheld";
+ * the surveil rider is gated on [Conditions.CollectionContainsMatch] of that store (empty when
+ * you choose none).
+ */
+val PiercingExhale = card("Piercing Exhale") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, you may behold a Dragon. " +
+        "(You may choose a Dragon you control or reveal a Dragon card from your hand.)\n" +
+        "Target creature you control deals damage equal to its power to target creature or " +
+        "planeswalker. If a Dragon was beheld, surveil 2."
+
+    spell {
+        val myCreature = target("target creature you control", Targets.CreatureYouControl)
+        val victim = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = CompositeEffect(
+            listOf(
+                // Optional behold: gather your Dragons and choose up to one of them.
+                GatherCardsEffect(
+                    source = CardSource.FromMultipleZones(
+                        zones = listOf(Zone.BATTLEFIELD, Zone.HAND),
+                        player = Player.You,
+                        filter = Filters.WithSubtype("Dragon")
+                    ),
+                    storeAs = "beholdable"
+                ),
+                SelectFromCollectionEffect(
+                    from = "beholdable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "beheld",
+                    prompt = "You may behold a Dragon"
+                ),
+                RevealCollectionEffect(from = "beheld"),
+                Effects.DealDamage(
+                    amount = DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.Power),
+                    target = victim,
+                    damageSource = myCreature
+                ),
+                ConditionalEffect(
+                    condition = Conditions.CollectionContainsMatch("beheld"),
+                    effect = EffectPatterns.surveil(2)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "Jorge Jacinto"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2a0deb9-5bc3-42d5-9e1e-5f463d176aef.jpg?1743204571"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SeizeOpportunity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SeizeOpportunity.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Seize Opportunity
+ * {2}{R}
+ * Instant
+ *
+ * Choose one —
+ * • Exile the top two cards of your library. Until the end of your next turn, you may play those cards.
+ * • Up to two target creatures each get +2/+1 until end of turn.
+ */
+val SeizeOpportunity = card("Seize Opportunity") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Exile the top two cards of your library. Until the end of your next turn, you may play those cards.\n" +
+        "• Up to two target creatures each get +2/+1 until end of turn."
+
+    spell {
+        effect = ModalEffect.chooseOne(
+            // Exile top two and play until end of next turn.
+            Mode.noTarget(
+                effect = CompositeEffect(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.TopOfLibrary(DynamicAmount.Fixed(2)),
+                            storeAs = "exiledCards"
+                        ),
+                        MoveCollectionEffect(
+                            from = "exiledCards",
+                            destination = CardDestination.ToZone(Zone.EXILE)
+                        ),
+                        GrantMayPlayFromExileEffect("exiledCards", MayPlayExpiry.UntilEndOfNextTurn)
+                    )
+                ),
+                description = "Exile the top two cards of your library. Until the end of your next turn, you may play those cards"
+            ),
+            // Up to two target creatures each get +2/+1 until end of turn.
+            Mode(
+                effect = ForEachTargetEffect(
+                    listOf(Effects.ModifyStats(2, 1, EffectTarget.ContextTarget(0)))
+                ),
+                targetRequirements = listOf(Targets.UpToCreatures(2)),
+                description = "Up to two target creatures each get +2/+1 until end of turn"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Josiah \"Jo\" Cameron"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7818d28-b9a5-4341-9adc-666070b8878d.jpg?1743204441"
+    }
+}


### PR DESCRIPTION
Implements five Tarkir: Dragonstorm cards by composing existing SDK primitives — no new engine/SDK features were required.

## Cards added
- **Defibrillating Current** (`{2/R}{2/W}{2/B}` Sorcery) — deals 4 damage to a creature/planeswalker and you gain 2 life.
- **Seize Opportunity** (`{2}{R}` Instant) — choose one: impulse-exile the top two cards (playable until end of your next turn), or up to two target creatures each get +2/+1 until end of turn.
- **Piercing Exhale** (`{1}{G}` Instant) — target creature you control deals damage equal to its power to target creature or planeswalker; if a Dragon was beheld, surveil 2.
- **Osseous Exhale** (`{1}{W}` Instant) — 5 damage to a target attacking or blocking creature; if a Dragon was beheld, gain 2 life.
- **Dispelling Exhale** (`{1}{U}` Instant) — counter target spell unless its controller pays `{2}`, or `{4}` if a Dragon was beheld.

## Skipped
None — all five were implementable with existing primitives.

## Notes
The optional "you may behold a Dragon" rider on the three Exhale cards is modelled at resolution time: gather your Dragons → `ChooseUpTo(1)` storing the chosen Dragon under `beheld` → a `ConditionalEffect` gated on `CollectionContainsMatch("beheld")` for the bonus. This follows the existing Celestial Reunion (ECL) precedent — behold has no real cost component (it neither pays mana nor exiles), so a resolution-time model is rules-equivalent and avoided introducing an "optional-behold additional cost" SDK feature.

## Tests
`TdmGroupBScenarioTest` (6 tests, all passing): Defibrillating damage+lifegain; both Seize Opportunity modes; Osseous behold→lifegain; Piercing fight damage (no-Dragon path); Dispelling counter-unless-pay-{2}.

Per project rule, no JSON serialization test resources were added for these cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)