### PR TITLE
Fix flaky StackOverflow in state projection (battlefield-aggregate source conditions)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -94,10 +94,20 @@ import com.wingedsheep.engine.state.components.player.PlayerCitysBlessingCompone
 
 /**
  * Evaluates conditions from the SDK against the game state.
+ *
+ * [defaultProjection] is forwarded to this evaluator's [DynamicAmountEvaluator] for battlefield
+ * reads when a caller doesn't thread a projection. Resolution-time callers leave the default
+ * (the canonical lazy [GameState.projectedState]). A mid-projection caller — the
+ * [com.wingedsheep.engine.mechanics.layers.EffectApplicator] evaluating a source condition while
+ * the projection is still being computed — must swap in a non-reentrant projection, otherwise an
+ * aggregate `Compare` (e.g. "while you control N+ creatures") re-enters the lazy `projectedState`
+ * initializer and recurses until the stack overflows.
  */
-class ConditionEvaluator {
+class ConditionEvaluator(
+    defaultProjection: (GameState) -> ProjectedState = { it.projectedState }
+) {
 
-    private val dynamicAmountEvaluator = DynamicAmountEvaluator(this)
+    private val dynamicAmountEvaluator = DynamicAmountEvaluator(this, defaultProjection)
 
     /**
      * Evaluate a condition at resolution time, when a full [EffectContext] is available.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -22,7 +22,13 @@ internal class EffectApplicator(
     private val dynamicAmountEvaluator: DynamicAmountEvaluator
 ) {
 
-    private val conditionEvaluator = ConditionEvaluator()
+    // Source conditions are evaluated while the projection is still being built. Hand the
+    // ConditionEvaluator a non-reentrant projection (mirroring StateProjector's own evaluator):
+    // reaching for the canonical lazy GameState.projectedState here would re-enter our own
+    // initializer and recurse until the stack overflows (e.g. a Layer-7 conditional P/T static
+    // ability whose source condition counts creatures via a battlefield aggregate). The empty
+    // projection falls back to base CardComponent values, exactly as CDA resolution does.
+    private val conditionEvaluator = ConditionEvaluator(defaultProjection = { ProjectedState(it, emptyMap()) })
 
     fun applyEffect(
         effect: ContinuousEffect,


### PR DESCRIPTION
## Problem

`GameEnvironmentTest > playGame with random agents and sealed decks completes` recently became flaky, crashing intermittently with:

```
java.lang.StackOverflowError
  at AffectsFilterResolver.kt:79
```

## Root cause

The deepest frame was misleading — the real failure is **infinite recursion through the lazy `GameState.projectedState`**:

```
StateProjector.project            (applying a Layer-7 effect)
  EffectApplicator.applyEffect     (evaluates the effect's sourceCondition)
    ConditionEvaluator.evaluateCompareCtx
      DynamicAmountEvaluator.evaluateBattlefieldAggregate
        resolveProjection → defaultProjection = { it.projectedState }   ← re-enters the lazy initializer
          StateProjector.project   ← recurse → StackOverflow
```

When a permanent on the battlefield has a continuous static ability whose `sourceCondition` is a `Compare` over a **battlefield aggregate** (e.g. a conditional P/T buff gated on *"as long as you control N+ creatures"*), applying that effect during projection evaluated the condition via `EffectApplicator`'s own `ConditionEvaluator()`. Its nested `DynamicAmountEvaluator` used the default projection supplier `{ it.projectedState }`, which re-entered the lazy projection that was still being computed.

`StateProjector` already guards *its own* `DynamicAmountEvaluator` with an empty, non-reentrant projection — but the source-condition path bypassed that guard. It only manifested once a card with such a gated static ability happened to be on the battlefield, hence the flakiness.

## Fix

- `ConditionEvaluator` gains an injectable `defaultProjection`, defaulting to the canonical lazy `{ it.projectedState }` so all resolution-time callers are unchanged.
- `EffectApplicator` constructs its `ConditionEvaluator` with the empty, non-reentrant projection `{ ProjectedState(it, emptyMap()) }`, mirroring the approximation `StateProjector` already uses for CDA resolution (battlefield reads fall back to base `CardComponent` values).

## Verification

- Reproduced reliably with a loop of random sealed Bloomburrow games (overflowed ~1/50). After the fix, **400 random games complete cleanly**.
- Full `rules-engine` suite: **2174 tests, 0 failures**.
- Original `GameEnvironmentTest` class: all 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)