### PR TITLE
Add Desert Nomads with Desertwalk keyword support

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -52,7 +52,7 @@
 - [x] Ali Baba
 - [ ] Ali from Cairo
 - [x] Bird Maiden
-- [ ] Desert Nomads
+- [x] Desert Nomads
 - [x] Hurr Jackal
 - [x] Kird Ape
 - [ ] Magnetic Mountain

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1429,7 +1429,8 @@ activatedAbility {
 
 **`Keyword` enum (display-level)**
 
-Flying, Menace, Intimidate, Fear, Shadow, Horsemanship, all landwalks (Plainswalk … Forestwalk), First Strike, Double
+Flying, Menace, Intimidate, Fear, Shadow, Horsemanship, all basic landwalks (Plainswalk … Forestwalk), Desertwalk
+(nonbasic landwalk variant — `Keyword.DESERTWALK`, keyed off `Subtype.DESERT`), First Strike, Double
 Strike, Trample, Deathtouch, Lifelink, Vigilance, Reach, Provoke, Flanking, Defender, Indestructible, Hexproof, Shroud, Haste,
 Flash, Prowess, Flurry, Changeling, Convoke, Delve, Affinity, Storm, Flashback, Harmonize, Evoke, Impending, Conspire, Hideaway, Cascade, Plot,
 Offspring, Persist, Ascend, Wither, Toxic, Eerie, Vivid, Fateful Bite, … (display-only — engine effect lives in handlers or

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DesertNomadsScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DesertNomadsScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Desert Nomads' two abilities:
+ *  1. Desertwalk — can't be blocked when defending player controls a Desert.
+ *     (CR 702.14 landwalk variant, keyed off [com.wingedsheep.sdk.core.Subtype.DESERT].)
+ *  2. Damage prevention — prevent all damage that would be dealt to Desert Nomads by Deserts.
+ *     Implemented as a continuous `PreventDamage` replacement (CR 615) with source filter
+ *     `Land.withSubtype("Desert")` and recipient `RecipientFilter.Self`.
+ */
+class DesertNomadsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Desertwalk evasion") {
+
+            test("cannot be blocked when defending player controls a Desert") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Desert Nomads")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Desert")
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val attack = game.declareAttackers(mapOf("Desert Nomads" to 2))
+                withClue("Declaring Desert Nomads as attacker should succeed: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.execute(
+                    DeclareBlockers(
+                        game.player2Id,
+                        mapOf(game.findPermanent("Grizzly Bears")!! to listOf(game.findPermanent("Desert Nomads")!!))
+                    )
+                )
+                withClue("Blocking should fail due to Desertwalk: error was ${block.error}") {
+                    block.isSuccess shouldBe false
+                    (block.error ?: "").lowercase().contains("desertwalk") shouldBe true
+                }
+            }
+
+            test("CAN be blocked when defending player controls no Desert") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Desert Nomads")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Mountain")
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Desert Nomads" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Grizzly Bears" to listOf("Desert Nomads")))
+                withClue("Blocking should succeed when defender controls no Desert: ${block.error}") {
+                    block.error shouldBe null
+                }
+            }
+        }
+
+        context("Desert damage prevention") {
+
+            test("Desert's ping is prevented when targeting Desert Nomads") {
+                // Attacker = player 2 so player 1's Desert can ping the attacking Desert Nomads.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Desert Nomads")
+                    .withCardOnBattlefield(1, "Desert")
+                    .withActivePlayer(2)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Desert Nomads" to 1)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                // Active player has priority first in END_COMBAT; pass to the Desert's owner.
+                if (game.state.priorityPlayerId == game.player2Id) {
+                    game.passPriority()
+                }
+
+                val nomadsId = game.findPermanent("Desert Nomads")!!
+                val desertId = game.findPermanent("Desert")!!
+                val pingAbility = cardRegistry.getCard("Desert")!!.script.activatedAbilities[1]
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = desertId,
+                        abilityId = pingAbility.id,
+                        targets = listOf(entityIdToChosenTarget(game.state, nomadsId)),
+                    )
+                )
+                withClue("Desert activation should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Verify the prevention actually zeroed the damage: no damage marked.
+                val damage = game.state.getEntity(nomadsId)
+                    ?.get<com.wingedsheep.engine.state.components.battlefield.DamageComponent>()
+                    ?.amount ?: 0
+                withClue("Desert's ping should be fully prevented (damage marked = 0)") {
+                    damage shouldBe 0
+                }
+                withClue("Desert Nomads should still be on the battlefield") {
+                    game.isOnBattlefield("Desert Nomads") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/d/desert-nomads.json
+++ b/manual-scenarios/cards/d/desert-nomads.json
@@ -1,0 +1,33 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Desert Nomads"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Desert Nomads"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Desert"},
+      {"name": "Moorish Cavalry"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_BLOCKERS", "END_COMBAT"],
+  "player2StopAtSteps": ["DECLARE_BLOCKERS", "END_COMBAT"],
+  "player1OpponentStopAtSteps": ["DECLARE_BLOCKERS", "END_COMBAT"],
+  "player2OpponentStopAtSteps": ["DECLARE_BLOCKERS", "END_COMBAT"]
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -18,6 +18,7 @@ enum class Keyword(val displayName: String) {
     ISLANDWALK("Islandwalk"),
     MOUNTAINWALK("Mountainwalk"),
     PLAINSWALK("Plainswalk"),
+    DESERTWALK("Desertwalk"),
 
     // ── Combat ───────────────────────────────────────────────
     FIRST_STRIKE("First strike"),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Subtype.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Subtype.kt
@@ -176,6 +176,9 @@ value class Subtype(val value: String) {
         val MOUNTAIN = Subtype("Mountain")
         val FOREST = Subtype("Forest")
 
+        // Nonbasic land types
+        val DESERT = Subtype("Desert")
+
         // Enchantment subtypes
         val AURA = Subtype("Aura")
         val CLASS = Subtype("Class")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/DesertNomads.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/DesertNomads.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * Desert Nomads
+ * {2}{R}
+ * Creature — Human Nomad
+ * 2/2
+ *
+ * Desertwalk (CR 702.13 landwalk variant — engine-supported via the new [Keyword.DESERTWALK]
+ * wired into [com.wingedsheep.engine.mechanics.combat.rules.LandwalkRule], keyed off
+ * [com.wingedsheep.sdk.core.Subtype.DESERT]).
+ *
+ * The Desert damage-prevention clause is a continuous [PreventDamage] replacement (CR 615):
+ *  - recipient filter = [RecipientFilter.Self] (only Desert Nomads itself),
+ *  - source filter = any Desert (a permanent with the Desert land subtype).
+ */
+val DesertNomads = card("Desert Nomads") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Nomad"
+    power = 2
+    toughness = 2
+    oracleText = "Desertwalk (This creature can't be blocked as long as defending player " +
+        "controls a Desert.)\n" +
+        "Prevent all damage that would be dealt to this creature by Deserts."
+
+    keywords(Keyword.DESERTWALK)
+
+    replacementEffect(
+        PreventDamage(
+            appliesTo = GameEvent.DamageEvent(
+                recipient = RecipientFilter.Self,
+                source = SourceFilter.Matching(GameObjectFilter.Land.withSubtype("Desert"))
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "Christopher Rush"
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e46d0c10-ec09-48ba-9e93-1392dca8111a.jpg?1562937684"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
@@ -107,7 +107,8 @@ class LandwalkRule : BlockEvasionRule {
         Keyword.SWAMPWALK to Subtype.SWAMP,
         Keyword.ISLANDWALK to Subtype.ISLAND,
         Keyword.MOUNTAINWALK to Subtype.MOUNTAIN,
-        Keyword.PLAINSWALK to Subtype.PLAINS
+        Keyword.PLAINSWALK to Subtype.PLAINS,
+        Keyword.DESERTWALK to Subtype.DESERT
     )
 
     override fun check(ctx: BlockCheckContext): String? {

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -152,6 +152,7 @@ export enum Keyword {
   ISLANDWALK = 'ISLANDWALK',
   MOUNTAINWALK = 'MOUNTAINWALK',
   PLAINSWALK = 'PLAINSWALK',
+  DESERTWALK = 'DESERTWALK',
   // Combat
   FIRST_STRIKE = 'FIRST_STRIKE',
   DOUBLE_STRIKE = 'DOUBLE_STRIKE',
@@ -217,6 +218,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.ISLANDWALK]: 'Islandwalk',
   [Keyword.MOUNTAINWALK]: 'Mountainwalk',
   [Keyword.PLAINSWALK]: 'Plainswalk',
+  [Keyword.DESERTWALK]: 'Desertwalk',
   [Keyword.FIRST_STRIKE]: 'First strike',
   [Keyword.DOUBLE_STRIKE]: 'Double strike',
   [Keyword.TRAMPLE]: 'Trample',


### PR DESCRIPTION
Engine feature: nonbasic landwalk variant (CR 702.14). Adds `Keyword.DESERTWALK` to the keyword enum, `Subtype.DESERT` to the subtype catalog, and wires both into `LandwalkRule.landwalkToSubtype` so a creature with DESERTWALK can't be blocked while the defending player controls a Desert. The web client display table and the SDK reference doc gain a matching entry.

Card: Desert Nomads composes the keyword with a continuous `PreventDamage` replacement (Camel-style) — recipient `Self`, source any `Land.withSubtype("Desert")` — so Desert pings (e.g. the ARN Desert's end-of-combat ability) are zeroed for Desert Nomads while still damaging other attackers.

Scenario test covers all three cases:
 * Desertwalk blocks the block declaration when defender controls a Desert.
 * Without a Desert, the same creature can be blocked normally.
 * A Desert's ping leaves damage marked = 0 on Desert Nomads.

Existing `LandwalkEvasionTest` and the banding suites still pass.