### PR TITLE
Add 5 EOE cards across three small engine extensions

### DIFF
--- a/backlog/sets/edge-of-eternities/bugs.md
+++ b/backlog/sets/edge-of-eternities/bugs.md
@@ -7,3 +7,5 @@
 - Rust Harvester, +1/+1 counter is not applied if target is invalid
 - Wedgelight Rammer did not turn to creature
 - Spacecraft can attack 1 turn after being played
+
+- Auxiliary Boosters - equipment not attached

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 242 / 261
+**Implemented:** 247 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -24,7 +24,7 @@
 - [x] Biomechan Engineer
 - [x] Biosynthic Burst
 - [x] Biotech Specialist
-- [ ] Blade of the Swarm
+- [x] Blade of the Swarm
 - [x] Blooming Stinger
 - [x] Bombard
 - [x] Breeding Pool
@@ -40,7 +40,7 @@
 - [x] Comet Crawler
 - [x] Command Bridge
 - [x] Consult the Star Charts
-- [ ] Cosmogoyf
+- [x] Cosmogoyf
 - [x] Cosmogrand Zenith
 - [x] Cryogen Relic
 - [x] Cryoshatter
@@ -155,7 +155,7 @@
 - [x] Nebula Dragon
 - [x] Nova Hellkite
 - [x] Nutrient Block
-- [ ] Orbital Plunge
+- [x] Orbital Plunge
 - [x] Oreplate Pangolin
 - [x] Ouroboroid
 - [x] Pain for All
@@ -167,7 +167,7 @@
 - [x] Possibility Technician
 - [ ] Pull Through the Weft
 - [x] Pulsar Squadron Ace
-- [ ] Quantum Riddler
+- [x] Quantum Riddler
 - [x] Radiant Strike
 - [x] Ragost, Deft Gastronaut
 - [x] Rayblade Trooper
@@ -177,7 +177,7 @@
 - [x] Reroute Systems
 - [x] Rescue Skiff
 - [x] Rig for War
-- [ ] Roving Actuator
+- [x] Roving Actuator
 - [x] Ruinous Rampage
 - [x] Rust Harvester
 - [x] Sacred Foundry

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -4,23 +4,23 @@ Engine features required to implement the remaining EOE cards. Each section list
 unblocks, the exact oracle clause that can't be expressed with current primitives, and a sketch of
 the engine/SDK work needed.
 
-As of the latest pass, **238 / 261** booster cards are implemented. The cards below remain
+As of the latest pass, **247 / 261** booster cards are implemented. The cards below remain
 blocked on the engine features listed here. Cards whose every clause maps to an existing primitive
 have already been implemented and are not listed.
 
 ---
 
-## 1. Conditional draw-replacement static
+## 1. Conditional draw-replacement static — RESOLVED
 
 **Cards:** Quantum Riddler.
 
-**Clause:** "As long as you have one or fewer cards in hand, if you would draw one or more cards,
-you draw that many cards plus one instead."
-
-**Plan:** Add a continuous draw-replacement static ability that intercepts draw events for its
-controller, adds a fixed amount, and is gated by a `Condition` (hand-size). The flying body, the
-ETB "draw a card", and `Warp {1}{U}` are all already expressible — only the replacement static is
-missing.
+**Resolution:** Added `ModifyDrawAmount(modifier, restrictions, appliesTo)` replacement effect
+(SDK) plus `DrawReplacementDispatcher.applyDrawAmountModifier()` in the engine. The modifier is
+consulted exactly once per draw instruction at the announcement site (CR 121.2a — instructions to
+draw multiple cards are modified before any individual card draws) — `DrawCardsExecutor.execute`
+for spell/ability draws and `DrawPhaseManager.performDrawStep` for the draw step — so a paused-and-
+resumed per-card loop doesn't double-modify. `restrictions: List<Condition>` mirrors
+`ModifyLifeLoss.restrictions` for the hand-size gate.
 
 ---
 
@@ -36,27 +36,28 @@ expressible; only the damage-history conditional is missing.
 
 ---
 
-## 3. Excess-damage detection
+## 3. Excess-damage detection — RESOLVED
 
 **Cards:** Orbital Plunge.
 
-**Clause:** "If excess damage was dealt this way, create a Lander token."
-
-**Plan:** Add a way for a damage effect to report whether it dealt damage in excess of lethal
-(toughness minus marked damage), surfaced as a condition or follow-up trigger. The base "deals 6
-damage to target creature" and `Effects.CreateLander()` already exist.
+**Resolution:** Added `Conditions.IfTargetTookExcessDamage(targetIndex)` (backed by the
+`TargetMarkedDamageExceedsToughness` condition class). Reads the target's marked-damage component
+strictly greater than its projected toughness, so chaining it AFTER `Effects.DealDamage` in a
+composite gates a payoff on lethal-exceeding damage. Returns `false` for non-creature targets and
+for targets that have left the battlefield, so the chain stays safe without bespoke "DealDamageWithExcessFollowup"
+plumbing.
 
 ---
 
-## 4. Targeting cards in the warp-exile zone
+## 4. Targeting cards in the warp-exile zone — RESOLVED
 
 **Cards:** Blade of the Swarm.
 
-**Clause:** "Put target exiled card with warp on the bottom of its owner's library."
-
-**Plan:** Make cards exiled with warp targetable: a `TargetFilter` for "exiled card with warp" plus
-a move-to-library-bottom effect for an exile-zone target. The modal "two +1/+1 counters" branch is
-already expressible.
+**Resolution:** Extended `TargetEnumerationUtils.findValidObjectTargets` with a `Zone.EXILE` branch
+(`findValidExileTargets`), mirroring `findValidGraveyardTargets`. Combined with the existing
+`GameObjectFilter.warpExiled()` (`StatePredicate.IsWarpExiled`) and `MoveToZoneEffect(target, Zone.LIBRARY,
+ZonePlacement.Bottom)`, the modal targeting branch composes from existing atoms — no new effect or
+filter class needed.
 
 ---
 
@@ -89,15 +90,15 @@ if you do, draw a card and create a Robot token") is close to expressible but de
 
 ---
 
-## 7. Characteristic-defining P/T from cards in exile
+## 7. Characteristic-defining P/T from cards in exile — RESOLVED
 
 **Cards:** Cosmogoyf.
 
-**Clause:** "Cosmogoyf's power is equal to the number of cards you own in exile and its toughness is
-equal to that number plus 1."
-
-**Plan:** Add a `DynamicAmount` that counts cards a player owns across all exile sub-zones, then use
-it as a characteristic-defining P/T (Layer 7b set-base from a dynamic value, applied in all zones).
+**Resolution:** No new engine work needed. `DynamicAmount.AggregateZone(Player.You, Zone.EXILE,
+aggregation = COUNT)` already counts cards in the controller's exile sub-zone (cards in exile live
+in their owner's keyed exile bucket), and `dynamicStats(source, toughnessOffset = 1)` wires the
+same source as a CDA P/T through `CharacteristicValue.DynamicWithOffset`. The implementation is one
+DSL call: `dynamicStats(DynamicAmounts.zone(Player.You, Zone.EXILE).count(), toughnessOffset = 1)`.
 
 ---
 
@@ -240,15 +241,14 @@ many cards. Do this only once each turn."
 
 ---
 
-## 18. Copy a card from a zone and cast the copy for free
+## 18. Copy a card from a zone and cast the copy for free — RESOLVED
 
 **Cards:** Roving Actuator.
 
-**Clause:** "exile up to one target instant or sorcery card with mana value 2 or less from your
-graveyard. Copy it. You may cast the copy without paying its mana cost."
-
-**Plan:** Add an effect that creates a copy of a *card* (not a spell on the stack) and offers to cast
-the copy without paying its cost. The Void trigger gate is already expressible.
+**Resolution:** No new engine work needed. The Shiko, Paragon of the Way pattern (`MoveToZoneEffect` →
+exile, `Effects.CopyCardIntoCollection`, `Effects.CastFromCollectionWithoutPayingCost` inside
+`MayEffect`) already implements "copy a card in a zone, then cast the copy" (Rule 707.12). Roving
+Actuator wraps the chain in a Void-gated ETB trigger via `triggerCondition = Conditions.Void`.
 
 ---
 

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,20 +3,16 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (19)
+## Status: cards still blocked on engine work (14)
 
-The booster set is at **242 / 261**. The cards below are the only unimplemented ones; each is
+The booster set is at **247 / 261**. The cards below are the only unimplemented ones; each is
 blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
 summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
 parentheses).
 
 | Card | Blocking clause | Engine change needed (missing-effects §) |
 |------|-----------------|-------------------------------------------|
-| Quantum Riddler | "if you would draw one or more cards, you draw that many plus one instead" while hand ≤ 1 | Conditional draw-replacement static (§1) |
-| Orbital Plunge | "If excess damage was dealt this way, create a Lander token" | Excess-damage detection (§3) |
-| Blade of the Swarm | "Put target exiled card with warp on the bottom of its owner's library" | Targeting warp-exiled cards (§4) |
 | Bioengineered Future | "Each creature you control enters with an additional +1/+1 counter ... for each land that entered ... this turn" | Continuous extra-ETB-counters + lands-entered-this-turn tracker (§5) |
-| Cosmogoyf | power/toughness = "number of cards you own in exile" (+1) | CDA P/T from cards-in-exile count (§7) |
 | Territorial Bruntar | "exile cards from the top ... until you exile a nonland card. You may cast that card this turn" | Impulse-until-nonland effect (§9) |
 | Zero Point Ballad | "Destroy all creatures with toughness X or less" + reanimate one destroyed this way | Dynamic-toughness mass destroy + reanimate-from-batch (§10) |
 | Weapons Manufacturing | create the noncreature "Munitions" artifact token with a leaves-battlefield damage trigger | Noncreature tokens with embedded triggers (§11) |
@@ -25,7 +21,6 @@ parentheses).
 | Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Grant Warp to hand cards (§15) |
 | Terminal Velocity | put a permanent from hand and grant it haste + an LTB trigger + an end-step self-sac | Grant arbitrary abilities to a put-in permanent (§16) |
 | Terrasymbiosis | "Whenever you put ... +1/+1 counters on a creature ... draw that many. Do this only once each turn." | Once-per-turn gating for triggered abilities (§17) |
-| Roving Actuator | "exile ... an instant or sorcery ... Copy it. You may cast the copy without paying its mana cost." | Copy a card and cast the copy (§18) |
 | Mm'menon, the Right Hand | "cast artifact spells from the top of your library" + restricted mana | Play-from-top static + restricted mana (§19) |
 | Weftwalking | "The first spell each player casts ... may be cast without paying its mana cost" | First-spell-free static (§20) |
 | Xu-Ifit, Osteoharmonist | reanimate "It's a Skeleton ... and has no abilities" | Reanimate as typed, ability-stripped permanent (§21) |

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1548,6 +1548,17 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
 - `TargetControlsCreature(target)` — target player has a creature.
 - `TargetControlsLand(target)` — target player has a land.
 - `TargetMatchesFilter(filter, targetIndex = 0)` — the context target matches a `GameObjectFilter`.
+- `IfTargetTookExcessDamage(targetIndex = 0)` — true post-damage when the target creature's marked
+  damage strictly exceeds its (projected) toughness. Chain after `Effects.DealDamage` in a composite
+  so the marked-damage update applies before the condition reads it. Used by Orbital Plunge ("If
+  excess damage was dealt this way, create a Lander token"). Semantics caveat: the read is
+  `marked > toughness` regardless of which preceding step dealt the damage — Composite doesn't
+  interleave SBA or fire triggers mid-chain, so for the canonical "deal N, then check" pipeline
+  this is equivalent to "did the preceding step deal excess". A chain that deals damage in
+  multiple steps within the same composite would see cumulative damage; reach for a different
+  condition there. Defensive guards return false for non-creature targets and targets no longer
+  on the battlefield (unreachable under `Targets.Creature` + Composite, retained for future
+  callers).
 - `TargetSharesMostCommonColor(targetIndex = 0)` — the context target shares a color with the
   most common color among all permanents, or a color tied for most common. Tallies each of the
   five colors across every battlefield permanent (multicolored permanents count once per color,
@@ -1996,6 +2007,19 @@ replacementEffect {
   the copy ("When you do, exile that card"). `filterByTotalManaSpent` restricts copy targets to mana
   value ≤ total mana spent (Mockingbird). The copy snapshots a `CopyOfComponent` so it reverts to its
   printed identity when it leaves the battlefield (CR 400.7 / 707.2).
+- `ModifyDrawAmount(modifier, restrictions, appliesTo)` — modify the number of cards a draw
+  instruction announces by a fixed amount, optionally gated by extra `restrictions: List<Condition>`
+  evaluated against the drawing player as controller. Applied **once** per draw instruction at the
+  announcement site — `DrawCardsExecutor.execute` for spell/ability draws and
+  `DrawPhaseManager.performDrawStep` for the draw step (CR 121.2a: "An instruction to draw multiple
+  cards can be modified by replacement effects that refer to the number of cards drawn. This
+  modification occurs before considering any of the individual card draws.") — so a paused-and-
+  resumed per-card loop doesn't double-modify. Note that "you" in restriction text reads as the
+  drawing player, not the source's controller; for `DrawEvent(player = Player.You)` they coincide,
+  but `DrawEvent(player = Player.Opponent)` cards needing "you" = source controller would have to
+  use a source-relative condition instead. Use for "if you would draw one or more cards, you draw
+  that many cards plus N instead" (Quantum Riddler:
+  `ModifyDrawAmount(modifier = 1, restrictions = listOf(Conditions.CardsInHandAtMost(1)), appliesTo = DrawEvent(player = Player.You))`).
 - Custom — implement the `ReplacementEffect` interface directly.
 
 Amount-modifying replacements expose **both** `multiplier` (×) and `modifier` (±) on the same type — do not split into

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BladeOfTheSwarmScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/BladeOfTheSwarmScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.WarpExiledComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Blade of the Swarm (EOE) — {3}{B} Creature — Insect Assassin, 3/1.
+ *
+ * "When this creature enters, choose one —
+ *  • Put two +1/+1 counters on this creature.
+ *  • Put target exiled card with warp on the bottom of its owner's library."
+ *
+ * Exercises the modal ETB trigger, the new exile-zone branch of
+ * [com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils.findValidObjectTargets],
+ * and the cross-zone move from exile to library bottom.
+ */
+class BladeOfTheSwarmScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Blade of the Swarm's ETB modal trigger") {
+
+            test("mode 2 puts a warp-exiled card on the bottom of its owner's library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Blade of the Swarm")
+                    .withCardInExile(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Stamp the WarpExiledComponent on the exiled Grizzly Bears so the warp-exile
+                // predicate matches it at targeting time.
+                val exileZone = game.state.getZone(ZoneKey(game.player1Id, Zone.EXILE))
+                val warpBears = exileZone.first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                game.state = game.state.updateEntity(warpBears) { container ->
+                    container.with(WarpExiledComponent(controllerId = game.player1Id))
+                }
+
+                val cast = game.castSpell(1, "Blade of the Swarm")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // The ETB trigger is on the stack; resolving it surfaces a ChooseModeDecision.
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision for the ETB trigger; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 1))
+
+                // Mode 1 (zero-indexed) is the warp-exile branch — engine then asks for the target.
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision after mode pick; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(warpBears))))
+                game.resolveStack()
+
+                val libraryAfter = game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY))
+                val exileAfter = game.state.getZone(ZoneKey(game.player1Id, Zone.EXILE))
+                withClue("Grizzly Bears should have moved out of exile") {
+                    exileAfter.contains(warpBears) shouldBe false
+                }
+                withClue("Grizzly Bears should be on the bottom of player 1's library") {
+                    libraryAfter.last() shouldBe warpBears
+                }
+            }
+
+            test("opponent's warp-exiled card is also a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Blade of the Swarm")
+                    .withCardInExile(2, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Stamp opponent's Hill Giant as warp-exiled (warp markers point at the
+                // *original* controller — the opponent — so they still own it in exile).
+                val exileZone = game.state.getZone(ZoneKey(game.player2Id, Zone.EXILE))
+                val warpGiant = exileZone.first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Hill Giant"
+                }
+                game.state = game.state.updateEntity(warpGiant) { container ->
+                    container.with(WarpExiledComponent(controllerId = game.player2Id))
+                }
+
+                game.castSpell(1, "Blade of the Swarm").error shouldBe null
+                game.resolveStack()
+
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 1))
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision after mode pick")
+                withClue("Opponent's warp-exiled Hill Giant should be a legal target") {
+                    targetDecision.legalTargets[0]?.contains(warpGiant) shouldBe true
+                }
+
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(warpGiant))))
+                game.resolveStack()
+
+                val opponentLibrary = game.state.getZone(ZoneKey(game.player2Id, Zone.LIBRARY))
+                withClue("Hill Giant should be on the bottom of opponent's library (it's its owner)") {
+                    opponentLibrary.last() shouldBe warpGiant
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CosmogoyfScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/CosmogoyfScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Cosmogoyf (EOE) — {B}{G} Creature — Elemental Lhurgoyf.
+ *
+ * "Cosmogoyf's power is equal to the number of cards you own in exile and its toughness is
+ *  equal to that number plus 1."
+ *
+ * Tarmogoyf-style CDA composed from existing primitives: dynamic power/toughness via
+ * `DynamicAmounts.zone(Player.You, Zone.EXILE).count()`, with a +1 toughness offset.
+ */
+class CosmogoyfScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Cosmogoyf's */*+1 stats track cards in its controller's exile") {
+
+            test("with no cards in exile, Cosmogoyf is 0/1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cosmogoyf")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goyf = game.findPermanent("Cosmogoyf")!!
+                val projected = stateProjector.project(game.state)
+                projected.getPower(goyf) shouldBe 0
+                projected.getToughness(goyf) shouldBe 1
+            }
+
+            test("with three cards in controller's exile, Cosmogoyf is 3/4") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cosmogoyf")
+                    .withCardInExile(1, "Grizzly Bears")
+                    .withCardInExile(1, "Hill Giant")
+                    .withCardInExile(1, "Shock")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goyf = game.findPermanent("Cosmogoyf")!!
+                val projected = stateProjector.project(game.state)
+                withClue("Power = cards in your exile = 3") {
+                    projected.getPower(goyf) shouldBe 3
+                }
+                withClue("Toughness = that number + 1 = 4") {
+                    projected.getToughness(goyf) shouldBe 4
+                }
+            }
+
+            test("cards in the OPPONENT's exile do not count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cosmogoyf")
+                    .withCardInExile(2, "Grizzly Bears")
+                    .withCardInExile(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goyf = game.findPermanent("Cosmogoyf")!!
+                val projected = stateProjector.project(game.state)
+                projected.getPower(goyf) shouldBe 0
+                projected.getToughness(goyf) shouldBe 1
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/OrbitalPlungeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/OrbitalPlungeScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Orbital Plunge (EOE) — {3}{R} Sorcery.
+ *
+ * "Orbital Plunge deals 6 damage to target creature. If excess damage was dealt this way,
+ *  create a Lander token."
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.conditions.TargetMarkedDamageExceedsToughness]
+ * condition: the conditional Lander payoff fires only when the marked damage left on the
+ * creature after resolution STRICTLY exceeds its (projected) toughness — equality is not excess.
+ */
+class OrbitalPlungeScenarioTest : ScenarioTestBase() {
+
+    // Vanilla 0/6 wall used to pin the equality boundary: 6 damage to toughness 6.
+    private val testWall = card("Orbital Plunge Test Wall") {
+        manaCost = "{4}"
+        typeLine = "Creature — Wall"
+        power = 0
+        toughness = 6
+    }
+
+    init {
+        cardRegistry.register(testWall)
+
+        context("Orbital Plunge's excess-damage Lander payoff") {
+
+            test("6 damage to a 2/2 creature is excess → create a Lander") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Orbital Plunge")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Orbital Plunge", bears)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // Grizzly Bears took 6 damage with toughness 2 → 4 excess. Lander created.
+                withClue("A Lander token should exist on player 1's battlefield") {
+                    game.state.getBattlefield().any { entityId ->
+                        val card = game.state.getEntity(entityId)?.get<CardComponent>()
+                        card?.name == "Lander"
+                    } shouldBe true
+                }
+            }
+
+            test("6 damage to a 0/6 creature exactly equals toughness → no Lander") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Orbital Plunge")
+                    .withCardOnBattlefield(2, "Orbital Plunge Test Wall") // 0/6
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Orbital Plunge Test Wall")!!
+                game.castSpell(1, "Orbital Plunge", target).error shouldBe null
+                game.resolveStack()
+
+                // marked damage (6) == toughness (6) — the condition uses strict-greater,
+                // so the Lander payoff must not fire on the equality boundary.
+                withClue("No Lander when damage exactly equals toughness (strict-greater)") {
+                    game.state.getBattlefield().none { entityId ->
+                        val card = game.state.getEntity(entityId)?.get<CardComponent>()
+                        card?.name == "Lander"
+                    } shouldBe true
+                }
+            }
+
+            test("6 damage to a 9/9 creature is below lethal → no Lander") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Orbital Plunge")
+                    .withCardOnBattlefield(2, "Bygone Colossus") // 9/9
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Bygone Colossus")!!
+                game.castSpell(1, "Orbital Plunge", target).error shouldBe null
+                game.resolveStack()
+
+                withClue("No Lander when damage is less than toughness") {
+                    game.state.getBattlefield().none { entityId ->
+                        val card = game.state.getEntity(entityId)?.get<CardComponent>()
+                        card?.name == "Lander"
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/QuantumRiddlerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/QuantumRiddlerScenarioTest.kt
@@ -104,7 +104,7 @@ class QuantumRiddlerScenarioTest : ScenarioTestBase() {
 
             test("cycling's 'Draw a card' is modified when the hand-size restriction holds") {
                 // Regression for the third announcement site wired into the modifier:
-                // CycleCardHandler. Cycling is "Discard this, Draw a card" (CR 702.32a), so
+                // CycleCardHandler. Cycling is "Discard this, Draw a card" (CR 702.29a), so
                 // its draw is its own announcement site — Quantum Riddler must add +1 when
                 // its restriction holds. Hundroog ({6}{G}, cycling {3}) is registered via
                 // LegionsSet; with only Hundroog in hand, the post-discard hand is empty and

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/QuantumRiddlerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/QuantumRiddlerScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Quantum Riddler (EOE) — {3}{U}{U} Creature — Sphinx, 4/6.
+ *
+ * "Flying
+ *  When this creature enters, draw a card.
+ *  As long as you have one or fewer cards in hand, if you would draw one or more cards,
+ *  you draw that many cards plus one instead.
+ *  Warp {1}{U}"
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.ModifyDrawAmount] replacement:
+ * the +1 modifier applies to draw events while the hand-size restriction holds and
+ * does not apply once the restriction lifts.
+ *
+ * Verified by casting Quantum Riddler itself — once it resolves and its ETB
+ * "draw a card" trigger goes on the stack, the modifier evaluates the hand size at
+ * trigger-resolution time (after Riddler has left hand). With an otherwise empty hand,
+ * the ETB-draw 1 becomes draw 2.
+ */
+class QuantumRiddlerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Quantum Riddler's conditional +1 draw replacement") {
+
+            test("ETB-draw 1 becomes draw 2 when hand is otherwise empty after casting") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Quantum Riddler")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Quantum Riddler")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // After Riddler enters and its ETB-draw trigger resolves:
+                // - Hand = empty just before the trigger resolves (Riddler left as cast)
+                // - The +1 modifier applies because hand-size ≤ 1, so draw 1 → draw 2.
+                withClue("Hand should hold 2 drawn cards (1 + 1 from modifier)") {
+                    game.handSize(1) shouldBe 2
+                }
+            }
+
+            test("ETB-draw 1 stays 1 when hand size > 1 after casting") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Quantum Riddler")
+                    .withCardInHand(1, "Plains")
+                    .withCardInHand(1, "Swamp")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Quantum Riddler")
+                cast.error shouldBe null
+                game.resolveStack()
+
+                // After casting Riddler, hand = {Plains, Swamp} (size 2). When the ETB-draw
+                // trigger resolves, hand-size > 1, so the modifier does NOT apply: draw 1.
+                withClue("Hand should hold the original 2 cards plus 1 drawn (no modifier)") {
+                    game.handSize(1) shouldBe 3
+                }
+            }
+
+            test("draw-step draw is modified — turn 2 with hand = 0 draws 2 instead of 1") {
+                // Regression for the second announcement site wired into the modifier:
+                // DrawPhaseManager.performDrawStep. Turn 2 (not first-turn-first-player so the
+                // step isn't skipped), Quantum Riddler already on the battlefield, an empty
+                // hand → the +1 modifier applies and the draw step draws 2.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Quantum Riddler", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .withTurnNumber(2)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                    .build()
+
+                game.handSize(1) shouldBe 0
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                withClue("Draw step with hand-size = 0 should draw 1 + 1 = 2") {
+                    game.handSize(1) shouldBe 2
+                }
+            }
+
+            test("cycling's 'Draw a card' is modified when the hand-size restriction holds") {
+                // Regression for the third announcement site wired into the modifier:
+                // CycleCardHandler. Cycling is "Discard this, Draw a card" (CR 702.32a), so
+                // its draw is its own announcement site — Quantum Riddler must add +1 when
+                // its restriction holds. Hundroog ({6}{G}, cycling {3}) is registered via
+                // LegionsSet; with only Hundroog in hand, the post-discard hand is empty and
+                // the cycle draws 2.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Quantum Riddler", summoningSickness = false)
+                    .withCardInHand(1, "Hundroog")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cycle = game.cycleCard(1, "Hundroog")
+                withClue("Cycle should succeed: ${cycle.error}") { cycle.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Cycling with post-discard hand-size = 0 should draw 1 + 1 = 2") {
+                    game.handSize(1) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RovingActuatorScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/RovingActuatorScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Roving Actuator (EOE) — {3}{R} Artifact Creature — Robot, 3/4.
+ *
+ * "Void — When this creature enters, if a nonland permanent left the battlefield this turn or a
+ *  spell was warped this turn, exile up to one target instant or sorcery card with mana value 2
+ *  or less from your graveyard. Copy it. You may cast the copy without paying its mana cost."
+ *
+ * The card is pure composition (no new SDK): a Void-gated ETB trigger
+ * ([com.wingedsheep.sdk.dsl.Conditions.Void]) wrapping the Shiko-style exile → copy → may-cast
+ * pipeline. These tests cover the card's own wiring — the Void gate firing/not-firing and the
+ * composite order — rather than the shared pipeline (exercised by ShikoParagonOfTheWayScenarioTest).
+ *
+ * Void is satisfied by setting [com.wingedsheep.engine.state.GameState.nonlandPermanentLeftBattlefieldThisTurn]
+ * directly — the same flag [com.wingedsheep.engine.handlers.ConditionEvaluator] reads for
+ * `VoidCondition` — so the trigger condition holds deterministically without staging a separate
+ * removal spell.
+ */
+class RovingActuatorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Roving Actuator's Void-gated ETB") {
+
+            test("Void satisfied — exiles a graveyard Shock, copies it, casts the copy for free") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Roving Actuator")
+                    .withCardInGraveyard(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Satisfy Void: a nonland permanent left the battlefield this turn.
+                game.state = game.state.copy(nonlandPermanentLeftBattlefieldThisTurn = true)
+
+                val shockId = game.state.getGraveyard(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Shock"
+                }
+
+                val cast = game.castSpell(1, "Roving Actuator")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // Roving Actuator enters; its Void-gated ETB fires and pauses for its target.
+                game.selectTargets(listOf(shockId))
+                // Trigger resolves: exile Shock, copy it, prompt "you may cast the copy".
+                game.resolveStack()
+                game.answerYesNo(true)
+                // The Shock copy is "deals 2 damage to any target" — point it at the opponent.
+                game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+
+                withClue("Shock copy should deal 2 damage to the opponent") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("The original Shock is exiled, not returned to the graveyard") {
+                    game.isInGraveyard(1, "Shock") shouldBe false
+                }
+            }
+
+            test("Void not satisfied — the ETB ability does not trigger") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Roving Actuator")
+                    .withCardInGraveyard(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInLibrary(1, "Mountain")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // No nonland permanent left and no spell was warped this turn — Void is off.
+                val cast = game.castSpell(1, "Roving Actuator")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("With Void off, no target/choice decision should be pending") {
+                    game.state.pendingDecision shouldBe null
+                }
+                withClue("Shock stays in the graveyard — nothing was exiled") {
+                    game.isInGraveyard(1, "Shock") shouldBe true
+                }
+                withClue("No copy was cast, so the opponent took no damage") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/b/blade-of-the-swarm.json
+++ b/manual-scenarios/cards/b/blade-of-the-swarm.json
@@ -1,0 +1,75 @@
+{
+  "player1Name": "Swarmlord",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Blade of the Swarm",
+      "Perigee Beckoner",
+      "Blessed Light"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Loading Zone"
+    ],
+    "battlefield": [
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "END"
+  ],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/c/cosmogoyf.json
+++ b/manual-scenarios/cards/c/cosmogoyf.json
@@ -1,0 +1,42 @@
+{
+  "player1Name": "Lhurgoyf",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Anticausal Vestige",
+      "All-Fates Stalker",
+      "Loading Zone"
+    ],
+    "battlefield": [
+      {"name": "Cosmogoyf"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Swamp", "Plains", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/o/orbital-plunge.json
+++ b/manual-scenarios/cards/o/orbital-plunge.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Kav Pilot",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Orbital Plunge"
+    ],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Hill Giant"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/q/quantum-riddler.json
+++ b/manual-scenarios/cards/q/quantum-riddler.json
@@ -1,0 +1,46 @@
+{
+  "player1Name": "Sphinx",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Quantum Riddler"
+    ],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Grizzly Bears",
+      "Hill Giant",
+      "Shock",
+      "Island",
+      "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Hill Giant"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/r/roving-actuator.json
+++ b/manual-scenarios/cards/r/roving-actuator.json
@@ -1,0 +1,43 @@
+{
+  "player1Name": "Actuator",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Roving Actuator",
+      "Bygone Colossus"
+    ],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [
+      "Shock",
+      "Plasma Bolt"
+    ],
+    "library": ["Mountain", "Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -233,6 +233,25 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TargetSharesMostCommonColor(targetIndex)
 
     /**
+     * "If excess damage was dealt this way" — true post-damage when the target creature's
+     * marked damage strictly exceeds its (projected) toughness. Chain after `DealDamage`
+     * in a composite to fire a payoff on lethal-exceeding damage. Used by Orbital Plunge:
+     * `Composite(DealDamage(6, t), Conditional(IfTargetTookExcessDamage(), CreateLander()))`.
+     *
+     * Semantics caveat: the condition reads marked-damage > toughness on the target as it
+     * stands when the chain reaches this step, regardless of which preceding effect dealt
+     * the damage. CompositeEffect resolves sub-effects sequentially without an interleaved
+     * SBA pass and without firing other triggered abilities mid-chain, so for a "deal N
+     * to a target, then check" pipeline the only marked damage in play is the damage just
+     * dealt — making this read equivalent to "did the source effect deal excess to the
+     * target". A future card that deals damage in multiple steps within the same composite
+     * (or chains past SBA somehow) would see cumulative marked damage instead, so prefer
+     * a different condition for those shapes.
+     */
+    fun IfTargetTookExcessDamage(targetIndex: Int = 0): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TargetMarkedDamageExceedsToughness(targetIndex)
+
+    /**
      * If another permanent with the same name as the target is on the battlefield.
      * The target permanent itself is excluded from the comparison. Used by Winnow.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -511,6 +511,63 @@ data class CapDamage(
 // =============================================================================
 
 /**
+ * Modify the number of cards a draw event draws by a fixed amount, optionally gated by
+ * additional [restrictions]. Applied at the call site where the original draw count is
+ * announced (spell/ability resolution and the draw step), so the modifier fires once per
+ * draw instruction (CR 121.2a: "An instruction to draw multiple cards can be modified by
+ * replacement effects that refer to the number of cards drawn. This modification occurs
+ * before considering any of the individual card draws.") and is not re-applied when a
+ * paused per-card draw loop resumes.
+ *
+ * Each entry in [restrictions] is a [Condition] evaluated against the drawing player as
+ * the controller context; the modification only applies when ALL restrictions hold. This
+ * mirrors [ModifyLifeLoss]'s shape — use it for cards whose extra-draw clause is gated by
+ * arbitrary additional conditions. Note that "you" in restriction text reads as the drawing
+ * player, not the source's controller — for `DrawEvent(player = Player.You)` they're the
+ * same, but a future `DrawEvent(player = Player.Opponent)` card whose restriction means
+ * "you" = source controller would need a source-relative condition instead.
+ *
+ * Examples:
+ * - Quantum Riddler ("As long as you have one or fewer cards in hand, if you would draw
+ *   one or more cards, you draw that many cards plus one instead"):
+ *     `ModifyDrawAmount(modifier = 1,
+ *                       restrictions = listOf(Conditions.CardsInHandAtMost(1)),
+ *                       appliesTo = DrawEvent(player = Player.You))`
+ *
+ * @param modifier Flat amount added to the draw count when the event fires for a matching
+ *        player. Negative values reduce the draw (clamped to ≥ 0 by the caller).
+ * @param restrictions Additional [Condition]s gating when the modifier applies. Evaluated
+ *        against the drawing player as controller; ALL must hold.
+ */
+@SerialName("ModifyDrawAmount")
+@Serializable
+data class ModifyDrawAmount(
+    val modifier: Int,
+    val restrictions: List<Condition> = emptyList(),
+    override val appliesTo: GameEvent = GameEvent.DrawEvent()
+) : ReplacementEffect {
+    override val description: String = buildString {
+        val restrictionDesc = restrictions.joinToString(" and ") { it.description.removePrefix("if ") }
+        if (restrictionDesc.isNotEmpty()) {
+            append(restrictionDesc.replaceFirstChar { it.uppercase() })
+            append(", if ")
+        } else {
+            append("If ")
+        }
+        append(appliesTo.description)
+        append(", they draw that many cards plus $modifier instead")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        val newRestrictions = restrictions.map { it.applyTextReplacement(replacer) }
+        val anyChanged = newAppliesTo !== appliesTo ||
+            newRestrictions.zip(restrictions).any { (n, o) -> n !== o }
+        return if (anyChanged) copy(appliesTo = newAppliesTo, restrictions = newRestrictions) else this
+    }
+}
+
+/**
  * Replace drawing with another effect.
  * Example: Underrealm Lich (look at 3, put 1 in hand, rest in graveyard)
  */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -190,6 +190,40 @@ data class TargetMatchesFilter(
 }
 
 /**
+ * Condition: "if excess damage was dealt this way" — true when the target creature's
+ * marked damage now strictly exceeds its (projected) toughness.
+ *
+ * Reads post-damage state, so chain it AFTER a [com.wingedsheep.sdk.scripting.effects.DealDamageEffect]
+ * with `Effects.Composite(DealDamage(N, t), ConditionalEffect(IfTargetTookExcessDamage(0), ...))`.
+ *
+ * What this actually checks is `marked > toughness` on the target at evaluation time,
+ * regardless of which preceding step in the chain dealt the damage. CompositeEffect
+ * resolves sub-effects sequentially without an interleaved SBA pass or mid-chain trigger
+ * processing, so for the canonical "deal N to a target, then check" pipeline this is
+ * equivalent to "did the preceding deal-damage step push the target past lethal" — there
+ * is no other source of marked damage in scope. Don't reuse this in a chain that deals
+ * damage in multiple steps within the same composite, or that runs past SBA somehow; you'd
+ * see cumulative marked damage instead, and the condition would lie about which step caused
+ * the excess.
+ *
+ * Defensive guards (target is not a creature, target left the battlefield) return false.
+ * In the canonical Orbital Plunge chain these can't fire — `Targets.Creature` rules out
+ * non-creature targets, and Composite never reaches SBA between steps so the target is
+ * still on the battlefield. They exist for future callers that might wrap this in a longer
+ * chain crossing SBA or re-target between steps.
+ *
+ * Used by Orbital Plunge: "If excess damage was dealt this way, create a Lander token."
+ */
+@SerialName("TargetMarkedDamageExceedsToughness")
+@Serializable
+data class TargetMarkedDamageExceedsToughness(
+    val targetIndex: Int = 0
+) : Condition {
+    override val description: String = "if excess damage was dealt this way"
+    override fun applyTextReplacement(replacer: TextReplacer): Condition = this
+}
+
+/**
  * Condition: "if another permanent with the same name as [target] is on the battlefield".
  *
  * Resolves the context target at [targetIndex], reads its card name, and returns true when at

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/BladeOfTheSwarm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/BladeOfTheSwarm.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Blade of the Swarm
+ * {3}{B}
+ * Creature — Insect Assassin
+ * 3/1
+ *
+ * When this creature enters, choose one —
+ *  • Put two +1/+1 counters on this creature.
+ *  • Put target exiled card with warp on the bottom of its owner's library.
+ *
+ * The warp-exile-targeting mode reuses the engine's exile-zone target enumeration
+ * (extended in [com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils])
+ * with the existing [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsWarpExiled]
+ * marker, then composes [MoveToZoneEffect] with [ZonePlacement.Bottom] to send the
+ * targeted card to its owner's library bottom — no new effect class required.
+ */
+val BladeOfTheSwarm = card("Blade of the Swarm") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect Assassin"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature enters, choose one —\n" +
+        "• Put two +1/+1 counters on this creature.\n" +
+        "• Put target exiled card with warp on the bottom of its owner's library."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+                "Put two +1/+1 counters on this creature",
+            ),
+            Mode.withTarget(
+                MoveToZoneEffect(EffectTarget.ContextTarget(0), Zone.LIBRARY, ZonePlacement.Bottom),
+                TargetObject(
+                    filter = TargetFilter(
+                        GameObjectFilter.Any.warpExiled(),
+                        zone = Zone.EXILE,
+                    ),
+                ),
+                "Put target exiled card with warp on the bottom of its owner's library",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Nino Is"
+        flavorText = "The Eumidians sought the secret of weftwalking in Drix DNA. Though they failed, their attempts yielded other gains."
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b157330a-2652-4ed9-b8fa-8e72b4eda15c.jpg?1752946918"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Cosmogoyf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Cosmogoyf.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Cosmogoyf
+ * {B}{G}
+ * Creature — Elemental Lhurgoyf
+ *
+ * Cosmogoyf's power is equal to the number of cards you own in exile and its
+ * toughness is equal to that number plus 1.
+ *
+ * The Tarmogoyf-style star-over-star-plus-one body composed out of existing primitives — the
+ * dynamic power/toughness read the source's controller's exile sub-zone via
+ * [DynamicAmounts.zone] + COUNT, and `dynamicStats(toughnessOffset = 1)` wires
+ * the same source as a base-set characteristic-defining value through
+ * [com.wingedsheep.sdk.model.CharacteristicValue.DynamicWithOffset].
+ */
+val Cosmogoyf = card("Cosmogoyf") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Elemental Lhurgoyf"
+    dynamicStats(
+        DynamicAmounts.zone(Player.You, Zone.EXILE).count(),
+        toughnessOffset = 1,
+    )
+    oracleText = "Cosmogoyf's power is equal to the number of cards you own in exile and " +
+        "its toughness is equal to that number plus 1."
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "215"
+        artist = "Chris Rahn"
+        flavorText = ">Alert: COSMOGOYF\n>Recommended Action: RUN\n—PSS Erix shipboard computer, final transmission"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e07d3c6-60a5-44d1-a926-6414be85bd50.jpg?1752947436"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/OrbitalPlunge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/OrbitalPlunge.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Orbital Plunge
+ * {3}{R}
+ * Sorcery
+ *
+ * Orbital Plunge deals 6 damage to target creature. If excess damage was dealt
+ * this way, create a Lander token. (It's an artifact with "{2}, {T}, Sacrifice
+ * this token: Search your library for a basic land card, put it onto the
+ * battlefield tapped, then shuffle.")
+ *
+ * Composed from existing atoms — [Effects.DealDamage] writes marked damage to the
+ * target, then [Conditions.IfTargetTookExcessDamage] reads the post-damage state to
+ * gate the Lander payoff. No bespoke "excess damage detection" executor needed.
+ */
+val OrbitalPlunge = card("Orbital Plunge") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Orbital Plunge deals 6 damage to target creature. If excess damage was dealt " +
+        "this way, create a Lander token. (It's an artifact with \"{2}, {T}, Sacrifice this " +
+        "token: Search your library for a basic land card, put it onto the battlefield tapped, " +
+        "then shuffle.\")"
+
+    spell {
+        val damaged = target("creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.DealDamage(6, damaged),
+            ConditionalEffect(
+                condition = Conditions.IfTargetTookExcessDamage(),
+                effect = Effects.CreateLander(),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Inkognit"
+        flavorText = "The Kav pilot gleefully ignored his lander's collision warning."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2dc7cc17-5319-4694-99c6-8c56a0b40a44.jpg?1752947156"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/QuantumRiddler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/QuantumRiddler.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.ModifyDrawAmount
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Quantum Riddler
+ * {3}{U}{U}
+ * Creature — Sphinx
+ * 4/6
+ *
+ * Flying
+ * When this creature enters, draw a card.
+ * As long as you have one or fewer cards in hand, if you would draw one or more cards,
+ * you draw that many cards plus one instead.
+ * Warp {1}{U}
+ *
+ * The draw-replacement static is expressed as a [ModifyDrawAmount] gated on a hand-size
+ * restriction. The engine consults this at the draw instruction's announcement site
+ * (CR 121.2a) — `DrawCardsExecutor.execute` for spell/ability draws and
+ * `DrawPhaseManager.performDrawStep` for the draw step — so the modifier fires once per
+ * draw instruction and is not re-applied when the per-card loop pauses and resumes.
+ */
+val QuantumRiddler = card("Quantum Riddler") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    power = 4
+    toughness = 6
+    oracleText = "Flying\n" +
+        "When this creature enters, draw a card.\n" +
+        "As long as you have one or fewer cards in hand, if you would draw one or more cards, " +
+        "you draw that many cards plus one instead.\n" +
+        "Warp {1}{U} (You may cast this card from your hand for its warp cost. Exile this " +
+        "creature at the beginning of the next end step, then you may cast it from exile on a " +
+        "later turn.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+        description = "When this creature enters, draw a card."
+    }
+
+    replacementEffect(
+        ModifyDrawAmount(
+            modifier = 1,
+            restrictions = listOf(Conditions.CardsInHandAtMost(1)),
+            appliesTo = GameEvent.DrawEvent(player = Player.You),
+        )
+    )
+
+    warp = "{1}{U}"
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "72"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/120be808-ff3b-4fca-96a1-4db6b9825856.jpg?1752946843"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/RovingActuator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/RovingActuator.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Roving Actuator
+ * {3}{R}
+ * Artifact Creature — Robot
+ * 3/4
+ *
+ * Void — When this creature enters, if a nonland permanent left the battlefield this turn
+ * or a spell was warped this turn, exile up to one target instant or sorcery card with mana
+ * value 2 or less from your graveyard. Copy it. You may cast the copy without paying its mana
+ * cost.
+ *
+ * Composed entirely from existing primitives — Shiko-style exile → copy → may-cast pipeline
+ * (CR 707.12) wrapped in a Void-gated ETB trigger ([Conditions.Void]). The "up to one" wording
+ * surfaces as `TargetObject(optional = true)` so the controller may decline targeting if no
+ * legal card exists.
+ */
+val RovingActuator = card("Roving Actuator") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Robot"
+    power = 3
+    toughness = 4
+    oracleText = "Void — When this creature enters, if a nonland permanent left the battlefield " +
+        "this turn or a spell was warped this turn, exile up to one target instant or sorcery " +
+        "card with mana value 2 or less from your graveyard. Copy it. You may cast the copy " +
+        "without paying its mana cost."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.Void
+        description = "Void — When this creature enters, if a nonland permanent left the " +
+            "battlefield this turn or a spell was warped this turn, exile up to one target " +
+            "instant or sorcery card with mana value 2 or less from your graveyard. Copy it. " +
+            "You may cast the copy without paying its mana cost."
+        val exiledCard = target(
+            "instant or sorcery card with mana value 2 or less from your graveyard",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.InstantOrSorcery.manaValueAtMost(2).ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.Composite(
+            MoveToZoneEffect(exiledCard, Zone.EXILE),
+            Effects.CopyCardIntoCollection(exiledCard, storeAs = "copy"),
+            MayEffect(
+                Effects.CastFromCollectionWithoutPayingCost("copy"),
+                descriptionOverride = "You may cast the copy without paying its mana cost.",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "157"
+        artist = "Sergey Glushakov"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/1111173b-ea49-4de4-b5b0-07d768c626b9.jpg?1752947187"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DrawPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DrawPhaseManager.kt
@@ -62,14 +62,25 @@ class DrawPhaseManager(
             )
         }
 
+        // Apply ModifyDrawAmount replacements once at the draw-step's announcement
+        // site (CR 121.2a) — e.g., Quantum Riddler's "draw that many cards plus one
+        // instead" turns this step's draw of 1 into 2 while its restriction holds.
+        val drawCount = dispatcher.applyDrawAmountModifier(state, activePlayer, 1)
+        if (drawCount <= 0) {
+            return ExecutionResult.success(
+                state.withPriority(activePlayer),
+                listOf(StepChangedEvent(Step.DRAW))
+            )
+        }
+
         // Ask "prompt on draw" abilities (e.g., Words of Wind) once up-front.
         // The draw loop runs with skipPromptOnDraw=true to avoid asking again.
-        val promptResult = checkPromptOnDraw(state, activePlayer, 1, isDrawStep = true)
+        val promptResult = checkPromptOnDraw(state, activePlayer, drawCount, isDrawStep = true)
         if (promptResult != null) {
             return promptResult
         }
 
-        val drawResult = drawCards(state, activePlayer, 1)
+        val drawResult = drawCards(state, activePlayer, drawCount)
         if (!drawResult.isSuccess) {
             return drawResult
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -62,6 +62,7 @@ import com.wingedsheep.sdk.scripting.conditions.WasCastFromZone
 import com.wingedsheep.engine.state.components.battlefield.CastFromGraveyardComponent
 import com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentHadSubtype
 import com.wingedsheep.sdk.scripting.conditions.AnotherPermanentWithSameNameAsTarget
+import com.wingedsheep.sdk.scripting.conditions.TargetMarkedDamageExceedsToughness
 import com.wingedsheep.sdk.scripting.conditions.TargetMatchesFilter
 import com.wingedsheep.sdk.scripting.conditions.TargetSharesMostCommonColor
 import com.wingedsheep.sdk.scripting.conditions.ColorIsMostCommon
@@ -228,6 +229,8 @@ class ConditionEvaluator(
             is TriggeringSpellHasSingleTarget -> ifResolution { evaluateTriggeringSpellHasSingleTarget(state, it) }
             is TriggeringSpellMatchesFilter -> ifResolution { evaluateTriggeringSpellMatchesFilter(state, condition, it) }
             is TargetMatchesFilter -> ifResolution { evaluateTargetMatchesFilter(state, condition, it) }
+            is TargetMarkedDamageExceedsToughness ->
+                ifResolution { evaluateTargetMarkedDamageExceedsToughness(state, condition, it) }
             is TargetSharesMostCommonColor -> ifResolution { evaluateTargetSharesMostCommonColor(state, condition, it) }
             is AnotherPermanentWithSameNameAsTarget ->
                 ifResolution { evaluateAnotherPermanentWithSameNameAsTarget(state, condition, it) }
@@ -690,6 +693,36 @@ class ConditionEvaluator(
         val predicateContext = PredicateContext.fromEffectContext(context)
         val projected = state.projectedState
         return predicateEvaluator.matches(state, projected, entityId, condition.filter, predicateContext)
+    }
+
+    /**
+     * Evaluate "if excess damage was dealt this way" — true when the target creature's
+     * marked damage strictly exceeds its (projected) toughness. Chained after a `DealDamage`
+     * step in a composite, so the marked-damage component reflects damage just dealt by
+     * the preceding step (Composite doesn't interleave SBA or fire other triggers between
+     * its sub-effects, so for the canonical pipeline no other source contributes marked
+     * damage in scope).
+     *
+     * The non-creature and not-on-battlefield branches return false defensively — under
+     * `Targets.Creature` + Composite they can't fire, but they keep this condition safe
+     * if a future caller wraps it in a longer chain that crosses SBA or re-targets.
+     */
+    private fun evaluateTargetMarkedDamageExceedsToughness(
+        state: GameState,
+        condition: TargetMarkedDamageExceedsToughness,
+        context: EffectContext
+    ): Boolean {
+        val target = context.targets.getOrNull(condition.targetIndex) ?: return false
+        val entityId = (target as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent)
+            ?.entityId ?: return false
+        if (entityId !in state.getBattlefield()) return false
+        val projected = state.projectedState
+        if (!projected.isCreature(entityId)) return false
+        val marked = state.getEntity(entityId)
+            ?.get<com.wingedsheep.engine.state.components.battlefield.DamageComponent>()
+            ?.amount ?: 0
+        val toughness = projected.getToughness(entityId) ?: return false
+        return marked > toughness
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
@@ -236,7 +236,7 @@ class CycleCardHandler(
         }
 
         // Draw a card using DrawCardsExecutor (checks replacement shields and promptOnDraw).
-        // Cycling is "Discard this card: Draw a card" (CR 702.32a), so its draw is an
+        // Cycling is "Discard this card: Draw a card" (CR 702.29a), so its draw is an
         // announcement site for ModifyDrawAmount (CR 121.2a) — e.g. Quantum Riddler's +1
         // applies to a cycle draw while its hand-size restriction holds.
         val drawExecutor = DrawCardsExecutor(cardRegistry = cardRegistry)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
@@ -235,9 +235,13 @@ class CycleCardHandler(
             events.addAll(triggerResult.events)
         }
 
-        // Draw a card using DrawCardsExecutor (checks replacement shields and promptOnDraw)
+        // Draw a card using DrawCardsExecutor (checks replacement shields and promptOnDraw).
+        // Cycling is "Discard this card: Draw a card" (CR 702.32a), so its draw is an
+        // announcement site for ModifyDrawAmount (CR 121.2a) — e.g. Quantum Riddler's +1
+        // applies to a cycle draw while its hand-size restriction holds.
         val drawExecutor = DrawCardsExecutor(cardRegistry = cardRegistry)
-        val drawResult = drawExecutor.executeDraws(currentState, action.playerId, 1)
+        val drawCount = drawExecutor.applyDrawAmountModifier(currentState, action.playerId, 1)
+        val drawResult = drawExecutor.executeDraws(currentState, action.playerId, drawCount)
         if (drawResult.isPaused) {
             return ExecutionResult.paused(
                 drawResult.state,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawCardsExecutor.kt
@@ -42,11 +42,15 @@ class DrawCardsExecutor(
             return EffectResult.error(state, "No valid player for draw")
         }
 
-        val count = amountEvaluator.evaluate(state, effect.count, context)
+        val baseCount = amountEvaluator.evaluate(state, effect.count, context)
 
         var currentState = state
         val allEvents = mutableListOf<GameEvent>()
         for (playerId in playerIds) {
+            // Apply ModifyDrawAmount once per draw instruction (CR 121.2a), at the
+            // announcement site — Quantum Riddler-style "draw N+1 instead". Re-applying
+            // inside the per-card loop or on resume would double-fire; do it here only.
+            val count = applyDrawAmountModifier(currentState, playerId, baseCount)
             val result = executeDraws(currentState, playerId, count)
             currentState = result.state
             allEvents.addAll(result.events)
@@ -94,6 +98,23 @@ class DrawCardsExecutor(
             emptyLibraryReason = "Empty library"
         )
     }
+
+    /**
+     * Apply [com.wingedsheep.sdk.scripting.ModifyDrawAmount] replacements to an
+     * announced draw count of [originalCount] for [playerId] (CR 121.2a). Used by
+     * other announcement sites that bypass [execute] and drive [executeDraws]
+     * directly (cycling's "Draw a card" — CR 702.32a; Grothama-style "each player
+     * draws cards equal to the damage they dealt to this creature") so that the
+     * +N modifier still fires once per draw instruction. The resume paths inside
+     * [com.wingedsheep.engine.handlers.continuations.DrawReplacementContinuationResumer]
+     * and [com.wingedsheep.engine.handlers.continuations.CoreAutoResumerModule]
+     * intentionally skip this — they're continuing an already-modified instruction.
+     */
+    fun applyDrawAmountModifier(
+        state: GameState,
+        playerId: EntityId,
+        originalCount: Int
+    ): Int = dispatcher.applyDrawAmountModifier(state, playerId, originalCount)
 
     /**
      * Expose the prompt-on-draw check so

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementDispatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementDispatcher.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ModifyDrawAmount
 import com.wingedsheep.sdk.scripting.PreventDraw
 import com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
@@ -351,5 +352,60 @@ class DrawReplacementDispatcher(
             }
         }
         return null
+    }
+
+    /**
+     * Apply [ModifyDrawAmount] replacements to an announced draw count for [playerId]
+     * (CR 121.2a — the draw-N instruction is modified by replacement effects that refer
+     * to the number of cards drawn before any individual card draws). Called once at the
+     * call site where the draw instruction is announced — spell/ability resolution and the
+     * draw step — and NOT at every iteration of the per-card draw loop, so a paused-and-
+     * resumed loop doesn't double-modify.
+     *
+     * Iterates every battlefield permanent's replacement effects, gates each by the
+     * [DrawEvent]'s `player` filter relative to [playerId] and the source's controller,
+     * and (if all `restrictions` hold) sums the modifier into [originalCount]. The
+     * final result is clamped to `≥ 0`.
+     */
+    fun applyDrawAmountModifier(
+        state: GameState,
+        playerId: EntityId,
+        originalCount: Int
+    ): Int {
+        if (originalCount <= 0) return originalCount
+        val conditionEvaluator = com.wingedsheep.engine.handlers.ConditionEvaluator()
+        var adjusted = originalCount
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val replacementSource = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val sourceControllerId = container.get<ControllerComponent>()?.playerId
+
+            for (effect in replacementSource.replacementEffects) {
+                if (effect !is ModifyDrawAmount) continue
+                val drawEvent = effect.appliesTo as? com.wingedsheep.sdk.scripting.GameEvent.DrawEvent ?: continue
+
+                val matchesPlayer = when (drawEvent.player) {
+                    Player.Each -> true
+                    Player.You -> sourceControllerId != null && playerId == sourceControllerId
+                    Player.Opponent, Player.EachOpponent ->
+                        sourceControllerId != null && playerId != sourceControllerId
+                    else -> false
+                }
+                if (!matchesPlayer) continue
+
+                val effectContext = com.wingedsheep.engine.handlers.EffectContext(
+                    sourceId = entityId,
+                    controllerId = playerId,
+                    opponentId = state.getOpponent(playerId),
+                )
+                val restrictionsHold = effect.restrictions.all { restriction ->
+                    conditionEvaluator.evaluate(state, restriction, effectContext)
+                }
+                if (!restrictionsHold) continue
+
+                adjusted += effect.modifier
+            }
+        }
+        return adjusted.coerceAtLeast(0)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/EachPlayerDrawsForDamageDealtToSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/EachPlayerDrawsForDamageDealtToSourceExecutor.kt
@@ -37,7 +37,13 @@ class EachPlayerDrawsForDamageDealtToSourceExecutor(
         var currentState = state
         val events = mutableListOf<GameEvent>()
         for (playerId in ordered) {
-            val count = perPlayer[playerId] ?: continue
+            val baseCount = perPlayer[playerId] ?: continue
+            if (baseCount <= 0) continue
+            // Each player's draw is its own announcement (CR 121.2c — each player's draws
+            // resolve in turn order as separate instructions), so ModifyDrawAmount (CR 121.2a)
+            // applies per-player. Without this, e.g. Quantum Riddler on a player's side
+            // wouldn't add +1 to their Grothama-LTB draw while their hand-size restriction held.
+            val count = drawCardsExecutor.applyDrawAmountModifier(currentState, playerId, baseCount)
             if (count <= 0) continue
             val result = drawCardsExecutor.executeDraws(currentState, playerId, count)
             currentState = result.state

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -175,8 +175,34 @@ class TargetEnumerationUtils(
         return when (filter.zone) {
             Zone.BATTLEFIELD -> findValidPermanentTargets(state, playerId, filter, sourceId)
             Zone.GRAVEYARD -> findValidGraveyardTargets(state, playerId, filter, sourceId)
+            Zone.EXILE -> findValidExileTargets(state, playerId, filter, sourceId)
             Zone.STACK -> findValidSpellTargets(state, playerId, filter)
             else -> emptyList()
+        }
+    }
+
+    /**
+     * Enumerate exile-zone targets. Mirrors [findValidGraveyardTargets]: when the filter
+     * restricts to cards you own/control, only scan the targeting player's exile sub-zone;
+     * otherwise scan every player's exile. Used for cards that target cards in exile
+     * directly — e.g., Blade of the Swarm's "target exiled card with warp" mode.
+     */
+    fun findValidExileTargets(
+        state: GameState,
+        playerId: EntityId,
+        filter: TargetFilter,
+        sourceId: EntityId? = null
+    ): List<EntityId> {
+        val playerIds = when (filter.baseFilter.controllerPredicate) {
+            ControllerPredicate.ControlledByYou, ControllerPredicate.OwnedByYou -> listOf(playerId)
+            else -> state.turnOrder.toList()
+        }
+        val context = PredicateContext(controllerId = playerId, sourceId = sourceId)
+        return playerIds.flatMap { pid ->
+            state.getExile(pid).filter { entityId ->
+                if (filter.excludeSelf && entityId == sourceId) return@filter false
+                predicateEvaluator.matches(state, state.projectedState, entityId, filter.baseFilter, context)
+            }
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -609,7 +609,8 @@ class StaticAbilityHandler(
         it is com.wingedsheep.sdk.scripting.ModifyLifeLoss ||
         it is com.wingedsheep.sdk.scripting.PreventDraw ||
         it is com.wingedsheep.sdk.scripting.DamageCantBePrevented || it is ReplaceDamageWithCounters ||
-        it is com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect || it is com.wingedsheep.sdk.scripting.ModifyCounterPlacement ||
+        it is com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect || it is com.wingedsheep.sdk.scripting.ModifyDrawAmount ||
+        it is com.wingedsheep.sdk.scripting.ModifyCounterPlacement ||
         it is com.wingedsheep.sdk.scripting.RedirectZoneChange || it is com.wingedsheep.sdk.scripting.PreventExtraTurns ||
         it is com.wingedsheep.sdk.scripting.RedirectZoneChangeWithEffect || it is com.wingedsheep.sdk.scripting.EntersWithCounters ||
         it is com.wingedsheep.sdk.scripting.EntersWithDynamicCounters || it is com.wingedsheep.sdk.scripting.DoubleCounterPlacement ||

--- a/web-client/src/components/decisions/DecisionUI.tsx
+++ b/web-client/src/components/decisions/DecisionUI.tsx
@@ -34,23 +34,30 @@ function isPlayerOnlyTargeting(decision: ChooseTargetsDecision, playerIds: Entit
 }
 
 /**
- * Check if all legal targets in a ChooseTargetsDecision are in graveyards.
- * Returns the graveyard cards if true, null otherwise.
+ * Check if all legal targets in a ChooseTargetsDecision live in a hidden-from-battlefield zone
+ * (graveyard or exile). Returns the cards if true, null otherwise — the caller routes the
+ * resulting list into [GraveyardTargetingUI], which handles both zones (rendering owner-keyed
+ * tabs and selection) since their pile semantics are identical for targeting.
+ *
+ * Mixed-zone target sets fall through to `null` here so they reach the battlefield targeting
+ * path instead — that's a degenerate case today (Blade of the Swarm only targets exile, no
+ * known card mixes graveyard + exile in one target slot).
  */
-function getGraveyardTargets(decision: ChooseTargetsDecision, gameState: ClientGameState | null) {
+function getGraveyardOrExileTargets(decision: ChooseTargetsDecision, gameState: ClientGameState | null) {
   if (!gameState) return null
   const legalTargets = decision.legalTargets[0] ?? []
   if (legalTargets.length === 0) return null
 
-  const graveyardCards = []
+  const cards = []
   for (const targetId of legalTargets) {
     const card = gameState.cards[targetId]
-    if (!card || card.zone?.zoneType !== ZoneType.GRAVEYARD) {
-      return null // Not all targets are graveyard cards
+    const zoneType = card?.zone?.zoneType
+    if (!card || (zoneType !== ZoneType.GRAVEYARD && zoneType !== ZoneType.EXILE)) {
+      return null
     }
-    graveyardCards.push(card)
+    cards.push(card)
   }
-  return graveyardCards
+  return cards
 }
 
 /**
@@ -230,14 +237,14 @@ export function DecisionUI() {
   if (pendingDecision.type === 'ChooseTargetsDecision') {
     const playerIds = gameState?.players.map((p) => p.playerId) ?? []
     const isPlayerOnly = isPlayerOnlyTargeting(pendingDecision, playerIds)
-    const graveyardTargets = getGraveyardTargets(pendingDecision, gameState)
+    const zoneTargets = getGraveyardOrExileTargets(pendingDecision, gameState)
 
-    // If all targets are in graveyards, show a selection overlay
-    if (graveyardTargets && graveyardTargets.length > 0) {
+    // If all targets are in graveyards or exile, show a pile-selection overlay
+    if (zoneTargets && zoneTargets.length > 0) {
       return (
         <GraveyardTargetingUI
           decision={pendingDecision}
-          graveyardCards={graveyardTargets}
+          graveyardCards={zoneTargets}
           responsive={responsive}
         />
       )

--- a/web-client/src/components/decisions/GraveyardTargetingUI.tsx
+++ b/web-client/src/components/decisions/GraveyardTargetingUI.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
+import { ZoneType } from '@/types'
 import type { EntityId, ChooseTargetsDecision, ClientCard } from '@/types'
 import { calculateFittingCardWidth, type ResponsiveSizes } from '@/hooks/useResponsive.ts'
 import { ZoneSelectionUI, type ZoneCardInfo } from './ZoneSelectionUI'
@@ -7,8 +8,10 @@ import { getCardImageUrl } from '@/utils/cardImages.ts'
 import styles from './DecisionUI.module.css'
 
 /**
- * Graveyard targeting UI - uses the shared ZoneSelectionUI component.
- * Supports selecting from multiple graveyards with tabs.
+ * Graveyard / exile pile targeting UI — uses the shared ZoneSelectionUI component.
+ * Supports selecting from multiple piles with owner tabs. Labels adapt to the cards'
+ * actual zone (Graveyard vs Exile) so the same component renders Blade of the Swarm's
+ * exile-targeting mode and the existing graveyard-target spells with the right wording.
  */
 export function GraveyardTargetingUI({
   decision,
@@ -68,11 +71,16 @@ export function GraveyardTargetingUI({
     }))
   }, [currentCards])
 
+  // The list is homogenous-zone by construction (the caller's filter routes mixed-zone
+  // sets elsewhere), so we read the first card's zone to pick wording for everything.
+  const pileZoneType = graveyardCards[0]?.zone?.zoneType ?? ZoneType.GRAVEYARD
+  const pileNoun = pileZoneType === ZoneType.EXILE ? 'Exile' : 'Graveyard'
+
   // Get player names for tabs
   const getPlayerLabel = (ownerId: EntityId): string => {
-    if (ownerId === viewingPlayerId) return 'Your Graveyard'
+    if (ownerId === viewingPlayerId) return `Your ${pileNoun}`
     const player = gameState?.players.find((p) => p.playerId === ownerId)
-    return player ? `${player.name}'s Graveyard` : "Opponent's Graveyard"
+    return player ? `${player.name}'s ${pileNoun}` : `Opponent's ${pileNoun}`
   }
 
   const handleConfirm = (selectedCards: EntityId[]) => {
@@ -88,7 +96,7 @@ export function GraveyardTargetingUI({
   const isOptionalTarget = minTargets === 0
   const isMultiTarget = maxTargets > 1
   const sourceName = decision.context.sourceName ?? 'this ability'
-  const title = isOptionalTarget ? `Resolve ${sourceName}` : 'Choose from Graveyard'
+  const title = isOptionalTarget ? `Resolve ${sourceName}` : `Choose from ${pileNoun}`
 
   // Derive the action verb from effectHint so the button/text matches the actual effect
   // (e.g., "Exile card in a graveyard" → "Exile"; "Return … to its owner's hand" → "Return to Hand").


### PR DESCRIPTION
Implements Cosmogoyf, Roving Actuator (no engine work), Blade of the Swarm (target-enumeration for Zone.EXILE), Orbital Plunge (excess-damage condition), and Quantum Riddler (ModifyDrawAmount replacement). 242 → 247 / 261 EOE booster.

SDK additions:
- Conditions.IfTargetTookExcessDamage / TargetMarkedDamageExceedsToughness — post-damage check that the target creature's marked damage strictly exceeds toughness. The check is `marked > toughness` regardless of which preceding step dealt the damage; CompositeEffect doesn't interleave SBA or trigger processing between sub-effects, so for the canonical "deal N, then check" pipeline this is equivalent to "did the preceding step deal excess." The defensive guards (non-creature target, target left the battlefield) are unreachable under `Targets.Creature` + Composite and retained for future callers — documented in both KDocs and the SDK reference.
- ModifyDrawAmount(modifier, restrictions, appliesTo) replacement effect, shaped like ModifyLifeLoss with a Condition list for arbitrary gating.

Engine wiring:
- TargetEnumerationUtils gains Zone.EXILE support via findValidExileTargets, honoring ControlledByYou / OwnedByYou predicates the same way as graveyard.
- DrawReplacementDispatcher.applyDrawAmountModifier consulted once per draw instruction at every announcement site (CR 121.2a — modifications to the draw count happen before any individual card draws):
    * DrawCardsExecutor.execute for spell/ability draws
    * DrawPhaseManager.performDrawStep for the draw step
    * CycleCardHandler for "Discard this, Draw a card" (CR 702.32a)
    * EachPlayerDrawsForDamageDealtToSourceExecutor, per-player, since each player's instruction is independently announced (CR 121.2c) Exposed as DrawCardsExecutor.applyDrawAmountModifier so the cycle and per-player-draw call sites — which drive executeDraws directly instead of going through execute() — can wire the announcement without learning about the dispatcher abstraction. Resume paths (DrawReplacementContinuationResumer, CoreAutoResumerModule) intentionally skip — they're continuing an already-modified instruction.
- ModifyDrawAmount added to StaticAbilityHandler.isRuntimeReplacementEffect.

UI: generalize the graveyard targeting overlay to also handle Zone.EXILE so Blade of the Swarm's "target exiled card with warp" mode renders the same pile-selection UI with "Your Exile" / "Opponent's Exile" labels instead of falling back to BattlefieldTargetingUI.

Tests: per-card scenarios in game-server cover both branches of each new mechanic (excess vs equality vs sub-lethal damage; hand-size threshold met vs not; self-exile vs opponent-exile target). QuantumRiddlerScenarioTest additionally regresses the draw-step announcement site (turn 2 with hand = 0 draws 2) and the cycling announcement site (cycling Hundroog with the hand-size restriction holding draws 2). Manual dev scenarios under manual-scenarios/cards/ stage each card so the key behavior is reachable in the dev UI in a single cast or short play sequence.