### PR TITLE
Add descend mechanic (CR 700.11) and Ruin-Lurker Bat (LCI)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1652,6 +1652,19 @@ default to "you" so card authors don't need to pass it explicitly.
   `PermanentTypesEnteredBattlefieldThisTurnComponent`, cleared by `CleanupPhaseManager` at
   end of turn. Every battlefield entry must go through `BattlefieldEntry.place` for this
   tracker to stay in sync. Shortcut: `Conditions.ArtifactEnteredBattlefieldThisTurn`.
+- `YouDescendedThisTurn(atLeast = 1)` — CR 700.11 gate: at least `atLeast` nontoken
+  permanent cards were put into your graveyard from *any* zone this turn (battlefield,
+  hand, library, stack, exile). Tokens do not count, even though they briefly enter the
+  graveyard before ceasing to exist; instants and sorceries do not count. The cards
+  themselves need not still be in the graveyard when the gate evaluates — the count is a
+  pure event tracker. Composes through `Compare(DynamicAmount.TurnTracking(Player.You,
+  TurnTracker.DESCENDED), GTE, Fixed(atLeast))`, so the same plumbing supports the bare
+  descend gate (`atLeast = 1`, Ruin-Lurker Bat: "At the beginning of your end step, if
+  you descended this turn, scry 1") and the descend N / fathomless descent ability words
+  (`atLeast = 4`, `atLeast = 8`). Backed by the per-player
+  `PlayerDescendedThisTurnComponent`, incremented in `ZoneTransitionService` whenever a
+  permanent (nontoken) card lands in a player's graveyard, and cleared by
+  `CleanupPhaseManager` at end of turn.
 
 ### Composition
 
@@ -1855,6 +1868,10 @@ the spell when the rider needs the stack (typically because it requires a player
 - `LANDS_PLAYED` — lands played this turn.
 - `FOOD_SACRIFICED` — Food tokens sacrificed.
 - `CARDS_LEFT_GRAVEYARD` — cards leaving your graveyard.
+- `DESCENDED` — number of times a player has descended this turn (CR 700.11) — i.e.
+  count of nontoken permanent cards put into that player's graveyard from any zone.
+  Backs `Conditions.YouDescendedThisTurn(atLeast)` and `DynamicAmounts.descendedThisTurn`
+  (descend N / fathomless descent ability words).
 
 ---
 

--- a/manual-scenarios/cards/r/ruin-lurker-bat.json
+++ b/manual-scenarios/cards/r/ruin-lurker-bat.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 18,
+    "hand": ["Shock", "Homarid Explorer"],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Ruin-Lurker Bat"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Plains", "Plains", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -616,6 +616,20 @@ object Conditions {
         trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.FOOD_SACRIFICED)
 
     /**
+     * If you descended this turn (CR 700.11) — i.e. at least one nontoken permanent
+     * card was put into your graveyard from any zone this turn. Tokens do not count;
+     * non-permanent cards (instants, sorceries) do not count.
+     *
+     * Pass [atLeast] > 1 for the descend N / fathomless descent ability words
+     * ("if you descended four or more times this turn").
+     *
+     * Used by the descend gate on cards like Ruin-Lurker Bat ("At the beginning of
+     * your end step, if you descended this turn, scry 1").
+     */
+    fun YouDescendedThisTurn(atLeast: Int = 1): ConditionInterface =
+        trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.DESCENDED, atLeast = atLeast)
+
+    /**
      * If a permanent of the given card type entered the battlefield under the given player's
      * control this turn. The permanent need not still be on the battlefield, still be of that
      * type, or still be under that player's control — only the entry event matters.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -254,6 +254,14 @@ object DynamicAmounts {
     fun lifeGainedThisTurn(player: Player = Player.You): DynamicAmount =
         DynamicAmount.TurnTracking(player, TurnTracker.LIFE_GAINED)
 
+    /**
+     * "The number of times [player] descended this turn" (CR 700.11) — count of
+     * nontoken permanent cards put into [player]'s graveyard from any zone this turn.
+     * Used by the descend N / fathomless descent ability words.
+     */
+    fun descendedThisTurn(player: Player = Player.You): DynamicAmount =
+        DynamicAmount.TurnTracking(player, TurnTracker.DESCENDED)
+
     /** The starting life total of a player (20 in standard, 40 in commander). */
     fun startingLifeTotal(player: Player = Player.You): DynamicAmount =
         DynamicAmount.StartingLifeTotal(player)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -49,7 +49,13 @@ enum class TurnTracker {
     /** Indicator (0 or 1) that the player sacrificed at least one Food this turn. */
     FOOD_SACRIFICED,
     /** Total cards that left the player's graveyard this turn (Bonecache Overseer). */
-    CARDS_LEFT_GRAVEYARD;
+    CARDS_LEFT_GRAVEYARD,
+    /**
+     * Number of times the player descended this turn (CR 700.11) — count of nontoken
+     * permanent cards put into the player's graveyard from any zone. Backs the descend
+     * gate and the descend N / fathomless descent ability words.
+     */
+    DESCENDED;
 
     fun descriptionFor(player: Player): String = when (this) {
         CREATURES_DIED -> "the number of creatures that died under ${player.possessive} control this turn"
@@ -65,6 +71,7 @@ enum class TurnTracker {
         LANDS_PLAYED -> "the number of lands ${player.description} played this turn"
         FOOD_SACRIFICED -> "whether ${player.description} sacrificed a Food this turn"
         CARDS_LEFT_GRAVEYARD -> "the number of cards that left ${player.possessive} graveyard this turn"
+        DESCENDED -> "the number of times ${player.description} descended this turn"
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RuinLurkerBat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RuinLurkerBat.kt
@@ -51,7 +51,8 @@ val RuinLurkerBat = card("Ruin-Lurker Bat") {
         flavorText = "\"Look! Aclazotz sends his children to watch over our pilgrimage.\"\n" +
             "—Clavileño, First of the Blessed"
         imageUri = "https://cards.scryfall.io/normal/front/d/6/d6bedf13-c2bc-4e5d-aba3-3c0d5495a9bb.jpg?1699043372"
-        ruling("2023-11-10", "You descended if a permanent card was put into your graveyard from anywhere this turn. Tokens are not cards, and putting a token into the graveyard doesn't count.")
-        ruling("2023-11-10", "The ability triggers only once during your end step, no matter how many times you descended that turn. If you haven't descended by the time your end step begins, it won't trigger at all.")
+        ruling("2023-11-10", "Some cards refer to a player who has \"descended this turn.\" This means that a permanent card has been put into that player's graveyard from anywhere this turn.")
+        ruling("2023-11-10", "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, and while tokens are put into the graveyard before ceasing to exist, that action doesn't count as a player having descended.")
+        ruling("2023-11-10", "Abilities that begin with \"At the beginning of your end step, if you descended this turn\" will trigger only once during your end step, no matter how many times you descended this turn. However, if you haven't descended this turn as your end step begins, the ability won't trigger at all. It's not possible to put a permanent card into your graveyard during the end step in time to have the ability trigger.")
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RuinLurkerBat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RuinLurkerBat.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ruin-Lurker Bat
+ * {W}
+ * Creature — Bat
+ * 1/1
+ *
+ * Flying, lifelink
+ * At the beginning of your end step, if you descended this turn, scry 1.
+ *
+ * "Descended this turn" is CR 700.11: at least one nontoken permanent card was
+ * put into your graveyard from any zone this turn. The condition is the
+ * `Conditions.YouDescendedThisTurn()` SDK gate (defaults to `atLeast = 1`),
+ * which reads the per-player descend counter maintained by `ZoneTransitionService`
+ * and cleared each turn by `CleanupPhaseManager`.
+ *
+ * Per the Scryfall ruling, the ability fires only once per end step regardless
+ * of how many times you descended that turn — the intervening-if gate is a
+ * boolean check on the counter, not a multiplier.
+ */
+val RuinLurkerBat = card("Ruin-Lurker Bat") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bat"
+    power = 1
+    toughness = 1
+    oracleText = "Flying, lifelink\n" +
+        "At the beginning of your end step, if you descended this turn, scry 1. " +
+        "(You descended if a permanent card was put into your graveyard from anywhere.)"
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouDescendedThisTurn()
+        effect = EffectPatterns.scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Camille Alquier"
+        flavorText = "\"Look! Aclazotz sends his children to watch over our pilgrimage.\"\n" +
+            "—Clavileño, First of the Blessed"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6bedf13-c2bc-4e5d-aba3-3c0d5495a9bb.jpg?1699043372"
+        ruling("2023-11-10", "You descended if a permanent card was put into your graveyard from anywhere this turn. Tokens are not cards, and putting a token into the graveyard doesn't count.")
+        ruling("2023-11-10", "The ability triggers only once during your end step, no matter how many times you descended that turn. If you haven't descended by the time your end step begins, it won't trigger at all.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -39,6 +39,7 @@ import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageThisTu
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.NonTokenCreaturesDiedThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PlayerDescendedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.OpponentCreaturesExiledThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PlayerEffectRemoval
 import com.wingedsheep.engine.state.components.player.MayCastCreaturesFromGraveyardWithForageComponent
@@ -367,6 +368,9 @@ class CleanupPhaseManager(
                 }
                 if (result.has<OpponentCreaturesExiledThisTurnComponent>()) {
                     result = result.without<OpponentCreaturesExiledThisTurnComponent>()
+                }
+                if (result.has<PlayerDescendedThisTurnComponent>()) {
+                    result = result.without<PlayerDescendedThisTurnComponent>()
                 }
                 if (result.has<LifeGainedThisTurnComponent>()) {
                     result = result.without<LifeGainedThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -410,6 +410,7 @@ val engineSerializersModule = SerializersModule {
         subclass(MayCastCreaturesFromGraveyardWithForageComponent::class)
         subclass(NonTokenCreaturesDiedThisTurnComponent::class)
         subclass(OpponentCreaturesExiledThisTurnComponent::class)
+        subclass(PlayerDescendedThisTurnComponent::class)
         subclass(PlayerCitysBlessingComponent::class)
         subclass(PlayerHexproofComponent::class)
         subclass(PlayerShroudComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -323,6 +323,11 @@ class DynamicAmountEvaluator(
                             ?.get<com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurnComponent>()
                             ?.count ?: 0
                     }
+                    TurnTracker.DESCENDED -> playerIds.sumOf { playerId ->
+                        state.getEntity(playerId)
+                            ?.get<com.wingedsheep.engine.state.components.player.PlayerDescendedThisTurnComponent>()
+                            ?.count ?: 0
+                    }
                 }
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurn
 import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.NonTokenCreaturesDiedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.OpponentCreaturesExiledThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PlayerDescendedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.SacrificedFoodThisTurnComponent
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.CounterType
@@ -420,6 +421,24 @@ object ZoneTransitionService {
                 val existing = playerContainer.get<CardsLeftGraveyardThisTurnComponent>()
                     ?: CardsLeftGraveyardThisTurnComponent()
                 playerContainer.with(CardsLeftGraveyardThisTurnComponent(existing.count + 1))
+            }
+        }
+
+        // 8d. Descend (CR 700.11): track permanent cards put into a player's graveyard
+        // from any zone. Tokens are excluded per Scryfall ruling — although tokens are
+        // briefly placed in the graveyard before ceasing to exist, that placement does
+        // not count as the owner having descended. Non-permanent cards (instants /
+        // sorceries entering the graveyard from the stack, hand, or library) are also
+        // excluded. The count is keyed on the card's owner, not its last controller —
+        // "your graveyard" is the owner's graveyard.
+        if (actualDestZone == Zone.GRAVEYARD &&
+            cardComponent.typeLine.isPermanent &&
+            !container.has<TokenComponent>()
+        ) {
+            newState = newState.updateEntity(ownerId) { playerContainer ->
+                val existing = playerContainer.get<PlayerDescendedThisTurnComponent>()
+                    ?: PlayerDescendedThisTurnComponent()
+                playerContainer.with(PlayerDescendedThisTurnComponent(existing.count + 1))
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -546,6 +546,21 @@ data class CardsLeftGraveyardThisTurnComponent(val count: Int = 0) : Component
 data object SacrificedFoodThisTurnComponent : Component
 
 /**
+ * Tracks the number of permanent (nontoken) cards put into this player's graveyard from
+ * any zone during the current turn — i.e. the number of times this player has
+ * "descended" per CR 700.11. Cleared at end of turn by CleanupPhaseManager.
+ *
+ * Per CR 700.11 / Scryfall ruling, the cards do not need to still be in the graveyard;
+ * the count is a pure event tracker.
+ *
+ * Used for the descend gate ("if you descended this turn", Ruin-Lurker Bat) and the
+ * descend N / fathomless descent ability words ("if you descended four or more times
+ * this turn", "the number of times you descended this turn").
+ */
+@Serializable
+data class PlayerDescendedThisTurnComponent(val count: Int = 0) : Component
+
+/**
  * Tracks which card types have entered the battlefield under this player's control this turn.
  * Populated by `BattlefieldEntry.place` (via `PermanentEntryTracker.record`) from the projected
  * types at the moment of entry, so a permanent that's an artifact-by-effect at ETB is recorded

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DescendTrackerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DescendTrackerTest.kt
@@ -1,0 +1,255 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.player.PlayerDescendedThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the descend tracker (CR 700.11).
+ *
+ * "Some cards refer to whether a player has 'descended this turn.' This means that a
+ * permanent card has been put into that player's graveyard from anywhere this turn.
+ * 'The number of times [a player] descended this turn' means 'the number of permanent
+ * cards put into [that player's] graveyard from anywhere this turn.' In both cases, no
+ * permanent cards put into the player's graveyard that turn are required to still be
+ * in that graveyard." — CR 700.11
+ *
+ * Backed by `PlayerDescendedThisTurnComponent`, incremented in `ZoneTransitionService`
+ * whenever a permanent (nontoken) card lands in a player's graveyard, and cleared at
+ * cleanup by `CleanupPhaseManager`. Surfaced via `TurnTracker.DESCENDED` so it composes
+ * with the existing `Conditions.YouDescendedThisTurn(atLeast)` / `DynamicAmount` chain.
+ */
+class DescendTrackerTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of(
+                "Forest" to 10,
+                "Plains" to 10,
+                "Mountain" to 5,
+                "Grizzly Bears" to 5,
+                "Lightning Bolt" to 5,
+                "Centaur Courser" to 5
+            ),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    fun GameTestDriver.descendCount(playerId: EntityId): Int =
+        state.getEntity(playerId)
+            ?.get<PlayerDescendedThisTurnComponent>()?.count ?: 0
+
+    fun GameTestDriver.evalDescended(atLeast: Int = 1): Boolean {
+        val controller = activePlayer!!
+        val context = EffectContext(
+            sourceId = null,
+            controllerId = controller,
+            opponentId = getOpponent(controller),
+            targets = emptyList(),
+            xValue = 0
+        )
+        return ConditionEvaluator().evaluate(state, Conditions.YouDescendedThisTurn(atLeast), context)
+    }
+
+    fun GameTestDriver.move(entityId: EntityId, destination: Zone) {
+        val result = ZoneTransitionService.moveToZone(
+            state = state,
+            entityId = entityId,
+            destinationZone = destination
+        )
+        replaceState(result.state)
+    }
+
+    test("starts at zero and condition is false") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.descendCount(player) shouldBe 0
+        driver.evalDescended() shouldBe false
+    }
+
+    test("creature destroyed (battlefield → graveyard) counts as descend") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.descendCount(player) shouldBe 0
+
+        driver.move(bears, Zone.GRAVEYARD)
+
+        driver.descendCount(player) shouldBe 1
+        driver.evalDescended() shouldBe true
+    }
+
+    test("permanent card discarded (hand → graveyard) counts as descend") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+        driver.descendCount(player) shouldBe 0
+
+        driver.move(bears, Zone.GRAVEYARD)
+
+        driver.descendCount(player) shouldBe 1
+        driver.evalDescended() shouldBe true
+    }
+
+    test("permanent card milled (library → graveyard) counts as descend") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        // Put a known permanent card on top of the library.
+        val courser = driver.putCardOnTopOfLibrary(player, "Centaur Courser")
+        driver.descendCount(player) shouldBe 0
+
+        driver.move(courser, Zone.GRAVEYARD)
+
+        driver.descendCount(player) shouldBe 1
+    }
+
+    test("land going to graveyard counts as descend (lands are permanent cards)") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val forest = driver.putCardInHand(player, "Forest")
+        driver.move(forest, Zone.GRAVEYARD)
+
+        driver.descendCount(player) shouldBe 1
+    }
+
+    test("non-permanent card (instant) going to graveyard does NOT count") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.move(bolt, Zone.GRAVEYARD)
+
+        driver.descendCount(player) shouldBe 0
+        driver.evalDescended() shouldBe false
+    }
+
+    test("token going to graveyard does NOT count, even though it's a permanent card type") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        // Build a Saproling token entity by hand — `putCreatureOnBattlefield` won't
+        // attach `TokenComponent`, and that's the marker the descend hook checks.
+        val tokenId = EntityId.generate()
+        val tokenContainer = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = "token:Saproling",
+                name = "Saproling Token",
+                manaCost = ManaCost.ZERO,
+                typeLine = TypeLine.parse("Creature - Saproling"),
+                baseStats = CreatureStats(1, 1),
+                colors = setOf(Color.GREEN),
+                ownerId = player
+            ),
+            OwnerComponent(player),
+            TokenComponent,
+            ControllerComponent(player),
+            SummoningSicknessComponent
+        )
+        driver.replaceState(
+            driver.state
+                .withEntity(tokenId, tokenContainer)
+                .addToZone(ZoneKey(player, Zone.BATTLEFIELD), tokenId)
+        )
+
+        driver.move(tokenId, Zone.GRAVEYARD)
+
+        driver.descendCount(player) shouldBe 0
+        driver.evalDescended() shouldBe false
+    }
+
+    test("counts accumulate across multiple permanent cards entering the graveyard") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+        val courser = driver.putCardInHand(player, "Centaur Courser")
+        val forest = driver.putCardInHand(player, "Forest")
+
+        driver.move(bears, Zone.GRAVEYARD)
+        driver.move(courser, Zone.GRAVEYARD)
+        driver.move(forest, Zone.GRAVEYARD)
+
+        driver.descendCount(player) shouldBe 3
+        driver.evalDescended(atLeast = 1) shouldBe true
+        driver.evalDescended(atLeast = 3) shouldBe true
+        driver.evalDescended(atLeast = 4) shouldBe false
+    }
+
+    test("count is keyed on owner — opponent's descends do not satisfy your condition") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val opponentBears = driver.putCardInHand(opponent, "Grizzly Bears")
+        driver.move(opponentBears, Zone.GRAVEYARD)
+
+        driver.descendCount(opponent) shouldBe 1
+        driver.descendCount(player) shouldBe 0
+        driver.evalDescended() shouldBe false // active player has not descended
+    }
+
+    test("condition stays true after the card has left the graveyard (CR 700.11)") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+        driver.move(bears, Zone.GRAVEYARD)
+
+        driver.descendCount(player) shouldBe 1
+        driver.evalDescended() shouldBe true
+
+        // Exile the card out of the graveyard — descended is still true for the turn.
+        driver.move(bears, Zone.EXILE)
+
+        driver.descendCount(player) shouldBe 1
+        driver.evalDescended() shouldBe true
+    }
+
+    test("count resets at end of turn") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.move(bears, Zone.GRAVEYARD)
+        driver.descendCount(player) shouldBe 1
+
+        // Advance to the end step, then bothPass through cleanup — TurnManager
+        // wipes the descend counter as the turn rolls over.
+        driver.passPriorityUntil(Step.END, maxPasses = 200)
+        driver.bothPass()
+        driver.activePlayer shouldBe opponent
+
+        driver.descendCount(player) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuinLurkerBatScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuinLurkerBatScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.ScriedEvent
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.RuinLurkerBat
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ruin-Lurker Bat (LCI #33): {W} 1/1 Bat — Flying, lifelink. "At the beginning of
+ * your end step, if you descended this turn, scry 1."
+ *
+ * Engine-level coverage of the descend tracker itself lives in
+ * [DescendTrackerTest]. This test just confirms the card wires the EOT trigger,
+ * the descend intervening-if, and the scry payload together correctly — both
+ * the gated-off and gated-on paths — by checking whether a `ScriedEvent` ever
+ * lands.
+ */
+class RuinLurkerBatScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RuinLurkerBat))
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    // Drain through scry's two prompts (bottom-pick, top-reorder) without changing
+    // the order — same pattern used by ScryTriggerScenarioTest.
+    fun GameTestDriver.drainScryDecisions(player: EntityId) {
+        repeat(4) {
+            when (val decision = pendingDecision) {
+                is SelectCardsDecision ->
+                    submitDecision(player, CardsSelectedResponse(decision.id, emptyList()))
+                is ReorderLibraryDecision ->
+                    submitDecision(player, OrderedResponse(decision.id, decision.cards))
+                else -> return
+            }
+        }
+    }
+
+    test("no scry trigger fires at end step when the controller has not descended") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(player, "Ruin-Lurker Bat")
+
+        val before = driver.events.size
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass() // pass the end step
+        driver.drainScryDecisions(player)
+
+        driver.events.drop(before).filterIsInstance<ScriedEvent>() shouldBe emptyList()
+    }
+
+    test("scry 1 fires at end step when the controller has descended this turn") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(player, "Ruin-Lurker Bat")
+
+        // Send a permanent (creature) card from hand to graveyard — this is the
+        // canonical "you descended this turn" event for a card with no real
+        // discard outlet on the board.
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+        val transition = ZoneTransitionService.moveToZone(
+            state = driver.state,
+            entityId = bears,
+            destinationZone = Zone.GRAVEYARD
+        )
+        driver.replaceState(transition.state)
+
+        val before = driver.events.size
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass() // let the EOT trigger go on the stack and start resolving
+        driver.drainScryDecisions(player)
+
+        val scried = driver.events.drop(before).filterIsInstance<ScriedEvent>()
+        scried.size shouldBe 1
+        scried.single().playerId shouldBe player
+        scried.single().count shouldBe 1
+    }
+})


### PR DESCRIPTION
## Summary

- Adds the descend tracker (CR 700.11) as a per-player counter: incremented in
  `ZoneTransitionService` whenever a nontoken permanent card lands in a player's
  graveyard from any zone, cleared at cleanup by `CleanupPhaseManager`. Surfaced
  via the existing `TurnTracker.DESCENDED` enum + `Conditions.YouDescendedThisTurn(atLeast)`
  and `DynamicAmounts.descendedThisTurn(player)` — the same chain already supports
  descend N / fathomless descent without further API changes.
- Adds **Ruin-Lurker Bat** (LCI #33, {W} 1/1 Bat — Flying, lifelink, "At the
  beginning of your end step, if you descended this turn, scry 1") as a pure DSL
  composition: `Triggers.YourEndStep` + `Conditions.YouDescendedThisTurn()` +
  `EffectPatterns.scry(1)`. No card-specific logic.
- Updates `card-sdk-language-reference.md` with the new condition + `TurnTracker` entry.

