### PR TITLE
Add four TDM cards: Worthy Cost, Desperate Measures, Knockout Maneuver, Synchronized Charge

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroup2ScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroup2ScenarioTest.kt
@@ -1,0 +1,208 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.DistributeDecision
+import com.wingedsheep.engine.core.DistributionResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the TDM "group 2" batch:
+ *  - Worthy Cost (#99): {B} sorcery — sacrifice a creature, exile target creature or planeswalker.
+ *  - Desperate Measures (#78): {B} instant — +1/-1 + delayed "when it dies this turn, draw two".
+ *  - Knockout Maneuver (#147): {2}{G} sorcery — +1/+1 counter, then it deals damage equal to its
+ *    power to a creature an opponent controls.
+ *  - Synchronized Charge (#162): {1}{G} sorcery — distribute two +1/+1 counters, then creatures you
+ *    control with counters gain vigilance and trample.
+ */
+class TdmGroup2ScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        // Inline test creatures (ScenarioTestBase only has set-registered cards).
+        cardRegistry.register(
+            CardDefinition.creature("Bear Cub", ManaCost.parse("{1}{G}"), emptySet(), power = 2, toughness = 2)
+        )
+        cardRegistry.register(
+            CardDefinition.creature("Sacrificial Goat", ManaCost.parse("{G}"), emptySet(), power = 0, toughness = 1)
+        )
+
+        context("Worthy Cost") {
+            test("sacrifices a creature and exiles the target creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Worthy Cost")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardOnBattlefield(1, "Sacrificial Goat")
+                    .withCardOnBattlefield(2, "Bear Cub")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goat = game.findPermanent("Sacrificial Goat")!!
+                val bear = game.findPermanent("Bear Cub")!!
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.findCardsInHand(1, "Worthy Cost").first(),
+                        targets = listOf(ChosenTarget.Permanent(bear)),
+                        additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(goat))
+                    )
+                )
+                withClue("Casting Worthy Cost should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                withClue("The sacrificed creature should be gone from the battlefield") {
+                    game.isOnBattlefield("Sacrificial Goat") shouldBe false
+                }
+                game.resolveStack()
+
+                withClue("The targeted creature should be exiled") {
+                    game.isOnBattlefield("Bear Cub") shouldBe false
+                    game.state.getExile(game.player2Id).any {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Bear Cub"
+                    } shouldBe true
+                }
+            }
+        }
+
+        context("Desperate Measures") {
+            test("applies +1/-1 and draws two when the creature dies this turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Desperate Measures")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardOnBattlefield(1, "Sacrificial Goat") // 0/1 -> 1/0 -> dies
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goat = game.findPermanent("Sacrificial Goat")!!
+                val handBefore = game.handSize(1)
+
+                val cast = game.castSpell(1, "Desperate Measures", goat)
+                withClue("Casting Desperate Measures should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // The 0/1 becomes 1/0 and dies as a state-based action, firing the delayed draw trigger.
+                withClue("The creature should have died from -1 toughness") {
+                    game.isOnBattlefield("Sacrificial Goat") shouldBe false
+                }
+                game.resolveStack()
+
+                withClue("Controller should have drawn two cards (net +1: spell left hand, +2 drawn)") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+        }
+
+        context("Knockout Maneuver") {
+            test("adds a counter then deals damage equal to boosted power") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Knockout Maneuver")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(1, "Bear Cub")     // 2/2 -> 3/3 after counter
+                    .withCardOnBattlefield(2, "Bear Cub")     // 2/2 opponent target, takes 3 -> dies
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun controllerOf(id: com.wingedsheep.sdk.model.EntityId) =
+                    game.state.getEntity(id)?.get<ControllerComponent>()?.playerId
+                val mine = game.findPermanents("Bear Cub").first { controllerOf(it) == game.player1Id }
+                val theirs = game.findPermanents("Bear Cub").first { controllerOf(it) == game.player2Id }
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.findCardsInHand(1, "Knockout Maneuver").first(),
+                        targets = listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(theirs))
+                    )
+                )
+                withClue("Casting Knockout Maneuver should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("My creature should have a +1/+1 counter") {
+                    game.state.getEntity(mine)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+                withClue("The 3 damage from the boosted 3/3 should have killed the opponent's 2/2") {
+                    game.state.getBattlefield().contains(theirs) shouldBe false
+                }
+                withClue("Opponent's Bear Cub should be in their graveyard") {
+                    game.findCardsInGraveyard(2, "Bear Cub").size shouldBe 1
+                }
+            }
+        }
+
+        context("Synchronized Charge") {
+            test("distributes two counters then grants vigilance and trample to counter-bearing creatures") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Synchronized Charge")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Bear Cub")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Bear Cub")!!
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.findCardsInHand(1, "Synchronized Charge").first(),
+                        targets = listOf(ChosenTarget.Permanent(bear))
+                    )
+                )
+                withClue("Casting Synchronized Charge should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Distribute both counters onto the single target.
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision() as DistributeDecision
+                    game.submitDecision(
+                        DistributionResponse(decision.id, mapOf(bear to decision.totalAmount))
+                    )
+                    game.resolveStack()
+                }
+
+                withClue("Bear Cub should carry two +1/+1 counters") {
+                    game.state.getEntity(bear)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+                val keywords = stateProjector.getProjectedKeywords(game.state, bear)
+                withClue("Bear Cub should have gained vigilance") {
+                    keywords.contains(Keyword.VIGILANCE) shouldBe true
+                }
+                withClue("Bear Cub should have gained trample") {
+                    keywords.contains(Keyword.TRAMPLE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DesperateMeasures.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DesperateMeasures.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Desperate Measures — Tarkir: Dragonstorm #78
+ * {B} · Instant
+ *
+ * Target creature gets +1/-1 until end of turn. When it dies under your control this
+ * turn, draw two cards.
+ *
+ * Modeled as the +1/-1 stat change plus a watched-entity delayed triggered ability
+ * (`Triggers.Dies` scoped to the target via `watchedTarget`, expiring at end of turn).
+ * This mirrors the Long River Lurker / Commando Raid "whenever that creature ... this
+ * turn" pattern. The "under your control" clause is honored for the normal path (the
+ * creature dies while you control it); the rare control-change-then-dies case is the
+ * same watched-entity limitation shared by all such delayed triggers — the trigger is
+ * scoped by entity id, not by re-checking last-known controller.
+ */
+val DesperateMeasures = card("Desperate Measures") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/-1 until end of turn. When it dies under your control this turn, draw two cards."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = CompositeEffect(listOf(
+            ModifyStatsEffect(1, -1, t),
+            CreateDelayedTriggerEffect(
+                effect = Effects.DrawCards(2),
+                trigger = Triggers.Dies,
+                watchedTarget = t,
+                expiry = DelayedTriggerExpiry.EndOfTurn
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "78"
+        artist = "Gaboleps"
+        flavorText = "\"Sing for us when we depart for battle, and sing for us if we fail to return.\"\n—Mardu parting"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/ccbc6fd0-42bc-4e8b-96bc-69a631ba7106.jpg?1743204274"
+        ruling("2025-04-04", "As long as you control it, you will get to draw two cards when the target creature goes to the graveyard, regardless of whether it died due to having 0 toughness or something else.")
+        ruling("2025-04-04", "If the creature is no longer a creature at the time it goes to the graveyard, you will still draw two cards if you controlled it at that time.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KnockoutManeuver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KnockoutManeuver.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Knockout Maneuver — Tarkir: Dragonstorm #147
+ * {2}{G} · Sorcery
+ *
+ * Put a +1/+1 counter on target creature you control, then it deals damage equal to
+ * its power to target creature an opponent controls.
+ *
+ * The two clauses run in order: add the +1/+1 counter first, then have the buffed
+ * creature deal damage equal to its (now-increased) power to the opposing creature.
+ * `damageSource = ContextTarget(0)` makes the controlled creature the source of the
+ * damage; `DynamicAmounts.targetPower(0)` reads its power at resolution (after the
+ * counter is applied).
+ */
+val KnockoutManeuver = card("Knockout Maneuver") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Put a +1/+1 counter on target creature you control, then it deals damage equal to its power to target creature an opponent controls."
+
+    spell {
+        val mine = target("creature you control", Targets.CreatureYouControl)
+        val theirs = target("creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = CompositeEffect(listOf(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, mine),
+            Effects.DealDamage(
+                amount = DynamicAmounts.targetPower(0),
+                target = theirs,
+                damageSource = EffectTarget.ContextTarget(0)
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "147"
+        artist = "Aaron J. Riley"
+        flavorText = "An exceptional bout during the Zenith celebration will be noted by Temur elders and result in recruitment for higher ranks."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d218831-2a41-46a3-8e9d-93462cae5cab.jpg?1743204555"
+        ruling("2025-04-04", "You can't cast Knockout Maneuver unless you choose a creature you control and a creature an opponent controls as targets.")
+        ruling("2025-04-04", "If either creature is an illegal target as Knockout Maneuver resolves, the creature you control won't deal damage. If the creature you control is an illegal target, you won't put a +1/+1 counter on it even if it's still on the battlefield.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SynchronizedCharge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SynchronizedCharge.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Synchronized Charge — Tarkir: Dragonstorm #162
+ * {1}{G} · Sorcery
+ *
+ * Distribute two +1/+1 counters among one or two target creatures you control.
+ * Creatures you control with counters on them gain vigilance and trample until end of
+ * turn.
+ * Harmonize {4}{G} (You may cast this card from your graveyard for its harmonize cost.
+ * You may tap a creature you control to reduce that cost by {X}, where X is its power.
+ * Then exile this spell.)
+ *
+ * The keyword-grant clause runs after the counters are distributed, so the freshly
+ * buffed creatures (and any other creatures you control already carrying counters) are
+ * included in the `withAnyCounter()` group at resolution time. Harmonize is the standard
+ * graveyard alt-cost keyword (display + cast-from-graveyard support).
+ */
+val SynchronizedCharge = card("Synchronized Charge") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Distribute two +1/+1 counters among one or two target creatures you control. " +
+        "Creatures you control with counters on them gain vigilance and trample until end of turn.\n" +
+        "Harmonize {4}{G} (You may cast this card from your graveyard for its harmonize cost. " +
+        "You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)"
+
+    spell {
+        target("targets", TargetCreature(count = 2, minCount = 1, filter = com.wingedsheep.sdk.scripting.filters.unified.TargetFilter.CreatureYouControl))
+        effect = CompositeEffect(listOf(
+            Effects.DistributeCountersAmongTargets(totalCounters = 2),
+            ForEachInGroupEffect(
+                filter = GroupFilter(GameObjectFilter.Creature.youControl().withAnyCounter()),
+                effect = GrantKeywordEffect(Keyword.VIGILANCE, EffectTarget.Self)
+            ),
+            ForEachInGroupEffect(
+                filter = GroupFilter(GameObjectFilter.Creature.youControl().withAnyCounter()),
+                effect = GrantKeywordEffect(Keyword.TRAMPLE, EffectTarget.Self)
+            )
+        ))
+    }
+
+    keywordAbility(KeywordAbility.harmonize("{4}{G}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "162"
+        artist = "Johan Grenier"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f721f8d-fd2f-480b-8645-4bf6ce38dde9.jpg?1743204617"
+        ruling("2025-04-04", "If two targets are chosen, you must choose to give each of them a +1/+1 counter. If only one of those two creatures is still a legal target at the time the spell resolves, it will receive only one counter.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WorthyCost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WorthyCost.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreatureOrPlaneswalker
+
+/**
+ * Worthy Cost — Tarkir: Dragonstorm #99
+ * {B} · Sorcery
+ *
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Exile target creature or planeswalker.
+ */
+val WorthyCost = card("Worthy Cost") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\nExile target creature or planeswalker."
+
+    additionalCost(AdditionalCost.SacrificePermanent(GameObjectFilter.Creature))
+
+    spell {
+        val t = target("target", TargetCreatureOrPlaneswalker())
+        effect = MoveToZoneEffect(t, Zone.EXILE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Andrew Mar"
+        flavorText = "\"'Victory is survival' is the tenet that guides us. My love, know that I will always ensure your survivial.\"\n—Duvir, Mardu warrior, final letter"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/adc18edc-01d8-4a7e-a87b-a854e50aa75e.jpg?1743204359"
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) cards, all composed from existing SDK primitives (no new engine/SDK features required).

## Implemented

- **Worthy Cost** (#99, {B} sorcery) — sacrifice-a-creature additional cost + exile target creature or planeswalker. `AdditionalCost.SacrificePermanent(Creature)` + `MoveToZoneEffect(..., EXILE)`.
- **Desperate Measures** (#78, {B} instant) — target creature gets +1/-1; watched-entity delayed trigger ("when it dies this turn, draw two") via `ModifyStatsEffect` + `CreateDelayedTriggerEffect(trigger = Triggers.Dies, watchedTarget = t)`. The "under your control" clause is honored on the normal path; the rare control-change-then-dies case is the standard watched-entity-delayed-trigger limitation (scoped by entity id), noted in the card comment.
- **Knockout Maneuver** (#147, {2}{G} sorcery) — put a +1/+1 counter on target creature you control, then it deals damage equal to its (now-boosted) power to a creature an opponent controls. `AddCounters` + `DealDamage(DynamicAmounts.targetPower(0), damageSource = ContextTarget(0))`.
- **Synchronized Charge** (#162, {1}{G} sorcery) — distribute two +1/+1 counters among one or two target creatures you control, then creatures you control with counters gain vigilance and trample until end of turn; Harmonize {4}{G}. `DistributeCountersAmongTargets` + two `ForEachInGroupEffect` over `Creature.youControl().withAnyCounter()` + `KeywordAbility.harmonize`.

## Skipped

None — all four were cleanly implementable with existing primitives.

## Tests

New `TdmGroup2ScenarioTest` (game-server) exercises all four cards end to end. All four tests pass:
- Worthy Cost: sacrifice + exile
- Desperate Measures: +1/-1 kills a 0/1 and draws two
- Knockout Maneuver: counter + lethal power-damage to opposing creature
- Synchronized Charge: counters distributed, vigilance + trample granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)