### PR TITLE
Add TDM spells: Dragonclaw Strike, Riverwheel Sweep, Narset's Rebuke, Wail of War

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroup1ScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroup1ScenarioTest.kt
@@ -1,0 +1,242 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the TDM "group 1" batch of spells:
+ *  - Dragonclaw Strike (#180): double a creature you control's P/T, then it fights up to one
+ *    opponent creature.
+ *  - Riverwheel Sweep (#219): tap target + 3 stun counters, then impulse-pick one of the top two.
+ *  - Narset's Rebuke (#114): 5 damage to a creature, add {U}{R}{W}, exile-if-it-would-die.
+ *  - Wail of War (#98): modal — opponent's creatures get -1/-1, or return up to two creature
+ *    cards from your graveyard.
+ */
+class TdmGroup1ScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Dragonclaw Strike") {
+            test("doubles your creature's P/T, then it fights and kills the opponent's creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dragonclaw Strike")
+                    .withLandsOnBattlefield(1, "Mountain", 5) // {2/G}{2/U}{2/R}: only {2/R} discounts → 2+2+1
+                    .withCardOnBattlefield(1, "Grizzly Bears")   // 2/2 -> doubled to 4/4
+                    .withCardOnBattlefield(2, "Hill Giant")      // 3/3 victim
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mine = game.findPermanent("Grizzly Bears")!!
+                val victim = game.findPermanent("Hill Giant")!!
+                val cardId = game.findCardsInHand(1, "Dragonclaw Strike").first()
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(victim))
+                    )
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be doubled to 4/4") {
+                    stateProjector.getProjectedPower(game.state, mine) shouldBe 4
+                    stateProjector.getProjectedToughness(game.state, mine) shouldBe 4
+                }
+                withClue("Hill Giant (3/3) takes 4 damage and dies") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("Grizzly Bears (now 4/4) takes 3 damage and survives") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("with no opponent creature targeted, only doubles (fight has no second target)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dragonclaw Strike")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mine = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.findCardsInHand(1, "Dragonclaw Strike").first()
+                val cast = game.execute(
+                    CastSpell(game.player1Id, cardId, listOf(ChosenTarget.Permanent(mine)))
+                )
+                withClue("Cast with no opponent creature should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be doubled to 4/4 and survive (no fight)") {
+                    stateProjector.getProjectedPower(game.state, mine) shouldBe 4
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+        }
+
+        context("Riverwheel Sweep") {
+            test("taps the target, adds three stun counters, then impulse-picks one of two exiled cards") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Riverwheel Sweep")
+                    .withLandsOnBattlefield(1, "Island", 5) // {2/U}{2/R}{2/W}: only {2/U} discounts → 1+2+2
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Wind Drake")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val victim = game.findPermanent("Hill Giant")!!
+                val cast = game.castSpell(1, "Riverwheel Sweep", victim)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Hill Giant should be tapped") {
+                    game.state.getEntity(victim)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("Hill Giant should have three stun counters") {
+                    game.state.getEntity(victim)?.get<CountersComponent>()?.getCount(CounterType.STUN) shouldBe 3
+                }
+
+                withClue("Should prompt to choose one of the two exiled cards") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                withClue("Both exiled cards should be offered") {
+                    decision.options.size shouldBe 2
+                }
+                game.selectCards(listOf(decision.options.first()))
+
+                withClue("Both cards should now be in exile") {
+                    game.state.getExile(game.player1Id).count {
+                        val name = game.state.getEntity(it)?.get<CardComponent>()?.name
+                        name == "Grizzly Bears" || name == "Wind Drake"
+                    } shouldBe 2
+                }
+            }
+        }
+
+        context("Narset's Rebuke") {
+            test("deals 5 damage, adds three mana, and exiles the creature instead of it dying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Narset's Rebuke")
+                    .withLandsOnBattlefield(1, "Mountain", 5) // {4}{R}
+                    .withCardOnBattlefield(2, "Hill Giant")   // 3/3 — dies to 5 damage
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val victim = game.findPermanent("Hill Giant")!!
+                val cast = game.castSpell(1, "Narset's Rebuke", victim)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Hill Giant should be gone from the battlefield") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("Hill Giant should be exiled, not in its owner's graveyard") {
+                    game.findCardsInGraveyard(2, "Hill Giant").size shouldBe 0
+                    game.state.getExile(game.player2Id).count {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Hill Giant"
+                    } shouldBe 1
+                }
+            }
+        }
+
+        context("Wail of War") {
+            test("mode 1 gives the opponent's creatures -1/-1, killing a 1-toughness creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Wail of War")
+                    .withLandsOnBattlefield(1, "Swamp", 3) // {2}{B}
+                    .withCardOnBattlefield(2, "Willow Dryad") // 1/1 -> dies to -1/-1
+                    .withCardOnBattlefield(2, "Hill Giant")   // 3/3 -> 2/2 survives
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Wail of War").first(),
+                        listOf(ChosenTarget.Player(game.player2Id)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(game.player2Id)))
+                    )
+                )
+                withClue("Cast (mode 1) should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("The 1/1 should die to -1/-1") {
+                    game.isOnBattlefield("Willow Dryad") shouldBe false
+                }
+                val giant = game.findPermanent("Hill Giant")!!
+                withClue("Hill Giant should be a 2/2 and survive") {
+                    stateProjector.getProjectedPower(game.state, giant) shouldBe 2
+                    stateProjector.getProjectedToughness(game.state, giant) shouldBe 2
+                }
+            }
+
+            test("mode 2 returns two creature cards from your graveyard to your hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Wail of War")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").first()
+                val giant = game.findCardsInGraveyard(1, "Hill Giant").first()
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Wail of War").first(),
+                        emptyList(),
+                        chosenModes = listOf(1),
+                        modeTargetsOrdered = listOf(
+                            listOf(
+                                ChosenTarget.Card(bears, game.player1Id, Zone.GRAVEYARD),
+                                ChosenTarget.Card(giant, game.player1Id, Zone.GRAVEYARD)
+                            )
+                        )
+                    )
+                )
+                withClue("Cast (mode 2) should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Both creature cards should be back in hand") {
+                    game.findCardsInHand(1, "Grizzly Bears").size shouldBe 1
+                    game.findCardsInHand(1, "Hill Giant").size shouldBe 1
+                }
+                withClue("Graveyard should be empty of those creatures") {
+                    game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 0
+                    game.findCardsInGraveyard(1, "Hill Giant").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonclawStrike.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonclawStrike.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Dragonclaw Strike
+ * {2/G}{2/U}{2/R}
+ * Sorcery
+ *
+ * Double the power and toughness of target creature you control until end of turn.
+ * Then it fights up to one target creature an opponent controls.
+ * (Each deals damage equal to its power to the other.)
+ *
+ * "Doubling" is modelled per the Comprehensive Rules ruling: the creature gets +X/+X
+ * where X is its current power/toughness as the effect applies, so we feed the target's
+ * own power/toughness back in as the modification amount (handles negative power too,
+ * since the dynamic amount reflects the live value). The fight reuses [Effects.Fight];
+ * the opponent's creature is "up to one" so its target is optional.
+ */
+val DragonclawStrike = card("Dragonclaw Strike") {
+    manaCost = "{2/G}{2/U}{2/R}"
+    colorIdentity = "GUR"
+    typeLine = "Sorcery"
+    oracleText = "Double the power and toughness of target creature you control until end of turn. " +
+        "Then it fights up to one target creature an opponent controls. " +
+        "(Each deals damage equal to its power to the other.)"
+
+    spell {
+        val yourCreature = target(
+            "creature you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl)
+        )
+        val opponentCreature = target(
+            "creature an opponent controls",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureOpponentControls)
+        )
+        effect = Effects.ModifyStats(
+            power = DynamicAmounts.targetPower(0),
+            toughness = DynamicAmounts.targetToughness(0),
+            target = yourCreature
+        ).then(Effects.Fight(yourCreature, opponentCreature))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "180"
+        artist = "Yeong-Hao Han"
+        flavorText = "Some had doubted the whisperers' choice of Eshki for Dragonclaw. " +
+            "None did so after witnessing her in battle."
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc7692ef-7091-4365-85a8-1edbd374f279.jpg?1744577243"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NarsetsRebuke.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NarsetsRebuke.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Narset's Rebuke
+ * {4}{R}
+ * Instant
+ *
+ * Narset's Rebuke deals 5 damage to target creature. Add {U}{R}{W}.
+ * If that creature would die this turn, exile it instead.
+ *
+ * The "exile instead of die" clause reuses [MarkExileOnDeathEffect] (see Scorching Lava).
+ * The mana ({U}{R}{W}) and the death-replacement both happen regardless of whether the
+ * damaged creature survives, so all three sub-effects are composed unconditionally.
+ */
+val NarsetsRebuke = card("Narset's Rebuke") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Narset's Rebuke deals 5 damage to target creature. Add {U}{R}{W}. " +
+        "If that creature would die this turn, exile it instead."
+
+    spell {
+        val creature = target("target creature", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.DealDamage(5, creature)
+            .then(
+                CompositeEffect(
+                    listOf(
+                        Effects.AddMana(Color.BLUE),
+                        Effects.AddMana(Color.RED),
+                        Effects.AddMana(Color.WHITE),
+                        MarkExileOnDeathEffect(creature)
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Diego Gisbert"
+        flavorText = "With a swift motion Narset struck Sarkhan down. She would not let his " +
+            "fevered dreams of draconic dominance come to fruition. Not after all she had done to free Tarkir."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/5098bd73-d51c-4db4-bf06-fd4854089d37.jpg?1743204422"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RiverwheelSweep.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RiverwheelSweep.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Riverwheel Sweep
+ * {2/U}{2/R}{2/W}
+ * Sorcery
+ *
+ * Tap target creature. Put three stun counters on it.
+ * (If a permanent with a stun counter would become untapped, remove one from it instead.)
+ * Exile the top two cards of your library. Choose one of them. Until the end of your next
+ * turn, you may play that card.
+ *
+ * The impulse half composes the standard Gather → Move(EXILE) → Select(one) → grant
+ * may-play pipeline (see Fireglass Mentor); the only difference is the
+ * [MayPlayExpiry.UntilEndOfNextTurn] window. The other exiled card stays exiled with no
+ * play permission, matching "Choose one of them."
+ */
+val RiverwheelSweep = card("Riverwheel Sweep") {
+    manaCost = "{2/U}{2/R}{2/W}"
+    colorIdentity = "URW"
+    typeLine = "Sorcery"
+    oracleText = "Tap target creature. Put three stun counters on it. " +
+        "(If a permanent with a stun counter would become untapped, remove one from it instead.)\n" +
+        "Exile the top two cards of your library. Choose one of them. Until the end of your next turn, " +
+        "you may play that card."
+
+    spell {
+        val creature = target("target creature", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Tap(creature)
+            .then(Effects.AddCounters(Counters.STUN, 3, creature))
+            .then(
+                CompositeEffect(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.TopOfLibrary(DynamicAmount.Fixed(2)),
+                            storeAs = "exiled"
+                        ),
+                        MoveCollectionEffect(
+                            from = "exiled",
+                            destination = CardDestination.ToZone(Zone.EXILE)
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "exiled",
+                            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                            storeSelected = "chosen",
+                            prompt = "Choose a card you may play until the end of your next turn"
+                        ),
+                        GrantMayPlayFromExileEffect(
+                            from = "chosen",
+                            expiry = MayPlayExpiry.UntilEndOfNextTurn
+                        )
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "219"
+        artist = "Wayne Wu"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/686fe623-ee50-407d-87c9-664fb039f4d9.jpg?1743204865"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WailOfWar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WailOfWar.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Wail of War
+ * {2}{B}
+ * Instant
+ *
+ * Choose one —
+ * • Creatures target opponent controls get -1/-1 until end of turn.
+ * • Return up to two target creature cards from your graveyard to your hand.
+ *
+ * Mode 1 scopes the group debuff to the chosen opponent via
+ * [GameObjectFilter.Creature.targetOpponentControls] + the standard
+ * [EffectPatterns.modifyStatsForAll]; mode 2 reuses the up-to-two graveyard-return
+ * shape (see Dutiful Return).
+ */
+val WailOfWar = card("Wail of War") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Creatures target opponent controls get -1/-1 until end of turn.\n" +
+        "• Return up to two target creature cards from your graveyard to your hand."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Creatures target opponent controls get -1/-1 until end of turn") {
+                val opponent = target("target opponent", TargetOpponent())
+                effect = EffectPatterns.modifyStatsForAll(
+                    power = -1,
+                    toughness = -1,
+                    filter = GroupFilter(GameObjectFilter.Creature.targetPlayerControls(opponent))
+                )
+            }
+            mode("Return up to two target creature cards from your graveyard to your hand") {
+                target = TargetObject(
+                    count = 2,
+                    optional = true,
+                    filter = TargetFilter.CreatureInYourGraveyard
+                )
+                effect = ForEachTargetEffect(
+                    effects = listOf(MoveToZoneEffect(EffectTarget.ContextTarget(0), Zone.HAND))
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "98"
+        artist = "Izzy"
+        flavorText = "Mardu war shrieks ensure their enemies are defeated before the battle even starts."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e9430dd-f583-400d-808a-64e2b5fa54f1.jpg?1743204354"
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) spells, each composed from existing SDK primitives — no new effect/trigger/condition types were needed.

## Implemented
- **Dragonclaw Strike** (#180, `{2/G}{2/U}{2/R}` Sorcery) — Doubles the power/toughness of a creature you control until end of turn, then it fights up to one opponent creature. Doubling reuses `Effects.ModifyStats` fed the target's own power/toughness as the +X/+X amount (faithful to the CR doubling ruling, including negative power); the fight is `Effects.Fight` with an optional ("up to one") second target.
- **Riverwheel Sweep** (#219, `{2/U}{2/R}{2/W}` Sorcery) — Tap target creature, put three stun counters on it, then exile the top two of your library, choose one, and may play it until the end of your next turn. Composes the standard Gather → Move(EXILE) → Select(one) → `GrantMayPlayFromExile(UntilEndOfNextTurn)` impulse pipeline (same shape as Fireglass Mentor).
- **Narset's Rebuke** (#114, `{4}{R}` Instant) — 5 damage to target creature, add `{U}{R}{W}`, and `MarkExileOnDeathEffect` so the creature is exiled if it would die this turn (same pattern as Scorching Lava).
- **Wail of War** (#98, `{2}{B}` Instant) — Modal choose-one: either creatures a target opponent controls get -1/-1 (`modifyStatsForAll` scoped to the chosen player), or return up to two target creature cards from your graveyard to your hand.

## Skipped
None — all four were cleanly implementable with existing primitives.

## Tests
`TdmGroup1ScenarioTest` — 6 tests, all passing:
- Dragonclaw Strike: double + fight kills the opponent's creature and the doubled creature survives; and the no-opponent-target case (doubles only).
- Riverwheel Sweep: target tapped, three stun counters added, both cards exiled, one chosen as playable.
- Narset's Rebuke: creature takes 5, is exiled instead of going to the graveyard.
- Wail of War: mode 1 (-1/-1 kills the 1-toughness creature, 3/3 becomes a surviving 2/2); mode 2 (both creature cards returned to hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)