### PR TITLE
Add Reverberating Summons, Wild Ride, War Effort (TDM)

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroup3ScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGroup3ScenarioTest.kt
@@ -1,0 +1,218 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the TDM "group 3" batch:
+ *  - Reverberating Summons (#117): {1}{R} Enchantment — animates into a 3/3 Monk with haste at the
+ *    beginning of each combat if you've cast 2+ spells this turn; activated draw-two by discarding
+ *    your hand and sacrificing itself.
+ *  - Wild Ride (#132): {R} Sorcery — target creature gets +3/+0 and gains haste until end of turn.
+ *    (Harmonize {4}{R} reuses the keyword; the harmonize cast machinery is exercised in the
+ *    rules-engine HarmonizeKeywordTest.)
+ *  - War Effort (#131): {3}{R} Enchantment — anthem (+1/+0 to creatures you control) plus a
+ *    "whenever you attack, make a tapped & attacking 1/1 red Warrior, sacrificed at the next end step".
+ *
+ * Thunder of Unity (#231) was intentionally skipped: chapters II/III grant a turn-bounded
+ * "whenever a creature you control enters this turn" delayed triggered ability, but the engine's
+ * event-based delayed-trigger matcher (TriggerDetector.matchesEventForWatchedEntity) ignores the
+ * TriggerSpec filter for ZoneChange events, so it cannot scope to "a creature you control" — it
+ * would fire for every permanent entering the battlefield. Faithful support needs an engine change.
+ */
+class TdmGroup3ScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Reverberating Summons") {
+            test("animates into a 3/3 Monk with haste at combat after casting two spells") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Reverberating Summons")
+                    .withCardInHand(1, "Glory Seeker")
+                    .withCardInHand(1, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val summons = game.findPermanent("Reverberating Summons")!!
+                withClue("Reverberating Summons should not be a creature before combat") {
+                    game.state.projectedState.isCreature(summons) shouldBe false
+                }
+
+                // Cast two spells this turn.
+                val first = game.castSpell(1, "Glory Seeker")
+                withClue("First Glory Seeker should resolve: ${first.error}") { first.error shouldBe null }
+                game.resolveStack()
+                val second = game.castSpell(1, "Glory Seeker")
+                withClue("Second Glory Seeker should resolve: ${second.error}") { second.error shouldBe null }
+                game.resolveStack()
+
+                // Advance through real flow to the beginning of combat so the EachCombat trigger fires.
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("Reverberating Summons should now be a creature") {
+                    game.state.projectedState.isCreature(summons) shouldBe true
+                }
+                withClue("It should remain an Enchantment (in addition to its other types)") {
+                    game.state.projectedState.hasType(summons, "ENCHANTMENT") shouldBe true
+                }
+                withClue("It should be a 3/3") {
+                    game.state.projectedState.getPower(summons) shouldBe 3
+                    game.state.projectedState.getToughness(summons) shouldBe 3
+                }
+                withClue("It should be a Monk with haste") {
+                    game.state.projectedState.hasSubtype(summons, "Monk") shouldBe true
+                    game.state.projectedState.hasKeyword(summons, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("does not animate if fewer than two spells were cast") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Reverberating Summons")
+                    .withCardInHand(1, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val summons = game.findPermanent("Reverberating Summons")!!
+
+                val first = game.castSpell(1, "Glory Seeker")
+                withClue("Glory Seeker should resolve: ${first.error}") { first.error shouldBe null }
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("With only one spell cast, Reverberating Summons should stay a non-creature") {
+                    game.state.projectedState.isCreature(summons) shouldBe false
+                }
+            }
+
+            test("activated ability draws two cards, discarding hand and sacrificing itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Reverberating Summons")
+                    .withCardInHand(1, "Glory Seeker")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val summons = game.findPermanent("Reverberating Summons")!!
+                val abilityId = cardRegistry.getCard("Reverberating Summons")!!.activatedAbilities.first().id
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = summons,
+                        abilityId = abilityId,
+                    )
+                )
+                withClue("Activating the draw ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Reverberating Summons should be sacrificed (no longer on battlefield)") {
+                    game.isOnBattlefield("Reverberating Summons") shouldBe false
+                }
+                withClue("The Glory Seeker in hand should be discarded as part of the cost") {
+                    game.findCardsInGraveyard(1, "Glory Seeker").size shouldBe 1
+                }
+                withClue("Player should have drawn two cards (Island + Forest)") {
+                    game.findCardsInHand(1, "Island").size shouldBe 1
+                    game.findCardsInHand(1, "Forest").size shouldBe 1
+                }
+            }
+        }
+
+        context("Wild Ride") {
+            test("target creature gets +3/+0 and gains haste until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Wild Ride")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2, no haste
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("Grizzly Bears starts as a 2/2 without haste") {
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe false
+                }
+
+                val cast = game.castSpell(1, "Wild Ride", bears)
+                withClue("Casting Wild Ride should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be a 5/2 with haste") {
+                    game.state.projectedState.getPower(bears) shouldBe 5
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+            }
+        }
+
+        context("War Effort") {
+            test("anthem gives creatures you control +1/+0") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "War Effort")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 base
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("Grizzly Bears should be a 3/2 under War Effort's anthem") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+            }
+
+            test("whenever you attack, create a tapped attacking 1/1 red Warrior token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "War Effort")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                withClue("No Warrior tokens before attacking") {
+                    game.findPermanents("Warrior Token").size shouldBe 0
+                }
+
+                val attack = game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                withClue("Declaring attackers should succeed: ${attack.error}") { attack.error shouldBe null }
+                game.resolveStack()
+
+                val warriors = game.findPermanents("Warrior Token")
+                withClue("Exactly one Warrior token should have been created") {
+                    warriors.size shouldBe 1
+                }
+                val token = warriors.first()
+                withClue("The Warrior token should be tapped and attacking") {
+                    game.state.getEntity(token)?.has<TappedComponent>() shouldBe true
+                    game.state.getEntity(token)?.has<AttackingComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ReverberatingSummons.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ReverberatingSummons.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * Reverberating Summons
+ * {1}{R}
+ * Enchantment
+ *
+ * At the beginning of each combat, if you've cast two or more spells this turn, this enchantment
+ * becomes a 3/3 Monk creature with haste in addition to its other types until end of turn.
+ * {1}{R}, Discard your hand, Sacrifice this enchantment: Draw two cards.
+ */
+val ReverberatingSummons = card("Reverberating Summons") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of each combat, if you've cast two or more spells this turn, this enchantment becomes a 3/3 Monk creature with haste in addition to its other types until end of turn.\n" +
+        "{1}{R}, Discard your hand, Sacrifice this enchantment: Draw two cards."
+
+    triggeredAbility {
+        trigger = Triggers.EachCombat
+        triggerCondition = Conditions.YouCastSpellsThisTurn(atLeast = 2)
+        // Additive: no removeTypes, so the permanent stays an Enchantment while also becoming a creature.
+        effect = Effects.BecomeCreature(
+            power = 3,
+            toughness = 3,
+            keywords = setOf(Keyword.HASTE),
+            creatureTypes = setOf(Subtype.MONK.value),
+            duration = Duration.EndOfTurn
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{R}"),
+            Costs.DiscardHand,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "117"
+        artist = "Marco Gorlei"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1af19ce8-bc0c-420c-9e3b-9059b4df32cb.jpg?1743204431"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WarEffort.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WarEffort.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * War Effort — Tarkir: Dragonstorm #131
+ * {3}{R} · Enchantment · Uncommon
+ *
+ * Creatures you control get +1/+0.
+ * Whenever you attack, create a 1/1 red Warrior creature token that's tapped and attacking.
+ * Sacrifice it at the beginning of the next end step.
+ */
+val WarEffort = card("War Effort") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Creatures you control get +1/+0.\n" +
+        "Whenever you attack, create a 1/1 red Warrior creature token that's tapped and attacking. " +
+        "Sacrifice it at the beginning of the next end step."
+
+    // Creatures you control get +1/+0.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter.AllCreaturesYouControl
+        )
+    }
+
+    // Whenever you attack, create a 1/1 red Warrior token that's tapped and attacking,
+    // sacrificed at the next end step.
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        effect = CreateTokenEffect(
+            count = DynamicAmount.Fixed(1),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Warrior"),
+            tapped = true,
+            attacking = true,
+            sacrificeAtStep = Step.END,
+            imageUri = "https://cards.scryfall.io/normal/front/7/e/7edc0515-a130-45a7-aa09-0e23bba41587.jpg?1742506712"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "131"
+        artist = "Ioannis Fiore"
+        flavorText = "Community is strength.\n—Tenet of the Decree of Thunder"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd7f0413-c009-4c08-b877-9c1b776cbf26.jpg?1743204492"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WildRide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WildRide.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Wild Ride — Tarkir: Dragonstorm #132
+ * {R} · Sorcery · Common
+ *
+ * Target creature gets +3/+0 and gains haste until end of turn.
+ * Harmonize {4}{R} (You may cast this card from your graveyard for its harmonize cost. You may
+ * tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)
+ */
+val WildRide = card("Wild Ride") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Target creature gets +3/+0 and gains haste until end of turn.\n" +
+        "Harmonize {4}{R} (You may cast this card from your graveyard for its harmonize cost. " +
+        "You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(power = 3, toughness = 0, target = creature)
+            .then(Effects.GrantKeyword(Keyword.HASTE, creature, Duration.EndOfTurn))
+    }
+
+    keywordAbility(KeywordAbility.harmonize("{4}{R}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Filipe Pagliuso"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abc8c6f5-6135-428e-8476-1751f82623f9.jpg?1743233780"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarmonizeKeywordTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarmonizeKeywordTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.tdm.cards.ChanneledDragonfire
 import com.wingedsheep.mtg.sets.definitions.tdm.cards.MammothBellow
 import com.wingedsheep.mtg.sets.definitions.tdm.cards.UnendingWhisper
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.WildRide
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
@@ -38,6 +39,7 @@ class HarmonizeKeywordTest : FunSpec({
         driver.registerCard(UnendingWhisper)
         driver.registerCard(ChanneledDragonfire)
         driver.registerCard(MammothBellow)
+        driver.registerCard(WildRide)
         driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
         return driver
@@ -144,6 +146,32 @@ class HarmonizeKeywordTest : FunSpec({
 
         driver.getLifeTotal(opponent) shouldBe 18
         driver.state.getZone(ZoneKey(player, Zone.EXILE)).contains(spell) shouldBe true
+    }
+
+    test("Wild Ride harmonize cast pumps a target creature and exiles the spell") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val spell = driver.putCardInGraveyard(player, "Wild Ride")
+        val bears = driver.putCreatureOnBattlefield(player, "Grizzly Bears") // 2/2 target for the pump
+        driver.giveMana(player, Color.RED, 5) // full {4}{R}
+
+        driver.submit(
+            CastSpell(
+                player, spell,
+                targets = listOf(ChosenTarget.Permanent(bears)),
+                useAlternativeCost = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // +3/+0 and haste applied; the spell is exiled (harmonize), not back in the graveyard.
+        driver.state.projectedState.getPower(bears) shouldBe 5
+        driver.state.projectedState.getToughness(bears) shouldBe 2
+        driver.state.projectedState.hasKeyword(bears, com.wingedsheep.sdk.core.Keyword.HASTE) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.EXILE)).contains(spell) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(spell) shouldBe false
     }
 
     test("a harmonize card cast normally from hand still goes to the graveyard") {


### PR DESCRIPTION
Adds three Tarkir: Dragonstorm cards, all built from existing SDK primitives (no engine/SDK changes).

## Implemented
- **Reverberating Summons** (#117) — `{1}{R}` Enchantment. `Triggers.EachCombat` with a `YouCastSpellsThisTurn(atLeast = 2)` intervening-if condition animates it into a 3/3 Monk with haste (additive, stays an Enchantment) until end of turn via `Effects.BecomeCreature`. Activated ability `{1}{R}`, discard your hand, sacrifice → draw two.
- **Wild Ride** (#132) — `{R}` Sorcery. `ModifyStats(+3/+0)` then `GrantKeyword(HASTE)` on a target creature. Reuses the **Harmonize** keyword (`{4}{R}`); the harmonize graveyard-cast path is exercised in `HarmonizeKeywordTest`.
- **War Effort** (#131) — `{3}{R}` Enchantment. `ModifyStats` anthem (+1/+0 to creatures you control) plus a `Triggers.YouAttack` trigger creating a tapped & attacking 1/1 red Warrior token, sacrificed at the next end step (`CreateTokenEffect` with `sacrificeAtStep = Step.END`).

## Skipped
- **Thunder of Unity** (#231) — Saga whose chapters II/III grant a turn-bounded *"whenever a creature you control enters this turn"* delayed triggered ability. The engine's event-based delayed-trigger matcher (`TriggerDetector.matchesEventForWatchedEntity`) ignores the `TriggerSpec` filter for `ZoneChange` events, so it can't scope to "a creature you control" — it would fire for every permanent entering the battlefield. A faithful implementation requires an engine change, which is out of scope for a card PR.

## Tests
- `TdmGroup3ScenarioTest` (game-server): 6 tests — Reverberating Summons (animate / no-animate / activated draw), Wild Ride (pump + haste), War Effort (anthem / attack-token). All pass.
- `HarmonizeKeywordTest` (rules-engine): added a Wild Ride harmonize-cast case. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)