### PR TITLE
Fix Harmonize-X manual tap preview over-selecting lands

### DIFF
--- a/manual-scenarios/cards/n/natures-rhythm-harmonize-x.json
+++ b/manual-scenarios/cards/n/natures-rhythm-harmonize-x.json
@@ -1,0 +1,42 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Krotiq Nestguard", "summoningSickness": false},
+      {"name": "Kin-Tree Nurturer", "summoningSickness": false}
+    ],
+    "graveyard": ["Nature's Rhythm"],
+    "library": [
+      "Feral Deathgorger",
+      "Snowmelt Stag",
+      "Adorned Crocodile",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -201,6 +201,12 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     if (manaSelectionState.xValue > 0) {
       genericCount += manaSelectionState.xValue
     }
+    // A Harmonize creature-tap reduces the generic mana to pay by its power
+    // (printed {N} first, then the generic {X}); reflect it so the HUD shows the
+    // real owed cost rather than the pre-tap {X} amount.
+    if (manaSelectionState.harmonizeReduction > 0) {
+      genericCount = Math.max(0, genericCount - manaSelectionState.harmonizeReduction)
+    }
     const total = coloredReqs.length + genericCount
 
     // Build source list: each source has the set of colors it can pay

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -191,6 +191,12 @@ export interface ManaSelectionState {
   manaCost: string
   /** X value if spell has X cost */
   xValue: number
+  /**
+   * Generic mana the Harmonize creature-tap removes from the cost (the tapped
+   * creature's power), or 0 when none is tapped / not a Harmonize cast. Reduces
+   * both the pre-selected sources and the generic shown in the confirmation HUD.
+   */
+  harmonizeReduction: number
   /** Color production per source: entityId -> list of color symbols (W/U/B/R/G) */
   sourceColors: Readonly<Record<EntityId, readonly string[]>>
   /** Mana amount per source: entityId -> amount (e.g., 3 for Gilded Lotus) */

--- a/web-client/src/store/slices/ui/selectionSlice.ts
+++ b/web-client/src/store/slices/ui/selectionSlice.ts
@@ -23,6 +23,7 @@ import {
   parseManaCost as parseManaCostUtil,
   getRemainingCostSymbols,
   computeAutoTapPreview,
+  reduceCostByHarmonizeTap,
 } from '@/utils/manaCost'
 
 // Note: getWebSocket/createSubmitActionMessage are still used by confirmCrewSelection
@@ -449,10 +450,45 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
     // The server's autoTapPreview only covers the fixed cost (X is unknown
     // server-side), so we extend the pre-selection with enough additional
     // sources to also cover xValue * (number of {X} symbols).
-    const action = actionInfo.action as { xValue?: number }
+    const action = actionInfo.action as {
+      xValue?: number
+      alternativePayment?: { harmonizeCreature?: EntityId | null }
+    }
     const xValue = action.xValue ?? 0
     const manaCost = actionInfo.manaCostString ?? ''
     const xSymbolCount = Math.max(1, (manaCost.match(/\{X\}/g)?.length ?? 0))
+
+    // Harmonize creature-tap (chosen in the prior `harmonize` phase) reduces the
+    // generic mana to pay by the tapped creature's power. The server can't know
+    // which creature the player picked, so neither autoTapPreview nor the X
+    // extension below account for it — apply it here.
+    const harmonizeCreatureId = action.alternativePayment?.harmonizeCreature
+    const harmonizeReduction = harmonizeCreatureId
+      ? actionInfo.validHarmonizeCreatures?.find((c) => c.entityId === harmonizeCreatureId)?.power ?? 0
+      : 0
+
+    // When a creature was tapped, recompute the whole pre-selection from the
+    // reduced cost (colored pips + generic remaining after the tap) so we don't
+    // over-tap lands for generic the tap already covered.
+    if (harmonizeReduction > 0) {
+      const reduced = reduceCostByHarmonizeTap(manaCost, xValue, harmonizeReduction)
+      set({
+        selectedCardId: null,
+        manaSelectionState: {
+          action: actionInfo.action,
+          actionInfo,
+          validSources: sources.map((s) => s.entityId),
+          selectedSources: computeAutoTapPreview(sources, reduced),
+          manaCost,
+          xValue,
+          harmonizeReduction,
+          sourceColors,
+          sourceManaAmounts,
+        },
+      })
+      return
+    }
+
     const xManaNeeded = xValue * xSymbolCount
 
     // The server only computes [autoTapPreview] when the spell is affordable
@@ -493,6 +529,7 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
         selectedSources: preSelectedIds,
         manaCost,
         xValue,
+        harmonizeReduction: 0,
         sourceColors,
         sourceManaAmounts,
       },

--- a/web-client/src/utils/manaCost.test.ts
+++ b/web-client/src/utils/manaCost.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { manaCostCastableWith, manaCostColors, playableWithinColors } from './manaCost'
+import {
+  computeAutoTapPreview,
+  manaCostCastableWith,
+  manaCostColors,
+  playableWithinColors,
+  reduceCostByHarmonizeTap,
+  type TrimmableManaSource,
+} from './manaCost'
 
 const set = (...cs: string[]) => new Set(cs)
 
@@ -66,5 +73,51 @@ describe('playableWithinColors', () => {
   it('colorless card passes any allowed set', () => {
     expect(playableWithinColors('{2}', set(), set())).toBe(true)
     expect(playableWithinColors('{2}', set(), set('W'))).toBe(true)
+  })
+})
+
+describe('reduceCostByHarmonizeTap', () => {
+  // Nature's Rhythm — Harmonize {X}{G}{G}{G}{G}. Cast with X=5, then tap a power-4
+  // creature (Krotiq Nestguard). The tap reduces GENERIC mana — and {X} is generic —
+  // so the {5} drops to {1}: the player owes {1}{G}{G}{G}{G}, not {5}{G}{G}{G}{G}.
+  it('reduces the generic {X} of a Harmonize cost by the tapped power', () => {
+    expect(reduceCostByHarmonizeTap('{X}{G}{G}{G}{G}', 5, 4)).toEqual(['1', 'G', 'G', 'G', 'G'])
+  })
+
+  it('floors the generic at zero and never touches colored pips', () => {
+    // Power 6 tap against X=5: the extra reduction is wasted, {G}{G}{G}{G} stays.
+    expect(reduceCostByHarmonizeTap('{X}{G}{G}{G}{G}', 5, 6)).toEqual(['G', 'G', 'G', 'G'])
+  })
+
+  it('reduces printed generic before the X (Channeled Dragonfire-style)', () => {
+    // {2}{R}{R} with no X, tap power 2 -> {R}{R}.
+    expect(reduceCostByHarmonizeTap('{2}{R}{R}', 0, 2)).toEqual(['R', 'R'])
+    // Mixed printed + X: {1}{X}{G}, X=3, tap 2 -> 4 generic total, 2 removed -> {2}{G}.
+    expect(reduceCostByHarmonizeTap('{1}{X}{G}', 3, 2)).toEqual(['2', 'G'])
+  })
+
+  it('no tap (reduction 0) just expands {X}', () => {
+    expect(reduceCostByHarmonizeTap('{X}{G}{G}{G}{G}', 5, 0)).toEqual(['5', 'G', 'G', 'G', 'G'])
+  })
+})
+
+describe('Harmonize-X mana pre-selection', () => {
+  // Six Forests; the harmonize cost after the tap is {1}{G}{G}{G}{G} = 5 mana.
+  // The pre-selection must tap exactly 5 Forests, not all 6.
+  const forests: TrimmableManaSource<string>[] = Array.from({ length: 6 }, (_, i) => ({
+    entityId: `forest-${i}`,
+    producesColors: ['G'],
+    manaAmount: 1,
+  }))
+
+  it('pre-taps exactly the lands the reduced cost needs (regression: tapped all 6)', () => {
+    const reduced = reduceCostByHarmonizeTap('{X}{G}{G}{G}{G}', 5, 4) // power-4 tap
+    const preselect = computeAutoTapPreview(forests, reduced)
+    expect(preselect).toHaveLength(5)
+  })
+
+  it('without the tap it would need all 6 Forests for X=5', () => {
+    const reduced = reduceCostByHarmonizeTap('{X}{G}{G}{G}{G}', 5, 0)
+    expect(computeAutoTapPreview(forests, reduced)).toHaveLength(6)
   })
 })

--- a/web-client/src/utils/manaCost.ts
+++ b/web-client/src/utils/manaCost.ts
@@ -95,6 +95,27 @@ export function getRemainingCostSymbols(originalSymbols: string[], delveCount: n
 }
 
 /**
+ * Apply a Harmonize creature-tap to a mana cost. The tap reduces the *generic*
+ * mana the player must still pay by the chosen creature's power — printed {N}
+ * first, then the generic {X} (the {X} is generic per the TDM release notes,
+ * mirrored server-side by `CastSpellHandler.harmonizePaymentXValue`). Colored
+ * pips are untouched, and the effect's chosen X (sent as `action.xValue`) is
+ * unchanged — only the mana *paid* shrinks.
+ *
+ * Expands {X} to [xValue] first, then removes [reduction] generic in array order
+ * (which, for land pre-selection, has the same total as the printed-first engine
+ * rule — lands don't distinguish printed generic from the generic {X}).
+ */
+export function reduceCostByHarmonizeTap(
+  manaCost: string,
+  xValue: number,
+  reduction: number,
+): string[] {
+  const expanded = parseManaCost(manaCost).map((s) => (s === 'X' ? String(xValue) : s))
+  return getRemainingCostSymbols(expanded, reduction)
+}
+
+/**
  * Build the remaining mana cost symbols after applying convoke creatures.
  * Each creature pays for one colored symbol (exact or matching half of a hybrid,
  * per CR 107.4e / 702.51a) or one generic mana.


### PR DESCRIPTION
## Problem

Casting a Harmonize spell with `{X}` in **manual tap mode** pre-selected lands for the *full* chosen X and displayed the *pre-tap* cost — the manual-tap (`manaSource`) phase never accounted for the creature-tap reduction picked in the preceding `harmonize` phase.

Repro (matches the reported scenario):
- Cast **Nature's Rhythm** (`{X}{G}{G}{G}{G}`) via Harmonize, **X=5**, manual tap mode.
- Tap **Krotiq Nestguard** (power 4) for the reduction → real cost is `{1}{G}{G}{G}{G}`.
- **Bug:** preview tapped all **6** Forests and the HUD showed `{5}{G}{G}{G}{G}`.

This was **client preview-only** — the engine re-solves payment on submit (`CastPaymentProcessor.explicitPay`), so the actual cast was always correct; only the highlighted lands and the confirmation HUD were wrong.

## Fix

- **`manaCost.ts`** — new pure `reduceCostByHarmonizeTap(manaCost, xValue, reduction)`: expands `{X}`, then removes the tapped power from generic mana (printed `{N}` first, then the generic `{X}`), mirroring `CastSpellHandler.harmonizePaymentXValue`. Colored pips untouched; generic floored at zero.
- **`selectionSlice.startManaSelection`** — resolves the tapped creature's power from `validHarmonizeCreatures`; when a creature was tapped, recomputes the entire pre-selection from the reduced cost. Adds `harmonizeReduction` to `ManaSelectionState`.
- **`GameBoard.manaProgress`** — subtracts `harmonizeReduction` from the displayed generic count.

> Note: the `manaSource` phase only runs in manual tap mode (auto-tap skips it for Harmonize), which is exactly the reported path.

## Tests

`manaCost.test.ts` adds coverage for the reduction math (over-reduction floor, printed-generic-first, mixed printed+`{X}`) and asserts the pre-selection taps **exactly 5** of 6 Forests with the tap vs **6** without — directly pinning the "tapped all 6" regression.

`manual-scenarios/cards/n/natures-rhythm-harmonize-x.json` reproduces the case in the running client (6 Forests + power-4 Krotiq Nestguard + Nature's Rhythm in the graveyard).

`npx vitest run` ✅ · `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)