### PR TITLE
Scope ZoneChange delayed triggers by their filter (Thunder of Unity)

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -237,6 +237,20 @@ the overwhelming majority of the set.
     `withCardOnBattlefield` so tests can place real tokens.
     → **Hardened Tactician**
 
+21. **Filter-scoped "whenever a creature you control enters this turn" delayed trigger.** ✅ **DONE.**
+    No new SDK was needed — a Saga chapter installs the existing `CreateDelayedTriggerEffect` with
+    `trigger = Triggers.entersBattlefield(GameObjectFilter.Creature.youControl(), binding = ANY)`,
+    `fireOnce = false`, `expiry = EndOfTurn`. The engine fix: `TriggerDetector.matchesEventForWatchedEntity`
+    ignored the spec's `GameObjectFilter` for `ZoneChangeEvent` delayed triggers (it only narrowed by a
+    `watchedEntityId`), so a "creature you control enters" trigger would have fired for *every* permanent
+    entering. Split the ZoneChange branch: entity-scoped (`watchedEntityId != null`) keeps the
+    moving-entity narrowing; **filter-scoped** (`watchedEntityId == null`) delegates to
+    `TriggerMatcher.matchesZoneChangeTrigger`, so the type and `you control` predicates are honored
+    exactly like a battlefield-resident trigger. Locked in by `ThunderOfUnityTest` (creature-you-control
+    pings; non-creature and opponent-controlled creature do not; fires per creature; expires; survives
+    the Saga's post-III sacrifice).
+    → **Thunder of Unity**
+
 ---
 
 ## Recommended build order

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1166,11 +1166,21 @@ Triggers.youCastSpell(
       upcoming own turn rather than an intervening opponent turn. (Kav Landseeker.)
 - **Event-based delayed triggers** — pass `trigger = <TriggerSpec>` (instead of `step`) and the
   delayed ability fires whenever a matching *event* occurs, staying resident until `expiry`
-  (`DelayedTriggerExpiry.EndOfTurn`) removes it. `watchedTarget` scopes it to one entity (e.g.
-  "when **that** creature deals combat damage / dies this turn" — Long River Lurker, Deflecting
-  Palm). Matching delegates to the same `TriggerMatcher` the battlefield triggers use, so supported
-  events include `DealsDamageEvent`, `ZoneChangeEvent`, the internal `DamagePreventedEvent`, and the
-  attack-declaration events `YouAttackEvent` / `AttackEvent`.
+  (`DelayedTriggerExpiry.EndOfTurn`) removes it. Supported events include `DealsDamageEvent`,
+  `ZoneChangeEvent`, the internal `DamagePreventedEvent`, and the attack-declaration events
+  `YouAttackEvent` / `AttackEvent`. There are two ways to scope which events match:
+  - **Entity-scoped** — set `watchedTarget` to bind the trigger to one concrete entity (resolved at
+    creation time): "when **that** creature deals combat damage / dies this turn" (Long River Lurker,
+    Deflecting Palm). Only `DealsDamageEvent` (scoped on the damage source) and `ZoneChangeEvent`
+    (scoped on the moving entity) use this; the spec's `GameObjectFilter` is *not* applied — the
+    watched entity is the whole scope.
+  - **Filter-scoped** — leave `watchedTarget` null and let the `TriggerSpec`'s `GameObjectFilter` +
+    `TriggerBinding` describe the group, exactly like a battlefield-resident trigger. Use this for
+    "whenever a creature you control enters this turn, …" (Thunder of Unity chapters II/III):
+    `trigger = Triggers.entersBattlefield(GameObjectFilter.Creature.youControl(), binding = ANY)`.
+    Matching delegates to the same `TriggerMatcher` the battlefield triggers use, so the filter's
+    type **and** controller predicates are honored — it fires only for *your* creatures, not every
+    permanent that enters. (`YouAttackEvent` / `AttackEvent` are always filter-scoped this way.)
   - `fireOnce = true` makes it a **one-shot**: it's consumed the first time it fires, then gone —
     "when you **next** [event] this turn". Combine with `trigger = Triggers.YouAttack` for the
     common "when you next attack this turn, …" template (All-Out Assault: untap each creature you

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ThunderOfUnity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ThunderOfUnity.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thunder of Unity — Tarkir: Dragonstorm #231
+ * {R}{W}{B} · Enchantment — Saga · Rare
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — You draw two cards and you lose 2 life.
+ * II, III — Whenever a creature you control enters this turn, each opponent loses 1 life and
+ *           you gain 1 life.
+ *
+ * Chapters II and III each install a turn-bounded, filter-scoped event delayed triggered ability:
+ * `CreateDelayedTriggerEffect(trigger = entersBattlefield(Creature.youControl(), binding = ANY))`
+ * with `fireOnce = false` (it fires for *every* creature you control that enters, not just the
+ * first) and `expiry = EndOfTurn`. Because the trigger has no single watched entity, the delayed
+ * trigger detector scopes it by the GameObjectFilter (`creature you control`) rather than a
+ * watched entity — see [TriggerDetector.matchesEventForWatchedEntity]. The two chapters create two
+ * independent instances of the ability, matching the printed card.
+ */
+val ThunderOfUnity = card("Thunder of Unity") {
+    manaCost = "{R}{W}{B}"
+    colorIdentity = "WBR"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — You draw two cards and you lose 2 life.\n" +
+        "II, III — Whenever a creature you control enters this turn, each opponent loses 1 life and you gain 1 life."
+
+    // I — You draw two cards and you lose 2 life.
+    sagaChapter(1) {
+        effect = Effects.DrawCards(2) then Effects.LoseLife(2, EffectTarget.Controller)
+    }
+
+    // II, III — Whenever a creature you control enters this turn, each opponent loses 1 life and
+    // you gain 1 life.
+    sagaChapter(2) {
+        effect = thunderOfUnityDelayedTrigger()
+    }
+    sagaChapter(3) {
+        effect = thunderOfUnityDelayedTrigger()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "231"
+        artist = "Clint Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c953b36-f5e4-4258-91cb-f07e799321f7.jpg?1744578016"
+    }
+}
+
+/**
+ * "Whenever a creature you control enters this turn, each opponent loses 1 life and you gain 1
+ * life." A fresh instance is installed by each of chapters II and III.
+ */
+private fun thunderOfUnityDelayedTrigger(): CreateDelayedTriggerEffect =
+    CreateDelayedTriggerEffect(
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        ),
+        fireOnce = false,
+        expiry = DelayedTriggerExpiry.EndOfTurn,
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)) then
+            Effects.GainLife(1)
+    )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -538,11 +538,17 @@ class TriggerDetector(
     }
 
     /**
-     * Match an event against a delayed-trigger TriggerSpec, scoped to a watched entity.
-     * Supports DealsDamageEvent (scoped on damage source), ZoneChangeEvent (scoped on the
-     * moving entity — "when that creature dies this turn"), and the attack-declaration events
-     * (player-scoped — "when you next attack this turn"), which delegate to the shared
-     * [TriggerMatcher.matchesTrigger] logic so they behave identically to battlefield triggers.
+     * Match an event against a delayed-trigger TriggerSpec.
+     *
+     * Two scoping modes:
+     *  - **Entity-scoped** (`watchedEntityId != null`): the trigger watches one concrete entity —
+     *    DealsDamageEvent (scoped on damage source) and ZoneChangeEvent ("when *that* creature dies
+     *    this turn"). The spec's GameObjectFilter is not applied; the watched entity is the scope.
+     *  - **Filter-scoped** (`watchedEntityId == null`): the trigger watches a *group* described by
+     *    the spec's GameObjectFilter + TriggerBinding — the attack-declaration events ("when you next
+     *    attack this turn") and ZoneChangeEvent ("whenever a creature you control enters this turn").
+     *    These delegate to the shared [TriggerMatcher] so they behave identically to battlefield
+     *    triggers, honoring the filter (including its controller predicate) and binding.
      */
     private fun matchesEventForWatchedEntity(
         spec: com.wingedsheep.sdk.scripting.TriggerSpec,
@@ -574,11 +580,23 @@ class TriggerDetector(
             }
             is com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent -> {
                 if (event !is ZoneChangeEvent) return false
-                if (watchedEntityId != null && event.entityId != watchedEntityId) return false
-                if (specEvent.from != null && event.fromZone != specEvent.from) return false
-                if (specEvent.to != null && event.toZone != specEvent.to) return false
-                if (specEvent.excludeTo != null && event.toZone == specEvent.excludeTo) return false
-                true
+                if (watchedEntityId != null) {
+                    // Entity-scoped: "when *that* creature dies/leaves this turn". The watched
+                    // entity already narrows the trigger, so we only check the zone transition —
+                    // the spec's GameObjectFilter does not apply.
+                    if (event.entityId != watchedEntityId) return false
+                    if (specEvent.from != null && event.fromZone != specEvent.from) return false
+                    if (specEvent.to != null && event.toZone != specEvent.to) return false
+                    if (specEvent.excludeTo != null && event.toZone == specEvent.excludeTo) return false
+                    true
+                } else {
+                    // Filter-scoped: "whenever a creature you control enters this turn". There is no
+                    // single watched entity, so the spec's GameObjectFilter and TriggerBinding are
+                    // what scope the trigger. Delegate to the canonical zone-change matcher so it
+                    // behaves identically to a battlefield-resident "whenever a [filtered] permanent
+                    // enters/leaves" trigger (Thunder of Unity chapters II/III).
+                    matcher.matchesZoneChangeTrigger(specEvent, spec.binding, event, sourceId, controllerId, state)
+                }
             }
             else -> false
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThunderOfUnityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThunderOfUnityTest.kt
@@ -1,0 +1,296 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.ThunderOfUnity
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Thunder of Unity (Tarkir: Dragonstorm #231) and, through it, the *filter-scoped*
+ * event-based delayed triggered ability — "Whenever a creature you control enters this turn, …".
+ *
+ * {R}{W}{B} · Enchantment — Saga
+ *   I — You draw two cards and you lose 2 life.
+ *   II, III — Whenever a creature you control enters this turn, each opponent loses 1 life and
+ *             you gain 1 life.
+ *
+ * Chapters II/III install a `CreateDelayedTriggerEffect` whose trigger is
+ * `entersBattlefield(Creature.youControl(), binding = ANY)`, `fireOnce = false`,
+ * `expiry = EndOfTurn`. Because this delayed trigger has no single *watched entity*, the delayed
+ * trigger detector must scope it by the spec's GameObjectFilter — both the `IsCreature` type
+ * predicate and the `you control` controller predicate. Before the fix,
+ * `TriggerDetector.matchesEventForWatchedEntity` ignored the filter on ZoneChange delayed triggers
+ * and fired for *every* permanent that entered (opponents' permanents, lands, the Saga itself,
+ * etc.). The "does NOT ping" tests below are the regression guard for that bug.
+ *
+ * Note on turn numbers: `GameState.turnNumber` is the round number (both players' turns within a
+ * round share it — see `TurnManager.startTurn`), so the controller's Saga gains a lore counter on
+ * rounds 1/2/3 → chapter I is round 1, chapter II is round 2, chapter III is round 3 (after which
+ * the Saga is sacrificed).
+ */
+class ThunderOfUnityTest : FunSpec({
+
+    // A vanilla creature the controller can cast so a "creature you control" enters.
+    val bear = card("Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    // A non-creature permanent the controller can cast — must NOT ping the trigger (type filter).
+    val totem = card("Test Totem") {
+        manaCost = "{1}"
+        typeLine = "Enchantment"
+    }
+
+    // A sorcery the controller casts that puts a 2/2 onto the battlefield under each OPPONENT's
+    // control — an opponent-controlled creature entering must NOT ping the trigger (controller
+    // filter), even though it happens on the controller's turn while the trigger is live.
+    val giftBear = card("Gift a Bear") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            effect = CreateTokenEffect(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Bear"),
+                name = "Bear",
+                controller = EffectTarget.PlayerRef(Player.EachOpponent)
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ThunderOfUnity, bear, totem, giftBear))
+        return driver
+    }
+
+    /** Fully resolve the stack, resolving every triggered ability that lands on it. */
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            bothPass()
+            guard++
+        }
+    }
+
+    /**
+     * Advance priority pass-by-pass until the active player's [targetRound] precombat main begins.
+     * Stops the instant we enter that step, so any Saga chapter trigger queued by the lore-counter
+     * turn-based action is still sitting on the stack (resolve it with [resolveStack]).
+     */
+    fun GameTestDriver.advanceToMain(targetRound: Int) {
+        var guard = 0
+        while (!(state.turnNumber == targetRound && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to round $targetRound")
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> {
+                    autoSubmitCombatDeclarationIfNeeded()
+                    passPriority(state.priorityPlayerId!!)
+                }
+            }
+            guard++
+        }
+    }
+
+    /** Cast Thunder of Unity on the first turn and resolve it + its chapter I. */
+    fun GameTestDriver.castThunderOfUnity(controller: EntityId) {
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        giveMana(controller, Color.RED, 1)
+        giveMana(controller, Color.WHITE, 1)
+        giveMana(controller, Color.BLACK, 1)
+        val saga = putCardInHand(controller, "Thunder of Unity")
+        castSpell(controller, saga)
+        resolveStack() // saga enters (lore 1 → chapter I), then chapter I resolves
+    }
+
+    /** Cast a single Test Bear (the controller's creature) and resolve it + any triggers. */
+    fun GameTestDriver.castBear(controller: EntityId) {
+        giveMana(controller, Color.GREEN, 2)
+        val bearCard = putCardInHand(controller, "Test Bear")
+        castSpell(controller, bearCard)
+        resolveStack()
+    }
+
+    /** Cast Thunder of Unity, then advance to its chapter II (round 2) and resolve it. */
+    fun GameTestDriver.buildToChapterII(controller: EntityId) {
+        castThunderOfUnity(controller)
+        advanceToMain(2) // controller's second turn → lore 2 → chapter II
+        resolveStack()
+    }
+
+    test("Chapter I — you draw two cards and lose 2 life; no delayed trigger yet") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+
+        val handBefore = driver.getHandSize(controller)
+        driver.castThunderOfUnity(controller)
+
+        // Drew two; the Saga was injected into hand for the test and then cast (net zero), so the
+        // observable change vs. the pre-cast hand is +2.
+        driver.getHandSize(controller) shouldBe handBefore + 2
+        driver.assertLifeTotal(controller, 18)
+        // Chapter I does not install any delayed trigger.
+        driver.state.delayedTriggers.size shouldBe 0
+    }
+
+    test("Chapter II — installs a turn-bounded 'creature you control enters' delayed trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+
+        driver.buildToChapterII(controller)
+
+        // The Saga is still on the battlefield (lore 2 < final chapter 3).
+        driver.findPermanent(controller, "Thunder of Unity").shouldNotBeNull()
+
+        val delayed = driver.state.delayedTriggers
+        delayed.size shouldBe 1
+        delayed.first().trigger shouldBe Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        // Fires on *every* matching enter (not one-shot) and lasts until end of turn.
+        delayed.first().fireOnce shouldBe false
+        delayed.first().expiry shouldBe DelayedTriggerExpiry.EndOfTurn
+    }
+
+    test("A creature you control entering pings; a second one pings again (fireOnce = false)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.buildToChapterII(controller)
+
+        val ctrlLife = driver.getLifeTotal(controller)
+        val oppLife = driver.getLifeTotal(opponent)
+
+        // First creature you control enters → each opponent loses 1, you gain 1.
+        driver.castBear(controller)
+        driver.assertLifeTotal(opponent, oppLife - 1)
+        driver.assertLifeTotal(controller, ctrlLife + 1)
+
+        // Second creature enters the same turn → fires again (the ability is not one-shot).
+        driver.castBear(controller)
+        driver.assertLifeTotal(opponent, oppLife - 2)
+        driver.assertLifeTotal(controller, ctrlLife + 2)
+    }
+
+    test("Regression: a NON-creature you control entering does NOT ping (type filter)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.buildToChapterII(controller)
+
+        val ctrlLife = driver.getLifeTotal(controller)
+        val oppLife = driver.getLifeTotal(opponent)
+
+        // Cast a non-creature permanent (an enchantment) you control — it enters but is not a
+        // creature, so the trigger must not fire. (Before the fix this fired for any permanent.)
+        driver.giveMana(controller, Color.RED, 1)
+        val totemCard = driver.putCardInHand(controller, "Test Totem")
+        driver.castSpell(controller, totemCard)
+        driver.resolveStack()
+
+        driver.assertLifeTotal(opponent, oppLife)
+        driver.assertLifeTotal(controller, ctrlLife)
+    }
+
+    test("Regression: an OPPONENT's creature entering does NOT ping (controller filter)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.buildToChapterII(controller)
+
+        val ctrlLife = driver.getLifeTotal(controller)
+        val oppLife = driver.getLifeTotal(opponent)
+
+        // Controller casts a sorcery that puts a 2/2 onto the battlefield under the OPPONENT's
+        // control. A creature enters this turn, but it isn't one *you* control, so the trigger
+        // must not fire. (Before the fix, the "you control" predicate was ignored and this pinged.)
+        driver.giveMana(controller, Color.RED, 1)
+        val gift = driver.putCardInHand(controller, "Gift a Bear")
+        driver.castSpell(controller, gift)
+        driver.resolveStack()
+
+        // The opponent really did get a creature…
+        driver.getCreatures(opponent).isEmpty().shouldBeFalse()
+        // …but no life changed.
+        driver.assertLifeTotal(opponent, oppLife)
+        driver.assertLifeTotal(controller, ctrlLife)
+    }
+
+    test("The delayed trigger expires at end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        // Chapter III (round 3) installs the delayed trigger, then the Saga is sacrificed. Using
+        // chapter III means no later chapter re-installs the ability, so we can observe the expiry.
+        driver.castThunderOfUnity(controller)
+        driver.advanceToMain(3)
+        driver.resolveStack()
+        driver.state.delayedTriggers.size shouldBe 1
+
+        // Advance to the controller's next turn (round 4); the "this turn" trigger is gone and no
+        // chapter re-installs it (the Saga left after III), so a creature entering does nothing.
+        driver.advanceToMain(4)
+        driver.state.delayedTriggers.size shouldBe 0
+
+        val ctrlLife = driver.getLifeTotal(controller)
+        val oppLife = driver.getLifeTotal(opponent)
+        driver.castBear(controller)
+        driver.assertLifeTotal(opponent, oppLife)
+        driver.assertLifeTotal(controller, ctrlLife)
+    }
+
+    test("Chapter III installs the trigger and it survives the Saga's post-III sacrifice") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.castThunderOfUnity(controller)
+        driver.advanceToMain(3) // lore 3 → chapter III on the stack
+        driver.resolveStack() // chapter III resolves (installs trigger), then the Saga is sacrificed
+
+        // Saga is gone (sacrificed as a state-based action after its final chapter)…
+        driver.findPermanent(controller, "Thunder of Unity") shouldBe null
+        // …but the delayed trigger persists this turn, decoupled from its source.
+        driver.state.delayedTriggers.size shouldBe 1
+
+        // A creature you control entering still pings, even though the Saga that created the
+        // ability has left the battlefield.
+        val ctrlLife = driver.getLifeTotal(controller)
+        val oppLife = driver.getLifeTotal(opponent)
+        driver.castBear(controller)
+        driver.assertLifeTotal(opponent, oppLife - 1)
+        driver.assertLifeTotal(controller, ctrlLife + 1)
+    }
+})


### PR DESCRIPTION
## What

Makes **filter-scoped** event-based delayed triggers — "whenever a creature you control enters this turn, …" — actually honor the `TriggerSpec`'s `GameObjectFilter` for `ZoneChangeEvent`, and adds **Thunder of Unity** (TDM #231) as the first user.

Closes the engine gap behind issue #231.

## The bug

`TriggerDetector.matchesEventForWatchedEntity` checked only the zone transition for `ZoneChange` delayed triggers and returned `true`, ignoring the spec's filter. That's fine for **entity-scoped** triggers ("when *that* creature dies this turn", which carry a `watchedEntityId`), but a **group-scoped** trigger ("whenever a creature you control enters") would fire for *every* permanent entering the battlefield — opponents' permanents, lands, even the source itself.

## The fix

Split the `ZoneChangeEvent` branch in `matchesEventForWatchedEntity`:

- `watchedEntityId != null` → **entity-scoped**, unchanged (zone + entity narrowing).
- `watchedEntityId == null` → **filter-scoped**: delegate to `TriggerMatcher.matchesZoneChangeTrigger` so the `GameObjectFilter` (type **and** "you control" controller predicate) and `TriggerBinding` apply exactly as for a battlefield-resident trigger — mirroring how `YouAttackEvent`/`AttackEvent` already delegate.

No new SDK type was needed. A Saga chapter installs the existing `CreateDelayedTriggerEffect` with `trigger = entersBattlefield(Creature.youControl(), binding = ANY)`, `fireOnce = false`, `expiry = EndOfTurn`.

All existing event-based `ZoneChange` delayed triggers are entity-scoped (`watchedTarget` set), so this only activates the previously-broken filter-scoped path — no behavior change for existing cards.

## Thunder of Unity (TDM #231)

`{R}{W}{B}` · Enchantment — Saga
- **I** — You draw two cards and you lose 2 life.
- **II, III** — Whenever a creature you control enters this turn, each opponent loses 1 life and you gain 1 life.

## Tests

`ThunderOfUnityTest` (rules-engine) drives the Saga through real `ZoneChangeEvent`s and covers:
- Chapter I: draw two, lose two; no delayed trigger installed.
- Chapter II/III: installs the filter-scoped delayed trigger (correct spec, `fireOnce = false`, `EndOfTurn`).
- A creature **you control** entering pings life; fires **once per creature** (not one-shot).
- Regression — a **non-creature you control** entering does **not** ping (type predicate).
- Regression — an **opponent-controlled** creature entering does **not** ping (controller predicate).
- The trigger **expires** at end of turn.
- The trigger **survives the Saga's post-III sacrifice** (decoupled from its source).

Full `:rules-engine:test` suite is green; `./gradlew build` passes.

## Docs

- `docs/card-sdk-language-reference.md` — documents entity-scoped vs filter-scoped delayed triggers.
- `backlog/tdm-engine-gaps.md` — item 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)