### PR TITLE
Add Leyline of Hope to Duskmourn with leyline opening-hand mechanic

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -57,6 +57,11 @@ section; do not let SDK additions land without a corresponding doc update.
 - `replacementEffect { ... }` — "instead/if … would" replacement.
 - `keywords(...)` / `keywordAbility(...)` / `keywordAbilities(...)` — add keyword abilities.
 - `spell { ... }` — define the spell payload for instants/sorceries and Adventure / Omen faces.
+- `leyline()` — Leyline mechanic ("If this card is in your opening hand, you may begin the game with it on the
+  battlefield"). Sets `CardScript.mayStartOnBattlefield = true`. After all mulligans and bottoming resolve, the
+  engine walks each player in turn order from the active player and presents a yes/no decision per leyline card
+  in their opening hand; a "yes" routes the card to the battlefield through the standard zone-change pipeline
+  before the first turn begins, a "no" leaves it in hand.
 
 ---
 
@@ -2059,6 +2064,14 @@ replacementEffect {
   use a source-relative condition instead. Use for "if you would draw one or more cards, you draw
   that many cards plus N instead" (Quantum Riddler:
   `ModifyDrawAmount(modifier = 1, restrictions = listOf(Conditions.CardsInHandAtMost(1)), appliesTo = DrawEvent(player = Player.You))`).
+- `ModifyLifeGain(multiplier, modifier, appliesTo)` — modify life gain by a multiplicative *and/or* additive
+  factor: `gained = (original * multiplier) + modifier`, clamped to ≥ 0. `appliesTo` is a `LifeGainEvent` whose
+  `player` filter (default `Player.Each`) gates which players the replacement applies to. Used by Alhammarret's
+  Archive (`multiplier = 2`), Leyline of Hope (`multiplier = 1, modifier = 1, player = Player.You`). Multiple
+  instances stack (×s multiply, +s sum) — two Leylines of Hope add 2 to every life-gain event.
+- `ModifyLifeLoss(multiplier, modifier, restrictions, appliesTo)` — same shape as `ModifyLifeGain` for life loss
+  events (`LifeLossEvent`), plus a `restrictions: List<Condition>` list that further gates the replacement.
+- `PreventLifeGain(appliesTo)` — life gain matching the event is fully prevented (Sulfuric Vortex, Erebos).
 - Custom — implement the `ReplacementEffect` interface directly.
 
 Amount-modifying replacements expose **both** `multiplier` (×) and `modifier` (±) on the same type — do not split into

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/LeylineOfHopeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/LeylineOfHopeScenarioTest.kt
@@ -1,0 +1,341 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.KeepHand
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.handlers.effects.LifeGainModifiers
+import com.wingedsheep.engine.mechanics.layers.ContinuousEffectSourceComponent
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.player.MulliganStateComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Leyline of Hope (DSK #18).
+ *
+ * "{2}{W}{W} Enchantment
+ *  If this card is in your opening hand, you may begin the game with it on the battlefield.
+ *  If you would gain life, you gain that much life plus 1 instead.
+ *  As long as you have at least 7 life more than your starting life total,
+ *    creatures you control get +2/+2."
+ */
+class LeylineOfHopeScenarioTest : ScenarioTestBase() {
+
+    // A minimal sorcery that gives the caster 3 life. Used to drive [ModifyLifeGain].
+    private val gainThreeLife = card("Test Gain Three") {
+        manaCost = "{W}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(3) }
+    }
+
+    // A vanilla 1/1 creature so we can observe the conditional anthem applying / lifting.
+    private val testGrunt = card("Test Grunt") {
+        manaCost = "{W}"
+        typeLine = "Creature — Soldier"
+        power = 1
+        toughness = 1
+    }
+
+    private val stateProjector = StateProjector()
+
+    init {
+        cardRegistry.register(gainThreeLife)
+        cardRegistry.register(testGrunt)
+
+        context("Leyline of Hope") {
+
+            test("life gain is increased by 1 while Leyline of Hope is on the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Leyline of Hope")
+                    .withCardInHand(1, "Test Gain Three")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Test Gain Three")
+                withClue("Casting the test spell should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Gaining 3 life with Leyline of Hope should net 4") {
+                    game.getLifeTotal(1) shouldBe 24
+                }
+            }
+
+            test("combat lifelink life gain is increased by 1 while Leyline of Hope is on the battlefield") {
+                // Regression: combat lifelink used to bypass LifeGainModifiers, so Leyline of
+                // Hope's +1 only applied to spell-driven gainLife and noncombat lifelink.
+                // Healer's Hawk (1/1 flying lifelink) attacking unblocked should gain its
+                // controller 1 + 1 = 2 life with Leyline of Hope out.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Leyline of Hope")
+                    .withCardOnBattlefield(1, "Healer's Hawk", summoningSickness = false)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Healer's Hawk" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                var iterations = 0
+                while (game.state.step != Step.POSTCOMBAT_MAIN && iterations++ < 20) {
+                    game.passPriority()
+                }
+
+                withClue("Healer's Hawk (1/1 lifelink) deals 1 combat damage to the defender") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("Lifelink life gain should run through Leyline of Hope: 1 + 1 = 2") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+
+            test("multiple Leylines of Hope stack additively") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Leyline of Hope")
+                    .withCardOnBattlefield(1, "Leyline of Hope")
+                    .withCardInHand(1, "Test Gain Three")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Test Gain Three")
+                withClue("Casting the test spell should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Two Leylines → +1 +1 → 3 + 2 = 5 gained.
+                withClue("Two Leylines of Hope should add 2 to every life gain") {
+                    game.getLifeTotal(1) shouldBe 25
+                }
+            }
+
+            test("the +1 only applies to its controller, not opponents") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Leyline of Hope")
+                    .withCardInHand(2, "Test Gain Three")
+                    .withLandsOnBattlefield(2, "Plains", 1)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(2, "Test Gain Three")
+                withClue("Casting the test spell should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Opponent's life gain should be unaffected by player 1's Leyline of Hope") {
+                    game.getLifeTotal(2) shouldBe 23
+                }
+            }
+
+            test("creatures you control get +2/+2 once you reach 7 life above starting") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Leyline of Hope")
+                    .withCardOnBattlefield(1, "Test Grunt", summoningSickness = false)
+                    .withLifeTotal(1, 27)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gruntId = game.findPermanent("Test Grunt")!!
+                val projected = stateProjector.project(game.state)
+                withClue("At life=27 (starting 20 + 7) the anthem should be active") {
+                    projected.getPower(gruntId) shouldBe 3
+                    projected.getToughness(gruntId) shouldBe 3
+                }
+            }
+
+            test("the anthem does NOT apply when life is below starting + 7") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Leyline of Hope")
+                    .withCardOnBattlefield(1, "Test Grunt", summoningSickness = false)
+                    .withLifeTotal(1, 26)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gruntId = game.findPermanent("Test Grunt")!!
+                val projected = stateProjector.project(game.state)
+                withClue("At life=26 the anthem should be inactive (need ≥27)") {
+                    projected.getPower(gruntId) shouldBe 1
+                    projected.getToughness(gruntId) shouldBe 1
+                }
+            }
+
+            test("opening-hand leyline: yes puts the card onto the battlefield before turn 1") {
+                // Build a real game via GameInitializer so the mulligan → leyline → turn 1
+                // hand-off goes through the production code path.
+                val plainsHeavy = Deck.of("Leyline of Hope" to 1, "Plains" to 59)
+                val deck = Deck.of("Plains" to 60)
+                val initializer = GameInitializer(cardRegistry)
+                val init = initializer.initializeGame(
+                    GameConfig(
+                        players = listOf(
+                            PlayerConfig("P1", plainsHeavy),
+                            PlayerConfig("P2", deck)
+                        ),
+                        startingPlayerIndex = 0,
+                        // Force the Leyline into the opening hand by drawing the whole deck;
+                        // the leyline scan only inspects the opening hand.
+                        startingHandSize = 60
+                    )
+                )
+                val processor = ActionProcessor(cardRegistry)
+                var state = init.state
+                val p1Id = init.playerIds[0]
+                val p2Id = init.playerIds[1]
+
+                // Both players keep their hands without mulligans.
+                state = processor.process(state, KeepHand(p1Id)).result.let {
+                    withClue("P1 KeepHand should succeed: ${it.error}") { it.error shouldBe null }
+                    it.state
+                }
+                val afterP2Keep = processor.process(state, KeepHand(p2Id)).result
+                withClue("P2 KeepHand should pause for the leyline yes/no: ${afterP2Keep.error}") {
+                    afterP2Keep.error shouldBe null
+                }
+                state = afterP2Keep.state
+
+                val leylineDecision = state.pendingDecision
+                leylineDecision.shouldBeInstanceOf<YesNoDecision>()
+                withClue("The leyline prompt should be addressed to the player who owns the leyline (P1)") {
+                    leylineDecision.playerId shouldBe p1Id
+                }
+
+                // Answer yes — Leyline of Hope should move to P1's battlefield.
+                val afterYes = processor.process(
+                    state,
+                    SubmitDecision(p1Id, YesNoResponse(leylineDecision.id, true))
+                ).result
+                withClue("Submitting yes should succeed: ${afterYes.error}") {
+                    afterYes.error shouldBe null
+                }
+                state = afterYes.state
+
+                val battlefield = state.getZone(ZoneKey(p1Id, Zone.BATTLEFIELD))
+                val leylineId = battlefield.firstOrNull { id ->
+                    state.getEntity(id)?.get<CardComponent>()?.name == "Leyline of Hope"
+                }
+                withClue("Leyline of Hope should be on the battlefield after the yes answer") {
+                    leylineId shouldNotBe null
+                }
+
+                withClue("Pending decision should be cleared once the leyline phase finishes") {
+                    state.pendingDecision shouldBe null
+                }
+
+                val mulliganState = state.getEntity(p1Id)?.get<MulliganStateComponent>()
+                withClue("P1's pending leyline list should be empty") {
+                    mulliganState?.pendingLeylineCardIds shouldBe emptyList()
+                }
+
+                // Regression for leyline-yes wiring: the static ability + replacement effect
+                // components must be attached so the anthem reaches the projector and the +1
+                // life rider reaches the replacement-application path. Without these the
+                // permanent is on the battlefield in name only.
+                val leylineEntity = state.getEntity(leylineId!!)
+                withClue("Leyline of Hope must carry ContinuousEffectSourceComponent so its anthem reaches the projector") {
+                    leylineEntity?.get<ContinuousEffectSourceComponent>() shouldNotBe null
+                }
+                withClue("Leyline of Hope must carry ReplacementEffectSourceComponent so its +1 life rider fires") {
+                    leylineEntity?.get<ReplacementEffectSourceComponent>() shouldNotBe null
+                }
+                withClue("LifeGainModifiers should add 1 to a 3-life gain when Leyline of Hope is on P1's battlefield") {
+                    LifeGainModifiers.apply(state, p1Id, 3) shouldBe 4
+                }
+            }
+
+            test("opening-hand leyline: no leaves the card in hand and advances to turn 1") {
+                val plainsHeavy = Deck.of("Leyline of Hope" to 1, "Plains" to 59)
+                val deck = Deck.of("Plains" to 60)
+                val initializer = GameInitializer(cardRegistry)
+                val init = initializer.initializeGame(
+                    GameConfig(
+                        players = listOf(
+                            PlayerConfig("P1", plainsHeavy),
+                            PlayerConfig("P2", deck)
+                        ),
+                        startingPlayerIndex = 0,
+                        startingHandSize = 60
+                    )
+                )
+                val processor = ActionProcessor(cardRegistry)
+                var state = init.state
+                val p1Id = init.playerIds[0]
+                val p2Id = init.playerIds[1]
+
+                state = processor.process(state, KeepHand(p1Id)).result.state
+                state = processor.process(state, KeepHand(p2Id)).result.state
+
+                val leylineDecision = state.pendingDecision
+                leylineDecision.shouldBeInstanceOf<YesNoDecision>()
+
+                val afterNo = processor.process(
+                    state,
+                    SubmitDecision(p1Id, YesNoResponse(leylineDecision.id, false))
+                ).result
+                withClue("Submitting no should succeed: ${afterNo.error}") {
+                    afterNo.error shouldBe null
+                }
+                state = afterNo.state
+
+                val handHasLeyline = state.getHand(p1Id).any { id ->
+                    state.getEntity(id)?.get<CardComponent>()?.name == "Leyline of Hope"
+                }
+                withClue("Leyline of Hope should remain in P1's hand after declining") {
+                    handHasLeyline shouldBe true
+                }
+
+                val battlefield = state.getZone(ZoneKey(p1Id, Zone.BATTLEFIELD))
+                val leylineOnBattlefield = battlefield.any { id ->
+                    state.getEntity(id)?.get<CardComponent>()?.name == "Leyline of Hope"
+                }
+                withClue("Leyline of Hope should NOT be on the battlefield after declining") {
+                    leylineOnBattlefield shouldBe false
+                }
+
+                withClue("Pending decision should be cleared once the leyline phase finishes") {
+                    state.pendingDecision shouldBe null
+                }
+
+                // Players each still have 20 life (the leyline never resolved into life-gain).
+                state.getEntity(p1Id)?.get<LifeTotalComponent>()?.life shouldBe 20
+                state.getEntity(p2Id)?.get<LifeTotalComponent>()?.life shouldBe 20
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -276,6 +276,26 @@ class CardBuilder(private val name: String) {
      */
     var layout: CardLayout = CardLayout.NORMAL
 
+    /**
+     * Leyline marker. When true, the card carries the "If this card is in your opening
+     * hand, you may begin the game with it on the battlefield" ability. Set via the
+     * [leyline] DSL helper rather than by hand.
+     */
+    var mayStartOnBattlefield: Boolean = false
+
+    /**
+     * Leyline mechanic (Future Sight / M11 / M20 / Duskmourn cycles). "If this card is in
+     * your opening hand, you may begin the game with it on the battlefield." The engine
+     * resolves all Leyline choices after mulligans and bottoming complete, walking each
+     * player in turn order starting with the active player.
+     *
+     * Display-only at the SDK level; the engine reads [CardScript.mayStartOnBattlefield]
+     * to drive the per-card yes/no prompt during the leyline phase.
+     */
+    fun leyline() {
+        mayStartOnBattlefield = true
+    }
+
     // =========================================================================
     // Internal State
     // =========================================================================
@@ -956,7 +976,8 @@ class CardBuilder(private val name: String) {
             sagaChapters = sagaChaptersList.toList(),
             selfExileOnResolve = spellBuilder?.exilesOnResolve ?: false,
             selfAlternativeCost = selfAlternativeCost,
-            xManaRestriction = spellBuilder?.xManaRestriction ?: emptySet()
+            xManaRestriction = spellBuilder?.xManaRestriction ?: emptySet(),
+            mayStartOnBattlefield = mayStartOnBattlefield
         )
 
         // Build metadata

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
@@ -226,7 +226,19 @@ data class CardScript(
      * and the per-color amount actually spent on X is exposed via
      * [com.wingedsheep.sdk.scripting.values.DynamicAmount.ManaSpentOnX].
      */
-    val xManaRestriction: Set<Color> = emptySet()
+    val xManaRestriction: Set<Color> = emptySet(),
+
+    /**
+     * Leyline mechanic. "If this card is in your opening hand, you may begin the game
+     * with it on the battlefield." After all mulligans and bottoming resolve, the engine
+     * walks each player in turn order (starting with the active player) and presents a
+     * yes/no choice per Leyline card still in that player's opening hand. A "yes" puts the
+     * card onto the battlefield under its owner's control through the standard zone-change
+     * pipeline before the first turn begins; a "no" leaves it in hand.
+     *
+     * Wired via the `leyline()` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder].
+     */
+    val mayStartOnBattlefield: Boolean = false
 ) {
     /**
      * Whether this card has any scripted behavior.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -677,19 +677,46 @@ data class ReplaceLifeGain(
 }
 
 /**
- * Modify life gain amount.
- * Example: Alhammarret's Archive (double life gain)
+ * Modify life gain amount. Combines multiplicative and additive modifications:
+ * `newAmount = (originalAmount * multiplier) + modifier`, clamped to ≥ 0.
+ *
+ * Examples:
+ * - Alhammarret's Archive — double life gain: `ModifyLifeGain(multiplier = 2)`
+ * - Leyline of Hope — "you gain that much life plus 1 instead":
+ *     `ModifyLifeGain(modifier = 1, appliesTo = LifeGainEvent(player = Player.You))`
+ *
+ * @param multiplier Multiplicative factor applied first (default 2 to preserve the
+ *        historical Alhammarret's Archive default).
+ * @param modifier Flat amount added after multiplication (default 0 = unchanged).
  */
 @SerialName("ModifyLifeGain")
 @Serializable
 data class ModifyLifeGain(
     val multiplier: Int = 2,
+    val modifier: Int = 0,
     override val appliesTo: GameEvent = GameEvent.LifeGainEvent()
 ) : ReplacementEffect {
-    override val description: String = when (multiplier) {
-        2 -> "If ${appliesTo.description}, gain twice that much life instead"
-        0 -> "If ${appliesTo.description}, gain no life instead"
-        else -> "If ${appliesTo.description}, gain $multiplier times that much life instead"
+    override val description: String = buildString {
+        append("If ")
+        append(appliesTo.description)
+        append(", gain ")
+        when {
+            multiplier == 0 && modifier == 0 -> append("no life")
+            multiplier == 1 && modifier > 0 -> append("that much life plus $modifier")
+            multiplier == 1 && modifier < 0 -> append("${-modifier} less life")
+            multiplier != 1 && modifier == 0 -> when (multiplier) {
+                2 -> append("twice that much life")
+                else -> append("$multiplier times that much life")
+            }
+            else -> {
+                when (multiplier) {
+                    2 -> append("twice that much life")
+                    else -> append("$multiplier times that much life")
+                }
+                if (modifier > 0) append(" plus $modifier") else append(" minus ${-modifier}")
+            }
+        }
+        append(" instead")
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfHope.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfHope.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.ModifyLifeGain
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Leyline of Hope (DSK #18)
+ * {2}{W}{W}  Enchantment
+ *
+ * If this card is in your opening hand, you may begin the game with it on the battlefield.
+ * If you would gain life, you gain that much life plus 1 instead.
+ * As long as you have at least 7 life more than your starting life total, creatures you
+ * control get +2/+2.
+ */
+val LeylineOfHope = card("Leyline of Hope") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "If this card is in your opening hand, you may begin the game with it on the battlefield.\n" +
+        "If you would gain life, you gain that much life plus 1 instead.\n" +
+        "As long as you have at least 7 life more than your starting life total, creatures you control get +2/+2."
+
+    leyline()
+
+    replacementEffect(
+        ModifyLifeGain(
+            multiplier = 1,
+            modifier = 1,
+            appliesTo = GameEvent.LifeGainEvent(player = Player.You)
+        )
+    )
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(
+                powerBonus = 2,
+                toughnessBonus = 2,
+                filter = GroupFilter.AllCreaturesYouControl
+            ),
+            condition = Compare(
+                left = DynamicAmount.LifeTotal(Player.You),
+                operator = ComparisonOperator.GTE,
+                right = DynamicAmount.Add(
+                    DynamicAmount.StartingLifeTotal(Player.You),
+                    DynamicAmount.Fixed(7)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "18"
+        artist = "Sergey Glushakov"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40960e47-3065-485e-aede-29a62411034e.jpg?1726285926"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EngineServices.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EngineServices.kt
@@ -11,7 +11,9 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutorRegistry
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.mechanics.StateBasedActionChecker
+import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.mechanics.combat.CombatManager
 import com.wingedsheep.engine.mechanics.mana.AlternativePaymentHandler
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
@@ -41,6 +43,11 @@ class EngineServices(
 ) {
     init {
         DamageUtils.cardRegistry = cardRegistry
+        // ZoneTransitionService.applyBattlefieldEntry registers a permanent's static abilities
+        // and replacement effects on entry, so any code that moves a card to the battlefield
+        // (reanimation, exile returns, leyline starts) gets the same wiring the cast pipeline
+        // does. The handler is stateless beyond the registry, so a singleton is sufficient.
+        ZoneTransitionService.staticAbilityHandler = StaticAbilityHandler(cardRegistry)
     }
     val effectExecutorRegistry = EffectExecutorRegistry(cardRegistry = cardRegistry)
     val manaAbilitySideEffectExecutor = ManaAbilitySideEffectExecutor(
@@ -59,7 +66,7 @@ class EngineServices(
     val grantedKeywordResolver = GrantedKeywordResolver(cardRegistry)
     val alternativePaymentHandler = AlternativePaymentHandler(grantedKeywordResolver)
     val costHandler = CostHandler()
-    val mulliganHandler = MulliganHandler()
+    val mulliganHandler = MulliganHandler(cardRegistry)
     val conditionEvaluator = ConditionEvaluator()
     val targetValidator = TargetValidator()
     val targetFinder = TargetFinder()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LeylineContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LeylineContinuations.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.serialization.Serializable
+
+/**
+ * Resume after a player decides whether to put one of their leyline cards onto the
+ * battlefield from their opening hand.
+ *
+ * The leyline phase runs after all mulligans and bottoming complete but before the first
+ * turn begins (CR 103.6 / 103.6a: once mulligans are done, the starting player and then
+ * each other player in turn order may put any "begin the game with this on the battlefield"
+ * card from their opening hand onto the battlefield). The engine walks players in turn order
+ * starting with the active player; for each player it drains their
+ * [com.wingedsheep.engine.state.components.player.MulliganStateComponent.pendingLeylineCardIds]
+ * one card at a time, pausing each step with a yes/no decision and pushing a fresh
+ * [LeylineDecisionContinuation] for the next card.
+ *
+ * The resumer (see `LeylineContinuationResumer`) handles two outcomes:
+ *  - **yes**: route the card through the standard zone-change pipeline (hand → battlefield
+ *    under owner's control) so any ETB replacement effects and trackers fire normally.
+ *  - **no**: leave the card in hand; just drop it from the pending list.
+ * After applying the outcome it either pauses with the next leyline prompt or hands the
+ * state back to `SubmitDecisionHandler`, which advances the game from UNTAP into the first
+ * turn via `turnManager.advanceStep`.
+ *
+ * @property playerId Player making this decision (the leyline card's owner)
+ * @property leylineCardId The leyline card entity in [playerId]'s hand
+ * @property cardName Card name for prompt rendering (avoids a registry lookup at resume time)
+ */
+@Serializable
+data class LeylineDecisionContinuation(
+    override val decisionId: String,
+    val playerId: EntityId,
+    val leylineCardId: EntityId,
+    val cardName: String
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -276,6 +276,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CastAnyNumberFromCollectionContinuation::class)
         subclass(StaticDrawReplacementContinuation::class)
         subclass(TokenCreationReplacementContinuation::class)
+        subclass(LeylineDecisionContinuation::class)
     }
 
     // Component hierarchy (for GameState persistence)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
@@ -48,6 +48,7 @@ class ContinuationHandler(
         registerModule(TokenContinuationResumer(services))
         registerModule(RingTemptContinuationResumer(services))
         registerModule(AmassContinuationResumer(services))
+        registerModule(LeylineContinuationResumer(services))
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/MulliganHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/MulliganHandler.kt
@@ -1,12 +1,14 @@
 package com.wingedsheep.engine.handlers
 
 import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.MulliganStateComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import java.util.UUID
 
 /**
  * Handles mulligan-related actions during game setup.
@@ -24,7 +26,15 @@ import com.wingedsheep.sdk.model.EntityId
  * - [KeepHand]: Player accepts current hand
  * - [BottomCards]: Player puts cards on bottom after keeping
  */
-class MulliganHandler {
+class MulliganHandler(
+    /**
+     * Card registry used to look up [com.wingedsheep.sdk.model.CardDefinition]s during the
+     * leyline phase. Mulligan and bottoming themselves don't need the registry — it's only
+     * consulted when scanning a player's opening hand for leyline-marked cards once all
+     * players have kept and bottomed.
+     */
+    private val cardRegistry: CardRegistry? = null
+) {
 
     /**
      * Check if the game is still in mulligan phase.
@@ -278,5 +288,164 @@ class MulliganHandler {
         return state.getEntity(playerId)
             ?.get<MulliganStateComponent>()
             ?: MulliganStateComponent()
+    }
+
+    // =========================================================================
+    // Leyline phase
+    // =========================================================================
+
+    /**
+     * Whether any player still has pending leyline yes/no decisions, OR the leyline phase
+     * hasn't been initiated yet for at least one player (but mulligans are complete). This
+     * blocks the transition to turn 1 — see [com.wingedsheep.engine.handlers.actions.mulligan.KeepHandHandler]
+     * and `BottomCardsHandler.checkMulliganCompletion`.
+     */
+    fun isInLeylinePhase(state: GameState): Boolean {
+        return state.turnOrder.any { playerId ->
+            val mullState = getMulliganState(state, playerId)
+            mullState.hasPendingLeylineChoices
+        }
+    }
+
+    /**
+     * Populate each player's [MulliganStateComponent.pendingLeylineCardIds] by scanning
+     * their opening hand for cards whose [com.wingedsheep.sdk.model.CardScript.mayStartOnBattlefield]
+     * is true. Idempotent — sets `leylinePhaseStarted = true` so re-entry into the mulligan
+     * completion path doesn't re-scan.
+     *
+     * Returns the updated state. Callers should then call [tryStartNextLeylineDecision] to
+     * see whether a yes/no decision needs to be paused on.
+     */
+    fun initiateLeylinePhase(state: GameState): GameState {
+        val registry = cardRegistry ?: return state
+        var newState = state
+        for (playerId in newState.turnOrder) {
+            val mullState = getMulliganState(newState, playerId)
+            if (mullState.leylinePhaseStarted) continue
+
+            val hand = newState.getHand(playerId)
+            val leylineCardIds = hand.filter { cardId ->
+                val cardComponent = newState.getEntity(cardId)?.get<CardComponent>() ?: return@filter false
+                val cardDef = registry.getCard(cardComponent.cardDefinitionId) ?: return@filter false
+                cardDef.script.mayStartOnBattlefield
+            }
+
+            val updatedMullState = mullState.copy(
+                leylinePhaseStarted = true,
+                pendingLeylineCardIds = leylineCardIds
+            )
+            newState = newState.updateEntity(playerId) { container ->
+                container.with(updatedMullState)
+            }
+        }
+        return newState
+    }
+
+    /**
+     * Find the next leyline yes/no decision that needs to be asked, in turn order starting
+     * with the active player (CR 103.6: once mulligans are done, the starting player takes
+     * their opening-hand actions first, then each other player in turn order). Returns null
+     * if no decisions remain.
+     *
+     * The returned pair is `(playerId, cardId)` — the player making the choice and the
+     * specific leyline card in their hand.
+     */
+    fun getNextLeylineChoice(state: GameState): Pair<EntityId, EntityId>? {
+        val activePlayerId = state.activePlayerId
+        val ordered = if (activePlayerId != null && state.turnOrder.contains(activePlayerId)) {
+            val idx = state.turnOrder.indexOf(activePlayerId)
+            state.turnOrder.subList(idx, state.turnOrder.size) + state.turnOrder.subList(0, idx)
+        } else {
+            state.turnOrder
+        }
+        for (playerId in ordered) {
+            val mullState = getMulliganState(state, playerId)
+            val firstLeyline = mullState.pendingLeylineCardIds.firstOrNull() ?: continue
+            return playerId to firstLeyline
+        }
+        return null
+    }
+
+    /**
+     * Try to advance the game past the mulligan/leyline setup.
+     *
+     * Called from [com.wingedsheep.engine.handlers.actions.mulligan.KeepHandHandler] and
+     * [com.wingedsheep.engine.handlers.actions.mulligan.BottomCardsHandler] once their own
+     * work completes. Three outcomes:
+     *  - Mulligans/bottoming still pending → return the carried-through events; the next
+     *    KeepHand / BottomCards action will resume the flow.
+     *  - A leyline yes/no is still needed → pause with that decision.
+     *  - Setup is done → call [TurnManager.advanceStep] to start turn 1.
+     *
+     * Centralising the logic here keeps the two handlers from drifting and gives the leyline
+     * phase a single point of truth.
+     */
+    fun tryAdvancePastMulliganPhase(
+        state: GameState,
+        events: List<GameEvent>,
+        turnManager: TurnManager
+    ): ExecutionResult {
+        if (isInMulliganPhase(state) || needsBottomCards(state)) {
+            return ExecutionResult.success(state, events)
+        }
+
+        val stateWithLeylineScan = initiateLeylinePhase(state)
+        val nextLeyline = getNextLeylineChoice(stateWithLeylineScan)
+        if (nextLeyline != null) {
+            val (playerId, cardId) = nextLeyline
+            val (decision, continuation) = createLeylineDecision(stateWithLeylineScan, playerId, cardId)
+                ?: return ExecutionResult.success(stateWithLeylineScan, events)
+            val pausedState = stateWithLeylineScan
+                .pushContinuation(continuation)
+                .withPendingDecision(decision)
+            return ExecutionResult.paused(
+                pausedState,
+                decision,
+                events + DecisionRequestedEvent(
+                    decisionId = decision.id,
+                    playerId = playerId,
+                    decisionType = "YES_NO",
+                    prompt = decision.prompt
+                )
+            )
+        }
+
+        val advanceResult = turnManager.advanceStep(stateWithLeylineScan)
+        return ExecutionResult.success(
+            advanceResult.newState,
+            events + advanceResult.events
+        )
+    }
+
+    /**
+     * Build the [YesNoDecision] + [LeylineDecisionContinuation] pair for a specific leyline
+     * card in a player's opening hand. The caller is responsible for pushing the continuation
+     * and setting the pending decision on state.
+     *
+     * Returns null when the card no longer has a [CardComponent] (defensive — shouldn't happen).
+     */
+    fun createLeylineDecision(state: GameState, playerId: EntityId, leylineCardId: EntityId): Pair<YesNoDecision, LeylineDecisionContinuation>? {
+        val cardName = state.getEntity(leylineCardId)?.get<CardComponent>()?.name ?: return null
+        val decisionId = "leyline-${leylineCardId.value}-${UUID.randomUUID()}"
+        val decision = YesNoDecision(
+            id = decisionId,
+            playerId = playerId,
+            prompt = "Begin the game with $cardName on the battlefield?",
+            context = DecisionContext(
+                sourceId = leylineCardId,
+                sourceName = cardName,
+                phase = DecisionPhase.CASTING
+            ),
+            yesText = "Yes",
+            noText = "No",
+            hint = "Leyline — If this card is in your opening hand, you may begin the game with it on the battlefield."
+        )
+        val continuation = LeylineDecisionContinuation(
+            decisionId = decisionId,
+            playerId = playerId,
+            leylineCardId = leylineCardId,
+            cardName = cardName
+        )
+        return decision to continuation
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
@@ -73,7 +73,13 @@ class SubmitDecisionHandler(
                 )
             }
 
-            // Handle untap step completion (MAY_NOT_UNTAP decision resolved)
+            // Handle untap step completion. Two clients land here:
+            //   1. A MAY_NOT_UNTAP decision (e.g., Frozen Solid / Static Orb) just resolved.
+            //   2. The CR 103.6 leyline phase (LeylineContinuationResumer) just resolved its
+            //      last yes/no decision. The engine starts a new game at Step.UNTAP, and the
+            //      leyline phase deliberately leaves state.step == UNTAP with no pending
+            //      decision so this branch advances into turn 1's actual UNTAP processing.
+            // If you refactor either flow, make sure both still trigger this advance.
             if (result.isSuccess && !result.isPaused &&
                 result.state.step == Step.UNTAP &&
                 result.state.pendingDecision == null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/mulligan/BottomCardsHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/mulligan/BottomCardsHandler.kt
@@ -2,7 +2,6 @@ package com.wingedsheep.engine.handlers.actions.mulligan
 
 import com.wingedsheep.engine.core.BottomCards
 import com.wingedsheep.engine.core.ExecutionResult
-import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.TurnManager
 import com.wingedsheep.engine.handlers.MulliganHandler
 import com.wingedsheep.engine.core.EngineServices
@@ -16,6 +15,9 @@ import kotlin.reflect.KClass
  *
  * After keeping a mulligan hand, players must put a number of cards
  * equal to their mulligans on the bottom of their library (London mulligan).
+ * Once bottoming is complete (and the other player has also kept/bottomed),
+ * [MulliganHandler.tryAdvancePastMulliganPhase] runs the CR 103.6 leyline phase
+ * and advances to turn 1.
  */
 class BottomCardsHandler(
     private val mulliganHandler: MulliganHandler,
@@ -48,22 +50,7 @@ class BottomCardsHandler(
     override fun execute(state: GameState, action: BottomCards): ExecutionResult {
         val result = mulliganHandler.handleBottomCards(state, action)
         if (!result.isSuccess) return result
-        return checkMulliganCompletion(result.newState, result.events)
-    }
-
-    /**
-     * Check if all mulligans are complete and advance the game to the first turn if so.
-     */
-    private fun checkMulliganCompletion(state: GameState, events: List<GameEvent>): ExecutionResult {
-        if (mulliganHandler.isInMulliganPhase(state) || mulliganHandler.needsBottomCards(state)) {
-            return ExecutionResult.success(state, events)
-        }
-
-        val advanceResult = turnManager.advanceStep(state)
-        return ExecutionResult.success(
-            advanceResult.newState,
-            events + advanceResult.events
-        )
+        return mulliganHandler.tryAdvancePastMulliganPhase(result.newState, result.events, turnManager)
     }
 
     companion object {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/mulligan/KeepHandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/mulligan/KeepHandHandler.kt
@@ -1,7 +1,6 @@
 package com.wingedsheep.engine.handlers.actions.mulligan
 
 import com.wingedsheep.engine.core.ExecutionResult
-import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.KeepHand
 import com.wingedsheep.engine.core.TurnManager
 import com.wingedsheep.engine.handlers.MulliganHandler
@@ -16,7 +15,9 @@ import kotlin.reflect.KClass
  *
  * Players can keep their current hand during the mulligan phase.
  * After all players have kept, those who took mulligans must put
- * cards on the bottom of their library.
+ * cards on the bottom of their library. Once both mulligan and bottoming are done,
+ * [MulliganHandler.tryAdvancePastMulliganPhase] runs the CR 103.6 leyline phase and
+ * advances to turn 1.
  */
 class KeepHandHandler(
     private val mulliganHandler: MulliganHandler,
@@ -38,22 +39,7 @@ class KeepHandHandler(
     override fun execute(state: GameState, action: KeepHand): ExecutionResult {
         val result = mulliganHandler.handleKeepHand(state, action)
         if (!result.isSuccess) return result
-        return checkMulliganCompletion(result.newState, result.events)
-    }
-
-    /**
-     * Check if all mulligans are complete and advance the game to the first turn if so.
-     */
-    private fun checkMulliganCompletion(state: GameState, events: List<GameEvent>): ExecutionResult {
-        if (mulliganHandler.isInMulliganPhase(state) || mulliganHandler.needsBottomCards(state)) {
-            return ExecutionResult.success(state, events)
-        }
-
-        val advanceResult = turnManager.advanceStep(state)
-        return ExecutionResult.success(
-            advanceResult.newState,
-            events + advanceResult.events
-        )
+        return mulliganHandler.tryAdvancePastMulliganPhase(result.newState, result.events, turnManager)
     }
 
     companion object {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LeylineContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LeylineContinuationResumer.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.handlers.continuations
+
+import com.wingedsheep.engine.core.DecisionRequestedEvent
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.LeylineDecisionContinuation
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.MulliganStateComponent
+import com.wingedsheep.sdk.core.Zone
+
+/**
+ * Resumes [LeylineDecisionContinuation] frames: the per-card yes/no walk through every
+ * player's opening hand that runs once mulligans and bottoming are done.
+ *
+ * On each resume the resumer:
+ *  1. Pops the leyline card off the deciding player's `pendingLeylineCardIds` list.
+ *  2. If the player answered yes, routes the card from hand to battlefield through
+ *     [ZoneTransitionService] so the standard zone-change pipeline (controller assignment,
+ *     [com.wingedsheep.engine.handlers.effects.PermanentEntryTracker], ETB replacements
+ *     from other on-battlefield permanents, ZoneChangeEvent emission) fires.
+ *  3. Looks for the next leyline decision via [com.wingedsheep.engine.handlers.MulliganHandler.getNextLeylineChoice].
+ *     If one exists, pauses with the next [com.wingedsheep.engine.core.YesNoDecision]; otherwise
+ *     returns success, leaving the state at `step = UNTAP` with no pending decision so that
+ *     `SubmitDecisionHandler` advances into the first turn via `turnManager.advanceStep`.
+ */
+class LeylineContinuationResumer(
+    private val services: EngineServices
+) : ContinuationResumerModule {
+
+    override fun resumers(): List<ContinuationResumer<*>> = listOf(
+        resumer(LeylineDecisionContinuation::class, ::resumeLeylineDecision)
+    )
+
+    private fun resumeLeylineDecision(
+        state: GameState,
+        continuation: LeylineDecisionContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is YesNoResponse) {
+            return ExecutionResult.error(state, "Expected yes/no response for leyline decision")
+        }
+
+        var newState = state
+        val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
+
+        // Drop this card from the deciding player's pending list — whether the player said
+        // yes or no, the choice for this specific card is resolved.
+        val mullState = newState.getEntity(continuation.playerId)?.get<MulliganStateComponent>()
+        if (mullState != null) {
+            val updated = mullState.copy(
+                pendingLeylineCardIds = mullState.pendingLeylineCardIds.filter { it != continuation.leylineCardId }
+            )
+            newState = newState.updateEntity(continuation.playerId) { container ->
+                container.with(updated)
+            }
+        }
+
+        if (response.choice) {
+            // Route the card to the battlefield through the standard zone-change pipeline.
+            // Owner == controller for leyline starts; the card must already exist with its
+            // CardComponent + OwnerComponent set (it does — it was instantiated at init).
+            val transition = ZoneTransitionService.moveToZone(
+                state = newState,
+                entityId = continuation.leylineCardId,
+                destinationZone = Zone.BATTLEFIELD,
+                options = ZoneEntryOptions(controllerId = continuation.playerId)
+            )
+            newState = transition.state
+            events.addAll(transition.events)
+        }
+
+        // After applying this choice, look for the next leyline prompt in turn order.
+        val nextLeyline = services.mulliganHandler.getNextLeylineChoice(newState)
+        if (nextLeyline != null) {
+            val (nextPlayerId, nextCardId) = nextLeyline
+            val nextDecision = services.mulliganHandler.createLeylineDecision(newState, nextPlayerId, nextCardId)
+            if (nextDecision != null) {
+                val (decision, nextContinuation) = nextDecision
+                val pausedState = newState.pushContinuation(nextContinuation).withPendingDecision(decision)
+                return ExecutionResult.paused(
+                    pausedState,
+                    decision,
+                    events + DecisionRequestedEvent(
+                        decisionId = decision.id,
+                        playerId = nextPlayerId,
+                        decisionType = "YES_NO",
+                        prompt = decision.prompt
+                    )
+                )
+            }
+        }
+
+        // No more leyline prompts. Let SubmitDecisionHandler's "step == UNTAP, no pending"
+        // branch fire turnManager.advanceStep to start turn 1.
+        return checkForMore(newState, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -270,7 +270,9 @@ object DamageUtils {
         val targetIsFaceDown = targetContainer?.has<FaceDownComponent>() == true
         events.add(DamageDealtEvent(sourceId, targetId, effectiveAmount, false, sourceName = sourceName, targetName = targetName, targetIsPlayer = targetIsPlayer, targetWasFaceDown = targetIsFaceDown, excessAmount = creatureExcessDamage))
 
-        // Lifelink: if the source has lifelink, its controller gains life equal to the damage dealt (Rule 702.15)
+        // Lifelink: if the source has lifelink, its controller gains life equal to the damage dealt (Rule 702.15).
+        // Per CR 119.9 the lifelink life-gain is a separate event; ModifyLifeGain (Alhammarret's
+        // Archive, Leyline of Hope) replaces the actual amount gained.
         if (sourceId != null) {
             val projected = newState.projectedState
             if (projected.hasKeyword(sourceId, Keyword.LIFELINK.name)) {
@@ -279,11 +281,14 @@ object DamageUtils {
                 if (controllerId != null && !isLifeGainPrevented(newState, controllerId)) {
                     val currentLife = newState.getEntity(controllerId)?.get<LifeTotalComponent>()?.life
                     if (currentLife != null) {
-                        val newLife = currentLife + effectiveAmount
-                        newState = newState.updateEntity(controllerId) { container ->
-                            container.with(LifeTotalComponent(newLife))
+                        val modifiedAmount = LifeGainModifiers.apply(newState, controllerId, effectiveAmount)
+                        if (modifiedAmount > 0) {
+                            val newLife = currentLife + modifiedAmount
+                            newState = newState.updateEntity(controllerId) { container ->
+                                container.with(LifeTotalComponent(newLife))
+                            }
+                            events.add(LifeChangedEvent(controllerId, currentLife, newLife, LifeChangeReason.LIFE_GAIN))
                         }
-                        events.add(LifeChangedEvent(controllerId, currentLife, newLife, LifeChangeReason.LIFE_GAIN))
                     }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -271,8 +271,8 @@ object DamageUtils {
         events.add(DamageDealtEvent(sourceId, targetId, effectiveAmount, false, sourceName = sourceName, targetName = targetName, targetIsPlayer = targetIsPlayer, targetWasFaceDown = targetIsFaceDown, excessAmount = creatureExcessDamage))
 
         // Lifelink: if the source has lifelink, its controller gains life equal to the damage dealt (Rule 702.15).
-        // Per CR 119.9 the lifelink life-gain is a separate event; ModifyLifeGain (Alhammarret's
-        // Archive, Leyline of Hope) replaces the actual amount gained.
+        // Per CR 119.3 / 702.15b the lifelink damage causes a life-gain event; ModifyLifeGain
+        // (Alhammarret's Archive, Leyline of Hope) replaces the actual amount gained.
         if (sourceId != null) {
             val projected = newState.projectedState
             if (projected.hasKeyword(sourceId, Keyword.LIFELINK.name)) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LifeGainModifiers.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LifeGainModifiers.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.handlers.effects
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.ModifyLifeGain
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Shared application path for [ModifyLifeGain] replacement effects (Alhammarret's Archive,
+ * Leyline of Hope, etc.). Called from every life-gain emission point —
+ * [com.wingedsheep.engine.handlers.effects.life.GainLifeExecutor],
+ * [com.wingedsheep.engine.handlers.effects.life.OwnerGainsLifeExecutor], and the lifelink
+ * damage → life path in [DamageUtils] — so any source of life gain runs through the same
+ * replacement filter.
+ *
+ * The arithmetic mirrors [com.wingedsheep.sdk.scripting.ModifyLifeLoss.apply]:
+ * `newAmount = (originalAmount * multiplier) + modifier`, clamped to ≥ 0. Per the Leyline of
+ * Hope rulings, the modifier applies **once per life-gain event** regardless of how the
+ * original amount was assembled — so this helper is invoked once per receiving player per
+ * event, not per "+1" pip.
+ */
+object LifeGainModifiers {
+
+    /**
+     * Apply every applicable [ModifyLifeGain] effect on the battlefield to a single life-gain
+     * event. Returns the modified amount (≥ 0).
+     *
+     * @param state Current game state — read for [ReplacementEffectSourceComponent]s on the battlefield
+     * @param recipientId The player who is gaining life
+     * @param originalAmount The life amount the event would normally apply
+     */
+    fun apply(state: GameState, recipientId: EntityId, originalAmount: Int): Int {
+        if (originalAmount <= 0) return originalAmount
+
+        var multiplier = 1
+        var modifier = 0
+
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+
+            for (effect in replacementComponent.replacementEffects) {
+                if (effect !is ModifyLifeGain) continue
+
+                val lifeGainEvent = effect.appliesTo as? GameEvent.LifeGainEvent ?: continue
+
+                // Honor the recipient filter on the LifeGainEvent. Default is Player.Each.
+                val recipientMatches = when (lifeGainEvent.player) {
+                    Player.Each -> true
+                    Player.You -> recipientId == sourceControllerId
+                    Player.Opponent -> recipientId != sourceControllerId
+                    Player.TargetOpponent -> recipientId != sourceControllerId
+                    else -> recipientId == sourceControllerId
+                }
+                if (!recipientMatches) continue
+
+                // Multiple Leylines of Hope: each adds 1, so stack the modifiers additively.
+                // Multiple Archives stack multiplicatively (×2 × ×2 = ×4).
+                multiplier *= effect.multiplier
+                modifier += effect.modifier
+            }
+        }
+
+        val modified = originalAmount * multiplier + modifier
+        return modified.coerceAtLeast(0)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LifeGainModifiers.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LifeGainModifiers.kt
@@ -41,7 +41,12 @@ object LifeGainModifiers {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
-            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            // Projected controller so a control-changing effect (e.g. Confiscate stealing a
+            // Leyline of Hope) routes the "you" filter to the current controller, not the
+            // owner baked into the base ControllerComponent. Falls back to base for entities
+            // the projector hasn't assigned a controller to.
+            val sourceControllerId = state.projectedState.getController(entityId)
+                ?: container.get<ControllerComponent>()?.playerId ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is ModifyLifeGain) continue
@@ -60,6 +65,10 @@ object LifeGainModifiers {
 
                 // Multiple Leylines of Hope: each adds 1, so stack the modifiers additively.
                 // Multiple Archives stack multiplicatively (×2 × ×2 = ×4).
+                // Note: with mixed shapes (Archive ×2 + Leyline +1) this always applies
+                // multiply-then-add (2X+1). CR 616.1 lets the affected player choose
+                // replacement order, but same-shape stacks are order-independent and the
+                // mixed case is currently unreachable (Alhammarret's Archive isn't implemented).
                 multiplier *= effect.multiplier
                 modifier += effect.modifier
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.core.CountersAddedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -91,6 +92,16 @@ data class ZoneTransitionResult(
  * 9. Apply redirect additional effects if any
  */
 object ZoneTransitionService {
+
+    /**
+     * Handler used to register static abilities and replacement effects on permanents that
+     * enter the battlefield through [moveToZone] (reanimation, returns from exile, leyline
+     * starts, etc.). Wired by [com.wingedsheep.engine.core.EngineServices] at construction
+     * time. The cast pipeline ([com.wingedsheep.engine.mechanics.stack.StackResolver]) places
+     * permanents via [GameState.addToZone] directly, not [moveToZone], so it owns its own
+     * call to the handler and is unaffected by this wiring.
+     */
+    lateinit var staticAbilityHandler: StaticAbilityHandler
 
     /**
      * Move one entity between zones with full cleanup + setup.
@@ -613,6 +624,18 @@ object ZoneTransitionService {
                 if (options.morphData != null) {
                     updated = updated.with(options.morphData)
                 }
+            }
+
+            // Register static abilities (continuous effects) and runtime replacement effects.
+            // Without this, a permanent placed on the battlefield via moveToZone — leyline
+            // starts, reanimation, returns from exile — would carry its CardComponent but
+            // never surface its static / replacement payload to the projector or the
+            // replacement-application paths. Face-down entries are excluded because face-down
+            // permanents have no abilities (CR 708.2). The cast pipeline owns its own call,
+            // so this does not double-run for cast spells.
+            if (!options.faceDown && ::staticAbilityHandler.isInitialized) {
+                updated = staticAbilityHandler.addContinuousEffectComponent(updated)
+                updated = staticAbilityHandler.addReplacementEffectComponent(updated)
             }
 
             updated

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/GainLifeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/GainLifeExecutor.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.LifeGainModifiers
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
@@ -45,12 +46,18 @@ class GainLifeExecutor(
         for (playerId in playerIds) {
             if (isLifeGainPrevented(state, playerId, context.controllerId)) continue
 
+            // Apply ModifyLifeGain replacements (Alhammarret's Archive, Leyline of Hope).
+            // Per CR 614 / the Leyline of Hope rulings, the modifier is applied **once per
+            // life-gain event** regardless of the original amount.
+            val modifiedAmount = LifeGainModifiers.apply(newState, playerId, amount)
+            if (modifiedAmount <= 0) continue
+
             val currentLife = newState.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: continue
-            val newLife = currentLife + amount
+            val newLife = currentLife + modifiedAmount
             newState = newState.updateEntity(playerId) { container ->
                 container.with(LifeTotalComponent(newLife))
             }
-            newState = DamageUtils.markLifeGainedThisTurn(newState, playerId, amount)
+            newState = DamageUtils.markLifeGainedThisTurn(newState, playerId, modifiedAmount)
             events.add(LifeChangedEvent(playerId, currentLife, newLife, LifeChangeReason.LIFE_GAIN))
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/OwnerGainsLifeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/OwnerGainsLifeExecutor.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.core.LifeChangeReason
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.LifeGainModifiers
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
@@ -50,12 +51,18 @@ class OwnerGainsLifeExecutor : EffectExecutor<OwnerGainsLifeEffect> {
             return EffectResult.success(state)
         }
 
-        // Apply life gain
-        val newLife = currentLife + effect.amount
+        // Apply ModifyLifeGain replacements before any life is actually gained
+        // (Alhammarret's Archive, Leyline of Hope).
+        val modifiedAmount = LifeGainModifiers.apply(state, ownerId, effect.amount)
+        if (modifiedAmount <= 0) {
+            return EffectResult.success(state)
+        }
+
+        val newLife = currentLife + modifiedAmount
         var newState = state.updateEntity(ownerId) { container ->
             container.with(LifeTotalComponent(newLife))
         }
-        newState = DamageUtils.markLifeGainedThisTurn(newState, ownerId, effect.amount)
+        newState = DamageUtils.markLifeGainedThisTurn(newState, ownerId, modifiedAmount)
 
         return EffectResult.success(
             newState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.LifeGainModifiers
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.registry.CardRegistry
@@ -1343,11 +1344,16 @@ internal class CombatDamageManager(
             if (DamageUtils.isLifeGainPrevented(newState, controllerId)) continue
 
             val currentLife = newState.getEntity(controllerId)?.get<LifeTotalComponent>()?.life ?: continue
-            val newLife = currentLife + totalDamage
+            // Route through the shared replacement pipeline so Alhammarret's Archive,
+            // Leyline of Hope, etc. apply to combat lifelink the same way they do to
+            // noncombat lifelink (DamageUtils) and direct GainLife effects.
+            val modifiedAmount = LifeGainModifiers.apply(newState, controllerId, totalDamage)
+            if (modifiedAmount <= 0) continue
+            val newLife = currentLife + modifiedAmount
             newState = newState.updateEntity(controllerId) { container ->
                 container.with(LifeTotalComponent(newLife))
             }
-            newState = DamageUtils.markLifeGainedThisTurn(newState, controllerId, totalDamage)
+            newState = DamageUtils.markLifeGainedThisTurn(newState, controllerId, modifiedAmount)
             lifelinkEvents.add(LifeChangedEvent(controllerId, currentLife, newLife, LifeChangeReason.LIFE_GAIN))
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -607,6 +607,7 @@ class StaticAbilityHandler(
         it is PreventDamage || it is DoubleDamage || it is ModifyDamageAmount || it is PreventLifeGain ||
         it is com.wingedsheep.sdk.scripting.CapDamage || it is com.wingedsheep.sdk.scripting.RedirectDamage ||
         it is com.wingedsheep.sdk.scripting.ModifyLifeLoss ||
+        it is com.wingedsheep.sdk.scripting.ModifyLifeGain ||
         it is com.wingedsheep.sdk.scripting.PreventDraw ||
         it is com.wingedsheep.sdk.scripting.DamageCantBePrevented || it is ReplaceDamageWithCounters ||
         it is com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect || it is com.wingedsheep.sdk.scripting.ModifyDrawAmount ||

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -167,7 +167,23 @@ data class MulliganStateComponent(
     /** Number of mulligans taken so far */
     val mulligansTaken: Int = 0,
     /** Whether the player has decided to keep their current hand */
-    val hasKept: Boolean = false
+    val hasKept: Boolean = false,
+    /**
+     * Whether the Leyline phase has already been initiated for this player.
+     *
+     * The leyline phase runs once per player after all mulligans and bottoming complete:
+     * the engine populates [pendingLeylineCardIds] with the leyline cards currently in this
+     * player's opening hand and walks each one through a yes/no decision. Setting this flag
+     * prevents the phase from being re-initiated if the player draws another leyline card
+     * into hand later (per CR 103.5, the opening-hand window closes once the first turn begins).
+     */
+    val leylinePhaseStarted: Boolean = false,
+    /**
+     * Card entity IDs in this player's opening hand that still need a leyline yes/no decision.
+     * Drained as the player resolves each prompt (yes = card moved to battlefield, no = card
+     * stays in hand). The leyline phase for this player is "complete" once the list is empty.
+     */
+    val pendingLeylineCardIds: List<EntityId> = emptyList()
 ) : Component {
     companion object {
         const val STARTING_HAND_SIZE = 7
@@ -193,6 +209,11 @@ data class MulliganStateComponent(
      * Record that the player keeps their hand.
      */
     fun keep(): MulliganStateComponent = copy(hasKept = true)
+
+    /**
+     * Whether this player still has leyline cards awaiting a yes/no choice.
+     */
+    val hasPendingLeylineChoices: Boolean get() = pendingLeylineCardIds.isNotEmpty()
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -175,7 +175,7 @@ data class MulliganStateComponent(
      * the engine populates [pendingLeylineCardIds] with the leyline cards currently in this
      * player's opening hand and walks each one through a yes/no decision. Setting this flag
      * prevents the phase from being re-initiated if the player draws another leyline card
-     * into hand later (per CR 103.5, the opening-hand window closes once the first turn begins).
+     * into hand later (per CR 103.6, the opening-hand window closes once the first turn begins).
      */
     val leylinePhaseStarted: Boolean = false,
     /**


### PR DESCRIPTION
Implements DSK #18 with three new SDK/engine primitives:

1. Leyline mechanic. `CardBuilder.leyline()` sets `CardScript.mayStartOnBattlefield`. After mulligans and bottoming complete (CR 103.6), `MulliganHandler.initiateLeylinePhase` populates each player's `pendingLeylineCardIds` and the engine walks turn order from the active player, pausing per leyline card with a YesNoDecision resumed by `LeylineDecisionContinuation`. "Yes" routes the card through `ZoneTransitionService` (hand -> battlefield as owner); "no" leaves it in hand. `SubmitDecisionHandler` then advances the UNTAP step into turn 1. The keep/bottom completion paths now funnel through a single `MulliganHandler.tryAdvancePastMulliganPhase` so the leyline phase has one point of truth.

2. `ModifyLifeGain` gains a flat `modifier` (mirrors `ModifyLifeLoss`) and is now wired into `GainLifeExecutor`, `OwnerGainsLifeExecutor`, the noncombat lifelink path in `DamageUtils`, and the combat lifelink path in `CombatDamageManager` via the shared `LifeGainModifiers.apply` helper. Stacks additively across multiple sources per the Scryfall rulings.

3. The conditional anthem composes existing primitives: `ConditionalStaticAbility(ModifyStats(+2/+2, creaturesYouControl), Compare(LifeTotal(You) GTE Add(StartingLifeTotal(You), 7)))`.

`ZoneTransitionService.moveToZone` now registers `ContinuousEffect` and `ReplacementEffect` source components on permanents entering the battlefield through the shared path (leyline starts, reanimation, returns from exile). Without this, a leyline-yes would land Leyline of Hope on the battlefield with no anthem or +1 life rider active. The cast pipeline keeps its own registration in `StackResolver`, so this is additive — no double-registration.

Tests: 8 scenario tests in `LeylineOfHopeScenarioTest` cover the +1 modifier (single + stacking + opponent isolation + combat lifelink via Healer's Hawk), the conditional anthem on both sides of the 7-life threshold, and the opening-hand yes/no flow built on top of `GameInitializer` (asserting the +1 rider survives the leyline-yes path via `ContinuousEffectSourceComponent` /
`ReplacementEffectSourceComponent` attachment).