### PR TITLE
Add Intimidation Tactics to Aetherdrift

### DIFF
--- a/manual-scenarios/cards/i/intimidation-tactics.json
+++ b/manual-scenarios/cards/i/intimidation-tactics.json
@@ -1,0 +1,44 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Intimidation Tactics"
+    ],
+    "battlefield": [
+      {
+        "name": "Swamp"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Bog Imp",
+      "Flying Carpet",
+      "Cruel Bargain",
+      "Swamp"
+    ],
+    "battlefield": [],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/IntimidationTactics.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/IntimidationTactics.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Intimidation Tactics
+ * {B}
+ * Sorcery
+ * Target opponent reveals their hand. You choose an artifact or creature card from it. Exile that card.
+ * Cycling {3}
+ */
+val IntimidationTactics = card("Intimidation Tactics") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You choose an artifact or creature card from it. Exile that card.\n" +
+        "Cycling {3} ({3}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", TargetOpponent())
+        effect = CompositeEffect(
+            listOf(
+                RevealHandEffect(t),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "hand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    filter = GameObjectFilter.Artifact or GameObjectFilter.Creature,
+                    storeSelected = "toExile",
+                    prompt = "Choose an artifact or creature card to exile"
+                ),
+                MoveCollectionEffect(
+                    from = "toExile",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0))
+                )
+            )
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "92"
+        artist = "Cristi Balanescu"
+        flavorText = "\"This is still a negotiation. We haven't broken anything... yet.\"\n—Far Fortune"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b4e6022-44d2-4dfe-8f7a-51581e298f23.jpg?1738356324"
+    }
+}


### PR DESCRIPTION
Composes existing primitives: RevealHand → GatherCards (opponent's hand) → SelectFromCollection (Artifact ∪ Creature filter, controller-chosen) → MoveCollection to Exile, plus Cycling {3}.