### PR TITLE
Add Erg Raiders with per-creature SourceAttackedThisTurn predicate

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 51 / 78
+**Implemented:** 53 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -39,7 +39,7 @@
 - [x] Unstable Mutation
 - [ ] Cuombajj Witches
 - [x] El-Hajjâj
-- [ ] Erg Raiders
+- [x] Erg Raiders
 - [ ] Guardian Beast
 - [x] Hasran Ogress
 - [x] Junún Efreet

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1612,6 +1612,9 @@ contexts.
 - `SourceIsTapped` — source is tapped.
 - `SourceIsUntapped` — source is untapped.
 - `SourceEnteredThisTurn` — source entered the battlefield this turn.
+- `SourceAttackedThisTurn` — source was declared as an attacker at least once during the
+  current turn (per-creature, derived from the controller's `PlayerAttackersThisTurnComponent`).
+  Negate via `Conditions.Not(...)` for Erg Raiders-style "if it didn't attack this turn".
 - `SourceHasDealtDamage` — source has dealt damage since entering the battlefield.
 - `SourceHasDealtCombatDamageToPlayer` — saboteur-style payoff gate.
 - `SourceIsModified` — has counters, attached Equipment, or controller-owned Aura

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ErgRaidersScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ErgRaidersScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Erg Raiders' end-step self-damage trigger.
+ *
+ * Oracle: "At the beginning of your end step, if this creature didn't attack this turn,
+ * it deals 2 damage to you unless it came under your control this turn."
+ *
+ * Three cases:
+ *  1. Settled (no attack, didn't enter this turn) → triggers, 2 damage to controller.
+ *  2. Attacked this turn → doesn't trigger.
+ *  3. Just entered (summoning-sick) → doesn't trigger.
+ */
+class ErgRaidersScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Erg Raiders end-step self-damage") {
+
+            test("deals 2 damage to controller when it didn't attack and wasn't new") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Erg Raiders")
+                    .withActivePlayer(1)
+                    .build()
+
+                val startLife = game.getLifeTotal(1)
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Erg Raiders should deal 2 to its controller") {
+                    game.getLifeTotal(1) shouldBe startLife - 2
+                }
+            }
+
+            test("does not trigger when Erg Raiders attacked this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Erg Raiders")
+                    .withActivePlayer(1)
+                    .build()
+
+                val startLife = game.getLifeTotal(1)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Erg Raiders" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Erg Raiders attacked → no self-damage trigger; controller's life unchanged") {
+                    game.getLifeTotal(1) shouldBe startLife
+                }
+            }
+
+            test("does not trigger when Erg Raiders came under control this turn (summoning sickness proxy)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Erg Raiders", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .build()
+
+                // Mark Erg Raiders as having entered this turn (the proxy for the
+                // "came under your control this turn" oracle clause).
+                val raidersId = game.findPermanent("Erg Raiders")!!
+                game.state = game.state.updateEntity(raidersId) { it.with(EnteredThisTurnComponent) }
+
+                val startLife = game.getLifeTotal(1)
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Erg Raiders is new this turn → no self-damage; controller's life unchanged") {
+                    game.getLifeTotal(1) shouldBe startLife
+                }
+            }
+        }
+    }
+}

--- a/manual-scenarios/cards/e/erg-raiders.json
+++ b/manual-scenarios/cards/e/erg-raiders.json
@@ -1,0 +1,41 @@
+{
+  "_description": "Erg Raiders end-step self-damage trigger. Alice controls an Erg Raiders (2/3, B) that has been on the battlefield since last turn — no summoning sickness, did NOT enter this turn, and Alice does NOT attack with it. At the beginning of Alice's end step, the triggered ability fires: 'if this creature didn't attack this turn, it deals 2 damage to you unless it came under your control this turn.' Verify Alice's life drops from 20 → 18. Scenario starts in POSTCOMBAT_MAIN (combat already skipped) and stops at the END step so you can see the trigger go on the stack and resolve. To test the negative cases, you can either (a) attack with Erg Raiders during DECLARE_ATTACKERS — set phase to PRECOMBAT_MAIN and add player1StopAtSteps: ['DECLARE_ATTACKERS'], or (b) mark Erg Raiders as freshly entered — these are covered in ErgRaidersScenarioTest.kt.",
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Erg Raiders"],
+    "battlefield": [
+      {"name": "Erg Raiders", "summoningSickness": false},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Plains",
+      "Plains",
+      "Plains"
+    ]
+  },
+  "phase": "POSTCOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -464,6 +464,14 @@ object Conditions {
         SourceMatches(com.wingedsheep.sdk.scripting.GameObjectFilter.Any.enteredThisTurn())
 
     /**
+     * If this creature was declared as an attacker at least once during the current turn.
+     * Used by intervening-if triggers like Erg Raiders' "if this creature didn't attack this
+     * turn, deal 2 damage to you" (negate via [com.wingedsheep.sdk.scripting.conditions.NotCondition]).
+     */
+    val SourceAttackedThisTurn: ConditionInterface =
+        SourceMatches(com.wingedsheep.sdk.scripting.GameObjectFilter.Any.attackedThisTurn())
+
+    /**
      * As long as this creature is a specific subtype.
      * Used for conditional static abilities like "has defender as long as it's a Wall."
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -396,6 +396,14 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must have been declared as an attacker at least once during the current turn.
+     * Survives leaving combat; cleared at end-of-turn cleanup.
+     */
+    fun attackedThisTurn() = copy(
+        statePredicates = statePredicates + StatePredicate.AttackedThisTurn
+    )
+
+    /**
      * Must be in the same combat band as the effect's source (the source itself, or a band-mate
      * sharing its band id — CR 702.22). Source-relative; only matches while the source attacks.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -124,6 +124,20 @@ sealed interface StatePredicate {
         override val description: String = "has dealt combat damage to a player"
     }
 
+    /**
+     * Was declared as an attacker at least once during the current turn (CR 506.2 — applies
+     * once the controller has declared attackers). Backed by the controller's
+     * [com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent] (which
+     * the engine already maintains for raid / "attacked this turn" tribal triggers), so it
+     * does not need a separate per-entity marker. Survives leaving combat / blockers being
+     * declared; cleared at end-of-turn cleanup alongside the player marker.
+     */
+    @SerialName("AttackedThisTurn")
+    @Serializable
+    data object AttackedThisTurn : History {
+        override val description: String = "attacked this turn"
+    }
+
     // =============================================================================
     // Face-Down State (Entity)
     // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -125,8 +125,8 @@ sealed interface StatePredicate {
     }
 
     /**
-     * Was declared as an attacker at least once during the current turn (CR 506.2 — applies
-     * once the controller has declared attackers). Backed by the controller's
+     * Was declared as an attacker at least once during the current turn (set during the
+     * declare-attackers step, CR 508.1). Backed by the controller's
      * [com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent] (which
      * the engine already maintains for raid / "attacked this turn" tribal triggers), so it
      * does not need a separate per-entity marker. Survives leaving combat / blockers being

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/ErgRaiders.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/ErgRaiders.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Erg Raiders
+ * {1}{B}
+ * Creature — Human Warrior
+ * 2/3
+ *
+ * Modern oracle (errata from "...didn't come into play under your control this turn" to the
+ * SBA-friendly form): "At the beginning of your end step, if this creature didn't attack
+ * this turn, it deals 2 damage to you unless it came under your control this turn."
+ *
+ * Composes from existing primitives plus the new
+ * [com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttackedThisTurn] history
+ * predicate (per-creature, derived from the controller's
+ * [com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent]).
+ *
+ * Intervening-if = NOT attacked-this-turn AND NOT entered-this-turn. The latter is the
+ * standard summoning-sickness proxy for "came under your control this turn" — it covers
+ * every case except the rare control-change-without-ETB, which is not in scope here.
+ */
+val ErgRaiders = card("Erg Raiders") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 3
+    oracleText = "At the beginning of your end step, if this creature didn't attack this " +
+        "turn, it deals 2 damage to you unless it came under your control this turn."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.All(
+            Conditions.Not(Conditions.SourceAttackedThisTurn),
+            Conditions.Not(Conditions.SourceEnteredThisTurn),
+        )
+        effect = Effects.DealDamage(2, EffectTarget.Controller, damageSource = EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Dameon Willich"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35c73a97-531d-4dd5-8236-39b89c183c38.jpg?1562904951"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -370,6 +370,7 @@ class BeginningPhaseManager(
         StatePredicate.WasDealtDamageThisTurn,
         StatePredicate.HasDealtDamage,
         StatePredicate.HasDealtCombatDamageToPlayer,
+        StatePredicate.AttackedThisTurn,
         StatePredicate.IsFaceDown,
         StatePredicate.IsFaceUp,
         StatePredicate.HasMorphAbility,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1101,6 +1101,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasDealtDamageThisTurn,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasDealtDamage,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasDealtCombatDamageToPlayer,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttackedThisTurn,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsFaceUp,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasMorphAbility,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasAnyCounter,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -660,6 +660,18 @@ class PredicateEvaluator {
                 container.has<HasDealtCombatDamageToPlayerComponent>()
             }
 
+            // Whether this creature has been declared as an attacker this turn — derived
+            // from the controller's PlayerAttackersThisTurnComponent, the same set that
+            // backs raid / "you attacked with N creatures this turn" tribal triggers.
+            StatePredicate.AttackedThisTurn -> {
+                val controllerId = container.get<ControllerComponent>()?.playerId
+                    ?: return false
+                val attackerSet = state.getEntity(controllerId)
+                    ?.get<com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent>()
+                    ?.attackerIds ?: emptySet()
+                entityId in attackerSet
+            }
+
             // Face-down state
             StatePredicate.IsFaceDown -> container.has<FaceDownComponent>()
             StatePredicate.IsFaceUp -> !container.has<FaceDownComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTur
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.combat.BlockingComponent
+import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ChosenCreatureTypeComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
@@ -667,7 +668,7 @@ class PredicateEvaluator {
                 val controllerId = container.get<ControllerComponent>()?.playerId
                     ?: return false
                 val attackerSet = state.getEntity(controllerId)
-                    ?.get<com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent>()
+                    ?.get<PlayerAttackersThisTurnComponent>()
                     ?.attackerIds ?: emptySet()
                 entityId in attackerSet
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -325,6 +325,15 @@ internal class AffectsFilterResolver {
         StatePredicate.WasDealtDamageThisTurn -> container.has<WasDealtDamageThisTurnComponent>()
         StatePredicate.HasDealtDamage -> container.has<HasDealtDamageComponent>()
         StatePredicate.HasDealtCombatDamageToPlayer -> container.has<HasDealtCombatDamageToPlayerComponent>()
+        StatePredicate.AttackedThisTurn -> {
+            val controllerId = container.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()?.playerId
+            val attackerSet = controllerId?.let {
+                state.getEntity(it)
+                    ?.get<com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent>()
+                    ?.attackerIds
+            } ?: emptySet()
+            entityId in attackerSet
+        }
         StatePredicate.IsFaceDown -> isFaceDown
         StatePredicate.IsFaceUp -> !isFaceDown
         StatePredicate.HasMorphAbility ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTurnComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.combat.BlockingComponent
+import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ChosenCreatureTypeComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
@@ -326,10 +327,10 @@ internal class AffectsFilterResolver {
         StatePredicate.HasDealtDamage -> container.has<HasDealtDamageComponent>()
         StatePredicate.HasDealtCombatDamageToPlayer -> container.has<HasDealtCombatDamageToPlayerComponent>()
         StatePredicate.AttackedThisTurn -> {
-            val controllerId = container.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()?.playerId
+            val controllerId = container.get<ControllerComponent>()?.playerId
             val attackerSet = controllerId?.let {
                 state.getEntity(it)
-                    ?.get<com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent>()
+                    ?.get<PlayerAttackersThisTurnComponent>()
                     ?.attackerIds
             } ?: emptySet()
             entityId in attackerSet


### PR DESCRIPTION
Engine feature: a per-creature "attacked this turn" history predicate (CR 506.2-derived) — `StatePredicate.AttackedThisTurn`, paired with `ObjectFilter.attackedThisTurn()` and `Conditions.SourceAttackedThisTurn`.

The data already exists: `PlayerAttackersThisTurnComponent` is maintained on each player by `AttackPhaseManager.declareAttackers` (the same set behind raid / "you attacked with N creatures this turn" tribal triggers). The new predicate just reads it via the entity's controller, so no new component, lifecycle hook, or cleanup pass is needed.

Wires through:
 * `PredicateEvaluator` and `AffectsFilterResolver` evaluate it directly.
 * The exhaustive `when`s in `BeginningPhaseManager.matchesStatePredicate ForUntap` and `TriggerMatcher.matchesStatePredicateForTrigger` list it alongside the other history predicates with the same "no-op in this context" branch.

Card: Erg Raiders' end-step intervening-if composes as `AllConditions(Not(SourceAttackedThisTurn), Not(SourceEnteredThisTurn))`, the standard summoning-sickness proxy for "came under your control this turn". Effect: `DealDamage(2, EffectTarget.Controller, damageSource = EffectTarget.Self)`.

Scenario test covers all three branches:
 * settled, didn't attack → 2 damage to controller,
 * attacked this turn → trigger doesn't fire,
 * came under control this turn → trigger doesn't fire.

Existing `MarduSkullhunterTest` (the closest raid-style regression) still passes.