### PR TITLE
Fix recipient-based damage triggers missing creatures that die to the same combat damage

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -122,7 +122,18 @@ data class DamageDealtEvent(
     val sourceName: String? = null,
     val targetName: String? = null,
     val targetIsPlayer: Boolean = false,
-    val targetWasFaceDown: Boolean = false
+    val targetWasFaceDown: Boolean = false,
+    /**
+     * The recipient's controller at the instant the damage was dealt (CR 603.10 last-known
+     * information). Lets recipient-based damage triggers ("whenever a creature you control / an
+     * opponent controls is dealt damage") still match a recipient that left the battlefield to
+     * the same damage event — combat-damage state-based actions strip the dead creature's
+     * `ControllerComponent` before trigger detection runs. `null` for players and for events
+     * emitted before this was captured.
+     */
+    val targetControllerId: EntityId? = null,
+    /** Whether the recipient was a creature when the damage was dealt (LKI, see [targetControllerId]). */
+    val targetWasCreature: Boolean = false
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -836,20 +836,14 @@ class TriggerMatcher(
                 event.targetId in state.turnOrder && event.targetId != controllerId
             }
             RecipientFilter.CreatureOpponentControls -> {
-                val targetEntity = state.getEntity(event.targetId)
-                val targetCard = targetEntity?.get<CardComponent>()
-                val targetController = targetEntity?.get<ControllerComponent>()?.playerId
-                targetCard?.typeLine?.isCreature == true && targetController != null && targetController != controllerId
+                val targetController = recipientControllerLki(event, state)
+                recipientIsCreatureLki(event, state) && targetController != null && targetController != controllerId
             }
             RecipientFilter.CreatureYouControl -> {
-                val targetEntity = state.getEntity(event.targetId)
-                val targetCard = targetEntity?.get<CardComponent>()
-                val targetController = targetEntity?.get<ControllerComponent>()?.playerId
-                targetCard?.typeLine?.isCreature == true && targetController == controllerId
+                recipientIsCreatureLki(event, state) && recipientControllerLki(event, state) == controllerId
             }
             RecipientFilter.PermanentYouControl -> {
-                val targetController = state.getEntity(event.targetId)?.get<ControllerComponent>()?.playerId
-                targetController == controllerId
+                recipientControllerLki(event, state) == controllerId
             }
             RecipientFilter.AnyPermanent -> event.targetId !in state.turnOrder
             RecipientFilter.Self -> false // handled elsewhere
@@ -869,6 +863,23 @@ class TriggerMatcher(
         }
         return combatMatches && recipientMatches && sourceMatches
     }
+
+    /**
+     * The damage recipient's controller, preferring live state but falling back to the controller
+     * captured at damage time ([DamageDealtEvent.targetControllerId]). A creature destroyed by the
+     * same damage event has already moved to the graveyard — losing its [ControllerComponent] — by
+     * the time combat-damage triggers are detected, so without the LKI fallback a recipient-based
+     * trigger ("a creature you control / an opponent controls is dealt damage") would silently miss
+     * the killing blow (CR 603.10).
+     */
+    private fun recipientControllerLki(event: DamageDealtEvent, state: GameState): EntityId? =
+        state.getEntity(event.targetId)?.get<ControllerComponent>()?.playerId
+            ?: event.targetControllerId
+
+    /** Whether the damage recipient was a creature, with the same LKI fallback as [recipientControllerLki]. */
+    private fun recipientIsCreatureLki(event: DamageDealtEvent, state: GameState): Boolean =
+        state.getEntity(event.targetId)?.get<CardComponent>()?.typeLine?.isCreature == true ||
+            event.targetWasCreature
 
     fun matchesStepTrigger(
         trigger: GameEvent,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -256,7 +256,11 @@ object DamageUtils {
         val targetName = targetContainer?.get<CardComponent>()?.name
         val targetIsPlayer = targetContainer?.get<LifeTotalComponent>() != null
         val targetIsFaceDown = targetContainer?.has<FaceDownComponent>() == true
-        events.add(DamageDealtEvent(sourceId, targetId, effectiveAmount, false, sourceName = sourceName, targetName = targetName, targetIsPlayer = targetIsPlayer, targetWasFaceDown = targetIsFaceDown))
+        // Capture the recipient's controller + creature-ness now, while it's still on the
+        // battlefield, so recipient-based triggers match even if it dies to this damage (LKI).
+        val targetControllerId = projected.getController(targetId)
+        val targetWasCreature = projected.isCreature(targetId)
+        events.add(DamageDealtEvent(sourceId, targetId, effectiveAmount, false, sourceName = sourceName, targetName = targetName, targetIsPlayer = targetIsPlayer, targetWasFaceDown = targetIsFaceDown, targetControllerId = targetControllerId, targetWasCreature = targetWasCreature))
 
         // Lifelink: if the source has lifelink, its controller gains life equal to the damage dealt (Rule 702.15)
         if (sourceId != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -1089,8 +1089,15 @@ internal class CombatDamageManager(
             val sourceName = newState.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Creature"
             val targetName = newState.getEntity(targetId)?.get<CardComponent>()?.name ?: "Creature"
             val targetIsFaceDown = newState.getEntity(targetId)?.has<FaceDownComponent>() == true
+            // Capture the recipient's controller + creature-ness now, while it's still on the
+            // battlefield. Combat-damage SBAs strip the dead creature's ControllerComponent
+            // before trigger detection, so recipient-based triggers ("a creature you control /
+            // an opponent controls is dealt damage") rely on this LKI to still match (CR 603.10).
+            val targetControllerId = projected.getController(targetId)
+            val targetWasCreature = projected.isCreature(targetId)
             events.add(DamageDealtEvent(sourceId, targetId, amount, true,
-                sourceName = sourceName, targetName = targetName, targetIsPlayer = false, targetWasFaceDown = targetIsFaceDown))
+                sourceName = sourceName, targetName = targetName, targetIsPlayer = false, targetWasFaceDown = targetIsFaceDown,
+                targetControllerId = targetControllerId, targetWasCreature = targetWasCreature))
         }
 
         return newState

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DamageRecipientTriggerLkiScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DamageRecipientTriggerLkiScenarioTest.kt
@@ -1,0 +1,182 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression for the recipient-based damage-trigger last-known-information gap: a creature that
+ * dies to the same combat-damage event has its `ControllerComponent` stripped (it's in the
+ * graveyard) by the time triggers are detected — combat-damage state-based actions run before
+ * trigger detection. Before the fix, `RecipientFilter.CreatureOpponentControls` /
+ * `CreatureYouControl` resolved the recipient's controller from *live* state, so a trigger
+ * watching "a creature an opponent controls / you control is dealt combat damage" silently
+ * missed the killing blow. The fix captures the recipient's controller + creature-ness at
+ * damage time onto `DamageDealtEvent` and falls back to it in `TriggerMatcher` (CR 603.10).
+ *
+ * Noncombat damage already worked (its trigger detection sees the recipient before the kill
+ * SBA); the noncombat cases here guard that LKI population didn't regress that path and that
+ * control discrimination still holds.
+ */
+class DamageRecipientTriggerLkiScenarioTest : FunSpec({
+
+    // 0/8 sentinels (survive everything) that draw a card whenever the watched recipient is
+    // dealt combat damage. binding = ANY so they watch the whole table.
+    val OpponentCreatureWatcher = card("Opp Creature Watcher") {
+        manaCost = "{0}"; typeLine = "Creature — Spirit"; power = 0; toughness = 8
+        triggeredAbility {
+            trigger = Triggers.dealsDamage(
+                damageType = DamageType.Combat,
+                recipient = RecipientFilter.CreatureOpponentControls,
+                binding = TriggerBinding.ANY,
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+    val YourCreatureWatcher = card("Your Creature Watcher") {
+        manaCost = "{0}"; typeLine = "Creature — Spirit"; power = 0; toughness = 8
+        triggeredAbility {
+            trigger = Triggers.dealsDamage(
+                damageType = DamageType.Combat,
+                recipient = RecipientFilter.CreatureYouControl,
+                binding = TriggerBinding.ANY,
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+    // Noncombat version, to guard the already-working path + control discrimination.
+    val OpponentCreatureWatcherNoncombat = card("Opp Creature Watcher NC") {
+        manaCost = "{0}"; typeLine = "Creature — Spirit"; power = 0; toughness = 8
+        triggeredAbility {
+            trigger = Triggers.dealsDamage(
+                damageType = DamageType.NonCombat,
+                recipient = RecipientFilter.CreatureOpponentControls,
+                binding = TriggerBinding.ANY,
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    fun vanilla(n: String, p: Int, t: Int) = card(n) {
+        manaCost = "{0}"; typeLine = "Creature — Bear"; power = p; toughness = t
+    }
+    val Bear = vanilla("LKI Bear", 2, 2)          // dies to >=2
+    val Ogre = vanilla("LKI Ogre", 3, 3)          // 3 power attacker/blocker
+    val Smasher = vanilla("LKI Smasher", 5, 5)
+    val Wall = vanilla("LKI Wall", 0, 6)          // survives 5 damage
+
+    val Bolt = card("LKI Bolt") {
+        manaCost = "{0}"; typeLine = "Sorcery"; oracleText = "Deal 5 damage to target creature."
+        spell {
+            val c = target("target creature", Targets.Creature)
+            effect = Effects.DealDamage(5, c)
+        }
+    }
+
+    fun driver() = GameTestDriver().apply {
+        registerCards(
+            TestCards.all + listOf(
+                OpponentCreatureWatcher, YourCreatureWatcher, OpponentCreatureWatcherNoncombat,
+                Bear, Ogre, Smasher, Wall, Bolt
+            )
+        )
+    }
+
+    test("combat: an opponent's creature that DIES to combat damage still fires CreatureOpponentControls") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(active, "Opp Creature Watcher")
+        val attacker = d.putCreatureOnBattlefield(active, "LKI Smasher") // 5/5
+        val blocker = d.putCreatureOnBattlefield(opp, "LKI Bear")        // 2/2, dies to 5
+        d.removeSummoningSickness(attacker)
+
+        val handBefore = d.getHandSize(active)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(active, listOf(attacker), opp)
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(opp, mapOf(blocker to listOf(attacker)))
+        d.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        (blocker !in d.state.getBattlefield()) shouldBe true       // it really died
+        d.getHandSize(active) shouldBe handBefore + 1              // trigger fired -> drew
+    }
+
+    test("combat: YOUR creature that DIES to combat damage still fires CreatureYouControl") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(active, "Your Creature Watcher")
+        val attacker = d.putCreatureOnBattlefield(active, "LKI Bear")  // 2/2 attacker, will die
+        val blocker = d.putCreatureOnBattlefield(opp, "LKI Ogre")      // 3/3 blocker, survives the 2
+        d.removeSummoningSickness(attacker)
+
+        val handBefore = d.getHandSize(active)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(active, listOf(attacker), opp)
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(opp, mapOf(blocker to listOf(attacker)))
+        d.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        (attacker !in d.state.getBattlefield()) shouldBe true      // active's creature died
+        (blocker in d.state.getBattlefield()) shouldBe true        // opp's survived (only took 2)
+        d.getHandSize(active) shouldBe handBefore + 1
+    }
+
+    test("combat: an opponent's creature that SURVIVES still fires (live-state path intact, no regression)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(active, "Opp Creature Watcher")
+        val attacker = d.putCreatureOnBattlefield(active, "LKI Smasher") // 5/5
+        val blocker = d.putCreatureOnBattlefield(opp, "LKI Wall")        // 0/6, survives 5
+        d.removeSummoningSickness(attacker)
+
+        val handBefore = d.getHandSize(active)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(active, listOf(attacker), opp)
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(opp, mapOf(blocker to listOf(attacker)))
+        d.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        (blocker in d.state.getBattlefield()) shouldBe true
+        d.getHandSize(active) shouldBe handBefore + 1
+    }
+
+    test("noncombat: your own dying creature does NOT fire a CreatureOpponentControls trigger (control discrimination via LKI)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(active, "Opp Creature Watcher NC")
+        val ownBear = d.putCreatureOnBattlefield(active, "LKI Bear")  // active's own 2/2
+
+        val handBefore = d.getHandSize(active)
+        val bolt = d.putCardInHand(active, "LKI Bolt")
+        d.castSpell(active, bolt, listOf(ownBear))                    // 5 noncombat dmg, ownBear dies
+        d.bothPass()
+
+        (ownBear !in d.state.getBattlefield()) shouldBe true          // it died
+        d.getHandSize(active) shouldBe handBefore                     // own creature -> no fire
+    }
+})


### PR DESCRIPTION
## Summary

Fixes a pre-existing last-known-information gap surfaced while reviewing #381. Recipient-based "deals damage" triggers silently miss a creature that **dies to the same combat-damage event**.

`TriggerMatcher.matchesDealsDamageTrigger` resolved the recipient's controller for `RecipientFilter.CreatureOpponentControls` / `CreatureYouControl` / `PermanentYouControl` from **live** state:

```kotlin
val targetController = state.getEntity(event.targetId)?.get<ControllerComponent>()?.playerId
```

Combat-damage state-based actions move a creature that took lethal damage to the graveyard — stripping its `ControllerComponent` — **before** combat-damage triggers are detected. So a trigger watching *"whenever a creature an opponent controls / you control is dealt combat damage"* never matched the killing blow. (Noncombat damage happened to work because its trigger detection runs before the kill SBA.)

I confirmed this empirically before fixing: a non-indestructible 0/2 blocking a 5/5 dies and a `requireExcess` combat watcher fired **0** times; the same setup with an indestructible blocker fired correctly. The bug is independent of #381 — it predates the excess-damage work — which is why this is a standalone PR off `main`.

## Fix

Per CR 603.10 (last-known information), capture the recipient's controller + creature-ness **at damage-dealing time** onto `DamageDealtEvent`, and fall back to it in the matcher when the recipient has left the battlefield:

- `DamageDealtEvent` gains `targetControllerId: EntityId?` and `targetWasCreature: Boolean` (defaulted, so all existing constructors are unaffected).
- Populated at the two creature-damage emission sites — `DamageUtils.dealDamageToTarget` (noncombat) and `CombatDamageManager.dealFinalDamage` (combat) — while the creature is still on the battlefield.
- `TriggerMatcher` resolves the recipient's controller/creature-ness via small LKI-fallback helpers: **live state preferred**, event LKI only when the entity is gone. Surviving recipients and control discrimination are therefore unchanged.

No new `GameEvent` type and no client-visible state — only added fields on an existing internal event, so no `ClientEvent.kt` branch or `ClientStateTransformer` change is needed.

## Test plan

New `DamageRecipientTriggerLkiScenarioTest` (rules-engine):

- [x] combat: an opponent's creature that **dies** to combat damage now fires `CreatureOpponentControls`
- [x] combat: **your** creature that dies to combat damage now fires `CreatureYouControl`
- [x] combat: an opponent's creature that **survives** still fires (live-state path intact — no regression)
- [x] noncombat: your own dying creature still does **not** match a `CreatureOpponentControls` trigger (control discrimination via LKI)

Full `:rules-engine:test` suite green; `:game-server` and `:gym*` modules compile.

## Note for #381

#381 (LTR Gap 12) added `requireExcess` + an excess-damage trigger and documented this same combat caveat in `card-sdk-language-reference.md`. Once both land, that caveat can be relaxed — `requireExcess = true` + `DamageType.Combat` will fire correctly on dying recipients. The two PRs touch adjacent lines in `TriggerMatcher` / `DamageDealtEvent` / the two damage paths and will need a trivial merge resolution whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)