### PR TITLE
Add TDM cards (batch A): packbeasts, dragons, sentinel

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DalkovanEncampmentScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DalkovanEncampmentScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Dalkovan Encampment (TDM #253) — Land.
+ *
+ * "{2}{W}, {T}: Whenever you attack this turn, create two 1/1 red Warrior creature tokens that are
+ *  tapped and attacking. Sacrifice them at the beginning of the next end step."
+ *
+ * Exercises the activated-ability → event-based delayed-trigger composition: activating the ability
+ * installs a `CreateDelayedTriggerEffect(trigger = YouAttack)` that lasts the rest of the turn, so
+ * each declare-attackers this turn produces two tapped-and-attacking Warrior tokens. Tokens are
+ * sacrificed at the next end step.
+ */
+class DalkovanEncampmentScenarioTest : ScenarioTestBase() {
+
+    // The {2}{W},{T} mobilize-grant ability is the non-mana activated ability.
+    private val mobilizeAbilityId =
+        cardRegistry.getCard("Dalkovan Encampment")!!.activatedAbilities[1].id
+
+    init {
+        context("Dalkovan Encampment whenever-you-attack token ability") {
+
+            test("activating the ability then attacking creates two tapped, attacking Warrior tokens") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dalkovan Encampment", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val encampment = game.findPermanent("Dalkovan Encampment")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = encampment,
+                        abilityId = mobilizeAbilityId
+                    )
+                )
+                withClue("Activating the {2}{W},{T} ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("No Warrior tokens before attacking") {
+                    game.findPermanents("Warrior Token").size shouldBe 0
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                withClue("Declaring attackers should succeed: ${attack.error}") { attack.error shouldBe null }
+                game.resolveStack()
+
+                val warriors = game.findPermanents("Warrior Token")
+                withClue("Two Warrior tokens should have been created on attack") {
+                    warriors.size shouldBe 2
+                }
+                withClue("Each Warrior token should be tapped and attacking") {
+                    warriors.forEach { token ->
+                        game.state.getEntity(token)?.has<TappedComponent>() shouldBe true
+                        game.state.getEntity(token)?.has<AttackingComponent>() shouldBe true
+                    }
+                }
+            }
+
+            test("the tokens are sacrificed at the next end step") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dalkovan Encampment", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val encampment = game.findPermanent("Dalkovan Encampment")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = encampment,
+                        abilityId = mobilizeAbilityId
+                    )
+                )
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                game.resolveStack()
+
+                withClue("Two Warrior tokens exist during combat") {
+                    game.findPermanents("Warrior Token").size shouldBe 2
+                }
+
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                withClue("Warrior tokens are sacrificed by the next end step") {
+                    game.findPermanents("Warrior Token").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BoulderbornDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BoulderbornDragon.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boulderborn Dragon — Tarkir: Dragonstorm #239
+ * {5} · Artifact Creature — Dragon · 3/3
+ *
+ * Flying, vigilance
+ * Whenever this creature attacks, surveil 1. (Look at the top card of your library. You may put
+ * it into your graveyard.)
+ *
+ * Flying and vigilance are keyword helpers; the attack trigger uses the atomic
+ * [EffectPatterns.surveil] composition.
+ */
+val BoulderbornDragon = card("Boulderborn Dragon") {
+    manaCost = "{5}"
+    typeLine = "Artifact Creature — Dragon"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, vigilance\n" +
+        "Whenever this creature attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = EffectPatterns.surveil(1)
+        description = "Whenever this creature attacks, surveil 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "239"
+        artist = "Alexander Ostrowski"
+        flavorText = "The draconic power that flowed out from the dragonstorms imbued the " +
+            "landscape with draconic features—scales, claws, and appetites."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50c6e815-bfe7-4599-9227-d36504a3640f.jpg?1743204948"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DalkovanEncampment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DalkovanEncampment.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dalkovan Encampment — Tarkir: Dragonstorm #253
+ * Land · Rare
+ *
+ * This land enters tapped unless you control a Swamp or a Mountain.
+ * {T}: Add {W}.
+ * {2}{W}, {T}: Whenever you attack this turn, create two 1/1 red Warrior creature tokens
+ * that are tapped and attacking. Sacrifice them at the beginning of the next end step.
+ *
+ * Modeled as a check-land ([EntersTapped] with an Exists-Swamp-or-Mountain unless condition,
+ * mirroring Isolated Chapel) plus a {T}: Add {W} mana ability. The {2}{W},{T} ability installs
+ * a [CreateDelayedTriggerEffect] on [Triggers.YouAttack] that lasts the rest of the turn
+ * (default EndOfTurn expiry, fireOnce = false) — so each time you declare attackers this turn it
+ * creates two tapped-and-attacking 1/1 red Warrior tokens that are sacrificed at the next end
+ * step. The token shape and end-step sacrifice match the Mobilize wiring (CardBuilder.mobilize).
+ */
+val DalkovanEncampment = card("Dalkovan Encampment") {
+    typeLine = "Land"
+    colorIdentity = "W"
+    oracleText = "This land enters tapped unless you control a Swamp or a Mountain.\n" +
+        "{T}: Add {W}.\n" +
+        "{2}{W}, {T}: Whenever you attack this turn, create two 1/1 red Warrior creature tokens " +
+        "that are tapped and attacking. Sacrifice them at the beginning of the next end step."
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Conditions.Any(
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Swamp")),
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Mountain"))
+        )
+    ))
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.Tap)
+        effect = CreateDelayedTriggerEffect(
+            trigger = Triggers.YouAttack,
+            effect = CreateTokenEffect(
+                count = DynamicAmount.Fixed(2),
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.RED),
+                creatureTypes = setOf("Warrior"),
+                tapped = true,
+                attacking = true,
+                sacrificeAtStep = Step.END
+            )
+        )
+        description = "Whenever you attack this turn, create two 1/1 red Warrior creature tokens " +
+            "that are tapped and attacking. Sacrifice them at the beginning of the next end step."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "253"
+        artist = "Marina Ortega Lorente"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98ad5f0c-8775-4e89-8e92-84a6ade93e35.jpg?1743205000"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DalkovanPackbeasts.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DalkovanPackbeasts.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dalkovan Packbeasts — Tarkir: Dragonstorm #7
+ * {2}{W} · Creature — Ox · 0/4
+ *
+ * Vigilance
+ * Mobilize 3 (Whenever this creature attacks, create three tapped and attacking 1/1 red Warrior
+ * creature tokens. Sacrifice them at the beginning of the next end step.)
+ *
+ * Both abilities are keyword helpers: `keywords(Keyword.VIGILANCE)` for vigilance and the
+ * `mobilize(n)` builder helper, which adds the display-only "Mobilize 3" keyword ability plus the
+ * attack-triggered ability that creates three tapped-and-attacking Warrior tokens and schedules
+ * their sacrifice at the next end step.
+ */
+val DalkovanPackbeasts = card("Dalkovan Packbeasts") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Ox"
+    power = 0
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "Mobilize 3 (Whenever this creature attacks, create three tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)"
+
+    keywords(Keyword.VIGILANCE)
+    mobilize(3)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "7"
+        artist = "Constantin Marin"
+        flavorText = "A burden shared is a burden lightened.\n—Mardu proverb"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4df7b253-6107-47d6-b650-cb4d3e0aec6b.jpg?1743203980"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JadeCastSentinel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JadeCastSentinel.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Jade-Cast Sentinel — Tarkir: Dragonstorm #243
+ * {4} · Artifact Creature — Ape Snake · 1/5
+ *
+ * Reach
+ * {2}, {T}: Put target card from a graveyard on the bottom of its owner's library.
+ *
+ * Reach is a keyword helper. The graveyard-to-library-bottom activated ability mirrors
+ * Chrome Companion (EOE): a {2},{T} cost moving a targeted graveyard card to the bottom of
+ * its owner's library via [MoveToZoneEffect] with [ZonePlacement.Bottom].
+ */
+val JadeCastSentinel = card("Jade-Cast Sentinel") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Ape Snake"
+    power = 1
+    toughness = 5
+    oracleText = "Reach\n" +
+        "{2}, {T}: Put target card from a graveyard on the bottom of its owner's library."
+
+    keywords(Keyword.REACH)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val cardInGraveyard = target(
+            "target card from a graveyard",
+            TargetObject(filter = TargetFilter.CardInGraveyard)
+        )
+        effect = MoveToZoneEffect(
+            target = cardInGraveyard,
+            destination = Zone.LIBRARY,
+            placement = ZonePlacement.Bottom
+        )
+        description = "Put target card from a graveyard on the bottom of its owner's library."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "243"
+        artist = "David Astruga"
+        flavorText = "Set in motion by artificers long forgotten, it remained loyal through the " +
+            "ages to the occupants of Kheru City."
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/516ce5fa-bd00-429b-ba22-b38c7dd9306c.jpg?1743204961"
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) cards, each composed from existing SDK primitives — no new engine mechanic was required.

## Cards implemented

- **Dalkovan Packbeasts** (#7) — `{2}{W}` Creature — Ox, 0/4. Vigilance + Mobilize 3 (via the existing `mobilize(n)` builder helper).
- **Boulderborn Dragon** (#239) — `{5}` Artifact Creature — Dragon, 3/3. Flying, vigilance, and `Whenever this creature attacks, surveil 1` (atomic `EffectPatterns.surveil`).
- **Jade-Cast Sentinel** (#243) — `{4}` Artifact Creature — Ape Snake, 1/5. Reach + `{2}, {T}: Put target card from a graveyard on the bottom of its owner's library` (mirrors Chrome Companion: `MoveToZoneEffect` + `ZonePlacement.Bottom`).
- **Dalkovan Encampment** (#253) — Land. Check-land (`EntersTapped` unless you control a Swamp or a Mountain, like Isolated Chapel), `{T}: Add {W}`, and `{2}{W}, {T}: Whenever you attack this turn, create two tapped-and-attacking 1/1 red Warrior tokens; sacrifice them at the next end step` — an activated ability that installs an event-based `CreateDelayedTriggerEffect(trigger = Triggers.YouAttack)` producing the mobilize-style tokens on each attack this turn.

## Cards skipped

None — all four were implementable with existing primitives.

## Tests

- Added `DalkovanEncampmentScenarioTest` (game-server) covering: activate the `{2}{W},{T}` ability → declare attackers → two tapped/attacking Warrior tokens created → sacrificed at the next end step. Both cases pass.
- `:mtg-sets:test`, `:rules-engine:test`, and the new scenario test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)