### PR TITLE
Add TDM cards (batch C): goldkeeper, skyrider, sage, village

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KheruGoldkeeperScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KheruGoldkeeperScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Kheru Goldkeeper (TDM #199) — {1}{B}{G}{U} Dragon, 3/3, Flying.
+ *
+ * "Whenever one or more cards leave your graveyard during your turn, create a Treasure token."
+ * "Renew — {2}{B}{G}{U}, Exile this card from your graveyard: Put two +1/+1 counters and a
+ *  flying counter on target creature. Activate only as a sorcery."
+ *
+ * The leave-graveyard trigger is driven by activating *another* card's renew (Sagu Pummeler),
+ * which exiles itself from the graveyard as part of its cost — a card leaving the controller's
+ * graveyard during their turn — and Kheru's batching trigger then mints a Treasure. The second
+ * test exercises Kheru's own renew payoff: two +1/+1 counters plus a flying counter (granting
+ * Flying via projection), with Kheru exiled from the graveyard as part of the cost.
+ */
+class KheruGoldkeeperScenarioTest : ScenarioTestBase() {
+
+    private val kheruRenewAbilityId =
+        cardRegistry.getCard("Kheru Goldkeeper")!!.activatedAbilities.first().id
+    private val saguRenewAbilityId =
+        cardRegistry.getCard("Sagu Pummeler")!!.activatedAbilities.first().id
+
+    init {
+        context("Kheru Goldkeeper") {
+
+            test("creating a Treasure when a card leaves your graveyard during your turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kheru Goldkeeper")
+                    .withCardInGraveyard(1, "Sagu Pummeler")
+                    .withCardOnBattlefield(1, "Glory Seeker") // renew target, 2/2
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("No Treasure exists before any card leaves the graveyard") {
+                    game.findPermanent("Treasure") shouldBe null
+                }
+
+                val sagu = game.findCardsInGraveyard(1, "Sagu Pummeler").first()
+                val target = game.findPermanent("Glory Seeker")!!
+
+                // Activating Sagu's renew exiles it from the graveyard as part of the cost,
+                // so a card leaves Player 1's graveyard during their turn.
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = sagu,
+                        abilityId = saguRenewAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(target)),
+                    )
+                )
+                withClue("Activating Sagu Pummeler renew should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Kheru Goldkeeper's leave-graveyard trigger mints exactly one Treasure token") {
+                    game.findAllPermanents("Treasure").size shouldBe 1
+                }
+            }
+
+            test("renew puts two +1/+1 counters and a flying counter (granting Flying) on a target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Kheru Goldkeeper")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2, no flying
+                    .withLandsOnBattlefield(1, "Swamp", 2)   // renew cost {2}{B}{G}{U}
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kheru = game.findCardsInGraveyard(1, "Kheru Goldkeeper").first()
+                val creature = game.findPermanent("Glory Seeker")!!
+
+                withClue("Glory Seeker has no Flying before the counter is placed") {
+                    game.state.projectedState.hasKeyword(creature, Keyword.FLYING) shouldBe false
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = kheru,
+                        abilityId = kheruRenewAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(creature)),
+                    )
+                )
+                withClue("Activating Kheru renew should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                val counters = game.state.getEntity(creature)?.get<CountersComponent>()
+                withClue("Glory Seeker gets two +1/+1 counters") {
+                    (counters?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 2
+                }
+                withClue("Glory Seeker gets one flying counter") {
+                    (counters?.counters?.get(CounterType.FLYING) ?: 0) shouldBe 1
+                }
+                withClue("The flying counter grants the Flying keyword via projection") {
+                    game.state.projectedState.hasKeyword(creature, Keyword.FLYING) shouldBe true
+                }
+                withClue("Kheru Goldkeeper is exiled from the graveyard as part of the cost") {
+                    game.findCardsInGraveyard(1, "Kheru Goldkeeper").size shouldBe 0
+                    game.state.getExile(game.player1Id).contains(kheru) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StarryEyedSkyriderScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StarryEyedSkyriderScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Starry-Eyed Skyrider (TDM #25) — {2}{W} Human Scout, 1/3, Flying.
+ *
+ * "Whenever this creature attacks, another target creature you control gains flying until end of turn."
+ * "Attacking tokens you control have flying."
+ *
+ * The first test exercises the attack trigger: Skyrider attacks, and a non-flying creature you
+ * control (the only legal "another target creature") gains flying until end of turn. The second
+ * test exercises the continuous static: a token you control gains flying once it's attacking, and
+ * a token that is *not* attacking does not (the static is scoped to attacking tokens).
+ */
+class StarryEyedSkyriderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Starry-Eyed Skyrider") {
+
+            test("attack trigger grants flying to another target creature you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Starry-Eyed Skyrider", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Glory Seeker", summoningSickness = false) // 2/2, no flying
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val ally = game.findPermanent("Glory Seeker")!!
+                withClue("Glory Seeker has no flying before Skyrider attacks") {
+                    game.state.projectedState.hasKeyword(ally, Keyword.FLYING) shouldBe false
+                }
+
+                game.declareAttackers(mapOf("Starry-Eyed Skyrider" to 2))
+                game.resolveStack()
+
+                // "another target creature you control" — choose Glory Seeker if prompted.
+                if (game.hasPendingDecision() && game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.selectTargets(listOf(ally))
+                }
+                game.resolveStack()
+
+                withClue("Glory Seeker gains flying until end of turn from the attack trigger") {
+                    game.state.projectedState.hasKeyword(ally, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("attacking tokens you control have flying; non-attacking tokens do not") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Starry-Eyed Skyrider", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Glory Seeker", summoningSickness = false, isToken = true)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false, isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val attackingToken = game.findPermanent("Glory Seeker")!!
+                val idleToken = game.findPermanent("Grizzly Bears")!!
+
+                withClue("A token gains no flying from the static while it is not attacking") {
+                    game.state.projectedState.hasKeyword(attackingToken, Keyword.FLYING) shouldBe false
+                }
+
+                // Attack with only the Glory Seeker token; leave the Grizzly Bears token back.
+                game.declareAttackers(mapOf("Glory Seeker" to 2))
+                game.resolveStack()
+                // Resolve the Skyrider attack trigger if it fired (Skyrider itself isn't attacking here,
+                // so the trigger shouldn't fire — but drain any pending decision defensively).
+                if (game.hasPendingDecision() && game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.selectTargets(listOf(attackingToken))
+                    game.resolveStack()
+                }
+
+                withClue("The attacking token you control has flying from the static") {
+                    game.state.projectedState.hasKeyword(attackingToken, Keyword.FLYING) shouldBe true
+                }
+                withClue("The non-attacking token does not get flying from the static") {
+                    game.state.projectedState.hasKeyword(idleToken, Keyword.FLYING) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KheruGoldkeeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KheruGoldkeeper.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kheru Goldkeeper — Tarkir: Dragonstorm #199
+ * {1}{B}{G}{U} · Creature — Dragon · 3/3
+ *
+ * Flying
+ * Whenever one or more cards leave your graveyard during your turn, create a Treasure token.
+ * Renew — {2}{B}{G}{U}, Exile this card from your graveyard: Put two +1/+1 counters and a
+ *   flying counter on target creature. Activate only as a sorcery.
+ *
+ * The leave-graveyard trigger reuses the batching [Triggers.CardsLeaveYourGraveyard] (fires once
+ * per event batch) gated on [Conditions.IsYourTurn] for the "during your turn" restriction — the
+ * same composition as Attuned Hunter. The renew payoff puts both counter kinds on a single target
+ * via two chained [Effects.AddCounters] calls; the flying counter is a keyword counter (CR 122.1c),
+ * already wired into `StateProjector.KEYWORD_COUNTER_MAP` so the creature gains Flying via projection.
+ */
+val KheruGoldkeeper = card("Kheru Goldkeeper") {
+    manaCost = "{1}{B}{G}{U}"
+    colorIdentity = "BGU"
+    typeLine = "Creature — Dragon"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever one or more cards leave your graveyard during your turn, create a Treasure token. " +
+        "(It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\n" +
+        "Renew — {2}{B}{G}{U}, Exile this card from your graveyard: Put two +1/+1 counters and a " +
+        "flying counter on target creature. Activate only as a sorcery."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard()
+        triggerCondition = Conditions.IsYourTurn
+        effect = Effects.CreateTreasure(1)
+    }
+
+    renew("{2}{B}{G}{U}") {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, creature)
+            .then(Effects.AddCounters(Counters.FLYING, 1, creature))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "199"
+        artist = "Randy Vargas"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d11183a-57f5-4ddb-8a6e-15fff704b114.jpg?1743204780"
+        ruling("2025-04-04", "If multiple cards leave your graveyard at the same time, Kheru Goldkeeper's triggered ability will trigger only once.")
+        ruling("2025-04-04", "If a card with a renew ability is put into your graveyard during your turn, you can activate that ability if it's legal to do so before any other player can take any actions.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StarryEyedSkyrider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StarryEyedSkyrider.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Starry-Eyed Skyrider — Tarkir: Dragonstorm #25
+ * {2}{W} · Creature — Human Scout · 1/3
+ *
+ * Flying
+ * Whenever this creature attacks, another target creature you control gains flying until end of turn.
+ * Attacking tokens you control have flying.
+ *
+ * The attack trigger grants flying to a single other creature you control via [Effects.GrantKeyword]
+ * (until end of turn). The third line is a continuous static [GrantKeyword] over the group of
+ * attacking tokens you control — composed from [GameObjectFilter.Token] + `.youControl()` +
+ * `.attacking()`, so the flying is granted/removed dynamically by projected state as tokens enter or
+ * leave combat (and lost immediately if Skyrider leaves the battlefield).
+ */
+val StarryEyedSkyrider = card("Starry-Eyed Skyrider") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever this creature attacks, another target creature you control gains flying until end of turn.\n" +
+        "Attacking tokens you control have flying."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target("another creature you control", TargetCreature(filter = TargetFilter.OtherCreatureYouControl))
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.FLYING,
+            filter = GroupFilter(GameObjectFilter.Token.youControl().attacking())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "25"
+        artist = "Lindsey Look"
+        flavorText = "Too late, the elders realized the young prodigies shared a love of adventure and mischief."
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b3cc15e-1c82-454e-b541-4ab47c44814e.jpg?1743204050"
+        ruling("2025-04-04", "If Starry-Eyed Skyrider leaves the battlefield, any attacking tokens will no longer be granted flying by the last ability. If that happens before the declare blockers step, it may allow those tokens to be blocked by creatures without flying.")
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) cards. Two are implemented; two are skipped because they require genuinely new engine mechanics (out of scope for the add-card skill — should go through add-feature).

## Implemented

- **Kheru Goldkeeper** (#199, {1}{B}{G}{U} Dragon, 3/3) — Flying; "whenever one or more cards leave your graveyard during your turn, create a Treasure" via `Triggers.CardsLeaveYourGraveyard` + `Conditions.IsYourTurn` (same composition as Attuned Hunter); Renew — {2}{B}{G}{U} payoff puts two +1/+1 counters and a flying counter (keyword counter, granted via projection) on a target creature.
- **Starry-Eyed Skyrider** (#25, {2}{W} Human Scout, 1/3) — Flying; attack trigger grants flying to another target creature you control; continuous static grants flying to attacking tokens you control (`GrantKeyword` over `GameObjectFilter.Token.youControl().attacking()`).

Both reuse existing SDK primitives — no new effects/triggers/conditions/keywords. Scenario tests cover each ability (including the static's "non-attacking token gets nothing" scope check). All four tests pass.

## Skipped (need new engine mechanics)

- **Sage of the Skies** (#22) — "When you cast this spell, if you've cast another spell this turn, copy this spell." Requires a **"when you cast this spell" self-cast trigger** that fires on the spell's own cast while it's on the stack. The engine's self-cast trigger detection (`TriggerDetector.detectSelfCastNthSpellTriggers`) currently only handles `NthSpellCastEvent`, not a generic `SpellCastEvent`-on-self trigger, so this needs a new self-cast trigger spec + detector branch (plus copy-this-spell wiring). New mechanic → add-feature, not add-card.
- **Mistrise Village** (#261) — "{U}, {T}: The next spell you cast this turn can't be countered." The existing `Effects.GrantSpellsCantBeCountered` protects *all* matching spells for a duration, not just the **next** one; a faithful "next spell only" implementation needs a one-shot pending-rider mechanism (analogous to the existing `PendingSpellCopy` for "copy your next spell"). Approximating with the all-spells effect would be a behavioral shortcut, so it's left for add-feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)