### PR TITLE
Add TDM cards (batch B): stormshell, tawnyback, shrieker, village

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1559,6 +1559,11 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
 - `TargetControlsCreature(target)` — target player has a creature.
 - `TargetControlsLand(target)` — target player has a land.
 - `TargetMatchesFilter(filter, targetIndex = 0)` — the context target matches a `GameObjectFilter`.
+- `TargetIsPlayer(targetIndex = 0)` — the context target is a player (not a permanent/spell/card).
+  `TargetMatchesFilter` matches only game objects and returns false for a player target, so this is
+  the dedicated check for "any target" effects with a player-only follow-up. Used by Sonic Shrieker
+  ("If a player is dealt damage this way, they discard a card"); pair with
+  `EffectTarget.ContextTarget(index)` to make that same player the subject of the follow-up.
 - `IfTargetTookExcessDamage(targetIndex = 0)` — true post-damage when the target creature's marked
   damage strictly exceeds its (projected) toughness. Chain after `Effects.DealDamage` in a composite
   so the marked-damage update applies before the condition reads it. Used by Orbital Plunge ("If

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SonicShriekerScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/SonicShriekerScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sonic Shrieker (#226) and its new [com.wingedsheep.sdk.scripting.conditions.TargetIsPlayer]
+ * condition.
+ *
+ * ETB: "deals 2 damage to any target and you gain 2 life. If a player is dealt damage this way,
+ * they discard a card." The discard rider is gated on the damaged "any target" having been a
+ * player and aimed back at that same player via ContextTarget.
+ */
+class SonicShriekerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sonic Shrieker ETB") {
+            test("targets an opponent: 2 damage to the player, caster gains 2 life, the player discards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sonic Shrieker")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInHand(2, "Grizzly Bears") // a card to discard
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Sonic Shrieker")
+                withClue("Casting the creature should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack() // creature enters → ETB trigger asks for its "any target"
+
+                val targeted = game.selectTargets(listOf(game.player2Id))
+                withClue("Targeting Player 2 should be legal: ${targeted.error}") { targeted.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Player 2 takes 2 damage (20 -> 18)") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("Caster gains 2 life (20 -> 22)") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                withClue("Player 2 was dealt damage and discards their card") {
+                    game.state.getHand(game.player2Id).size shouldBe 0
+                }
+            }
+
+            test("targets a creature: no player damaged, so no discard happens") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sonic Shrieker")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3, survives 2 damage
+                    .withCardInHand(2, "Grizzly Bears") // should NOT be discarded
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Sonic Shrieker")
+                withClue("Casting the creature should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack() // creature enters → ETB trigger asks for its "any target"
+
+                val hillGiant = game.findPermanent("Hill Giant")!!
+                val targeted = game.selectTargets(listOf(hillGiant))
+                withClue("Targeting Hill Giant should be legal: ${targeted.error}") { targeted.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Hill Giant (3/3) survives 2 damage") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+                withClue("Caster gains 2 life (20 -> 22)") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                withClue("No player was dealt damage → Player 2 keeps their card") {
+                    game.state.getHand(game.player2Id).size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -226,6 +226,14 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TargetMatchesFilter(filter, targetIndex)
 
     /**
+     * If the context target at [targetIndex] is a player (not a permanent/spell/card).
+     * Used for "any target" effects with a player-only follow-up — e.g. Sonic Shrieker's
+     * "If a player is dealt damage this way, they discard a card."
+     */
+    fun TargetIsPlayer(targetIndex: Int = 0): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TargetIsPlayer(targetIndex)
+
+    /**
      * If the target shares a color with the most common color among all permanents
      * (or a color tied for most common). Used by Tsabo's Assassin.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -190,6 +190,25 @@ data class TargetMatchesFilter(
 }
 
 /**
+ * Condition: "if [target] is a player".
+ *
+ * True when the context target at [targetIndex] is a player (rather than a permanent, spell, or
+ * card). The companion [TargetMatchesFilter] only matches game objects and returns false for a
+ * player target, so this is the dedicated check for "any target" effects whose follow-up applies
+ * only when the chosen target was a player — e.g. Sonic Shrieker's "If a player is dealt damage
+ * this way, they discard a card." Pair with [com.wingedsheep.sdk.scripting.targets.EffectTarget.ContextTarget]
+ * to make that same player the subject of the follow-up.
+ */
+@SerialName("TargetIsPlayer")
+@Serializable
+data class TargetIsPlayer(
+    val targetIndex: Int = 0
+) : Condition {
+    override val description: String = "if a player is dealt damage this way"
+    override fun applyTextReplacement(replacer: TextReplacer): Condition = this
+}
+
+/**
  * Condition: "if excess damage was dealt this way" — true when the target creature's
  * marked damage now strictly exceeds its (projected) toughness.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AmblingStormshell.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AmblingStormshell.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Ambling Stormshell — Tarkir: Dragonstorm #37
+ * {3}{U}{U} · Creature — Turtle · 5/9
+ *
+ * Ward {2}
+ * Whenever this creature attacks, put three stun counters on it and draw three cards.
+ * Whenever you cast a Turtle spell, untap this creature.
+ *
+ * Composed entirely from existing primitives: [KeywordAbility.ward] for the ward cost,
+ * [Effects.AddCounters] + [Effects.DrawCards] on the attack trigger, and an untap-self
+ * effect keyed to the [Triggers.YouCastSubtype] Turtle-spell trigger. The three stun
+ * counters keep the shell tapped after attacking (CR 122.1c stun-counter replacement);
+ * casting a Turtle spell untaps it so it can attack again.
+ */
+val AmblingStormshell = card("Ambling Stormshell") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Turtle"
+    power = 5
+    toughness = 9
+    oracleText = "Ward {2}\n" +
+        "Whenever this creature attacks, put three stun counters on it and draw three cards. " +
+        "(If a permanent with a stun counter would become untapped, remove one from it instead.)\n" +
+        "Whenever you cast a Turtle spell, untap this creature."
+
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.AddCounters(Counters.STUN, 3, EffectTarget.Self)
+            .then(Effects.DrawCards(3))
+        description = "Whenever this creature attacks, put three stun counters on it and draw three cards."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSubtype(Subtype.TURTLE)
+        effect = Effects.Untap(EffectTarget.Self)
+        description = "Whenever you cast a Turtle spell, untap this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "37"
+        artist = "Carlos Palma Cruchaga"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c74d4a57-0f66-4965-9ed7-f88a08aa1d15.jpg?1743204109"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KishlaVillage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KishlaVillage.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Kishla Village — Tarkir: Dragonstorm #259
+ * Land
+ *
+ * This land enters tapped unless you control an Island or a Swamp.
+ * {T}: Add {G}.
+ * {3}{G}, {T}: Surveil 2.
+ *
+ * The conditional enters-tapped is the check-land replacement [EntersTapped] gated on
+ * controlling an Island or a Swamp (same shape as Isolated Chapel). {T}: Add {G} is a mana
+ * ability; the surveil ability is a non-mana activated ability ({3}{G} + tap) composed from
+ * the atomic [EffectPatterns.surveil] pipeline. The surveil ability has no timing restriction,
+ * so it can be activated at instant speed.
+ */
+val KishlaVillage = card("Kishla Village") {
+    typeLine = "Land"
+    colorIdentity = "G"
+    oracleText = "This land enters tapped unless you control an Island or a Swamp.\n" +
+        "{T}: Add {G}.\n" +
+        "{3}{G}, {T}: Surveil 2. (Look at the top two cards of your library, then put any number " +
+        "of them into your graveyard and the rest on top of your library in any order.)"
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Conditions.Any(
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Island")),
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Swamp"))
+        )
+    ))
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Composite(
+            listOf(
+                AbilityCost.Mana(ManaCost.parse("{3}{G}")),
+                AbilityCost.Tap
+            )
+        )
+        effect = EffectPatterns.surveil(2)
+        description = "Surveil 2."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "259"
+        artist = "Bruce Brenneise"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f0ff90d-7312-44df-afc5-29c768fa7758.jpg?1743205023"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SonicShrieker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SonicShrieker.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sonic Shrieker — Tarkir: Dragonstorm #226
+ * {2}{R}{W}{B} · Creature — Dragon · 4/4
+ *
+ * Flying
+ * When this creature enters, it deals 2 damage to any target and you gain 2 life.
+ * If a player is dealt damage this way, they discard a card.
+ *
+ * The ETB resolves as one composite: deal 2 to the chosen "any target" (source defaults to
+ * this creature), gain 2 life, then — only if that target was a player — that same player
+ * discards a card. The player-only follow-up is gated by [Conditions.TargetIsPlayer] (the
+ * companion `TargetMatchesFilter` matches game objects and returns false for a player target,
+ * so a dedicated player check is required), and the discard is aimed at the damaged player via
+ * [EffectTarget.ContextTarget]. Modeling "is dealt damage this way" as "the target was a player"
+ * matches the engine's damage model — a player target always takes the 2 damage absent a
+ * player-damage prevention shield, which the engine does not broadly support.
+ */
+val SonicShrieker = card("Sonic Shrieker") {
+    manaCost = "{2}{R}{W}{B}"
+    colorIdentity = "RWB"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, it deals 2 damage to any target and you gain 2 life. " +
+        "If a player is dealt damage this way, they discard a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val anyTarget = target("any target", Targets.Any)
+        effect = CompositeEffect(listOf(
+            Effects.DealDamage(2, anyTarget),
+            Effects.GainLife(2),
+            ConditionalEffect(
+                condition = Conditions.TargetIsPlayer(0),
+                effect = Effects.Discard(1, EffectTarget.ContextTarget(0))
+            )
+        ))
+        description = "When this creature enters, it deals 2 damage to any target and you gain 2 life. " +
+            "If a player is dealt damage this way, they discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "226"
+        artist = "Jason A. Engle"
+        flavorText = "To ensure a fair competition, the Great Assemblage's war shriek contest has " +
+            "two divisions: dragons, and everyone else."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c231437-8bec-42e0-9175-af74c752b119.jpg?1743204895"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TemurTawnyback.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TemurTawnyback.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temur Tawnyback — Tarkir: Dragonstorm #229
+ * {2/G}{2/U}{2/R} · Creature — Beast · 4/3
+ *
+ * When this creature enters, draw a card, then discard a card.
+ *
+ * Straight loot ETB via [EffectPatterns.loot] (draw a card, then discard a card). The mana
+ * cost is monocolored hybrid ("twobrid"): each symbol can be paid with 2 generic or one
+ * mana of the listed color, so it's castable in any of G/U/R decks.
+ */
+val TemurTawnyback = card("Temur Tawnyback") {
+    manaCost = "{2/G}{2/U}{2/R}"
+    colorIdentity = "GUR"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature enters, draw a card, then discard a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.loot()
+        description = "When this creature enters, draw a card, then discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "229"
+        artist = "Brian Valeza"
+        flavorText = "\"He just kind of followed me home one day. I mean, could you say no to this face?\"\n" +
+            "—Karasi, Mistrise provisioner"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3cdb383f-bc04-46d1-aa3a-7459d57f1fec.jpg?1743204904"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -63,6 +63,7 @@ import com.wingedsheep.engine.state.components.battlefield.CastFromGraveyardComp
 import com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentHadSubtype
 import com.wingedsheep.sdk.scripting.conditions.AnotherPermanentWithSameNameAsTarget
 import com.wingedsheep.sdk.scripting.conditions.TargetMarkedDamageExceedsToughness
+import com.wingedsheep.sdk.scripting.conditions.TargetIsPlayer
 import com.wingedsheep.sdk.scripting.conditions.TargetMatchesFilter
 import com.wingedsheep.sdk.scripting.conditions.TargetSharesMostCommonColor
 import com.wingedsheep.sdk.scripting.conditions.ColorIsMostCommon
@@ -229,6 +230,7 @@ class ConditionEvaluator(
             is TriggeringSpellHasSingleTarget -> ifResolution { evaluateTriggeringSpellHasSingleTarget(state, it) }
             is TriggeringSpellMatchesFilter -> ifResolution { evaluateTriggeringSpellMatchesFilter(state, condition, it) }
             is TargetMatchesFilter -> ifResolution { evaluateTargetMatchesFilter(state, condition, it) }
+            is TargetIsPlayer -> ifResolution { evaluateTargetIsPlayer(condition, it) }
             is TargetMarkedDamageExceedsToughness ->
                 ifResolution { evaluateTargetMarkedDamageExceedsToughness(state, condition, it) }
             is TargetSharesMostCommonColor -> ifResolution { evaluateTargetSharesMostCommonColor(state, condition, it) }
@@ -693,6 +695,19 @@ class ConditionEvaluator(
         val predicateContext = PredicateContext.fromEffectContext(context)
         val projected = state.projectedState
         return predicateEvaluator.matches(state, projected, entityId, condition.filter, predicateContext)
+    }
+
+    /**
+     * Evaluate "if a player is dealt damage this way" — true when the context target at the given
+     * index is a player target. Used by Sonic Shrieker to gate its discard follow-up on the
+     * damaged "any target" having been a player. Permanent/spell/card targets return false.
+     */
+    private fun evaluateTargetIsPlayer(
+        condition: TargetIsPlayer,
+        context: EffectContext
+    ): Boolean {
+        val target = context.targets.getOrNull(condition.targetIndex) ?: return false
+        return target is com.wingedsheep.engine.state.components.stack.ChosenTarget.Player
     }
 
     /**


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) cards.

## Implemented

- **Ambling Stormshell** (#37) — {3}{U}{U} Turtle 5/9. Ward {2}; whenever it attacks, put three stun counters on it and draw three cards; whenever you cast a Turtle spell, untap it. Composed from existing primitives (`KeywordAbility.ward`, `Effects.AddCounters` + `Effects.DrawCards`, `Triggers.YouCastSubtype(TURTLE)` + `Effects.Untap`).
- **Temur Tawnyback** (#229) — {2/G}{2/U}{2/R} Beast 4/3. ETB loot via `EffectPatterns.loot()` (draw a card, then discard a card). Monocolored-hybrid cost.
- **Sonic Shrieker** (#226) — {2}{R}{W}{B} Dragon 4/4, flying. ETB deals 2 damage to any target and you gain 2 life; if a player was dealt damage this way, they discard a card. Introduces a new reusable **`TargetIsPlayer(targetIndex)`** condition — the existing `TargetMatchesFilter` matches only game objects and returns false for a player target, so a dedicated player check was required. Wired across SDK condition → `Conditions` facade → `ConditionEvaluator`, with the discard aimed at the damaged player via `EffectTarget.ContextTarget`. Scenario test covers both the player-target (discard fires) and creature-target (no discard) paths.
- **Kishla Village** (#259) — Land. Check-land "enters tapped unless you control an Island or a Swamp"; {T}: Add {G}; {3}{G}, {T}: Surveil 2 (via `EffectPatterns.surveil(2)`).

## Skipped

None — all four cards implemented.

## Tests

- `:mtg-sdk:test` and `:rules-engine:test` — pass (covers the new condition's serialization round-trip and card validation).
- `:mtg-sets:test` — pass (image URIs + card discovery for all four cards).
- New `SonicShriekerScenarioTest` — both cases pass.

Updated `docs/card-sdk-language-reference.md` with the `TargetIsPlayer` condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)