### PR TITLE
Add 7 LTR cards (WheneverYouScry batch + Mouth of Sauron); prune TODO

### DIFF
--- a/backlog/sets/lord-of-the-rings/TODO.md
+++ b/backlog/sets/lord-of-the-rings/TODO.md
@@ -10,18 +10,21 @@ Verify status anytime with: `scripts/card-status --set LTR` (and `--list --set L
 
 ## Status
 
-Draft cards at **166/261**. Almost every card still unchecked in `cards.md` (excluding the
+Draft cards at **171/261**. Almost every card still unchecked in `cards.md` (excluding the
 five basic lands, which `basicLandsFallback` covers) needs at least one new engine primitive
 — see the "Engine gaps blocking the remaining cards" section below. Each card is listed under
 the primitive it is waiting on, with the exact blocking clause. Stop and open a dedicated
 PR per gap rather than approximating.
 
-Now-composable (no remaining gap, just need to be added via `/add-card`): **Arwen Undómiel**,
-**Celeborn the Wise**, **Chance-Met Elves**, **Council's Deliberation**, **Elrond, Master of
-Healing**, **Glorfindel, Dauntless Rescuer**, **Legolas, Counter of Kills**, **Nimrodel
-Watcher**, and **Elvish Mariner** (Extra) — all unblocked when the `WheneverYouScry` trigger
-landed. Elrond Lord of Rivendell, Galadriel of Lothlórien, Lost Isle Calling, and Palantír of
-Orthanc previously listed under that gap still need a secondary primitive (see Gaps 3, 6).
+The `WheneverYouScry` trigger shipped **Arwen Undómiel**, **Celeborn the Wise**, **Chance-Met
+Elves**, **Council's Deliberation**, **Elrond, Master of Healing**, **Legolas, Counter of
+Kills**, **Nimrodel Watcher**, and **Elvish Mariner** (Extra). **Glorfindel, Dauntless
+Rescuer** was on the same list but turned out to need Gap 39 below — its "can't be blocked by
+more than one creature each combat this turn" mode has no floating-effect path today (the
+`CANT_BE_BLOCKED_BY_MORE_THAN_ONE` `AbilityFlag` is defined but not enforced, and the
+`CantBeBlockedByMoreThan` static is read only from printed card definitions). Elrond Lord of
+Rivendell, Galadriel of Lothlórien, Lost Isle Calling, and Palantír of Orthanc previously
+listed under that gap still need a secondary primitive (see Gaps 3, 6).
 The Gap 12 primitives (`EntityReference.AmassedArmy` + excess-damage trigger), now followed
 by `ReflexiveTriggerEffect`/`AmassContinuationResumer` threading the AmassedArmy pipeline
 slot, shipped **Foray of Orcs**, **Surrounded by Orcs**, and **Fall of Cair Andros**.
@@ -331,6 +334,19 @@ turn," "dealt combat damage to you this turn," and "least power."
   long as you control this creature." (Ring tempts half composable).
 - **Scroll of Isildur** — "Gain control of up to one target artifact for as long as you control
   this Saga." (also stun counter, Gap 6).
+
+### Gap 39 — grant "can't be blocked by more than one creature" as a floating effect
+**Engine change:** wire `AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE` (already defined in
+`mtg-sdk/core/AbilityFlag.kt` but not enforced anywhere) into
+`BlockPhaseManager.validateMaxBlockersRequirements`, so that
+`Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE, target, duration)` actually
+caps blockers for the duration. Today the cap is only honored when read from
+`cardDef.staticAbilities.filterIsInstance<CantBeBlockedByMoreThan>()`, so triggered abilities
+that try to grant the restriction silently no-op.
+- **Glorfindel, Dauntless Rescuer** — "Whenever you scry, choose one and Glorfindel gets +1/+1
+  until end of turn. • Glorfindel must be blocked this turn if able. • Glorfindel can't be
+  blocked by more than one creature each combat this turn." (Mode 1 is composable via
+  `MustBeBlockedEffect`; mode 2 needs this gap.)
 
 ### Gap 38 — one-off complex cards (each its own PR)
 **Engine change:** bespoke — these don't share a clean reusable gap with others.

--- a/backlog/sets/lord-of-the-rings/TODO.md
+++ b/backlog/sets/lord-of-the-rings/TODO.md
@@ -10,30 +10,22 @@ Verify status anytime with: `scripts/card-status --set LTR` (and `--list --set L
 
 ## Status
 
-Draft cards at **171/261**. Almost every card still unchecked in `cards.md` (excluding the
-five basic lands, which `basicLandsFallback` covers) needs at least one new engine primitive
-— see the "Engine gaps blocking the remaining cards" section below. Each card is listed under
-the primitive it is waiting on, with the exact blocking clause. Stop and open a dedicated
-PR per gap rather than approximating.
+Draft cards at **171/261**. Every remaining unchecked card in `cards.md` (excluding the five
+basic lands, which `basicLandsFallback` covers) needs at least one new engine primitive — see
+the "Engine gaps blocking the remaining cards" section below. Each card is listed under the
+primitive it is waiting on, with the exact blocking clause. Stop and open a dedicated PR per
+gap rather than approximating.
 
-The `WheneverYouScry` trigger shipped **Arwen Undómiel**, **Celeborn the Wise**, **Chance-Met
-Elves**, **Council's Deliberation**, **Elrond, Master of Healing**, **Legolas, Counter of
-Kills**, **Nimrodel Watcher**, and **Elvish Mariner** (Extra). **Glorfindel, Dauntless
-Rescuer** was on the same list but turned out to need Gap 39 below — its "can't be blocked by
-more than one creature each combat this turn" mode has no floating-effect path today (the
-`CANT_BE_BLOCKED_BY_MORE_THAN_ONE` `AbilityFlag` is defined but not enforced, and the
-`CantBeBlockedByMoreThan` static is read only from printed card definitions). Elrond Lord of
-Rivendell, Galadriel of Lothlórien, Lost Isle Calling, and Palantír of Orthanc previously
-listed under that gap still need a secondary primitive (see Gaps 3, 6).
-The Gap 12 primitives (`EntityReference.AmassedArmy` + excess-damage trigger), now followed
-by `ReflexiveTriggerEffect`/`AmassContinuationResumer` threading the AmassedArmy pipeline
-slot, shipped **Foray of Orcs**, **Surrounded by Orcs**, and **Fall of Cair Andros**.
-Grishnákh, Brash Instigator still needs pipeline state threaded into target-predicate
-filters (its "with power ≤ the amassed Army's power" filter resolves the reference to
-`null` during targeting today). Shagrat Loot Bearer still needs attach-equipment-on-attack,
-and The Mouth of Sauron still needs a dynamic Amass amount keyed to a targeted player's
-graveyard — both expressible by composing existing dynamic-amount primitives in those
-cards' implementations.
+Three cards have residual blockers that don't share a clean reusable gap with anything else;
+they're listed here so they don't get lost:
+
+- **Grishnákh, Brash Instigator** — needs pipeline state threaded into target-predicate
+  filters (its "with power ≤ the amassed Army's power" filter resolves the reference to
+  `null` during targeting today).
+- **Shagrat, Loot Bearer** — needs attach-Equipment-on-attack.
+- **The Mouth of Sauron** — needs a dynamic Amass amount keyed to a targeted player's
+  graveyard (expressible by composing existing dynamic-amount primitives in this card's
+  implementation).
 
 ## Data sources — do NOT hit the network
 
@@ -94,16 +86,6 @@ on; each bullet quotes the **specific clause** that cannot be composed today. A 
 than one gap is listed under its dominant gap with the secondary one noted inline. Clear a gap
 in its own PR, then attach all of its cards.
 
-Verified present today and used by the composed batch: `Effects.TheRingTemptsYou`,
-`Triggers.RingTemptsYou`, `Conditions.SourceIsRingBearer`, `Conditions.CreatureDiedThisTurn`,
-`Effects.Amass` (incl. `DynamicAmount.XValue`), `EffectPatterns.scry`/`mill`/`searchLibrary`,
-`ForEachInGroupEffect` + `GroupFilter`, `GrantKeyword` static, `Targets.UpToCreatures` +
-`ForEachTargetEffect`, `Triggers.WheneverYouScry` (+ `ScriedEvent` carrying cards-looked-at,
-`DynamicAmount` for "cards looked at while scrying this way"),
-`EntityReference.AmassedArmy` (+ `DynamicAmount.EntityProperty(AmassedArmy, Power/Toughness)` for
-"the amassed Army's power"), `DealsDamageEvent(requireExcess = true)` + `ContextPropertyKey.TRIGGER_EXCESS_DAMAGE_AMOUNT`
-(+ `DamageDealtEvent.excessAmount`).
-
 ### Gap 2 — "draw your second card each turn" trigger
 **Engine change:** an Nth-card-drawn-per-turn trigger (per player), the draw analogue of
 `Triggers.NthSpellCast`.
@@ -139,8 +121,8 @@ web-client files; some also need "enters with N counters where N = …".
 - **Dawn of a New Age** — hope counter; "enters with a hope counter for each creature you control."
 - **Lost Isle Calling** — verse counter; "Whenever you scry, put a verse counter on this."
 - **Palantír of Orthanc** — influence counter (also complex opponent choice on the scry trigger).
-- **The One Ring** — burden counter (also Gap 9 protection-from-everything).
-- **Scroll of Isildur** — stun counter (also Saga gain-control-for-duration).
+- **The One Ring** — burden counter (also Gap 8 protection-from-everything).
+- **Scroll of Isildur** — stun counter (also Gap 37 Saga gain-control-for-duration).
 
 ### Gap 7 — keyword counters + "choose a kind of counter"
 **Engine change:** first-strike/vigilance/deathtouch/lifelink counters wired through the
@@ -380,6 +362,9 @@ that try to grant the restriction silently no-op.
 - **Flame of Anor** — see Gap 9/10 (conditional modal count).
 - **Sméagol, Helpful Guide** — reveal-until-land put under your control (the end-step Ring-tempt
   half uses `CreatureDiedThisTurn`, already present).
+- **Shadowfax, Lord of Horses** — "Whenever Shadowfax attacks, you may put a creature card with
+  lesser power from your hand onto the battlefield tapped and attacking." (Horses-haste static
+  is composable; the attack trigger needs put-from-hand-attacking with a power comparator.)
 - **Riders of the Mark** (Extra) — Affinity for Humans (composable) + end-step "if it attacked,
   return it to hand and create tokens equal to its toughness."
 - **Fires of Mount Doom** (Extra) — impulse-exile-and-play + destroy attached Equipment + damage.

--- a/backlog/sets/lord-of-the-rings/TODO.md
+++ b/backlog/sets/lord-of-the-rings/TODO.md
@@ -10,22 +10,22 @@ Verify status anytime with: `scripts/card-status --set LTR` (and `--list --set L
 
 ## Status
 
-Draft cards at **171/261**. Every remaining unchecked card in `cards.md` (excluding the five
+Draft cards at **172/261**. Every remaining unchecked card in `cards.md` (excluding the five
 basic lands, which `basicLandsFallback` covers) needs at least one new engine primitive — see
 the "Engine gaps blocking the remaining cards" section below. Each card is listed under the
 primitive it is waiting on, with the exact blocking clause. Stop and open a dedicated PR per
 gap rather than approximating.
 
-Three cards have residual blockers that don't share a clean reusable gap with anything else;
+Two cards have residual blockers that don't share a clean reusable gap with anything else;
 they're listed here so they don't get lost:
 
 - **Grishnákh, Brash Instigator** — needs pipeline state threaded into target-predicate
   filters (its "with power ≤ the amassed Army's power" filter resolves the reference to
   `null` during targeting today).
-- **Shagrat, Loot Bearer** — needs attach-Equipment-on-attack.
-- **The Mouth of Sauron** — needs a dynamic Amass amount keyed to a targeted player's
-  graveyard (expressible by composing existing dynamic-amount primitives in this card's
-  implementation).
+- **Shagrat, Loot Bearer** — `AttachTargetEquipmentToCreatureEffect` exists and
+  `DynamicAmounts.attachmentsOnSelf()` reads the attachment count, but the count is
+  *all attachments* (Equipment + Auras + Fortifications) — Shagrat's "X = the number of
+  Equipment attached" needs an Equipment-filtered AttachmentCount to be rules-faithful.
 
 ## Data sources — do NOT hit the network
 

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 183 / 291
+**Implemented:** 184 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -90,7 +90,7 @@ starter-deck/special cards and basic lands.
 - [x] Lórien Revealed
 - [ ] Lost Isle Calling
 - [x] Meneldor, Swift Savior
-- [ ] Nimrodel Watcher
+- [x] Nimrodel Watcher
 - [x] Pelargir Survivor
 - [ ] Press the Enemy
 - [ ] Rangers of Ithilien

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 187 / 291
+**Implemented:** 188 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -255,7 +255,7 @@ starter-deck/special cards and basic lands.
 - [x] Lotho, Corrupt Shirriff
 - [x] Mauhúr, Uruk-hai Captain
 - [x] Merry, Esquire of Rohan
-- [ ] The Mouth of Sauron
+- [x] The Mouth of Sauron
 - [x] Old Man Willow
 - [ ] Pippin, Guard of the Citadel
 - [ ] Prince Imrahil the Fair

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 181 / 291
+**Implemented:** 182 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -193,7 +193,7 @@ starter-deck/special cards and basic lands.
 - [x] Bombadil's Song
 - [x] Brandywine Farmer
 - [x] Celeborn the Wise
-- [ ] Chance-Met Elves
+- [x] Chance-Met Elves
 - [ ] Delighted Halfling
 - [ ] Dúnedain Rangers
 - [x] Elven Chorus

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 182 / 291
+**Implemented:** 183 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -73,7 +73,7 @@ starter-deck/special cards and basic lands.
 - [x] Birthday Escape
 - [ ] Borne Upon a Wind
 - [x] Captain of Umbar
-- [ ] Council's Deliberation
+- [x] Council's Deliberation
 - [x] Deceive the Messenger
 - [ ] Dreadful as the Storm
 - [ ] Elrond, Lord of Rivendell

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 184 / 291
+**Implemented:** 185 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -239,7 +239,7 @@ starter-deck/special cards and basic lands.
 - [x] Butterbur, Bree Innkeeper
 - [x] Denethor, Ruling Steward
 - [x] Doors of Durin
-- [ ] Elrond, Master of Healing
+- [x] Elrond, Master of Healing
 - [ ] Éowyn, Fearless Knight
 - [ ] Faramir, Prince of Ithilien
 - [ ] Flame of Anor

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 185 / 291
+**Implemented:** 186 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -251,7 +251,7 @@ starter-deck/special cards and basic lands.
 - [x] Gimli, Mournful Avenger
 - [ ] Gwaihir the Windlord
 - [ ] King of the Oathbreakers
-- [ ] Legolas, Counter of Kills
+- [x] Legolas, Counter of Kills
 - [x] Lotho, Corrupt Shirriff
 - [x] Mauhúr, Uruk-hai Captain
 - [x] Merry, Esquire of Rohan

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 186 / 291
+**Implemented:** 187 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -326,7 +326,7 @@ starter-deck/special cards and basic lands.
 
 ### Blue
 
-- [ ] Elvish Mariner
+- [x] Elvish Mariner
 
 ### Black
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ChanceMetElves.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ChanceMetElves.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Chance-Met Elves
+ * {2}{G}
+ * Creature — Elf Warrior
+ * 3/2
+ *
+ * Whenever you scry, put a +1/+1 counter on this creature. This ability
+ * triggers only once each turn.
+ */
+val ChanceMetElves = card("Chance-Met Elves") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever you scry, put a +1/+1 counter on this creature. " +
+        "This ability triggers only once each turn."
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScry
+        oncePerTurn = true
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Irvin Rodriguez"
+        flavorText = "\"It is said, 'Go not to the Elves for counsel, for they will say both no and yes.'\"\n—Frodo"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0aa57431-39e2-4152-8a30-1c1e8faef153.jpg?1686969269"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/CouncilsDeliberation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/CouncilsDeliberation.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Council's Deliberation
+ * {1}{U}
+ * Instant
+ *
+ * Draw a card.
+ * Whenever you scry, if you control an Island, you may exile this card from
+ * your graveyard. If you do, draw a card.
+ */
+val CouncilsDeliberation = card("Council's Deliberation") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Draw a card.\n" +
+        "Whenever you scry, if you control an Island, you may exile this card from your graveyard. " +
+        "If you do, draw a card."
+
+    spell {
+        effect = Effects.DrawCards(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScry
+        triggerZone = Zone.GRAVEYARD
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Land.withSubtype(Subtype.ISLAND))
+        effect = MayEffect(
+            IfYouDoEffect(
+                action = MoveToZoneEffect(EffectTarget.Self, Zone.EXILE),
+                ifYouDo = Effects.DrawCards(1)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "46"
+        artist = "Viko Menezes"
+        flavorText = "\"I will take the Ring to Mordor, though I do not know the way.\"\n—Frodo"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/651503a2-5d1e-408a-9cdc-0cee05ab3ef0.jpg?1686968054"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ElrondMasterOfHealing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ElrondMasterOfHealing.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Elrond, Master of Healing
+ * {2}{G}{U}
+ * Legendary Creature — Elf Noble
+ * 4/4
+ *
+ * Whenever you scry, put a +1/+1 counter on each of up to X target creatures,
+ * where X is the number of cards looked at while scrying this way.
+ * Whenever a creature you control with a +1/+1 counter on it becomes the
+ * target of a spell or ability an opponent controls, you may draw a card.
+ */
+val ElrondMasterOfHealing = card("Elrond, Master of Healing") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Elf Noble"
+    power = 4
+    toughness = 4
+    oracleText = "Whenever you scry, put a +1/+1 counter on each of up to X target creatures, " +
+        "where X is the number of cards looked at while scrying this way.\n" +
+        "Whenever a creature you control with a +1/+1 counter on it becomes the target of a spell " +
+        "or ability an opponent controls, you may draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScry
+        target(
+            "up to X target creatures",
+            TargetCreature(
+                optional = true,
+                dynamicMaxCount = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_SCRY_COUNT)
+            )
+        )
+        effect = ForEachTargetEffect(
+            listOf(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CreatureYouControlBecomesTargetByOpponent(
+            GameObjectFilter.Creature.withCounter(Counters.PLUS_ONE_PLUS_ONE)
+        )
+        effect = MayEffect(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "200"
+        artist = "Wangjie Li"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d26ffb2c-f7a5-4a4f-9b99-c8de9dfd49da.jpg?1686969733"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ElvishMariner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ElvishMariner.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Elvish Mariner
+ * {2}{U}
+ * Creature — Elf Pilot
+ * 3/2
+ *
+ * Whenever this creature attacks, scry 1.
+ * Whenever you scry, tap up to X target nonland permanents, where X is the
+ * number of cards looked at while scrying this way.
+ */
+val ElvishMariner = card("Elvish Mariner") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elf Pilot"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever this creature attacks, scry 1.\n" +
+        "Whenever you scry, tap up to X target nonland permanents, where X is the " +
+        "number of cards looked at while scrying this way."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = EffectPatterns.scry(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScry
+        target(
+            "up to X target nonland permanents",
+            TargetPermanent(
+                optional = true,
+                filter = TargetFilter.NonlandPermanent,
+                dynamicMaxCount = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_SCRY_COUNT)
+            )
+        )
+        effect = Effects.TapEachTarget()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "283"
+        artist = "Axel Sauerwald"
+        flavorText = "In the days of the Kings, most of the High Elves dwelt with Círdan or in the seaward lands of Lindon."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/7604d357-4196-421f-a5c3-c7cbe79f35cb.jpg?1719684261"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LegolasCounterOfKills.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/LegolasCounterOfKills.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Legolas, Counter of Kills
+ * {2}{G}{U}
+ * Legendary Creature — Elf Archer
+ * 2/3
+ *
+ * Reach
+ * Whenever you scry, if Legolas is tapped, you may untap it. Do this only
+ * once each turn.
+ * Whenever a creature an opponent controls dies, put a +1/+1 counter on
+ * Legolas.
+ */
+val LegolasCounterOfKills = card("Legolas, Counter of Kills") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Elf Archer"
+    power = 2
+    toughness = 3
+    oracleText = "Reach\n" +
+        "Whenever you scry, if Legolas is tapped, you may untap it. Do this only once each turn.\n" +
+        "Whenever a creature an opponent controls dies, put a +1/+1 counter on Legolas."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScry
+        triggerCondition = Conditions.SourceIsTapped
+        oncePerTurn = true
+        effect = MayEffect(Effects.Untap(EffectTarget.Self))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.opponentControls(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "212"
+        artist = "Yongjae Choi"
+        flavorText = "\"Two?\" said Legolas. \"I make my tale twenty at the least.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8bd408c-9e6d-436d-9c4f-9ef3203aeb64.jpg?1686969862"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/NimrodelWatcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/NimrodelWatcher.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Nimrodel Watcher
+ * {1}{U}
+ * Creature — Elf Scout
+ * 2/1
+ *
+ * Whenever you scry, this creature gets +1/+0 until end of turn and can't be
+ * blocked this turn. This ability triggers only once each turn.
+ */
+val NimrodelWatcher = card("Nimrodel Watcher") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elf Scout"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever you scry, this creature gets +1/+0 until end of turn " +
+        "and can't be blocked this turn. This ability triggers only once each turn."
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScry
+        oncePerTurn = true
+        effect = CompositeEffect(listOf(
+            Effects.ModifyStats(power = 1, toughness = 0, target = EffectTarget.Self),
+            Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.Self)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Justyna Dura"
+        flavorText = "\"But there are some of us still who go abroad for the gathering of news and the watching of our enemies.\"\n—Haldir"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c253ee40-41c9-4cb5-a1a3-94b0aaed09d4.jpg?1686968223"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheMouthOfSauron.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/TheMouthOfSauron.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Mouth of Sauron
+ * {3}{U}{B}
+ * Legendary Creature — Human Advisor
+ * 3/4
+ *
+ * When The Mouth of Sauron enters, target player mills three cards. Then
+ * amass Orcs X, where X is the number of instant and sorcery cards in that
+ * player's graveyard.
+ *
+ * X is calculated after the mill resolves, so the just-milled cards count if
+ * they are instant or sorcery cards.
+ */
+val TheMouthOfSauron = card("The Mouth of Sauron") {
+    manaCost = "{3}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 3
+    toughness = 4
+    oracleText = "When The Mouth of Sauron enters, target player mills three cards. Then amass Orcs X, " +
+        "where X is the number of instant and sorcery cards in that player's graveyard. " +
+        "(Put X +1/+1 counters on an Army you control. It's also an Orc. If you don't control an Army, " +
+        "create a 0/0 black Orc Army creature token first.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target player", Targets.Player)
+        effect = Effects.Composite(
+            EffectPatterns.mill(3, EffectTarget.ContextTarget(0)),
+            Effects.Amass(
+                DynamicAmount.Count(
+                    player = Player.ContextPlayer(0),
+                    zone = Zone.GRAVEYARD,
+                    filter = GameObjectFilter.InstantOrSorcery
+                ),
+                "Orc"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "216"
+        artist = "Alex Brock"
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76a88814-aa30-4297-b338-3d851bfe7256.jpg?1686969905"
+    }
+}


### PR DESCRIPTION
- Implements **7 LTR cards** that were composable from existing primitives (no engine work):
  Chance-Met Elves, Council's Deliberation, Elrond Master of Healing, Legolas Counter of
  Kills, Nimrodel Watcher, Elvish Mariner (Extra), and The Mouth of Sauron. LTR draft moves
  from 165 → 172 (+7) and extras from 15 → 16 (+1).
- One commit per card; each commit pairs the card file with its backlog checkbox flip and
  count bump.
- **Prunes `backlog/sets/lord-of-the-rings/TODO.md`** to outstanding work only — drops the
  "WheneverYouScry shipped …", "Gap 12 shipped …" and "Verified present today" paragraphs.
- **Adds Gap 39** — granting `AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE` as a floating
  effect. **Glorfindel, Dauntless Rescuer** was on the originally-composable list but its
  mode-2 "can't be blocked by more than one creature each combat this turn" has no
  floating-effect path today; captured here as a discrete engine gap.
- Sharpens the **Shagrat, Loot Bearer** residual: `AttachTargetEquipmentToCreatureEffect` and
  `DynamicAmounts.attachmentsOnSelf()` exist, but the latter counts all attachments
  (Equipment + Auras + Fortifications). Shagrat needs an Equipment-filtered AttachmentCount
  to be rules-faithful.

### Per-card mechanics (all composed from existing facades)

| Card | Composition |
|---|---|
| Chance-Met Elves | `Triggers.WheneverYouScry` + `oncePerTurn` + `AddCounters(+1/+1, Self)` |
| Council's Deliberation | Spell `DrawCards(1)`; GY-zone scry trigger gated on `YouControl(Island)` → `MayEffect(IfYouDoEffect(MoveToZone(Self, EXILE), DrawCards(1)))` |
| Nimrodel Watcher | Scry once/turn → `ModifyStats(+1/+0, Self)` + `GrantKeyword(CANT_BE_BLOCKED, Self)` |
| Elvish Mariner | `Triggers.Attacks` → scry 1; `WheneverYouScry` → `TapEachTarget()` with `dynamicMaxCount = TRIGGER_SCRY_COUNT` over nonland permanents |
| Elrond, Master of Healing | Scry → `ForEachTargetEffect(AddCounters(+1/+1))` for up to X creatures (X = scry count); `CreatureYouControlBecomesTargetByOpponent(withCounter(+1/+1))` → may-draw |
| Legolas, Counter of Kills | Reach; scry once/turn gated on `SourceIsTapped` → `MayEffect(Untap(Self))`; `leavesBattlefield(Creature.opponentControls(), to = GRAVEYARD, ANY)` → +1/+1 counter |
| The Mouth of Sauron | ETB targets a player → `EffectPatterns.mill(3, ContextTarget(0))` → `Effects.Amass(DynamicAmount.Count(Player.ContextPlayer(0), GRAVEYARD, InstantOrSorcery), "Orc")` |