### PR TITLE
TDM cards batch A: Agent of Kotis, Armament Dragon, Bone-Cairn Butcher, Dragonback Lancer

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmBatchAScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmBatchAScenarioTest.kt
@@ -1,0 +1,176 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.DistributeDecision
+import com.wingedsheep.engine.core.DistributionResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the TDM "batch A" cards:
+ *  - Agent of Kotis (#36): {1}{U} Human Rogue 2/1 — Renew {3}{U}: put two +1/+1 counters on a creature.
+ *  - Armament Dragon (#168): {3}{W}{B}{G} Dragon 3/4, Flying — ETB distribute three +1/+1 counters
+ *    among one, two, or three target creatures you control.
+ *  - Dragonback Lancer (#9): {3}{W} Human Soldier 3/3, Flying, Mobilize 1.
+ *  - Bone-Cairn Butcher (#173): {1}{R}{W}{B} Demon 4/4, Mobilize 2, attacking tokens you control
+ *    have deathtouch.
+ */
+class TdmBatchAScenarioTest : ScenarioTestBase() {
+
+    private val agentRenewAbilityId =
+        cardRegistry.getCard("Agent of Kotis")!!.activatedAbilities.first().id
+
+    init {
+        context("Agent of Kotis") {
+            test("renew puts two +1/+1 counters on target creature, exiling Agent from the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Agent of Kotis")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withLandsOnBattlefield(1, "Island", 4) // renew cost {3}{U}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val agent = game.findCardsInGraveyard(1, "Agent of Kotis").first()
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = agent,
+                        abilityId = agentRenewAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bear)),
+                    )
+                )
+                withClue("Activating Agent of Kotis renew should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears gets two +1/+1 counters") {
+                    game.state.getEntity(bear)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+                withClue("Agent of Kotis is exiled from the graveyard as part of the cost") {
+                    game.findCardsInGraveyard(1, "Agent of Kotis").size shouldBe 0
+                    game.state.getExile(game.player1Id).contains(agent) shouldBe true
+                }
+            }
+        }
+
+        context("Armament Dragon") {
+            test("flying, and ETB distributes three +1/+1 counters among target creatures you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Armament Dragon")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // distribute target
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                // Cast the Dragon; resolving the stack puts it on the battlefield and fires its ETB.
+                withClue("Casting Armament Dragon should succeed") {
+                    game.castSpell(1, "Armament Dragon").error shouldBe null
+                }
+                game.resolveStack() // dragon enters → ETB trigger asks for targets
+
+                val dragon = game.findPermanent("Armament Dragon")!!
+                withClue("Armament Dragon has flying") {
+                    game.state.projectedState.hasKeyword(dragon, Keyword.FLYING) shouldBe true
+                }
+
+                // Choose the Bear as the single target, then distribute all three counters onto it.
+                withClue("Targeting the Bear should be legal") {
+                    game.selectTargets(listOf(bear)).error shouldBe null
+                }
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision() as DistributeDecision
+                    game.submitDecision(
+                        DistributionResponse(decision.id, mapOf(bear to decision.totalAmount))
+                    )
+                    game.resolveStack()
+                }
+
+                withClue("All three +1/+1 counters land on the single target") {
+                    game.state.getEntity(bear)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 3
+                }
+            }
+        }
+
+        context("Dragonback Lancer") {
+            test("flying, and Mobilize 1 makes one tapped, attacking Warrior token on attack") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dragonback Lancer", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lancer = game.findPermanent("Dragonback Lancer")!!
+                withClue("Dragonback Lancer has flying") {
+                    game.state.projectedState.hasKeyword(lancer, Keyword.FLYING) shouldBe true
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Dragonback Lancer" to 2))
+                withClue("Declaring Dragonback Lancer as attacker should succeed: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+                game.resolveStack()
+
+                val warriors = game.findPermanents("Warrior Token")
+                withClue("Mobilize 1 creates one Warrior token") { warriors.size shouldBe 1 }
+                withClue("The Warrior token is tapped and attacking") {
+                    warriors.forEach { token ->
+                        game.state.getEntity(token)?.has<TappedComponent>() shouldBe true
+                        game.state.getEntity(token)?.has<AttackingComponent>() shouldBe true
+                    }
+                }
+            }
+        }
+
+        context("Bone-Cairn Butcher") {
+            test("Mobilize 2 makes two Warrior tokens that gain deathtouch while attacking") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bone-Cairn Butcher", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Bone-Cairn Butcher" to 2))
+                withClue("Declaring Bone-Cairn Butcher as attacker should succeed: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+                game.resolveStack()
+
+                val warriors = game.findPermanents("Warrior Token")
+                withClue("Mobilize 2 creates two Warrior tokens") { warriors.size shouldBe 2 }
+                withClue("Each attacking Warrior token gains deathtouch from Bone-Cairn Butcher's static") {
+                    warriors.forEach { token ->
+                        game.state.projectedState.hasKeyword(token, Keyword.DEATHTOUCH) shouldBe true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AgentOfKotis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AgentOfKotis.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Agent of Kotis — Tarkir: Dragonstorm #36
+ * {1}{U} · Creature — Human Rogue · 2/1
+ *
+ * Renew — {3}{U}, Exile this card from your graveyard: Put two +1/+1 counters on target
+ * creature. Activate only as a sorcery.
+ *
+ * The `renew(cost)` builder helper adds the display-only "Renew" keyword ability plus the
+ * graveyard-only activated ability (exile this card from your graveyard as a cost, sorcery
+ * timing). The payoff is a single [Effects.AddCounters] of two +1/+1 counters on one target.
+ */
+val AgentOfKotis = card("Agent of Kotis") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    power = 2
+    toughness = 1
+    oracleText = "Renew — {3}{U}, Exile this card from your graveyard: Put two +1/+1 counters " +
+        "on target creature. Activate only as a sorcery."
+
+    renew("{3}{U}") {
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, target("creature", Targets.Creature))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/812d0462-0158-467f-951d-a7a121188a10.jpg?1743204105"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ArmamentDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ArmamentDragon.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Armament Dragon — Tarkir: Dragonstorm #168
+ * {3}{W}{B}{G} · Creature — Dragon · 3/4
+ *
+ * Flying
+ * When this creature enters, distribute three +1/+1 counters among one, two, or three target
+ * creatures you control.
+ *
+ * Same ETB shape as Armament Corps, scaled to three counters across up to three controlled
+ * creatures: the [TargetCreature] requirement enforces "one, two, or three target creatures you
+ * control" (minCount = 1, count = 3) and [Effects.DistributeCountersAmongTargets] presents the
+ * allocation decision over the chosen targets.
+ */
+val ArmamentDragon = card("Armament Dragon") {
+    manaCost = "{3}{W}{B}{G}"
+    colorIdentity = "WBG"
+    typeLine = "Creature — Dragon"
+    power = 3
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, distribute three +1/+1 counters among one, two, or three target creatures you control."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = TargetCreature(count = 3, minCount = 1, filter = TargetFilter.CreatureYouControl)
+        effect = Effects.DistributeCountersAmongTargets(totalCounters = 3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "168"
+        artist = "Maxime Minard"
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/17f61c01-0a41-4fa1-ac34-ffa83baad989.jpg?1743204643"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BoneCairnButcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BoneCairnButcher.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bone-Cairn Butcher — Tarkir: Dragonstorm #173
+ * {1}{R}{W}{B} · Creature — Demon · 4/4
+ *
+ * Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior
+ * creature tokens. Sacrifice them at the beginning of the next end step.)
+ * Attacking tokens you control have deathtouch.
+ *
+ * The `mobilize(n)` builder helper adds the display-only "Mobilize 2" keyword ability plus the
+ * attack-triggered ability that creates two tapped-and-attacking Warrior tokens and schedules
+ * their sacrifice at the next end step. The deathtouch clause is a continuous static
+ * [GrantKeyword] over the group of attacking tokens you control — since only creatures attack,
+ * the group is constrained to creature tokens you control that are attacking, evaluated each time
+ * the static is applied so the freshly mobilized Warriors gain deathtouch for that combat.
+ */
+val BoneCairnButcher = card("Bone-Cairn Butcher") {
+    manaCost = "{1}{R}{W}{B}"
+    colorIdentity = "RWB"
+    typeLine = "Creature — Demon"
+    power = 4
+    toughness = 4
+    oracleText = "Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)\n" +
+        "Attacking tokens you control have deathtouch."
+
+    mobilize(2)
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.DEATHTOUCH,
+            GroupFilter((GameObjectFilter.Creature and GameObjectFilter.Token).youControl()).attacking()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "173"
+        artist = "David Palumbo"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78bf36bc-6702-4c5d-b52d-ab7217cc8787.jpg?1743204667"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonbackLancer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonbackLancer.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonback Lancer — Tarkir: Dragonstorm #9
+ * {3}{W} · Creature — Human Soldier · 3/3
+ *
+ * Flying
+ * Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior
+ * creature token. Sacrifice it at the beginning of the next end step.)
+ *
+ * Both abilities are keyword helpers: `keywords(Keyword.FLYING)` for the evasion keyword and the
+ * `mobilize(n)` builder helper, which adds the display-only "Mobilize 1" keyword ability plus the
+ * attack-triggered ability that creates the tapped-and-attacking Warrior token and schedules its
+ * sacrifice at the next end step.
+ */
+val DragonbackLancer = card("Dragonback Lancer") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)"
+
+    keywords(Keyword.FLYING)
+    mobilize(1)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Diego Gisbert"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/0200a8c5-3293-48d0-a523-ba148680f588.jpg?1743203987"
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm cards. All four reuse existing TDM mechanics, so no SDK/engine changes were required.

## Implemented

- **Agent of Kotis** (#36) — `{1}{U}` Human Rogue 2/1. Renew `{3}{U}`: put two +1/+1 counters on target creature (sorcery timing, exiles itself from the graveyard as a cost). Uses the `renew(cost)` builder + a single `Effects.AddCounters`.
- **Armament Dragon** (#168) — `{3}{W}{B}{G}` Dragon 3/4, Flying. ETB distributes three +1/+1 counters among one, two, or three target creatures you control. Same shape as Khans' Armament Corps, scaled to three counters / up to three targets via `TargetCreature(count = 3, minCount = 1, ...)` + `Effects.DistributeCountersAmongTargets(3)`.
- **Dragonback Lancer** (#9) — `{3}{W}` Human Soldier 3/3, Flying + Mobilize 1. Keyword helpers only (`keywords(Keyword.FLYING)` + `mobilize(1)`).
- **Bone-Cairn Butcher** (#173) — `{1}{R}{W}{B}` Demon 4/4, Mobilize 2 + "Attacking tokens you control have deathtouch". Modeled as `mobilize(2)` plus a continuous static `GrantKeyword(DEATHTOUCH, ...)` over attacking creature tokens you control.

## Skipped

None — all four landed.

## Tests

`TdmBatchAScenarioTest` (game-server) covers all four: renew counter placement + graveyard exile, flying + distribute-onto-target, Mobilize token creation (tapped/attacking), and attacking-token deathtouch via projection. All 4 pass.

Canonical printing placement verified with `just check-card-printing` for each (TDM is the earliest real printing for all four).

🤖 Generated with [Claude Code](https://claude.com/claude-code)