### PR TITLE
TDM cards batch C: Jeskai Shrinekeeper, Sunpearl Kirin, Zurgo's Vanguard

### DIFF
--- a/backlog/tdm-engine-gaps.md
+++ b/backlog/tdm-engine-gaps.md
@@ -251,6 +251,19 @@ the overwhelming majority of the set.
     the Saga's post-III sacrifice).
     → **Thunder of Unity**
 
+22. **Grant Harmonize to a graveyard card until end of turn.** ❌ **NOT DONE — blocks Songcrafter Mage.**
+    Harmonize today is only a *static* `KeywordAbility.Harmonize(cost)` printed on a card; the
+    cast-from-graveyard path (`CastFromZoneEnumerator.enumerateHarmonize`) and the payment path
+    (`AlternativePaymentHandler.hasHarmonize`, 3 call sites) read it straight off `cardDef.keywordAbilities`.
+    Songcrafter Mage needs to *grant* harmonize at resolution to a chosen instant/sorcery in your
+    graveyard, **until end of turn**, with the granted harmonize cost equal to that card's mana cost.
+    That requires a runtime "granted harmonize" component (cost + EndOfTurn duration), the enumerator
+    and payment handler consulting it alongside the static keyword, end-of-turn cleanup, and the
+    harmonize-creature power reduction interacting with the granted cost. This is an `add-feature`-sized,
+    multi-layer change (SDK effect + component → enumerator → payment handler → cleanup → client), not a
+    single-card composition, so Songcrafter Mage is deferred until that feature lands.
+    → **Songcrafter Mage**
+
 ---
 
 ## Recommended build order

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmBatchCExtraScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmBatchCExtraScenarioTest.kt
@@ -1,0 +1,159 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the "TDM batch C" cards:
+ *  - Jeskai Shrinekeeper (#197) — combat-damage gain-life + draw
+ *  - Sunpearl Kirin (#29) — ETB bounce of an own nonland permanent; token → draw
+ *  - Zurgo's Vanguard (#133) — characteristic-defining power = creatures you control
+ */
+class TdmBatchCExtraScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Jeskai Shrinekeeper") {
+
+            test("combat damage to a player gains 1 life and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Jeskai Shrinekeeper", summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.declareAttackers(mapOf("Jeskai Shrinekeeper" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                var iterations = 0
+                while (game.state.step == Step.COMBAT_DAMAGE && !game.hasPendingDecision() && iterations++ < 20) {
+                    game.passPriority()
+                }
+                game.resolveStack()
+
+                withClue("Jeskai Shrinekeeper (3/3) deals 3 combat damage to the defender") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+                withClue("Controller gains 1 life from the trigger") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+                withClue("Controller draws a card from the trigger") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+        }
+
+        context("Sunpearl Kirin") {
+
+            test("returns a chosen nontoken permanent to hand and draws no card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sunpearl Kirin")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                val cast = game.castSpell(1, "Sunpearl Kirin")
+                withClue("Casting Sunpearl Kirin should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack() // Kirin enters → ETB trigger on stack, asks for a target.
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("The chosen Grizzly Bears returns to its owner's hand") {
+                    game.findCardsInHand(1, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("Grizzly Bears left the battlefield") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                // Cast Kirin (-1 hand), bounced Bears (+1 hand) → net unchanged; no extra draw (nontoken).
+                withClue("Returning a nontoken permanent draws no card") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("The library card was not drawn") {
+                    game.findCardsInLibrary(1, "Mountain").size shouldBe 1
+                }
+            }
+
+            test("returning a token draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sunpearl Kirin")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false, isToken = true)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                val cast = game.castSpell(1, "Sunpearl Kirin")
+                withClue("Casting Sunpearl Kirin should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val tokenBears = game.findPermanent("Grizzly Bears")!!
+                game.selectTargets(listOf(tokenBears))
+                game.resolveStack()
+
+                withClue("The token ceases to exist when it leaves the battlefield (not in hand)") {
+                    game.findCardsInHand(1, "Grizzly Bears").size shouldBe 0
+                }
+                withClue("The token left the battlefield") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                // Cast Kirin (-1 hand), token doesn't go to hand, but the token clause draws (+1).
+                withClue("Returning a token draws a card, so hand size is unchanged after casting Kirin") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("The library card was drawn by the token clause") {
+                    game.findCardsInLibrary(1, "Mountain").size shouldBe 0
+                }
+            }
+        }
+
+        context("Zurgo's Vanguard") {
+
+            test("power equals the number of creatures you control; toughness stays 3") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Zurgo's Vanguard")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vanguard = game.findPermanent("Zurgo's Vanguard")!!
+                val projected = stateProjector.project(game.state)
+                withClue("Power = 3 creatures you control (Vanguard + Bears + Giant); opponent's creature excluded") {
+                    projected.getPower(vanguard) shouldBe 3
+                }
+                withClue("Toughness is the fixed printed 3") {
+                    projected.getToughness(vanguard) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiShrinekeeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiShrinekeeper.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jeskai Shrinekeeper — Tarkir: Dragonstorm #197
+ * {2}{U}{R}{W} · Creature — Dragon · 3/3
+ *
+ * Flying, haste
+ * Whenever this creature deals combat damage to a player, you gain 1 life and draw a card.
+ *
+ * Composes the two combat-damage payoffs with [Effects.Composite] over [Effects.GainLife] and
+ * [Effects.DrawCards], both controller-scoped. The trigger reuses [Triggers.DealsCombatDamageToPlayer].
+ */
+val JeskaiShrinekeeper = card("Jeskai Shrinekeeper") {
+    manaCost = "{2}{U}{R}{W}"
+    colorIdentity = "URW"
+    typeLine = "Creature — Dragon"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, haste\n" +
+        "Whenever this creature deals combat damage to a player, you gain 1 life and draw a card."
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Composite(
+            Effects.GainLife(1),
+            Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "197"
+        artist = "Andrew Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6ec8fa0b-c695-4326-aebd-042cb1974925.jpg?1743204771"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SunpearlKirin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SunpearlKirin.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Sunpearl Kirin — Tarkir: Dragonstorm #29
+ * {1}{W} · Creature — Kirin · 2/1
+ *
+ * Flash
+ * Flying
+ * When this creature enters, return up to one other target nonland permanent you control to its
+ * owner's hand. If it was a token, draw a card.
+ *
+ * The ETB targets an optional ("up to one") other nonland permanent you control and returns it to
+ * hand. The "if it was a token, draw a card" reflexive clause is modeled by capturing the chosen
+ * target into a pipeline collection ([CardSource.ChosenTargets]) and gating an [Effects.DrawCards]
+ * on [Conditions.CollectionContainsMatch] for [CardPredicate.IsToken]. The token check is evaluated
+ * (and the draw resolved) before [Effects.ReturnToHand] removes the permanent, so the token's
+ * [com.wingedsheep.engine.state.components.identity.TokenComponent] is still present when checked —
+ * both happen in the same resolution, so the visible game state is identical to bouncing first.
+ * Declining the optional target leaves the captured collection empty: no draw, no bounce.
+ */
+val SunpearlKirin = card("Sunpearl Kirin") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kirin"
+    power = 2
+    toughness = 1
+    oracleText = "Flash\n" +
+        "Flying\n" +
+        "When this creature enters, return up to one other target nonland permanent you control to " +
+        "its owner's hand. If it was a token, draw a card."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target(
+            "other nonland permanent you control",
+            TargetPermanent(
+                optional = true,
+                filter = TargetFilter.NonlandPermanent.youControl().other()
+            )
+        )
+        effect = CompositeEffect(listOf(
+            // Capture the chosen permanent so we can inspect its token status before it leaves.
+            GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "returned"),
+            // If the captured permanent was a token, draw a card (resolved while it's still in play).
+            ConditionalEffect(
+                condition = Conditions.CollectionContainsMatch(
+                    "returned",
+                    GameObjectFilter(cardPredicates = listOf(CardPredicate.IsToken))
+                ),
+                effect = Effects.DrawCards(1)
+            ),
+            // Return the chosen permanent to its owner's hand (no-op if no target was chosen).
+            Effects.ReturnToHand(permanent)
+        ))
+        description = "When this creature enters, return up to one other target nonland permanent you " +
+            "control to its owner's hand. If it was a token, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "Allen Morris"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18292b9c-0f42-4ce2-8b85-35d06cf45a63.jpg?1743204071"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ZurgosVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ZurgosVanguard.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CharacteristicValue
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Zurgo's Vanguard — Tarkir: Dragonstorm #133
+ * {2}{R} · Creature — Dog Soldier · star/3 (power is a characteristic-defining count)
+ *
+ * Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior
+ * creature token. Sacrifice it at the beginning of the next end step.)
+ * Zurgo's Vanguard's power is equal to the number of creatures you control.
+ *
+ * `mobilize(1)` supplies the attack-triggered Warrior token. The characteristic-defining power is a
+ * power-only [CharacteristicValue.dynamic] over [DynamicAmount.AggregateBattlefield] counting
+ * creatures you control (toughness stays fixed at 3). Because Mobilize's token enters tapped and
+ * attacking before damage, the Warrior it makes is itself a creature you control, so the
+ * count-based power already reflects the new token when combat damage is assigned.
+ */
+val ZurgosVanguard = card("Zurgo's Vanguard") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dog Soldier"
+    toughness = 3
+    oracleText = "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red " +
+        "Warrior creature token. Sacrifice it at the beginning of the next end step.)\n" +
+        "Zurgo's Vanguard's power is equal to the number of creatures you control."
+
+    mobilize(1)
+    dynamicPower = CharacteristicValue.dynamic(
+        DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature)
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "133"
+        artist = "Michele Giorgi"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1aa3501-5738-4063-a7f4-51d2600b0041.jpg?1743204499"
+    }
+}


### PR DESCRIPTION
Implements three Tarkir: Dragonstorm (TDM) cards using existing SDK primitives, with a scenario test, and defers one card that needs a new engine feature.

## Implemented

- **Jeskai Shrinekeeper** (#197) — `{2}{U}{R}{W}` Dragon 3/3. Flying, haste; "Whenever this creature deals combat damage to a player, you gain 1 life and draw a card." Composes `Effects.GainLife(1)` + `Effects.DrawCards(1)` via `Effects.Composite` on `Triggers.DealsCombatDamageToPlayer`.
- **Sunpearl Kirin** (#29) — `{1}{W}` Kirin 2/1. Flash, flying; ETB returns up to one other target nonland permanent you control to hand, and if it was a token, draw a card. The token clause captures the chosen target (`CardSource.ChosenTargets`) and gates a draw on `Conditions.CollectionContainsMatch` for `CardPredicate.IsToken`, evaluated before `Effects.ReturnToHand` removes the permanent so the token's component is still present.
- **Zurgo's Vanguard** (#133) — `{2}{R}` Dog Soldier, star/3. Mobilize 1 (`mobilize(1)` helper); power-only characteristic-defining value via `CharacteristicValue.dynamic(DynamicAmount.AggregateBattlefield(Player.You, Creature))`, toughness fixed at 3.

Added `TdmBatchCExtraScenarioTest` (4 tests, all passing): combat-damage gain-life+draw, the nontoken bounce branch (no draw), the token bounce branch (draws), and the creature-count CDA (opponent creatures excluded, fixed toughness).

## Skipped

- **Songcrafter Mage** (#225) — needs to *grant* Harmonize to a chosen instant/sorcery in your graveyard until end of turn (with harmonize cost = the card's mana cost). Today Harmonize is only a static `KeywordAbility.Harmonize(cost)` read directly off `cardDef.keywordAbilities` by the cast-from-graveyard enumerator and the alternative-payment handler. A faithful implementation requires a runtime "granted harmonize" component (cost + EndOfTurn duration) consulted by both paths, end-of-turn cleanup, and the harmonize-creature power-reduction interaction — an `add-feature`-sized, multi-layer change (SDK → enumerator → payment handler → cleanup → client), not a single-card composition. Documented as gap #22 in `backlog/tdm-engine-gaps.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)