### PR TITLE
Add 6 dinosaur-deck cards (Zombify, Ghalta, Gishath, Palani's Hatcher, Conduit Pylons, Raph & Mikey)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -68,6 +68,7 @@ import com.wingedsheep.mtg.sets.definitions.otj.OutlawsOfThunderJunctionSet
 import com.wingedsheep.mtg.sets.definitions.spm.SpiderManSet
 import com.wingedsheep.mtg.sets.definitions.tdm.TarkirDragonstormSet
 import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
+import com.wingedsheep.mtg.sets.definitions.tmt.TeenageMutantNinjaTurtlesSet
 import com.wingedsheep.mtg.sets.definitions.war.WarOfTheSparkSet
 import com.wingedsheep.mtg.sets.definitions.woe.WildsOfEldrainSet
 import com.wingedsheep.mtg.sets.definitions.wwk.WorldwakeSet
@@ -137,6 +138,7 @@ object MtgSetCatalog {
         SpiderManSet,
         TarkirDragonstormSet,
         AvatarTheLastAirbenderSet,
+        TeenageMutantNinjaTurtlesSet,
         WarOfTheSparkSet,
         OdysseySet,
         JudgmentSet,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ZombifyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ZombifyReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zombify reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in
+ * the Odyssey (ODY) set's `cards/` package. This file contributes only the FDN-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ZombifyReprint = Printing(
+    oracleId = "bb95db4d-5017-4121-bf79-d68476602d8c",
+    name = "Zombify",
+    setCode = "FDN",
+    collectorNumber = "187",
+    scryfallId = "dc798e6f-13c4-457c-b052-b7b65bc83cfe",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dc798e6f-13c4-457c-b052-b7b65bc83cfe.jpg?1730489291",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/LostCavernsOfIxalanSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/LostCavernsOfIxalanSet.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.lci
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
 
 /**
  * The Lost Caverns of Ixalan Set (2023)
@@ -19,6 +20,10 @@ object LostCavernsOfIxalanSet : MtgSet {
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }
 
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.lci.cards"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GhaltaStampedeTyrant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GhaltaStampedeTyrant.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Ghalta, Stampede Tyrant
+ * {5}{G}{G}{G}
+ * Legendary Creature — Elder Dinosaur
+ * 12/12
+ *
+ * Trample
+ * When Ghalta enters, put any number of creature cards from your hand
+ * onto the battlefield.
+ */
+val GhaltaStampedeTyrant = card("Ghalta, Stampede Tyrant") {
+    manaCost = "{5}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Elder Dinosaur"
+    power = 12
+    toughness = 12
+    oracleText = "Trample\nWhen Ghalta enters, put any number of creature cards from your hand onto the battlefield."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CompositeEffect(listOf(
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.You, GameObjectFilter.Creature),
+                storeAs = "ghalta_candidates"
+            ),
+            SelectFromCollectionEffect(
+                from = "ghalta_candidates",
+                selection = SelectionMode.ChooseAnyNumber,
+                storeSelected = "ghalta_putting",
+                prompt = "Choose any number of creature cards to put onto the battlefield"
+            ),
+            MoveCollectionEffect(
+                from = "ghalta_putting",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You)
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "185"
+        artist = "Lars Grant-West"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72e805e9-69be-45c1-aa04-f460641a0c1e.jpg?1699044395"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GishathSunsAvatarReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GishathSunsAvatarReprint.kt
@@ -1,0 +1,25 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gishath, Sun's Avatar reprint in LCI.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T)
+ * lives in the Ixalan (XLN) set's `cards/` package. This file contributes only
+ * the LCI-specific presentation row — set, collector number, art — picked up
+ * automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's
+ * `printings`.
+ */
+val GishathSunsAvatarReprint = Printing(
+    oracleId = "a311daab-40dc-4433-9ed8-feab7c558bbf",
+    name = "Gishath, Sun's Avatar",
+    setCode = "LCI",
+    collectorNumber = "229",
+    scryfallId = "bc4a65de-23b5-48f0-b8b7-94608eaced3e",
+    artist = "Zack Stella",
+    imageUri = "https://cards.scryfall.io/normal/front/b/c/bc4a65de-23b5-48f0-b8b7-94608eaced3e.jpg?1699044539",
+    releaseDate = "2023-11-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PalanisHatcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PalanisHatcher.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Palani's Hatcher
+ * {3}{R}{G}
+ * Creature — Dinosaur
+ * 5/3
+ *
+ * Other Dinosaurs you control have haste.
+ * When this creature enters, create two 0/1 green Dinosaur Egg creature tokens.
+ * At the beginning of combat on your turn, if you control one or more Eggs,
+ * sacrifice an Egg, then create a 3/3 green Dinosaur creature token.
+ */
+val PalanisHatcher = card("Palani's Hatcher") {
+    manaCost = "{3}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Dinosaur"
+    power = 5
+    toughness = 3
+    oracleText = "Other Dinosaurs you control have haste.\n" +
+        "When this creature enters, create two 0/1 green Dinosaur Egg creature tokens.\n" +
+        "At the beginning of combat on your turn, if you control one or more Eggs, sacrifice an Egg, then create a 3/3 green Dinosaur creature token."
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype("Dinosaur").youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Dinosaur", "Egg"),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/a/7/a7e24a8f-3663-47c6-94b1-4525ae9da3b5.jpg?1699017427"
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Creature.withSubtype("Egg"))
+        effect = CompositeEffect(listOf(
+            ForceSacrificeEffect(
+                filter = GameObjectFilter.Creature.withSubtype("Egg"),
+                count = 1,
+                target = EffectTarget.PlayerRef(Player.You)
+            ),
+            Effects.CreateToken(
+                power = 3,
+                toughness = 3,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Dinosaur"),
+                count = 1,
+                imageUri = "https://cards.scryfall.io/normal/front/2/b/2bbb7151-cf71-49bc-8d99-b0230d5465e5.jpg?1699017364"
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "237"
+        artist = "Aaron Miller"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86ff73c7-428c-469c-b564-6aa9f4eeca14.jpg?1699044564"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/Zombify.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/Zombify.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ody.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zombify
+ * {3}{B}
+ * Sorcery
+ *
+ * Return target creature card from your graveyard to the battlefield.
+ */
+val Zombify = card("Zombify") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to the battlefield."
+
+    spell {
+        val creature = target("target creature card from your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.PutOntoBattlefield(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Mark Romanoski"
+        flavorText = "\"The first birth celebrates life. The second birth mocks it.\"\n—Mystic elder"
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/513a2a6f-9ae6-42cb-b75f-6b45fc35f36e.jpg?1562909871"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ConduitPylons.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ConduitPylons.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
+
+/**
+ * Conduit Pylons
+ * Land — Desert
+ *
+ * When this land enters, surveil 1.
+ * {T}: Add {C}.
+ * {1}, {T}: Add one mana of any color.
+ */
+val ConduitPylons = card("Conduit Pylons") {
+    typeLine = "Land — Desert"
+    colorIdentity = ""
+    oracleText = "When this land enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.surveil(1)
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddColorlessManaEffect(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "254"
+        artist = "Raymond Bonilla"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5ffa48cc-b991-4d47-b7ec-cf678915c758.jpg?1712356314"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/TeenageMutantNinjaTurtlesSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/TeenageMutantNinjaTurtlesSet.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.tmt
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Teenage Mutant Ninja Turtles (2026)
+ *
+ * Set Code: TMT
+ * Release Date: March 6, 2026
+ */
+object TeenageMutantNinjaTurtlesSet : MtgSet {
+
+    override val code = "TMT"
+    override val displayName = "Teenage Mutant Ninja Turtles"
+    override val releaseDate = "2026-03-06"
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.tmt.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphAndMikeyTroublemakers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphAndMikeyTroublemakers.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Raph & Mikey, Troublemakers
+ * {5}{R/G}{R/G}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 7/7
+ *
+ * Trample, haste
+ * Whenever Raph & Mikey attack, reveal cards from the top of your library
+ * until you reveal a creature card. Put that card onto the battlefield
+ * tapped and attacking and the rest on the bottom of your library in a
+ * random order.
+ */
+val RaphAndMikeyTroublemakers = card("Raph & Mikey, Troublemakers") {
+    manaCost = "{5}{R/G}{R/G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    power = 7
+    toughness = 7
+    oracleText = "Trample, haste\nWhenever Raph & Mikey attack, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield tapped and attacking and the rest on the bottom of your library in a random order."
+
+    keywords(Keyword.TRAMPLE, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = CompositeEffect(listOf(
+            GatherUntilMatchEffect(
+                filter = GameObjectFilter.Creature,
+                storeMatch = "raph_creature",
+                storeRevealed = "raph_revealed"
+            ),
+            RevealCollectionEffect(
+                from = "raph_revealed",
+                fromZone = Zone.LIBRARY,
+                toZone = Zone.BATTLEFIELD
+            ),
+            MoveCollectionEffect(
+                from = "raph_creature",
+                destination = CardDestination.ToZone(
+                    Zone.BATTLEFIELD,
+                    Player.You,
+                    ZonePlacement.TappedAndAttacking
+                )
+            ),
+            MoveCollectionEffect(
+                from = "raph_revealed",
+                destination = CardDestination.ToZone(
+                    Zone.LIBRARY,
+                    Player.You,
+                    ZonePlacement.Bottom
+                ),
+                order = CardOrder.Random
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "167"
+        artist = "Aaron J. Riley"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/8795fba4-0ff3-4c04-a81c-60408608a00c.jpg?1769006366"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GishathSunsAvatar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GishathSunsAvatar.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gishath, Sun's Avatar
+ * {5}{R}{G}{W}
+ * Legendary Creature — Dinosaur Avatar
+ * 7/6
+ *
+ * Vigilance, trample, haste
+ * Whenever Gishath, Sun's Avatar deals combat damage to a player, reveal that many
+ * cards from the top of your library. Put any number of Dinosaur creature cards
+ * from among them onto the battlefield and the rest on the bottom of your library
+ * in a random order.
+ */
+val GishathSunsAvatar = card("Gishath, Sun's Avatar") {
+    manaCost = "{5}{R}{G}{W}"
+    colorIdentity = "RGW"
+    typeLine = "Legendary Creature — Dinosaur Avatar"
+    power = 7
+    toughness = 6
+    oracleText = "Vigilance, trample, haste\nWhenever Gishath, Sun's Avatar deals combat damage to a player, reveal that many cards from the top of your library. Put any number of Dinosaur creature cards from among them onto the battlefield and the rest on the bottom of your library in a random order."
+
+    keywords(Keyword.VIGILANCE, Keyword.TRAMPLE, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val damageDealt = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+        effect = CompositeEffect(listOf(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(count = damageDealt, player = Player.You),
+                storeAs = "gishath_revealed",
+                revealed = true
+            ),
+            SelectFromCollectionEffect(
+                from = "gishath_revealed",
+                selection = SelectionMode.ChooseAnyNumber,
+                filter = GameObjectFilter.Creature.withSubtype("Dinosaur"),
+                showAllCards = true,
+                storeSelected = "gishath_toBattlefield",
+                storeRemainder = "gishath_toBottom",
+                prompt = "Put any number of Dinosaur creature cards onto the battlefield",
+                selectedLabel = "Put onto the battlefield",
+                remainderLabel = "Put on the bottom of your library"
+            ),
+            MoveCollectionEffect(
+                from = "gishath_toBattlefield",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You)
+            ),
+            MoveCollectionEffect(
+                from = "gishath_toBottom",
+                destination = CardDestination.ToZone(Zone.LIBRARY, Player.You, ZonePlacement.Bottom),
+                order = CardOrder.Random
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "222"
+        artist = "Zack Stella"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/7335e500-342d-476d-975c-817512e6e3d6.jpg?1562558022"
+    }
+}


### PR DESCRIPTION
## Summary

Implements six cards from a Standard 4-color dinosaur brew that were
missing from the engine. Each lands as its own commit; all are pure
composition over existing SDK primitives — no new effects, keywords,
conditions, or executors were added.

| Card | Canonical set | Notes |
|---|---|---|
| Zombify | ODY (+ FDN reprint) | `Effects.PutOntoBattlefield` on `Targets.CreatureCardInYourGraveyard` |
| Conduit Pylons | OTJ | ETB surveil 1 + standard `{T}: {C}` / `{1},{T}: any color` mana script (Hidden Grotto shape) |
| Palani's Hatcher | LCI | "Other Dinosaurs have haste" lord via `GrantKeyword` + `excludeSelf`; BeginCombat trigger with `triggerCondition = YouControl(Egg)` sequencing `ForceSacrificeEffect` + a 3/3 token |
| Ghalta, Stampede Tyrant | LCI | ETB Gather → Select(`ChooseAnyNumber`, creature filter) → Move pipeline from hand to battlefield |
| Gishath, Sun's Avatar | XLN (+ LCI reprint) | Combat-damage trigger using `TRIGGER_DAMAGE_AMOUNT` to drive a Reveal → Select(any-number, Dinosaur creature) → Move pipeline; remainder to library bottom in
random order. Also wires `printings` into LCI's set object so the reprint row is picked up. |
| Raph & Mikey, Troublemakers | TMT (scaffolded) | Attack trigger using `GatherUntilMatchEffect` → reveal → move to battlefield with `ZonePlacement.TappedAndAttacking` → bottom-the-rest in random order.
Scaffolds the Teenage Mutant Ninja Turtles (TMT, 2026-03-06) set and registers it in `MtgSetCatalog`. |

## Cards from the decklist that are *not* in this PR

These were intentionally skipped because they would each require new SDK or
engine work, which the dinosaur-deck rollout is keeping out of scope:

- **Starting Town** — "enters tapped unless it's your first, second, or third
  turn of the game" needs a turn-of-game condition the engine doesn't track.
- **Razortrap Gorge** — "enters tapped unless a player has 13 or less life"
  needs an existential-over-players life-threshold condition (`Player.Any`
  isn't enough; `DynamicAmount.LifeTotal` resolves to a single player's life).
- **Bitter Triumph** — "discard a card or pay 3 life" needs a new
  `AdditionalCost` modal variant alongside `BlightOrPay` / `BeholdOrPay`.
- **Saheeli's Lattice** — Craft keyword + transform DFC with
  power-equals-exiled-pile back face.
- **Foggy Swamp Visions** — Waterbend keyword isn't implemented.
- **Trumpeting Carnosaur** — Discover N isn't implemented.
- **Vaultborn Tyrant** — "create a token that's a copy of it, except it's
  an artifact in addition to its other types" needs `CreateTokenCopyOfSourceEffect`
  to carry extra card types; BIG set is also unscaffolded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
