### PR TITLE
TDM cards batch B: Champion of Dusan, Effortless Master, Fangkeeper's Familiar, Furious Forebear

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ChampionOfDusanScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/ChampionOfDusanScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Champion of Dusan (TDM #137) — {2}{G} Human Warrior, 4/2, Trample.
+ *
+ * "Renew — {1}{G}, Exile this card from your graveyard: Put a +1/+1 counter and a trample
+ *  counter on target creature. Activate only as a sorcery."
+ *
+ * Exercises the renew payoff: a +1/+1 counter plus a trample counter (granting Trample via
+ * projection, CR 122.1c), with Champion of Dusan exiled from the graveyard as part of the cost.
+ */
+class ChampionOfDusanScenarioTest : ScenarioTestBase() {
+
+    private val renewAbilityId =
+        cardRegistry.getCard("Champion of Dusan")!!.activatedAbilities.first().id
+
+    init {
+        context("Champion of Dusan") {
+
+            test("renew puts a +1/+1 counter and a trample counter (granting Trample) on a target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Champion of Dusan")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2, no trample
+                    .withLandsOnBattlefield(1, "Forest", 2) // renew cost {1}{G}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val champion = game.findCardsInGraveyard(1, "Champion of Dusan").first()
+                val creature = game.findPermanent("Glory Seeker")!!
+
+                withClue("Glory Seeker has no Trample before the counter is placed") {
+                    game.state.projectedState.hasKeyword(creature, Keyword.TRAMPLE) shouldBe false
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = champion,
+                        abilityId = renewAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(creature)),
+                    )
+                )
+                withClue("Activating Champion of Dusan renew should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                val counters = game.state.getEntity(creature)?.get<CountersComponent>()
+                withClue("Glory Seeker gets one +1/+1 counter") {
+                    (counters?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 1
+                }
+                withClue("Glory Seeker gets one trample counter") {
+                    (counters?.counters?.get(CounterType.TRAMPLE) ?: 0) shouldBe 1
+                }
+                withClue("The trample counter grants the Trample keyword via projection") {
+                    game.state.projectedState.hasKeyword(creature, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("Champion of Dusan is exiled from the graveyard as part of the cost") {
+                    game.findCardsInGraveyard(1, "Champion of Dusan").size shouldBe 0
+                    game.state.getExile(game.player1Id).contains(champion) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EffortlessMasterScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/EffortlessMasterScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Effortless Master (TDM #181) — {2}{U}{R} Orc Monk, 4/3, Vigilance, Menace.
+ *
+ * "This creature enters with two +1/+1 counters on it if you've cast two or more spells this turn."
+ *
+ * The spell-count is recorded at cast time, so casting Effortless Master itself counts. Casting one
+ * prior spell (Opt) and then Effortless Master = two spells this turn → it enters with two counters.
+ * Casting Effortless Master as the only spell of the turn = one spell → no counters.
+ */
+class EffortlessMasterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Effortless Master's conditional enters-with-counters") {
+
+            test("enters with two +1/+1 counters after casting two or more spells this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hill Giant")
+                    .withCardInHand(1, "Effortless Master")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // First spell of the turn: Hill Giant ({3}{R}).
+                val first = game.castSpell(1, "Hill Giant")
+                withClue("Casting Hill Giant should succeed: ${first.error}") { first.error shouldBe null }
+                game.resolveStack()
+
+                // Second spell: Effortless Master itself. At ETB, two spells have been cast.
+                val cast = game.castSpell(1, "Effortless Master")
+                withClue("Casting Effortless Master should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val master = game.findPermanent("Effortless Master")!!
+                val counters = game.state.getEntity(master)?.get<CountersComponent>()
+                withClue("Effortless Master enters with two +1/+1 counters") {
+                    (counters?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 2
+                }
+            }
+
+            test("enters with no counters when it is the only spell cast this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Effortless Master")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Effortless Master")
+                withClue("Casting Effortless Master should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val master = game.findPermanent("Effortless Master")!!
+                val counters = game.state.getEntity(master)?.get<CountersComponent>()
+                withClue("Effortless Master enters with no +1/+1 counters") {
+                    (counters?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FangkeepersFamiliarScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FangkeepersFamiliarScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Fangkeeper's Familiar (TDM #183) — {1}{B}{G}{U} Snake, 3/3, Flash.
+ *
+ * "When this creature enters, choose one —
+ *  • You gain 3 life and surveil 3.
+ *  • Destroy target enchantment.
+ *  • Counter target creature spell."
+ *
+ * Exercises the modal ETB trigger: casting the creature, resolving the ETB to a ChooseOption
+ * decision, picking mode 0 (gain 3 life + surveil 3), and resolving the surveil look.
+ */
+class FangkeepersFamiliarScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Fangkeeper's Familiar's ETB modal trigger") {
+
+            test("mode 1 gains 3 life and surveils 3") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Fangkeeper's Familiar")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardInLibrary(1, "Mountain") // surveil fodder (top three)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Forest")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Fangkeeper's Familiar")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // The ETB trigger is on the stack; resolving it surfaces a mode choice.
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision for the ETB trigger; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 0))
+
+                // Mode 0 = gain 3 life and surveil 3 → a card selection over the top three cards.
+                val surveil = game.getPendingDecision()
+                withClue("Surveil 3 should pause for a library look") {
+                    surveil.shouldBeInstanceOf<SelectCardsDecision>()
+                }
+                val lookedAt = (surveil as SelectCardsDecision).options
+                withClue("Surveil 3 looks at the top three cards") { lookedAt.size shouldBe 3 }
+                game.selectCards(lookedAt) // bin all three
+                game.resolveStack()
+
+                withClue("Player 1 gained 3 life") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+                withClue("Surveil 3 binned all three looked-at cards") {
+                    game.findCardsInGraveyard(1, "Mountain").size shouldBe 1
+                    game.findCardsInGraveyard(1, "Plains").size shouldBe 1
+                    game.findCardsInGraveyard(1, "Forest").size shouldBe 1
+                }
+                withClue("Fangkeeper's Familiar is on the battlefield") {
+                    game.isOnBattlefield("Fangkeeper's Familiar") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FuriousForebearScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/FuriousForebearScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Furious Forebear (TDM #13) — {1}{W} Spirit Warrior, 3/1.
+ *
+ * "Whenever a creature you control dies while this card is in your graveyard, you may pay {1}{W}.
+ *  If you do, return this card from your graveyard to your hand."
+ *
+ * A graveyard-zone triggered ability gated to fire only while Furious Forebear sits in its owner's
+ * graveyard. We kill another creature the controller owns (Caustic Exhale, -3/-3), then the
+ * "you may pay {1}{W}" YesNoDecision surfaces; paying returns Forebear from graveyard to hand.
+ * Declining leaves it in the graveyard.
+ */
+class FuriousForebearScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Furious Forebear's graveyard death trigger") {
+
+            test("paying {1}{W} when a creature you control dies returns it from graveyard to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Furious Forebear")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 victim
+                    .withCardInHand(1, "Caustic Exhale")
+                    .withLandsOnBattlefield(1, "Swamp", 2) // Caustic Exhale: {B} + {1}
+                    .withLandsOnBattlefield(1, "Plains", 2) // pay {1}{W} for the trigger
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Caustic Exhale", bears)
+                withClue("Casting Caustic Exhale on Grizzly Bears should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears dies to -3/-3") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+
+                // The death triggers Furious Forebear's graveyard ability → "you may pay {1}{W}".
+                val decision = game.getPendingDecision()
+                withClue("A pay-{1}{W} YesNo decision should be pending; got $decision") {
+                    decision.shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                // Paying {1}{W} requires selecting mana sources (no floating mana) — auto-tap.
+                game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Furious Forebear returns from graveyard to hand") {
+                    game.findCardsInGraveyard(1, "Furious Forebear").size shouldBe 0
+                    game.findCardsInHand(1, "Furious Forebear").size shouldBe 1
+                }
+            }
+
+            test("declining the payment leaves Furious Forebear in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Furious Forebear")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Caustic Exhale")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Caustic Exhale", bears)
+                withClue("Casting Caustic Exhale should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("A pay-{1}{W} YesNo decision should be pending; got $decision") {
+                    decision.shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Declining leaves Furious Forebear in the graveyard") {
+                    game.findCardsInGraveyard(1, "Furious Forebear").size shouldBe 1
+                    game.findCardsInHand(1, "Furious Forebear").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ChampionOfDusan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ChampionOfDusan.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Champion of Dusan
+ * {2}{G}
+ * Creature — Human Warrior
+ * 4/2
+ *
+ * Trample
+ * Renew — {1}{G}, Exile this card from your graveyard: Put a +1/+1 counter and a
+ *   trample counter on target creature. Activate only as a sorcery.
+ *
+ * The renew payoff puts both counter kinds on a single target via two chained
+ * [Effects.AddCounters] calls (same pattern as Kheru Goldkeeper); the trample counter
+ * is a keyword counter (CR 122.1c) granting trample through the layer system.
+ */
+val ChampionOfDusan = card("Champion of Dusan") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Warrior"
+    power = 4
+    toughness = 2
+    oracleText = "Trample\n" +
+        "Renew — {1}{G}, Exile this card from your graveyard: Put a +1/+1 counter and a " +
+        "trample counter on target creature. Activate only as a sorcery."
+
+    keywords(Keyword.TRAMPLE)
+
+    renew("{1}{G}") {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+            .then(Effects.AddCounters(Counters.TRAMPLE, 1, creature))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Bastien L. Deharme"
+        flavorText = "Dusan boxing matches allow contestants no weapons, no allies, and no excuses."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c51dcdab-38ee-4804-8859-09adc353c182.jpg?1743204513"
+        ruling("2025-04-04", "If a card with a renew ability is put into your graveyard during your turn, you can activate that ability if it's legal to do so before any other player can take any actions.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/EffortlessMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/EffortlessMaster.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Effortless Master
+ * {2}{U}{R}
+ * Creature — Orc Monk
+ * 4/3
+ *
+ * Vigilance
+ * Menace
+ * This creature enters with two +1/+1 counters on it if you've cast two or more spells this turn.
+ */
+val EffortlessMaster = card("Effortless Master") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Creature — Orc Monk"
+    power = 4
+    toughness = 3
+    oracleText = "Vigilance\nMenace\n" +
+        "This creature enters with two +1/+1 counters on it if you've cast two or more spells this turn."
+
+    keywords(Keyword.VIGILANCE, Keyword.MENACE)
+
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 2,
+        selfOnly = true,
+        condition = Conditions.YouCastSpellsThisTurn(atLeast = 2)
+    ))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "181"
+        artist = "Lie Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0ae03ca5-cd4b-42b7-8cd5-3f7e753b4147.jpg?1743204705"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FangkeepersFamiliar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FangkeepersFamiliar.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fangkeeper's Familiar
+ * {1}{B}{G}{U}
+ * Creature — Snake
+ * 3/3
+ *
+ * Flash
+ * When this creature enters, choose one —
+ * • You gain 3 life and surveil 3.
+ * • Destroy target enchantment.
+ * • Counter target creature spell.
+ *
+ * The ETB ability is modal (choose one) via [ModalEffect.chooseOne]; each mode carries its own
+ * targeting. Flash lets it enter at instant speed, making the "counter target creature spell"
+ * mode meaningful.
+ */
+val FangkeepersFamiliar = card("Fangkeeper's Familiar") {
+    manaCost = "{1}{B}{G}{U}"
+    colorIdentity = "BGU"
+    typeLine = "Creature — Snake"
+    power = 3
+    toughness = 3
+    oracleText = "Flash\n" +
+        "When this creature enters, choose one —\n" +
+        "• You gain 3 life and surveil 3.\n" +
+        "• Destroy target enchantment.\n" +
+        "• Counter target creature spell."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                Effects.GainLife(3).then(EffectPatterns.surveil(3)),
+                "You gain 3 life and surveil 3"
+            ),
+            Mode.withTarget(
+                Effects.Destroy(EffectTarget.ContextTarget(0)),
+                Targets.Enchantment,
+                "Destroy target enchantment"
+            ),
+            Mode.withTarget(
+                Effects.CounterSpell(),
+                Targets.CreatureSpell,
+                "Counter target creature spell"
+            )
+        )
+        description = "When this creature enters, choose one — You gain 3 life and surveil 3; " +
+            "or destroy target enchantment; or counter target creature spell."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "183"
+        artist = "David Szabo"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/655fa2e1-3e1c-424c-b17a-daa7b8fface4.jpg?1743204714"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FuriousForebear.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FuriousForebear.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Furious Forebear
+ * {1}{W}
+ * Creature — Spirit Warrior
+ * 3/1
+ *
+ * Whenever a creature you control dies while this card is in your graveyard, you may pay {1}{W}.
+ * If you do, return this card from your graveyard to your hand.
+ *
+ * Modeled as a graveyard-zone triggered ability (triggerZone = GRAVEYARD), gated to fire only
+ * while Furious Forebear sits in its owner's graveyard. The "you may pay {1}{W}" clause uses
+ * [MayPayManaEffect]; on payment the card returns itself from the graveyard to hand.
+ *
+ * Furious Forebear's own death cannot trigger this: at the moment a creature dies the trigger
+ * checks the graveyard zone, where Forebear must already reside, so the dying creature is always
+ * a different one.
+ */
+val FuriousForebear = card("Furious Forebear") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Warrior"
+    power = 3
+    toughness = 1
+    oracleText = "Whenever a creature you control dies while this card is in your graveyard, " +
+        "you may pay {1}{W}. If you do, return this card from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.YourCreatureDies
+        triggerZone = Zone.GRAVEYARD
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}{W}"),
+            effect = Effects.ReturnToHand(EffectTarget.Self)
+        )
+        description = "Whenever a creature you control dies while this card is in your graveyard, " +
+            "you may pay {1}{W}. If you do, return this card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "13"
+        artist = "Izzy"
+        flavorText = "\"Your hatred dampens the land with my kin's blood. My love will flood it with yours.\"\n—Hazena, spirit of House Emesh"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4f247b6-8212-4e78-a452-d2d3be228d8e.jpg?1743204001"
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) cards. All four compose existing SDK primitives — no engine/SDK/docs changes were required.

## Implemented

- **Champion of Dusan** (#137, {2}{G}, 4/2) — Trample + Renew {1}{G}: puts a +1/+1 counter and a trample counter on target creature. Two chained `Effects.AddCounters` calls sharing one target, mirroring Kheru Goldkeeper. The trample counter grants Trample via the layer system.
- **Effortless Master** (#181, {2}{U}{R}, 4/3) — Vigilance, Menace, and `EntersWithCounters(count = 2, selfOnly = true, condition = YouCastSpellsThisTurn(atLeast = 2))`. Its own cast counts toward the spell total at ETB.
- **Fangkeeper's Familiar** (#183, {1}{B}{G}{U}, 3/3) — Flash + modal ETB (`ModalEffect.chooseOne`): gain 3 life and surveil 3; or destroy target enchantment; or counter target creature spell.
- **Furious Forebear** (#13, {1}{W}, 3/1) — graveyard-zone `YourCreatureDies` trigger (`triggerZone = GRAVEYARD`) + `MayPayManaEffect` → `ReturnToHand(Self)`, modeled like Persistent Marshstalker. Forebear's own death can't trigger it (it must already be in the graveyard when the death is checked).

## Skipped

None — all four landed.

## Tests

Six new Kotest scenario tests, all passing:
- Champion of Dusan: renew places both counter kinds and grants Trample; source exiled from graveyard.
- Effortless Master: two counters after two spells; zero counters when it's the only spell.
- Fangkeeper's Familiar: mode 1 gains 3 life and surveils 3.
- Furious Forebear: paying {1}{W} returns it from graveyard to hand; declining leaves it.

`just check-card-printing` confirms all four are canonical in TDM (the only non-promo printing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)