### PR TITLE
Add "when you cast this spell" self-cast trigger (Sage of the Skies)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1156,6 +1156,17 @@ Triggers.youCastSpell(
 ### Conditional
 
 - `NthSpellCast(n, player?)` — fires on the Nth spell cast.
+- `WhenYouCastThisSpell()` — a "cast trigger" that fires on the spell's **own** cast while it is on
+  the stack (`GameEvent.CastThisSpellEvent`, `binding = SELF`). Distinct from a battlefield
+  `SpellCast`/`NthSpellCast` trigger that observes *other* spells: this one travels with the spell
+  onto the stack and is detected only by `TriggerDetector`'s self-cast path (it is deliberately
+  **not** indexed against battlefield permanents, so it never fires after the spell resolves).
+  Pair with a `triggerCondition` for an intervening "if" (CR 603.4). Sage of the Skies — "When you
+  cast this spell, if you've cast another spell this turn, copy this spell" — uses
+  `triggerCondition = Conditions.YouCastSpellsThisTurn(atLeast = 2)` (the spell itself is already
+  counted, so "two or more" = "another spell") and `Effects.CopyTargetSpell(TriggeringEntity)` to
+  copy itself; copying a permanent spell yields a token (CR 707.10f), and the copy isn't cast so it
+  doesn't re-trigger (CR 707.10).
 - `Expend(threshold)` — Expend N (CLB mechanic).
 
 ### Delayed & granted triggers

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1284,6 +1284,20 @@ object Triggers {
         binding = TriggerBinding.ANY
     )
 
+    /**
+     * When you cast this spell — a "cast trigger" that fires on the spell's own cast while it is
+     * still on the stack, distinct from [SpellCast] (which observes *other* spells from the
+     * battlefield). Pair with `triggerCondition` for an intervening "if" (CR 603.4).
+     *
+     * Example: Sage of the Skies — "When you cast this spell, if you've cast another spell this
+     * turn, copy this spell." (`triggerCondition = Conditions.YouCastSpellsThisTurn(atLeast = 2)`,
+     * since the spell itself is already counted when its cast trigger is checked.)
+     */
+    fun WhenYouCastThisSpell(): TriggerSpec = TriggerSpec(
+        event = CastThisSpellEvent,
+        binding = TriggerBinding.SELF
+    )
+
     // =========================================================================
     // Expend Triggers (Bloomburrow)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
@@ -757,6 +757,26 @@ sealed interface GameEvent : TextReplaceable<GameEvent> {
     }
 
     /**
+     * When you cast this spell — a "cast trigger" (CR 603.2) that fires on the spell's *own*
+     * cast while it is on the stack; the ability travels with the spell. This is distinct from
+     * [SpellCastEvent], which observes *other* spells being cast from a permanent on the
+     * battlefield. A [CastThisSpellEvent] trigger is detected only via the dedicated self-cast
+     * path in the engine's TriggerDetector and is never indexed against battlefield permanents,
+     * so it cannot fire once the spell has resolved into a permanent.
+     *
+     * The controller is always the caster, so there is no player parameter. For an intervening
+     * "if" (CR 603.4) such as Sage of the Skies' "if you've cast another spell this turn",
+     * attach a `triggerCondition` to the triggered ability rather than encoding it here.
+     */
+    @SerialName("CastThisSpellEvent")
+    @Serializable
+    data object CastThisSpellEvent : GameEvent {
+        override val description: String = "you cast this spell"
+
+        override fun applyTextReplacement(replacer: TextReplacer): GameEvent = this
+    }
+
+    /**
      * When you expend N — i.e., you spend your Nth total mana to cast spells
      * during a turn. Triggers at most once per turn per threshold.
      *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SageOfTheSkies.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SageOfTheSkies.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sage of the Skies — Tarkir: Dragonstorm #22
+ * {2}{W} · Creature — Human Monk · 2/3
+ *
+ * When you cast this spell, if you've cast another spell this turn, copy this spell.
+ * (The copy becomes a token.)
+ * Flying, lifelink
+ *
+ * The cast trigger fires from the stack via [Triggers.WhenYouCastThisSpell]. The intervening
+ * "if" (CR 603.4) is `Conditions.YouCastSpellsThisTurn(atLeast = 2)`: the spell itself is already
+ * counted when its own cast trigger is checked, so "two or more" means "you've cast another spell
+ * this turn". `Effects.CopyTargetSpell(TriggeringEntity)` copies the triggering spell (the same
+ * primitive Taigam, Master Opportunist uses) — since Sage is a permanent spell the copy resolves
+ * into a token (CR 707.10f), and because a copy is put on the stack rather than cast (CR 707.10),
+ * it does not re-trigger this ability.
+ */
+val SageOfTheSkies = card("Sage of the Skies") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Monk"
+    power = 2
+    toughness = 3
+    oracleText = "When you cast this spell, if you've cast another spell this turn, copy this " +
+        "spell. (The copy becomes a token.)\n" +
+        "Flying, lifelink"
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        triggerCondition = Conditions.YouCastSpellsThisTurn(atLeast = 2)
+        effect = Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity)
+        description = "When you cast this spell, if you've cast another spell this turn, copy this spell."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "22"
+        artist = "Justyna Dura"
+        flavorText = "\"Gravity is just a suggestion.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6ade6918-6d1d-448d-ab56-93996051e9a9.jpg?1743204040"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1017,25 +1017,32 @@ class TriggerDetector(
             detectControlChangeTriggers(state, event, triggers)
         }
 
-        // Handle NthSpellCast triggers on the spell currently being cast (e.g. Hearthborn
-        // Battler cast as the second spell of the turn). The spell is on the stack, not the
-        // battlefield, so the main index scan above skips it.
+        // Handle self-cast triggers on the spell currently being cast — both NthSpellCast
+        // (e.g. Hearthborn Battler cast as the second spell of the turn) and "when you cast
+        // this spell" cast triggers (e.g. Sage of the Skies). The spell is on the stack, not
+        // the battlefield, so the main index scan above skips it.
         if (event is SpellCastEvent) {
-            detectSelfCastNthSpellTriggers(state, event, triggers)
+            detectSelfCastTriggers(state, event, triggers)
         }
 
         return triggers
     }
 
     /**
-     * Detect NthSpellCast triggers on the spell currently being cast.
+     * Detect self-cast triggers on the spell currently being cast — triggers whose event keys off
+     * the spell's own casting and travels with it onto the stack.
      *
-     * When a card like Hearthborn Battler is itself the Nth spell cast this turn, its
-     * trigger ("whenever a player casts their second spell each turn") should fire even
-     * though the card is on the stack rather than the battlefield. The trigger event is
-     * the cast itself, and the ability travels with the spell onto the stack.
+     * Two kinds qualify:
+     *  - [GameEvent.NthSpellCastEvent] — when a card like Hearthborn Battler is itself the Nth
+     *    spell cast this turn ("whenever a player casts their second spell each turn").
+     *  - [GameEvent.CastThisSpellEvent] — a "when you cast this spell" cast trigger (Sage of the
+     *    Skies). These are never indexed against battlefield permanents, so this is the only path
+     *    that fires them.
+     *
+     * The spell is on the stack rather than the battlefield, so the main index scan skips it; this
+     * pass reads the cast spell's own triggered abilities and matches them against the cast event.
      */
-    private fun detectSelfCastNthSpellTriggers(
+    private fun detectSelfCastTriggers(
         state: GameState,
         event: SpellCastEvent,
         triggers: MutableList<PendingTrigger>
@@ -1049,7 +1056,9 @@ class TriggerDetector(
         val controllerId = event.casterId
 
         for (ability in abilities) {
-            if (ability.trigger !is GameEvent.NthSpellCastEvent) continue
+            if (ability.trigger !is GameEvent.NthSpellCastEvent &&
+                ability.trigger !is GameEvent.CastThisSpellEvent
+            ) continue
             if (matcher.matchesTrigger(ability.trigger, ability.binding, event, entityId, controllerId, state)) {
                 triggers.add(
                     PendingTrigger(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -165,6 +165,10 @@ class TriggerIndex(
                     if (trigger.source == SourceFilter.Any) listOf(TriggerCategory.DAMAGE_RECEIVED) else emptyList()
                 is SdkGameEvent.SpellCastEvent -> listOf(TriggerCategory.SPELL_CAST)
                 is SdkGameEvent.NthSpellCastEvent -> listOf(TriggerCategory.SPELL_CAST)
+                // "When you cast this spell" fires only via TriggerDetector's self-cast path while
+                // the spell is on the stack — never index it against battlefield permanents, or a
+                // resolved Sage of the Skies would re-fire on every later spell.
+                is SdkGameEvent.CastThisSpellEvent -> emptyList()
                 is SdkGameEvent.ExpendEvent -> listOf(TriggerCategory.SPELL_CAST)
                 is SdkGameEvent.SpellOrAbilityOnStackEvent -> listOf(TriggerCategory.SPELL_OR_ABILITY)
                 is SdkGameEvent.AbilityActivatedEvent -> listOf(TriggerCategory.SPELL_OR_ABILITY)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -166,6 +166,13 @@ class TriggerMatcher(
                 val currentCount = state.playerSpellsCastThisTurn[event.casterId] ?: 0
                 currentCount == trigger.nthSpell
             }
+            is GameEvent.CastThisSpellEvent -> {
+                // "When you cast this spell" — fires on the spell's own cast while on the stack.
+                // detectSelfCastTriggers only invokes the matcher for the spell being cast, so
+                // this just confirms the event is that very spell's cast (intervening-if, if any,
+                // is enforced separately by filterByTriggerCondition per CR 603.4).
+                event is SpellCastEvent && event.spellEntityId == sourceId
+            }
             is GameEvent.ExpendEvent -> {
                 // Expend triggers when cumulative mana spent on spells this turn
                 // crosses the threshold. Fires on SpellCastEvent only.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SageOfTheSkiesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SageOfTheSkiesTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.SageOfTheSkies
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Sage of the Skies' "when you cast this spell" cast trigger.
+ *
+ * Sage of the Skies: {2}{W}
+ * Creature — Human Monk · 2/3 · Flying, lifelink
+ * "When you cast this spell, if you've cast another spell this turn, copy this spell.
+ *  (The copy becomes a token.)"
+ *
+ * Rules exercised:
+ *  - CR 603.2: the cast trigger fires from the stack on Sage's own cast.
+ *  - CR 603.4: the intervening "if" ("you've cast another spell this turn") gates the trigger
+ *    at detection time — Sage cast as the first spell of the turn does nothing.
+ *  - CR 707.10f: copying a permanent spell yields a token permanent.
+ *  - CR 707.10: a copy is put on the stack, not cast, so it does not re-trigger (no copy-of-copy).
+ */
+class SageOfTheSkiesTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SageOfTheSkies))
+        return driver
+    }
+
+    /** Pass priority back and forth until the stack is empty (one object resolves per round). */
+    fun GameTestDriver.resolveStack(p1: com.wingedsheep.sdk.model.EntityId, p2: com.wingedsheep.sdk.model.EntityId) {
+        var guard = 0
+        while (stackSize > 0 && pendingDecision == null && guard++ < 25) {
+            passPriority(p1)
+            passPriority(p2)
+        }
+    }
+
+    fun GameTestDriver.sages(playerId: com.wingedsheep.sdk.model.EntityId) =
+        getCreatures(playerId).filter { getCardName(it) == "Sage of the Skies" }
+
+    fun GameTestDriver.castSage(playerId: com.wingedsheep.sdk.model.EntityId) {
+        val sage = putCardInHand(playerId, "Sage of the Skies")
+        giveMana(playerId, Color.WHITE, 1)
+        giveColorlessMana(playerId, 2)
+        castSpell(playerId, sage, emptyList())
+    }
+
+    test("copies itself when cast as your second spell this turn (token)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Lightning Bolt" to 20), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // First spell of the turn.
+        val bolt = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.giveMana(player1, Color.RED, 1)
+        driver.castSpell(player1, bolt, listOf(player2))
+        driver.resolveStack(player1, player2)
+
+        // Sage is the second spell: its cast trigger fires and copies it.
+        driver.castSage(player1)
+        // Stack: [cast trigger, Sage].
+        driver.stackSize shouldBe 2
+        driver.resolveStack(player1, player2)
+
+        // Two Sages on the battlefield: the real one plus exactly one token copy (CR 707.10f).
+        val sages = driver.sages(player1)
+        sages.size shouldBe 2
+        sages.count { driver.state.getEntity(it)?.has<TokenComponent>() == true } shouldBe 1
+    }
+
+    test("does not copy when cast as your first spell this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Sage is the only/first spell: intervening "if" is false, no trigger goes on the stack.
+        driver.castSage(player1)
+        driver.stackSize shouldBe 1 // just Sage, no cast trigger
+        driver.resolveStack(player1, player2)
+
+        val sages = driver.sages(player1)
+        sages.size shouldBe 1
+        sages.count { driver.state.getEntity(it)?.has<TokenComponent>() == true } shouldBe 0
+    }
+
+    test("copies when cast as a later spell — 'another spell', not 'exactly the second'") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Lightning Bolt" to 20), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cast two prior spells so Sage is the third spell of the turn.
+        repeat(2) {
+            val bolt = driver.putCardInHand(player1, "Lightning Bolt")
+            driver.giveMana(player1, Color.RED, 1)
+            driver.castSpell(player1, bolt, listOf(player2))
+            driver.resolveStack(player1, player2)
+        }
+
+        driver.castSage(player1)
+        driver.stackSize shouldBe 2 // cast trigger still fires on the third spell
+        driver.resolveStack(player1, player2)
+
+        driver.sages(player1).size shouldBe 2
+    }
+
+    test("the token copy does not itself re-trigger (no copy of a copy)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Lightning Bolt" to 20), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bolt = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.giveMana(player1, Color.RED, 1)
+        driver.castSpell(player1, bolt, listOf(player2))
+        driver.resolveStack(player1, player2)
+
+        driver.castSage(player1)
+        driver.resolveStack(player1, player2)
+
+        // Exactly one copy was made. A copy is put on the stack, not cast (CR 707.10), so it does
+        // not fire "when you cast this spell" again — there is no runaway copy chain.
+        driver.sages(player1).size shouldBe 2
+        driver.stackSize shouldBe 0
+    }
+})


### PR DESCRIPTION
## Summary

Adds a generic **cast trigger** — "When you cast this spell" — that fires on a spell's *own* cast while it is on the stack, distinct from the existing battlefield `SpellCast`/`NthSpellCast` triggers that observe *other* spells. Implements **Sage of the Skies** (TDM #22, `{2}{W}` 2/3 Human Monk, Flying/Lifelink):

> When you cast this spell, if you've cast another spell this turn, copy this spell. (The copy becomes a token.)

## Design

**Composition-first:** the copy itself needs no new effect — it reuses `Effects.CopyTargetSpell(EffectTarget.TriggeringEntity)`, the exact primitive **Taigam, Master Opportunist** already uses. A `SpellCastEvent` sets the triggering entity to the cast spell; the existing `CopyTargetSpellExecutor` already copies a no-target permanent spell into a token. The only genuinely new vocabulary is the trigger.

### SDK
- `GameEvent.CastThisSpellEvent` (`data object`) + `Triggers.WhenYouCastThisSpell()` facade (`binding = SELF`). No player parameter — the controller is always the caster; intervening-if clauses live on the ability's `triggerCondition`.

### Engine
- `TriggerDetector.detectSelfCastNthSpellTriggers` → generalized to `detectSelfCastTriggers`, now detecting both `NthSpellCast` and `CastThisSpell` on the spell being cast (on the stack, not battlefield-indexed).
- `TriggerMatcher`: `CastThisSpellEvent` matches when the cast event's spell is the trigger source.
- `TriggerIndex.triggerToCategories`: maps `CastThisSpellEvent` to **no** category, so a *resolved* Sage permanent never re-fires the trigger on later casts.

### Rules correctness
- **CR 603.4** intervening-if (`Conditions.YouCastSpellsThisTurn(atLeast = 2)` — the spell itself is already counted when its cast trigger is checked, so "two or more" = "another spell"), filtered at detection time.
- **CR 707.10f** copying a permanent spell yields a token.
- **CR 707.10** a copy is *put on the stack, not cast*, so it does not re-trigger → no runaway copy chain.

## Cross-layer trace
Internal engine trigger; **no** new runtime `GameEvent`, server DTO, legal action, or client-visible state (the token's Flying/Lifelink render via existing paths), so no UI work is required. The copy is automatic (no target), so no decision/continuation.

## Tests
`SageOfTheSkiesTest` (4 cases): copy-as-second-spell (asserts exactly one **token**), no-copy-as-first-spell, copies-on-a-later-spell (pins "another spell" vs "exactly the second"), and no copy-of-a-copy. Full `rules-engine` + `mtg-sdk` suites green; `game-server` compiles. Updated `docs/card-sdk-language-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)