### PR TITLE
Show DFC hover previews side by side in the deckbuilder

### DIFF
--- a/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
@@ -108,6 +108,16 @@
   gap: var(--space-2);
 }
 
+/* Double-faced card: lay the two faces out horizontally so both are visible at once. */
+.deckHoverPreviewDual {
+  flex-direction: row;
+}
+
+.deckHoverPreviewDual .deckHoverPreviewImageWrap {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
 .deckHoverPreviewImageWrap {
   position: relative;
   width: 100%;

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -23,7 +23,6 @@ import type { PrintingRef } from '@/types'
 import { PrintingPicker, type PrintingDTO } from './PrintingPicker'
 import { ManaCost, ManaSymbol } from '@/components/ui/ManaSymbols'
 import { HoverCardPreview } from '@/components/ui/HoverCardPreview'
-import { useDfcHoverFlip } from '@/components/ui/useDfcHoverFlip'
 import { SetIcon } from '@/components/ui/SetIcon'
 import { getCardImageUrl } from '@/utils/cardImages'
 import {
@@ -913,27 +912,12 @@ export function DeckbuilderPage() {
         }
       : deckHoverCard
     : null
-  const deckHoverDfc = useDfcHoverFlip(
-    effectiveDeckHoverCard
-      ? {
-          name: effectiveDeckHoverCard.name,
-          imageUri: effectiveDeckHoverCard.imageUri ?? null,
-          isDoubleFaced: effectiveDeckHoverCard.isDoubleFaced ?? false,
-          backFaceName: effectiveDeckHoverCard.backFaceName ?? null,
-          backFaceImageUri: effectiveDeckHoverCard.backFaceImageUri ?? null,
-        }
-      : null,
-  )
-  const resetDeckHoverDfc = deckHoverDfc.resetFlip
   const handleDeckHoverEnter = useCallback(
     (entry: { name: string; card: CardSummary | undefined }) => {
-      setDeckHoverName((prev) => {
-        if (prev !== entry.name) resetDeckHoverDfc()
-        return entry.name
-      })
+      setDeckHoverName(entry.name)
       setDeckHoverCard(entry.card ?? null)
     },
-    [resetDeckHoverDfc],
+    [],
   )
   const handleDeckHoverLeave = useCallback(() => {
     setDeckHoverName(null)
@@ -1054,13 +1038,9 @@ export function DeckbuilderPage() {
         />
         {viewMode === 'deck' ? (
           <DeckHoverPreview
-            name={deckHoverName ? (deckHoverDfc.displayName ?? deckHoverName) : null}
-            imageUri={
-              deckHoverName
-                ? (deckHoverDfc.displayImageUri ?? effectiveDeckHoverCard?.imageUri ?? null)
-                : null
-            }
-            overlay={deckHoverDfc.hint}
+            name={deckHoverName ? (effectiveDeckHoverCard?.name ?? deckHoverName) : null}
+            imageUri={deckHoverName ? (effectiveDeckHoverCard?.imageUri ?? null) : null}
+            {...dfcBackFace(deckHoverName ? effectiveDeckHoverCard : null)}
           />
         ) : (
           <FilterSection
@@ -3299,31 +3279,11 @@ function CardGrid({
   onShowMore: () => void
 }) {
   const [hoverCard, setHoverCard] = useState<CardSummary | null>(null)
-  const dfc = useDfcHoverFlip(
-    hoverCard
-      ? {
-          name: hoverCard.name,
-          imageUri: hoverCard.imageUri ?? null,
-          isDoubleFaced: hoverCard.isDoubleFaced ?? false,
-          backFaceName: hoverCard.backFaceName ?? null,
-          backFaceImageUri: hoverCard.backFaceImageUri ?? null,
-        }
-      : null,
-  )
-  const resetDfcFlip = dfc.resetFlip
 
   // Stable hover handlers so memoized CardTiles don't re-render every time the
   // hovered card changes — without this, swapping hovered card replaces both
   // closures' identity for all ~100 visible tiles.
-  const handleTileHover = useCallback(
-    (c: CardSummary) => {
-      setHoverCard((prev) => {
-        if (prev?.name !== c.name) resetDfcFlip()
-        return c
-      })
-    },
-    [resetDfcFlip],
-  )
+  const handleTileHover = useCallback((c: CardSummary) => setHoverCard(c), [])
   const handleTileLeave = useCallback(() => setHoverCard(null), [])
 
   if (cards.length === 0) {
@@ -3361,9 +3321,9 @@ function CardGrid({
         )}
       </div>
       <HoverFollowPreview
-        name={hoverCard ? (dfc.displayName ?? hoverCard.name) : null}
-        imageUri={hoverCard ? (dfc.displayImageUri ?? hoverCard.imageUri ?? null) : null}
-        overlay={dfc.hint}
+        name={hoverCard?.name ?? null}
+        imageUri={hoverCard?.imageUri ?? null}
+        {...dfcBackFace(hoverCard)}
       />
     </>
   )
@@ -3469,6 +3429,27 @@ function resolveImageUrl(card: CardSummary): string {
 }
 
 /**
+ * Back-face image to show beside the front in a deckbuilder hover preview. Only true
+ * double-faced cards qualify (mirrors the gating the old flip preview used), so single-faced
+ * cards return nulls and render as a single image.
+ */
+function dfcBackFace(
+  card:
+    | {
+        isDoubleFaced?: boolean | undefined
+        backFaceName?: string | null | undefined
+        backFaceImageUri?: string | null | undefined
+      }
+    | null
+    | undefined,
+): { backFaceName: string | null; backFaceImageUri: string | null } {
+  if (!card || card.isDoubleFaced !== true || !card.backFaceImageUri) {
+    return { backFaceName: null, backFaceImageUri: null }
+  }
+  return { backFaceName: card.backFaceName ?? null, backFaceImageUri: card.backFaceImageUri }
+}
+
+/**
  * Floats a card preview that follows the cursor while a row/tile is hovered.
  * The position state lives here, not on the parent panel — so mouse motion
  * doesn't re-render the (potentially large) sibling list. The parent only
@@ -3477,11 +3458,13 @@ function resolveImageUrl(card: CardSummary): string {
 function HoverFollowPreview({
   name,
   imageUri,
-  overlay,
+  backFaceName,
+  backFaceImageUri,
 }: {
   name: string | null
   imageUri: string | null
-  overlay?: React.ReactNode
+  backFaceName?: string | null
+  backFaceImageUri?: string | null
 }) {
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
   useEffect(() => {
@@ -3506,7 +3489,15 @@ function HoverFollowPreview({
     }
   }, [name])
   if (!name || !pos) return null
-  return <HoverCardPreview name={name} imageUri={imageUri} pos={pos} overlay={overlay} />
+  return (
+    <HoverCardPreview
+      name={name}
+      imageUri={imageUri}
+      pos={pos}
+      backFaceName={backFaceName ?? null}
+      backFaceImageUri={backFaceImageUri ?? null}
+    />
+  )
 }
 
 /**
@@ -3517,11 +3508,13 @@ function HoverFollowPreview({
 function DeckHoverPreview({
   name,
   imageUri,
-  overlay,
+  backFaceName,
+  backFaceImageUri,
 }: {
   name: string | null
   imageUri: string | null
-  overlay?: React.ReactNode
+  backFaceName?: string | null
+  backFaceImageUri?: string | null
 }) {
   if (!name) {
     return (
@@ -3531,12 +3524,19 @@ function DeckHoverPreview({
     )
   }
   const imageUrl = getCardImageUrl(name, imageUri, 'large')
+  // Double-faced card: show both faces side by side in the rail rather than hiding the
+  // back behind a flip key.
+  const backImageUrl = backFaceImageUri != null ? getCardImageUrl(backFaceName ?? name, backFaceImageUri, 'large') : null
   return (
-    <div className={styles.deckHoverPreview}>
+    <div className={`${styles.deckHoverPreview} ${backImageUrl ? styles.deckHoverPreviewDual : ''}`}>
       <div className={styles.deckHoverPreviewImageWrap}>
         <img className={styles.deckHoverPreviewImage} src={imageUrl} alt={name} />
-        {overlay}
       </div>
+      {backImageUrl && (
+        <div className={styles.deckHoverPreviewImageWrap}>
+          <img className={styles.deckHoverPreviewImage} src={backImageUrl} alt={backFaceName ?? name} />
+        </div>
+      )}
     </div>
   )
 }
@@ -3595,31 +3595,15 @@ function DeckListPanel({
         }
       : hoverCard
     : null
-  const dfc = useDfcHoverFlip(
-    effectiveHoverCard
-      ? {
-          name: effectiveHoverCard.name,
-          imageUri: effectiveHoverCard.imageUri ?? null,
-          isDoubleFaced: effectiveHoverCard.isDoubleFaced ?? false,
-          backFaceName: effectiveHoverCard.backFaceName ?? null,
-          backFaceImageUri: effectiveHoverCard.backFaceImageUri ?? null,
-        }
-      : null,
-  )
-  const resetDfcFlip = dfc.resetFlip
-
   // Stable identities so memoized DeckRow children skip re-render when hover
   // state changes. Functional setters keep us correct without putting hoverName
   // in the deps array.
   const handleEnter = useCallback(
     (entry: { name: string; card: CardSummary | undefined }) => {
-      setHoverName((prev) => {
-        if (prev !== entry.name) resetDfcFlip()
-        return entry.name
-      })
+      setHoverName(entry.name)
       setHoverCard(entry.card ?? null)
     },
-    [resetDfcFlip],
+    [],
   )
   const handleLeave = useCallback(() => {
     setHoverName(null)
@@ -3681,9 +3665,9 @@ function DeckListPanel({
         </p>
       )}
       <HoverFollowPreview
-        name={hoverName ? (dfc.displayName ?? hoverName) : null}
-        imageUri={hoverName ? (dfc.displayImageUri ?? effectiveHoverCard?.imageUri ?? null) : null}
-        overlay={dfc.hint}
+        name={hoverName ? (effectiveHoverCard?.name ?? hoverName) : null}
+        imageUri={hoverName ? (effectiveHoverCard?.imageUri ?? null) : null}
+        {...dfcBackFace(hoverName ? effectiveHoverCard : null)}
       />
     </div>
   )
@@ -3925,18 +3909,6 @@ function AddCardSearch({
   const [hoverCard, setHoverCard] = useState<CardSummary | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
-  const dfc = useDfcHoverFlip(
-    hoverCard
-      ? {
-          name: hoverCard.name,
-          imageUri: hoverCard.imageUri ?? null,
-          isDoubleFaced: hoverCard.isDoubleFaced ?? false,
-          backFaceName: hoverCard.backFaceName ?? null,
-          backFaceImageUri: hoverCard.backFaceImageUri ?? null,
-        }
-      : null,
-  )
-  const resetDfcFlip = dfc.resetFlip
 
   const matches = useMemo(() => {
     const t = text.trim().toLowerCase()
@@ -4027,10 +3999,7 @@ function AddCardSearch({
                 aria-selected={false}
                 className={styles.addCardResult}
                 onClick={() => handleAdd(card)}
-                onMouseEnter={() => {
-                  if (hoverCard?.name !== card.name) resetDfcFlip()
-                  setHoverCard(card)
-                }}
+                onMouseEnter={() => setHoverCard(card)}
                 onMouseLeave={() => setHoverCard(null)}
                 disabled={atCap}
                 title={atCap ? 'At copy limit' : `Add ${card.name}`}
@@ -4046,9 +4015,9 @@ function AddCardSearch({
         </div>
       )}
       <HoverFollowPreview
-        name={hoverCard ? (dfc.displayName ?? hoverCard.name) : null}
-        imageUri={hoverCard ? (dfc.displayImageUri ?? hoverCard.imageUri ?? null) : null}
-        overlay={dfc.hint}
+        name={hoverCard?.name ?? null}
+        imageUri={hoverCard?.imageUri ?? null}
+        {...dfcBackFace(hoverCard)}
       />
     </div>
   )

--- a/web-client/src/components/ui/HoverCardPreview.tsx
+++ b/web-client/src/components/ui/HoverCardPreview.tsx
@@ -14,8 +14,16 @@ export interface HoverCardPreviewProps {
   rulings?: readonly { date: string; text: string }[] | undefined
   /** Extra content rendered below the card image (e.g., stats breakdown, keywords) */
   children?: ReactNode
-  /** Content rendered as an overlay on top of the card image */
+  /** Content rendered as an overlay on top of the (front) card image */
   overlay?: ReactNode
+  /**
+   * Back face of a double-faced card. When both fields are provided, the preview shows
+   * both faces side by side horizontally instead of a single image — the deckbuilder has
+   * the room for it, so there's no need to flip. Leave unset for single-faced cards (and
+   * for the in-game preview, which stays compact).
+   */
+  backFaceName?: string | null
+  backFaceImageUri?: string | null
   /** Estimated extra height from children, used for vertical positioning (default 0) */
   extraHeight?: number
   /**
@@ -31,7 +39,7 @@ export interface HoverCardPreviewProps {
  * Shared card hover preview — positions a large card image near the cursor.
  * Used by the game board, deck builder, and all draft overlays.
  */
-export function HoverCardPreview({ name, imageUri, imageSize = 'large', pos, rulings, children, overlay, extraHeight = 0, imageRotateDeg = 0 }: HoverCardPreviewProps) {
+export function HoverCardPreview({ name, imageUri, imageSize = 'large', pos, rulings, children, overlay, backFaceName, backFaceImageUri, extraHeight = 0, imageRotateDeg = 0 }: HoverCardPreviewProps) {
   const [showRulings, setShowRulings] = useState(false)
   const [lastCardName, setLastCardName] = useState<string | null>(null)
 
@@ -50,6 +58,10 @@ export function HoverCardPreview({ name, imageUri, imageSize = 'large', pos, rul
   }, [name, lastCardName])
 
   const imageUrl = getCardImageUrl(name, imageUri, imageSize)
+  // Double-faced cards show both faces horizontally. Rotation (Rooms) and DFCs never
+  // coincide, so they don't need to compose.
+  const backImageUrl =
+    backFaceImageUri != null ? getCardImageUrl(backFaceName ?? name, backFaceImageUri, imageSize) : null
   const portraitWidth = PREVIEW_WIDTH
   const portraitHeight = Math.round(portraitWidth * 1.4)
   // For sideways layouts (Rooms), the displayed container is landscape; the image element
@@ -57,6 +69,10 @@ export function HoverCardPreview({ name, imageUri, imageSize = 'large', pos, rul
   const isLandscape = imageRotateDeg === 90 || imageRotateDeg === 270
   const previewWidth = isLandscape ? portraitHeight : portraitWidth
   const previewHeight = isLandscape ? portraitWidth : portraitHeight
+  const FACE_GAP = 10
+  // Total horizontal footprint used for viewport clamping — doubles (plus a gap) when the
+  // back face sits beside the front.
+  const contentWidth = backImageUrl ? previewWidth * 2 + FACE_GAP : previewWidth
   const hasRulings = rulings && rulings.length > 0
 
   // Estimate total height for positioning
@@ -72,14 +88,14 @@ export function HoverCardPreview({ name, imageUri, imageSize = 'large', pos, rul
   if (pos) {
     const vw = window.innerWidth
 
-    if (pos.x + previewWidth + MARGIN < vw - VIEWPORT_PADDING) {
+    if (pos.x + contentWidth + MARGIN < vw - VIEWPORT_PADDING) {
       left = pos.x + MARGIN
-    } else if (pos.x - previewWidth - MARGIN > VIEWPORT_PADDING) {
-      left = pos.x - previewWidth - MARGIN
+    } else if (pos.x - contentWidth - MARGIN > VIEWPORT_PADDING) {
+      left = pos.x - contentWidth - MARGIN
     } else {
-      left = Math.max(VIEWPORT_PADDING, (vw - previewWidth) / 2)
+      left = Math.max(VIEWPORT_PADDING, (vw - contentWidth) / 2)
     }
-    left = Math.max(VIEWPORT_PADDING, Math.min(left, vw - previewWidth - VIEWPORT_PADDING))
+    left = Math.max(VIEWPORT_PADDING, Math.min(left, vw - contentWidth - VIEWPORT_PADDING))
 
     // Place the preview above the cursor, falling back to below if too close to top
     const aboveTop = pos.y - estimatedHeight - MARGIN
@@ -103,33 +119,53 @@ export function HoverCardPreview({ name, imageUri, imageSize = 'large', pos, rul
         gap: GAP,
       }}
     >
-      <div
-        style={{
-          position: 'relative',
-          width: previewWidth,
-          height: previewHeight,
-          borderRadius: 12,
-          overflow: 'hidden',
-          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.8), 0 0 0 2px rgba(255, 255, 255, 0.1)',
-        }}
-      >
-        <img
-          src={imageUrl}
-          alt={name}
-          style={imageRotateDeg
-            ? {
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                width: portraitWidth,
-                height: portraitHeight,
-                transform: `translate(-50%, -50%) rotate(${imageRotateDeg}deg)`,
-                objectFit: 'cover',
-              }
-            : { width: '100%', height: '100%', objectFit: 'cover' }
-          }
-        />
-        {overlay}
+      <div style={{ display: 'flex', flexDirection: 'row', gap: FACE_GAP }}>
+        <div
+          style={{
+            position: 'relative',
+            width: previewWidth,
+            height: previewHeight,
+            borderRadius: 12,
+            overflow: 'hidden',
+            boxShadow: '0 8px 32px rgba(0, 0, 0, 0.8), 0 0 0 2px rgba(255, 255, 255, 0.1)',
+          }}
+        >
+          <img
+            src={imageUrl}
+            alt={name}
+            style={imageRotateDeg
+              ? {
+                  position: 'absolute',
+                  top: '50%',
+                  left: '50%',
+                  width: portraitWidth,
+                  height: portraitHeight,
+                  transform: `translate(-50%, -50%) rotate(${imageRotateDeg}deg)`,
+                  objectFit: 'cover',
+                }
+              : { width: '100%', height: '100%', objectFit: 'cover' }
+            }
+          />
+          {overlay}
+        </div>
+        {backImageUrl && (
+          <div
+            style={{
+              position: 'relative',
+              width: previewWidth,
+              height: previewHeight,
+              borderRadius: 12,
+              overflow: 'hidden',
+              boxShadow: '0 8px 32px rgba(0, 0, 0, 0.8), 0 0 0 2px rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <img
+              src={backImageUrl}
+              alt={backFaceName ?? name}
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          </div>
+        )}
       </div>
 
       {children}


### PR DESCRIPTION
## What

In the deckbuilder, hovering a double-faced card now shows **both faces side by side horizontally** instead of just the front face with a press-`F` flip to reveal the back.

The press-`F` flip was originally added to keep the *in-game* preview compact (limited real estate). The deckbuilder has the horizontal room, so showing both faces at once is friendlier — no hidden keyboard shortcut to discover.

## How

- `HoverCardPreview` gains optional `backFaceName` / `backFaceImageUri` props. When both are present it renders the two faces in a horizontal row and widens its viewport-clamp footprint accordingly. The props are unset for the game board and draft overlays, so those previews are unchanged and keep the flip.
- All four deckbuilder hover surfaces — catalog grid, deck-list rows, add-card search dropdown, and the deck-mode left-rail pane — feed both faces through a small shared `dfcBackFace()` helper and no longer use `useDfcHoverFlip`.
- The left-rail pane (`DeckHoverPreview`) lays the two faces out horizontally via a new `.deckHoverPreviewDual` modifier.

`useDfcHoverFlip` is retained for the draft / sealed overlays, which remain compact.

## Scope note

This intentionally reverses the earlier "flip, don't show side by side" decision **only for the constructed deckbuilder**. The sealed deck-builder overlay and draft overlays are out of scope and still flip.

## Screenshots

Cursor-follow preview (catalog grid) — both faces of a transform card:

![Deckbuilder DFC horizontal hover preview](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deckbuilder-dfc-horizontal-preview-screenshots/dfc-horizontal.png)

Deck-mode left-rail preview — both faces in the rail:

![Deck-mode left-rail DFC preview](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deckbuilder-dfc-horizontal-preview-screenshots/dfc-horizontal-rail.png)

_Screenshots are hosted on the throwaway `deckbuilder-dfc-horizontal-preview-screenshots` branch, not committed to this PR._

## Testing

- `npm run typecheck` — clean
- `npm run build` — clean
- Verified visually in the running app (both screenshots above captured from the dev server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)