### PR TITLE
Fix flaky GameFlowTest "turn counter increments correctly"

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameFlowTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameFlowTest.kt
@@ -81,15 +81,18 @@ class GameFlowTest : GameServerTestBase() {
         context("Multi-Turn Gameplay") {
             test("turn counter increments correctly") {
                 val ctx = setupGame(monoGreenLands)
-                var state = ctx.player1.client.requireLatestState()
-                state.turnNumber shouldBe 1
+                ctx.player1.client.requireLatestState().turnNumber shouldBe 1
 
-                var limit = 0
-                while (state.turnNumber == 1 && limit++ < 50) {
-                    ctx.safePassPriority()
-                    state = ctx.player1.client.requireLatestState()
+                // Pass priority (resolving any pending decisions) until the second turn begins.
+                // Each pass is best-effort: under full-suite load an individual pass can be a no-op
+                // — a stale priorityPlayerId read sends a pass for a player who no longer holds
+                // priority (rejected with an Error, never a StateUpdate), or a legitimate round-trip
+                // simply takes longer than the per-pass wait. Retrying within a generous overall
+                // deadline self-heals those transients instead of failing on the first stalled pass.
+                eventually(60.seconds) {
+                    runCatching { ctx.safePassPriority() }
+                    ctx.player1.client.requireLatestState().turnNumber shouldBe 2
                 }
-                state.turnNumber shouldBe 2
             }
         }
     }


### PR DESCRIPTION
## Problem

`GameFlowTest > Multi-Turn Gameplay > turn counter increments correctly` has recently become very flaky.

## Root cause

The test drove the game forward with `safePassPriority`, which sends one action and asserts via `eventually(5.seconds) { stateUpdateCount > countBefore }` that *each individual* pass produced a fresh `StateUpdate`. The turn-counter test chained up to 50 such passes, making it the most round-trip-heavy test in the suite — so it flaked first.

A single pass can legitimately produce no `StateUpdate` within 5s:
- **Stale priority read:** between async websocket updates, `priorityPlayerId` can be momentarily stale, so the test sends `PassPriority` for a player who no longer holds priority. The server rejects it with an `Error` (never a `StateUpdate`) → the per-pass wait times out and throws.
- **Suite-load latency:** under the full `:game-server` run (many `@SpringBootTest` contexts in one JVM), a legitimate round-trip can exceed the 5s window.

In isolation the test is rock-solid — **0 failures in 65+ runs**. The flakiness only appears under concurrent-suite load. The delta-update path was verified clean (`StateDiffCalculator` includes every changed scalar, including `priorityPlayerId`/`turnNumber`), so this is purely a test-harness timing fragility, not an engine/data bug.

## Fix

Drive on the *meaningful* condition (turn reaches 2) within a generous overall deadline, treating each pass as best-effort. A stalled or rejected pass is now retried instead of failing the whole test — the loop self-heals once priority settles.

```kotlin
eventually(60.seconds) {
    runCatching { ctx.safePassPriority() }
    ctx.player1.client.requireLatestState().turnNumber shouldBe 2
}
```

If the game genuinely fails to advance, the outer `eventually` still fails after 60s with a clear `turnNumber shouldBe 2` assertion, so real regressions are not masked.

## Testing

- `GameFlowTest` passes (both tests).
- Full `:game-server:test` suite passes.
- Turn-counter test: 10/10 reruns green after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)