### PR TITLE
Show split cards landscape in deckbuilder hover preview

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/CardsController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/CardsController.kt
@@ -114,6 +114,12 @@ class CardsController(
         val backFaceName: String? = null,
         val backFaceImageUri: String? = null,
         /**
+         * The card's printed layout (e.g. `NORMAL`, `SPLIT`, `ADVENTURE`). Lets the deckbuilder
+         * render split cards (Pain // Suffering, Rooms like Unholy Annex // Ritual Chamber) rotated
+         * to landscape in the hover preview, since their single catalog image is printed sideways.
+         */
+        val layout: String = "NORMAL",
+        /**
          * The printing the catalog grid renders by default. Lets the deckbuilder picker
          * highlight the row that matches the catalog thumbnail without re-deriving it from
          * `setCode + collectorNumber` on the client. Null only for cards missing both
@@ -156,6 +162,7 @@ class CardsController(
             isDoubleFaced = isDoubleFaced,
             backFaceName = backFace?.name,
             backFaceImageUri = latest?.backFaceImageUri ?: backFace?.metadata?.imageUri,
+            layout = layout.name,
             defaultPrinting = latestRef ?: defaultPrintingRef,
             printingSetCodes = printingRegistry.printingsOf(name)
                 .map { it.setCode }

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -1061,6 +1061,7 @@ export function DeckbuilderPage() {
                 : null
             }
             overlay={deckHoverDfc.hint}
+            imageRotateDeg={splitImageRotateDeg(effectiveDeckHoverCard)}
           />
         ) : (
           <FilterSection
@@ -3364,6 +3365,7 @@ function CardGrid({
         name={hoverCard ? (dfc.displayName ?? hoverCard.name) : null}
         imageUri={hoverCard ? (dfc.displayImageUri ?? hoverCard.imageUri ?? null) : null}
         overlay={dfc.hint}
+        imageRotateDeg={splitImageRotateDeg(hoverCard)}
       />
     </>
   )
@@ -3469,6 +3471,15 @@ function resolveImageUrl(card: CardSummary): string {
 }
 
 /**
+ * Split-layout cards (Pain // Suffering, Rooms like Unholy Annex // Ritual Chamber) have a
+ * single image that's printed sideways, so the hover preview rotates it 90° to read landscape.
+ * Mirrors the game-board treatment in CardPreview.tsx.
+ */
+function splitImageRotateDeg(card: { layout?: string } | null | undefined): 0 | 90 {
+  return card?.layout === 'SPLIT' ? 90 : 0
+}
+
+/**
  * Floats a card preview that follows the cursor while a row/tile is hovered.
  * The position state lives here, not on the parent panel — so mouse motion
  * doesn't re-render the (potentially large) sibling list. The parent only
@@ -3478,10 +3489,12 @@ function HoverFollowPreview({
   name,
   imageUri,
   overlay,
+  imageRotateDeg = 0,
 }: {
   name: string | null
   imageUri: string | null
   overlay?: React.ReactNode
+  imageRotateDeg?: 0 | 90
 }) {
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
   useEffect(() => {
@@ -3506,7 +3519,15 @@ function HoverFollowPreview({
     }
   }, [name])
   if (!name || !pos) return null
-  return <HoverCardPreview name={name} imageUri={imageUri} pos={pos} overlay={overlay} />
+  return (
+    <HoverCardPreview
+      name={name}
+      imageUri={imageUri}
+      pos={pos}
+      overlay={overlay}
+      imageRotateDeg={imageRotateDeg}
+    />
+  )
 }
 
 /**
@@ -3518,10 +3539,12 @@ function DeckHoverPreview({
   name,
   imageUri,
   overlay,
+  imageRotateDeg = 0,
 }: {
   name: string | null
   imageUri: string | null
   overlay?: React.ReactNode
+  imageRotateDeg?: 0 | 90
 }) {
   if (!name) {
     return (
@@ -3531,10 +3554,34 @@ function DeckHoverPreview({
     )
   }
   const imageUrl = getCardImageUrl(name, imageUri, 'large')
+  const landscape = imageRotateDeg === 90
   return (
     <div className={styles.deckHoverPreview}>
-      <div className={styles.deckHoverPreviewImageWrap}>
-        <img className={styles.deckHoverPreviewImage} src={imageUrl} alt={name} />
+      {/* Split cards (Rooms etc.) are printed sideways: swap the wrap to a landscape aspect
+          ratio and rotate the portrait image into it. The percentage dims are the relative
+          equivalent of HoverCardPreview's pixel approach — width 5/7 and height 7/5 of the
+          landscape box make the rotated 5:7 image fill it exactly. */}
+      <div
+        className={styles.deckHoverPreviewImageWrap}
+        style={landscape ? { aspectRatio: '7 / 5' } : undefined}
+      >
+        <img
+          className={styles.deckHoverPreviewImage}
+          src={imageUrl}
+          alt={name}
+          style={
+            landscape
+              ? {
+                  position: 'absolute',
+                  top: '50%',
+                  left: '50%',
+                  width: '71.4286%',
+                  height: '140%',
+                  transform: 'translate(-50%, -50%) rotate(90deg)',
+                }
+              : undefined
+          }
+        />
         {overlay}
       </div>
     </div>
@@ -3684,6 +3731,7 @@ function DeckListPanel({
         name={hoverName ? (dfc.displayName ?? hoverName) : null}
         imageUri={hoverName ? (dfc.displayImageUri ?? effectiveHoverCard?.imageUri ?? null) : null}
         overlay={dfc.hint}
+        imageRotateDeg={splitImageRotateDeg(effectiveHoverCard)}
       />
     </div>
   )
@@ -4049,6 +4097,7 @@ function AddCardSearch({
         name={hoverCard ? (dfc.displayName ?? hoverCard.name) : null}
         imageUri={hoverCard ? (dfc.displayImageUri ?? hoverCard.imageUri ?? null) : null}
         overlay={dfc.hint}
+        imageRotateDeg={splitImageRotateDeg(hoverCard)}
       />
     </div>
   )

--- a/web-client/src/components/deckbuilder/cardFilter.ts
+++ b/web-client/src/components/deckbuilder/cardFilter.ts
@@ -56,6 +56,12 @@ export interface CardSummary {
   isDoubleFaced?: boolean
   backFaceName?: string | null
   backFaceImageUri?: string | null
+  /**
+   * Printed layout (`NORMAL`, `SPLIT`, `ADVENTURE`, …). `SPLIT` cards (Pain // Suffering, Rooms
+   * like Unholy Annex // Ritual Chamber) have a single sideways-printed image, so the hover
+   * preview rotates them 90° to read landscape. Defaults to `NORMAL` for legacy fixtures.
+   */
+  layout?: string
 }
 
 export type { CardPredicate, ParseResult, ParseError } from './query'


### PR DESCRIPTION
## What

Split-layout cards — double cards like **Pain // Suffering** and Rooms like **Unholy Annex // Ritual Chamber** — have a single image that's printed sideways. In the deckbuilder, the hover preview showed them as a portrait crop with sideways, hard-to-read text. They now rotate 90° to landscape on hover, matching the existing game-board treatment in `CardPreview.tsx`.

| Unholy Annex // Ritual Chamber (Room) | Pain // Suffering (split) |
|---|---|
| ![Unholy Annex](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deckbuilder-split-hover-screenshots/unholy-annex.png) | ![Pain // Suffering](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deckbuilder-split-hover-screenshots/pain-suffering.png) |

## How

The deckbuilder catalog DTO carried no layout info, so the client couldn't tell a split card apart. This threads the printed layout through:

- **game-server** — add `layout` to `CardSummaryDTO`, mapped from `CardDefinition.layout`.
- **web-client** — add `layout` to the `CardSummary` catalog type. A small `splitImageRotateDeg()` helper returns `90` for `SPLIT` cards and feeds `imageRotateDeg` into:
  - the cursor-following `HoverFollowPreview` (used by the catalog grid, the deck-list panel, and the add-card search dropdown), via the existing `imageRotateDeg` support in `HoverCardPreview`;
  - the static deck-mode `DeckHoverPreview` pane, which swaps to a landscape aspect ratio and rotates the portrait image into it.

DFCs are untouched — split cards are never double-faced, so the existing `useDfcHoverFlip` path stays inert for them.

## Testing

- `npm run typecheck` (web-client) — clean.
- `./gradlew :game-server:compileKotlin` — clean.
- Ran the full stack and confirmed `GET /api/cards` now returns `layout: "SPLIT"` for the 6 split cards, and that both example cards render landscape on hover (screenshots above).

> The `deckbuilder-split-hover-screenshots` branch is a throwaway image host, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)