### PR TITLE
Add TDM cards: Sunset Strikemaster, Reigning Victor, Stormshriek Feral

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StormshriekFeralScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StormshriekFeralScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Stormshriek Feral // Flush Out (TDM #124).
+ *
+ * Stormshriek Feral — {4}{R} Dragon, 3/3, Flying, haste; {1}{R}: +1/+0 until end of turn.
+ * Flush Out — {1}{R} Sorcery — Omen: "Discard a card. If you do, draw two cards."
+ *
+ * Exercises the Omen face: the mandatory discard then a conditional draw two ([IfYouDoEffect]),
+ * and the Omen-specific shuffle-back (the card returns to its owner's library on resolution, not
+ * the graveyard).
+ */
+class StormshriekFeralScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Flush Out Omen face") {
+
+            test("discard a card, draw two, then shuffle the Omen back into the library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stormshriek Feral")
+                    .withCardInHand(1, "Mountain") // the card to discard
+                    .withLandsOnBattlefield(1, "Mountain", 2) // {1}{R}
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Stormshriek Feral"
+                }
+                val libraryBefore = game.librarySize(1) // 3
+
+                // Cast the Omen face (faceIndex = 0).
+                val cast = game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = cardId, faceIndex = 0)
+                )
+                withClue("Casting Flush Out should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                // Resolve: discard prompt may surface; resolveStack drives the mandatory discard.
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    val mountain = game.findCardsInHand(1, "Mountain").first()
+                    game.selectTargets(listOf(mountain))
+                    game.resolveStack()
+                }
+
+                withClue("The Mountain was discarded to the graveyard") {
+                    game.graveyardSize(1) shouldBe 1
+                }
+                // Net library: started at 3, drew 2, then Stormshriek Feral shuffles back in → 3 - 2 + 1 = 2.
+                withClue("Drew two cards and shuffled the Omen back into the library") {
+                    game.librarySize(1) shouldBe libraryBefore - 2 + 1
+                }
+                withClue("Flush Out resolved to the library, not the graveyard or battlefield") {
+                    game.findCardsInLibrary(1, "Stormshriek Feral").size shouldBe 1
+                    game.isOnBattlefield("Stormshriek Feral") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmSunsetReigningScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmSunsetReigningScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for two Tarkir: Dragonstorm cards built from existing primitives.
+ *
+ *  - Sunset Strikemaster (TDM #126) — {1}{R} Human Monk, 3/1.
+ *      "{T}: Add {R}.
+ *       {2}{R}, {T}, Sacrifice this creature: It deals 6 damage to target creature with flying."
+ *
+ *  - Reigning Victor (TDM #216) — {2/R}{2/W}{2/B} Orc Warrior, 3/3, Mobilize 1.
+ *      "When this creature enters, target creature gets +1/+0 and gains indestructible until end of
+ *       turn."
+ */
+class TdmSunsetReigningScenarioTest : ScenarioTestBase() {
+
+    // Sunset Strikemaster's sacrifice ability is the second activated ability (the first is the
+    // {T}: Add {R} mana ability).
+    private val strikemasterSacAbilityId =
+        cardRegistry.getCard("Sunset Strikemaster")!!.activatedAbilities[1].id
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Flyer",
+                manaCost = ManaCost.parse("{4}{U}"),
+                subtypes = setOf(Subtype("Bird")),
+                power = 4,
+                toughness = 4,
+                keywords = setOf(Keyword.FLYING),
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Groundling",
+                manaCost = ManaCost.parse("{2}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 3,
+                toughness = 3,
+            )
+        )
+
+        context("Sunset Strikemaster") {
+
+            test("sacrifice ability deals 6 damage to a flying creature, killing it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sunset Strikemaster", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 3) // {2}{R}
+                    .withCardOnBattlefield(2, "Test Flyer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val strikemaster = game.findPermanent("Sunset Strikemaster")!!
+                val flyer = game.findPermanent("Test Flyer")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = strikemaster,
+                        abilityId = strikemasterSacAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(flyer)),
+                    )
+                )
+                withClue("Activating the sacrifice ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Sunset Strikemaster was sacrificed as a cost and left the battlefield") {
+                    game.isOnBattlefield("Sunset Strikemaster") shouldBe false
+                }
+                withClue("6 damage kills the 4/4 flyer") {
+                    game.isOnBattlefield("Test Flyer") shouldBe false
+                }
+            }
+        }
+
+        context("Reigning Victor") {
+
+            test("ETB gives target creature +1/+0 and indestructible until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Reigning Victor")
+                    .withLandsOnBattlefield(1, "Mountain", 6) // {2/R}{2/W}{2/B} paid as 6 generic
+                    .withCardOnBattlefield(1, "Test Groundling", summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Reigning Victor").error shouldBe null
+                game.resolveStack() // creature enters → ETB trigger on stack, asks for a target
+
+                val groundling = game.findPermanent("Test Groundling")!!
+
+                withClue("Base groundling is 3/3 with no indestructible before the trigger resolves") {
+                    game.state.projectedState.getPower(groundling) shouldBe 3
+                    game.getClientState(1).cards[groundling]?.keywords?.contains(Keyword.INDESTRUCTIBLE) shouldBe false
+                }
+
+                val select = game.selectTargets(listOf(groundling))
+                withClue("Selecting the target creature should succeed: ${select.error}") {
+                    select.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Target creature gets +1/+0 (power 3 -> 4)") {
+                    game.state.projectedState.getPower(groundling) shouldBe 4
+                }
+                withClue("Toughness is unchanged (+1/+0)") {
+                    game.state.projectedState.getToughness(groundling) shouldBe 3
+                }
+                withClue("Target creature gains indestructible") {
+                    game.getClientState(1).cards[groundling]?.keywords?.contains(Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ReigningVictor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ReigningVictor.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reigning Victor — Tarkir: Dragonstorm #216
+ * {2/R}{2/W}{2/B} · Creature — Orc Warrior · 3/3
+ *
+ * Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior
+ * creature token. Sacrifice it at the beginning of the next end step.)
+ * When this creature enters, target creature gets +1/+0 and gains indestructible until end of turn.
+ *
+ * `mobilize(1)` supplies the display keyword plus the attack-triggered tapped-and-attacking Warrior
+ * token. The enters-the-battlefield ability targets any creature (the printed card says "target
+ * creature", not "you control") and grants +1/+0 via [Effects.ModifyStats] plus indestructible via
+ * [Effects.GrantKeyword]; both default to end-of-turn duration.
+ */
+val ReigningVictor = card("Reigning Victor") {
+    manaCost = "{2/R}{2/W}{2/B}"
+    colorIdentity = "RWB"
+    typeLine = "Creature — Orc Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red " +
+        "Warrior creature token. Sacrifice it at the beginning of the next end step.)\n" +
+        "When this creature enters, target creature gets +1/+0 and gains indestructible until end of turn. " +
+        "(Damage and effects that say \"destroy\" don't destroy it.)"
+
+    mobilize(1)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature to get +1/+0 and gain indestructible", Targets.Creature)
+        effect = Effects.ModifyStats(1, 0, creature)
+            .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature))
+        description = "When this creature enters, target creature gets +1/+0 and gains indestructible until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a394112a-032b-4047-887a-6522cf7b83d5.jpg?1743204853"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormshriekFeral.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormshriekFeral.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stormshriek Feral // Flush Out — Tarkir: Dragonstorm #124
+ * {4}{R} · Creature — Dragon · 3/3
+ *
+ * Flying, haste
+ * {1}{R}: This creature gets +1/+0 until end of turn.
+ *
+ * Omen: Flush Out — {1}{R}, Sorcery — Omen
+ * Discard a card. If you do, draw two cards. (Then shuffle this card into its owner's library.)
+ *
+ * (Omen, Tarkir: Dragonstorm: casting the Omen face shuffles this card into its owner's library on
+ * resolution instead of putting it in the graveyard. From every zone other than the stack the card
+ * is just the Dragon — see [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ *
+ * "If you do" is modeled with [IfYouDoEffect]: the mandatory discard runs first, and the draw only
+ * happens when a card was actually discarded (matters with an otherwise-empty hand).
+ */
+val StormshriekFeral = card("Stormshriek Feral") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, haste\n{1}{R}: This creature gets +1/+0 until end of turn."
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{1}{R}: This creature gets +1/+0 until end of turn."
+    }
+
+    // Omen: Flush Out — Sorcery. Discard a card. If you do, draw two cards.
+    omen("Flush Out") {
+        manaCost = "{1}{R}"
+        typeLine = "Sorcery — Omen"
+        oracleText = "Discard a card. If you do, draw two cards. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            effect = IfYouDoEffect(
+                action = EffectPatterns.discardCards(1),
+                ifYouDo = Effects.DrawCards(2),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "124"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0ec92c44-7cf0-48a5-a3ca-bc633496d887.jpg?1743204459"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SunsetStrikemaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SunsetStrikemaster.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Sunset Strikemaster — Tarkir: Dragonstorm #126
+ * {1}{R} · Creature — Human Monk · 3/1
+ *
+ * {T}: Add {R}.
+ * {2}{R}, {T}, Sacrifice this creature: It deals 6 damage to target creature with flying.
+ *
+ * The first ability is a vanilla red mana ability ({T}: Add {R}). The second is an activated
+ * ability whose cost is the composite of {2}{R}, tapping, and sacrificing the source; on
+ * resolution it deals 6 damage to a target creature with flying (via the `withKeyword(FLYING)`
+ * target filter). Both abilities tap the source, so they compete for the same tap — exactly as
+ * the printed card intends.
+ */
+val SunsetStrikemaster = card("Sunset Strikemaster") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Monk"
+    power = 3
+    toughness = 1
+    oracleText = "{T}: Add {R}.\n" +
+        "{2}{R}, {T}, Sacrifice this creature: It deals 6 damage to target creature with flying."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{R}"),
+            AbilityCost.Tap,
+            AbilityCost.SacrificeSelf,
+        )
+        val t = target(
+            "target creature with flying",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Creature.withKeyword(Keyword.FLYING))),
+        )
+        effect = DealDamageEffect(6, t)
+        description = "{2}{R}, {T}, Sacrifice this creature: It deals 6 damage to target creature with flying."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "126"
+        artist = "Zara Alfonso"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8f1a2f2-526d-4b2c-985b-0acfdc21a2ee.jpg?1743204467"
+    }
+}


### PR DESCRIPTION
Implements three Tarkir: Dragonstorm (TDM) cards, each composed from existing SDK primitives (no new engine/SDK features):

## Cards added
- **Sunset Strikemaster** (TDM #126, {1}{R} 3/1 Human Monk) — `{T}: Add {R}` mana ability plus a `{2}{R}, {T}, Sacrifice this creature` activated ability that deals 6 damage to target creature with flying.
- **Reigning Victor** (TDM #216, {2/R}{2/W}{2/B} 3/3 Orc Warrior) — Mobilize 1 plus an enters-the-battlefield triggered ability giving target creature +1/+0 and indestructible until end of turn.
- **Stormshriek Feral // Flush Out** (TDM #124, {4}{R} 3/3 Dragon) — Flying, haste, and `{1}{R}: +1/+0 until end of turn`; the Omen face *Flush Out* discards a card and, if it does, draws two (modeled with `IfYouDoEffect`), then shuffles back into the library on resolution.

## Tests
- `TdmSunsetReigningScenarioTest` — Strikemaster sacrifice damage kills a flyer; Reigning Victor ETB buff + indestructible on a target creature.
- `StormshriekFeralScenarioTest` — Flush Out discards one, draws two, and shuffles the Omen back into the library (not the graveyard).

All scenario tests pass.

## Skipped (would require new engine/SDK features, out of scope)
- **Hundred-Battle Veteran** — needs a new "three or more different kinds of counters among creatures you control" static condition (no such condition/dynamic-amount exists).
- **Temur Battlecrier** — needs a new cost-reduction source (count creatures you control with power 4+) combined with a "during your turn" gate on a per-unit reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)