### PR TITLE
Add TDM cards: Rainveil Rejuvenator, Kishla Trawlers, Yathan Roadwatcher, Unrooted Ancestor

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGraveyardBatchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmGraveyardBatchScenarioTest.kt
@@ -1,0 +1,272 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for a batch of graveyard-centric TDM cards:
+ *  - Rainveil Rejuvenator (#152): ETB may mill 3; {T}: add {G} equal to power.
+ *  - Kishla Trawlers (#50): ETB may exile a creature card from your graveyard; when you do,
+ *    return target instant/sorcery card from your graveyard to hand.
+ *  - Yathan Roadwatcher (#236): ETB (if cast) mill 4; when you do, reanimate a creature card
+ *    with mana value 3 or less from your graveyard.
+ *  - Unrooted Ancestor (#96): {1}, Sacrifice another creature: gain indestructible EOT, tap it.
+ */
+class TdmGraveyardBatchScenarioTest : ScenarioTestBase() {
+
+    private val rainveilManaAbilityId =
+        cardRegistry.getCard("Rainveil Rejuvenator")!!.activatedAbilities.first().id
+    private val unrootedAbilityId =
+        cardRegistry.getCard("Unrooted Ancestor")!!.activatedAbilities.first().id
+
+    init {
+        context("Rainveil Rejuvenator") {
+            test("ETB may mill three cards") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Rainveil Rejuvenator")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Shock")
+                    .withCardInLibrary(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Rainveil Rejuvenator")
+                withClue("Casting Rainveil Rejuvenator should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("ETB should present a 'may mill' yes/no decision") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val libBefore = game.librarySize(1)
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Milling three should move three cards from library to graveyard") {
+                    game.librarySize(1) shouldBe libBefore - 3
+                    game.findCardsInGraveyard(1, "Forest").size shouldBe 1
+                }
+            }
+
+            test("tap adds {G} equal to power") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    // Place it directly so it has no summoning sickness; its {T} is a mana ability.
+                    .withCardOnBattlefield(1, "Rainveil Rejuvenator")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rejuvenator = game.findPermanent("Rainveil Rejuvenator")!!
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rejuvenator,
+                        abilityId = rainveilManaAbilityId,
+                    )
+                )
+                withClue("Activating the mana ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+
+                withClue("Rainveil Rejuvenator should be tapped after the mana ability") {
+                    game.state.getEntity(rejuvenator)?.has<TappedComponent>() shouldBe true
+                }
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("Mana pool should hold 2 green (equal to power)") {
+                    (pool?.green ?: 0) shouldBe 2
+                }
+            }
+
+            test("ETB may mill three can be declined") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Rainveil Rejuvenator")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Rainveil Rejuvenator")
+                game.resolveStack()
+
+                val libBefore = game.librarySize(1)
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Declining the mill leaves the library untouched") {
+                    game.librarySize(1) shouldBe libBefore
+                }
+            }
+        }
+
+        context("Kishla Trawlers") {
+            test("ETB exiles a creature card and returns an instant/sorcery to hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Kishla Trawlers")
+                    .withCardInGraveyard(1, "Glory Seeker") // creature card to exile
+                    .withCardInGraveyard(1, "Shock")        // instant to return
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Kishla Trawlers")
+                withClue("Casting Kishla Trawlers should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Reflexive "you may" yes/no.
+                withClue("ETB should present a 'you may exile' yes/no decision") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                // With a single creature card in the graveyard, it is auto-selected and
+                // exiled; the reflexive trigger then prompts for the instant/sorcery target.
+                withClue("Glory Seeker should be exiled from the graveyard") {
+                    game.findCardsInGraveyard(1, "Glory Seeker").size shouldBe 0
+                }
+                withClue("Should now prompt to return an instant/sorcery to hand") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val shock = game.findCardsInGraveyard(1, "Shock").first()
+                game.selectTargets(listOf(shock))
+                game.resolveStack()
+
+                withClue("Glory Seeker should be exiled from the graveyard") {
+                    game.findCardsInGraveyard(1, "Glory Seeker").size shouldBe 0
+                }
+                withClue("Shock should be returned to hand") {
+                    game.findCardsInHand(1, "Shock").size shouldBe 1
+                    game.findCardsInGraveyard(1, "Shock").size shouldBe 0
+                }
+            }
+
+            test("ETB does nothing when there is no creature card to exile") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Kishla Trawlers")
+                    .withCardInGraveyard(1, "Shock") // only an instant, no creature card
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Kishla Trawlers")
+                game.resolveStack()
+
+                withClue("With no creature card to exile, the may-decision is skipped entirely") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("Shock stays in the graveyard") {
+                    game.findCardsInGraveyard(1, "Shock").size shouldBe 1
+                }
+            }
+        }
+
+        context("Yathan Roadwatcher") {
+            test("ETB (cast) mills four and reanimates a creature with mana value 3 or less") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Yathan Roadwatcher")
+                    .withCardInGraveyard(1, "Glory Seeker") // MV 2 — legal reanimation target
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Yathan Roadwatcher")
+                withClue("Casting Yathan Roadwatcher should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // The mill is non-optional; reflexive return then asks for a target.
+                withClue("Should prompt for a reanimation target after milling") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                withClue("Four cards should have been milled") {
+                    game.librarySize(1) shouldBe 0
+                }
+                val glorySeeker = game.findCardsInGraveyard(1, "Glory Seeker").first()
+                game.selectTargets(listOf(glorySeeker))
+                game.resolveStack()
+
+                withClue("Glory Seeker should be returned to the battlefield") {
+                    game.isOnBattlefield("Glory Seeker") shouldBe true
+                    game.findCardsInGraveyard(1, "Glory Seeker").size shouldBe 0
+                }
+            }
+        }
+
+        context("Unrooted Ancestor") {
+            test("activated ability sacrifices another creature, grants indestructible, and taps itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Unrooted Ancestor")
+                    .withCardOnBattlefield(1, "Glory Seeker") // fodder
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ancestor = game.findPermanent("Unrooted Ancestor")!!
+                val fodder = game.findPermanent("Glory Seeker")!!
+
+                withClue("Unrooted Ancestor is not indestructible before activation") {
+                    game.state.projectedState.hasKeyword(ancestor, Keyword.INDESTRUCTIBLE) shouldBe false
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = ancestor,
+                        abilityId = unrootedAbilityId,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder)),
+                    )
+                )
+                withClue("Activating Unrooted Ancestor should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Glory Seeker should be sacrificed to the graveyard") {
+                    game.findPermanents("Glory Seeker").contains(fodder) shouldBe false
+                    game.findCardsInGraveyard(1, "Glory Seeker").size shouldBe 1
+                }
+                withClue("Unrooted Ancestor gains indestructible") {
+                    game.state.projectedState.hasKeyword(ancestor, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+                withClue("Unrooted Ancestor is tapped by its own ability") {
+                    game.state.getEntity(ancestor)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KishlaTrawlers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KishlaTrawlers.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Kishla Trawlers — Tarkir: Dragonstorm #50
+ * {2}{U} · Creature — Human Citizen · 3/2
+ *
+ * When this creature enters, you may exile a creature card from your graveyard.
+ * When you do, return target instant or sorcery card from your graveyard to your hand.
+ *
+ * Modeled as a reflexive trigger. The optional action selects a creature card in your
+ * graveyard and exiles it (the "may exile" half); the reflexive payoff then targets an
+ * instant or sorcery card in your graveyard to return to hand. If the action can't be
+ * performed (no creature cards in your graveyard) the may-decision is skipped entirely,
+ * so the reflexive return never fires.
+ */
+val KishlaTrawlers = card("Kishla Trawlers") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Citizen"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, you may exile a creature card from your graveyard. " +
+        "When you do, return target instant or sorcery card from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = CompositeEffect(
+                listOf(
+                    Effects.SelectTarget(Targets.CreatureCardInYourGraveyard, storeAs = "exiledCreature"),
+                    Effects.Exile(EffectTarget.PipelineTarget("exiledCreature"))
+                )
+            ),
+            optional = true,
+            reflexiveEffect = Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(
+                TargetObject(filter = TargetFilter.InstantOrSorceryInGraveyard.ownedByYou())
+            ),
+            descriptionOverride = "You may exile a creature card from your graveyard. " +
+                "When you do, return target instant or sorcery card from your graveyard to your hand."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "Iris Compiet"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/190fbc55-e8e9-4077-9532-1de7406baabf.jpg?1743204163"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RainveilRejuvenator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RainveilRejuvenator.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Rainveil Rejuvenator — Tarkir: Dragonstorm #152
+ * {3}{G} · Creature — Elephant Druid · 2/4
+ *
+ * When this creature enters, you may mill three cards.
+ * {T}: Add an amount of {G} equal to this creature's power.
+ *
+ * The mana ability reads the creature's current power at activation
+ * ([DynamicAmounts.sourcePower]); it is a mana ability (no stack, can't be responded to).
+ */
+val RainveilRejuvenator = card("Rainveil Rejuvenator") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elephant Druid"
+    power = 2
+    toughness = 4
+    oracleText = "When this creature enters, you may mill three cards. " +
+        "(You may put the top three cards of your library into your graveyard.)\n" +
+        "{T}: Add an amount of {G} equal to this creature's power."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            EffectPatterns.mill(3),
+            descriptionOverride = "You may mill three cards."
+        )
+        description = "When this creature enters, you may mill three cards."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN, DynamicAmounts.sourcePower())
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "152"
+        artist = "Michele Giorgi"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9bc5c316-6a41-48ba-864b-da3030dd3e0e.jpg?1743204573"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/UnrootedAncestor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/UnrootedAncestor.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Unrooted Ancestor — Tarkir: Dragonstorm #96
+ * {2}{B} · Creature — Spirit Cleric · 3/2
+ *
+ * Flash
+ * {1}, Sacrifice another creature: This creature gains indestructible until end of turn. Tap it.
+ *
+ * The activated ability grants indestructible to itself until end of turn, then taps it. The
+ * sacrifice cost excludes the source ([Costs.SacrificeAnother]).
+ */
+val UnrootedAncestor = card("Unrooted Ancestor") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit Cleric"
+    power = 3
+    toughness = 2
+    oracleText = "Flash\n" +
+        "{1}, Sacrifice another creature: This creature gains indestructible until end of turn. Tap it."
+
+    keywords(Keyword.FLASH)
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        effect = CompositeEffect(
+            listOf(
+                Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self),
+                Effects.Tap(EffectTarget.Self)
+            )
+        )
+        description = "This creature gains indestructible until end of turn. Tap it."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "96"
+        artist = "Elizabeth Peiró"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/6394b125-21a8-4439-9958-94b76684138e.jpg?1743204347"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/YathanRoadwatcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/YathanRoadwatcher.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Yathan Roadwatcher — Tarkir: Dragonstorm #236
+ * {1}{W}{B}{G} · Creature — Human Scout · 3/3
+ *
+ * When this creature enters, if you cast it, mill four cards. When you do, return target
+ * creature card with mana value 3 or less from your graveyard to the battlefield.
+ *
+ * The "if you cast it" clause is an intervening-if ([Conditions.WasCast]) on the enters
+ * trigger. The mill is non-optional, so the reflexive return ("When you do") always fires
+ * — the player then targets a creature card with mana value 3 or less in their graveyard
+ * to put onto the battlefield. If no such target exists the reflexive payoff is skipped.
+ */
+val YathanRoadwatcher = card("Yathan Roadwatcher") {
+    manaCost = "{1}{W}{B}{G}"
+    colorIdentity = "WBG"
+    typeLine = "Creature — Human Scout"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, if you cast it, mill four cards. " +
+        "When you do, return target creature card with mana value 3 or less from your graveyard to the battlefield."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        effect = ReflexiveTriggerEffect(
+            action = EffectPatterns.mill(4),
+            optional = false,
+            reflexiveEffect = Effects.PutOntoBattlefield(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(
+                TargetObject(filter = TargetFilter.CreatureInYourGraveyard.manaValueAtMost(3))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "236"
+        artist = "Inkognit"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e77339b-dd82-481c-9ee2-4156ca69ad35.jpg?1743204933"
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) graveyard-centric cards by composing existing SDK primitives — no new engine/SDK features.

## Cards added
- **Rainveil Rejuvenator** (#152) — `{3}{G}` Elephant Druid 2/4. ETB: you may mill three (`MayEffect` + `EffectPatterns.mill`). `{T}: Add {G}` equal to its power (mana ability using `DynamicAmounts.sourcePower`).
- **Kishla Trawlers** (#50) — `{2}{U}` Human Citizen 3/2. ETB reflexive trigger: you may exile a creature card from your graveyard (`SelectTarget` + `Exile`); when you do, return target instant/sorcery card from your graveyard to hand.
- **Yathan Roadwatcher** (#236) — `{1}{W}{B}{G}` Human Scout 3/3. ETB "if you cast it" (`Conditions.WasCast` intervening-if): mill four; when you do, return a target creature card with mana value 3 or less from your graveyard to the battlefield.
- **Unrooted Ancestor** (#96) — `{2}{B}` Spirit Cleric 3/2. Flash. `{1}, Sacrifice another creature`: gains indestructible until end of turn, then tap it.

## Tests
`TdmGraveyardBatchScenarioTest` (7 cases, all passing): ETB mill (yes/decline), the power-scaling mana ability, the reflexive exile/return plus its no-creature no-op, the cast-gated mill + reanimation, and the sacrifice → indestructible → tap activation.

## Skipped
- **Songcrafter Mage** — needs a new "grant Harmonize to a graveyard card until end of turn" SDK effect (documented as a known gap in `backlog/tdm-engine-gaps.md` item 22). Out of scope for a card-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)