### PR TITLE
Add TDM cards: Stormplain Detainment, Overwhelming Surge, Spectral Denial, Inevitable Defeat

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmControlBatchScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/TdmControlBatchScenarioTest.kt
@@ -1,0 +1,194 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for a TDM control/removal batch:
+ *  - Stormplain Detainment (#28): O-Ring — exile a nonland permanent until it leaves.
+ *  - Overwhelming Surge (#115): modal "choose one or both" — 3 damage to a creature
+ *    and/or destroy a noncreature artifact.
+ *  - Spectral Denial (#58): {X}{U} counter-unless-pays-{X}, costing {1} less per controlled
+ *    creature with power 4 or greater.
+ *  - Inevitable Defeat (#194): can't be countered; exile a nonland permanent, its controller
+ *    loses 3 life and you gain 3 life.
+ */
+class TdmControlBatchScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Stormplain Detainment") {
+            // The exile-until-leaves / return-on-LTB seam is exercised end-to-end by
+            // BanishingLightTest; here we just confirm Stormplain Detainment exiles an opponent's
+            // nonland permanent on ETB and links it for return.
+            test("exiles an opponent's creature on ETB") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Stormplain Detainment")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val victim = game.findPermanent("Hill Giant")!!
+                val cast = game.castSpell(1, "Stormplain Detainment")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack() // enchantment enters → ETB trigger on stack asks for target
+
+                val selected = game.selectTargets(listOf(victim))
+                withClue("ETB target selection should succeed: ${selected.error}") {
+                    selected.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Hill Giant should be exiled while the enchantment is in play") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.state.getExile(game.player2Id).count {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Hill Giant"
+                    } shouldBe 1
+                }
+                withClue("Stormplain Detainment should be on the battlefield holding the exile") {
+                    game.isOnBattlefield("Stormplain Detainment") shouldBe true
+                }
+            }
+        }
+
+        context("Overwhelming Surge") {
+            test("mode 0 deals 3 damage to a creature, killing a 3-toughness creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Overwhelming Surge")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3 — dies to 3 damage
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val victim = game.findPermanent("Hill Giant")!!
+                val cast = game.castSpellWithMode(1, "Overwhelming Surge", modeIndex = 0, targetId = victim)
+                withClue("Cast (damage mode) should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Hill Giant should be dead") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+            }
+
+            test("mode 2 deals 3 damage to a creature and destroys a noncreature artifact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Overwhelming Surge")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardOnBattlefield(2, "Mind Stone") // Artifact (noncreature artifact)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val creature = game.findPermanent("Hill Giant")!!
+                val artifact = game.findPermanent("Mind Stone")!!
+                val modeTargets = listOf(
+                    ChosenTarget.Permanent(creature),
+                    ChosenTarget.Permanent(artifact),
+                )
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Overwhelming Surge").first(),
+                        modeTargets, // flat union of mode targets
+                        chosenModes = listOf(2),
+                        modeTargetsOrdered = listOf(modeTargets)
+                    )
+                )
+                withClue("Cast (both modes) should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Hill Giant should be dead and Mind Stone destroyed") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isOnBattlefield("Mind Stone") shouldBe false
+                }
+            }
+        }
+
+        context("Spectral Denial") {
+            test("counters a spell whose tapped-out controller cannot pay {X}") {
+                // Player 2 taps out casting Grizzly Bears; Player 1 responds with Spectral Denial
+                // for X=2, which Player 2 cannot pay, so the spell is countered.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Spectral Denial")
+                    .withLandsOnBattlefield(1, "Island", 3) // {X}{U} with X=2 → {2}{U}
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2) // taps out
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gbCast = game.castSpell(2, "Grizzly Bears")
+                withClue("Grizzly Bears cast should succeed: ${gbCast.error}") { gbCast.error shouldBe null }
+                game.passPriority()
+
+                val targetSpell = game.state.stack.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Spectral Denial").first(),
+                        listOf(ChosenTarget.Spell(targetSpell)),
+                        xValue = 2,
+                    )
+                )
+                withClue("Spectral Denial cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+
+                withClue("Grizzly Bears should be countered") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+        }
+
+        context("Inevitable Defeat") {
+            test("exiles a nonland permanent, the controller loses 3 life and you gain 3 life") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Inevitable Defeat")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val victim = game.findPermanent("Hill Giant")!!
+                val cast = game.castSpell(1, "Inevitable Defeat", victim)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Hill Giant should be exiled") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.state.getExile(game.player2Id).count {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Hill Giant"
+                    } shouldBe 1
+                }
+                withClue("Opponent should lose 3 life and caster gain 3 life") {
+                    game.getLifeTotal(2) shouldBe 17
+                    game.getLifeTotal(1) shouldBe 23
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/InevitableDefeat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/InevitableDefeat.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Inevitable Defeat
+ * {1}{R}{W}{B}
+ * Instant
+ * This spell can't be countered.
+ * Exile target nonland permanent. Its controller loses 3 life and you gain 3 life.
+ *
+ * The life loss / gain resolves before the exile so `TargetController` can still read the
+ * permanent's controller — exiling first would move it off the battlefield and the
+ * controller lookup would silently fail (same ordering trick as Undermine / Agonizing
+ * Demise). All three happen in one resolution, so the order is imperceptible to players.
+ */
+val InevitableDefeat = card("Inevitable Defeat") {
+    manaCost = "{1}{R}{W}{B}"
+    colorIdentity = "WBR"
+    typeLine = "Instant"
+    cantBeCountered = true
+    oracleText = "This spell can't be countered.\n" +
+        "Exile target nonland permanent. Its controller loses 3 life and you gain 3 life."
+
+    spell {
+        val permanent = target("nonland permanent", Targets.NonlandPermanent)
+        effect = Effects.LoseLife(3, EffectTarget.TargetController) then
+            Effects.GainLife(3, EffectTarget.Controller) then
+            Effects.Exile(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "194"
+        artist = "Cristi Balanescu"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d677980-b608-407e-9f17-790a81263f15.jpg?1743204760"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/OverwhelmingSurge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/OverwhelmingSurge.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Overwhelming Surge
+ * {2}{R}
+ * Instant
+ * Choose one or both —
+ * • Overwhelming Surge deals 3 damage to target creature.
+ * • Destroy target noncreature artifact.
+ *
+ * Modeled as three modes (damage only / destroy only / both), so "choose one or both"
+ * is expressed as choosing exactly one of the combined options — the same shape as
+ * Winterflame.
+ */
+private val NoncreatureArtifact = TargetFilter(
+    GameObjectFilter(cardPredicates = listOf(CardPredicate.IsArtifact, CardPredicate.IsNoncreature))
+)
+
+val OverwhelmingSurge = card("Overwhelming Surge") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one or both —\n" +
+        "• Overwhelming Surge deals 3 damage to target creature.\n" +
+        "• Destroy target noncreature artifact."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Overwhelming Surge deals 3 damage to target creature") {
+                val creature = target("creature", TargetCreature())
+                effect = Effects.DealDamage(3, creature)
+            }
+            mode("Destroy target noncreature artifact") {
+                val artifact = target("noncreature artifact", TargetPermanent(filter = NoncreatureArtifact))
+                effect = Effects.Destroy(artifact)
+            }
+            mode("Deal 3 damage to target creature and destroy target noncreature artifact") {
+                val creature = target("creature", TargetCreature())
+                val artifact = target("noncreature artifact", TargetPermanent(filter = NoncreatureArtifact))
+                effect = CompositeEffect(
+                    listOf(
+                        Effects.DealDamage(3, creature),
+                        Effects.Destroy(artifact),
+                    )
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "115"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd7af85f-354e-468a-990b-bd774e68240f.jpg?1743204422"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SpectralDenial.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SpectralDenial.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Spectral Denial
+ * {X}{U}
+ * Instant
+ * This spell costs {1} less to cast for each creature you control with power 4 or greater.
+ * Counter target spell unless its controller pays {X}.
+ *
+ * The cost reduction counts only creatures the caster controls with power 4 or greater
+ * (PermanentsOnBattlefieldMatching honors the controller/power predicates in the filter),
+ * and the counter resolves against the spell's chosen X via the same XValue pump used by
+ * Mindswipe.
+ */
+val SpectralDenial = card("Spectral Denial") {
+    manaCost = "{X}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {1} less to cast for each creature you control with power " +
+        "4 or greater.\nCounter target spell unless its controller pays {X}."
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterUnlessDynamicPays(DynamicAmount.XValue)
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.PermanentsOnBattlefieldMatching(
+                    GameObjectFilter.Creature.youControl().powerAtLeast(4)
+                )
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "Xabi Gaztelua"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee4e732a-1ffd-463d-92c2-26187659cfc3.jpg?1743204193"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormplainDetainment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormplainDetainment.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Stormplain Detainment
+ * {2}{W}
+ * Enchantment
+ * When this enchantment enters, exile target nonland permanent an opponent controls
+ * until this enchantment leaves the battlefield.
+ *
+ * Modeled with paired ETB / LTB triggers using LinkedExileComponent for the link,
+ * the same shape as Banishing Light.
+ */
+val StormplainDetainment = card("Stormplain Detainment") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, exile target nonland permanent an opponent " +
+        "controls until this enchantment leaves the battlefield."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target(
+            "nonland permanent an opponent controls",
+            TargetPermanent(filter = TargetFilter.NonlandPermanentOpponentControls)
+        )
+        effect = Effects.ExileUntilLeaves(permanent)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Livia Prima"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39f3aab5-7b54-4b55-8114-c6f9f79c255d.jpg?1743204069"
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) cards, all composed from existing SDK primitives — no engine/SDK changes required.

## Cards added
- **Stormplain Detainment** (`{2}{W}` Enchantment, #28) — ETB exile target nonland permanent an opponent controls until it leaves; the Banishing Light shape (`ExileUntilLeaves` + `ReturnLinkedExileUnderOwnersControl`).
- **Overwhelming Surge** (`{2}{R}` Instant, #115) — "choose one or both": 3 damage to target creature and/or destroy target noncreature artifact, modeled as the three-mode (A / B / both) pattern.
- **Spectral Denial** (`{X}{U}` Instant, #58) — counter target spell unless its controller pays `{X}` (`CounterUnlessDynamicPays(XValue)`), with a `SelfCast` `ModifySpellCost` reduction of `{1}` per controlled creature with power 4 or greater.
- **Inevitable Defeat** (`{1}{R}{W}{B}` Instant, #194) — can't be countered; exile target nonland permanent, its controller loses 3 life and you gain 3 life. Life resolves before the exile so `TargetController` still reads the permanent's controller.

## Tests
- `TdmControlBatchScenarioTest` covers all four (ETB exile, both modal paths, counter-on-can't-pay, exile + life swing). All passing.
- The exile-until-leaves return-on-LTB seam is already covered end-to-end by `BanishingLightTest`.

## Skipped
- **Static Snare** — feasible but intentionally left out to keep the batch focused; it's the same exile-until-leaves family already represented by Stormplain Detainment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)