### PR TITLE
Restore default Draft booster count to 3

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -552,7 +552,7 @@ class LobbyHandler(
         }
 
         // Set appropriate default booster count based on format
-        // Draft: default 4 packs, max 6
+        // Draft: default 3 packs, max 6
         // Commander Draft: default 3 packs, max 6
         // Sealed: default 6 boosters, max 16
         // Winston: default 6 boosters, max 16
@@ -565,7 +565,7 @@ class LobbyHandler(
         // default; otherwise we honor the explicit client value within the format's range.
         val boosterCount = when (format) {
             TournamentFormat.DRAFT -> {
-                if (message.boosterCount == 6) 4 else message.boosterCount.coerceIn(1, 6)
+                if (message.boosterCount == 6) 3 else message.boosterCount.coerceIn(1, 6)
             }
             TournamentFormat.COMMANDER_DRAFT -> {
                 if (message.boosterCount == 6) 3 else message.boosterCount.coerceIn(1, 6)
@@ -1849,7 +1849,7 @@ class LobbyHandler(
                     }
                 }
                 lobby.boosterCount = when (newFormat) {
-                    TournamentFormat.DRAFT -> 4
+                    TournamentFormat.DRAFT -> 3
                     TournamentFormat.COMMANDER_DRAFT -> 3
                     TournamentFormat.COMMANDER_SEALED -> 8
                     TournamentFormat.SEALED -> 6


### PR DESCRIPTION
## Summary
The default number of booster packs for **Draft** drifted to 4 in commit `14e9df019` ("Tighten tournament lobby format picker and add Chaos boosters"). Draft should default to **3** packs. This restores it.

## Changes
`game-server/.../handler/LobbyHandler.kt`:
- `handleCreateTournamentLobby`: when the client sends the sentinel `6`, DRAFT now resolves to **3** packs (was 4).
- `handleUpdateLobbySettings`: switching the lobby format to DRAFT now resets `boosterCount` to **3** (was 4).
- Updated the accompanying comment.

Commander Draft already defaulted to 3 and is unchanged. The web client sends the sentinel `6` and renders whatever count the server returns, so no frontend change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)