### PR TITLE
Add Static Snare to Tarkir: Dragonstorm

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StaticSnare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StaticSnare.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Static Snare
+ * {4}{W}
+ * Enchantment
+ *
+ * Flash
+ * This spell costs {1} less to cast for each attacking creature.
+ * When this enchantment enters, exile target artifact or creature an opponent controls
+ * until this enchantment leaves the battlefield.
+ *
+ * Same exile-until-leaves family as Banishing Light / Suspension Field: an ETB trigger
+ * exiles the target with a source link, and a LTB trigger returns it. The cost reduction
+ * reuses [CostReductionSource.PermanentsOnBattlefieldMatching] over `Creature.attacking()`
+ * to count every attacking creature on the battlefield (both players').
+ */
+val StaticSnare = card("Static Snare") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Flash\nThis spell costs {1} less to cast for each attacking creature.\nWhen this enchantment enters, exile target artifact or creature an opponent controls until this enchantment leaves the battlefield."
+
+    keywords(Keyword.FLASH)
+
+    // {1} less for each attacking creature (counts all attackers on the battlefield).
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.PermanentsOnBattlefieldMatching(
+                    filter = GameObjectFilter.Creature.attacking(),
+                ),
+            ),
+        )
+    }
+
+    // ETB: exile target artifact or creature an opponent controls until this leaves.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target(
+            "artifact or creature an opponent controls",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrArtifact.opponentControls()))
+        )
+        effect = Effects.ExileUntilLeaves(permanent)
+    }
+
+    // LTB: return the exiled card under its owner's control.
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "26"
+        artist = "Yohann Schepacz"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1ce50932-03a6-48bc-8aee-bc8defd896cf.jpg?1743204059"
+    }
+}


### PR DESCRIPTION
## Static Snare — `{4}{W}` Enchantment (TDM #26, uncommon)

> Flash
> This spell costs {1} less to cast for each attacking creature.
> When this enchantment enters, exile target artifact or creature an opponent controls until this enchantment leaves the battlefield.

Same exile-until-leaves family as Banishing Light / Suspension Field. Implemented entirely by **composing existing primitives — no new SDK types, effects, or executors**:

- `keyword(FLASH)`
- **Cost reduction** — `ModifySpellCost(SelfCast, ReduceGenericBy(PermanentsOnBattlefieldMatching(GameObjectFilter.Creature.attacking())))`. Reuses the existing `PermanentsOnBattlefieldMatching` source (counts attackers across all players); `CostCalculator` already evaluates it through the projection-aware predicate path.
- **ETB exile** — `EntersBattlefield` trigger → `Effects.ExileUntilLeaves(target)` targeting `CreatureOrArtifact.opponentControls()`.
- **LTB return** — `LeavesBattlefield` trigger → `Effects.ReturnLinkedExileUnderOwnersControl()` (source-linked exile).

### Verification
- All fields checked against Scryfall (name, `{4}{W}`, Enchantment, oracle text, Flash, uncommon, #26, Yohann Schepacz); image URL returns HTTP 200.
- `just check-card-printing "Static Snare"` → canonical correctly placed in TDM (its only printing).
- `just build` green (compiles + full test suite).
- No new engine mechanics, so no new scenario test required (mirrors Banishing Light); no TDM backlog file to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)