### PR TITLE
Always show the action menu for multi-mode cards, even when a mode is unaffordable

### DIFF
--- a/web-client/src/components/game/board/shared.test.ts
+++ b/web-client/src/components/game/board/shared.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowCastModal } from './shared'
+import type { LegalActionInfo } from '../../../types'
+import { entityId } from '../../../types'
+
+// --- Fixture builders -------------------------------------------------------
+// Minimal LegalActionInfo objects — `shouldShowCastModal` only reads `actionType`
+// and `action.type`, so we keep these as small as the type allows.
+
+const PLAYER = entityId('p1')
+const CARD = entityId('c1')
+
+function castSpell(opts: { affordable?: boolean } = {}): LegalActionInfo {
+  return {
+    actionType: 'CastSpell',
+    description: 'Cast',
+    action: { type: 'CastSpell', playerId: PLAYER, cardId: CARD },
+    ...(opts.affordable !== undefined ? { isAffordable: opts.affordable } : {}),
+  }
+}
+
+function cycle(opts: { affordable?: boolean } = {}): LegalActionInfo {
+  return {
+    actionType: 'CycleCard',
+    description: 'Cycle',
+    action: { type: 'CycleCard', playerId: PLAYER, cardId: CARD },
+    ...(opts.affordable !== undefined ? { isAffordable: opts.affordable } : {}),
+  }
+}
+
+function typecycle(): LegalActionInfo {
+  return {
+    actionType: 'TypecycleCard',
+    description: 'Plainscycling',
+    action: { type: 'TypecycleCard', playerId: PLAYER, cardId: CARD },
+  }
+}
+
+function plot(): LegalActionInfo {
+  return {
+    actionType: 'PlotCard',
+    description: 'Plot',
+    action: { type: 'PlotCard', playerId: PLAYER, cardId: CARD },
+  }
+}
+
+function morph(): LegalActionInfo {
+  return {
+    actionType: 'CastFaceDown',
+    description: 'Cast Face-Down',
+    action: { type: 'CastSpell', playerId: PLAYER, cardId: CARD, castFaceDown: true },
+  }
+}
+
+function playLand(): LegalActionInfo {
+  return {
+    actionType: 'PlayLand',
+    description: 'Play land',
+    action: { type: 'PlayLand', playerId: PLAYER, cardId: CARD },
+  }
+}
+
+describe('shouldShowCastModal', () => {
+  it('does not open the menu when there are no legal actions', () => {
+    expect(shouldShowCastModal([])).toBe(false)
+  })
+
+  it('does not open the menu for a single plain cast', () => {
+    expect(shouldShowCastModal([castSpell()])).toBe(false)
+  })
+
+  it('opens the menu when both cast and cycle are affordable (two actions)', () => {
+    expect(shouldShowCastModal([castSpell(), cycle()])).toBe(true)
+  })
+
+  // The core fix: a cycling card the player can only afford to *cycle*. The server omits
+  // the unaffordable normal cast, so the only legal action is CycleCard — but dragging it
+  // must still open the menu (with a grayed-out "Cast") so the player can choose or cancel
+  // rather than silently cycling a card they meant to hard-cast.
+  it('opens the menu for a card with only the cycle action affordable', () => {
+    expect(shouldShowCastModal([cycle({ affordable: true })])).toBe(true)
+  })
+
+  it('opens the menu even when the cycle action itself is unaffordable', () => {
+    expect(shouldShowCastModal([cycle({ affordable: false })])).toBe(true)
+  })
+
+  it('opens the menu for a card with only typecycling', () => {
+    expect(shouldShowCastModal([typecycle()])).toBe(true)
+  })
+
+  it('opens the menu for a card with only a plot action', () => {
+    expect(shouldShowCastModal([plot()])).toBe(true)
+  })
+
+  it('opens the menu for a cycling land that already played a land (cycle only)', () => {
+    expect(shouldShowCastModal([cycle()])).toBe(true)
+  })
+
+  it('opens the menu for a cycling land with both play-land and cycle', () => {
+    expect(shouldShowCastModal([playLand(), cycle()])).toBe(true)
+  })
+
+  it('does not open the menu for a plain land with only a play-land action', () => {
+    expect(shouldShowCastModal([playLand()])).toBe(false)
+  })
+
+  it('opens the menu for multiple casting variants (morph + normal cast)', () => {
+    expect(shouldShowCastModal([castSpell(), morph()])).toBe(true)
+  })
+})

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -198,6 +198,38 @@ export function hasMultipleCastingOptions(cardLegalActions: LegalActionInfo[]): 
 }
 
 /**
+ * Decide whether dragging a card to play should open the action menu (so the player
+ * deliberately picks a casting mode) rather than immediately firing the single available
+ * action.
+ *
+ * The menu must appear whenever a card has more than one way to be played — *even when some
+ * of those ways are currently unaffordable*. The server omits an unaffordable normal cast
+ * from `legalActions`, so a card you can only afford to cycle arrives with just its
+ * `CycleCard` action. But a non-land card that can be cycled/typecycled/plotted always carries
+ * an implicit, grayed-out "Cast" option in the menu (see `ActionMenu.buildActionOptions`), and
+ * a land that already played a land this turn carries a grayed-out "Play land". Treat both as
+ * multi-option so we never silently cycle a card the player might have meant to hard-cast (or
+ * cancel). (Whether the grayed-out button reads "Cast" or "Play land" is decided later, by
+ * `ActionMenu.buildActionOptions`, from the card's types — it doesn't affect this decision.)
+ *
+ * @param cardLegalActions Legal actions for this specific card from the server
+ */
+export function shouldShowCastModal(cardLegalActions: LegalActionInfo[]): boolean {
+  if (cardLegalActions.length === 0) return false
+  // More than one legal action, or multiple casting variants (morph + normal cast, etc.).
+  if (cardLegalActions.length > 1) return true
+  if (hasMultipleCastingOptions(cardLegalActions)) return true
+  // A lone alternative play mode still implies a second (possibly-unaffordable) option the
+  // menu surfaces as a grayed-out button: "Play land" for lands, "Cast" for everything else.
+  return cardLegalActions.some(
+    (a) =>
+      a.action.type === 'CycleCard' ||
+      a.action.type === 'TypecycleCard' ||
+      a.action.type === 'PlotCard'
+  )
+}
+
+/**
  * Handle image load error by falling back to Scryfall API.
  */
 export function handleImageError(

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -10,7 +10,7 @@ import { ManaCost } from '@/components/ui/ManaSymbols.tsx'
 import { HoverCardPreview } from '@/components/ui/HoverCardPreview.tsx'
 import {
   useResponsiveContext,
-  hasMultipleCastingOptions,
+  shouldShowCastModal as computeShouldShowCastModal,
   getPTColor,
   getCounterStatModifier,
   hasStatCounters,
@@ -402,12 +402,11 @@ function GameCardImpl({
            (action.type === 'PlotCard' && action.cardId === card.id)
   }), [legalActions, card.id])
   const playableAction = playableActions[0]
-  // Show modal if multiple legal actions OR if card has multiple potential options (e.g., morph + normal cast)
-  const hasMultiplePotentialOptions = hasMultipleCastingOptions(playableActions)
-  // Also show modal for cycling lands where play land is unavailable (so player sees grayed-out "Play land")
-  const isCyclingLandWithoutPlayLand = card.cardTypes.includes('LAND') &&
-    playableActions.length === 1 && (playableActions[0]?.action.type === 'CycleCard' || playableActions[0]?.action.type === 'TypecycleCard')
-  const shouldShowCastModal = playableActions.length > 1 || (hasMultiplePotentialOptions && playableActions.length > 0) || isCyclingLandWithoutPlayLand
+  // Open the action menu when the card has more than one way to be played — including cards
+  // whose only affordable option is an alternative cast (cycling/typecycling/plot), so the
+  // player still sees the grayed-out "Cast"/"Play land" and can choose deliberately or cancel
+  // instead of silently auto-firing the lone affordable action.
+  const shouldShowCastModal = computeShouldShowCastModal(playableActions)
   const canDragToPlay = (inHand || enableDragToCast) && playableAction && !isInCombatMode && !isInTargetingMode
 
   // Determine mana cost display for cards the player can cast directly from a face-up zone


### PR DESCRIPTION
When a card has more than one way to be played, dragging it to play could silently fire the single *affordable* action instead of asking the player how to play it — auto-cycling or auto-casting one face when the player might have meant the other, with no chance to cancel. This PR makes the action menu always appear for these cards, with unaffordable modes shown **grayed out**.

Two distinct cases, two fixes:

## 1. Cycling (and typecycling / plot) — client-only

Repro: a card that costs `{2}` to cycle and `{5}` to cast normally, dragged with only 2 mana, would **auto-cycle**.

The server omits an unaffordable normal cast from `legalActions` (`CastSpellEnumerator` skips a spell it can't pay for by any path), so drag-to-play saw only the `CycleCard` action and treated it as unambiguous. The `ActionMenu` *already* synthesizes a grayed-out "Cast" button for non-land cards with cycling/plot — the only gap was that the menu never **opened** on drag.

Fix (no server change — preserves the "dumb terminal" contract; the grayed cast carries `action: null` and can't be submitted): extract the drag-to-play "open the menu?" decision into a pure `shouldShowCastModal()` helper in `game/board/shared.ts` and treat a lone `CycleCard` / `TypecycleCard` / `PlotCard` action as multi-option. This also subsumes the previous cycling-land special case.

## 2. Adventure / Omen / modal-DFC — server-side

Repro: an Adventure card (e.g. Brightcap Badger — creature `{3}{G}`, adventure `{2}{G}`) with mana for only one face would surface a single `CastSpell` action, and drag-to-play would fire it immediately.

Unlike cycling, the client **can't** synthesize the missing face — it doesn't know its cost/targets/`faceIndex`. So this one is a server fix in `CastSpellEnumerator`: when one face is affordable, also emit the unaffordable sibling face with `affordable = false` (a grayed-out placeholder). The client already opens the menu and renders two cast buttons when two `CastSpell` actions are present, so no further client change is needed.

- `enumerateSecondaryFace` takes `primaryFaceAffordable` and returns whether it emitted an affordable cast; emits a grayed placeholder for the secondary face when it's unaffordable but the primary is affordable.
- The primary-face skip point emits a grayed placeholder when the secondary face is affordable.
- Neither face affordable → nothing emitted (card stays unplayable), matching the single-faced-spell contract. AI is unaffected — `GameSimulator` already filters `affordable` actions.
- Scoped to the secondary-face path (ADVENTURE/OMEN/MODAL_DFC). SPLIT/Room cards share the gap (see `RoomCastTest`) but are a distinct mechanic — left as a follow-up.

## Tests

- `web-client` `game/board/shared.test.ts` (vitest, 11 cases): the reported cycling case (only an affordable cycle → menu opens), plus cast+cycle, unaffordable-cycle, typecycling, plot, land, and morph variants. Full web-client suite 111/111; `npm run typecheck` clean.
- `rules-engine` `AdventureFaceEnumerationTest` (Kotest, 4 cases): both faces affordable, only-secondary affordable (grayed primary), only-primary affordable (grayed secondary), neither affordable (nothing emitted). Full `:rules-engine:test` green.

## Screenshots

No new UI is introduced — the action menu and its grayed-out cast buttons already exist (`ActionMenu.buildActionOptions`). Both changes only affect *when* the existing menu opens / which existing buttons it shows, so a screenshot would depict an already-shipped menu state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)