### PR TITLE
Add "different kinds of counters" condition + Hundred-Battle Veteran

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1580,6 +1580,13 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
 - `OpponentControlsMoreCreatures` — an opponent outpaces you.
 - `OpponentControlsMoreLands` — an opponent has more lands.
 - `OpponentControlsLandType(type)` — opponent controls land of a type.
+- `DifferentCounterKindsAtLeast(count, filter = Creature)` — true when `count` or more *different
+  kinds* of counters are among permanents you control matching `filter` (default: creatures). A
+  +1/+1 and a finality counter is two kinds; the same kind on several permanents counts once.
+  Board-derived only, so it gates a `ConditionalStaticAbility` (evaluates identically in resolution
+  and projection). Desugars to `Compare(AggregateBattlefield(You, filter, DISTINCT_COUNTER_TYPES),
+  GTE, count)`. Used by Hundred-Battle Veteran ("three or more different kinds of counters among
+  creatures you control").
 - `TargetControlsCreature(target)` — target player has a creature.
 - `TargetControlsLand(target)` — target player has a land.
 - `TargetMatchesFilter(filter, targetIndex = 0)` — the context target matches a `GameObjectFilter`.
@@ -1635,7 +1642,11 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
 
 - `WasCast` — source was cast (not put onto the stack).
 - `WasCastFromHand` — cast specifically from hand.
-- `WasCastFromZone(zone)` — cast from a specific zone.
+- `WasCastFromZone(zone)` — cast from a specific zone. For resolving spells it reads the spell's
+  cast-origin; for a permanent already on the battlefield it falls back to the cast-origin marker
+  stamped as it entered (`HAND` → `CastFromHandComponent`, `GRAVEYARD` → `CastFromGraveyardComponent`),
+  so it can gate an entering permanent's own replacement effect (Hundred-Battle Veteran: "enters with
+  a finality counter if cast from your graveyard").
 - `WasKicked` — cast with kicker / multikicker / offspring (i.e. an `OptionalAdditionalCost` with `branchesEffect = true` whose extra cost was paid). FlashKicker payments are intentionally invisible to this condition.
 - `BlightWasPaid(amount)` — the Blight X additional cost was paid.
 
@@ -1774,7 +1785,12 @@ Numbers computed at resolution time.
 
 ### Battlefield aggregation
 
-- `AggregateBattlefield(player, filter)` — count matching permanents.
+- `AggregateBattlefield(player, filter, aggregation?, property?)` — aggregate over matching
+  permanents. `aggregation` defaults to `COUNT`; other modes: `MAX`/`MIN`/`SUM` over a
+  `property` (`POWER`/`TOUGHNESS`/`MANA_VALUE`), and the distinct-set counters
+  `DISTINCT_TYPES`, `DISTINCT_COLORS`, `DISTINCT_NAMES`, `DISTINCT_BASIC_LAND_SUBTYPES`
+  (Domain), and `DISTINCT_COUNTER_TYPES` (the number of different kinds of counters present
+  across the group — same kind on several permanents counts once).
 - `AggregateZone(player, zone, filter?, aggregation?)` — count cards in a zone.
 - `CountPermanentsOfType(player, subtype)` — count by creature type.
 - `CountCreaturesYouControl` — shorthand for "your creatures".

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HundredBattleVeteranScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/HundredBattleVeteranScenarioTest.kt
@@ -1,0 +1,193 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hundred-Battle Veteran ({3}{B}, 4/2 Zombie Warrior).
+ *
+ * Exercises the new "three or more different kinds of counters among creatures you control"
+ * static condition (DISTINCT_COUNTER_TYPES aggregation) gating a +2/+4 self-buff, plus the
+ * "cast from graveyard → enters with a finality counter" recursion.
+ */
+class HundredBattleVeteranScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hundred-Battle Veteran — counter-kinds buff") {
+
+            test("gets +2/+4 once three different kinds of counters are among creatures you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hundred-Battle Veteran")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val veteran = game.findPermanent("Hundred-Battle Veteran")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                // Two distinct kinds of counters → buff is off, base 4/2.
+                game.state = game.state.updateEntity(bears) {
+                    it.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+                }
+                game.state = game.state.updateEntity(giant) {
+                    it.with(CountersComponent(mapOf(CounterType.FLYING to 1)))
+                }
+                withClue("Two kinds of counters → no buff, base 4/2") {
+                    game.state.projectedState.getPower(veteran) shouldBe 4
+                    game.state.projectedState.getToughness(veteran) shouldBe 2
+                }
+
+                // A third distinct kind crosses the threshold → +2/+4.
+                game.state = game.state.updateEntity(veteran) {
+                    it.with(CountersComponent(mapOf(CounterType.FIRST_STRIKE to 1)))
+                }
+                withClue("Three kinds of counters → +2/+4, now 6/6") {
+                    game.state.projectedState.getPower(veteran) shouldBe 6
+                    game.state.projectedState.getToughness(veteran) shouldBe 6
+                }
+            }
+
+            test("the same kind on several creatures counts only once") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hundred-Battle Veteran")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val veteran = game.findPermanent("Hundred-Battle Veteran")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                // Two creatures share +1/+1 (one kind) and a third has flying (second kind).
+                game.state = game.state.updateEntity(bears) {
+                    it.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+                }
+                game.state = game.state.updateEntity(giant) {
+                    it.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+                }
+                game.state = game.state.updateEntity(veteran) {
+                    it.with(CountersComponent(mapOf(CounterType.FLYING to 1)))
+                }
+                withClue("Duplicate +1/+1 counts once → only two kinds → no buff") {
+                    game.state.projectedState.getPower(veteran) shouldBe 4
+                    game.state.projectedState.getToughness(veteran) shouldBe 2
+                }
+            }
+
+            test("counters on the Veteran itself count toward the total") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hundred-Battle Veteran")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val veteran = game.findPermanent("Hundred-Battle Veteran")!!
+
+                // All three kinds on the Veteran — it is itself a creature you control.
+                game.state = game.state.updateEntity(veteran) {
+                    it.with(
+                        CountersComponent(
+                            mapOf(
+                                CounterType.PLUS_ONE_PLUS_ONE to 1,
+                                CounterType.FLYING to 1,
+                                CounterType.FIRST_STRIKE to 1
+                            )
+                        )
+                    )
+                }
+                withClue("Three kinds on itself → +2/+4. Base 4/2 + (+1/+1 counter) + (+2/+4) = 7/7") {
+                    // 4/2 base, +1/+1 from the +1/+1 counter (layer 7c), +2/+4 from the static buff.
+                    game.state.projectedState.getPower(veteran) shouldBe 7
+                    game.state.projectedState.getToughness(veteran) shouldBe 7
+                }
+            }
+
+            test("counters on creatures you don't control are ignored") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hundred-Battle Veteran")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val veteran = game.findPermanent("Hundred-Battle Veteran")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                // Three distinct kinds, but spread across the opponent's creatures.
+                game.state = game.state.updateEntity(bears) {
+                    it.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1, CounterType.FLYING to 1)))
+                }
+                game.state = game.state.updateEntity(giant) {
+                    it.with(CountersComponent(mapOf(CounterType.FIRST_STRIKE to 1)))
+                }
+                withClue("Opponent's counters don't count → no buff, base 4/2") {
+                    game.state.projectedState.getPower(veteran) shouldBe 4
+                    game.state.projectedState.getToughness(veteran) shouldBe 2
+                }
+            }
+        }
+
+        context("Hundred-Battle Veteran — graveyard recursion") {
+
+            test("cast from the graveyard, it enters with a finality counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Hundred-Battle Veteran")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellFromGraveyard(1, "Hundred-Battle Veteran")
+                withClue("Casting Hundred-Battle Veteran from the graveyard should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val veteran = game.findPermanent("Hundred-Battle Veteran")!!
+                val counters = game.state.getEntity(veteran)?.get<CountersComponent>()
+                withClue("Cast from graveyard → enters with one finality counter") {
+                    (counters?.getCount(CounterType.FINALITY) ?: 0) shouldBe 1
+                }
+            }
+
+            test("cast from hand, it does NOT enter with a finality counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hundred-Battle Veteran")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Hundred-Battle Veteran")
+                withClue("Casting Hundred-Battle Veteran from hand should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val veteran = game.findPermanent("Hundred-Battle Veteran")!!
+                val counters = game.state.getEntity(veteran)?.get<CountersComponent>()
+                withClue("Cast from hand → no finality counter") {
+                    (counters?.getCount(CounterType.FINALITY) ?: 0) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -29,6 +29,7 @@ import com.wingedsheep.sdk.scripting.conditions.PlayerAttackedWithCreaturesThisT
 import com.wingedsheep.sdk.scripting.conditions.PlayerCastSpellsThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PlayerHasCitysBlessing
 import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.Aggregation
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
 import com.wingedsheep.sdk.scripting.values.EntityReference
@@ -175,6 +176,23 @@ object Conditions {
     fun ControlCreaturesAtLeast(count: Int): ConditionInterface =
         Compare(
             DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(count)
+        )
+
+    /**
+     * If [count] or more different kinds of counters are among permanents you control matching
+     * [filter] (default: creatures). Counts distinct counter kinds across the whole group — a
+     * +1/+1 and a finality counter on two creatures is two kinds; the same kind on several
+     * permanents counts once. Used for Hundred-Battle Veteran ("three or more different kinds of
+     * counters among creatures you control").
+     */
+    fun DifferentCounterKindsAtLeast(
+        count: Int,
+        filter: GameObjectFilter = GameObjectFilter.Creature
+    ): ConditionInterface =
+        Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, filter, Aggregation.DISTINCT_COUNTER_TYPES),
             ComparisonOperator.GTE,
             DynamicAmount.Fixed(count)
         )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/CardNumericProperty.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/CardNumericProperty.kt
@@ -32,5 +32,13 @@ enum class Aggregation {
      * Bounded by 5; nonbasic lands with basic subtypes (e.g., Tundra → Plains+Island)
      * contribute each of their basic subtypes.
      */
-    DISTINCT_BASIC_LAND_SUBTYPES
+    DISTINCT_BASIC_LAND_SUBTYPES,
+    /**
+     * Count distinct kinds of counters across all matched entities — i.e. the number of
+     * different [com.wingedsheep.sdk.core.CounterType]s present on at least one matched
+     * permanent. A permanent with both +1/+1 and finality counters contributes two kinds;
+     * the same kind on several permanents still counts once. Used for "different kinds of
+     * counters among <group>" (e.g. Hundred-Battle Veteran).
+     */
+    DISTINCT_COUNTER_TYPES
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -587,6 +587,11 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                     if (excludeSelf) append("other ")
                     append(pluralize(filter.description))
                 }
+                Aggregation.DISTINCT_COUNTER_TYPES -> {
+                    append("the number of different kinds of counters among ")
+                    if (excludeSelf) append("other ")
+                    append(pluralize(filter.description))
+                }
             }
             append(" ")
             when (player) {
@@ -667,6 +672,10 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                 }
                 Aggregation.DISTINCT_BASIC_LAND_SUBTYPES -> {
                     append("the number of basic land types among ")
+                    append(pluralize(filter.description))
+                }
+                Aggregation.DISTINCT_COUNTER_TYPES -> {
+                    append("the number of different kinds of counters among ")
                     append(pluralize(filter.description))
                 }
             }

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/DifferentCounterKindsConditionTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/DifferentCounterKindsConditionTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Unit tests for the "different kinds of counters among a group" DSL surface —
+ * the DISTINCT_COUNTER_TYPES aggregation and Conditions.DifferentCounterKindsAtLeast(n).
+ */
+class DifferentCounterKindsConditionTest : DescribeSpec({
+
+    describe("AggregateBattlefield with DISTINCT_COUNTER_TYPES") {
+        it("renders an Oracle-style description") {
+            DynamicAmount.AggregateBattlefield(
+                Player.You,
+                GameObjectFilter.Creature,
+                Aggregation.DISTINCT_COUNTER_TYPES
+            ).description shouldBe
+                "the number of different kinds of counters among creatures you control"
+        }
+    }
+
+    describe("Conditions.DifferentCounterKindsAtLeast") {
+        it("defaults to creatures you control and compares against a fixed threshold with GTE") {
+            val condition = Conditions.DifferentCounterKindsAtLeast(3)
+            condition.shouldBeInstanceOf<Compare>()
+            condition.left shouldBe DynamicAmount.AggregateBattlefield(
+                Player.You,
+                GameObjectFilter.Creature,
+                Aggregation.DISTINCT_COUNTER_TYPES
+            )
+            condition.operator shouldBe ComparisonOperator.GTE
+            condition.right shouldBe DynamicAmount.Fixed(3)
+        }
+
+        it("is parameterized over the group filter") {
+            val condition = Conditions.DifferentCounterKindsAtLeast(2, GameObjectFilter.Any)
+            condition.shouldBeInstanceOf<Compare>()
+            val left = condition.left
+            left.shouldBeInstanceOf<DynamicAmount.AggregateBattlefield>()
+            left.filter shouldBe GameObjectFilter.Any
+            left.aggregation shouldBe Aggregation.DISTINCT_COUNTER_TYPES
+        }
+    }
+})

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HundredBattleVeteran.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HundredBattleVeteran.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Hundred-Battle Veteran
+ * {3}{B}
+ * Creature — Zombie Warrior
+ * 4/2
+ * As long as there are three or more different kinds of counters among creatures you control,
+ * this creature gets +2/+4.
+ * You may cast this card from your graveyard. If you do, it enters with a finality counter on it.
+ * (If a creature with a finality counter on it would die, exile it instead.)
+ */
+val HundredBattleVeteran = card("Hundred-Battle Veteran") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Warrior"
+    power = 4
+    toughness = 2
+    oracleText = "As long as there are three or more different kinds of counters among creatures " +
+        "you control, this creature gets +2/+4.\n" +
+        "You may cast this card from your graveyard. If you do, it enters with a finality counter on it. " +
+        "(If a creature with a finality counter on it would die, exile it instead.)"
+
+    // +2/+4 while three or more different kinds of counters are among creatures you control.
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 4, filter = GroupFilter.source()),
+            condition = Conditions.DifferentCounterKindsAtLeast(3)
+        )
+    }
+
+    // You may cast this card from your graveyard...
+    staticAbility {
+        ability = MayCastSelfFromZones(zones = listOf(Zone.GRAVEYARD))
+    }
+
+    // ...If you do, it enters with a finality counter on it.
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.FINALITY),
+            count = 1,
+            selfOnly = true,
+            condition = Conditions.WasCastFromGraveyard
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "82"
+        artist = "Wayne Wu"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e53adf93-2db5-4087-a2dc-c8f53401d700.jpg?1743204289"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -543,12 +543,16 @@ class ConditionEvaluator(
     private fun evaluateWasCastFromZone(state: GameState, condition: WasCastFromZone, context: EffectContext): Boolean {
         // For spells resolving, check context.castFromZone (set from SpellOnStackComponent)
         if (context.castFromZone == condition.zone) return true
-        // For permanents (triggered abilities), fall back to battlefield components
+        // For permanents (e.g. an entering creature's own "enters with a counter if cast from
+        // graveyard" replacement, or a triggered ability), fall back to the cast-origin marker
+        // component stamped on the permanent as it resolved onto the battlefield.
         val sourceId = context.sourceId ?: return false
-        if (condition.zone == Zone.HAND) {
-            return state.getEntity(sourceId)?.has<CastFromHandComponent>() == true
+        val entity = state.getEntity(sourceId) ?: return false
+        return when (condition.zone) {
+            Zone.HAND -> entity.has<CastFromHandComponent>()
+            Zone.GRAVEYARD -> entity.has<CastFromGraveyardComponent>()
+            else -> false
         }
-        return false
     }
 
     private fun evaluateWasKicked(state: GameState, context: EffectContext): Boolean {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -502,6 +502,12 @@ class DynamicAmountEvaluator(
                         ?: emptySet()
                 }.intersect(BASIC_LAND_SUBTYPES)
             }.size
+            // Counters are physically stored on the permanent (base state, not layered), so read
+            // CountersComponent directly. The map only holds kinds with a positive count
+            // (CountersComponent.withRemoved drops the key at zero), so every key is a present kind.
+            Aggregation.DISTINCT_COUNTER_TYPES -> matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
+                state.getEntity(entityId)?.get<CountersComponent>()?.counters?.keys ?: emptySet()
+            }.size
         }
     }
 
@@ -564,6 +570,11 @@ class DynamicAmountEvaluator(
                     val subtypes: Set<String> = state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.subtypes?.map { it.value }?.toSet()
                         ?: emptySet()
                     subtypes.intersect(BASIC_LAND_SUBTYPES)
+                }.size
+            }
+            Aggregation.DISTINCT_COUNTER_TYPES -> {
+                matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
+                    state.getEntity(entityId)?.get<CountersComponent>()?.counters?.keys ?: emptySet()
                 }.size
             }
         }


### PR DESCRIPTION
## Summary

Implements **Hundred-Battle Veteran** (TDM) and the new static condition it needs: *"three or more different kinds of counters among creatures you control."*

### New SDK vocabulary (composition-first)
- **`Aggregation.DISTINCT_COUNTER_TYPES`** — a new battlefield/zone aggregation: the number of *different kinds* of counters present across a filtered group of permanents. Same kind on several permanents counts once; counters live in base state (`CountersComponent`, positive-count keys only), so the evaluator reads them directly rather than through projection.
- **`Conditions.DifferentCounterKindsAtLeast(count, filter = Creature)`** — parameterized over the group filter and threshold; desugars to `Compare(AggregateBattlefield(You, filter, DISTINCT_COUNTER_TYPES), GTE, count)`. Board-derived only, so it gates a `ConditionalStaticAbility` and evaluates identically at resolution and during projection. No bespoke condition type.

### Bug fix surfaced by the card
- **`WasCastFromZone` now works for permanents cast from a graveyard.** It already fell back to `CastFromHandComponent` for `HAND`; `GRAVEYARD` returned false for permanents. It now also falls back to `CastFromGraveyardComponent`, letting an entering permanent's own `EntersWithCounters` replacement be gated on *"if cast from your graveyard."*

### The card
`+2/+4` while the condition holds (`ConditionalStaticAbility(ModifyStats(2,4,source), …)`), plus *"You may cast this from your graveyard; if you do, it enters with a finality counter"* via `MayCastSelfFromZones(GRAVEYARD)` + a graveyard-gated `EntersWithCounters(finality)`.

## Tests
- **SDK** (`DifferentCounterKindsConditionTest`) — DSL round-trip / description / filter parameterization.
- **Scenario** (`HundredBattleVeteranScenarioTest`) — threshold (2 kinds → no buff, 3 → +2/+4), duplicate kind counts once, the Veteran's own counters count, opponent's counters excluded, and both graveyard-cast (finality counter added) and hand-cast (no counter) paths.

All 9 new tests pass; full project builds. Docs updated in `card-sdk-language-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)