### PR TITLE
Temur Battlecrier: conditional cost-gating + filtered controlled-permanent count

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1323,17 +1323,26 @@ staticAbility {
   "White spells you cast cost {W} more"), `IncreaseGenericPerOtherSpellThisTurn(amountPerSpell)`,
   `IncreaseLife(amount)`.
   Reduction `source: CostReductionSource` covers fixed amounts, counts of permanents/cards in
-  zones, target/condition gates, and a few mechanic-specific shapes — see
+  zones, target gates, and a few mechanic-specific shapes — e.g. `Fixed`, `CreaturesYouControl`,
+  `ArtifactsYouControl`, `PermanentsYouControlMatching(filter)` (the filtered "you control" count —
+  Temur Battlecrier's "creature you control with power 4 or greater" via
+  `GameObjectFilter.Creature.powerAtLeast(4)`), `PermanentsOnBattlefieldMatching(filter)` (the
+  same, all players), `CardsInGraveyardMatchingFilter`, `FixedIfAnyTargetMatches`, … — see
   `CostStaticAbilities.kt` for the full list.
-- `gating: CostGating` — restricts how often the modifier fires:
+- `gating: CostGating` — gates whether/how often the modifier fires:
   - `None` (default) — applies to every matching cast.
   - `NthOfTypePerTurn(n)` — only when this is the Nth matching spell each turn (1-indexed; counts the
     spell currently being cast). Use `n = 1` for "the first ... each turn" (Eluge); use
     `NthOfTypePerTurn(2)` with `target = YouCast(GameObjectFilter.Any)` for Uthros Psionicist's "the
-    second spell you cast each turn costs {2} less".
-
-`NthOfTypePerTurn` requires a filter-bearing target (`YouCast` / `AnyCaster`) — it needs a notion
-of "type" to count.
+    second spell you cast each turn costs {2} less". Requires a filter-bearing target
+    (`YouCast` / `AnyCaster`) — it needs a notion of "type" to count.
+  - `OnlyIf(condition)` — applies only while `condition` holds at cast time (evaluated with the
+    caster as controller). Gates the *whole* modification, so it composes with the dynamic per-unit
+    reductions that a fixed-amount source can't express: Temur Battlecrier's "During your turn, …"
+    is `OnlyIf(Conditions.IsYourTurn)` over `ReduceGenericBy(PermanentsYouControlMatching(…))`. For a
+    fixed conditional reduction pair it with `ReduceGeneric` (Mental Modulation:
+    `ReduceGeneric(1)` gated by `OnlyIf(IsYourTurn)`; Lashwhip Predator / Arwen's Gift gate on a
+    `Compare(...)`).
 
 **Global denial statics** (no `filter`/`duration` block — they're singleton-style)
 
@@ -1727,7 +1736,10 @@ default to "you" so card authors don't need to pass it explicitly.
 - `Not(c)` — negate.
 - `Compare(v1, op, v2)` — numeric comparison between `DynamicAmount`s.
 - `Exists(player, zone, filter)` — at least one matching object exists.
-- `FixedIfCondition(...)` — bake a condition into a static-ability gate.
+
+To gate a spell-cost reduction on a condition, use `CostGating.OnlyIf(condition)` on the
+`ModifySpellCost` ability (see **Spell cost statics**) rather than baking the condition into the
+reduction amount.
 
 ### Static-ability vs resolution-time evaluation
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -29,13 +29,12 @@ data class ModifySpellCost(
     override val description: String = buildDescription()
 
     private fun buildDescription(): String {
-        val gated = gating != CostGating.None
-        val gate = when (gating) {
-            is CostGating.NthOfTypePerTurn -> "The ${ordinal(gating.n)} "
-            CostGating.None -> ""
-        }
+        // Only the Nth-of-type gate rephrases the subject as a single spell ("The second spell ...").
+        // A conditional (OnlyIf) gate leaves the subject plural and tacks the condition on at the end.
+        val nthGating = gating as? CostGating.NthOfTypePerTurn
+        val gate = if (nthGating != null) "The ${ordinal(nthGating.n)} " else ""
         // A gated description ("The Nth ...") refers to a single spell, so phrase it in the singular.
-        val noun = if (gated) "spell" else "spells"
+        val noun = if (nthGating != null) "spell" else "spells"
         val subject = when (target) {
             SpellCostTarget.SelfCast -> "This spell"
             is SpellCostTarget.YouCast -> "${filterAdjective(target.filter)}$noun you cast"
@@ -57,14 +56,15 @@ data class ModifySpellCost(
                 "cost {${modification.amountPerSpell}} more to cast for each other spell that player has cast this turn"
             is CostModification.IncreaseLife -> "cost an additional ${modification.amount} life to cast"
         }
-        val perTurn = when (gating) {
-            is CostGating.NthOfTypePerTurn -> " each turn"
-            CostGating.None -> ""
-        }
+        val perTurn = if (nthGating != null) " each turn" else ""
         // The gated subject is singular, so make the verb agree ("cost" -> "costs").
-        val agreedVerb = if (gated) verb.replaceFirst("cost ", "costs ") else verb
+        val agreedVerb = if (nthGating != null) verb.replaceFirst("cost ", "costs ") else verb
         val prefix = if (gate.isNotEmpty()) gate + subject.replaceFirstChar { it.lowercase() } else subject
-        return "$prefix $agreedVerb$perTurn"
+        val conditionSuffix = when (val g = gating) {
+            is CostGating.OnlyIf -> " ${g.condition.description}"
+            else -> ""
+        }
+        return "$prefix $agreedVerb$perTurn$conditionSuffix"
     }
 
     // A filter that narrows nothing (e.g. GameObjectFilter.Any) describes itself as "card", which
@@ -263,6 +263,22 @@ sealed interface CostGating {
     @SerialName("NthOfTypePerTurn")
     @Serializable
     data class NthOfTypePerTurn(val n: Int) : CostGating
+
+    /**
+     * Modifier applies only while [condition] holds at cast time. The condition is evaluated with
+     * the casting player as `controllerId`, so player-scoped conditions ("during your turn",
+     * "if you've cast another spell this turn", "if your opponents control three or more creatures")
+     * all work out of the box.
+     *
+     * Gates the *entire* modification, so it composes with any [CostModification] — including the
+     * dynamic per-unit reductions ([CostModification.ReduceGenericBy]) that a fixed-amount source
+     * cannot express. This is the home for "During your turn, ..." cost effects such as
+     * Temur Battlecrier; for a fixed conditional reduction pair it with [CostModification.ReduceGeneric]
+     * (e.g. Mental Modulation: `ReduceGeneric(1)` gated by `OnlyIf(IsYourTurn)`).
+     */
+    @SerialName("OnlyIf")
+    @Serializable
+    data class OnlyIf(val condition: Condition) : CostGating
 }
 
 /**
@@ -446,17 +462,22 @@ sealed interface CostReductionSource {
     }
 
     /**
-     * Reduces cost by a fixed amount if the given [Condition] evaluates true at cast time.
-     * The condition is evaluated with the caster as `controllerId`, so "your turn",
-     * "you have the city's blessing", etc. all work out of the box.
+     * Reduces cost by the number of permanents the caster controls matching a filter.
+     * The "you control" analogue of [PermanentsOnBattlefieldMatching]; the filter carries the
+     * narrowing (type, power, subtype, ...). Power/type checks honor projected state, so buffs
+     * and lords count (e.g. Temur Battlecrier: "for each creature you control with power 4 or
+     * greater" via `PermanentsYouControlMatching(Creature.powerAtLeast(4))`).
      *
-     * Used for cards like Mental Modulation
-     * (`FixedIfCondition(1, IsYourTurn)` — "costs {1} less to cast during your turn").
+     * Generalizes the fixed [CreaturesYouControl] / [ArtifactsYouControl] shorthands to an
+     * arbitrary filter.
      */
-    @SerialName("FixedIfCondition")
+    @SerialName("PermanentsYouControlMatching")
     @Serializable
-    data class FixedIfCondition(val amount: Int, val condition: Condition) : CostReductionSource {
-        override val description: String = "$amount ${condition.description}"
+    data class PermanentsYouControlMatching(
+        val filter: GameObjectFilter
+    ) : CostReductionSource {
+        override val description: String =
+            "the number of ${filter.description} you control"
     }
 
     /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GigastormTitan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GigastormTitan.kt
@@ -3,8 +3,8 @@ package com.wingedsheep.mtg.sets.definitions.eoe.cards
 import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
 import com.wingedsheep.sdk.scripting.CostModification
-import com.wingedsheep.sdk.scripting.CostReductionSource
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.SpellCostTarget
 
@@ -31,12 +31,8 @@ val GigastormTitan = card("Gigastorm Titan") {
     staticAbility {
         ability = ModifySpellCost(
             target = SpellCostTarget.SelfCast,
-            modification = CostModification.ReduceGenericBy(
-                CostReductionSource.FixedIfCondition(
-                    amount = 3,
-                    condition = Conditions.YouCastSpellsThisTurn(atLeast = 1),
-                ),
-            ),
+            modification = CostModification.ReduceGeneric(3),
+            gating = CostGating.OnlyIf(Conditions.YouCastSpellsThisTurn(atLeast = 1)),
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LashwhipPredator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LashwhipPredator.kt
@@ -3,8 +3,8 @@ package com.wingedsheep.mtg.sets.definitions.eoe.cards
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
 import com.wingedsheep.sdk.scripting.CostModification
-import com.wingedsheep.sdk.scripting.CostReductionSource
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.SpellCostTarget
@@ -34,14 +34,12 @@ val LashwhipPredator = card("Lashwhip Predator") {
     staticAbility {
         ability = ModifySpellCost(
             target = SpellCostTarget.SelfCast,
-            modification = CostModification.ReduceGenericBy(
-                CostReductionSource.FixedIfCondition(
-                    amount = 2,
-                    condition = Compare(
-                        DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature),
-                        ComparisonOperator.GTE,
-                        DynamicAmount.Fixed(3),
-                    ),
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(
+                Compare(
+                    DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(3),
                 ),
             ),
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MentalModulation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MentalModulation.kt
@@ -3,8 +3,8 @@ package com.wingedsheep.mtg.sets.definitions.eoe.cards
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
 import com.wingedsheep.sdk.scripting.CostModification
-import com.wingedsheep.sdk.scripting.CostReductionSource
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.SpellCostTarget
@@ -31,9 +31,8 @@ val MentalModulation = card("Mental Modulation") {
     staticAbility {
         ability = ModifySpellCost(
             target = SpellCostTarget.SelfCast,
-            modification = CostModification.ReduceGenericBy(
-                CostReductionSource.FixedIfCondition(amount = 1, condition = IsYourTurn),
-            ),
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.OnlyIf(IsYourTurn),
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ArwensGift.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ArwensGift.kt
@@ -4,8 +4,8 @@ import com.wingedsheep.sdk.dsl.EffectPatterns
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
 import com.wingedsheep.sdk.scripting.CostModification
-import com.wingedsheep.sdk.scripting.CostReductionSource
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.SpellCostTarget
@@ -32,17 +32,15 @@ val ArwensGift = card("Arwen's Gift") {
     staticAbility {
         ability = ModifySpellCost(
             target = SpellCostTarget.SelfCast,
-            modification = CostModification.ReduceGenericBy(
-                CostReductionSource.FixedIfCondition(
-                    amount = 1,
-                    condition = Compare(
-                        left = DynamicAmount.AggregateBattlefield(
-                            player = Player.You,
-                            filter = GameObjectFilter.Creature.legendary()
-                        ),
-                        operator = ComparisonOperator.GTE,
-                        right = DynamicAmount.Fixed(2)
-                    )
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.OnlyIf(
+                Compare(
+                    left = DynamicAmount.AggregateBattlefield(
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature.legendary()
+                    ),
+                    operator = ComparisonOperator.GTE,
+                    right = DynamicAmount.Fixed(2)
                 )
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FocusTheMind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FocusTheMind.kt
@@ -4,8 +4,8 @@ import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
 import com.wingedsheep.sdk.scripting.CostModification
-import com.wingedsheep.sdk.scripting.CostReductionSource
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.SpellCostTarget
 
@@ -28,12 +28,8 @@ val FocusTheMind = card("Focus the Mind") {
     staticAbility {
         ability = ModifySpellCost(
             target = SpellCostTarget.SelfCast,
-            modification = CostModification.ReduceGenericBy(
-                CostReductionSource.FixedIfCondition(
-                    amount = 2,
-                    condition = Conditions.YouCastSpellsThisTurn(atLeast = 1),
-                ),
-            ),
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.YouCastSpellsThisTurn(atLeast = 1)),
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TemurBattlecrier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TemurBattlecrier.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Temur Battlecrier — Tarkir: Dragonstorm #228
+ * {G}{U}{R} · Creature — Orc Ranger · 4/3
+ *
+ * During your turn, spells you cast cost {1} less to cast for each creature you
+ * control with power 4 or greater.
+ *
+ * Modeled as a battlefield-sourced [ModifySpellCost] over every spell its controller casts
+ * ([SpellCostTarget.YouCast] with no card filter). The per-unit reduction counts creatures
+ * the controller has with power 4+ via [CostReductionSource.PermanentsYouControlMatching]
+ * (projected power, so counters and lords count — and the Battlecrier itself, a 4-power
+ * creature, contributes once it resolves). The "During your turn" clause is the
+ * [CostGating.OnlyIf] gate on [Conditions.IsYourTurn], so the discount vanishes on opponents'
+ * turns.
+ */
+val TemurBattlecrier = card("Temur Battlecrier") {
+    manaCost = "{G}{U}{R}"
+    colorIdentity = "GUR"
+    typeLine = "Creature — Orc Ranger"
+    power = 4
+    toughness = 3
+    oracleText = "During your turn, spells you cast cost {1} less to cast for each creature " +
+        "you control with power 4 or greater."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.PermanentsYouControlMatching(
+                    GameObjectFilter.Creature.powerAtLeast(4),
+                ),
+            ),
+            gating = CostGating.OnlyIf(Conditions.IsYourTurn),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Brent Hollowell"
+        flavorText = "When called to the land's defense, all come to protect their shared home. " +
+            "It's why many of the Temur use \"family\" and \"herd\" interchangeably."
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72184791-0767-4108-920c-763e92dae2d4.jpg?1743204904"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -265,6 +265,13 @@ class CostCalculator(
                 val priorMatching = records.count { predicateEvaluator.matchesFilter(it, filter) }
                 priorMatching == gating.n - 1
             }
+            is CostGating.OnlyIf -> {
+                // Player-scoped conditions ("during your turn", "you've cast another spell", ...)
+                // evaluate against the caster. The cost modifier's source is a non-spell permanent
+                // (or the spell card itself for SelfCast), neither of which the condition needs.
+                val ctx = EffectContext(sourceId = null, controllerId = casterId, opponentId = null)
+                conditionEvaluator.evaluate(state, gating.condition, ctx)
+            }
         }
     }
 
@@ -367,14 +374,31 @@ class CostCalculator(
                     source.amount
                 else 0
             }
-            is CostReductionSource.FixedIfCondition -> {
-                val ctx = EffectContext(sourceId = null, controllerId = playerId, opponentId = null)
-                if (conditionEvaluator.evaluate(state, source.condition, ctx)) source.amount else 0
-            }
+            is CostReductionSource.PermanentsYouControlMatching ->
+                countControlledPermanentsMatching(state, playerId, source.filter)
             is CostReductionSource.DifferentlyNamedPermanentsYouControl ->
                 countDifferentlyNamedPermanents(state, playerId, source.filter)
             is CostReductionSource.PermanentsOnBattlefieldMatching ->
                 countBattlefieldPermanentsMatching(state, playerId, source.filter)
+        }
+    }
+
+    /**
+     * Count permanents the player controls matching the filter. Iterates the projected-control
+     * view (`controlledBattlefield`) so control-changing effects are honored, and evaluates the
+     * filter through [PredicateEvaluator] against projected state so type/power/subtype checks
+     * see buffs, counters, and lords (CR 613). The "you control" analogue of
+     * [countBattlefieldPermanentsMatching].
+     */
+    private fun countControlledPermanentsMatching(
+        state: GameState,
+        playerId: EntityId,
+        filter: GameObjectFilter
+    ): Int {
+        val projected = state.projectedState
+        val context = PredicateContext(controllerId = playerId)
+        return state.controlledBattlefield(playerId).count { entityId ->
+            predicateEvaluator.matches(state, projected, entityId, filter, context)
         }
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TemurBattlecrierTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TemurBattlecrierTest.kt
@@ -1,0 +1,267 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.conditions.IsYourTurn
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Temur Battlecrier and the two SDK primitives it introduces:
+ *
+ *  - `CostReductionSource.PermanentsYouControlMatching(filter)` — the filtered "you control" count
+ *    (projected power, so counters/lords count).
+ *  - `CostGating.OnlyIf(condition)` — gates the whole modification on a cast-time condition
+ *    (here `IsYourTurn`, for "During your turn, ...").
+ *
+ * Temur Battlecrier: {G}{U}{R}, Creature — Orc Ranger, 4/3.
+ * "During your turn, spells you cast cost {1} less to cast for each creature you control with
+ *  power 4 or greater."
+ */
+class TemurBattlecrierTest : FunSpec({
+
+    val Battlecrier = card("Temur Battlecrier") {
+        manaCost = "{G}{U}{R}"
+        typeLine = "Creature — Orc Ranger"
+        power = 4
+        toughness = 3
+        staticAbility {
+            ability = ModifySpellCost(
+                target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+                modification = CostModification.ReduceGenericBy(
+                    CostReductionSource.PermanentsYouControlMatching(
+                        GameObjectFilter.Creature.powerAtLeast(4),
+                    ),
+                ),
+                gating = CostGating.OnlyIf(IsYourTurn),
+            )
+        }
+    }
+
+    // A power-4 creature (counts toward the discount).
+    val Beefy = card("Beefy Brute") {
+        manaCost = "{2}{G}"
+        typeLine = "Creature — Bear"
+        power = 4
+        toughness = 4
+    }
+
+    // A power-3 creature (below the threshold).
+    val Runt = card("Scrawny Runt") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 3
+        toughness = 3
+    }
+
+    // Anthem granting +1/+1 to creatures you control — proves the count reads projected power.
+    val Anthem = card("Herd Anthem") {
+        manaCost = "{1}{G}"
+        typeLine = "Enchantment"
+        staticAbility {
+            ability = ModifyStats(1, 1, GroupFilter.AllCreaturesYouControl)
+        }
+    }
+
+    // The spell whose cost we measure: {4}{R} → 4 generic, CMC 5.
+    val TestSpell = card("Test Bolt") {
+        manaCost = "{4}{R}"
+        typeLine = "Sorcery"
+    }
+
+    // SelfCast + OnlyIf(IsYourTurn) — the migrated Mental Modulation shape.
+    val SelfDuringTurn = card("Self During Turn") {
+        manaCost = "{4}{U}"
+        typeLine = "Instant"
+        staticAbility {
+            ability = ModifySpellCost(
+                target = SpellCostTarget.SelfCast,
+                modification = CostModification.ReduceGeneric(1),
+                gating = CostGating.OnlyIf(IsYourTurn),
+            )
+        }
+    }
+
+    // SelfCast + OnlyIf(Compare) — the migrated Lashwhip Predator shape.
+    val SelfIfOpponentCreatures = card("Self If Opp Creatures") {
+        manaCost = "{4}{G}"
+        typeLine = "Creature — Beast"
+        power = 5
+        toughness = 7
+        staticAbility {
+            ability = ModifySpellCost(
+                target = SpellCostTarget.SelfCast,
+                modification = CostModification.ReduceGeneric(2),
+                gating = CostGating.OnlyIf(
+                    Compare(
+                        DynamicAmount.AggregateBattlefield(Player.Opponent, GameObjectFilter.Creature),
+                        ComparisonOperator.GTE,
+                        DynamicAmount.Fixed(3),
+                    ),
+                ),
+            )
+        }
+    }
+
+    val allCards = listOf(Battlecrier, Beefy, Runt, Anthem, TestSpell, SelfDuringTurn, SelfIfOpponentCreatures)
+
+    fun createRegistry(): CardRegistry =
+        CardRegistry().apply {
+            register(TestCards.all)
+            register(allCards)
+        }
+
+    fun createDriver(): GameTestDriver =
+        GameTestDriver().apply {
+            registerCards(TestCards.all)
+            allCards.forEach { registerCard(it) }
+            initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+            passPriorityUntil(Step.PRECOMBAT_MAIN)
+        }
+
+    test("counts the Battlecrier itself (a 4-power creature) — {4}{R} → {3}{R}") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(me, "Temur Battlecrier")
+
+        val cost = calculator.calculateEffectiveCost(driver.state, registry.requireCard("Test Bolt"), me)
+        cost.genericAmount shouldBe 3
+        cost.cmc shouldBe 4
+    }
+
+    test("power-3 creatures do not count, power-4 creatures do") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(me, "Temur Battlecrier") // power 4 → counts
+        driver.putCreatureOnBattlefield(me, "Scrawny Runt")      // power 3 → does NOT count
+        driver.putCreatureOnBattlefield(me, "Beefy Brute")       // power 4 → counts
+
+        // Two qualifying creatures → reduce by {2}: {4}{R} → {2}{R}.
+        val cost = calculator.calculateEffectiveCost(driver.state, registry.requireCard("Test Bolt"), me)
+        cost.genericAmount shouldBe 2
+        cost.cmc shouldBe 3
+    }
+
+    test("reduction reads projected power — an anthem lifts a 3-power creature to 4") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(me, "Temur Battlecrier") // base 4 → 5 with anthem, counts
+        driver.putCreatureOnBattlefield(me, "Scrawny Runt")      // base 3 → 4 with anthem, now counts
+
+        val before = calculator.calculateEffectiveCost(driver.state, registry.requireCard("Test Bolt"), me)
+        before.genericAmount shouldBe 3 // only the Battlecrier qualifies (count 1)
+
+        driver.putPermanentOnBattlefield(me, "Herd Anthem")
+
+        val after = calculator.calculateEffectiveCost(driver.state, registry.requireCard("Test Bolt"), me)
+        after.genericAmount shouldBe 2 // Runt now power 4 too → count 2
+    }
+
+    test("reduction never reduces colored pips below the cost (floors generic at 0)") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // 5 power-4 creatures on a {4}{R} spell: generic floors at 0, {R} preserved.
+        driver.putCreatureOnBattlefield(me, "Temur Battlecrier")
+        repeat(4) { driver.putCreatureOnBattlefield(me, "Beefy Brute") }
+
+        val cost = calculator.calculateEffectiveCost(driver.state, registry.requireCard("Test Bolt"), me)
+        cost.genericAmount shouldBe 0
+        cost.cmc shouldBe 1 // just {R}
+    }
+
+    test("'During your turn' — no reduction on an opponent's turn") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Temur Battlecrier")
+
+        // My turn → discount applies.
+        calculator.calculateEffectiveCost(driver.state, registry.requireCard("Test Bolt"), me)
+            .genericAmount shouldBe 3
+
+        // Flip the active player: now it's the opponent's turn. The gate (IsYourTurn) is false for
+        // the Battlecrier's controller, so my instant-speed casts get no discount.
+        driver.replaceState(driver.state.copy(activePlayerId = opponent))
+        calculator.calculateEffectiveCost(driver.state, registry.requireCard("Test Bolt"), me)
+            .genericAmount shouldBe 4
+    }
+
+    test("reduction is controller-scoped — opponents get no discount from my Battlecrier") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Temur Battlecrier")
+
+        // The opponent casting the same spell sees full cost (YouCast matches only my casts).
+        calculator.calculateEffectiveCost(driver.state, registry.requireCard("Test Bolt"), opponent)
+            .genericAmount shouldBe 4
+    }
+
+    test("migrated SelfCast OnlyIf(IsYourTurn): {4}{U} → {3}{U} on your turn, full otherwise") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        calculator.calculateEffectiveCost(driver.state, registry.requireCard("Self During Turn"), me)
+            .genericAmount shouldBe 3
+
+        driver.replaceState(driver.state.copy(activePlayerId = opponent))
+        calculator.calculateEffectiveCost(driver.state, registry.requireCard("Self During Turn"), me)
+            .genericAmount shouldBe 4
+    }
+
+    test("migrated SelfCast OnlyIf(Compare): discount only when opponents control 3+ creatures") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        // Opponent controls 2 creatures → no discount: {4}{G} stays 4 generic.
+        repeat(2) { driver.putCreatureOnBattlefield(opponent, "Beefy Brute") }
+        calculator.calculateEffectiveCost(driver.state, registry.requireCard("Self If Opp Creatures"), me)
+            .genericAmount shouldBe 4
+
+        // A third opponent creature trips the gate → reduce by {2}.
+        driver.putCreatureOnBattlefield(opponent, "Beefy Brute")
+        calculator.calculateEffectiveCost(driver.state, registry.requireCard("Self If Opp Creatures"), me)
+            .genericAmount shouldBe 2
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Temur Battlecrier** (TDM #228, {G}{U}{R} 4/3 Orc Ranger):

> During your turn, spells you cast cost {1} less to cast for each creature you control with power 4 or greater.

This card needs two things the cost system couldn't express: a **per-unit count of creatures *you* control with power 4+**, and a **"during your turn" gate on that dynamic, per-unit reduction**. Rather than a one-off, both are added as reusable, parameterized primitives.

## New SDK primitives

- **`CostGating.OnlyIf(condition)`** — gates the *entire* `ModifySpellCost` modification on a cast-time `Condition` (evaluated with the caster as controller). Unlike a fixed "… if condition" reduction *source*, it composes with the dynamic per-unit reductions that "for each …" requires. It's the home for any "During your turn, …" / "if you've cast another spell …" cost effect.
- **`CostReductionSource.PermanentsYouControlMatching(filter)`** — the controller-scoped analogue of `PermanentsOnBattlefieldMatching`. The filter carries the narrowing (`Creature.powerAtLeast(4)`); the count reads **projected** state via `PredicateEvaluator`, so +1/+1 counters and lords are honored (and the Battlecrier counts itself).

## Refactor (no parallel variants)

`CostReductionSource.FixedIfCondition` is now fully subsumed by `ReduceGeneric(n)` + `OnlyIf(condition)`, so it's **removed** and its five users migrated 1:1: Mental Modulation, Focus the Mind, Gigastorm Titan, Lashwhip Predator, Arwen's Gift.

## Engine

`CostCalculator.gatingApplies` evaluates `OnlyIf`; `evaluateReduction` counts through the projected-control view (`controlledBattlefield`). Purely a cost-calculation change — **no new GameEvent, decision, keyword, or client-visible state**, so it surfaces through existing legal-action / cost rendering (the discount appears/disappears with the turn automatically).

## Tests

`TemurBattlecrierTest` (rules-engine) pins every clause of the rules text and both migrated shapes:
- counts the Battlecrier itself; power-3 excluded, power-4 included; multiple creatures stack
- **projected power** — an anthem lifts a 3-power creature into the count
- generic floors at 0, colored pips preserved
- **"During your turn"** gate — full price on the opponent's turn
- controller-scoped (opponents get no discount)
- migrated SelfCast shapes: `OnlyIf(IsYourTurn)` and `OnlyIf(Compare(...))`

Existing coverage re-run green: `TdmGroupCScenarioTest` (Focus the Mind reduced-cost cast), `KrosanDroverTest`, mana suite, mtg-sdk serialization round-trips.

Docs: `card-sdk-language-reference.md` updated for the new gating + source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)