### PR TITLE
Reject Blight cost against creatures that can't have counters put on them

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -196,9 +196,12 @@ class CostHandler(
                 graveyardSize >= 3 || hasFood
             }
             is AbilityCost.Blight -> {
-                // Blight requires at least one creature you control to place -1/-1 counters on
+                // Blight requires at least one creature you control that can have -1/-1 counters
+                // put on it. A creature that "can't have counters put on it" (Blossombind) is not
+                // a legal blight target — CR 614.17b: the cost's event can't happen.
                 val projected = state.projectedState
-                projected.getBattlefieldControlledBy(controllerId).any { projected.isCreature(it) }
+                projected.getBattlefieldControlledBy(controllerId)
+                    .any { projected.isCreature(it) && projected.canReceiveCounters(it) }
             }
             is AbilityCost.RemoveCountersFromAmongFilteredPermanents ->
                 com.wingedsheep.engine.handlers.costs.RemoveCountersFromAmongFilteredPermanentsCostHandler
@@ -627,6 +630,9 @@ class CostHandler(
                 val projected = state.projectedState
                 if (projected.getController(targetId) != controllerId || !projected.isCreature(targetId)) {
                     return CostPaymentResult.failure("Blight target must be a creature you control")
+                }
+                if (!projected.canReceiveCounters(targetId)) {
+                    return CostPaymentResult.failure("Blight target can't have counters put on it")
                 }
                 val counters = targetContainer.get<CountersComponent>() ?: CountersComponent()
                 val firstThisTurn = com.wingedsheep.engine.handlers.effects.DamageUtils

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1105,6 +1105,9 @@ class CastSpellHandler(
                         if (!projected.isCreature(targetId)) {
                             return "Blight target must be a creature"
                         }
+                        if (!projected.canReceiveCounters(targetId)) {
+                            return "Blight target can't have counters put on it"
+                        }
                     }
                     // If blightTargets is empty, the player is paying extra mana instead
                 }
@@ -1119,7 +1122,8 @@ class CastSpellHandler(
                     val maxToughness = state.getBattlefield()
                         .filter { permId ->
                             projected.getController(permId) == action.playerId &&
-                                projected.isCreature(permId)
+                                projected.isCreature(permId) &&
+                                projected.canReceiveCounters(permId)
                         }
                         .maxOfOrNull { projected.getToughness(it) ?: 0 } ?: 0
                     if (amount > maxToughness) {
@@ -1143,6 +1147,9 @@ class CastSpellHandler(
                         }
                         if (!projected.isCreature(targetId)) {
                             return "Blight target must be a creature"
+                        }
+                        if (!projected.canReceiveCounters(targetId)) {
+                            return "Blight target can't have counters put on it"
                         }
                     }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/ExploreEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/ExploreEffectExecutor.kt
@@ -9,7 +9,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
-import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -134,7 +133,7 @@ class ExploreEffectExecutor : EffectExecutor<ExploreEffect> {
         creatureId: EntityId,
         context: EffectContext
     ): Pair<GameState, List<GameEvent>> {
-        if (state.projectedState.hasKeyword(creatureId, AbilityFlag.CANT_RECEIVE_COUNTERS)) {
+        if (!state.projectedState.canReceiveCounters(creatureId)) {
             return state to emptyList()
         }
         val current = state.getEntity(creatureId)?.get<CountersComponent>() ?: CountersComponent()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersExecutor.kt
@@ -9,7 +9,6 @@ import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
 import kotlin.reflect.KClass
@@ -30,7 +29,7 @@ class AddCountersExecutor : EffectExecutor<AddCountersEffect> {
         val targetId = context.resolveTarget(effect.target, state)
             ?: return EffectResult.error(state, "No valid target for counters")
 
-        if (state.projectedState.hasKeyword(targetId, AbilityFlag.CANT_RECEIVE_COUNTERS)) {
+        if (!state.projectedState.canReceiveCounters(targetId)) {
             return EffectResult.success(state, emptyList())
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DoubleCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DoubleCountersExecutor.kt
@@ -9,7 +9,6 @@ import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.scripting.effects.DoubleCountersEffect
 import kotlin.reflect.KClass
 
@@ -35,7 +34,7 @@ class DoubleCountersExecutor : EffectExecutor<DoubleCountersEffect> {
         val targetId = context.resolveTarget(effect.target, state)
             ?: return EffectResult.error(state, "No valid target to double counters on")
 
-        if (state.projectedState.hasKeyword(targetId, AbilityFlag.CANT_RECEIVE_COUNTERS)) {
+        if (!state.projectedState.canReceiveCounters(targetId)) {
             return EffectResult.success(state, emptyList())
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/MoveAllLastKnownCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/MoveAllLastKnownCountersExecutor.kt
@@ -9,7 +9,6 @@ import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.scripting.effects.MoveAllLastKnownCountersEffect
 import kotlin.reflect.KClass
 
@@ -41,7 +40,7 @@ class MoveAllLastKnownCountersExecutor : EffectExecutor<MoveAllLastKnownCounters
             return EffectResult.success(state, emptyList())
         }
 
-        if (state.projectedState.hasKeyword(targetId, AbilityFlag.CANT_RECEIVE_COUNTERS)) {
+        if (!state.projectedState.canReceiveCounters(targetId)) {
             return EffectResult.success(state, emptyList())
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -242,7 +242,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     is AbilityCost.Blight -> {
                         blightCost = effectiveCost
                         blightCreatures = projected.getBattlefieldControlledBy(playerId)
-                            .filter { projected.isCreature(it) }
+                            .filter { projected.isCreature(it) && projected.canReceiveCounters(it) }
                         if (blightCreatures.isEmpty()) continue
                     }
                     is AbilityCost.Discard -> {
@@ -390,7 +390,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                 is AbilityCost.Blight -> {
                                     blightCost = subCost
                                     blightCreatures = projected.getBattlefieldControlledBy(playerId)
-                                        .filter { projected.isCreature(it) }
+                                        .filter { projected.isCreature(it) && projected.canReceiveCounters(it) }
                                     if (blightCreatures.isEmpty()) {
                                         costCanBePaid = false
                                         break

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -428,7 +428,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         ?.firstOrNull()
                     val blightCreatures = if (printedBlightOrPay != null) {
                         val projected = state.projectedState
-                        projected.getBattlefieldControlledBy(playerId).filter { projected.isCreature(it) }
+                        projected.getBattlefieldControlledBy(playerId)
+                            .filter { projected.isCreature(it) && projected.canReceiveCounters(it) }
                     } else emptyList()
                     val canAffordBlightPath = printedBlightOrPay != null &&
                         blightCreatures.isNotEmpty() &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -198,7 +198,7 @@ class CastSpellEnumerator : ActionEnumerator {
                         blightOrPayCost = cost
                         val projected = state.projectedState
                         blightCreatures = projected.getBattlefieldControlledBy(playerId)
-                            .filter { projected.isCreature(it) }
+                            .filter { projected.isCreature(it) && projected.canReceiveCounters(it) }
                     }
                     is AdditionalCost.BlightVariable -> {
                         // Always payable when minCount = 0 (X = 0 is valid even with no
@@ -206,7 +206,7 @@ class CastSpellEnumerator : ActionEnumerator {
                         // prompt the player for X and a creature.
                         val projected = state.projectedState
                         val ownCreatures = projected.getBattlefieldControlledBy(playerId)
-                            .filter { projected.isCreature(it) }
+                            .filter { projected.isCreature(it) && projected.canReceiveCounters(it) }
                         val maxToughness = ownCreatures.maxOfOrNull { projected.getToughness(it) ?: 0 } ?: 0
                         if (maxToughness < cost.minCount) {
                             canPayAdditionalCosts = false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/GraveyardAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/GraveyardAbilityEnumerator.kt
@@ -81,7 +81,7 @@ class GraveyardAbilityEnumerator : ActionEnumerator {
                     is AbilityCost.Blight -> {
                         blightCost = effectiveCost
                         blightCreatures = context.projected.getBattlefieldControlledBy(playerId)
-                            .filter { context.projected.isCreature(it) }
+                            .filter { context.projected.isCreature(it) && context.projected.canReceiveCounters(it) }
                         if (blightCreatures.isEmpty()) costCanBePaid = false
                     }
                     is AbilityCost.Composite -> {
@@ -110,7 +110,7 @@ class GraveyardAbilityEnumerator : ActionEnumerator {
                                 is AbilityCost.Blight -> {
                                     blightCost = subCost
                                     blightCreatures = context.projected.getBattlefieldControlledBy(playerId)
-                                        .filter { context.projected.isCreature(it) }
+                                        .filter { context.projected.isCreature(it) && context.projected.canReceiveCounters(it) }
                                     if (blightCreatures.isEmpty()) {
                                         costCanBePaid = false; break
                                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedState.kt
@@ -52,6 +52,16 @@ class ProjectedState(
     fun hasKeyword(entityId: EntityId, flag: com.wingedsheep.sdk.core.AbilityFlag): Boolean =
         hasKeyword(entityId, flag.name)
 
+    /**
+     * Whether counters can be put on this object, per "[this] can't have counters put on it"
+     * effects (e.g. Blossombind). Centralizes the prohibition so every counter-placing path —
+     * effects (AddCounters, DoubleCounters, ...) and costs (Blight) alike — agrees. CR 614.17b:
+     * because the event can't happen, a player can't even choose to pay a cost that includes it,
+     * so blight target pools must exclude such creatures rather than silently dropping the counter.
+     */
+    fun canReceiveCounters(entityId: EntityId): Boolean =
+        !hasKeyword(entityId, com.wingedsheep.sdk.core.AbilityFlag.CANT_RECEIVE_COUNTERS)
+
     fun getColors(entityId: EntityId): Set<String> = projectedValues[entityId]?.colors ?: emptySet()
 
     fun hasColor(entityId: EntityId, color: Color): Boolean =

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlossombindBlightTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlossombindBlightTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ecl.cards.Blossombind
+import com.wingedsheep.mtg.sets.definitions.ecl.cards.BoneclubBerserker
+import com.wingedsheep.mtg.sets.definitions.ecl.cards.BurningCuriosity
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression for: a creature enchanted with Blossombind ("can't have counters put on it")
+ * still received a -1/-1 counter when its controller paid a Blight cost (Burning Curiosity).
+ *
+ * CR 614.17b — because putting a counter on that creature is an event that can't happen, the
+ * player can't even choose to pay a cost that includes it. So such a creature must be excluded
+ * from the legal blight-target pool and the cast must be rejected, rather than the counter being
+ * silently dropped while the cost still "succeeds".
+ */
+class BlossombindBlightTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(Blossombind, BoneclubBerserker, BurningCuriosity))
+        return driver
+    }
+
+    /** Resolve everything on the stack (the aura, then its enters-the-battlefield tap trigger). */
+    fun GameTestDriver.resolveStack() {
+        var safety = 0
+        while (stackSize > 0 && !isPaused && safety < 20) {
+            bothPass()
+            safety++
+        }
+    }
+
+    test("Blossombind-enchanted creature is excluded from the blight-target pool") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Island" to 10))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val boneclub = driver.putCreatureOnBattlefield(player, "Boneclub Berserker")
+        val grizzly = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        repeat(4) { driver.putLandOnBattlefield(player, "Mountain") }
+        repeat(2) { driver.putLandOnBattlefield(player, "Island") }
+
+        // Enchant the Boneclub Berserker with Blossombind.
+        val blossombind = driver.putCardInHand(player, "Blossombind")
+        driver.castSpell(player, blossombind, listOf(boneclub))
+        driver.resolveStack()
+        driver.findPermanent(player, "Blossombind") shouldNotBe null
+
+        val burningCuriosity = driver.putCardInHand(player, "Burning Curiosity")
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val blightAction = enumerator.enumerate(driver.state, player).firstOrNull { action ->
+            action.actionType == "CastSpell" &&
+                (action.action as? CastSpell)?.cardId == burningCuriosity &&
+                action.additionalCostInfo?.costType == "Blight"
+        }
+        blightAction shouldNotBe null
+        val validTargets = blightAction!!.additionalCostInfo!!.validBlightTargets
+        // The unenchanted creature is a legal blight target; the enchanted one is not.
+        validTargets shouldContain grizzly
+        validTargets shouldNotContain boneclub
+    }
+
+    test("casting Burning Curiosity blighting the enchanted creature is rejected, no counter placed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Island" to 10))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val boneclub = driver.putCreatureOnBattlefield(player, "Boneclub Berserker")
+        repeat(4) { driver.putLandOnBattlefield(player, "Mountain") }
+        repeat(2) { driver.putLandOnBattlefield(player, "Island") }
+
+        val blossombind = driver.putCardInHand(player, "Blossombind")
+        driver.castSpell(player, blossombind, listOf(boneclub))
+        driver.resolveStack()
+
+        val burningCuriosity = driver.putCardInHand(player, "Burning Curiosity")
+        driver.submitExpectFailure(
+            CastSpell(
+                playerId = player,
+                cardId = burningCuriosity,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                additionalCostPayment = AdditionalCostPayment(blightTargets = listOf(boneclub))
+            )
+        )
+
+        val counters = driver.state.getEntity(boneclub)?.get<CountersComponent>()
+        (counters?.getCount(CounterType.MINUS_ONE_MINUS_ONE) ?: 0) shouldBe 0
+    }
+
+    test("blighting an unenchanted creature still places the -1/-1 counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Island" to 10))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val grizzly = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        repeat(3) { driver.putLandOnBattlefield(player, "Mountain") }
+
+        val burningCuriosity = driver.putCardInHand(player, "Burning Curiosity")
+        driver.submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = burningCuriosity,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                additionalCostPayment = AdditionalCostPayment(blightTargets = listOf(grizzly))
+            )
+        )
+
+        // The blight counter is applied as the spell is cast (cost payment), before resolution.
+        val counters = driver.state.getEntity(grizzly)?.get<CountersComponent>()
+        counters?.getCount(CounterType.MINUS_ONE_MINUS_ONE) shouldBe 1
+    }
+})


### PR DESCRIPTION
## The bug

Player 1 has Boneclub Berserker. Player 2 enchants it with **Blossombind** ("Enchanted creature … can't have counters put on it"). Player 1 then casts **Burning Curiosity** paying its **Blight 1** cost, targeting the enchanted Boneclub Berserker — and it still received a -1/-1 counter, violating Blossombind.

## Root cause

Effect-based counter placement (`AddCounters`, `DoubleCounters`, `MoveAllLastKnownCounters`, `Explore`) already checked the `CANT_RECEIVE_COUNTERS` flag. But the **Blight cost** paths placed -1/-1 counters during cost payment without that check, and the legal-action enumerators offered the enchanted creature as a valid blight target.

## The rule

[CR 614.17b](https://magic.wizards.com/en/rules): *"If an event can't happen, a player can't choose to pay a cost that includes that event."* Because putting a counter on the enchanted creature is an event that can't happen, the creature must be excluded from the legal blight-target pool and the cast/activation rejected — **not** silently drop the counter while the cost still "succeeds" (which would otherwise let a hard-Blight spell be cast for free).

## Changes

- **`ProjectedState.canReceiveCounters()`** — single source of truth for the prohibition. The four existing counter executors are routed through it so every counter-placing path agrees.
- **Blight target pools** exclude can't-receive-counters creatures in all four enumerators (`CastSpell`, `CastFromZone`, `ActivatedAbility`, `GraveyardAbility`), and the `BlightVariable` X cap no longer counts them.
- **Validation/payment guards** in `CastSpellHandler.validate` and `CostHandler` (`canPay` + `pay`) as a defensive net for direct/buggy clients.
- **`BlossombindBlightTest`** scenario regression: enchanted creature excluded from the pool, casting against it is rejected with no counter placed, and an unenchanted creature still gets its counter.

## Testing

`BlossombindBlightTest` (3 cases) passes. Regression run of `EvershrikesGiftTest`, `GristleGluttonTest`, `FrozenSolidTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)