### PR TITLE
Fix "until end of your next turn" may-play expiry for the non-starting player

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -526,11 +526,19 @@ class CleanupPhaseManager(
         }
 
         // Expire non-permanent may-play permissions whose duration has elapsed.
+        // `turnNumber` is round-based (it increments only when the starting player begins a
+        // new turn), so it can't distinguish the controller's turn from the opponent's within
+        // the same round. A permission that should last "until the end of your next turn" must
+        // therefore only expire at the cleanup of the *controller's own* turn — otherwise the
+        // non-starting player would lose it at the end of the starting player's turn in the
+        // target round, one turn early (Burning Curiosity, Sizzling Changeling).
         if (newState.mayPlayPermissions.isNotEmpty()) {
             newState = newState.copy(
                 mayPlayPermissions = newState.mayPlayPermissions.filterNot { permission ->
                     !permission.permanent && when {
-                        permission.expiresAfterTurn != null -> newState.turnNumber >= permission.expiresAfterTurn
+                        permission.expiresAfterTurn != null ->
+                            newState.turnNumber >= permission.expiresAfterTurn &&
+                                newState.activePlayerId == permission.controllerId
                         else -> true
                     }
                 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BurningCuriosityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BurningCuriosityTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ecl.cards.BurningCuriosity
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Burning Curiosity.
+ *
+ * Burning Curiosity {2}{R}
+ * Sorcery
+ *
+ * As an additional cost to cast this spell, you may blight 1.
+ * Exile the top two cards of your library. If this spell's additional cost was paid, exile the
+ * top three cards instead. Until the end of your next turn, you may play those cards.
+ *
+ * Regression guard for "until the end of your next turn" when the controller is NOT the starting
+ * player. `GameState.turnNumber` is round-based — it only increments when the starting player
+ * begins a new turn — so two players share a turn number within a round. The expiry must be gated
+ * on the *controller's own* turn; otherwise the non-starting player loses the permission at the end
+ * of the starting player's turn in the target round, one full turn too early, and can no longer
+ * play the exiled land on their next turn (the reported bug).
+ */
+class BurningCuriosityTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BurningCuriosity))
+        return driver
+    }
+
+    /**
+     * Advance to the next turn's precombat main phase. Stepping out via the END step first is
+     * required: calling [GameTestDriver.passPriorityUntil] for PRECOMBAT_MAIN while already in a
+     * precombat main is a no-op.
+     */
+    fun advanceToNextTurnMain(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+    }
+
+    /**
+     * Cast Burning Curiosity (declining the optional blight, so it exiles the top two cards) on the
+     * given player's precombat main phase, then resolve it. Returns the exiled card entity ids.
+     */
+    fun castAndResolve(driver: GameTestDriver, caster: com.wingedsheep.sdk.model.EntityId): List<com.wingedsheep.sdk.model.EntityId> {
+        driver.giveMana(caster, Color.RED, 3) // {2}{R}, paid from pool
+        val spell = driver.putCardInHand(caster, "Burning Curiosity")
+        driver.castSpell(caster, spell).isSuccess shouldBe true
+        // Resolve the spell (exile top two + grant may-play) without leaving the caster's turn.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN, maxPasses = 200)
+        return driver.getExile(caster)
+    }
+
+    test("exiles the top two cards and grants permission to play them") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val exiled = castAndResolve(driver, p1)
+
+        exiled.size shouldBe 2
+        driver.getExileCardNames(p1) shouldBe listOf("Mountain", "Mountain")
+        exiled.all { id -> driver.state.mayPlayPermissions.any { id in it.cardIds } } shouldBe true
+    }
+
+    // The non-starting player is the case the original bug broke: the permission expired at the end
+    // of the starting player's turn in the next round instead of at the end of the controller's own.
+    test("exiled land is still playable on the NON-STARTING controller's next turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        // Move from P1's first turn into P2's first turn, then cast there.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.state.activePlayerId shouldBe p1
+        advanceToNextTurnMain(driver)
+        driver.state.activePlayerId shouldBe p2
+
+        val exiled = castAndResolve(driver, p2)
+        val land = exiled.first()
+        driver.state.mayPlayPermissions.any { land in it.cardIds } shouldBe true
+
+        // Advance through P1's next turn (same round number as P2's next turn) into P2's next turn.
+        advanceToNextTurnMain(driver)
+        driver.state.activePlayerId shouldBe p1
+        advanceToNextTurnMain(driver)
+        driver.state.activePlayerId shouldBe p2
+
+        // The "until end of your next turn" window must still be open here.
+        driver.state.mayPlayPermissions.any { land in it.cardIds } shouldBe true
+        driver.playLand(p2, land).isSuccess shouldBe true
+        driver.getExile(p2).contains(land) shouldBe false
+    }
+
+    test("permission expires after the NON-STARTING controller's next turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        advanceToNextTurnMain(driver)
+        driver.state.activePlayerId shouldBe p2
+
+        val exiled = castAndResolve(driver, p2)
+        val land = exiled.first()
+
+        // P2's next turn (window still open — verified above).
+        advanceToNextTurnMain(driver) // P1, next round
+        advanceToNextTurnMain(driver) // P2, next round
+        driver.state.activePlayerId shouldBe p2
+        driver.state.mayPlayPermissions.any { land in it.cardIds } shouldBe true
+
+        // One more turn cycle — past the end of P2's next turn.
+        advanceToNextTurnMain(driver) // P1
+        advanceToNextTurnMain(driver) // P2
+        driver.state.activePlayerId shouldBe p2
+
+        // The window has now closed.
+        driver.state.mayPlayPermissions.any { land in it.cardIds } shouldBe false
+    }
+
+    test("exiled land is still playable on the STARTING controller's next turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.state.activePlayerId shouldBe p1
+        val exiled = castAndResolve(driver, p1)
+        val land = exiled.first()
+
+        // Advance through P2's turn into P1's next turn.
+        advanceToNextTurnMain(driver)
+        advanceToNextTurnMain(driver)
+        driver.state.activePlayerId shouldBe p1
+
+        driver.state.mayPlayPermissions.any { land in it.cardIds } shouldBe true
+        driver.playLand(p1, land).isSuccess shouldBe true
+        driver.getExile(p1).contains(land) shouldBe false
+    }
+})


### PR DESCRIPTION
## Problem

`Burning Curiosity` (and any `GrantMayPlayFromExileEffect` using `MayPlayExpiry.UntilEndOfNextTurn`) grants *"until the end of your next turn, you may play those cards."* When the **non-starting** player cast it, the exiled land became unplayable on their actual next turn — the window expired one full turn early.

## Root cause

`GameState.turnNumber` is **round-based**: it only increments when the *starting* player begins a new turn, so both players share a turn number within a round. The cleanup-phase expiry compared only:

```kotlin
permission.expiresAfterTurn != null -> newState.turnNumber >= permission.expiresAfterTurn
```

So a permission meant to last until the controller's next turn was removed at the cleanup of whichever turn *first* reached that turn number. For the non-starting player that is the **starting player's** turn in the target round — one turn before the controller's own. The starting player was never affected (their turn comes first in the round), which is why `SizzlingChangelingTest` didn't catch it.

## Fix

Gate the `expiresAfterTurn` cleanup on the controller's own turn:

```kotlin
permission.expiresAfterTurn != null ->
    newState.turnNumber >= permission.expiresAfterTurn &&
        newState.activePlayerId == permission.controllerId
```

Permanent permissions and end-of-turn permissions (`expiresAfterTurn == null`) are untouched. Only `UntilControllerStep` expiries carry a non-null `expiresAfterTurn`, and those are exactly the ones that should expire on the controller's turn — so this gate is safe across all `MayPlayPermission` producers (cascade, plot, warp, foretell-style grants all use `permanent = true` or the end-of-turn default).

## Tests

Adds `BurningCuriosityTest` covering the non-starting and starting controller, including expiry *after* the next turn. The two non-starting-player cases fail without the gate and pass with it (verified by temporarily reverting the gate). Existing `SizzlingChangelingTest` and the full `rules-engine` suite remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)