### PR TITLE
Add TDM cards: Avenger of the Fallen, Delta Bloodflies, Dragonstorm Globe

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1506,6 +1506,10 @@ composite abilities).
   ability plus a "whenever this attacks" triggered `CreateTokenEffect` (`tapped = true`, `attacking = true`)
   whose `sacrificeAtStep = Step.END` schedules one delayed `SacrificeTargetEffect` per created token at the
   next end step (mirrors `rampage()`). `n` may be any fixed value (Mobilize 1/2/3, …).
+  For a dynamic count ("Mobilize X, where X is …"), use the `card { mobilize(amount, amountDescription, label) }`
+  overload: it adds a `KeywordAbility.Variable(MOBILIZE, label)` display tag (prints "Mobilize X") plus the same
+  attack-triggered `CreateTokenEffect`, but with `count = amount` (any `DynamicAmount`) resolved at attack time.
+  Avenger of the Fallen passes `DynamicAmounts.creatureCardsInYourGraveyard()`.
 - `Decayed` — "This creature can't block, and when it attacks, sacrifice it at end of combat" (CR 702.147,
   Innistrad: Midnight Hunt). Display-only; wire the behavior with the `card { decayed() }` builder helper, which adds
   the keyword plus a `CantBlock(GroupFilter.source())` static ability and a "whenever this attacks" triggered

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AvengerOfTheFallenScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/AvengerOfTheFallenScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Avenger of the Fallen (TDM #73) — {2}{B} Human Warrior, 2/4.
+ *
+ * Deathtouch
+ * Mobilize X, where X is the number of creature cards in your graveyard.
+ *
+ * Exercises the dynamic `mobilize(amount, ...)` DSL overload: the number of tapped/attacking
+ * Warrior tokens created when Avenger attacks must equal the number of creature cards in the
+ * controller's graveyard, counted (per Scryfall ruling) when the mobilize ability resolves.
+ * Noncreature cards in the graveyard are ignored.
+ */
+class AvengerOfTheFallenScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Dead Bear A",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Dead Bear B",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Dead Bear C",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.instant(
+                name = "Test Bolt",
+                manaCost = ManaCost.parse("{R}"),
+                oracleText = "Test Bolt deals 3 damage to any target."
+            )
+        )
+
+        context("Avenger of the Fallen") {
+
+            test("has deathtouch") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Avenger of the Fallen", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val avenger = game.findPermanent("Avenger of the Fallen")!!
+                withClue("Avenger of the Fallen has deathtouch") {
+                    game.state.projectedState.hasKeyword(avenger, Keyword.DEATHTOUCH) shouldBe true
+                }
+            }
+
+            test("Mobilize X creates one Warrior token per creature card in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Avenger of the Fallen", tapped = false, summoningSickness = false)
+                    .withCardInGraveyard(1, "Dead Bear A")
+                    .withCardInGraveyard(1, "Dead Bear B")
+                    .withCardInGraveyard(1, "Dead Bear C")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Avenger of the Fallen" to 2))
+                withClue("Declaring Avenger of the Fallen as attacker should succeed: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+                game.resolveStack()
+
+                val warriors = game.findPermanents("Warrior Token")
+                withClue("Three creature cards in the graveyard → Mobilize 3 → three Warrior tokens") {
+                    warriors.size shouldBe 3
+                }
+                withClue("Each Warrior token enters tapped and attacking") {
+                    warriors.forEach { token ->
+                        game.state.getEntity(token)?.has<TappedComponent>() shouldBe true
+                        game.state.getEntity(token)?.has<AttackingComponent>() shouldBe true
+                    }
+                }
+            }
+
+            test("noncreature cards in the graveyard do not count toward Mobilize X") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Avenger of the Fallen", tapped = false, summoningSickness = false)
+                    .withCardInGraveyard(1, "Dead Bear A")
+                    .withCardInGraveyard(1, "Test Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Avenger of the Fallen" to 2))
+                withClue("Declaring Avenger of the Fallen as attacker should succeed: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+                game.resolveStack()
+
+                val warriors = game.findPermanents("Warrior Token")
+                withClue("Only the single creature card counts; the instant is ignored → one token") {
+                    warriors.size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DragonstormGlobeScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/DragonstormGlobeScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Dragonstorm Globe (TDM #241) — {3} Artifact.
+ *
+ * "Each Dragon you control enters with an additional +1/+1 counter on it.
+ *  {T}: Add one mana of any color."
+ *
+ * Verifies the entering-Dragon replacement (Rule 614): a Dragon you control entering the
+ * battlefield gains one extra +1/+1 counter, while a non-Dragon creature is unaffected.
+ */
+class DragonstormGlobeScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, name: String): Int {
+        val permanent = game.findPermanent(name)!!
+        return game.state.getEntity(permanent)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Dragon",
+                manaCost = ManaCost.parse("{4}{R}"),
+                subtypes = setOf(Subtype.DRAGON),
+                power = 4,
+                toughness = 4
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Soldier",
+                manaCost = ManaCost.parse("{1}{W}"),
+                subtypes = setOf(Subtype("Soldier")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Dragonstorm Globe") {
+
+            test("a Dragon you control enters with an extra +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dragonstorm Globe", summoningSickness = false)
+                    .withCardInHand(1, "Test Dragon")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Dragon").error shouldBe null
+                game.resolveStack()
+
+                withClue("Test Dragon enters with one extra +1/+1 counter from Dragonstorm Globe") {
+                    plusOneCounters(game, "Test Dragon") shouldBe 1
+                }
+            }
+
+            test("a non-Dragon creature is unaffected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dragonstorm Globe", summoningSickness = false)
+                    .withCardInHand(1, "Test Soldier")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Soldier").error shouldBe null
+                game.resolveStack()
+
+                withClue("A non-Dragon creature enters with no +1/+1 counters") {
+                    plusOneCounters(game, "Test Soldier") shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -461,6 +461,43 @@ class CardBuilder(private val name: String) {
     }
 
     /**
+     * Add Mobilize X (Tarkir: Dragonstorm) — keyword ability + triggered ability where
+     * the token count is a [DynamicAmount] resolved on attack rather than a fixed integer.
+     *
+     * "Whenever this creature attacks, create X tapped and attacking 1/1 red Warrior
+     * creature tokens. Sacrifice those tokens at the beginning of the next end step."
+     *
+     * Used by Avenger of the Fallen ("Mobilize X, where X is the number of creature cards
+     * in your graveyard"). [label] is the placeholder rendered after "Mobilize" in the
+     * keyword list (defaults to "X"); [amountDescription] is the natural-language phrase
+     * describing the count, woven into the triggered-ability reminder text. The tokens
+     * enter tapped and attacking and are sacrificed at the next end step, identical to the
+     * fixed-count [mobilize] helper.
+     */
+    fun mobilize(amount: DynamicAmount, amountDescription: String, label: String = "X") {
+        keywordAbilityList.add(KeywordAbility.mobilizeVariable(label))
+        triggeredAbilities.add(
+            TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = CreateTokenEffect(
+                    count = amount,
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.RED),
+                    creatureTypes = setOf("Warrior"),
+                    tapped = true,
+                    attacking = true,
+                    sacrificeAtStep = Step.END
+                ),
+                descriptionOverride = "Whenever this creature attacks, create $amountDescription " +
+                    "tapped and attacking 1/1 red Warrior creature tokens. Sacrifice those tokens " +
+                    "at the beginning of the next end step."
+            )
+        )
+    }
+
+    /**
      * Add Decayed (CR 702.147, Innistrad: Midnight Hunt) — keyword + static ability
      * + triggered ability.
      *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -150,6 +150,23 @@ sealed interface KeywordAbility {
     }
 
     /**
+     * A numeric keyword whose count is determined dynamically rather than by a fixed
+     * integer — e.g. "Mobilize X, where X is the number of creature cards in your
+     * graveyard" (Avenger of the Fallen). The keyword ability itself is display-only;
+     * the dynamic count lives in the composed triggered ability that the DSL helper
+     * wires alongside it. [label] is the placeholder shown after the keyword name
+     * (defaults to "X"), so the card prints "Mobilize X".
+     *
+     * Examples:
+     * - `Variable(Keyword.MOBILIZE)` — "Mobilize X"
+     */
+    @SerialName("Variable")
+    @Serializable
+    data class Variable(override val keyword: Keyword, val label: String = "X") : KeywordAbility {
+        override val description: String = "${keyword.displayName} $label"
+    }
+
+    /**
      * Flanking.
      * "Flanking" - Whenever this creature becomes blocked by a creature without flanking,
      * the blocking creature gets -1/-1 until end of turn.
@@ -762,6 +779,15 @@ sealed interface KeywordAbility {
         fun fabricate(n: Int): KeywordAbility = Numeric(Keyword.FABRICATE, n)
         fun tribute(n: Int): KeywordAbility = Numeric(Keyword.TRIBUTE, n)
         fun mobilize(n: Int): KeywordAbility = Numeric(Keyword.MOBILIZE, n)
+
+        /**
+         * Mobilize X — display tag for a Mobilize whose count is dynamic (e.g.
+         * "Mobilize X, where X is the number of creature cards in your graveyard").
+         * The dynamic token count lives in the attack-triggered ability wired by the
+         * `mobilize(amount, ...)` DSL helper; this factory only provides the
+         * "Mobilize X" display text.
+         */
+        fun mobilizeVariable(label: String = "X"): KeywordAbility = Variable(Keyword.MOBILIZE, label)
 
         /**
          * Hideaway N — display tag for the parameterized hideaway keyword. The

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AvengerOfTheFallen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AvengerOfTheFallen.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Avenger of the Fallen — Tarkir: Dragonstorm #73
+ * {2}{B} · Creature — Human Warrior · 2/4
+ *
+ * Deathtouch
+ * Mobilize X, where X is the number of creature cards in your graveyard. (Whenever this
+ * creature attacks, create X tapped and attacking 1/1 red Warrior creature tokens.
+ * Sacrifice them at the beginning of the next end step.)
+ *
+ * The dynamic Mobilize is wired via the `mobilize(amount, ...)` DSL overload: it adds the
+ * "Mobilize X" display keyword plus the attack-triggered token creation, with the count
+ * supplied by [DynamicAmounts.creatureCardsInYourGraveyard] (DynamicAmount.Count over the
+ * graveyard filtered to creature cards) resolved at attack time, not cast time.
+ */
+val AvengerOfTheFallen = card("Avenger of the Fallen") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 4
+    oracleText = "Deathtouch\n" +
+        "Mobilize X, where X is the number of creature cards in your graveyard. (Whenever this " +
+        "creature attacks, create X tapped and attacking 1/1 red Warrior creature tokens. " +
+        "Sacrifice them at the beginning of the next end step.)"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    mobilize(
+        amount = DynamicAmounts.creatureCardsInYourGraveyard(),
+        amountDescription = "X, where X is the number of creature cards in your graveyard",
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "73"
+        artist = "Winona Nelson"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5397366-151f-46b0-b9b2-fa4d5bd892d8.jpg?1743204251"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DeltaBloodflies.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DeltaBloodflies.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Delta Bloodflies — Tarkir: Dragonstorm #77
+ * {1}{B} · Creature — Insect · 1/2
+ *
+ * Flying
+ * Whenever this creature attacks, if you control a creature with a counter on it, each opponent
+ * loses 1 life.
+ *
+ * The attack trigger carries an intervening-if condition (Rule 603.4) via `triggerCondition`:
+ * [Conditions.YouControl] over `GameObjectFilter.Creature.withAnyCounter()` ("a creature with a
+ * counter on it"). The condition is checked both when the ability would trigger and again on
+ * resolution, so removing the last counter before resolution fizzles the life loss. The payoff is
+ * [Effects.LoseLife] aimed at [Player.EachOpponent].
+ */
+val DeltaBloodflies = card("Delta Bloodflies") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever this creature attacks, if you control a creature with a counter on it, " +
+        "each opponent loses 1 life."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Creature.withAnyCounter())
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        description = "Whenever this creature attacks, if you control a creature with a counter on it, " +
+            "each opponent loses 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Inkognit"
+        flavorText = "With the rising waters, bloodflies were found far from their usual swamps."
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/119bb72d-aed9-47dc-9285-7bc836cc3776.jpg?1743204268"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonstormGlobe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonstormGlobe.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dragonstorm Globe — Tarkir: Dragonstorm #241
+ * {3} · Artifact
+ *
+ * Each Dragon you control enters with an additional +1/+1 counter on it.
+ * {T}: Add one mana of any color.
+ *
+ * The first ability is a self-replacement on entering Dragons (Rule 614): an
+ * [EntersWithDynamicCounters] whose `appliesTo` matches Dragon creatures you control moving
+ * to the battlefield, adding one extra +1/+1 counter (mirrors Grumgully, the Generous). The
+ * second is a standard tap-for-any-color mana ability via [Effects.AddAnyColorMana].
+ */
+val DragonstormGlobe = card("Dragonstorm Globe") {
+    manaCost = "{3}"
+    typeLine = "Artifact"
+    oracleText = "Each Dragon you control enters with an additional +1/+1 counter on it.\n" +
+        "{T}: Add one mana of any color."
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmount.Fixed(1),
+            // otherOnly = true routes this through the battlefield-scan path in
+            // EntersWithCountersHelper, so the artifact grants counters to *other*
+            // permanents (Dragons you control) as they enter, not to itself.
+            otherOnly = true,
+            appliesTo = GameEvent.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl().withSubtype(Subtype.DRAGON),
+                to = Zone.BATTLEFIELD,
+            ),
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddAnyColorMana(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "241"
+        artist = "Adrián Rodríguez Pérez"
+        flavorText = "Jeskai scholars fashioned devices to forecast the behavior of the dragonstorms."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f50aa6e-ce6a-4479-9725-202926245f2c.jpg?1743204954"
+    }
+}


### PR DESCRIPTION
Adds three Tarkir: Dragonstorm (TDM) cards.

## Avenger of the Fallen — {2}{B} 2/4 Human Warrior (#73, rare)
Deathtouch; **Mobilize X, where X is the number of creature cards in your graveyard.**

The fixed-count `mobilize(n)` helper couldn't express a dynamic X, so this adds a
reusable variant:
- `KeywordAbility.Variable(keyword, label)` — a numeric keyword whose count is dynamic; prints "Mobilize X".
- A `card { mobilize(amount: DynamicAmount, amountDescription, label) }` builder overload that adds the display tag plus the same attack-triggered tapped/attacking 1/1 red Warrior `CreateTokenEffect`, but with `count = amount`. Here the amount is `DynamicAmounts.creatureCardsInYourGraveyard()`, resolved when the mobilize ability resolves (per Scryfall ruling, X is counted once).

Scenario test: token count equals the number of creature cards in the graveyard; noncreature cards in the graveyard are ignored; deathtouch present.

## Delta Bloodflies — {1}{B} 1/2 Insect (#77, common)
Flying; **Whenever this creature attacks, if you control a creature with a counter on it, each opponent loses 1 life.**

Pure composition of existing primitives — no engine changes. The attack trigger uses an intervening-if (`triggerCondition`, checked on trigger and again on resolution) of `Conditions.YouControl(Creature.withAnyCounter())`, paying off with `Effects.LoseLife(1, EachOpponent)`.

## Dragonstorm Globe — {3} Artifact (#241, common)
**Each Dragon you control enters with an additional +1/+1 counter on it. {T}: Add one mana of any color.**

The entering-Dragon clause uses `EntersWithDynamicCounters(otherOnly = true, ...)` filtered to Dragons you control moving to the battlefield (mirrors Grumgully, the Generous — `otherOnly = true` routes through the battlefield-scan path so the artifact grants counters to *other* entering permanents). The mana ability is a standard `Costs.Tap` + `Effects.AddAnyColorMana(1)`.

Scenario test: a Dragon you control enters with one extra +1/+1 counter; a non-Dragon enters with none.

## SDK / docs
- New `KeywordAbility.Variable` + `mobilizeVariable()` factory + dynamic `mobilize(...)` overload.
- `docs/card-sdk-language-reference.md` updated to document the dynamic Mobilize overload.

## Testing
- `AvengerOfTheFallenScenarioTest`, `DragonstormGlobeScenarioTest` — pass.
- Existing `TdmBatchAScenarioTest` / `StadiumHeadlinerScenarioTest` (fixed-count mobilize) still pass, confirming the DSL change is backward-compatible.
- `:mtg-sets:test` and `:mtg-sdk:test` suites pass (catalog load + serialization of the new keyword ability).
- All three image URIs verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)