### PR TITLE
Surface unaffordable Adventure/DFC face as a grayed-out cast option

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -80,12 +80,27 @@ class CastSpellEnumerator : ActionEnumerator {
             // fields. (MODAL_DFC, ADVENTURE, and OMEN differ only at resolution — exile-then-recast
             // for Adventure, shuffle-into-library for Omen, plain graveyard for modal DFC — which
             // is handled in StackResolver, not here.)
+            // When true, the secondary (spell) face of an Adventure/Omen/modal-DFC card is
+            // affordable. The primary-face logic below reads this so that, when the primary
+            // (creature) face itself is unaffordable, it can still surface a grayed-out
+            // placeholder — keeping both faces in the drag-to-play action menu.
+            var secondaryFaceAffordable = false
             if ((cardDef.layout == com.wingedsheep.sdk.model.CardLayout.ADVENTURE ||
                     cardDef.layout == com.wingedsheep.sdk.model.CardLayout.OMEN ||
                     cardDef.layout == com.wingedsheep.sdk.model.CardLayout.MODAL_DFC) &&
                 cardDef.cardFaces.isNotEmpty()
             ) {
-                enumerateSecondaryFace(context, cardId, cardDef, result)
+                // Approximate primary-face affordability (plain mana only — convoke/delve/alt
+                // costs are ignored here; a false negative just means we don't surface a
+                // grayed-out secondary face in those rare cases). Used by enumerateSecondaryFace
+                // to decide whether an unaffordable secondary face is still worth showing.
+                val primaryFaceCost = context.costCalculator.calculateMinPossibleCost(state, cardDef, playerId)
+                val primaryFaceAffordable = context.manaSolver.canPay(
+                    state, playerId, primaryFaceCost, precomputedSources = context.availableManaSources
+                )
+                secondaryFaceAffordable = enumerateSecondaryFace(
+                    context, cardId, cardDef, result, primaryFaceAffordable = primaryFaceAffordable
+                )
                 // Don't `continue` — let the surrounding loop also enumerate the primary face.
             }
 
@@ -374,7 +389,23 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, beholdBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
-            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordBlightPath && !canAffordBeholdPath) continue
+            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordBlightPath && !canAffordBeholdPath) {
+                // The primary face can't be paid for by any path. Normally we skip it entirely.
+                // But if this is an Adventure/Omen/modal-DFC card whose *secondary* face is
+                // affordable, surface a grayed-out placeholder for the primary face so the
+                // drag-to-play menu shows both faces — the player picks the affordable one or
+                // cancels, instead of the menu silently auto-firing the only enumerated option.
+                if (secondaryFaceAffordable) {
+                    result.add(LegalAction(
+                        actionType = "CastSpell",
+                        description = "Cast ${cardComponent.name}",
+                        action = CastSpell(playerId, cardId),
+                        affordable = false,
+                        manaCostString = effectiveCost.toString(),
+                    ))
+                }
+                continue
+            }
 
             val targetReqs = buildList {
                 addAll(cardDef.script.targetRequirements)
@@ -1776,27 +1807,51 @@ class CastSpellEnumerator : ActionEnumerator {
      * costs declared on the face's script are honoured for affordability but the full
      * additional-cost UX (sacrifice picker, blight, etc.) is not yet wired for these faces —
      * cards that need that can extend this method later.
+     *
+     * @param primaryFaceAffordable Whether the card's primary (creature) face is affordable.
+     *        When the secondary face is unaffordable but the primary is affordable, a grayed-out
+     *        placeholder for the secondary face is still emitted so the drag-to-play menu shows
+     *        both faces.
+     * @return True if an *affordable* secondary-face cast was emitted. The caller uses this to
+     *        decide whether to emit a grayed-out placeholder for an unaffordable primary face.
      */
     private fun enumerateSecondaryFace(
         context: EnumerationContext,
         cardId: EntityId,
         cardDef: CardDefinition,
         result: MutableList<LegalAction>,
-    ) {
+        primaryFaceAffordable: Boolean,
+    ): Boolean {
         val state = context.state
         val playerId = context.playerId
-        val face = cardDef.cardFaces.firstOrNull() ?: return
-        val playerEntity = state.getEntity(playerId) ?: return
+        val face = cardDef.cardFaces.firstOrNull() ?: return false
+        state.getEntity(playerId) ?: return false
 
         val isInstantAdventure = face.typeLine.isInstant
-        if (!isInstantAdventure && !context.canPlaySorcerySpeed) return
+        if (!isInstantAdventure && !context.canPlaySorcerySpeed) return false
 
         val effectiveCost = context.costCalculator
             .calculateEffectiveCostWithAlternativeBase(state, cardDef, face.manaCost, playerId)
         val cachedSources = context.availableManaSources
         val canAfford = context.manaSolver
             .canPay(state, playerId, effectiveCost, precomputedSources = cachedSources)
-        if (!canAfford) return
+        if (!canAfford) {
+            // Secondary face is unaffordable. If the primary face is affordable, still surface
+            // this face as a grayed-out option so the drag-to-play menu presents both and the
+            // player can choose deliberately or cancel (rather than auto-firing the primary).
+            if (primaryFaceAffordable) {
+                result.add(
+                    LegalAction(
+                        actionType = "CastSpell",
+                        description = "Cast ${face.name}",
+                        action = CastSpell(playerId, cardId, faceIndex = 0),
+                        affordable = false,
+                        manaCostString = effectiveCost.toString(),
+                    )
+                )
+            }
+            return false
+        }
 
         val targetReqs = face.script.targetRequirements
         val autoTapPreview = if (context.skipAutoTapPreview) null else {
@@ -1816,11 +1871,11 @@ class CastSpellEnumerator : ActionEnumerator {
                     autoTapPreview = autoTapPreview,
                 )
             )
-            return
+            return true
         }
 
         val targetInfos = context.targetUtils.buildTargetInfos(state, playerId, targetReqs)
-        if (!context.targetUtils.allRequirementsSatisfied(targetInfos)) return
+        if (!context.targetUtils.allRequirementsSatisfied(targetInfos)) return false
         val firstReq = targetReqs.first()
         val firstInfo = targetInfos.first()
         result.add(
@@ -1838,5 +1893,6 @@ class CastSpellEnumerator : ActionEnumerator {
                 autoTapPreview = autoTapPreview,
             )
         )
+        return true
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/AdventureFaceEnumerationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/AdventureFaceEnumerationTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.support.setupP1
+import com.wingedsheep.mtg.sets.definitions.blc.cards.BrightcapBadger
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * An Adventure / Omen / modal-DFC card should surface BOTH faces to the drag-to-play menu
+ * even when only one face is affordable: the unaffordable face is emitted with
+ * `affordable = false` (a grayed-out placeholder) so the client shows both options and the
+ * player can choose deliberately or cancel — rather than the menu silently auto-firing the
+ * single enumerated face.
+ *
+ * When *neither* face is affordable, nothing is emitted (the card stays unplayable), matching
+ * the contract for ordinary single-faced spells.
+ *
+ * Brightcap Badger // Fungus Frolic — creature face {3}{G}, Adventure (Instant) face {2}{G}.
+ */
+class AdventureFaceEnumerationTest : FunSpec({
+
+    test("both faces affordable: two affordable cast actions, one per face") {
+        val driver = setupP1(
+            hand = listOf("Brightcap Badger"),
+            battlefield = listOf("Forest", "Forest", "Forest", "Forest"), // {3}{G} and {2}{G} both ok
+            extraSetCards = listOf(BrightcapBadger),
+        )
+
+        val casts = driver.enumerateFor(driver.player1).castActionsFor("Brightcap Badger")
+
+        casts shouldHaveSize 2
+        casts.all { it.affordable } shouldBe true
+        casts.map { (it.action as CastSpell).faceIndex }.toSet() shouldBe setOf(null, 0)
+    }
+
+    test("only the cheaper Adventure face affordable: creature face surfaces as a grayed-out placeholder") {
+        val driver = setupP1(
+            hand = listOf("Brightcap Badger"),
+            battlefield = listOf("Forest", "Forest", "Forest"), // {2}{G} adventure yes, {3}{G} creature no
+            extraSetCards = listOf(BrightcapBadger),
+        )
+
+        val casts = driver.enumerateFor(driver.player1).castActionsFor("Brightcap Badger")
+
+        casts shouldHaveSize 2
+        val adventure = casts.single { (it.action as CastSpell).faceIndex == 0 }
+        val creature = casts.single { (it.action as CastSpell).faceIndex == null }
+        adventure.affordable shouldBe true
+        creature.affordable shouldBe false
+        // The grayed-out placeholder still carries the creature face's cost for display.
+        creature.manaCostString shouldBe "{3}{G}"
+    }
+
+    test("neither face affordable: the card is not enumerated at all") {
+        val driver = setupP1(
+            hand = listOf("Brightcap Badger"),
+            battlefield = listOf("Forest", "Forest"), // 2 mana: neither {2}{G} nor {3}{G}
+            extraSetCards = listOf(BrightcapBadger),
+        )
+
+        driver.enumerateFor(driver.player1).castActionsFor("Brightcap Badger").shouldBeEmpty()
+    }
+
+    // The reverse direction: a (synthetic) adventurer whose creature face is cheaper than its
+    // Adventure face. When only the creature face is affordable, the unaffordable Adventure face
+    // must still surface as a grayed-out placeholder.
+    val cheapBodyAdventure = card("Test Sprout") {
+        manaCost = "{G}"
+        typeLine = "Creature — Elf"
+        power = 1
+        toughness = 1
+        adventure("Overgrow") {
+            manaCost = "{4}{G}"
+            typeLine = "Sorcery — Adventure"
+            spell { effect = Effects.DrawCards(1) }
+        }
+    }
+
+    test("only the creature face affordable: Adventure face surfaces as a grayed-out placeholder") {
+        val driver = setupP1(
+            hand = listOf("Test Sprout"),
+            battlefield = listOf("Forest"), // {G} creature yes, {4}{G} adventure no
+            extraSetCards = listOf(cheapBodyAdventure),
+        )
+
+        val casts = driver.enumerateFor(driver.player1).castActionsFor("Test Sprout")
+
+        casts shouldHaveSize 2
+        val creature = casts.single { (it.action as CastSpell).faceIndex == null }
+        val adventure = casts.single { (it.action as CastSpell).faceIndex == 0 }
+        creature.affordable shouldBe true
+        adventure.affordable shouldBe false
+        adventure.manaCostString shouldBe "{4}{G}"
+    }
+})


### PR DESCRIPTION
Companion to the cycling drag-to-play fix (#414), server-side this time.

## Problem
An Adventure / Omen / modal-DFC card whose two faces have different costs could surface only the affordable face: with mana for just one face, `CastSpellEnumerator` emitted a single `CastSpell` action, so drag-to-play treated it as unambiguous and fired it immediately — the player never saw they couldn't cast the other face, nor had a chance to cancel.

## Fix
Unlike cycling, the client can't synthesize the missing face (it doesn't know its cost/targets/faceIndex), so this is a server fix: when one face is affordable, also emit the unaffordable sibling face with `affordable = false` (a grayed-out placeholder). The client already opens the menu and renders two cast buttons when two `CastSpell` actions are present, so no client change is needed.

- `enumerateSecondaryFace` now takes `primaryFaceAffordable` and returns whether it emitted an affordable cast; when the secondary face is unaffordable but the primary is affordable, it emits a grayed placeholder.
- The primary-face skip point emits a grayed placeholder when the secondary face is affordable.
- When neither face is affordable, nothing is emitted (card stays unplayable), matching the single-faced-spell contract. AI is unaffected — `GameSimulator` already filters `affordable` actions.

Scoped to the secondary-face path (ADVENTURE/OMEN/MODAL_DFC). SPLIT/Room cards have the same gap (see `RoomCastTest`) but are a distinct mechanic, left as a follow-up.

## Tests
Adds `AdventureFaceEnumerationTest` covering both faces affordable, only-secondary affordable (grayed primary), only-primary affordable (grayed secondary), and neither affordable (nothing emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)