### PR TITLE
Add Stormbrood Omen-Dragon cycle to Tarkir: Dragonstorm

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StormbroodCycleScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/StormbroodCycleScenarioTest.kt
@@ -1,0 +1,316 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the TDM "Stormbrood" Omen-Dragon cycle (TDM #178/#213/#221/#232/#234).
+ *
+ * Each card is a [com.wingedsheep.sdk.model.CardLayout.OMEN] double face: cast the creature
+ * (Dragon) front, or cast the cheaper Omen spell face — which shuffles the card back into the
+ * owner's library on resolution. These tests exercise both faces and the cycle's ETB / cast /
+ * static abilities, all composed from existing SDK primitives.
+ */
+class StormbroodCycleScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private fun TestGame.castOmenFace(
+        playerNumber: Int,
+        cardName: String,
+        targets: List<ChosenTarget>,
+    ) = run {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        val cardId = state.getHand(playerId).first {
+            state.getEntity(it)?.get<CardComponent>()?.name == cardName
+        }
+        execute(CastSpell(playerId, cardId, targets, faceIndex = 0))
+    }
+
+    init {
+
+        // ---------------------------------------------------------------------
+        // Disruptive Stormbrood // Petty Revenge
+        // ---------------------------------------------------------------------
+        context("Disruptive Stormbrood") {
+
+            test("ETB destroys up to one target artifact or enchantment") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Disruptive Stormbrood")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withCardOnBattlefield(2, "Slate of Ancestry") // artifact
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Disruptive Stormbrood").error shouldBe null
+                game.resolveStack() // creature enters → ETB asks for target
+
+                val target = game.findPermanent("Slate of Ancestry")!!
+                game.selectTargets(listOf(target)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Targeted artifact is destroyed") {
+                    game.isOnBattlefield("Slate of Ancestry") shouldBe false
+                }
+                withClue("Disruptive Stormbrood (3/3 flier) is on the battlefield") {
+                    game.isOnBattlefield("Disruptive Stormbrood") shouldBe true
+                }
+            }
+        }
+
+        context("Petty Revenge Omen face") {
+            test("destroys target creature with power 3 or less and shuffles into library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Disruptive Stormbrood")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2 — power 2 <= 3
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val libBefore = game.librarySize(1)
+                game.castOmenFace(1, "Disruptive Stormbrood", listOf(ChosenTarget.Permanent(bears))).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears is destroyed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("Omen card shuffled back into library (not graveyard)") {
+                    game.graveyardSize(1) shouldBe 0
+                    game.librarySize(1) shouldBe libBefore + 1
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Purging Stormbrood // Absorb Essence
+        // ---------------------------------------------------------------------
+        context("Purging Stormbrood") {
+            test("ETB removes all counters from up to one target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Purging Stormbrood")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Seed the opponent's creature with +1/+1 counters to clear.
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.state = game.state.withEntity(
+                    bears,
+                    game.state.getEntity(bears)!!
+                        .with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2))),
+                )
+
+                game.castSpell(1, "Purging Stormbrood").error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("All +1/+1 counters removed") {
+                    val counters = game.state.getEntity(bears)
+                        ?.get<CountersComponent>()
+                        ?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 0
+                }
+            }
+        }
+
+        context("Absorb Essence Omen face") {
+            test("target creature gets +2/+2 and gains lifelink and hexproof") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Purging Stormbrood")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castOmenFace(1, "Purging Stormbrood", listOf(ChosenTarget.Permanent(bears))).error shouldBe null
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+                withClue("Grizzly Bears is now 4/4") {
+                    projected.getPower(bears) shouldBe 4
+                    projected.getToughness(bears) shouldBe 4
+                }
+                withClue("gains lifelink and hexproof") {
+                    projected.hasKeyword(bears, Keyword.LIFELINK) shouldBe true
+                    projected.hasKeyword(bears, Keyword.HEXPROOF) shouldBe true
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Runescale Stormbrood // Chilling Screech
+        // ---------------------------------------------------------------------
+        context("Runescale Stormbrood") {
+            test("gets +2/+0 when you cast a noncreature spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Runescale Stormbrood") // 2/4
+                    .withCardInHand(1, "Shock") // noncreature (instant) spell
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val brood = game.findPermanent("Runescale Stormbrood")!!
+                game.castSpellTargetingPlayer(1, "Shock", 2).error shouldBe null
+                // Resolve the triggered ability (and Shock) so the +2/+0 buff applies.
+                game.resolveStack()
+
+                val projected = stateProjector.project(game.state)
+                withClue("Runescale Stormbrood is 4/4 after casting a noncreature spell") {
+                    projected.getPower(brood) shouldBe 4
+                    projected.getToughness(brood) shouldBe 4
+                }
+            }
+        }
+
+        context("Chilling Screech Omen face") {
+            test("counters target spell with mana value 2 or less") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Runescale Stormbrood")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(2, "Grizzly Bears") // MV 2 creature spell
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Player 2 casts Grizzly Bears (MV 2); player 1 responds with Chilling Screech.
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority() // active player passes → priority to player 1
+                val bearsOnStack = game.state.stack.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                game.castOmenFace(1, "Runescale Stormbrood", listOf(ChosenTarget.Spell(bearsOnStack))).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears was countered — never reaches the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Twinmaw Stormbrood // Charring Bite
+        // ---------------------------------------------------------------------
+        context("Twinmaw Stormbrood") {
+            test("ETB gains 5 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Twinmaw Stormbrood")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+                game.castSpell(1, "Twinmaw Stormbrood").error shouldBe null
+                game.resolveStack()
+
+                withClue("Controller gains 5 life") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 5
+                }
+            }
+        }
+
+        context("Charring Bite Omen face") {
+            test("deals 5 damage to a creature without flying") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Twinmaw Stormbrood")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3, no flying
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                game.castOmenFace(1, "Twinmaw Stormbrood", listOf(ChosenTarget.Permanent(giant))).error shouldBe null
+                game.resolveStack()
+
+                withClue("Hill Giant takes 5 damage and dies") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Whirlwing Stormbrood // Dynamic Soar
+        // ---------------------------------------------------------------------
+        context("Whirlwing Stormbrood") {
+            test("creature face has flash and flying") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Whirlwing Stormbrood")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val brood = game.findPermanent("Whirlwing Stormbrood")!!
+                val projected = stateProjector.project(game.state)
+                withClue("Whirlwing Stormbrood has flying and flash") {
+                    projected.hasKeyword(brood, Keyword.FLYING) shouldBe true
+                    projected.hasKeyword(brood, Keyword.FLASH) shouldBe true
+                }
+            }
+        }
+
+        context("Dynamic Soar Omen face") {
+            test("puts three +1/+1 counters on target creature you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Whirlwing Stormbrood")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castOmenFace(1, "Whirlwing Stormbrood", listOf(ChosenTarget.Permanent(bears))).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears has three +1/+1 counters") {
+                    val counters = game.state.getEntity(bears)
+                        ?.get<CountersComponent>()
+                        ?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DisruptiveStormbrood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DisruptiveStormbrood.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Disruptive Stormbrood // Petty Revenge — Tarkir: Dragonstorm #178
+ * {4}{G} · Creature — Dragon · 3/3
+ *
+ * Flying
+ * When this creature enters, destroy up to one target artifact or enchantment.
+ *
+ * Omen: Petty Revenge — {1}{B}, Sorcery — Omen
+ * Destroy target creature with power 3 or less.
+ *
+ * (Omen, Tarkir: Dragonstorm: casting the Omen face shuffles this card into its owner's
+ * library on resolution instead of putting it in the graveyard. From every zone other than
+ * the stack the card is just the Dragon — see [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ */
+val DisruptiveStormbrood = card("Disruptive Stormbrood") {
+    manaCost = "{4}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Dragon"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\nWhen this creature enters, destroy up to one target artifact or enchantment."
+
+    keywords(Keyword.FLYING)
+
+    // ETB: destroy up to one target artifact or enchantment.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to one target artifact or enchantment",
+            TargetPermanent(filter = TargetFilter.ArtifactOrEnchantment, count = 1, optional = true)
+        )
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+    }
+
+    // Omen: Petty Revenge — Sorcery. Destroy target creature with power 3 or less.
+    omen("Petty Revenge") {
+        manaCost = "{1}{B}"
+        typeLine = "Sorcery — Omen"
+        oracleText = "Destroy target creature with power 3 or less. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            val creature = target("creature with power 3 or less", Targets.CreatureWithPowerAtMost(3))
+            effect = Effects.Destroy(creature)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Edgar Sánchez Hidalgo"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd78e8ae-e927-40e7-9580-966c5e81f53c.jpg?1743204689"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/PurgingStormbrood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/PurgingStormbrood.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Purging Stormbrood // Absorb Essence — Tarkir: Dragonstorm #213
+ * {4}{B} · Creature — Dragon · 4/4
+ *
+ * Flying
+ * Ward—Pay 2 life.
+ * When this creature enters, remove all counters from up to one target creature.
+ *
+ * Omen: Absorb Essence — {1}{W}, Instant — Omen
+ * Target creature gets +2/+2 and gains lifelink and hexproof until end of turn.
+ *
+ * (Omen, Tarkir: Dragonstorm: casting the Omen face shuffles this card into its owner's
+ * library on resolution instead of putting it in the graveyard. From every zone other than
+ * the stack the card is just the Dragon — see [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ */
+val PurgingStormbrood = card("Purging Stormbrood") {
+    manaCost = "{4}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\nWard—Pay 2 life. (Whenever this creature becomes the target of a spell " +
+        "or ability an opponent controls, counter it unless that player pays 2 life.)\n" +
+        "When this creature enters, remove all counters from up to one target creature."
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.wardLife(2))
+
+    // ETB: remove all counters from up to one target creature.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("up to one target creature", Targets.UpToCreatures(1))
+        effect = Effects.RemoveAllCounters(EffectTarget.ContextTarget(0))
+    }
+
+    // Omen: Absorb Essence — Instant. Target creature gets +2/+2 and gains lifelink and hexproof.
+    omen("Absorb Essence") {
+        manaCost = "{1}{W}"
+        typeLine = "Instant — Omen"
+        oracleText = "Target creature gets +2/+2 and gains lifelink and hexproof until end of turn. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.Composite(
+                Effects.ModifyStats(2, 2, creature),
+                Effects.GrantKeyword(Keyword.LIFELINK, creature),
+                Effects.GrantHexproof(creature),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "213"
+        artist = "David Astruga"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/3988dc76-072c-4f43-849d-2e73c6f6ff58.jpg?1743204843"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RunescaleStormbrood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RunescaleStormbrood.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Runescale Stormbrood // Chilling Screech — Tarkir: Dragonstorm #221
+ * {3}{R} · Creature — Dragon · 2/4
+ *
+ * Flying
+ * Whenever you cast a noncreature spell or a Dragon spell, this creature gets +2/+0 until end of turn.
+ *
+ * Omen: Chilling Screech — {1}{U}, Instant — Omen
+ * Counter target spell with mana value 2 or less.
+ *
+ * (Omen, Tarkir: Dragonstorm: casting the Omen face shuffles this card into its owner's
+ * library on resolution instead of putting it in the graveyard. From every zone other than
+ * the stack the card is just the Dragon — see [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ */
+val RunescaleStormbrood = card("Runescale Stormbrood") {
+    manaCost = "{3}{R}"
+    colorIdentity = "RU"
+    typeLine = "Creature — Dragon"
+    power = 2
+    toughness = 4
+    oracleText = "Flying\nWhenever you cast a noncreature spell or a Dragon spell, " +
+        "this creature gets +2/+0 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    // Whenever you cast a noncreature spell OR a Dragon spell, +2/+0 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Noncreature or GameObjectFilter.Any.withSubtype(Subtype.DRAGON)
+        )
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    // Omen: Chilling Screech — Instant. Counter target spell with mana value 2 or less.
+    omen("Chilling Screech") {
+        manaCost = "{1}{U}"
+        typeLine = "Instant — Omen"
+        oracleText = "Counter target spell with mana value 2 or less. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            target("spell with mana value 2 or less", Targets.SpellWithManaValueAtMost(2))
+            effect = Effects.CounterSpell()
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "221"
+        artist = "Loïc Canavaggia"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/317744d1-ed78-4b53-a4d8-8c7ecfd9c4ae.jpg?1743204873"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TwinmawStormbrood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TwinmawStormbrood.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Twinmaw Stormbrood // Charring Bite — Tarkir: Dragonstorm #232
+ * {5}{W} · Creature — Dragon · 5/4
+ *
+ * Flying
+ * When this creature enters, you gain 5 life.
+ *
+ * Omen: Charring Bite — {1}{R}, Sorcery — Omen
+ * Charring Bite deals 5 damage to target creature without flying.
+ *
+ * (Omen, Tarkir: Dragonstorm: casting the Omen face shuffles this card into its owner's
+ * library on resolution instead of putting it in the graveyard. From every zone other than
+ * the stack the card is just the Dragon — see [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ */
+val TwinmawStormbrood = card("Twinmaw Stormbrood") {
+    manaCost = "{5}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Dragon"
+    power = 5
+    toughness = 4
+    oracleText = "Flying\nWhen this creature enters, you gain 5 life."
+
+    keywords(Keyword.FLYING)
+
+    // ETB: you gain 5 life.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(5)
+    }
+
+    // Omen: Charring Bite — Sorcery. Deals 5 damage to target creature without flying.
+    omen("Charring Bite") {
+        manaCost = "{1}{R}"
+        typeLine = "Sorcery — Omen"
+        oracleText = "Charring Bite deals 5 damage to target creature without flying. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            val creature = target(
+                "creature without flying",
+                TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withoutKeyword(Keyword.FLYING)))
+            )
+            effect = Effects.DealDamage(5, creature)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "232"
+        artist = "Tuan Duong Chu"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/2999e3b1-6510-42b2-9429-28c07a64a44f.jpg?1743204919"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WhirlwingStormbrood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WhirlwingStormbrood.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Whirlwing Stormbrood // Dynamic Soar — Tarkir: Dragonstorm #234
+ * {4}{U} · Creature — Dragon · 4/3
+ *
+ * Flash
+ * Flying
+ * You may cast sorcery spells and Dragon spells as though they had flash.
+ *
+ * Omen: Dynamic Soar — {2}{G}, Sorcery — Omen
+ * Put three +1/+1 counters on target creature you control.
+ *
+ * (Omen, Tarkir: Dragonstorm: casting the Omen face shuffles this card into its owner's
+ * library on resolution instead of putting it in the graveyard. From every zone other than
+ * the stack the card is just the Dragon — see [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ */
+val WhirlwingStormbrood = card("Whirlwing Stormbrood") {
+    manaCost = "{4}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 3
+    oracleText = "Flash\nFlying\nYou may cast sorcery spells and Dragon spells as though they had flash."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    // You may cast sorcery spells and Dragon spells as though they had flash.
+    staticAbility {
+        ability = GrantFlashToSpellType(
+            filter = GameObjectFilter.Sorcery or GameObjectFilter.Any.withSubtype(Subtype.DRAGON),
+            controllerOnly = true
+        )
+    }
+
+    // Omen: Dynamic Soar — Sorcery. Put three +1/+1 counters on target creature you control.
+    omen("Dynamic Soar") {
+        manaCost = "{2}{G}"
+        typeLine = "Sorcery — Omen"
+        oracleText = "Put three +1/+1 counters on target creature you control. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            val creature = target("creature you control", Targets.CreatureYouControl)
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, creature)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "234"
+        artist = "Fajareka Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56a25eb1-bdb8-4f86-8d9a-3055ad1b2a13.jpg?1743204927"
+    }
+}


### PR DESCRIPTION
## Summary

Implements the five-card **Stormbrood** cycle of `OMEN` double-faced Dragons from Tarkir: Dragonstorm (TDM #178/#213/#221/#232/#234). Every card is composed entirely from existing SDK primitives — **no new engine/SDK types were needed**. The OMEN layout (creature front + cheaper Omen-spell face that shuffles back into the library on resolution) was already supported.

| Card | Front (Dragon) | Omen face |
|------|----------------|-----------|
| **Disruptive Stormbrood** // Petty Revenge | {4}{G} 3/3 Flying; ETB destroy up to one artifact/enchantment | {1}{B} destroy a creature with power 3 or less |
| **Purging Stormbrood** // Absorb Essence | {4}{B} 4/4 Flying, Ward—Pay 2 life; ETB remove all counters from up to one creature | {1}{W} target creature gets +2/+2 and gains lifelink and hexproof |
| **Runescale Stormbrood** // Chilling Screech | {3}{R} 2/4 Flying; +2/+0 on casting a noncreature or Dragon spell | {1}{U} counter a spell with mana value 2 or less |
| **Twinmaw Stormbrood** // Charring Bite | {5}{W} 5/4 Flying; ETB gain 5 life | {1}{R} deal 5 damage to a creature without flying |
| **Whirlwing Stormbrood** // Dynamic Soar | {4}{U} 4/3 Flash, Flying; may cast sorceries and Dragon spells as though they had flash | {2}{G} put three +1/+1 counters on a creature you control |

### Notable composition choices
- "Noncreature spell or a Dragon spell" / "sorcery spells and Dragon spells" use the `GameObjectFilter.X or GameObjectFilter.Any.withSubtype(Subtype.DRAGON)` OR-combinator (`youCastSpell(spellFilter = ...)` and existing `GrantFlashToSpellType`).
- "Up to one target artifact or enchantment" uses `TargetPermanent(filter = ArtifactOrEnchantment, count = 1, optional = true)`.
- Absorb Essence composes `ModifyStats` + `GrantKeyword(LIFELINK)` + `GrantHexproof` via `Effects.Composite`.

## Tests

`StormbroodCycleScenarioTest` (game-server, Kotest) — 10 tests, all passing. Covers both faces of every card: ETB targeting, the cast-spell pump trigger, the flash/flying static, spell counter on the stack, damage, life gain, counter placement, and the Omen shuffle-into-library resolution (asserting the card returns to library, not graveyard).

```
./gradlew :game-server:test --tests "StormbroodCycleScenarioTest"  # 10/10 PASSED
```

`scripts/check-card-printing.py` confirms TDM is the canonical (earliest) printing for each; `scripts/card-status --cards TDM` now marks all five `[x]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)