### PR TITLE
Add DynamicAmount.SpellsCastThisTurn to the engine

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -93,7 +93,7 @@ gather over it.
   The Gitrog Ravenous Ride & Calamity (consume the saddlers), **Luxurious Locomotive** (Treasure per
   creature that crewed it this turn). Same shape — build once, share between Saddle and Crew.
 
-### 3. `DynamicAmount` over spells cast this turn (filtered, per-player, exclude-self)
+### 3. `DynamicAmount` over spells cast this turn (filtered, per-player, exclude-self) — ✅ DONE
 
 The data exists (`GameState.spellsCastThisTurnByPlayer: Map<EntityId, List<CastSpellRecord>>`) and
 there is a `YouCastSpellsThisTurn` **condition**, but **no `DynamicAmount`** that reads a *count* of
@@ -102,6 +102,12 @@ turn. Add a `DynamicAmount.SpellsCastThisTurn(player, filter, excludeSelf)`.
 
 → **Thunder Salvo** ("2 plus the number of other spells you've cast this turn"), **Magebane Lizard**
   ("noncreature spells they've cast this turn").
+
+**Implemented:** `DynamicAmount.SpellsCastThisTurn(player, filter, excludeSelf)` +
+`DynamicAmounts.spellsCastThisTurn(...)` facade. `excludeSelf` matches the resolving spell by its
+stack entity id via a new `CastSpellRecord.sourceEntityId`. Both cards are now buildable (Thunder
+Salvo via `Add(Fixed(2), …excludeSelf=true)`; Magebane via the `Noncreature` filter). Tests:
+`SpellsCastThisTurnAmountTest`.
 
 ### 4. "Cast from your hand" cast-zone qualifier on the spell-cast tracker
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1823,6 +1823,19 @@ Numbers computed at resolution time.
 - `HandSize(player)` — cards in hand.
 - `TurnCount(player)` — turn number for that player.
 - `TurnTracking(player, TurnTracker)` — value of a per-turn counter (see below).
+- `SpellsCastThisTurn(player, filter?, excludeSelf?)` — count of spells `player` has cast this
+  turn, read from the per-player cast history (`GameState.spellsCastThisTurnByPlayer`). `filter`
+  matches a spell characteristic captured at cast time — type/color/mana value (face-down casts
+  never match a non-empty filter); defaults to `GameObjectFilter.Any`. `excludeSelf` (default
+  `false`) drops the resolving spell's *own* record, matched by its stack entity id, for "the
+  number of **other** spells you've cast this turn". The triggering spell is already recorded and
+  counts unless `excludeSelf`. DSL: `DynamicAmounts.spellsCastThisTurn(player, filter, excludeSelf)`.
+  - Thunder Salvo ("2 plus the number of other spells you've cast this turn"):
+    `Add(Fixed(2), SpellsCastThisTurn(Player.You, excludeSelf = true))`.
+  - Magebane Lizard ("the number of noncreature spells they've cast this turn"):
+    `SpellsCastThisTurn(Player.TriggeringPlayer, GameObjectFilter.Noncreature)`.
+  - Pairs with the `YouCastSpellsThisTurn` **condition** (§ conditions) — that gates a yes/no
+    threshold, this yields the count.
 
 ### Counters
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -262,6 +262,25 @@ object DynamicAmounts {
     fun descendedThisTurn(player: Player = Player.You): DynamicAmount =
         DynamicAmount.TurnTracking(player, TurnTracker.DESCENDED)
 
+    /**
+     * "The number of [filter] spells [player] has cast this turn", optionally excluding the
+     * resolving spell itself. Reads the per-player cast history, so the triggering spell counts
+     * unless [excludeSelf].
+     *
+     * ```kotlin
+     * // "other spells you've cast this turn" (Thunder Salvo's variable half)
+     * DynamicAmounts.spellsCastThisTurn(excludeSelf = true)
+     * // "noncreature spells they've cast this turn" (Magebane Lizard)
+     * DynamicAmounts.spellsCastThisTurn(Player.TriggeringPlayer, GameObjectFilter.Noncreature)
+     * ```
+     */
+    fun spellsCastThisTurn(
+        player: Player = Player.You,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        excludeSelf: Boolean = false
+    ): DynamicAmount =
+        DynamicAmount.SpellsCastThisTurn(player, filter, excludeSelf)
+
     /** The starting life total of a player (20 in standard, 40 in commander). */
     fun startingLifeTotal(player: Player = Player.You): DynamicAmount =
         DynamicAmount.StartingLifeTotal(player)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -754,4 +754,57 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
     }
 
+    /**
+     * Counts the spells a player has cast this turn, optionally filtered and optionally
+     * excluding the currently-resolving spell itself.
+     *
+     * Reads the per-player `spellsCastThisTurnByPlayer` history (a list of [CastSpellRecord]
+     * snapshots taken at cast time), so it counts spells regardless of where they are now —
+     * the spell that triggered an ability is already recorded and counts unless [excludeSelf].
+     *
+     * - [filter] narrows to a spell characteristic captured at cast time (type, color, mana
+     *   value). Face-down (Morph/Disguise) casts never match a non-empty filter. With
+     *   [GameObjectFilter.Any] every cast counts.
+     * - [excludeSelf] drops the resolving spell's own record (matched by its stack entity id
+     *   against the evaluation context's source), for "the number of *other* spells you've
+     *   cast this turn". It only has an effect when the source is itself the resolving spell.
+     *
+     * ```kotlin
+     * // Thunder Salvo: "2 plus the number of other spells you've cast this turn"
+     * DynamicAmount.Add(DynamicAmount.Fixed(2),
+     *     DynamicAmount.SpellsCastThisTurn(Player.You, excludeSelf = true))
+     *
+     * // Magebane Lizard: "the number of noncreature spells they've cast this turn"
+     * DynamicAmount.SpellsCastThisTurn(Player.TriggeringPlayer, GameObjectFilter.Noncreature)
+     * ```
+     *
+     * @param player Whose cast history to count (summed when the ref resolves to several players)
+     * @param filter Spell characteristics to match (default [GameObjectFilter.Any])
+     * @param excludeSelf Exclude the resolving spell's own cast record (default false)
+     */
+    @SerialName("SpellsCastThisTurn")
+    @Serializable
+    data class SpellsCastThisTurn(
+        val player: Player = Player.You,
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val excludeSelf: Boolean = false
+    ) : DynamicAmount {
+        override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+        override val description: String = buildString {
+            append("the number of ")
+            if (excludeSelf) append("other ")
+            if (filter == GameObjectFilter.Any) append("spells")
+            else append("${filter.description} spells")
+            append(" ")
+            when (player) {
+                Player.You -> append("you've cast")
+                else -> append("${player.description} has cast")
+            }
+            append(" this turn")
+        }
+    }
+
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -331,6 +331,20 @@ class DynamicAmountEvaluator(
                 }
             }
 
+            is DynamicAmount.SpellsCastThisTurn -> {
+                val playerIds = resolveUnifiedPlayerIds(state, amount.player, context)
+                // excludeSelf drops the resolving spell's own record, matched by the spell's
+                // stack entity id (CastSpellRecord.sourceEntityId == context.sourceId).
+                val selfId = if (amount.excludeSelf) context.sourceId else null
+                playerIds.sumOf { playerId ->
+                    val records = state.spellsCastThisTurnByPlayer[playerId] ?: emptyList()
+                    records.count { record ->
+                        (selfId == null || record.sourceEntityId != selfId) &&
+                            predicateEvaluator.matchesFilter(record, amount.filter)
+                    }
+                }
+            }
+
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -2079,6 +2079,9 @@ class CastSpellHandler(
                 colors = cardComponent.colors,
                 isFaceDown = action.castFaceDown,
                 paidWithTreasureMana = paymentResult.paidWithTreasureMana,
+                // The cast card moves to the stack keeping its entity id, so this matches the
+                // resolving spell's EffectContext.sourceId (used by SpellsCastThisTurn excludeSelf).
+                sourceEntityId = action.cardId,
             )
             val existing = currentState.spellsCastThisTurnByPlayer[action.playerId] ?: emptyList()
             currentState = currentState.copy(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -636,6 +636,11 @@ data class CommanderDamageEntry(
  * [paidWithTreasureMana] captures whether any of the mana spent to cast the spell was
  * added by tapping a Treasure (see Rain of Riches, "the first spell you cast each turn
  * that mana from a Treasure was spent to cast").
+ *
+ * [sourceEntityId] is the entity id of the spell on the stack (the card entity that was cast).
+ * It lets a resolving spell exclude its own record from a count of spells cast this turn —
+ * e.g. Thunder Salvo's "the number of *other* spells you've cast this turn". Null for synthetic
+ * records constructed only for retroactive filter matching.
  */
 @Serializable
 data class CastSpellRecord(
@@ -644,4 +649,5 @@ data class CastSpellRecord(
     val colors: Set<Color>,
     val isFaceDown: Boolean,
     val paidWithTreasureMana: Boolean = false,
+    val sourceEntityId: EntityId? = null,
 )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpellsCastThisTurnAmountTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpellsCastThisTurnAmountTest.kt
@@ -1,0 +1,261 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.CastSpellRecord
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [DynamicAmount.SpellsCastThisTurn] — counts the spells a player has cast this turn,
+ * optionally filtered (e.g. noncreature) and optionally excluding the resolving spell.
+ *
+ * Backs Thunder Salvo ("2 plus the number of *other* spells you've cast this turn") and
+ * Magebane Lizard ("the number of noncreature spells they've cast this turn"). The first
+ * group of tests drives the full cast pipeline through stand-in cards; the second pins the
+ * counting/filter/exclude-self/per-player rules directly on the evaluator.
+ */
+class SpellsCastThisTurnAmountTest : FunSpec({
+
+    // A 0/20 wall so spells can deal it damage without killing it — lets us read the amount
+    // off its DamageComponent.
+    val DamageSponge = card("Damage Sponge") {
+        manaCost = "{0}"
+        typeLine = "Creature — Wall"
+        power = 0
+        toughness = 20
+        oracleText = ""
+    }
+
+    // Thunder Salvo stand-in: deals (2 + other spells you've cast this turn) to target creature.
+    val OtherSpellsSalvo = card("Other Spells Salvo") {
+        manaCost = "{R}"
+        colorIdentity = "R"
+        typeLine = "Instant"
+        oracleText = "Deals damage to target creature equal to 2 plus the number of other spells you've cast this turn."
+        spell {
+            val t = target("target", TargetCreature())
+            effect = DealDamageEffect(
+                DynamicAmount.Add(
+                    DynamicAmount.Fixed(2),
+                    DynamicAmount.SpellsCastThisTurn(Player.You, excludeSelf = true)
+                ),
+                t
+            )
+        }
+    }
+
+    // Magebane Lizard stand-in: deals (noncreature spells you've cast this turn, including itself)
+    // to target creature.
+    val NoncreatureCount = card("Noncreature Count") {
+        manaCost = "{R}"
+        colorIdentity = "R"
+        typeLine = "Instant"
+        oracleText = "Deals damage to target creature equal to the number of noncreature spells you've cast this turn."
+        spell {
+            val t = target("target", TargetCreature())
+            effect = DealDamageEffect(
+                DynamicAmount.SpellsCastThisTurn(Player.You, GameObjectFilter.Noncreature),
+                t
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + DamageSponge + OtherSpellsSalvo + NoncreatureCount)
+        return driver
+    }
+
+    fun damageOn(driver: GameTestDriver, entity: EntityId): Int =
+        driver.state.getEntity(entity)?.get<DamageComponent>()?.amount ?: 0
+
+    // =========================================================================
+    // End-to-end through the cast pipeline
+    // =========================================================================
+
+    test("excludeSelf: salvo cast alone deals only its base 2 (no other spells)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val sponge = driver.putCreatureOnBattlefield(you, "Damage Sponge")
+
+        val salvo = driver.putCardInHand(you, "Other Spells Salvo")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, salvo, listOf(sponge)).isSuccess shouldBe true
+        driver.bothPass() // resolve the salvo
+
+        // records = [salvo]; excludeSelf drops it → 0 other → damage = 2.
+        damageOn(driver, sponge) shouldBe 2
+    }
+
+    test("excludeSelf: salvo counts other spells cast earlier this turn but not itself") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val sponge = driver.putCreatureOnBattlefield(you, "Damage Sponge")
+
+        // Two prior spells this turn (left on the stack — the record is taken at cast time).
+        val bolt1 = driver.putCardInHand(you, "Lightning Bolt")
+        val bolt2 = driver.putCardInHand(you, "Lightning Bolt")
+        val salvo = driver.putCardInHand(you, "Other Spells Salvo")
+        driver.giveMana(you, Color.RED, 3)
+
+        driver.castSpell(you, bolt1, listOf(you)).isSuccess shouldBe true
+        driver.castSpell(you, bolt2, listOf(you)).isSuccess shouldBe true
+        driver.castSpell(you, salvo, listOf(sponge)).isSuccess shouldBe true
+        driver.bothPass() // resolve the salvo (top of stack), bolts remain beneath
+
+        // records = [bolt1, bolt2, salvo]; excludeSelf drops salvo → 2 others → damage = 2 + 2 = 4.
+        damageOn(driver, sponge) shouldBe 4
+    }
+
+    test("filter (excludeSelf=false): noncreature count includes the resolving spell itself") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val sponge = driver.putCreatureOnBattlefield(you, "Damage Sponge")
+
+        val counter = driver.putCardInHand(you, "Noncreature Count")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, counter, listOf(sponge)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // records = [counter] (an instant = noncreature); includes itself → 1.
+        damageOn(driver, sponge) shouldBe 1
+    }
+
+    test("filter: a prior creature spell is excluded; a prior noncreature spell is counted") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val sponge = driver.putCreatureOnBattlefield(you, "Damage Sponge")
+
+        val courser = driver.putCardInHand(you, "Centaur Courser") // creature spell — filtered out
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")     // noncreature — counted
+        val counter = driver.putCardInHand(you, "Noncreature Count")
+        driver.giveMana(you, Color.GREEN, 6)
+        driver.giveMana(you, Color.RED, 6)
+
+        driver.castSpell(you, courser, emptyList()).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature so it isn't left blocking the stack
+        driver.castSpell(you, bolt, listOf(you)).isSuccess shouldBe true
+        driver.castSpell(you, counter, listOf(sponge)).isSuccess shouldBe true
+        driver.bothPass() // resolve Noncreature Count
+
+        // noncreature records = [bolt, counter] (courser is a creature) → 2.
+        damageOn(driver, sponge) shouldBe 2
+    }
+
+    // =========================================================================
+    // Evaluator-level: per-player resolution, filter, and exclude-self matching
+    // =========================================================================
+
+    test("evaluator: counts per player and honors Player.You vs Player.Opponent") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.player1
+        val opp = driver.player2
+        val evaluator = DynamicAmountEvaluator()
+
+        val instant = TypeLine.parse("Instant")
+        val creature = TypeLine.parse("Creature")
+        val state = driver.state.copy(
+            spellsCastThisTurnByPlayer = mapOf(
+                you to listOf(
+                    CastSpellRecord(instant, 1, emptySet(), false, sourceEntityId = EntityId("1001")),
+                    CastSpellRecord(creature, 2, emptySet(), false, sourceEntityId = EntityId("1002")),
+                ),
+                opp to listOf(
+                    CastSpellRecord(instant, 1, emptySet(), false, sourceEntityId = EntityId("2001")),
+                )
+            )
+        )
+        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+
+        // Player.You, Any → both your spells.
+        evaluator.evaluate(state, DynamicAmount.SpellsCastThisTurn(Player.You), ctx) shouldBe 2
+        // Player.You, Noncreature → only the instant.
+        evaluator.evaluate(
+            state,
+            DynamicAmount.SpellsCastThisTurn(Player.You, GameObjectFilter.Noncreature),
+            ctx
+        ) shouldBe 1
+        // Player.Opponent, Any → the single opponent spell.
+        evaluator.evaluate(state, DynamicAmount.SpellsCastThisTurn(Player.Opponent), ctx) shouldBe 1
+    }
+
+    test("evaluator: excludeSelf drops the record whose sourceEntityId matches the source") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.player1
+        val evaluator = DynamicAmountEvaluator()
+
+        val instant = TypeLine.parse("Instant")
+        val state = driver.state.copy(
+            spellsCastThisTurnByPlayer = mapOf(
+                you to listOf(
+                    CastSpellRecord(instant, 1, emptySet(), false, sourceEntityId = EntityId("1001")),
+                    CastSpellRecord(instant, 1, emptySet(), false, sourceEntityId = EntityId("1002")),
+                    CastSpellRecord(instant, 1, emptySet(), false, sourceEntityId = EntityId("1003")),
+                )
+            )
+        )
+
+        // Source is the spell with id 1003 (the resolving one) → excludeSelf counts the other 2.
+        val ctxSelf = EffectContext(sourceId = EntityId("1003"), controllerId = you, opponentId = null)
+        evaluator.evaluate(
+            state,
+            DynamicAmount.SpellsCastThisTurn(Player.You, excludeSelf = true),
+            ctxSelf
+        ) shouldBe 2
+
+        // Without excludeSelf, all 3 count regardless of source.
+        evaluator.evaluate(
+            state,
+            DynamicAmount.SpellsCastThisTurn(Player.You, excludeSelf = false),
+            ctxSelf
+        ) shouldBe 3
+
+        // excludeSelf with a source that isn't in the list drops nothing.
+        val ctxOther = EffectContext(sourceId = EntityId("9999"), controllerId = you, opponentId = null)
+        evaluator.evaluate(
+            state,
+            DynamicAmount.SpellsCastThisTurn(Player.You, excludeSelf = true),
+            ctxOther
+        ) shouldBe 3
+    }
+
+    test("description reads as oracle-style text") {
+        DynamicAmount.SpellsCastThisTurn(Player.You, excludeSelf = true).description shouldBe
+            "the number of other spells you've cast this turn"
+        DynamicAmount.SpellsCastThisTurn(Player.You, GameObjectFilter.Noncreature).description shouldBe
+            "the number of noncreature spells you've cast this turn"
+    }
+})


### PR DESCRIPTION
## Summary

Adds a `DynamicAmount` that reads the **count** of spells a player has cast this turn — optionally filtered (e.g. noncreature) and optionally excluding the resolving spell itself. The per-player cast history (`GameState.spellsCastThisTurnByPlayer`) and a `YouCastSpellsThisTurn` *condition* already existed, but there was no amount node to read the count. Closes item #3 of `backlog/otj-engine-gaps.md`.

## What changed

- **SDK** — new `DynamicAmount.SpellsCastThisTurn(player, filter = Any, excludeSelf = false)` variant + `DynamicAmounts.spellsCastThisTurn(...)` facade. Pure serializable data; description renders oracle-style (`"the number of other spells you've cast this turn"`).
- **`excludeSelf`** — identifies the resolving spell by its **stack entity id** via a new nullable `CastSpellRecord.sourceEntityId`, populated in `CastSpellHandler` with `action.cardId` (the card entity moves to the stack keeping its id, so it equals the resolving spell's `EffectContext.sourceId`). This correctly excludes *this* spell even when other instants were cast in response.
- **Engine** — one branch in `DynamicAmountEvaluator` reusing `PredicateEvaluator.matchesFilter` (the same path the condition uses) and `resolveUnifiedPlayerIds` for per-player resolution.
- **Docs** — documented in `docs/card-sdk-language-reference.md` (§13).

## Why this shape

- Reuses the existing cast-record filter path rather than re-implementing spell matching; `filter` is a `GameObjectFilter`, `player` is a `Player` ref — parameterized for the next card, not just these two.
- Sibling of the `YouCastSpellsThisTurn` condition: the condition gates a yes/no threshold, this yields the count.

## Unlocks

- **Thunder Salvo** — `Add(Fixed(2), SpellsCastThisTurn(Player.You, excludeSelf = true))`
- **Magebane Lizard** — `SpellsCastThisTurn(Player.TriggeringPlayer, GameObjectFilter.Noncreature)`

## Tests

`SpellsCastThisTurnAmountTest` — end-to-end through the cast pipeline (excludeSelf base case, counting prior spells but not itself, noncreature filter including/excluding self) plus evaluator-level coverage of per-player resolution, filter, and exclude-self entity-id matching, and the description text. Full `just build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)