### PR TITLE
Add PayXLife ability cost + four Tarkir: Dragonstorm cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -108,6 +108,9 @@ the `CardDefinition`.
 - `Costs.Untap` — `{Q}`; untap this permanent.
 - `Costs.Mana("{2}{U}")` — pay the given mana cost (string or `ManaCost`).
 - `Costs.PayLife(amount)` — pay N life.
+- `Costs.PayXLife` — pay life equal to the ability's X value (e.g. "{X}{B}, {T}, Pay X life", Krumar
+  Initiate). X is shared with the `{X}` mana symbol; the legal-action enumerator caps X at the
+  player's current life (CR 119.4 — paying down to exactly 0 is legal).
 - `Costs.Sacrifice(filter)` — sacrifice a permanent matching the filter (may include self).
 - `Costs.SacrificeAnother(filter)` — sacrifice a *different* permanent matching the filter.
 - `Costs.DiscardCard` — discard a card you choose (any card).

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KrumarInitiateScenarioTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/scenarios/KrumarInitiateScenarioTest.kt
@@ -1,0 +1,167 @@
+package com.wingedsheep.gameserver.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Krumar Initiate and its "{X}{B}, {T}, Pay X life" endure-X ability.
+ *
+ * Card reference:
+ * - Krumar Initiate ({1}{B}, 2/2 Human Cleric):
+ *   "{X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery.
+ *    (Put X +1/+1 counters on it or create an X/X white Spirit creature token.)"
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.AbilityCost.PayXLife] cost: the X
+ * from the `{X}{B}` mana symbol drives both the mana paid and the life paid, and feeds
+ * the Endure X amount.
+ */
+class KrumarInitiateScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Krumar Initiate - endure X via {X}{B}, {T}, Pay X life") {
+
+            test("endure X choosing +1/+1 counters pays X life and X mana") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krumar Initiate")
+                    .withLandsOnBattlefield(1, "Swamp", 3) // {X}{B} with X=2 needs 3 mana
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ability = cardRegistry.getCard("Krumar Initiate")!!.script.activatedAbilities.first()
+                val krumarId = game.findPermanent("Krumar Initiate")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = krumarId,
+                        abilityId = ability.id,
+                        xValue = 2
+                    )
+                )
+                withClue("Activating Krumar Initiate with X=2 should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                // Paid 2 life as part of the cost (20 -> 18).
+                game.getLifeTotal(1) shouldBe 18
+
+                game.resolveStack()
+
+                // Endure presents a modal choice: option 0 = +1/+1 counters, option 1 = token.
+                val decision = game.getPendingDecision()
+                decision shouldNotBe null
+                (decision is ChooseOptionDecision) shouldBe true
+                game.submitDecision(OptionChosenResponse(decision!!.id, 0))
+                game.resolveStack()
+
+                // Chose counters: 2 +1/+1 counters on Krumar, no Spirit token.
+                val counters = game.state.getEntity(krumarId)?.get<CountersComponent>()
+                (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 2
+                game.findPermanents("Spirit Token").size shouldBe 0
+            }
+
+            test("endure X choosing the token creates an X/X white Spirit") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krumar Initiate")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ability = cardRegistry.getCard("Krumar Initiate")!!.script.activatedAbilities.first()
+                val krumarId = game.findPermanent("Krumar Initiate")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = krumarId,
+                        abilityId = ability.id,
+                        xValue = 2
+                    )
+                ).error shouldBe null
+
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                (decision is ChooseOptionDecision) shouldBe true
+                game.submitDecision(OptionChosenResponse(decision!!.id, 1))
+                game.resolveStack()
+
+                // Chose the token: a 2/2 white Spirit, and no counters on Krumar.
+                val spirits = game.findPermanents("Spirit Token")
+                spirits.size shouldBe 1
+                val counters = game.state.getEntity(krumarId)?.get<CountersComponent>()
+                (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+            }
+
+            test("X=0 is payable and costs no life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krumar Initiate")
+                    .withLandsOnBattlefield(1, "Swamp", 1) // {X}{B} with X=0 needs just {B}
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ability = cardRegistry.getCard("Krumar Initiate")!!.script.activatedAbilities.first()
+                val krumarId = game.findPermanent("Krumar Initiate")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = krumarId,
+                        abilityId = ability.id,
+                        xValue = 0
+                    )
+                )
+                withClue("Activating Krumar Initiate with X=0 should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                // No life paid for X=0.
+                game.getLifeTotal(1) shouldBe 20
+            }
+
+            test("cannot activate at instant speed (sorcery only)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krumar Initiate")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.DECLARE_BLOCKERS) // not a main phase
+                    .build()
+
+                val ability = cardRegistry.getCard("Krumar Initiate")!!.script.activatedAbilities.first()
+                val krumarId = game.findPermanent("Krumar Initiate")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = krumarId,
+                        abilityId = ability.id,
+                        xValue = 2
+                    )
+                )
+                withClue("Activating at instant speed should be rejected") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -62,6 +62,11 @@ object Costs {
     fun PayLife(amount: Int): AbilityCost =
         AbilityCost.PayLife(amount)
 
+    /**
+     * Pay life equal to the ability's X value (e.g. "Pay X life" alongside an `{X}` mana cost).
+     */
+    val PayXLife: AbilityCost = AbilityCost.PayXLife
+
     // =========================================================================
     // Sacrifice Costs
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -349,6 +349,22 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
         }
     }
 
+    /**
+     * Pay a variable amount of life equal to the ability's X value.
+     * Example: "{X}{B}, {T}, Pay X life: ..." for Krumar Initiate.
+     *
+     * Mirrors [ExileXFromGraveyard] / [TapXPermanents]: the engine reads X from the
+     * activation's chosen X (the `{X}` mana symbol) and pays that much life. X can be 0.
+     * The legal-action enumerator caps X so the player can't reduce their own life to 0
+     * or below via this cost.
+     */
+    @SerialName("CostPayXLife")
+    @Serializable
+    data object PayXLife : AbilityCost {
+        override val description: String = "Pay X life"
+        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost = this
+    }
+
     /** Multiple costs combined */
     @SerialName("CostComposite")
     @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CausticExhale.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CausticExhale.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Caustic Exhale — Tarkir: Dragonstorm #74
+ * {B} · Instant
+ *
+ * As an additional cost to cast this spell, behold a Dragon or pay {1}.
+ * (To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)
+ * Target creature gets -3/-3 until end of turn.
+ */
+val CausticExhale = card("Caustic Exhale") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, behold a Dragon or pay {1}. " +
+        "(To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)\n" +
+        "Target creature gets -3/-3 until end of turn."
+
+    additionalCost(
+        AdditionalCost.BeholdOrPay(
+            filter = Filters.WithSubtype("Dragon"),
+            alternativeManaCost = "{1}"
+        )
+    )
+
+    spell {
+        val t = target("target creature", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(power = -3, toughness = -3, target = t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Camille Alquier"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/488152ce-2048-4ccb-b2d6-b9628958286f.jpg?1743204258"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KrumarInitiate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/KrumarInitiate.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Krumar Initiate — Tarkir: Dragonstorm #84
+ * {1}{B} · Creature — Human Cleric · 2/2
+ *
+ * {X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery.
+ * (Put X +1/+1 counters on it or create an X/X white Spirit creature token.)
+ *
+ * Endure is modeled as data (no keyword line) — a modal choice between X +1/+1 counters
+ * on this creature or an X/X white Spirit token. X is the ability's X value, shared by the
+ * {X} mana symbol and the "Pay X life" cost (the new [com.wingedsheep.sdk.scripting.AbilityCost.PayXLife]).
+ */
+val KrumarInitiate = card("Krumar Initiate") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "{X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery. " +
+        "(Put X +1/+1 counters on it or create an X/X white Spirit creature token.)"
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{X}{B}"),
+            Costs.Tap,
+            Costs.PayXLife
+        )
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Endure(DynamicAmount.XValue)
+        description = "{X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Josu Solano"
+        flavorText = "\"Welcome,\" the spirits of House Emesh whispered to Cemal. " +
+            "\"Welcome, newest sprout of our Kin-Tree.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc66680f-24ab-433a-8197-feac3a174075.jpg?1743204296"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RescueLeopard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RescueLeopard.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Rescue Leopard — Tarkir: Dragonstorm #116
+ * {2}{R} · Creature — Cat · 4/2
+ *
+ * Whenever this creature becomes tapped, you may discard a card. If you do, draw a card.
+ */
+val RescueLeopard = card("Rescue Leopard") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cat"
+    power = 4
+    toughness = 2
+    oracleText = "Whenever this creature becomes tapped, you may discard a card. If you do, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.BecomesTapped
+        effect = MayEffect(
+            effect = IfYouDoEffect(
+                action = EffectPatterns.discardCards(1),
+                ifYouDo = Effects.DrawCards(1)
+            ),
+            descriptionOverride = "You may discard a card. If you do, draw a card."
+        )
+        description = "Whenever this creature becomes tapped, you may discard a card. If you do, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Hector Ortiz"
+        flavorText = "\"The scouts should have been back hours ago. They might be in trouble. " +
+            "I'm sending Kyra.\"\n—Eshki Dragonclaw"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/056136a8-84be-477c-b654-63238fb8236e.jpg?1743204430"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TempestHawk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TempestHawk.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Tempest Hawk — Tarkir: Dragonstorm #31
+ * {2}{W} · Creature — Bird · 2/2
+ *
+ * Flying
+ * Whenever this creature deals combat damage to a player, you may search your library
+ * for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.
+ * A deck can have any number of cards named Tempest Hawk.
+ *
+ * The final line is a deckbuilding rule (like Relentless Rats); it has no in-game effect
+ * and requires no special wiring.
+ */
+val TempestHawk = card("Tempest Hawk") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever this creature deals combat damage to a player, you may search your library " +
+        "for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.\n" +
+        "A deck can have any number of cards named Tempest Hawk."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = MayEffect(
+            EffectPatterns.searchLibrary(
+                filter = GameObjectFilter.Any.named("Tempest Hawk"),
+                count = 1,
+                destination = SearchDestination.HAND,
+                reveal = true,
+                shuffleAfter = true
+            )
+        )
+        description = "Whenever this creature deals combat damage to a player, you may search your " +
+            "library for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Abz J Harding"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/422f9453-ab12-4e3c-8c51-be87391395a1.jpg?1743204081"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -144,6 +144,11 @@ class CostHandler(
                 // maxAffordableX is capped by untapped permanent count in LegalActionsCalculator
                 true
             }
+            is AbilityCost.PayXLife -> {
+                // X can be 0, so this is always payable
+                // maxAffordableX is capped by current life (must stay > 0) in LegalActionsCalculator
+                true
+            }
             is AbilityCost.TapAttachedCreature -> {
                 val attachedId = state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId
                     ?: return false
@@ -257,6 +262,24 @@ class CostHandler(
                     newState, manaPool,
                     events = listOf(LifeChangedEvent(controllerId, currentLife, newLife, LifeChangeReason.PAYMENT))
                 )
+            }
+            is AbilityCost.PayXLife -> {
+                val amount = choices.xValue
+                if (amount == 0) {
+                    CostPaymentResult.success(state, manaPool)
+                } else {
+                    val currentLife = state.getEntity(controllerId)?.get<LifeTotalComponent>()?.life
+                        ?: return CostPaymentResult.failure("Player has no life total")
+                    val newLife = currentLife - amount
+                    var newState = state.updateEntity(controllerId) { container ->
+                        container.with(LifeTotalComponent(newLife))
+                    }
+                    newState = DamageUtils.markLifeLostThisTurn(newState, controllerId)
+                    CostPaymentResult.success(
+                        newState, manaPool,
+                        events = listOf(LifeChangedEvent(controllerId, currentLife, newLife, LifeChangeReason.PAYMENT))
+                    )
+                }
             }
             is AbilityCost.Sacrifice, is AbilityCost.SacrificeChosenCreatureType -> {
                 val requiredCount = when (cost) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ChosenCreatureTypeComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
@@ -478,6 +479,19 @@ class CostEnumerationUtils(
         }
         if (tapXCost != null) {
             maxX = minOf(maxX, findAbilityTapTargets(state, playerId, tapXCost.filter).size)
+        }
+
+        // Cap by current life if PayXLife. Per CR 119.4 a player may pay an amount of life
+        // greater than 0 only if their life total is greater than or equal to that amount —
+        // so X can be at most the player's current life (paying down to exactly 0 is legal).
+        val hasPayXLife = when (abilityCost) {
+            is AbilityCost.PayXLife -> true
+            is AbilityCost.Composite -> abilityCost.costs.any { it is AbilityCost.PayXLife }
+            else -> false
+        }
+        if (hasPayXLife) {
+            val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+            maxX = minOf(maxX, life.coerceAtLeast(0))
         }
 
         return maxX


### PR DESCRIPTION
## Summary
Recovered in-flight work that was sitting uncommitted in a worktree and turned it into a PR.

Adds a new SDK ability-cost primitive **`AbilityCost.PayXLife`** — pay life equal to the ability's X value (the same X as the `{X}` mana symbol) — plus four Tarkir: Dragonstorm cards.

### SDK / engine
- `Costs.PayXLife` facade + `AbilityCost.PayXLife` data object (serializable).
- `CostHandler` pays X life and marks life-lost-this-turn; X = 0 is free.
- `CostEnumerationUtils` caps X at the player's current life — a player can't pay more life than they have, and paying down to exactly 0 is legal.
- Documented in `docs/card-sdk-language-reference.md`.

### Cards (TDM)
- **Krumar Initiate** — `{X}{B}, {T}, Pay X life`: endure X (exercises `PayXLife`).
- **Caustic Exhale** — behold-a-Dragon-or-pay `{1}` additional cost; target creature gets -3/-3.
- **Rescue Leopard** — becomes-tapped "you may discard a card; if you do, draw a card."
- **Tempest Hawk** — flying; on combat damage to a player, tutor for another Tempest Hawk.

## Testing
`./gradlew :game-server:test --tests "*KrumarInitiateScenarioTest*"` — all 4 scenarios pass (counters mode, token mode, X=0 free, sorcery-speed-only).

## Note
The `PayXLife` enumerator comment cites CR 119.4 for the can't-pay-more-life-than-you-have rule — worth a quick confirm against the comprehensive rules before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)