### PR TITLE
Add Saheeli's Lattice and the Craft mechanic (CR 702.167)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1612,10 +1612,13 @@ composite abilities).
   ("Mastercraft Raptor's power is equal to the total power of the exiled cards used to craft it", CR 702.167c)
   can read them via `DynamicAmount.CraftedMaterialsTotalPower`. Declares `Keyword.CRAFT` for display.
 
-  Material selection: the engine accepts the chosen materials via
-  `ActivateAbility.costPayment.exiledCards`. The cost handler validates that every chosen entity is either a
-  permanent the activator controls or a card in their graveyard matching `filter`. Client-side material
-  selection UI is not yet plumbed through — game-server callers must supply the chosen IDs directly.
+  Material selection: the engine surfaces the combined BF + GY candidate pool on each Craft activation as
+  `AdditionalCostData.validCraftMaterials` / `craftMinCount`. The web client renders both zones side-by-side
+  via the dedicated `CraftMaterialOverlay` (routed by the `Craft` cost-type branch in `pipelinePhases`) and
+  submits the picked IDs back as `ActivateAbility.costPayment.exiledCards`. Headless / game-server callers can
+  supply the chosen IDs directly. The cost handler validates that every chosen entity is either a permanent
+  the activator controls or a card in their graveyard matching `filter`, and rejects activation when no
+  choices are supplied (no silent auto-pick).
 
 - `Renew(cost)` — `card { renew(cost) { effect = … } }` builder helper (Tarkir: Dragonstorm, Sultai clan keyword).
   A graveyard-activated ability: "Renew — [cost], Exile this card from your graveyard: [effect]. Activate only as a

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -136,6 +136,18 @@ the `CardDefinition`.
   "Discard two cards at random").
 - `Costs.DiscardHand` — discard your entire hand.
 - `Costs.DiscardSelf` — discard this card (cycling-style).
+- `Costs.ExileSelf` — exile this permanent (or graveyard card, for graveyard-activated abilities).
+- `Costs.ExileFromGraveyard(count, filter)` — exile N matching cards from your graveyard.
+- `Costs.ExileXFromGraveyard(filter)` — exile X cards from your graveyard (X = the ability's
+  chosen X value).
+- `Costs.Craft(filter, minCount = 1)` — Craft material cost (CR 702.167a): exile this permanent
+  **and** exile at least `minCount` cards matching `filter` selected from the combined pool of
+  permanents you control and cards in your graveyard. Atomic because CR 702.167a pairs the
+  self-exile with the materials-exile in one clause. Records the chosen materials on the source's
+  `CraftedFromExiledComponent` so the back face's CDA can read them after the source returns
+  transformed. Always combined with `Mana(...)` and used with the
+  `Effects.ReturnSelfFromExileTransformed` resolution effect (the `card { craft(filter, cost) }`
+  helper wires the whole pattern).
 - `Costs.Composite(c1, c2, ...)` — multiple costs paid together.
 
 **Spell-level alternatives**
@@ -254,6 +266,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `PutOntoBattlefieldUnderYourControl(target)` — under controller's control.
 - `PutOntoBattlefieldFaceDown(count, target?)` — enter face-down (2/2 morph shape).
 - `ReturnSelfToBattlefieldAttached(target)` — return source attached to target (Aura recursion).
+- `ReturnSelfFromExileTransformed` — Craft resolution (CR 702.167a). Returns the source from exile to the
+  battlefield as its back face, under its owner's control, and re-attaches the source's
+  `CraftedFromExiledComponent` recording the exiled materials. Pair with `AbilityCost.Craft`; see the `Craft`
+  keyword helper in the keyword catalog.
 - `ReturnCreaturesPutInGraveyardThisTurn(player)` — Patriarch's Bidding shape.
 
 ### Hand reveal
@@ -1585,6 +1601,22 @@ composite abilities).
     off the stack with a zone-move); a printed `suspend N—[cost]` exiles from hand as its cast cost.
   - **Taigam, Master Opportunist** is the first user: `Composite(CopyTargetSpell(TriggeringEntity),
     CounterEffect(TriggeringEntity → Exile), Suspend(TriggeringEntity, 4))`.
+- `Craft(filter, cost)` — `card { craft(filter, cost) }` builder helper (CR 702.167, The Lost Caverns of
+  Ixalan). On the front face of a transforming DFC: "Craft with [filter] [cost] ([cost], Exile this permanent,
+  Exile [filter] you control and/or [filter] cards from your graveyard: Return this card to the battlefield
+  transformed under its owner's control. Activate only as a sorcery.)" Composes entirely from existing primitives
+  — `AbilityCost.Composite(Mana(cost), AbilityCost.Craft(filter))` (the atomic `Craft` sub-cost handles both the
+  self-exile and the materials-exile because CR 702.167a defines them as one paired clause), plus
+  `Effects.ReturnSelfFromExileTransformed` as the resolution effect, and `timing = TimingRule.SorcerySpeed`.
+  Records the exiled materials on the source's `CraftedFromExiledComponent` so the back face's CDA
+  ("Mastercraft Raptor's power is equal to the total power of the exiled cards used to craft it", CR 702.167c)
+  can read them via `DynamicAmount.CraftedMaterialsTotalPower`. Declares `Keyword.CRAFT` for display.
+
+  Material selection: the engine accepts the chosen materials via
+  `ActivateAbility.costPayment.exiledCards`. The cost handler validates that every chosen entity is either a
+  permanent the activator controls or a card in their graveyard matching `filter`. Client-side material
+  selection UI is not yet plumbed through — game-server callers must supply the chosen IDs directly.
+
 - `Renew(cost)` — `card { renew(cost) { effect = … } }` builder helper (Tarkir: Dragonstorm, Sultai clan keyword).
   A graveyard-activated ability: "Renew — [cost], Exile this card from your graveyard: [effect]. Activate only as a
   sorcery." The helper composes it entirely from existing primitives — `AbilityCost.Composite(Mana(cost), ExileSelf)`,
@@ -1868,6 +1900,10 @@ Numbers computed at resolution time.
     `SpellsCastThisTurn(Player.TriggeringPlayer, GameObjectFilter.Noncreature)`.
   - Pairs with the `YouCastSpellsThisTurn` **condition** (§ conditions) — that gates a yes/no
     threshold, this yields the count.
+- `CraftedMaterialsTotalPower` — total printed power of the cards exiled to craft the source
+  permanent (CR 702.167c). Reads the source's `CraftedFromExiledComponent`. Used for the
+  `*`-power CDA on Mastercraft Raptor (Saheeli's Lattice back face). Evaluates to 0 when the
+  source has no recorded materials.
 
 ### Counters
 

--- a/manual-scenarios/cards/s/saheelis-lattice.json
+++ b/manual-scenarios/cards/s/saheelis-lattice.json
@@ -1,0 +1,43 @@
+{
+  "player1Name": "Saheeli",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Saheeli's Lattice",
+      "Mountain"
+    ],
+    "battlefield": [
+      {"name": "Saheeli's Lattice"},
+      {"name": "Palani's Hatcher", "summoningSickness": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false}
+    ],
+    "graveyard": ["Palani's Hatcher"],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Grizzly Bears"},
+      {"name": "Grizzly Bears"},
+      {"name": "Forest", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -83,6 +83,22 @@ enum class Keyword(val displayName: String) {
      */
     DEVOUR("Devour"),
 
+    /**
+     * Craft (CR 702.167, The Lost Caverns of Ixalan). On a transforming
+     * double-faced permanent. "Craft with [filter] [cost] ([cost], Exile this
+     * permanent, Exile [filter] you control and/or [filter] cards from your
+     * graveyard: Return this card transformed under its owner's control.
+     * Craft only as a sorcery.)"
+     *
+     * Display tag — the full mechanic is composed in the DSL via
+     * [com.wingedsheep.sdk.dsl.CardBuilder.craft], which pairs
+     * [com.wingedsheep.sdk.scripting.AbilityCost.Craft] with
+     * [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect].
+     * The back face's "exiled cards used to craft it" CDA (CR 702.167c) reads
+     * [com.wingedsheep.sdk.scripting.values.DynamicAmount.CraftedMaterialsTotalPower].
+     */
+    CRAFT("Craft"),
+
     // ── Cost reduction ───────────────────────────────────────
     CONVOKE("Convoke"),
     DELVE("Delve"),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -670,6 +670,51 @@ class CardBuilder(private val name: String) {
     }
 
     /**
+     * Craft with [filter] — [cost] (CR 702.167, The Lost Caverns of Ixalan).
+     *
+     * "[Cost], Exile this permanent, Exile [filter] from among permanents you control and/or
+     * [filter] cards from your graveyard: Return this card to the battlefield transformed under
+     * its owner's control. Activate only as a sorcery."
+     *
+     * Composed from existing primitives — no special handling at the DSL layer:
+     *  - cost = [AbilityCost.Mana] ⊕ [AbilityCost.Craft] (the latter handles both the self-exile
+     *    and the materials-exile in one atomic cost shape, recording the exiled materials on
+     *    the source so the back face's CDA can read them).
+     *  - effect = [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect].
+     *  - `timing = TimingRule.SorcerySpeed` enforces "Activate only as a sorcery".
+     *
+     * Marks the front face with the [Keyword.CRAFT] tag for client display.
+     *
+     * ```kotlin
+     * craft(filter = Filters.Dinosaur, cost = "{4}{R}")
+     * ```
+     *
+     * @param filter The material filter (the [filter] in "Craft with [filter]").
+     * @param cost The mana portion of the craft cost.
+     * @param materialDescription Optional override for the filter's name in the rendered cost
+     *   description — e.g. "one or more Dinosaurs". Defaults to the filter's own description.
+     */
+    fun craft(
+        filter: com.wingedsheep.sdk.scripting.GameObjectFilter,
+        cost: String,
+        materialDescription: String? = null
+    ) {
+        val materials = materialDescription ?: "one or more ${filter.description}s"
+        activatedAbilities.add(
+            ActivatedAbility(
+                cost = AbilityCost.Composite(
+                    listOf(AbilityCost.Mana(ManaCost.parse(cost)), AbilityCost.Craft(filter))
+                ),
+                effect = com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect,
+                targetRequirements = emptyList(),
+                timing = TimingRule.SorcerySpeed,
+                descriptionOverride = "Craft with $materials — $cost"
+            )
+        )
+        keywordSet.add(Keyword.CRAFT)
+    }
+
+    /**
      * Add a parameterized keyword ability.
      * Examples: ward {2}, protection from blue, annihilator 2
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -268,4 +268,16 @@ object Costs {
      * Used as part of an activated ability cost (e.g., "{T}, Blight 1: ...").
      */
     fun Blight(amount: Int): AbilityCost = AbilityCost.Blight(amount)
+
+    /**
+     * Craft (CR 702.167a) — the "Exile this permanent, Exile [filter] from among permanents
+     * you control and/or [filter] cards from your graveyard" portion of the Craft activated
+     * ability. Combine with [Mana] inside [Composite] to express the full cost shape:
+     *
+     * ```kotlin
+     * Costs.Composite(Costs.Mana("{4}{R}"), Costs.Craft(Filters.Dinosaur))
+     * ```
+     */
+    fun Craft(filter: GameObjectFilter, minCount: Int = 1): AbilityCost =
+        AbilityCost.Craft(filter, minCount)
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -101,6 +101,7 @@ import com.wingedsheep.sdk.scripting.effects.ExileAndGrantOwnerPlayPermissionEff
 import com.wingedsheep.sdk.scripting.effects.CreateGlobalTriggeredAbilityEffect
 import com.wingedsheep.sdk.scripting.effects.ReturnCreaturesPutInGraveyardThisTurnEffect
 import com.wingedsheep.sdk.scripting.effects.ReturnOneFromLinkedExileEffect
+import com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect
 import com.wingedsheep.sdk.scripting.effects.ReturnSelfToBattlefieldAttachedEffect
 import com.wingedsheep.sdk.scripting.effects.DrawUpToEffect
 import com.wingedsheep.sdk.scripting.effects.RemoveFromCombatEffect
@@ -505,6 +506,13 @@ object Effects {
      * The active player chooses one of their owned exiled cards.
      */
     fun ReturnOneFromLinkedExile(): Effect = ReturnOneFromLinkedExileEffect
+
+    /**
+     * Craft resolution effect — return the source from exile to the battlefield transformed
+     * under its owner's control. Paired with [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+     * as the activated ability's effect; see CR 702.167a.
+     */
+    val ReturnSelfFromExileTransformed: Effect = ReturnSelfFromExileTransformedEffect
 
     /**
      * Return to hand all creature cards in a player's graveyard that were put there this turn.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -536,6 +536,15 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
      * Pair with [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect]
      * as the ability effect and `timing = TimingRule.SorcerySpeed`.
      *
+     * **Composition note.** The legal-action enumerator surfaces a Craft sub-cost as the sole
+     * payload on [com.wingedsheep.engine.legalactions.AdditionalCostData]: any sibling
+     * AdditionalCost-bearing sub-cost inside the same `Composite` (tap, sacrifice, discard,
+     * counter-removal, …) will be dropped from the legal-action DTO. In practice the
+     * `card { craft(...) }` helper only pairs Craft with `Mana`, which travels through the
+     * separate mana-payment channel, so this is exhaustive. If you ever compose Craft with a
+     * second AdditionalCost-bearing sub-cost, generalize `ActivatedAbilityEnumerator.buildAdditionalCostData`
+     * to merge both payloads first.
+     *
      * @property filter Material filter (typically the same one used in the Craft display text,
      *   e.g. `Filters.Dinosaur` for Saheeli's Lattice).
      * @property minCount Minimum number of materials to exile (1 for "one or more").

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -516,4 +516,48 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
             return if (newFilter !== filter) copy(filter = newFilter) else this
         }
     }
+
+    /**
+     * Craft materials (CR 702.167a). The combined "Exile this permanent, Exile [filter] from
+     * among permanents you control and/or [filter] cards from your graveyard" portion of the
+     * Craft activated ability.
+     *
+     * Atomic because the self-exile and the materials-exile are a single named cost shape in
+     * the Comprehensive Rules — pulling them apart would let a card pay one half without the
+     * other. The mana portion stays as a separate [Mana] sub-cost combined via [Composite].
+     *
+     * Payment selects [minCount]+ materials from a **single combined pool** spanning the
+     * activator's controlled battlefield permanents and graveyard cards matching [filter]
+     * (CR 702.167b). The exiled materials are recorded on the source's
+     * [com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent] so the
+     * back face's CDA (Mastercraft Raptor's "power = total power of the exiled cards") can read
+     * them after the source returns to the battlefield transformed.
+     *
+     * Pair with [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect]
+     * as the ability effect and `timing = TimingRule.SorcerySpeed`.
+     *
+     * @property filter Material filter (typically the same one used in the Craft display text,
+     *   e.g. `Filters.Dinosaur` for Saheeli's Lattice).
+     * @property minCount Minimum number of materials to exile (1 for "one or more").
+     */
+    @SerialName("CostCraft")
+    @Serializable
+    data class Craft(
+        val filter: GameObjectFilter,
+        val minCount: Int = 1,
+    ) : AbilityCost {
+        override val description: String = buildString {
+            append("Exile this permanent, Exile ")
+            if (minCount == 1) append("one or more ") else append("$minCount or more ")
+            append(filter.description)
+            append("s you control and/or ")
+            append(filter.description)
+            append(" cards from your graveyard")
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TransformEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TransformEffects.kt
@@ -23,3 +23,26 @@ data class TransformEffect(
 
     override fun applyTextReplacement(replacer: TextReplacer): Effect = this
 }
+
+/**
+ * Return the source of a Craft activated ability (CR 702.167a) from exile to the battlefield
+ * transformed under its owner's control.
+ *
+ * The source has just been exiled by the Craft cost (paired with
+ * [com.wingedsheep.sdk.scripting.AbilityCost.Craft]); this effect is what the activated
+ * ability resolves to. It zone-moves the source from EXILE → BATTLEFIELD, sets its
+ * [com.wingedsheep.engine.state.components.identity.DoubleFacedComponent] to its back face,
+ * and re-attaches the `CraftedFromExiledComponent` recording the exiled materials so the
+ * back face's "exiled cards used to craft it" CDA (CR 702.167c) can read them.
+ *
+ * Not a generic "return-and-transform" — only valid for the Craft pattern, where the source
+ * being in exile and the materials being linked to it are guaranteed by the paired cost.
+ */
+@SerialName("ReturnSelfFromExileTransformed")
+@Serializable
+data object ReturnSelfFromExileTransformedEffect : Effect {
+    override val description: String =
+        "Return this card to the battlefield transformed under its owner's control"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect = this
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -807,4 +807,24 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         }
     }
 
+    /**
+     * Total printed power of the cards exiled to craft the source permanent (CR 702.167c).
+     *
+     * Reads the source's
+     * `com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent` —
+     * attached on battlefield entry by
+     * [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect] when the
+     * Craft activated ability resolves — and sums the printed power of those exiled cards.
+     * Used by the Mastercraft Raptor back face of Saheeli's Lattice.
+     *
+     * Evaluates to zero when the source was not crafted (no component) — the back face has
+     * no other way of legitimately existing, but a benign zero keeps the projector total order.
+     */
+    @SerialName("CraftedMaterialsTotalPower")
+    @Serializable
+    data object CraftedMaterialsTotalPower : DynamicAmount {
+        override val description: String = "the total power of the exiled cards used to craft it"
+        override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount = this
+    }
+
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SaheelisLattice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SaheelisLattice.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CharacteristicValue
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Saheeli's Lattice // Mastercraft Raptor (CR 702.167, The Lost Caverns of Ixalan)
+ * {1}{R}
+ * Artifact // Artifact Creature — Dinosaur
+ *
+ * Front face — Saheeli's Lattice ({1}{R}, Artifact)
+ *   When this artifact enters, you may discard a card. If you do, draw two cards.
+ *   Craft with one or more Dinosaurs {4}{R} ({4}{R}, Exile this artifact, Exile
+ *   one or more Dinosaurs you control and/or Dinosaur cards from your graveyard:
+ *   Return this card transformed under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Mastercraft Raptor (Artifact Creature — Dinosaur, &#42;/4)
+ *   Mastercraft Raptor's power is equal to the total power of the exiled cards
+ *   used to craft it.
+ *
+ * Implementation: built from the engine's Craft primitives. The front face's `craft(...)`
+ * helper wires the activated ability with a [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+ * material cost paired with the printed mana cost; the resolution effect
+ * ([com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect]) returns the
+ * source from exile to the battlefield as the back face and re-attaches the
+ * `CraftedFromExiledComponent` recording the chosen materials. The back face uses
+ * [DynamicAmount.CraftedMaterialsTotalPower] as its power CDA so projection reads the total
+ * printed power of those exiled cards each layer pass.
+ */
+
+private val DinosaurFilter: GameObjectFilter = GameObjectFilter.Any.withSubtype(Subtype.DINOSAUR)
+
+private val SaheelisLatticeFront = card("Saheeli's Lattice") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, you may discard a card. If you do, draw two cards.\n" +
+        "Craft with one or more Dinosaurs {4}{R} ({4}{R}, Exile this artifact, Exile one or more Dinosaurs you control and/or Dinosaur cards from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // ETB: you may discard a card. If you do, draw two cards.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            IfYouDoEffect(
+                action = EffectPatterns.discardCards(1),
+                ifYouDo = Effects.DrawCards(2)
+            )
+        )
+    }
+
+    craft(filter = DinosaurFilter, cost = "{4}{R}", materialDescription = "one or more Dinosaurs")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "164"
+        artist = "Zoltan Boros"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg?1699044333"
+    }
+}
+
+private val MastercraftRaptor = card("Mastercraft Raptor") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Dinosaur"
+    // Power = total power of cards exiled to craft this permanent (CR 702.167c).
+    // The CDA reads CraftedFromExiledComponent on this entity each projection pass.
+    dynamicPower = CharacteristicValue.Dynamic(DynamicAmount.CraftedMaterialsTotalPower)
+    toughness = 4
+    oracleText = "Mastercraft Raptor's power is equal to the total power of the exiled cards used to craft it."
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "164"
+        artist = "Zoltan Boros"
+        flavorText = "While Huatli ventured underground, Saheeli used her unique expertise to bolster the Sun Empire's defenses."
+        imageUri = "https://cards.scryfall.io/normal/back/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg?1699044333"
+    }
+}
+
+val SaheelisLattice: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = SaheelisLatticeFront,
+    backFace = MastercraftRaptor
+)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -358,6 +358,7 @@ val engineSerializersModule = SerializersModule {
         subclass(GraveyardPlayPermissionUsedComponent::class)
         subclass(ExileEntryTurnComponent::class)
         subclass(LinkedExileComponent::class)
+        subclass(CraftedFromExiledComponent::class)
         subclass(MayCastFromLinkedExileUsedThisTurnComponent::class)
         subclass(ReplacementEffectSourceComponent::class)
         subclass(SagaComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -1068,8 +1068,17 @@ class CostHandler(
         choices: CostPaymentChoices
     ): CostPaymentResult {
         val candidates = findCraftMaterialCandidates(state, controllerId, cost.filter, sourceId).toSet()
-        val chosen = choices.exileChoices.takeIf { it.isNotEmpty() }
-            ?: candidates.take(cost.minCount)
+        // Materials are a player choice (CR 702.167a-b): the activator picks which permanents
+        // and/or graveyard cards to exile. No silent auto-pick — callers must supply the
+        // chosen IDs via CostPaymentChoices.exileChoices (web client routes them through the
+        // CraftMaterialOverlay; game-server callers populate the field directly).
+        val chosen = choices.exileChoices
+        if (chosen.isEmpty()) {
+            return CostPaymentResult.failure(
+                "Craft requires the activator to choose at least ${cost.minCount} " +
+                    "${cost.filter.description}(s) to exile via costPayment.exiledCards"
+            )
+        }
         if (chosen.size < cost.minCount) {
             return CostPaymentResult.failure(
                 "Craft requires at least ${cost.minCount} ${cost.filter.description}(s) to exile"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -206,6 +206,12 @@ class CostHandler(
             is AbilityCost.RemoveCountersFromAmongFilteredPermanents ->
                 com.wingedsheep.engine.handlers.costs.RemoveCountersFromAmongFilteredPermanentsCostHandler
                     .canPay(state, cost, controllerId)
+            is AbilityCost.Craft -> {
+                // Source on battlefield + enough materials in the unified BF+GY pool (CR 702.167a-b).
+                val battlefieldZone = ZoneKey(controllerId, Zone.BATTLEFIELD)
+                if (!state.getZone(battlefieldZone).contains(sourceId)) return false
+                findCraftMaterialCandidates(state, controllerId, cost.filter, sourceId).size >= cost.minCount
+            }
             is AbilityCost.Composite -> {
                 cost.costs.all { canPayAbilityCost(state, it, sourceId, controllerId, manaPool, abilityContext) }
             }
@@ -657,6 +663,7 @@ class CostHandler(
             is AbilityCost.RemoveCountersFromAmongFilteredPermanents ->
                 com.wingedsheep.engine.handlers.costs.RemoveCountersFromAmongFilteredPermanentsCostHandler
                     .pay(state, cost, controllerId, manaPool, choices.counterRemovalChoices)
+            is AbilityCost.Craft -> payCraftCost(state, cost, sourceId, controllerId, manaPool, choices)
             is AbilityCost.Composite -> {
                 var currentState = state
                 var currentPool = manaPool
@@ -1030,6 +1037,81 @@ class CostHandler(
             }
         }
         return CostPaymentResult.success(newState, manaPool)
+    }
+
+    /**
+     * Find the combined BF+GY pool of legal Craft materials (CR 702.167a-b):
+     * permanents the activator controls **and** cards in their graveyard that match [filter].
+     * The source permanent itself is never a valid material — it's exiled separately by the
+     * paired self-exile clause.
+     */
+    private fun findCraftMaterialCandidates(
+        state: GameState,
+        controllerId: EntityId,
+        filter: GameObjectFilter,
+        sourceId: EntityId
+    ): List<EntityId> {
+        val battlefield = findMatchingPermanentsUnified(state, controllerId, filter)
+            .filter { it != sourceId }
+        val graveyardCards = findMatchingCardsUnified(
+            state, state.getZone(ZoneKey(controllerId, Zone.GRAVEYARD)), filter, controllerId
+        )
+        return battlefield + graveyardCards
+    }
+
+    private fun payCraftCost(
+        state: GameState,
+        cost: AbilityCost.Craft,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        manaPool: ManaPool,
+        choices: CostPaymentChoices
+    ): CostPaymentResult {
+        val candidates = findCraftMaterialCandidates(state, controllerId, cost.filter, sourceId).toSet()
+        val chosen = choices.exileChoices.takeIf { it.isNotEmpty() }
+            ?: candidates.take(cost.minCount)
+        if (chosen.size < cost.minCount) {
+            return CostPaymentResult.failure(
+                "Craft requires at least ${cost.minCount} ${cost.filter.description}(s) to exile"
+            )
+        }
+        if (chosen.any { it !in candidates }) {
+            return CostPaymentResult.failure("Craft material is not a legal candidate")
+        }
+        if (chosen.contains(sourceId)) {
+            return CostPaymentResult.failure("Craft material cannot include the source permanent")
+        }
+
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+
+        // 1. Exile each chosen material from its zone via the standard zone-transition pipeline
+        //    (LTB triggers, attachment cleanup, last-known info — all handled there).
+        for (materialId in chosen) {
+            val transition = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+                newState, materialId, Zone.EXILE
+            )
+            newState = transition.state
+            events.addAll(transition.events)
+        }
+
+        // 2. Exile the source itself. The Craft resolution effect will lift it back to the
+        //    battlefield as its back face; the materials remain in exile so the back face's
+        //    CDA can keep reading their power.
+        val selfTransition = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+            newState, sourceId, Zone.EXILE
+        )
+        newState = selfTransition.state
+        events.addAll(selfTransition.events)
+
+        // 3. Record the materials on the source's CraftedFromExiledComponent so the resolution
+        //    effect can re-attach the component on battlefield re-entry (it's stripped on
+        //    every battlefield entry by applyBattlefieldEntry per Rule 400.7).
+        newState = newState.updateEntity(sourceId) { c ->
+            c.with(com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent(chosen))
+        }
+
+        return CostPaymentResult.success(newState, manaPool, events)
     }
 
     // Helper functions

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -345,6 +345,21 @@ class DynamicAmountEvaluator(
                 }
             }
 
+            is DynamicAmount.CraftedMaterialsTotalPower -> {
+                val sourceId = context.sourceId
+                if (sourceId == null) 0 else {
+                    val materials = state.getEntity(sourceId)
+                        ?.get<com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent>()
+                    if (materials == null) 0 else {
+                        var total = 0
+                        for (exiledId in materials.exiledIds) {
+                            total += basePowerOfPrintedCard(state, exiledId)
+                        }
+                        total
+                    }
+                }
+            }
+
         }
     }
 
@@ -854,6 +869,24 @@ class DynamicAmountEvaluator(
             is CharacteristicValue.Fixed -> value.value
             is CharacteristicValue.Dynamic -> evaluate(state, value.source, context)
             is CharacteristicValue.DynamicWithOffset -> evaluate(state, value.source, context) + value.offset
+            null -> 0
+        }
+    }
+
+    /**
+     * Read the printed base power of a card. Used by
+     * [DynamicAmount.CraftedMaterialsTotalPower] to sum the power of cards in exile (CR 712.8a:
+     * a card outside the battlefield/stack shows only its front-face characteristics, which is
+     * the printed face for non-DFCs). Dynamic CDA values on the printed card are evaluated with
+     * a fresh context targeting that card, falling back to 0 if anything is unset.
+     */
+    private fun basePowerOfPrintedCard(state: GameState, entityId: EntityId): Int {
+        val card = state.getEntity(entityId)?.get<CardComponent>() ?: return 0
+        val ctx = EffectContext(sourceId = entityId, controllerId = card.ownerId ?: return 0, opponentId = null)
+        return when (val p = card.baseStats?.power) {
+            is CharacteristicValue.Fixed -> p.value
+            is CharacteristicValue.Dynamic -> evaluate(state, p.source, ctx)
+            is CharacteristicValue.DynamicWithOffset -> evaluate(state, p.source, ctx) + p.offset
             null -> 0
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -27,6 +27,7 @@ import com.wingedsheep.engine.state.components.battlefield.WarpedComponent
 import com.wingedsheep.engine.state.components.battlefield.EvokedComponent
 import com.wingedsheep.engine.state.components.battlefield.CastRecordComponent
 import com.wingedsheep.engine.state.components.battlefield.WasKickedComponent
+import com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent
 import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
 import com.wingedsheep.engine.state.components.battlefield.MayCastFromLinkedExileUsedThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
@@ -304,6 +305,10 @@ object ZoneMovementUtils {
             // Strip linked exile tracking so the new instance starts with no exiled cards.
             .without<LinkedExileComponent>()
             .without<MayCastFromLinkedExileUsedThisTurnComponent>()
+            // Craft materials linked to the prior battlefield existence (CR 702.167c) — the
+            // re-entering object is a new object, so it has no recorded materials. The
+            // craft-return executor explicitly re-attaches this component on its own entry path.
+            .without<CraftedFromExiledComponent>()
             // Combat
             .without<AttackingComponent>()
             .without<BlockingComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -590,6 +590,12 @@ object ZoneTransitionService {
             // its previous existence, so it should not retain links to previously exiled cards)
             updated = updated.without<LinkedExileComponent>()
 
+            // Same for CraftedFromExiledComponent (CR 702.167c materials link): the
+            // re-entering object is a new object, so it has no recorded materials. The
+            // craft-return executor explicitly re-attaches the component immediately after
+            // this entry path runs.
+            updated = updated.without<CraftedFromExiledComponent>()
+
             // Track that this permanent entered the battlefield this turn
             updated = updated.with(EnteredThisTurnComponent)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -64,6 +64,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.types.EachPermanentBeco
 import com.wingedsheep.engine.handlers.effects.permanent.types.SetCreatureSubtypesExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.SetGroupCreatureSubtypesExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.SetLandTypeExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.types.ReturnSelfFromExileTransformedExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TransformEffectExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TurnFaceDownExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TurnFaceUpExecutor
@@ -130,6 +131,7 @@ class PermanentExecutors(
         SetCreatureSubtypesExecutor(),
         SetGroupCreatureSubtypesExecutor(),
         TransformEffectExecutor(cardRegistry),
+        ReturnSelfFromExileTransformedExecutor(cardRegistry),
         TurnFaceDownExecutor(),
         TurnFaceUpExecutor(cardRegistry),
         // attachments

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromExileTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromExileTransformedExecutor.kt
@@ -1,7 +1,6 @@
 package com.wingedsheep.engine.handlers.effects.permanent.types
 
 import com.wingedsheep.engine.core.EffectResult
-import com.wingedsheep.engine.core.TransformedEvent
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
@@ -13,7 +12,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect
 import kotlin.reflect.KClass
 
@@ -31,7 +29,11 @@ import kotlin.reflect.KClass
  *  3. Moves the source from EXILE → BATTLEFIELD under its owner's control via the standard
  *     zone-transition pipeline (ETB triggers, static-ability registration, etc.).
  *
- * Emits a [TransformedEvent] so triggers keyed on "when this transforms" fire.
+ * Does **not** emit a `TransformedEvent` — CR 701.27a defines transforming as turning over
+ * a permanent that is already on the battlefield. Craft's "return ... transformed" produces
+ * a new battlefield object with its back face up; no transform action occurs, so triggers
+ * keyed on `Triggers.TransformsToBack` / `TransformsToFront` must not fire. ETB triggers on
+ * the back face are dispatched normally by the `ZoneChangeEvent` emitted from the move.
  */
 class ReturnSelfFromExileTransformedExecutor(
     private val cardRegistry: CardRegistry
@@ -53,7 +55,7 @@ class ReturnSelfFromExileTransformedExecutor(
         val dfc = container.get<DoubleFacedComponent>()
             ?: return EffectResult.error(state, "Craft source is not a double-faced permanent")
 
-        val backDef: CardDefinition = cardRegistry.getCard(dfc.backCardDefinitionId)
+        val backDef = cardRegistry.getCard(dfc.backCardDefinitionId)
             ?: return EffectResult.error(state, "Back face not registered: ${dfc.backCardDefinitionId}")
 
         val ownerId = container.get<OwnerComponent>()?.playerId
@@ -69,21 +71,8 @@ class ReturnSelfFromExileTransformedExecutor(
         val frontFaceCard = container.get<CardComponent>()
             ?: return EffectResult.error(state, "Craft source has no CardComponent")
 
-        // Build the back face's CardComponent (mirrors TransformEffectExecutor.buildCardComponentForFace).
-        val backCard = CardComponent(
-            cardDefinitionId = backDef.name,
-            name = backDef.name,
-            manaCost = backDef.manaCost,
-            typeLine = backDef.typeLine,
-            oracleText = backDef.oracleText,
-            baseStats = backDef.creatureStats,
-            baseKeywords = backDef.keywords,
-            baseFlags = backDef.flags,
-            colors = backDef.colors,
-            ownerId = frontFaceCard.ownerId ?: ownerId,
-            spellEffect = backDef.spellEffect,
-            imageUri = backDef.metadata.imageUri ?: frontFaceCard.imageUri
-        )
+        // Build the back face's CardComponent via the same helper TransformEffectExecutor uses.
+        val backCard = buildCardComponentForDfcFace(frontFaceCard, backDef)
 
         // Flip the DFC face + swap CardComponent while the entity is still in exile so the
         // zone transition picks up the back face's static abilities cleanly. Save the front
@@ -106,20 +95,14 @@ class ReturnSelfFromExileTransformedExecutor(
         )
         newState = transition.state
 
-        // Re-attach CraftedFromExiledComponent after applyBattlefieldEntry strips it (it strips
-        // every transient battlefield component on entry per Rule 400.7 — the deliberate craft
-        // path re-establishes the materials link here).
+        // Re-attach CraftedFromExiledComponent: ZoneTransitionService.applyBattlefieldEntry
+        // strips it as part of the Rule 400.7 "new object" cleanup (alongside
+        // LinkedExileComponent), so this is the deliberate re-establishment of the materials
+        // link on the craft-return entry path.
         if (materials != null && newState.getEntity(sourceId) != null) {
             newState = newState.updateEntity(sourceId) { c -> c.with(materials) }
         }
 
-        val events = transition.events + TransformedEvent(
-            entityId = sourceId,
-            intoBackFace = true,
-            newFaceName = backDef.name,
-            controllerId = ownerId
-        )
-
-        return EffectResult.success(newState, events)
+        return EffectResult.success(newState, transition.events)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromExileTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromExileTransformedExecutor.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.handlers.effects.permanent.types
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.TransformedEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ReturnSelfFromExileTransformedEffect] (CR 702.167a).
+ *
+ * The source has been exiled by the paired [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+ * cost. This executor:
+ *  1. Flips the source's [DoubleFacedComponent] to its back face and rewrites
+ *     [CardComponent] to the back face's printed characteristics.
+ *  2. Re-attaches the [CraftedFromExiledComponent] recorded on the source during cost
+ *     payment — preserved across the exile sojourn — so it survives
+ *     [com.wingedsheep.engine.handlers.effects.ZoneTransitionService.applyBattlefieldEntry]'s
+ *     general battlefield-entry strip (Rule 400.7).
+ *  3. Moves the source from EXILE → BATTLEFIELD under its owner's control via the standard
+ *     zone-transition pipeline (ETB triggers, static-ability registration, etc.).
+ *
+ * Emits a [TransformedEvent] so triggers keyed on "when this transforms" fire.
+ */
+class ReturnSelfFromExileTransformedExecutor(
+    private val cardRegistry: CardRegistry
+) : EffectExecutor<ReturnSelfFromExileTransformedEffect> {
+
+    override val effectType: KClass<ReturnSelfFromExileTransformedEffect> =
+        ReturnSelfFromExileTransformedEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ReturnSelfFromExileTransformedEffect,
+        context: EffectContext
+    ): EffectResult {
+        val sourceId = context.sourceId
+            ?: return EffectResult.error(state, "Craft effect has no source")
+        val container = state.getEntity(sourceId)
+            ?: return EffectResult.error(state, "Craft source not found")
+
+        val dfc = container.get<DoubleFacedComponent>()
+            ?: return EffectResult.error(state, "Craft source is not a double-faced permanent")
+
+        val backDef: CardDefinition = cardRegistry.getCard(dfc.backCardDefinitionId)
+            ?: return EffectResult.error(state, "Back face not registered: ${dfc.backCardDefinitionId}")
+
+        val ownerId = container.get<OwnerComponent>()?.playerId
+            ?: return EffectResult.error(state, "Craft source has no owner")
+
+        val materials = container.get<CraftedFromExiledComponent>()
+
+        // Snapshot the front-face CardComponent (the entity is currently in exile, so per
+        // CR 712.8a the component on it is the front face's). Stashing it on the DFC lets
+        // ZoneTransitionService restore Saheeli's Lattice when Mastercraft Raptor later
+        // leaves the battlefield to a non-battlefield/non-stack zone — same path
+        // TransformEffectExecutor uses for transforming DFCs.
+        val frontFaceCard = container.get<CardComponent>()
+            ?: return EffectResult.error(state, "Craft source has no CardComponent")
+
+        // Build the back face's CardComponent (mirrors TransformEffectExecutor.buildCardComponentForFace).
+        val backCard = CardComponent(
+            cardDefinitionId = backDef.name,
+            name = backDef.name,
+            manaCost = backDef.manaCost,
+            typeLine = backDef.typeLine,
+            oracleText = backDef.oracleText,
+            baseStats = backDef.creatureStats,
+            baseKeywords = backDef.keywords,
+            baseFlags = backDef.flags,
+            colors = backDef.colors,
+            ownerId = frontFaceCard.ownerId ?: ownerId,
+            spellEffect = backDef.spellEffect,
+            imageUri = backDef.metadata.imageUri ?: frontFaceCard.imageUri
+        )
+
+        // Flip the DFC face + swap CardComponent while the entity is still in exile so the
+        // zone transition picks up the back face's static abilities cleanly. Save the front
+        // face on the DFC so Rule 712.8a's restore-on-leave path can swap back to it.
+        var newState = state.updateEntity(sourceId) { c ->
+            c.with(backCard).with(
+                dfc.copy(
+                    currentFace = DoubleFacedComponent.Face.BACK,
+                    frontFaceCard = frontFaceCard
+                )
+            )
+        }
+
+        // Move EXILE → BATTLEFIELD under owner's control.
+        val transition = ZoneTransitionService.moveToZone(
+            newState,
+            sourceId,
+            Zone.BATTLEFIELD,
+            options = ZoneEntryOptions(controllerId = ownerId)
+        )
+        newState = transition.state
+
+        // Re-attach CraftedFromExiledComponent after applyBattlefieldEntry strips it (it strips
+        // every transient battlefield component on entry per Rule 400.7 — the deliberate craft
+        // path re-establishes the materials link here).
+        if (materials != null && newState.getEntity(sourceId) != null) {
+            newState = newState.updateEntity(sourceId) { c -> c.with(materials) }
+        }
+
+        val events = transition.events + TransformedEvent(
+            entityId = sourceId,
+            intoBackFace = true,
+            newFaceName = backDef.name,
+            controllerId = ownerId
+        )
+
+        return EffectResult.success(newState, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
@@ -70,7 +70,7 @@ class TransformEffectExecutor(
         val currentCard = container.get<CardComponent>()
             ?: return EffectResult.error(state, "Target has no CardComponent")
 
-        val swappedCard = buildCardComponentForFace(currentCard, nextCardDef)
+        val swappedCard = buildCardComponentForDfcFace(currentCard, nextCardDef)
 
         val controllerId = container.get<ControllerComponent>()?.playerId ?: context.controllerId
 
@@ -110,25 +110,28 @@ class TransformEffectExecutor(
         )
     }
 
-    /**
-     * Build a fresh [CardComponent] for the given face while preserving the permanent's
-     * owner identity. This mirrors the wholesale-swap approach used by Clone's copy effect.
-     */
-    private fun buildCardComponentForFace(
-        current: CardComponent,
-        face: CardDefinition
-    ): CardComponent = CardComponent(
-        cardDefinitionId = face.name,
-        name = face.name,
-        manaCost = face.manaCost,
-        typeLine = face.typeLine,
-        oracleText = face.oracleText,
-        baseStats = face.creatureStats,
-        baseKeywords = face.keywords,
-        baseFlags = face.flags,
-        colors = face.colors,
-        ownerId = current.ownerId,
-        spellEffect = face.spellEffect,
-        imageUri = face.metadata.imageUri ?: current.imageUri
-    )
 }
+
+/**
+ * Build a fresh [CardComponent] for the given DFC face while preserving the permanent's
+ * owner identity and inheriting the prior face's `imageUri` when the new face doesn't
+ * declare its own. Shared by [TransformEffectExecutor] (CR 701.27 transform on the
+ * battlefield) and [ReturnSelfFromExileTransformedExecutor] (CR 702.167 Craft return).
+ */
+internal fun buildCardComponentForDfcFace(
+    current: CardComponent,
+    face: CardDefinition
+): CardComponent = CardComponent(
+    cardDefinitionId = face.name,
+    name = face.name,
+    manaCost = face.manaCost,
+    typeLine = face.typeLine,
+    oracleText = face.oracleText,
+    baseStats = face.creatureStats,
+    baseKeywords = face.keywords,
+    baseFlags = face.flags,
+    colors = face.colors,
+    ownerId = current.ownerId,
+    spellEffect = face.spellEffect,
+    imageUri = face.metadata.imageUri ?: current.imageUri
+)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -263,7 +263,18 @@ data class AdditionalCostData(
      * For [AdditionalCost.RemoveCountersFromYourCreatures]: total counters to remove
      * across all creatures you control (any counter types qualify).
      */
-    val distributedCounterRemovalTotal: Int = 0
+    val distributedCounterRemovalTotal: Int = 0,
+
+    /**
+     * Combined battlefield + graveyard candidate pool for an [AbilityCost.Craft] sub-cost
+     * (CR 702.167a-b). The activator selects [craftMinCount]+ of these to exile alongside
+     * the source. Battlefield candidates are permanents the activator controls matching the
+     * Craft filter; graveyard candidates are cards in their graveyard matching the same filter.
+     * The client renders both side-by-side and submits chosen IDs as
+     * `ActivateAbility.costPayment.exiledCards`.
+     */
+    val validCraftMaterials: List<EntityId> = emptyList(),
+    val craftMinCount: Int = 1
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -831,6 +831,14 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         craftMaterials: List<EntityId> = emptyList()
     ): AdditionalCostData? {
         if (craftCost != null) {
+            // Craft (CR 702.167) is handled exclusively: when a Composite cost contains a
+            // [AbilityCost.Craft] sub-cost, we surface only the Craft payload, dropping any
+            // sibling AdditionalCost data (tap, sacrifice, discard, etc.). The DSL helper
+            // `card { craft(...) }` always pairs Craft with `Mana` only — mana is handled
+            // separately via [costPayment.manaPayment] — so this is exhaustive in practice.
+            // Composing Craft with another AdditionalCost-bearing sub-cost (e.g.
+            // `Composite(Tap, Craft(...))`) would need this branch generalized to merge the
+            // two payloads; flag any such authoring upstream until that's added.
             return AdditionalCostData(
                 description = craftCost.description,
                 costType = "Craft",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -174,6 +174,8 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 var blightCreatures: List<EntityId> = emptyList()
                 var discardCost: AbilityCost.Discard? = null
                 var discardTargets: List<EntityId>? = null
+                var craftCost: AbilityCost.Craft? = null
+                var craftMaterials: List<EntityId> = emptyList()
                 var costAffordable = true
 
                 when (effectiveCost) {
@@ -436,6 +438,21 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                         break
                                     }
                                 }
+                                is AbilityCost.Craft -> {
+                                    // Combined BF+GY material pool (CR 702.167a-b). Records the cost
+                                    // and full candidate list so the UI can render BF + GY side-by-side.
+                                    val battlefieldMaterials = projected.getBattlefieldControlledBy(playerId)
+                                        .filter { it != entityId }
+                                        .filter { context.predicateEvaluator.matches(state, projected, it, subCost.filter, com.wingedsheep.engine.handlers.PredicateContext(controllerId = playerId)) }
+                                    val graveyardMaterials = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))
+                                        .filter { context.predicateEvaluator.matches(state, state.projectedState, it, subCost.filter, com.wingedsheep.engine.handlers.PredicateContext(controllerId = playerId)) }
+                                    if (battlefieldMaterials.size + graveyardMaterials.size < subCost.minCount) {
+                                        costCanBePaid = false
+                                        break
+                                    }
+                                    craftCost = subCost
+                                    craftMaterials = battlefieldMaterials + graveyardMaterials
+                                }
                                 else -> {}
                             }
                         }
@@ -515,7 +532,8 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     counterRemovalCreatures,
                     hasForageCost, forageGraveyardCards, forageFoodTargets,
                     blightCost, blightCreatures,
-                    discardCost, discardTargets
+                    discardCost, discardTargets,
+                    craftCost, craftMaterials
                 )
 
                 // Calculate X cost info for activated abilities with X in their mana cost
@@ -808,8 +826,19 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         blightCost: AbilityCost.Blight? = null,
         blightCreatures: List<EntityId> = emptyList(),
         discardCost: AbilityCost.Discard? = null,
-        discardTargets: List<EntityId>? = null
+        discardTargets: List<EntityId>? = null,
+        craftCost: AbilityCost.Craft? = null,
+        craftMaterials: List<EntityId> = emptyList()
     ): AdditionalCostData? {
+        if (craftCost != null) {
+            return AdditionalCostData(
+                description = craftCost.description,
+                costType = "Craft",
+                validCraftMaterials = craftMaterials,
+                craftMinCount = craftCost.minCount,
+                counterRemovalCreatures = counterRemovalCreatures
+            )
+        }
         if (tapTargets != null && tapCost != null) {
             return AdditionalCostData(
                 description = tapCost.description,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -532,10 +532,12 @@ data class LinkedExileComponent(
  * when the Craft ability resolves; read by the `DynamicAmount.CraftedMaterialsTotalPower`
  * evaluator on the back face.
  *
- * Stripped on every battlefield entry by [applyBattlefieldEntry] — Rule 400.7 makes the
- * re-entering object a new object, so a Mastercraft Raptor that subsequently leaves and
- * returns by some other means (blink, reanimate) starts fresh with no crafted materials.
- * The craft-return effect explicitly re-attaches it on its specific entry path.
+ * Stripped on battlefield exit by `ZoneMovementUtils.stripBattlefieldComponents` and on
+ * battlefield entry by `ZoneTransitionService.applyBattlefieldEntry` — Rule 400.7 makes any
+ * re-entering object a new object with no memory of its prior existence, so a Mastercraft
+ * Raptor that subsequently leaves and returns by some other means (blink, reanimate) starts
+ * fresh with no crafted materials. The craft-return effect explicitly re-attaches the
+ * component on its specific entry path, after the entry strip has run.
  */
 @Serializable
 data class CraftedFromExiledComponent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -526,6 +526,23 @@ data class LinkedExileComponent(
 ) : Component
 
 /**
+ * Cards exiled to pay the Craft activation cost that put this permanent onto the battlefield
+ * (CR 702.167c). Attached fresh by
+ * [com.wingedsheep.engine.handlers.effects.permanent.types.ReturnSelfFromExileTransformedExecutor]
+ * when the Craft ability resolves; read by the `DynamicAmount.CraftedMaterialsTotalPower`
+ * evaluator on the back face.
+ *
+ * Stripped on every battlefield entry by [applyBattlefieldEntry] — Rule 400.7 makes the
+ * re-entering object a new object, so a Mastercraft Raptor that subsequently leaves and
+ * returns by some other means (blink, reanimate) starts fresh with no crafted materials.
+ * The craft-return effect explicitly re-attaches it on its specific entry path.
+ */
+@Serializable
+data class CraftedFromExiledComponent(
+    val exiledIds: List<EntityId> = emptyList()
+) : Component
+
+/**
  * Marks a permanent as having been dealt damage this turn.
  * Cleared at end of turn by CleanupPhaseManager.
  * Used for StatePredicate.WasDealtDamageThisTurn.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -147,7 +147,9 @@ class LegalActionEnricher(
         validBlightTargets = validBlightTargets,
         blightAmount = blightAmount,
         blightVariableMaxX = blightVariableMaxX,
-        distributedCounterRemovalTotal = distributedCounterRemovalTotal
+        distributedCounterRemovalTotal = distributedCounterRemovalTotal,
+        validCraftMaterials = validCraftMaterials,
+        craftMinCount = craftMinCount
     )
 
     private fun ConvokeCreatureData.toDto() = ConvokeCreatureInfo(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -181,7 +181,16 @@ data class AdditionalCostInfo(
     /** For BlightVariable: cap on X (greatest toughness among creatures you control). */
     val blightVariableMaxX: Int = 0,
     /** Total counters to remove across creatures you control (RemoveCountersFromYourCreatures cost). */
-    val distributedCounterRemovalTotal: Int = 0
+    val distributedCounterRemovalTotal: Int = 0,
+
+    /**
+     * Combined battlefield + graveyard candidate pool for an `AbilityCost.Craft` sub-cost
+     * (CR 702.167a-b). The activator picks [craftMinCount]+ of these to exile alongside the
+     * source. The client renders both zones side-by-side; chosen IDs are submitted as
+     * `ActivateAbility.costPayment.exiledCards`.
+     */
+    val validCraftMaterials: List<EntityId> = emptyList(),
+    val craftMinCount: Int = 1
 )
 
 @Serializable

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SaheelisLatticeCraftScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SaheelisLatticeCraftScenarioTest.kt
@@ -163,6 +163,30 @@ class SaheelisLatticeCraftScenarioTest : FunSpec({
         projected.getPower(saheeli) shouldBe 6
     }
 
+    test("rejects activation when the activator supplies no chosen materials even though candidates exist") {
+        // Materials are a player choice (CR 702.167a-b). With at least one valid Dinosaur on
+        // the battlefield the ability is *legal* to activate, but the activator must still
+        // explicitly pick the materials — the engine must not auto-pick silently.
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val saheeli = driver.putPermanentOnBattlefield(p1, "Saheeli's Lattice")
+        driver.putCreatureOnBattlefield(p1, "Test Big Dino")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 5)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = saheeli,
+                abilityId = craftAbilityId()
+                // costPayment intentionally omitted
+            )
+        )
+        result.isSuccess shouldBe false
+        result.error.shouldNotBeNull() shouldContain "Craft"
+    }
+
     test("rejects activation when no Dinosaur material is available") {
         val driver = setup()
         val p1 = driver.activePlayer!!
@@ -227,13 +251,16 @@ class SaheelisLatticeCraftScenarioTest : FunSpec({
     }
 
     test("rejects activation at instant speed (CR 702.167a: \"Activate only as a sorcery\")") {
+        // Use UPKEEP so the active player has priority but it is *not* a main phase — that's
+        // the cleanest "instant speed but not sorcery speed" canvas (combat steps also have
+        // stack-empty subtleties that conflate the test).
         val driver = setup()
         val p1 = driver.activePlayer!!
 
         val saheeli = driver.putPermanentOnBattlefield(p1, "Saheeli's Lattice")
         driver.putCreatureOnBattlefield(p1, "Test Tiny Dino")
         driver.giveMana(p1, Color.RED, 5)
-        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.passPriorityUntil(Step.UPKEEP)
 
         val result = driver.submit(
             ActivateAbility(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SaheelisLatticeCraftScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SaheelisLatticeCraftScenarioTest.kt
@@ -1,0 +1,252 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SaheelisLattice
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Supertype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Scenario tests for the Craft mechanic (CR 702.167), exercised end-to-end via
+ * Saheeli's Lattice // Mastercraft Raptor.
+ *
+ * Covers:
+ *  - Cost: pays mana, exiles self, exiles ≥1 Dinosaur material from the combined
+ *    battlefield-controlled / graveyard pool (CR 702.167a-b).
+ *  - Effect resolution: source returns to battlefield as its back face under owner's
+ *    control with a [CraftedFromExiledComponent] recording the materials.
+ *  - Back-face *-power CDA (CR 702.167c): Mastercraft Raptor's projected power equals
+ *    the total printed power of the exiled materials.
+ *  - Timing: "Activate only as a sorcery" — rejected outside main phase / non-empty stack.
+ *  - Validation: rejected when no Dinosaur material is available.
+ */
+class SaheelisLatticeCraftScenarioTest : FunSpec({
+
+    // Test materials — distinct printed powers so totals tell us which were used.
+    val smallDino = CardDefinition.creature(
+        name = "Test Tiny Dino",
+        manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype.DINOSAUR),
+        power = 1,
+        toughness = 1,
+        oracleText = ""
+    )
+    val bigDino = CardDefinition.creature(
+        name = "Test Big Dino",
+        manaCost = ManaCost.parse("{4}{R}"),
+        subtypes = setOf(Subtype.DINOSAUR),
+        power = 5,
+        toughness = 4,
+        oracleText = ""
+    )
+    val nonDino = CardDefinition.creature(
+        name = "Test Non-Dino",
+        manaCost = ManaCost.parse("{1}{R}"),
+        subtypes = setOf(Subtype("Goblin")),
+        power = 2,
+        toughness = 1,
+        oracleText = ""
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SaheelisLattice, smallDino, bigDino, nonDino))
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    // The front face holds only one activated ability — the Craft. (The ETB rummage is a
+    // triggered ability and lives in a separate list.)
+    fun craftAbilityId() = SaheelisLattice.activatedAbilities.single().id
+
+    test("pays mana, exiles self and a battlefield Dinosaur, returns as Mastercraft Raptor with power = exiled Dino power") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val saheeli = driver.putPermanentOnBattlefield(p1, "Saheeli's Lattice")
+        val dino = driver.putCreatureOnBattlefield(p1, "Test Big Dino")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 5)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = saheeli,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(dino))
+            )
+        )
+        result.isSuccess shouldBe true
+
+        // Resolve the ability on the stack.
+        driver.bothPass()
+
+        // Material exiled.
+        driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(p1, Zone.EXILE)).shouldContain(dino)
+
+        // Source returned to battlefield as back face.
+        val saheeliContainer = driver.state.getEntity(saheeli)
+        saheeliContainer.shouldNotBeNull()
+        val card = saheeliContainer.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Mastercraft Raptor"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+
+        val dfc = saheeliContainer.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // CraftedFromExiledComponent re-attached on entry with the chosen material.
+        val crafted = saheeliContainer.get<CraftedFromExiledComponent>()
+        crafted.shouldNotBeNull()
+        crafted.exiledIds shouldBe listOf(dino)
+
+        // Projected power = total power of exiled cards used to craft it = 5.
+        val projected = projector.project(driver.state)
+        projected.getPower(saheeli) shouldBe 5
+        projected.getToughness(saheeli) shouldBe 4
+    }
+
+    test("materials may be selected across battlefield and graveyard simultaneously (CR 702.167b)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val saheeli = driver.putPermanentOnBattlefield(p1, "Saheeli's Lattice")
+        val battlefieldDino = driver.putCreatureOnBattlefield(p1, "Test Tiny Dino")    // 1 power
+        val graveyardDino = driver.putCardInGraveyard(p1, "Test Big Dino")             // 5 power
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 5)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = saheeli,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(battlefieldDino, graveyardDino))
+            )
+        )
+        driver.bothPass()
+
+        val exile = driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(p1, Zone.EXILE))
+        exile.shouldContainExactlyInAnyOrder(battlefieldDino, graveyardDino)
+
+        val crafted = driver.state.getEntity(saheeli)!!.get<CraftedFromExiledComponent>()!!
+        crafted.exiledIds.toSet() shouldBe setOf(battlefieldDino, graveyardDino)
+
+        // Projected power = 1 + 5 = 6.
+        val projected = projector.project(driver.state)
+        projected.getPower(saheeli) shouldBe 6
+    }
+
+    test("rejects activation when no Dinosaur material is available") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val saheeli = driver.putPermanentOnBattlefield(p1, "Saheeli's Lattice")
+        driver.putCreatureOnBattlefield(p1, "Test Non-Dino")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 5)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = saheeli,
+                abilityId = craftAbilityId()
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("Mastercraft Raptor reverts to Saheeli's Lattice (front face) when it leaves the battlefield (CR 712.8a)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val saheeli = driver.putPermanentOnBattlefield(p1, "Saheeli's Lattice")
+        val dino = driver.putCreatureOnBattlefield(p1, "Test Big Dino")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 5)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = saheeli,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(dino))
+            )
+        )
+        driver.bothPass()
+
+        // Sanity: the source is on the battlefield as Mastercraft Raptor.
+        driver.state.getEntity(saheeli)!!.get<CardComponent>()!!.name shouldBe "Mastercraft Raptor"
+
+        // Send Mastercraft Raptor to the graveyard (any leave-battlefield event will do).
+        val transition = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+            state = driver.state,
+            entityId = saheeli,
+            destinationZone = Zone.GRAVEYARD
+        )
+        driver.replaceState(transition.state)
+
+        // Per CR 712.8a, in any non-battlefield/non-stack zone the DFC has only the
+        // characteristics of its front face — so the card in the graveyard is Saheeli's
+        // Lattice, not Mastercraft Raptor.
+        val graveyardContainer = driver.state.getEntity(saheeli)
+        graveyardContainer.shouldNotBeNull()
+        val graveyardCard = graveyardContainer.get<CardComponent>()
+        graveyardCard.shouldNotBeNull()
+        graveyardCard.name shouldBe "Saheeli's Lattice"
+
+        val dfc = graveyardContainer.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.FRONT
+    }
+
+    test("rejects activation at instant speed (CR 702.167a: \"Activate only as a sorcery\")") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val saheeli = driver.putPermanentOnBattlefield(p1, "Saheeli's Lattice")
+        driver.putCreatureOnBattlefield(p1, "Test Tiny Dino")
+        driver.giveMana(p1, Color.RED, 5)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = saheeli,
+                abilityId = craftAbilityId()
+            )
+        )
+        result.isSuccess shouldBe false
+        result.error.shouldNotBeNull() shouldContain "sorcery"
+    }
+})
+
+private fun List<com.wingedsheep.sdk.model.EntityId>.shouldContain(id: com.wingedsheep.sdk.model.EntityId) {
+    if (id !in this) throw AssertionError("Expected zone to contain $id, but was $this")
+}

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -796,6 +796,18 @@ class GameTestDriver {
         if (cardDef.script.cantBeCountered) {
             container = container.with(com.wingedsheep.engine.state.components.identity.CantBeCounteredComponent)
         }
+        // Attach DoubleFacedComponent so transforms work (Rule 712) — mirrors the DFC wiring
+        // in putCreatureOnBattlefield so non-creature DFC artifacts (Saheeli's Lattice etc.)
+        // can also be exercised in scenario tests.
+        if (cardDef.isDoubleFaced) {
+            container = container.with(
+                com.wingedsheep.engine.state.components.identity.DoubleFacedComponent(
+                    frontCardDefinitionId = cardDef.name,
+                    backCardDefinitionId = cardDef.backFace!!.name,
+                    currentFace = com.wingedsheep.engine.state.components.identity.DoubleFacedComponent.Face.FRONT
+                )
+            )
+        }
 
         // Add continuous effects and replacement effects from static abilities
         val staticAbilityHandler = com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler(cardRegistry)

--- a/web-client/src/components/decisions/CraftMaterialOverlay.tsx
+++ b/web-client/src/components/decisions/CraftMaterialOverlay.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react'
+import { useGameStore } from '@/store/gameStore.ts'
+import type { ClientCard, EntityId } from '@/types'
+import { ZoneType } from '@/types'
+import {
+  calculateFittingCardWidth,
+  type ResponsiveSizes,
+} from '@/hooks/useResponsive.ts'
+import { DecisionCard, DecisionCardPreview } from './DecisionComponents'
+import styles from './DecisionUI.module.css'
+
+/**
+ * Cross-zone selection overlay for the Craft activated-ability cost (CR 702.167a-b).
+ *
+ * Saheeli's Lattice and every other Craft card lets the player exile materials from a
+ * **single combined pool** of permanents they control and cards in their graveyard. The
+ * existing per-zone targeting overlays (battlefield / graveyard) can't show both at once,
+ * so this overlay renders the two pools side-by-side and submits the chosen IDs through
+ * the standard `confirmTargeting` pipeline (which routes them to
+ * `ActivateAbility.costPayment.exiledCards`).
+ *
+ * Triggered when `targetingState.isCraftMaterialSelection` is set by the costPayment
+ * phase in [pipelinePhases.ts]; the rest of the pipeline (priority release, mana payment
+ * preview, activation submission) is unchanged.
+ */
+export function CraftMaterialOverlay({
+  responsive,
+}: {
+  responsive: ResponsiveSizes
+}) {
+  const targetingState = useGameStore((s) => s.targetingState)
+  const gameState = useGameStore((s) => s.gameState)
+  const addTarget = useGameStore((s) => s.addTarget)
+  const removeTarget = useGameStore((s) => s.removeTarget)
+  const confirmTargeting = useGameStore((s) => s.confirmTargeting)
+  const cancelTargeting = useGameStore((s) => s.cancelTargeting)
+
+  const [hoveredCardId, setHoveredCardId] = useState<EntityId | null>(null)
+
+  if (!targetingState || !targetingState.isCraftMaterialSelection) return null
+
+  const { validTargets, selectedTargets, minTargets, maxTargets } = targetingState
+
+  // Partition candidates by zone. Anything that isn't on the battlefield falls into the
+  // graveyard bucket (the server only enumerates BF + GY for Craft, so this is safe).
+  const battlefieldCards: { id: EntityId; card: ClientCard | undefined }[] = []
+  const graveyardCards: { id: EntityId; card: ClientCard | undefined }[] = []
+  for (const id of validTargets) {
+    const card = gameState?.cards[id]
+    if (card?.zone?.zoneType === ZoneType.BATTLEFIELD) {
+      battlefieldCards.push({ id, card })
+    } else {
+      graveyardCards.push({ id, card })
+    }
+  }
+
+  const selectedCount = selectedTargets.length
+  const canConfirm = selectedCount >= minTargets && selectedCount <= maxTargets
+
+  const toggle = (cardId: EntityId) => {
+    if (selectedTargets.includes(cardId)) {
+      removeTarget(cardId)
+    } else if (selectedCount < maxTargets) {
+      addTarget(cardId)
+    }
+  }
+
+  const groups = [
+    { label: 'Battlefield', cards: battlefieldCards },
+    { label: 'Graveyard', cards: graveyardCards },
+  ].filter((g) => g.cards.length > 0)
+
+  const availableWidth =
+    responsive.viewportWidth - responsive.containerPadding * 2 - 32
+  const gap = responsive.isMobile ? 4 : 8
+  const maxCardWidth = responsive.isMobile ? 90 : 130
+  const maxCardsInAnyGroup = Math.max(...groups.map((g) => g.cards.length), 1)
+  const cardWidth = calculateFittingCardWidth(
+    maxCardsInAnyGroup,
+    availableWidth,
+    gap,
+    maxCardWidth,
+    45,
+  )
+
+  const hoveredCard = hoveredCardId ? gameState?.cards[hoveredCardId] : null
+  const sourceCardName = targetingState.sourceCardName
+
+  const selectionLabel =
+    minTargets === maxTargets
+      ? `Selected: ${selectedCount} / ${minTargets}`
+      : `Selected: ${selectedCount} (${minTargets}+ required)`
+
+  return (
+    <div className={styles.overlay}>
+      <h2 className={styles.title}>
+        {targetingState.targetDescription ?? 'Choose Craft materials'}
+      </h2>
+      {sourceCardName && <p className={styles.sourceLabel}>{sourceCardName}</p>}
+      <p className={styles.hint}>{selectionLabel}</p>
+
+      <div className={styles.multiZoneContainer}>
+        {groups.map((group) => (
+          <div key={group.label} className={styles.zoneSection}>
+            <div className={styles.zoneSectionHeader}>
+              <span className={styles.zoneSectionLabel}>{group.label}</span>
+              <span className={styles.zoneSectionCount}>
+                {group.cards.length} card{group.cards.length !== 1 ? 's' : ''}
+              </span>
+            </div>
+            <div className={styles.cardContainer} style={{ gap }}>
+              {group.cards.map(({ id, card }) => {
+                const cardName = card?.name ?? 'Unknown Card'
+                return (
+                  <DecisionCard
+                    key={id}
+                    cardId={id}
+                    cardName={cardName}
+                    imageUri={card?.imageUri}
+                    isSelected={selectedTargets.includes(id)}
+                    onClick={() => toggle(id)}
+                    cardWidth={cardWidth}
+                    onMouseEnter={() => setHoveredCardId(id)}
+                    onMouseLeave={() => setHoveredCardId(null)}
+                  />
+                )
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.optionButtonRow}>
+        <button onClick={cancelTargeting} className={styles.viewBattlefieldButton}>
+          Cancel
+        </button>
+        <button
+          onClick={confirmTargeting}
+          disabled={!canConfirm}
+          className={styles.confirmButton}
+        >
+          Confirm Selection ({selectedCount})
+        </button>
+      </div>
+
+      {hoveredCard && !responsive.isMobile && (
+        <DecisionCardPreview
+          cardName={hoveredCard.name}
+          imageUri={hoveredCard.imageUri}
+        />
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/game/overlay/TargetingOverlay.tsx
+++ b/web-client/src/components/game/overlay/TargetingOverlay.tsx
@@ -7,6 +7,7 @@ import { getCardImageUrl } from '@/utils/cardImages.ts'
 import { useResponsiveContext, handleImageError } from '../board/shared'
 import { styles } from '../board/styles'
 import { TARGET_COLOR, TARGET_COLOR_BRIGHT } from '@/styles/targetingColors.ts'
+import { CraftMaterialOverlay } from '@/components/decisions/CraftMaterialOverlay'
 
 /**
  * Graveyard targeting overlay - shows when targeting mode requires selecting cards from graveyards.
@@ -451,6 +452,12 @@ export function TargetingOverlay() {
 
   // Only show when in targeting mode
   if (!targetingState) return null
+
+  // Craft material selection (CR 702.167) spans BF + GY simultaneously — route to the
+  // dedicated cross-zone overlay rather than the single-zone targeting flows below.
+  if (targetingState.isCraftMaterialSelection) {
+    return <CraftMaterialOverlay responsive={responsive} />
+  }
 
   const selectedCount = targetingState.selectedTargets.length
   const minTargets = targetingState.minTargets

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -79,6 +79,13 @@ export interface TargetingState {
   isBounceSelection?: boolean
   /** If set, this targeting phase is for beholding (choosing from battlefield or hand) */
   isBeholdSelection?: boolean
+  /**
+   * If set, this targeting phase is for selecting Craft materials across the activator's
+   * battlefield and graveyard (CR 702.167a-b). Materials live in both zones simultaneously
+   * — render with a dedicated overlay rather than the single-zone battlefield/graveyard
+   * targeting flows.
+   */
+  isCraftMaterialSelection?: boolean
   /** The original action info, used to chain sacrifice -> spell targeting -> damage distribution */
   pendingActionInfo?: LegalActionInfo
   /** Current target requirement index for multi-target spells (0-indexed) */

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -140,6 +140,7 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
       'ChooseEntity',
       'Blight',
       'Conspire',
+      'Craft',
     ]
 
     if (costTypesNeedingSelection.includes(costType)) {
@@ -337,7 +338,7 @@ export function mergeResult(
               ? { discardedCards: selectedTargets }
               : costType === 'BouncePermanent'
                 ? { bouncedPermanents: selectedTargets }
-                : costType === 'ExileFromGraveyard'
+                : costType === 'ExileFromGraveyard' || costType === 'Craft'
                   ? { exiledCards: selectedTargets }
                   : costType === 'Blight'
                     ? { blightTargets: selectedTargets }
@@ -614,6 +615,18 @@ export function enterPhase(
             costType === 'BlightVariable'
               ? `Choose a creature to receive ${(action as { additionalCostPayment?: { blightAmount?: number } }).additionalCostPayment?.blightAmount ?? 0} -1/-1 counter(s)`
               : costInfo.description
+          break
+        case 'Craft':
+          // Craft materials span both battlefield and graveyard (CR 702.167a-b). Route to the
+          // dedicated cross-zone overlay rather than the single-zone targeting flow.
+          validTargets = [...(costInfo.validCraftMaterials ?? [])]
+          minTargets = costInfo.craftMinCount ?? 1
+          maxTargets = validTargets.length
+          flags.isCraftMaterialSelection = true
+          flags.targetDescription = costInfo.description
+          flags.sourceCardName = actionInfo.description
+            .replace(/^Cast /, '')
+            .replace(/^Activate /, '')
           break
         default:
           return

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -180,6 +180,7 @@ export enum Keyword {
   PROWESS = 'PROWESS',
   FLURRY = 'FLURRY',
   CHANGELING = 'CHANGELING',
+  CRAFT = 'CRAFT',
   // Cost reduction
   CONVOKE = 'CONVOKE',
   DELVE = 'DELVE',
@@ -243,6 +244,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.PROWESS]: 'Prowess',
   [Keyword.FLURRY]: 'Flurry',
   [Keyword.CHANGELING]: 'Changeling',
+  [Keyword.CRAFT]: 'Craft',
   [Keyword.CONVOKE]: 'Convoke',
   [Keyword.DELVE]: 'Delve',
   [Keyword.AFFINITY]: 'Affinity',

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -854,6 +854,15 @@ export interface AdditionalCostInfo {
    * `RemoveCountersFromYourCreatures` costs (e.g. Dawnhand Dissident's cast cost).
    */
   readonly distributedCounterRemovalTotal?: number
+  /**
+   * Combined battlefield + graveyard candidate pool for an `AbilityCost.Craft` sub-cost
+   * (CR 702.167a-b). The activator picks `craftMinCount`+ of these to exile alongside the
+   * source. Battlefield candidates are permanents the activator controls matching the
+   * Craft filter; graveyard candidates are cards in their graveyard matching the same
+   * filter. Chosen IDs are submitted as `ActivateAbility.costPayment.exiledCards`.
+   */
+  readonly validCraftMaterials?: readonly EntityId[]
+  readonly craftMinCount?: number
 }
 
 export interface CounterRemovalCreatureInfo {


### PR DESCRIPTION
Implements the Craft keyword end-to-end through Saheeli's Lattice //
Mastercraft Raptor: composite multi-zone exile cost, `*`-power CDA on
the back face, and the cross-zone client selection UI.

## SDK
- `AbilityCost.Craft(filter, minCount)` — atomic CR 702.167a cost
  pairing the self-exile with the materials-exile in one clause.
- `Effects.ReturnSelfFromExileTransformed` — the paired resolution
  effect that returns the source as its back face under its owner's
  control. Does not emit a `TransformedEvent` (CR 701.27a — Craft
  returns a new object; it doesn't transform a permanent).
- `DynamicAmount.CraftedMaterialsTotalPower` — sums the printed power
  of the materials (CR 702.167c).
- `card { craft(filter, cost) }` builder helper composing the whole
  pattern plus the `Keyword.CRAFT` display tag.

## Engine
- `CraftedFromExiledComponent` records the materials on the source.
  Stripped on both battlefield exit and entry, then deliberately
  re-attached on the craft-return entry path (Rule 400.7).
- `CostHandler` validates the BF + GY combined pool (CR 702.167a-b)
  and requires an explicit material choice — no silent auto-pick.
- `DoubleFacedComponent.frontFaceCard` snapshot lets the existing
  CR 712.8a restore path revert Mastercraft Raptor to Saheeli's
  Lattice when it later leaves the battlefield.
- Activated-ability enumerator surfaces the candidate pool as
  `AdditionalCostData.validCraftMaterials` / `craftMinCount`.

## Web client
- `CraftMaterialOverlay` renders BF + GY candidates side-by-side and
  submits picks as `costPayment.exiledCards` through the standard
  targeting pipeline.

## Tests
Six scenario tests: cost payment + back-face emergence + power;
BF + GY combined pool (CR 702.167b); rejection when no candidates
exist; rejection when no choice supplied; LTB face revert (CR 712.8a);
sorcery-speed timing (CR 702.167a). Manual scenario JSON for dev play.