### PR TITLE
Fix Raph & Mikey trigger pulling the revealed creature back off the b…

### DIFF
--- a/manual-scenarios/cards/r/raph-and-mikey-troublemakers.json
+++ b/manual-scenarios/cards/r/raph-and-mikey-troublemakers.json
@@ -1,0 +1,50 @@
+{
+  "player1Name": "Raph Pilot",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Raph & Mikey, Troublemakers"},
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Forest",
+      "Hill Giant",
+      "Mountain",
+      "Forest",
+      "Mountain"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Grizzly Bears",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": ["DECLARE_BLOCKERS"],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphAndMikeyTroublemakers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphAndMikeyTroublemakers.kt
@@ -8,7 +8,9 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
@@ -58,8 +60,17 @@ val RaphAndMikeyTroublemakers = card("Raph & Mikey, Troublemakers") {
                     ZonePlacement.TappedAndAttacking
                 )
             ),
-            MoveCollectionEffect(
+            // Everything revealed minus the creature that hit the battlefield goes to
+            // the bottom of the library. Without this split, the creature's entity id
+            // is still in "raph_revealed" and the next MoveCollection would pull it
+            // off the battlefield right after it landed.
+            FilterCollectionEffect(
                 from = "raph_revealed",
+                filter = CollectionFilter.ExcludeOtherCollection("raph_creature"),
+                storeMatching = "raph_rest"
+            ),
+            MoveCollectionEffect(
+                from = "raph_rest",
                 destination = CardDestination.ToZone(
                     Zone.LIBRARY,
                     Player.You,


### PR DESCRIPTION
…attlefield

The attack trigger stored the matched creature in both `raph_creature` and `raph_revealed` (per GatherUntilMatchEffect's contract). Moving the creature to the battlefield first, then moving all of `raph_revealed` to the bottom of the library, dragged the creature off again immediately. Split the revealed pile with FilterCollection(ExcludeOtherCollection) — same pattern Aurora Awakener uses — so only the non-matches go to the bottom.

Also add a manual scenario for the attack trigger + trample interaction.