### PR TITLE
Add Territorial Bruntar, Terrasymbiosis, and Pull Through the Weft to EOE

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 248 / 261
+**Implemented:** 249 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -232,7 +232,7 @@
 - [ ] Terminal Velocity
 - [x] Terrapact Intimidator
 - [ ] Terrasymbiosis
-- [ ] Territorial Bruntar
+- [x] Territorial Bruntar
 - [ ] Tezzeret, Cruel Captain
 - [x] Thaumaton Torpedo
 - [x] Thawbringer

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 250 / 261
+**Implemented:** 251 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -165,7 +165,7 @@
 - [x] Pinnacle Starcage
 - [x] Plasma Bolt
 - [x] Possibility Technician
-- [ ] Pull Through the Weft
+- [x] Pull Through the Weft
 - [x] Pulsar Squadron Ace
 - [x] Quantum Riddler
 - [x] Radiant Strike

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 249 / 261
+**Implemented:** 250 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -231,7 +231,7 @@
 - [x] Temporal Intervention
 - [ ] Terminal Velocity
 - [x] Terrapact Intimidator
-- [ ] Terrasymbiosis
+- [x] Terrasymbiosis
 - [x] Territorial Bruntar
 - [ ] Tezzeret, Cruel Captain
 - [x] Thaumaton Torpedo

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -4,7 +4,7 @@ Engine features required to implement the remaining EOE cards. Each section list
 unblocks, the exact oracle clause that can't be expressed with current primitives, and a sketch of
 the engine/SDK work needed.
 
-As of the latest pass, **248 / 261** booster cards are implemented. The cards below remain
+As of the latest pass, **251 / 261** booster cards are implemented. The cards below remain
 blocked on the engine features listed here. Cards whose every clause maps to an existing primitive
 have already been implemented and are not listed. Section numbers are preserved from earlier
 revisions of this document so that [`problem-cards.md`](problem-cards.md) cross-references stay
@@ -26,18 +26,6 @@ expressible.
 
 ---
 
-## 9. Impulse "exile from top until a nonland card, you may cast it this turn" — RESOLVED
-
-**Cards:** Territorial Bruntar.
-
-**Resolution:** No new effect was needed. The existing pipeline composes:
-`GatherUntilMatchEffect(filter = Nonland, storeMatch, storeRevealed)` walks the library top-down,
-storing the matching nonland and every walked card. `MoveCollectionEffect` routes the whole
-walked pile into exile, and `GrantMayPlayFromExileEffect(from = storeMatch)` grants may-play
-(end-of-turn by default) on just the nonland. The lands stay in exile without permission.
-
----
-
 ## 10. Dynamic-toughness mass destroy + reanimate-from-batch
 
 **Cards:** Zero Point Ballad.
@@ -49,19 +37,6 @@ card put into a graveyard this way to the battlefield under your control."
 variant (`toughnessAtMost(DynamicAmount)`) so the destroy filter can read X. (b) Track which
 creatures were put into a graveyard by this destruction and allow selecting one to return when
 X ≥ 6. "Lose X life" is already expressible.
-
----
-
-## 11. Noncreature artifact tokens with custom names + embedded triggered abilities — RESOLVED
-
-**Cards:** Weapons Manufacturing.
-
-**Resolution:** Added `Munitions` to `PredefinedTokens.kt` (typeLine `"Artifact"`, with the
-leaves-battlefield damage trigger as a `triggeredAbility { }` block) and exposed
-`Effects.CreateMunitionsToken(count)` as the facade. The predefined-token path automatically
-picks up the LTB trigger via `cardRegistry.getCard("Munitions")` in `TriggerAbilityResolver`,
-so no token-creation change was needed — the predefined-token registry already supports
-noncreature type lines and embedded abilities.
 
 ---
 
@@ -117,18 +92,6 @@ trigger + haste) to a specific permanent put onto the battlefield. Put-from-hand
 
 ---
 
-## 17. Once-per-turn gating for triggered abilities (counters-placed → draw) — RESOLVED
-
-**Cards:** Terrasymbiosis.
-
-**Resolution:** No engine work was needed. `TriggeredAbility.oncePerTurn` already exists
-(used by Scavenger's Talent, Mechan Assembler, etc.), `Triggers.PlusOneCountersPlacedOnYourCreature`
-covers the counters-placed trigger, and `DynamicAmount.ContextProperty(TRIGGER_COUNTERS_PLACED_AMOUNT)`
-is the "that many" amount. Pairing them with `optional = true` for the "may" gives the full
-ability.
-
----
-
 ## 19. Cast spells from the top of your library (type-filtered) + restricted mana
 
 **Cards:** Mm'menon, the Right Hand.
@@ -167,20 +130,6 @@ addition to its other types and has no abilities."
 
 ---
 
-## 23. Multi-group graveyard return with split destinations — RESOLVED
-
-**Cards:** Pull Through the Weft.
-
-**Resolution:** No new SDK types were needed. Two independent cast-time `targets("…",
-optional = true)` calls register both prompts with their own legal-target lists. At
-resolution, `GatherCardsEffect(CardSource.ChosenTargets)` collects every selected target
-into one pipeline collection, and `FilterCollectionEffect(MatchesFilter(Land))` partitions
-the pile into `chosenLands` and `chosenNonlands`. Each subset is then routed to its own
-destination via `MoveCollectionEffect` (hand vs. battlefield-tapped). Partitioning by type
-sidesteps the `buildNamedTargets` flattening so per-requirement chosen counts don't have to
-align with the `count` maximums.
-
----
 
 ## 24. Planeswalker emblem + "becomes a 0/0 Robot artifact creature"
 

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -26,17 +26,15 @@ expressible.
 
 ---
 
-## 9. Impulse "exile from top until a nonland card, you may cast it this turn"
+## 9. Impulse "exile from top until a nonland card, you may cast it this turn" — RESOLVED
 
 **Cards:** Territorial Bruntar.
 
-**Clause:** "Whenever a land you control enters, exile cards from the top of your library until you
-exile a nonland card. You may cast that card this turn."
-
-**Plan:** Add an effect/pattern that exiles from the top until a nonland card is hit and grants
-may-play-this-turn on it (`GrantMayPlayFromExileEffect`). `ExileFromTopRepeatingEffect` puts the
-card into hand and doesn't grant impulse, so it can't be reused. Reach and the landfall trigger are
-already expressible.
+**Resolution:** No new effect was needed. The existing pipeline composes:
+`GatherUntilMatchEffect(filter = Nonland, storeMatch, storeRevealed)` walks the library top-down,
+storing the matching nonland and every walked card. `MoveCollectionEffect` routes the whole
+walked pile into exile, and `GrantMayPlayFromExileEffect(from = storeMatch)` grants may-play
+(end-of-turn by default) on just the nonland. The lands stay in exile without permission.
 
 ---
 

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -6,58 +6,9 @@ the engine/SDK work needed.
 
 As of the latest pass, **248 / 261** booster cards are implemented. The cards below remain
 blocked on the engine features listed here. Cards whose every clause maps to an existing primitive
-have already been implemented and are not listed.
-
----
-
-## 1. Conditional draw-replacement static — RESOLVED
-
-**Cards:** Quantum Riddler.
-
-**Resolution:** Added `ModifyDrawAmount(modifier, restrictions, appliesTo)` replacement effect
-(SDK) plus `DrawReplacementDispatcher.applyDrawAmountModifier()` in the engine. The modifier is
-consulted exactly once per draw instruction at the announcement site (CR 121.2a — instructions to
-draw multiple cards are modified before any individual card draws) — `DrawCardsExecutor.execute`
-for spell/ability draws and `DrawPhaseManager.performDrawStep` for the draw step — so a paused-and-
-resumed per-card loop doesn't double-modify. `restrictions: List<Condition>` mirrors
-`ModifyLifeLoss.restrictions` for the hand-size gate.
-
----
-
-## 2. "Was dealt damage this turn" tracking
-
-**Cards:** Faller's Faithful.
-
-**Clause:** "If that creature wasn't dealt damage this turn, its controller draws two cards."
-
-**Plan:** Track per-permanent "damaged this turn" state (cleared at cleanup) and expose it as a
-`Condition` usable on a context target. The ETB "destroy up to one target creature" is already
-expressible; only the damage-history conditional is missing.
-
----
-
-## 3. Excess-damage detection — RESOLVED
-
-**Cards:** Orbital Plunge.
-
-**Resolution:** Added `Conditions.IfTargetTookExcessDamage(targetIndex)` (backed by the
-`TargetMarkedDamageExceedsToughness` condition class). Reads the target's marked-damage component
-strictly greater than its projected toughness, so chaining it AFTER `Effects.DealDamage` in a
-composite gates a payoff on lethal-exceeding damage. Returns `false` for non-creature targets and
-for targets that have left the battlefield, so the chain stays safe without bespoke "DealDamageWithExcessFollowup"
-plumbing.
-
----
-
-## 4. Targeting cards in the warp-exile zone — RESOLVED
-
-**Cards:** Blade of the Swarm.
-
-**Resolution:** Extended `TargetEnumerationUtils.findValidObjectTargets` with a `Zone.EXILE` branch
-(`findValidExileTargets`), mirroring `findValidGraveyardTargets`. Combined with the existing
-`GameObjectFilter.warpExiled()` (`StatePredicate.IsWarpExiled`) and `MoveToZoneEffect(target, Zone.LIBRARY,
-ZonePlacement.Bottom)`, the modal targeting branch composes from existing atoms — no new effect or
-filter class needed.
+have already been implemented and are not listed. Section numbers are preserved from earlier
+revisions of this document so that [`problem-cards.md`](problem-cards.md) cross-references stay
+stable; gaps in the numbering correspond to features that have since been resolved.
 
 ---
 
@@ -72,45 +23,6 @@ that entered the battlefield under your control this turn."
 turn". (b) Add a continuous static replacement that adds ETB +1/+1 counters to *other* creatures
 you control (not just self), with a dynamic count. The "create a Lander" ETB is already
 expressible.
-
----
-
-## 6. `DynamicAmount` = mana spent to cast (usable in ETB replacement)
-
-**Cards:** Dyadrine, Synthesis Amalgam.
-
-**Clause:** "Dyadrine enters with a number of +1/+1 counters on it equal to the amount of mana spent
-to cast it."
-
-**Plan:** Persist `manaSpentToCast` on the permanent and expose a `DynamicAmount` that
-`EntersWithDynamicCounters` can read (today `TotalManaSpent` is only meaningful during cast
-resolution). The attack ability ("remove a +1/+1 counter from each of two creatures you control;
-if you do, draw a card and create a Robot token") is close to expressible but depends on a
-"remove a counter from each of N chosen creatures" cost/effect — verify before implementing.
-
----
-
-## 7. Characteristic-defining P/T from cards in exile — RESOLVED
-
-**Cards:** Cosmogoyf.
-
-**Resolution:** No new engine work needed. `DynamicAmount.AggregateZone(Player.You, Zone.EXILE,
-aggregation = COUNT)` already counts cards in the controller's exile sub-zone (cards in exile live
-in their owner's keyed exile bucket), and `dynamicStats(source, toughnessOffset = 1)` wires the
-same source as a CDA P/T through `CharacteristicValue.DynamicWithOffset`. The implementation is one
-DSL call: `dynamicStats(DynamicAmounts.zone(Player.You, Zone.EXILE).count(), toughnessOffset = 1)`.
-
----
-
-## 7b. Land: "sacrifice unless you tap an untapped permanent"
-
-**Cards:** Command Bridge.
-
-**Clause:** "When this land enters, sacrifice it unless you tap an untapped permanent you control."
-
-**Plan:** Add an ETB "sacrifice this unless you pay <cost>" intervening-choice effect where the
-alternative cost is tapping an untapped permanent you control. The "enters tapped" and the
-any-color mana ability are already expressible.
 
 ---
 
@@ -182,24 +94,6 @@ aura-attached "copy of enchanted permanent" token source.
 
 ---
 
-## 14. Affinity granted to the spells you cast / affinity for a subtype — RESOLVED
-
-**Cards:** Sami, Wildcat Captain (affinity for artifacts on all your spells);
-Thrumming Hivepool (affinity for Slivers on itself).
-
-**Clause:** "Spells you cast have affinity for artifacts." / "Affinity for Slivers."
-
-**Resolution:** No new engine work needed.
-- `KeywordAbility.AffinityForSubtype` already exists, so Hivepool's "Affinity for Slivers"
-  is just `KeywordAbility.AffinityForSubtype(Subtype.SLIVER)`.
-- Per CR 702.41a, "affinity for artifacts" is *defined* as "this spell costs {1} less for
-  each artifact you control", so Sami's "spells you cast have affinity for artifacts" is
-  mechanically identical to a battlefield-sourced
-  `ModifySpellCost(YouCast(Any), ReduceGenericBy(ArtifactsYouControl))` — no separate
-  "granted affinity" plumbing required.
-
----
-
 ## 15. Grant the Warp alternative-cast cost to cards in hand
 
 **Cards:** Tannuk, Steadfast Second.
@@ -235,17 +129,6 @@ many cards. Do this only once each turn."
 **Plan:** The trigger and "draw that many"
 (`ContextPropertyKey.TRIGGER_COUNTERS_PLACED_AMOUNT`) likely exist; the gap is a generic
 "do this only once each turn" limiter on a triggered ability.
-
----
-
-## 18. Copy a card from a zone and cast the copy for free — RESOLVED
-
-**Cards:** Roving Actuator.
-
-**Resolution:** No new engine work needed. The Shiko, Paragon of the Way pattern (`MoveToZoneEffect` →
-exile, `Effects.CopyCardIntoCollection`, `Effects.CastFromCollectionWithoutPayingCost` inside
-`MayEffect`) already implements "copy a card in a zone, then cast the copy" (Rule 707.12). Roving
-Actuator wraps the chain in a Void-gated ETB trigger via `triggerCondition = Conditions.Void`.
 
 ---
 
@@ -287,19 +170,6 @@ addition to its other types and has no abilities."
 
 ---
 
-## 22. Odd/even mass destroy + mass temporary control of all creatures
-
-**Cards:** Mutinous Massacre.
-
-**Clause:** "Choose odd or even. Destroy each creature with mana value of the chosen quality. Then
-gain control of all creatures until end of turn. Untap them. They gain haste until end of turn."
-
-**Plan:** Add (a) an odd/even mana-value filter (parity predicate) for the destroy, and (b) mass
-"gain control of all creatures until end of turn" (today `Effects.GainControl` targets a single
-permanent). Untap-all + grant-haste-all are expressible.
-
----
-
 ## 23. Multi-group graveyard return with split destinations
 
 **Cards:** Pull Through the Weft.
@@ -326,12 +196,3 @@ creature.'"
 recurring combat-trigger ability, and (b) a "becomes a 0/0 Robot artifact creature" type-set on a
 noncreature artifact. The passive ("whenever an artifact you control enters, add a loyalty
 counter"), the 0 untap, and the −3 tutor are expressible.
-
----
-
-## Already covered elsewhere
-
-Poison counters (Virulent Silencer), token doubling (Exalted Sunborn), devour-land (Famished
-Worldsire), "mana spent" for X-counters (Astelli Reclaimer), and "your next turn" delayed-trigger
-timing (Kav Landseeker — `CreateDelayedTriggerEffect.timing = DelayedTriggerTiming.NEXT_TURN`) were previously listed
-here and are now implemented; their entries have been removed.

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -167,17 +167,18 @@ addition to its other types and has no abilities."
 
 ---
 
-## 23. Multi-group graveyard return with split destinations
+## 23. Multi-group graveyard return with split destinations — RESOLVED
 
 **Cards:** Pull Through the Weft.
 
-**Clause:** "Return up to two target nonland permanent cards from your graveyard to your hand, then
-return up to two target land cards from your graveyard to the battlefield tapped."
-
-**Plan:** A single spell with two independent "up to two target" graveyard selections that route to
-*different* zones (hand vs. battlefield-tapped). Single-group graveyard return to one zone exists
-(e.g. Scout for Survivors); the dual-group/dual-destination shape needs verification or a new
-multi-target pattern.
+**Resolution:** No new SDK types were needed. Two independent cast-time `targets("…",
+optional = true)` calls register both prompts with their own legal-target lists. At
+resolution, `GatherCardsEffect(CardSource.ChosenTargets)` collects every selected target
+into one pipeline collection, and `FilterCollectionEffect(MatchesFilter(Land))` partitions
+the pile into `chosenLands` and `chosenNonlands`. Each subset is then routed to its own
+destination via `MoveCollectionEffect` (hand vs. battlefield-tapped). Partitioning by type
+sidesteps the `buildNamedTargets` flattening so per-requirement chosen counts don't have to
+align with the `count` maximums.
 
 ---
 

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -117,16 +117,15 @@ trigger + haste) to a specific permanent put onto the battlefield. Put-from-hand
 
 ---
 
-## 17. Once-per-turn gating for triggered abilities (counters-placed → draw)
+## 17. Once-per-turn gating for triggered abilities (counters-placed → draw) — RESOLVED
 
 **Cards:** Terrasymbiosis.
 
-**Clause:** "Whenever you put one or more +1/+1 counters on a creature you control, you may draw that
-many cards. Do this only once each turn."
-
-**Plan:** The trigger and "draw that many"
-(`ContextPropertyKey.TRIGGER_COUNTERS_PLACED_AMOUNT`) likely exist; the gap is a generic
-"do this only once each turn" limiter on a triggered ability.
+**Resolution:** No engine work was needed. `TriggeredAbility.oncePerTurn` already exists
+(used by Scavenger's Talent, Mechan Assembler, etc.), `Triggers.PlusOneCountersPlacedOnYourCreature`
+covers the counters-placed trigger, and `DynamicAmount.ContextProperty(TRIGGER_COUNTERS_PLACED_AMOUNT)`
+is the "that many" amount. Pairing them with `optional = true` for the "may" gives the full
+ability.
 
 ---
 

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,9 +3,9 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (13: 6 small + 7 large)
+## Status: cards still blocked on engine work (12: 5 small + 7 large)
 
-The booster set is at **248 / 261**. The cards below are the only unimplemented ones; each is
+The booster set is at **249 / 261**. The cards below are the only unimplemented ones; each is
 blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
 summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
 parentheses).
@@ -14,11 +14,10 @@ Cards are split by the scope of the engine work each one requires. "Small" = a s
 SDK/engine addition that composes with existing primitives. "Large" = multiple coupled features,
 a new subsystem, or work that reaches across several engine layers.
 
-### Small engine work (6)
+### Small engine work (5)
 
 | Card | Blocking clause | Engine change needed (missing-effects §) |
 |------|-----------------|-------------------------------------------|
-| Territorial Bruntar | "exile cards from the top ... until you exile a nonland card. You may cast that card this turn" | Impulse-until-nonland effect (§9) |
 | Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Static that grants Warp (with cost) to filtered hand cards (§15) |
 | Terrasymbiosis | "Whenever you put ... +1/+1 counters on a creature ... draw that many. Do this only once each turn." | Generic once-per-turn gate on a triggered ability (§17) |
 | Weftwalking | "The first spell each player casts ... may be cast without paying its mana cost" | First-spell-each-turn free-cast static, per-player gate (§20) |

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,25 +3,36 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (13)
+## Status: cards still blocked on engine work (13: 6 small + 7 large)
 
 The booster set is at **248 / 261**. The cards below are the only unimplemented ones; each is
 blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
 summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
 parentheses).
 
+Cards are split by the scope of the engine work each one requires. "Small" = a single focused
+SDK/engine addition that composes with existing primitives. "Large" = multiple coupled features,
+a new subsystem, or work that reaches across several engine layers.
+
+### Small engine work (6)
+
 | Card | Blocking clause | Engine change needed (missing-effects §) |
 |------|-----------------|-------------------------------------------|
-| Bioengineered Future | "Each creature you control enters with an additional +1/+1 counter ... for each land that entered ... this turn" | Continuous extra-ETB-counters + lands-entered-this-turn tracker (§5) |
 | Territorial Bruntar | "exile cards from the top ... until you exile a nonland card. You may cast that card this turn" | Impulse-until-nonland effect (§9) |
-| Zero Point Ballad | "Destroy all creatures with toughness X or less" + reanimate one destroyed this way | Dynamic-toughness mass destroy + reanimate-from-batch (§10) |
-| Lightstall Inquisitor | "each opponent exiles a card from their hand and may play that card ..." (+cost/tapped) | Opponent exile-from-hand-may-play with modifiers (§12) |
-| Moonlit Meditation | "instead create that many tokens that are copies of enchanted permanent" (once/turn) | Token-creation replacement → copies (§13) |
-| Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Grant Warp to hand cards (§15) |
-| Terminal Velocity | put a permanent from hand and grant it haste + an LTB trigger + an end-step self-sac | Grant arbitrary abilities to a put-in permanent (§16) |
-| Terrasymbiosis | "Whenever you put ... +1/+1 counters on a creature ... draw that many. Do this only once each turn." | Once-per-turn gating for triggered abilities (§17) |
-| Mm'menon, the Right Hand | "cast artifact spells from the top of your library" + restricted mana | Play-from-top static + restricted mana (§19) |
-| Weftwalking | "The first spell each player casts ... may be cast without paying its mana cost" | First-spell-free static (§20) |
-| Xu-Ifit, Osteoharmonist | reanimate "It's a Skeleton ... and has no abilities" | Reanimate as typed, ability-stripped permanent (§21) |
+| Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Static that grants Warp (with cost) to filtered hand cards (§15) |
+| Terrasymbiosis | "Whenever you put ... +1/+1 counters on a creature ... draw that many. Do this only once each turn." | Generic once-per-turn gate on a triggered ability (§17) |
+| Weftwalking | "The first spell each player casts ... may be cast without paying its mana cost" | First-spell-each-turn free-cast static, per-player gate (§20) |
+| Xu-Ifit, Osteoharmonist | reanimate "It's a Skeleton ... and has no abilities" | Continuous layer-4 add-subtype + layer-6 strip-abilities tied to one permanent (§21) |
 | Pull Through the Weft | return up to two nonland permanents to hand **and** up to two lands to the battlefield tapped | Dual-group graveyard return with split destinations (§23) |
-| Tezzeret, Cruel Captain | −7 emblem; "it becomes a 0/0 Robot artifact creature" | Emblem creation + becomes-Robot type-set (§24) |
+
+### Large engine work (7)
+
+| Card | Blocking clause | Engine change needed (missing-effects §) |
+|------|-----------------|-------------------------------------------|
+| Bioengineered Future | "Each creature you control enters with an additional +1/+1 counter ... for each land that entered ... this turn" | New turn tracker (lands ETB'd under you) + continuous extra-ETB-counters static targeting *other* creatures (§5) |
+| Zero Point Ballad | "Destroy all creatures with toughness X or less" + reanimate one destroyed this way | Dynamic-toughness mass-destroy filter + batch tracking for "destroyed this way" reanimation (§10) |
+| Lightstall Inquisitor | "each opponent exiles a card from their hand and may play that card ..." (+cost/tapped) | Opponent exile-from-hand granting may-play to *owner* + scoped cost increase + scoped lands-enter-tapped (§12) |
+| Moonlit Meditation | "instead create that many tokens that are copies of enchanted permanent" (once/turn) | CreateToken replacement effect + once-per-turn gate + copy-of-enchanted token source (§13) |
+| Terminal Velocity | put a permanent from hand and grant it haste + an LTB trigger + an end-step self-sac | Grant arbitrary bundle of abilities (incl. new triggered abilities) to a put-in permanent (§16) |
+| Mm'menon, the Right Hand | "cast artifact spells from the top of your library" + restricted mana | Play-from-top-of-library static + restricted mana (non-hand only) + look-at-top-anytime (§19) |
+| Tezzeret, Cruel Captain | −7 emblem; "it becomes a 0/0 Robot artifact creature" | Emblem creation with recurring combat trigger + "becomes 0/0 Robot artifact creature" type-set on a noncreature (§24) |

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,9 +3,9 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (11: 4 small + 7 large)
+## Status: cards still blocked on engine work (10: 3 small + 7 large)
 
-The booster set is at **250 / 261**. The cards below are the only unimplemented ones; each is
+The booster set is at **251 / 261**. The cards below are the only unimplemented ones; each is
 blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
 summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
 parentheses).
@@ -14,14 +14,13 @@ Cards are split by the scope of the engine work each one requires. "Small" = a s
 SDK/engine addition that composes with existing primitives. "Large" = multiple coupled features,
 a new subsystem, or work that reaches across several engine layers.
 
-### Small engine work (4)
+### Small engine work (3)
 
 | Card | Blocking clause | Engine change needed (missing-effects §) |
 |------|-----------------|-------------------------------------------|
 | Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Static that grants Warp (with cost) to filtered hand cards (§15) |
 | Weftwalking | "The first spell each player casts ... may be cast without paying its mana cost" | First-spell-each-turn free-cast static, per-player gate (§20) |
 | Xu-Ifit, Osteoharmonist | reanimate "It's a Skeleton ... and has no abilities" | Continuous layer-4 add-subtype + layer-6 strip-abilities tied to one permanent (§21) |
-| Pull Through the Weft | return up to two nonland permanents to hand **and** up to two lands to the battlefield tapped | Dual-group graveyard return with split destinations (§23) |
 
 ### Large engine work (7)
 

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,9 +3,9 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (12: 5 small + 7 large)
+## Status: cards still blocked on engine work (11: 4 small + 7 large)
 
-The booster set is at **249 / 261**. The cards below are the only unimplemented ones; each is
+The booster set is at **250 / 261**. The cards below are the only unimplemented ones; each is
 blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
 summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
 parentheses).
@@ -14,12 +14,11 @@ Cards are split by the scope of the engine work each one requires. "Small" = a s
 SDK/engine addition that composes with existing primitives. "Large" = multiple coupled features,
 a new subsystem, or work that reaches across several engine layers.
 
-### Small engine work (5)
+### Small engine work (4)
 
 | Card | Blocking clause | Engine change needed (missing-effects §) |
 |------|-----------------|-------------------------------------------|
 | Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Static that grants Warp (with cost) to filtered hand cards (§15) |
-| Terrasymbiosis | "Whenever you put ... +1/+1 counters on a creature ... draw that many. Do this only once each turn." | Generic once-per-turn gate on a triggered ability (§17) |
 | Weftwalking | "The first spell each player casts ... may be cast without paying its mana cost" | First-spell-each-turn free-cast static, per-player gate (§20) |
 | Xu-Ifit, Osteoharmonist | reanimate "It's a Skeleton ... and has no abilities" | Continuous layer-4 add-subtype + layer-6 strip-abilities tied to one permanent (§21) |
 | Pull Through the Weft | return up to two nonland permanents to hand **and** up to two lands to the battlefield tapped | Dual-group graveyard return with split destinations (§23) |

--- a/manual-scenarios/mechanics/eoe-small-rollout.json
+++ b/manual-scenarios/mechanics/eoe-small-rollout.json
@@ -1,0 +1,64 @@
+{
+  "_description": "Test bench for the four EOE 'small' cards added on the eoe-small branch (Territorial Bruntar, Terrasymbiosis, Xu-Ifit Osteoharmonist, Pull Through the Weft). Alice opens with all three permanents already on the battlefield (not summoning sick), two Biosynthic Bursts in hand to drive Terrasymbiosis, plus Bombard for opt-in killing of the reanimated Skeleton and enough Forests to cast everything. Suggested test sequence: (1) Play the Forest from hand — Territorial Bruntar's landfall walks the library, exiles the top Forest then the Bombard (the first nonland), and grants may-play on Bombard for the turn. (2) Cast Biosynthic Burst targeting Xu-Ifit (or any creature you control) — the +1/+1 counter fires Terrasymbiosis's 'whenever you put one or more +1/+1 counters on a creature you control, you may draw that many cards', netting one card. Cast the SECOND Biosynthic Burst — the +1/+1 counter still lands but Terrasymbiosis stays silent because the trigger is gated 'only once each turn'. (3) Tap Xu-Ifit, targeting Festering Goblin in the graveyard — it returns as a Skeleton with no abilities; cast the impulse-granted Bombard at it to confirm the printed 'When this creature dies, target creature gets -1/-1 until end of turn' trigger does NOT fire. (4) Cast Pull Through the Weft ({3}{G}{G}) — pick up to two nonland permanent cards (Galvanizing Sawship + Festering Goblin if not already reanimated, or just the Sawship) for your hand, and up to two lands (Mountain + Forest) for the battlefield tapped. Each land entering re-triggers Bruntar's landfall, demonstrating the chain.",
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Pull Through the Weft",
+      "Forest",
+      "Biosynthic Burst",
+      "Biosynthic Burst",
+      "Synchronized Charge"
+    ],
+    "battlefield": [
+      {"name": "Territorial Bruntar", "summoningSickness": false},
+      {"name": "Terrasymbiosis"},
+      {"name": "Xu-Ifit, Osteoharmonist", "summoningSickness": false},
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [
+      "Festering Goblin",
+      "Galvanizing Sawship",
+      "Forest",
+      "Mountain"
+    ],
+    "library": [
+      "Forest",
+      "Bombard",
+      "Grizzly Bears",
+      "Llanowar Elves",
+      "Cosmogoyf"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Glory Seeker"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Plains",
+      "Plains",
+      "Plains"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PullThroughTheWeft.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PullThroughTheWeft.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Pull Through the Weft
+ * {3}{G}{G}
+ * Sorcery
+ * Return up to two target nonland permanent cards from your graveyard to your hand, then
+ * return up to two target land cards from your graveyard to the battlefield tapped.
+ *
+ * Two independent cast-time `targets("…", optional = true)` calls give the player two
+ * prompts (each "up to two") with their own legal-target lists. At resolution the engine
+ * places every chosen target into `context.targets` as a flat list; the effect gathers
+ * those via `CardSource.ChosenTargets` and partitions them by `GameObjectFilter.Land` —
+ * lands into `chosenLands`, the rest (the nonland permanent cards from the first prompt)
+ * into `chosenNonlands`. Each pile then routes to its own destination (hand vs.
+ * battlefield-tapped), keeping the two-target-group routing accurate even when the per-
+ * requirement chosen counts differ.
+ */
+val PullThroughTheWeft = card("Pull Through the Weft") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Return up to two target nonland permanent cards from your graveyard to your hand, " +
+        "then return up to two target land cards from your graveyard to the battlefield tapped."
+
+    spell {
+        targets(
+            "nonland permanent card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.NonlandPermanent.ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+                count = 2,
+                optional = true,
+            ),
+        )
+        targets(
+            "land card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Land.ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+                count = 2,
+                optional = true,
+            ),
+        )
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.ChosenTargets,
+                    storeAs = "chosen",
+                ),
+                FilterCollectionEffect(
+                    from = "chosen",
+                    filter = CollectionFilter.MatchesFilter(GameObjectFilter.Land),
+                    storeMatching = "chosenLands",
+                    storeNonMatching = "chosenNonlands",
+                ),
+                MoveCollectionEffect(
+                    from = "chosenNonlands",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                ),
+                MoveCollectionEffect(
+                    from = "chosenLands",
+                    destination = CardDestination.ToZone(
+                        Zone.BATTLEFIELD,
+                        placement = ZonePlacement.Tapped,
+                    ),
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "202"
+        artist = "Andrew Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a70d0877-1a1e-436b-bf8c-0ff6df9efc6a.jpg?1752947378"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Terrasymbiosis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Terrasymbiosis.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Terrasymbiosis
+ * {2}{G}
+ * Enchantment
+ * Whenever you put one or more +1/+1 counters on a creature you control, you may draw
+ * that many cards. Do this only once each turn.
+ *
+ * Implementation: `Triggers.PlusOneCountersPlacedOnYourCreature` (a `CountersPlacedEvent`
+ * for `Counters.PLUS_ONE_PLUS_ONE` filtered to creatures you control) gives us the
+ * trigger and exposes the placed count via `TRIGGER_COUNTERS_PLACED_AMOUNT`. The "may"
+ * is `optional = true`, and the "do this only once each turn" gate uses the existing
+ * `oncePerTurn = true` flag on `TriggeredAbility` (the same mechanism as Scavenger's
+ * Talent).
+ */
+val Terrasymbiosis = card("Terrasymbiosis") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you put one or more +1/+1 counters on a creature you control, " +
+        "you may draw that many cards. Do this only once each turn."
+
+    triggeredAbility {
+        trigger = Triggers.PlusOneCountersPlacedOnYourCreature
+        optional = true
+        oncePerTurn = true
+        effect = Effects.DrawCards(
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_COUNTERS_PLACED_AMOUNT)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "210"
+        artist = "Viko Menezes"
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26008c7d-5dbe-4da2-b475-4dd307e7bc68.jpg?1752947411"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TerritorialBruntar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TerritorialBruntar.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+
+/**
+ * Territorial Bruntar
+ * {4}{R}{R}
+ * Creature — Beast
+ * 6/6
+ * Reach
+ * Landfall — Whenever a land you control enters, exile cards from the top of your library
+ * until you exile a nonland card. You may cast that card this turn.
+ *
+ * Pipeline: `GatherUntilMatch(Nonland)` walks the library top-down, storing every walked
+ * card in `exiledCards` and the matching nonland (if any) in `impulseCard`. `MoveCollection`
+ * routes the whole revealed pile — lands and the nonland alike — into exile. Finally
+ * `GrantMayPlayFromExile("impulseCard")` grants may-play (default end-of-turn) on just
+ * the nonland; the lands remain in exile without any may-play permission.
+ *
+ * If no nonland is found the entire library is exiled and `impulseCard` is empty, so the
+ * grant is a no-op.
+ */
+val TerritorialBruntar = card("Territorial Bruntar") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 6
+    toughness = 6
+    oracleText = "Reach\n" +
+        "Landfall — Whenever a land you control enters, exile cards from the top of your library " +
+        "until you exile a nonland card. You may cast that card this turn."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = CompositeEffect(
+            listOf(
+                GatherUntilMatchEffect(
+                    filter = GameObjectFilter.Nonland,
+                    storeMatch = "impulseCard",
+                    storeRevealed = "exiledCards"
+                ),
+                MoveCollectionEffect(
+                    from = "exiledCards",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                ),
+                Effects.GrantMayPlayFromExile(from = "impulseCard")
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Julie Dillon"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbb25585-6048-4a85-828e-675bf0da6508.jpg?1752947221"
+    }
+}


### PR DESCRIPTION
Implements three EOE cards that compose existing SDK primitives — no new
engine types, no executor changes. Bumps booster progress 248 → 251 / 261.

- **Territorial Bruntar** (§9) — Landfall: GatherUntilMatch(Nonland) →
  MoveCollection(EXILE) → GrantMayPlayFromExile on just the matching
  nonland; lands stay in exile without play permission.
- **Terrasymbiosis** (§17) — PlusOneCountersPlacedOnYourCreature trigger +
  optional=true + oncePerTurn=true + DrawCards(TRIGGER_COUNTERS_PLACED_AMOUNT).
  Reuses Scavenger's Talent's once-per-turn flag and Simic Ascendancy's
  "that many" dynamic amount.
- **Pull Through the Weft** (§23) — Two targets() prompts (nonland permanent
  cards, then land cards, each "up to two") flatten into ChosenTargets;
  FilterCollection(MatchesFilter(Land)) partitions the chosen pile and routes
  each half to its destination (hand vs. battlefield-tapped).

Also drops the resolved §1/§3/§4/§6/§7/§11 sections from missing-effects.md
(numbering preserved so problem-cards.md cross-refs stay stable) and
re-splits the remaining 10 blocked cards in problem-cards.md by engine-work
scope (3 small + 7 large).