### PR TITLE
Add Glacial Dragonhunt, Lie in Wait, and Winternight Stories (TDM)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GlacialDragonhunt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GlacialDragonhunt.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Glacial Dragonhunt — Tarkir: Dragonstorm #188
+ * {U}{R} · Sorcery · Uncommon
+ *
+ * Draw a card, then you may discard a card. When you discard a nonland card this way,
+ * Glacial Dragonhunt deals 3 damage to target creature.
+ * Harmonize {4}{U}{R}
+ *
+ * The "when you discard a nonland card this way" clause is a reflexive trigger: its target is
+ * chosen only after — and only if — a nonland card is actually discarded. We model that exactly
+ * by composing pipeline primitives rather than declaring a cast-time spell target:
+ *   1. draw a card;
+ *   2. gather the hand, let the controller discard UP TO one card (the printed "you may"), and
+ *      move the choice to the graveyard as a discard;
+ *   3. only when the discarded collection contains a [GameObjectFilter.Nonland] card, prompt for
+ *      a target creature (on-battlefield targeting UI) and deal 3 damage to it.
+ * If no card is discarded, or a land is discarded, no creature is chosen and no damage is dealt.
+ */
+val GlacialDragonhunt = card("Glacial Dragonhunt") {
+    manaCost = "{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Sorcery"
+    oracleText = "Draw a card, then you may discard a card. When you discard a nonland card this " +
+        "way, Glacial Dragonhunt deals 3 damage to target creature.\n" +
+        "Harmonize {4}{U}{R} (You may cast this card from your graveyard for its harmonize cost. " +
+        "You may tap a creature you control to reduce that cost by {X}, where X is its power. " +
+        "Then exile this spell.)"
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                Effects.DrawCards(1),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.You),
+                    storeAs = "hand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hand",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    storeSelected = "discarded",
+                    prompt = "You may discard a card"
+                ),
+                MoveCollectionEffect(
+                    from = "discarded",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+                    moveType = MoveType.Discard
+                ),
+                // Reflexive trigger: only when a nonland was discarded do we pick a target creature
+                // and deal it 3 damage.
+                ConditionalOnCollectionEffect(
+                    collection = "discarded",
+                    filter = GameObjectFilter.Nonland,
+                    ifNotEmpty = CompositeEffect(
+                        listOf(
+                            GatherCardsEffect(
+                                source = CardSource.BattlefieldMatching(
+                                    filter = GameObjectFilter.Creature,
+                                    player = Player.Each
+                                ),
+                                storeAs = "creatures"
+                            ),
+                            SelectFromCollectionEffect(
+                                from = "creatures",
+                                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                                chooser = Chooser.Controller,
+                                storeSelected = "damageTarget",
+                                prompt = "Choose a creature to deal 3 damage to",
+                                useTargetingUI = true
+                            ),
+                            Effects.DealDamage(
+                                3,
+                                EffectTarget.PipelineTarget("damageTarget"),
+                                damageSource = EffectTarget.Self
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    keywordAbility(KeywordAbility.harmonize("{4}{U}{R}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "188"
+        artist = "Igor Grechanyi"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95994c88-e404-4a4f-8be6-b99d703d4609.jpg?1743204732"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LieInWait.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LieInWait.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Lie in Wait — Tarkir: Dragonstorm #203
+ * {B}{G}{U} · Sorcery · Uncommon
+ *
+ * Return target creature card from your graveyard to your hand. Lie in Wait deals damage equal
+ * to that card's power to target creature.
+ *
+ * Two targets are chosen at cast (CR 601.2c): target #0 the creature card in your graveyard,
+ * target #1 the creature to damage. On resolution the graveyard card is returned to hand first,
+ * then we deal damage equal to that card's power — read via [DynamicAmount.EntityProperty] off
+ * [EntityReference.Target] 0. The card has moved to hand by then, but power off the battlefield
+ * resolves to its printed power, which is exactly "that card's power".
+ */
+val LieInWait = card("Lie in Wait") {
+    manaCost = "{B}{G}{U}"
+    colorIdentity = "BGU"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to your hand. Lie in Wait deals " +
+        "damage equal to that card's power to target creature."
+
+    spell {
+        target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+        target("target creature", Targets.Creature)
+        effect = CompositeEffect(
+            listOf(
+                Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+                Effects.DealDamage(
+                    DynamicAmount.EntityProperty(
+                        entity = EntityReference.Target(0),
+                        numericProperty = EntityNumericProperty.Power
+                    ),
+                    EffectTarget.ContextTarget(1),
+                    damageSource = EffectTarget.Self
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Diana Franco"
+        flavorText = "Some paths through Gurmag Swamp are deserted for good reason."
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96fff22c-282b-4849-82ce-890013b53262.jpg?1743204797"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WinternightStories.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WinternightStories.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Winternight Stories — Tarkir: Dragonstorm #67
+ * {2}{U} · Sorcery · Rare
+ *
+ * Draw three cards. Then discard two cards unless you discard a creature card.
+ * Harmonize {4}{U}
+ *
+ * "Discard two cards unless you discard a creature card" is a player choice (CR 701.8): the
+ * controller may instead discard a single creature card to satisfy the "unless". Modeled as
+ * Draw 3, then [ChooseActionEffect] between "discard a creature card" — feasible only when a
+ * creature card is in hand — and "discard two cards". With no creature card in hand, only the
+ * "discard two cards" branch is feasible, matching the printed card.
+ */
+val WinternightStories = card("Winternight Stories") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Draw three cards. Then discard two cards unless you discard a creature card.\n" +
+        "Harmonize {4}{U} (You may cast this card from your graveyard for its harmonize cost. " +
+        "You may tap a creature you control to reduce that cost by {X}, where X is its power. " +
+        "Then exile this spell.)"
+
+    spell {
+        effect = Effects.DrawCards(3)
+            .then(
+                ChooseActionEffect(
+                    choices = listOf(
+                        EffectChoice(
+                            label = "Discard a creature card",
+                            effect = CompositeEffect(
+                                listOf(
+                                    GatherCardsEffect(
+                                        source = CardSource.FromZone(
+                                            Zone.HAND,
+                                            Player.You,
+                                            GameObjectFilter.Creature
+                                        ),
+                                        storeAs = "creatures"
+                                    ),
+                                    SelectFromCollectionEffect(
+                                        from = "creatures",
+                                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                                        storeSelected = "discarded",
+                                        prompt = "Choose a creature card to discard"
+                                    ),
+                                    MoveCollectionEffect(
+                                        from = "discarded",
+                                        destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                                        moveType = MoveType.Discard
+                                    )
+                                )
+                            ),
+                            feasibilityCheck = FeasibilityCheck.HasCardsInZone(
+                                Zone.HAND,
+                                GameObjectFilter.Creature,
+                                1
+                            )
+                        ),
+                        EffectChoice(
+                            label = "Discard two cards",
+                            effect = EffectPatterns.discardCards(2)
+                        )
+                    )
+                )
+            )
+    }
+
+    keywordAbility(KeywordAbility.harmonize("{4}{U}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "67"
+        artist = "Zara Alfonso"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64d9367c-f50c-4568-aa63-6760c44ecaeb.jpg?1743204229"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlacialDragonhuntScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlacialDragonhuntScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.GlacialDragonhunt
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Glacial Dragonhunt — {U}{R} Sorcery.
+ *   "Draw a card, then you may discard a card. When you discard a nonland card this way,
+ *    Glacial Dragonhunt deals 3 damage to target creature."
+ *
+ * The "when you discard a nonland card this way" damage is reflexive: a target creature is only
+ * chosen — and only damaged — when a nonland card is actually discarded.
+ */
+class GlacialDragonhuntScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GlacialDragonhunt)
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("discarding a nonland card lets you deal 3 damage to a target creature") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != player }
+
+        val spell = driver.putCardInHand(player, "Glacial Dragonhunt")
+        // A nonland card in hand to discard (a creature card is nonland).
+        driver.putCardInHand(player, "Grizzly Bears")
+        // Two creatures so the reflexive damage genuinely presents a target choice.
+        val target = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2 — the one we damage
+        val bystander = driver.putCreatureOnBattlefield(opponent, "Centaur Courser") // 3/3 — left alone
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveMana(player, Color.RED, 1)
+
+        driver.submit(
+            CastSpell(player, spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // First decision: "you may discard a card" (up to one) — choose the Grizzly Bears card.
+        val discardDecision = driver.pendingDecision as? SelectCardsDecision
+        discardDecision shouldNotBe null
+        val nonlandCard = discardDecision!!.options.first { cardId ->
+            driver.state.getEntity(cardId)
+                ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                ?.name == "Grizzly Bears"
+        }
+        driver.submitDecision(player, CardsSelectedResponse(discardDecision.id, listOf(nonlandCard)))
+
+        // Reflexive: now choose the creature to deal 3 damage to.
+        val targetDecision = driver.pendingDecision as? SelectCardsDecision
+        targetDecision shouldNotBe null
+        targetDecision!!.options.contains(target) shouldBe true
+        targetDecision.options.contains(bystander) shouldBe true
+        driver.submitDecision(player, CardsSelectedResponse(targetDecision.id, listOf(target)))
+
+        // 2/2 takes 3 damage → dies; the untargeted 3/3 is untouched.
+        driver.state.getBattlefield().contains(target) shouldBe false
+        driver.state.getZone(ZoneKey(opponent, Zone.GRAVEYARD)).contains(target) shouldBe true
+        driver.state.getBattlefield().contains(bystander) shouldBe true
+        (driver.state.getEntity(bystander)?.get<DamageComponent>()?.amount ?: 0) shouldBe 0
+    }
+
+    test("declining to discard deals no damage") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != player }
+
+        val spell = driver.putCardInHand(player, "Glacial Dragonhunt")
+        driver.putCardInHand(player, "Grizzly Bears")
+        val survivor = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveMana(player, Color.RED, 1)
+
+        driver.submit(
+            CastSpell(player, spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // "You may discard a card" — decline by selecting zero cards.
+        val discardDecision = driver.pendingDecision as? SelectCardsDecision
+        discardDecision shouldNotBe null
+        discardDecision!!.minSelections shouldBe 0
+        driver.submitDecision(player, CardsSelectedResponse(discardDecision.id, emptyList()))
+
+        // No nonland discarded → no target prompt, no damage.
+        driver.pendingDecision shouldBe null
+        driver.state.getBattlefield().contains(survivor) shouldBe true
+        (driver.state.getEntity(survivor)?.get<DamageComponent>()?.amount ?: 0) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LieInWaitScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LieInWaitScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.LieInWait
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Lie in Wait — {B}{G}{U} Sorcery.
+ *   "Return target creature card from your graveyard to your hand. Lie in Wait deals damage
+ *    equal to that card's power to target creature."
+ *
+ * Verifies the two-target spell: the graveyard creature card is returned to hand, and the
+ * damage dealt equals that card's (printed) power.
+ */
+class LieInWaitScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(LieInWait)
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("returns the graveyard creature and deals damage equal to its power") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != player }
+
+        val spell = driver.putCardInHand(player, "Lie in Wait")
+        // Force of Nature is a 5/5 — power 5 — sitting in our graveyard.
+        val graveyardCreature = driver.putCardInGraveyard(player, "Force of Nature")
+        // Target a 3/3 Centaur Courser; 5 damage destroys it.
+        val damageTarget = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveMana(player, Color.BLUE, 1)
+
+        driver.submit(
+            CastSpell(
+                player, spell,
+                targets = listOf(
+                    ChosenTarget.Card(graveyardCreature, player, Zone.GRAVEYARD),
+                    ChosenTarget.Permanent(damageTarget)
+                ),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // The Force of Nature was returned to hand.
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).contains(graveyardCreature) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(graveyardCreature) shouldBe false
+        driver.state.getEntity(graveyardCreature)?.get<CardComponent>()?.name shouldBe "Force of Nature"
+
+        // 5 damage (Force of Nature's power) to a 3/3 → destroyed.
+        driver.state.getBattlefield().contains(damageTarget) shouldBe false
+        driver.state.getZone(ZoneKey(opponent, Zone.GRAVEYARD)).contains(damageTarget) shouldBe true
+    }
+
+    test("lower-power returned card deals only that much damage; tougher target survives") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != player }
+
+        val spell = driver.putCardInHand(player, "Lie in Wait")
+        // Grizzly Bears is a 2/2 — power 2.
+        val graveyardCreature = driver.putCardInGraveyard(player, "Grizzly Bears")
+        // Target a 3/3 Centaur Courser; 2 damage leaves it alive with 2 marked.
+        val damageTarget = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveMana(player, Color.BLUE, 1)
+
+        driver.submit(
+            CastSpell(
+                player, spell,
+                targets = listOf(
+                    ChosenTarget.Card(graveyardCreature, player, Zone.GRAVEYARD),
+                    ChosenTarget.Permanent(damageTarget)
+                ),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).contains(graveyardCreature) shouldBe true
+        driver.state.getBattlefield().contains(damageTarget) shouldBe true
+        (driver.state.getEntity(damageTarget)?.get<DamageComponent>()?.amount ?: 0) shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WinternightStoriesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WinternightStoriesScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.WinternightStories
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Winternight Stories — {2}{U} Sorcery.
+ *   "Draw three cards. Then discard two cards unless you discard a creature card."
+ *
+ * The "unless" is a player choice: discard one creature card, or discard two cards.
+ */
+class WinternightStoriesScenarioTest : FunSpec({
+
+    fun createDriver(deck: Deck): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(WinternightStories)
+        driver.initMirrorMatch(deck = deck, startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("choosing to discard a creature card discards only one card") {
+        // Library is all Grizzly Bears (creature cards) so the three drawn cards are creatures.
+        val driver = createDriver(Deck.of("Grizzly Bears" to 40))
+        val player = driver.activePlayer!!
+
+        val spell = driver.putCardInHand(player, "Winternight Stories")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, 2)
+
+        val handBefore = driver.state.getZone(ZoneKey(player, Zone.HAND)).size // includes the spell
+
+        driver.submit(
+            CastSpell(player, spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // After drawing three, choose between "discard a creature card" and "discard two cards".
+        val choice = driver.pendingDecision as? ChooseOptionDecision
+        choice shouldNotBe null
+        val creatureOptionIndex = choice!!.options.indexOfFirst { it.contains("creature", ignoreCase = true) }
+        creatureOptionIndex shouldBeGreaterThan -1
+        driver.submitDecision(player, OptionChosenResponse(choice.id, creatureOptionIndex))
+
+        // Then pick which creature card to discard.
+        val discardDecision = driver.pendingDecision as? SelectCardsDecision
+        discardDecision shouldNotBe null
+        discardDecision!!.minSelections shouldBe 1
+        discardDecision.maxSelections shouldBe 1
+        val creatureCard = discardDecision.options.first { cardId ->
+            driver.state.getEntity(cardId)?.get<CardComponent>()?.name == "Grizzly Bears"
+        }
+        driver.submitDecision(player, CardsSelectedResponse(discardDecision.id, listOf(creatureCard)))
+
+        // Net: spell left hand (−1) + drew 3 (+3) + discarded 1 (−1) = +1 versus before-cast count.
+        // handBefore counted the spell; the spell is now on the stack/graveyard so subtract it too.
+        val handAfter = driver.state.getZone(ZoneKey(player, Zone.HAND)).size
+        handAfter shouldBe (handBefore - 1) + 3 - 1
+    }
+
+    test("with no creature card in hand, you must discard two cards") {
+        // All-land deck: neither the opening hand nor the three drawn cards are creatures.
+        val driver = createDriver(Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+
+        val spell = driver.putCardInHand(player, "Winternight Stories")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, 2)
+
+        driver.submit(
+            CastSpell(player, spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // No creature in hand → the only feasible branch is "discard two cards" (auto-chosen).
+        val discardDecision = driver.pendingDecision as? SelectCardsDecision
+        discardDecision shouldNotBe null
+        discardDecision!!.minSelections shouldBe 2
+        discardDecision.maxSelections shouldBe 2
+    }
+})


### PR DESCRIPTION
Implements three Tarkir: Dragonstorm spells, each composed entirely from existing SDK primitives — no new effects, triggers, conditions, or engine changes.

## Cards

- **Glacial Dragonhunt** `{U}{R}` · Sorcery · Harmonize `{4}{U}{R}`
  "Draw a card, then you may discard a card. When you discard a nonland card this way, deals 3 damage to target creature."
  The "this way" damage is a reflexive trigger: a `ConditionalOnCollectionEffect` (filter = Nonland) gates a battlefield targeting selection + `DealDamage(3)`, so a creature is targeted — and damaged — only when a nonland is actually discarded. The discard itself is "up to one" (`ChooseUpTo`), honoring "you may".

- **Lie in Wait** `{B}{G}{U}` · Sorcery
  "Return target creature card from your graveyard to your hand. Lie in Wait deals damage equal to that card's power to target creature."
  Two cast-time targets (graveyard creature card, battlefield creature). On resolution the card is returned to hand, then `DealDamage(EntityProperty(Target(0), Power))` — power off the battlefield resolves to the returned card's printed power, i.e. "that card's power".

- **Winternight Stories** `{2}{U}` · Sorcery · Harmonize `{4}{U}`
  "Draw three cards. Then discard two cards unless you discard a creature card."
  Draw 3, then a `ChooseActionEffect` between "discard a creature card" (feasible only when a creature card is in hand) and "discard two cards" — matching the player-choice "unless".

## Tests

`rules-engine` scenario tests (all green):
- Glacial Dragonhunt: nonland discard deals 3 to a chosen creature (untargeted bystander untouched); declining the discard deals no damage.
- Lie in Wait: 5/5 returns and kills a 3/3; a 2/2 returns and only marks 2 damage on a 3/3.
- Winternight Stories: discarding one creature card vs. the forced two-card discard with no creature in hand.

All three cards are canonical in TDM (verified earliest printing via `just check-card-printing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)