### PR TITLE
Add Rite of Renewal, Wingspan Stride, and United Battlefront to Tarkir: Dragonstorm

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RiteOfRenewal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RiteOfRenewal.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Rite of Renewal
+ * {3}{G}
+ * Sorcery
+ * Return up to two target permanent cards from your graveyard to your hand.
+ * Target player shuffles up to four target cards from their graveyard into their library.
+ * Exile Rite of Renewal.
+ *
+ * Modeling note — both "up to N target ..." selections are modeled with the resolution-time
+ * Gather → Select → Move pipeline rather than cast-time target requirements. The engine slices
+ * a cast's flat target list to requirements by each requirement's *maximum* count, so two
+ * "up to N" target groups in one spell can't be disambiguated when an earlier group is only
+ * partially filled (see `EffectContext.buildNamedTargets` / `TargetValidator`). The pipeline
+ * handles "up to N" cleanly and is the established pattern for graveyard selection
+ * (Thundertrap Trainer, The Bath Song). Graveyard cards can't have hexproof/shroud, so there
+ * is no targeting-protection fidelity loss from resolving these as pipeline selections.
+ *
+ * The shuffle clause follows the Gaea's Blessing precedent in this codebase: each selected
+ * card is shuffled into its owner's library (the correct net result of "target player shuffles
+ * ... into their library"); the engine has no cross-target "owned by the separately targeted
+ * player" scoping, so the redundant standalone player target is omitted.
+ */
+val RiteOfRenewal = card("Rite of Renewal") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Return up to two target permanent cards from your graveyard to your hand. " +
+        "Target player shuffles up to four target cards from their graveyard into their library. " +
+        "Exile Rite of Renewal."
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                // Return up to two permanent cards from your graveyard to your hand.
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.You,
+                        filter = GameObjectFilter.Permanent
+                    ),
+                    storeAs = "yourGraveyard"
+                ),
+                SelectFromCollectionEffect(
+                    from = "yourGraveyard",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    storeSelected = "toHand",
+                    selectedLabel = "Return to hand"
+                ),
+                MoveCollectionEffect(
+                    from = "toHand",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                ),
+                // Shuffle up to four cards from graveyards into their owners' libraries.
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.Each
+                    ),
+                    storeAs = "anyGraveyard"
+                ),
+                SelectFromCollectionEffect(
+                    from = "anyGraveyard",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(4)),
+                    storeSelected = "toLibrary",
+                    selectedLabel = "Shuffle into library"
+                ),
+                MoveCollectionEffect(
+                    from = "toLibrary",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Shuffled)
+                )
+            )
+        )
+        selfExile()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "153"
+        artist = "Gaboleps"
+        flavorText = "The greatest honor a Sultai can receive is to be returned to the realm of the living."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f737698a-d934-4851-b238-828959ef4835.jpg?1743204579"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/UnitedBattlefront.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/UnitedBattlefront.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * United Battlefront
+ * {3}{W}
+ * Sorcery
+ * Look at the top seven cards of your library. Put up to two noncreature, nonland
+ * permanent cards with mana value 3 or less from among them onto the battlefield.
+ * Put the rest on the bottom of your library in a random order.
+ *
+ * Gather (top 7) → Select (up to 2 matching) → Move kept to battlefield, rest to the
+ * bottom in a random order. Per the printed ruling, {X} in a card's mana cost counts
+ * as 0 for mana value, which `CardPredicate.ManaValueAtMost` already honors.
+ */
+val UnitedBattlefront = card("United Battlefront") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top seven cards of your library. Put up to two noncreature, nonland " +
+        "permanent cards with mana value 3 or less from among them onto the battlefield. " +
+        "Put the rest on the bottom of your library in a random order."
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(7)),
+                    storeAs = "looked"
+                ),
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    filter = GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.IsNoncreature,
+                            CardPredicate.IsNonland,
+                            CardPredicate.IsPermanent,
+                            CardPredicate.ManaValueAtMost(3)
+                        )
+                    ),
+                    storeSelected = "onto",
+                    storeRemainder = "rest",
+                    selectedLabel = "Put onto the battlefield",
+                    remainderLabel = "Put on bottom"
+                ),
+                MoveCollectionEffect(
+                    from = "onto",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "32"
+        artist = "Darren Tan"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dff398be-4ba4-4976-9acc-be99d2e07a61.jpg?1743204090"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WingspanStride.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/WingspanStride.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wingspan Stride
+ * {U}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +1/+1 and has flying.
+ * {2}{U}: Return this Aura to its owner's hand.
+ */
+val WingspanStride = card("Wingspan Stride") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+1 and has flying.\n" +
+        "{2}{U}: Return this Aura to its owner's hand."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        effect = MoveToZoneEffect(EffectTarget.Self, Zone.HAND)
+        description = "{2}{U}: Return this Aura to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Jake Murray"
+        ruling(
+            "2025-04-04",
+            "If the creature this Aura is attached to leaves the battlefield or stops being a creature " +
+                "before the activated ability resolves, Wingspan Stride will be put into its owner's " +
+                "graveyard as a state-based action before that ability resolves, and it won't be returned " +
+                "to its owner's hand."
+        )
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/339a0e24-c332-4558-bb60-f5504ddde88c.jpg?1743204222"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmRiteWingspanBattlefrontScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmRiteWingspanBattlefrontScenarioTest.kt
@@ -1,0 +1,246 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for three Tarkir: Dragonstorm cards:
+ *  - Rite of Renewal (#153): return up to two permanent cards from your graveyard to hand,
+ *    shuffle up to four cards from graveyards into their libraries, then exile itself.
+ *  - Wingspan Stride (#66): Aura granting +1/+1 and flying with a {2}{U} self-bounce.
+ *  - United Battlefront (#32): look at top seven, put up to two noncreature/nonland permanent
+ *    cards with mana value 3 or less onto the battlefield, rest on the bottom at random.
+ */
+class TdmRiteWingspanBattlefrontScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private val wingspanBounceId =
+        cardRegistry.getCard("Wingspan Stride")!!.activatedAbilities.first().id
+
+    init {
+        context("Rite of Renewal") {
+            test("returns two permanent cards to hand, shuffles graveyard cards into library, and exiles itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Rite of Renewal")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    // Permanent cards eligible for return-to-hand.
+                    .withCardInGraveyard(1, "Glory Seeker")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    // A nonpermanent (instant) — eligible for the shuffle clause but not the return clause.
+                    .withCardInGraveyard(1, "Shock")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Rite of Renewal")
+                withClue("Casting Rite of Renewal should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // First selection: up to two permanent cards from your graveyard to hand.
+                withClue("Should prompt to choose permanent cards to return to hand") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val glory = game.findCardsInGraveyard(1, "Glory Seeker").first()
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").first()
+                game.selectCards(listOf(glory, bears))
+                game.resolveStack()
+
+                // Second selection: up to four cards from graveyards into their library.
+                withClue("Should prompt to choose cards to shuffle into library") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val shock = game.findCardsInGraveyard(1, "Shock").first()
+                game.selectCards(listOf(shock))
+                game.resolveStack()
+
+                withClue("Glory Seeker and Grizzly Bears should be in hand") {
+                    game.findCardsInHand(1, "Glory Seeker").size shouldBe 1
+                    game.findCardsInHand(1, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("Shock should have left the graveyard (shuffled into library)") {
+                    game.findCardsInGraveyard(1, "Shock").size shouldBe 0
+                }
+                withClue("Rite of Renewal should be exiled, not in the graveyard") {
+                    game.state.getExile(game.player1Id).any {
+                        game.state.getEntity(it)?.let { e ->
+                            e.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name
+                        } == "Rite of Renewal"
+                    } shouldBe true
+                    game.findCardsInGraveyard(1, "Rite of Renewal").size shouldBe 0
+                }
+            }
+
+            test("both selections may be declined; the card still exiles itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Rite of Renewal")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInGraveyard(1, "Glory Seeker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Rite of Renewal")
+                game.resolveStack()
+
+                // Decline the return-to-hand selection.
+                withClue("Should prompt to return permanent cards") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.skipSelection()
+                game.resolveStack()
+
+                // Decline the shuffle selection.
+                withClue("Should prompt to shuffle cards into library") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("Glory Seeker stays in the graveyard when nothing is chosen") {
+                    game.findCardsInGraveyard(1, "Glory Seeker").size shouldBe 1
+                }
+                withClue("Rite of Renewal is still exiled") {
+                    game.findCardsInGraveyard(1, "Rite of Renewal").size shouldBe 0
+                }
+            }
+        }
+
+        context("Wingspan Stride") {
+            test("grants +1/+1 and flying, then can bounce itself to hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Wingspan Stride")
+                    .withCardOnBattlefield(1, "Glory Seeker") // 2/2 vanilla
+                    // 4 Islands: {U} for the cast leaves 3 for the {2}{U} bounce.
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gloryId = game.findPermanent("Glory Seeker")!!
+
+                val cast = game.castSpell(1, "Wingspan Stride", gloryId)
+                withClue("Casting Wingspan Stride targeting Glory Seeker should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Enchanted creature gets +1/+1 (2/2 -> 3/3)") {
+                    projector.getProjectedPower(game.state, gloryId) shouldBe 3
+                    projector.getProjectedToughness(game.state, gloryId) shouldBe 3
+                }
+                withClue("Enchanted creature has flying") {
+                    game.state.projectedState.hasKeyword(gloryId, Keyword.FLYING) shouldBe true
+                }
+
+                val stride = game.findPermanent("Wingspan Stride")!!
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = stride,
+                        abilityId = wingspanBounceId
+                    )
+                )
+                withClue("Activating the {2}{U} bounce should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Wingspan Stride returns to its owner's hand") {
+                    game.findCardsInHand(1, "Wingspan Stride").size shouldBe 1
+                    game.isOnBattlefield("Wingspan Stride") shouldBe false
+                }
+                withClue("Glory Seeker reverts to 2/2 with no flying once the Aura is gone") {
+                    projector.getProjectedPower(game.state, gloryId) shouldBe 2
+                    projector.getProjectedToughness(game.state, gloryId) shouldBe 2
+                    game.state.projectedState.hasKeyword(gloryId, Keyword.FLYING) shouldBe false
+                }
+            }
+        }
+
+        context("United Battlefront") {
+            test("puts up to two matching permanents onto the battlefield; rest go to the bottom") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "United Battlefront")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    // Eligible: noncreature, nonland permanent with MV <= 3 (Enchantment, MV 2).
+                    .withCardInLibrary(1, "Test Enchantment")
+                    .withCardInLibrary(1, "Rite of Renewal") // Sorcery — NOT a permanent, ineligible
+                    .withCardInLibrary(1, "Glory Seeker")    // Creature — ineligible
+                    .withCardInLibrary(1, "Forest")          // Land — ineligible
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "United Battlefront")
+                withClue("Casting United Battlefront should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Should prompt to choose permanents to put onto the battlefield") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val enchantInLib = game.findCardsInLibrary(1, "Test Enchantment").first()
+                game.selectCards(listOf(enchantInLib))
+                game.resolveStack()
+
+                withClue("Test Enchantment should be on the battlefield") {
+                    game.isOnBattlefield("Test Enchantment") shouldBe true
+                }
+                withClue("The other six looked-at cards should be back in the library (on the bottom)") {
+                    game.librarySize(1) shouldBe 6
+                }
+            }
+
+            test("nothing eligible — all seven cards go to the bottom") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "United Battlefront")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInLibrary(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "United Battlefront")
+                game.resolveStack()
+
+                // With no eligible card, either no decision is presented or it is skippable.
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+
+                withClue("All seven cards remain in the library") {
+                    game.librarySize(1) shouldBe 7
+                }
+                withClue("Nothing entered the battlefield") {
+                    game.isOnBattlefield("Glory Seeker") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three Tarkir: Dragonstorm (TDM) cards using existing SDK primitives — no engine or SDK changes were required.

## Cards

### Rite of Renewal — {3}{G} Sorcery (#153)
> Return up to two target permanent cards from your graveyard to your hand. Target player shuffles up to four target cards from their graveyard into their library. Exile Rite of Renewal.

Both "up to N" selections use the resolution-time **Gather → Select → Move** pipeline instead of cast-time target requirements. The engine slices a cast's flat target list to requirements by each requirement's *maximum* count (`EffectContext.buildNamedTargets` / `TargetValidator`), so two "up to N" target groups in one spell can't be disambiguated when an earlier group is only partially filled. The pipeline handles "up to N" cleanly and is the established graveyard-selection pattern (Thundertrap Trainer, The Bath Song). Graveyard cards can't have hexproof/shroud, so resolving these as pipeline selections loses no targeting-protection fidelity. The shuffle clause follows the existing **Gaea's Blessing** precedent: each selected card is shuffled into its owner's library.

### Wingspan Stride — {U} Enchantment — Aura (#66)
> Enchant creature. Enchanted creature gets +1/+1 and has flying. {2}{U}: Return this Aura to its owner's hand.

Same shape as Shimmering Wings / On Serra's Wings — `ModifyStats(1,1)` + `GrantKeyword(FLYING)` static abilities and a `MoveToZoneEffect(Self, HAND)` activated ability.

### United Battlefront — {3}{W} Sorcery (#32)
> Look at the top seven cards of your library. Put up to two noncreature, nonland permanent cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.

Gather (top 7) → Select up to 2 matching (`IsNoncreature`, `IsNonland`, `IsPermanent`, `ManaValueAtMost(3)`) → move kept to the battlefield, rest to the bottom with `CardOrder.Random`.

## Tests

`TdmRiteWingspanBattlefrontScenarioTest` (5 tests, all passing):
- Rite of Renewal: return + shuffle + self-exile happy path, and both selections declined.
- Wingspan Stride: +1/+1 and flying granted, then the {2}{U} bounce returns it and the buff/flying fall off.
- United Battlefront: a matching permanent enters while the rest go to the bottom, and the no-eligible-card case leaves the library intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)