### PR TITLE
Add Aggressive Negotiations, Dragon's Prey, and Dragonback Assault (TDM)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1354,7 +1354,10 @@ staticAbility {
   `ReduceColored(symbols)`, `ReduceColoredPerUnit(symbols, source)`, `IncreaseGeneric(amount)`,
   `IncreaseColored(symbols)` (colored tax — adds colored pips, e.g. the Invasion Leeches'
   "White spells you cast cost {W} more"), `IncreaseGenericPerOtherSpellThisTurn(amountPerSpell)`,
-  `IncreaseLife(amount)`.
+  `IncreaseGenericIfAnyTargetMatches(amount, filter)` (target-gated tax — "{N} more if it targets
+  a Dragon", Dragon's Prey; the increase analogue of the `FixedIfAnyTargetMatches` reduction;
+  applies only once a matching target is chosen, so affordability enumeration treats it as not
+  applying), `IncreaseLife(amount)`.
   Reduction `source: CostReductionSource` covers fixed amounts, counts of permanents/cards in
   zones, target gates, and a few mechanic-specific shapes — e.g. `Fixed`, `CreaturesYouControl`,
   `ArtifactsYouControl`, `PermanentsYouControlMatching(filter)` (the filtered "you control" count —

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -54,6 +54,8 @@ data class ModifySpellCost(
             is CostModification.IncreaseColored -> "cost ${modification.symbols} more to cast"
             is CostModification.IncreaseGenericPerOtherSpellThisTurn ->
                 "cost {${modification.amountPerSpell}} more to cast for each other spell that player has cast this turn"
+            is CostModification.IncreaseGenericIfAnyTargetMatches ->
+                "cost {${modification.amount}} more to cast if it targets ${modification.filter.description}"
             is CostModification.IncreaseLife -> "cost an additional ${modification.amount} life to cast"
         }
         val perTurn = if (nthGating != null) " each turn" else ""
@@ -232,6 +234,29 @@ sealed interface CostModification {
     data class IncreaseGenericPerOtherSpellThisTurn(
         val amountPerSpell: Int = 1,
     ) : CostModification
+
+    /**
+     * Increase generic mana by a fixed amount if the spell targets any object matching
+     * the filter. The increase analogue of
+     * [CostReductionSource.FixedIfAnyTargetMatches]; used for cards like Dragon's Prey
+     * ("This spell costs {2} more to cast if it targets a Dragon").
+     *
+     * At cast resolution, the increase applies if any of the spell's chosen targets match.
+     * For affordability enumeration (before targets are chosen) the increase is treated as
+     * NOT applying, since the minimum possible cost is achieved by targeting something the
+     * filter doesn't match.
+     */
+    @SerialName("IncreaseGenericIfAnyTargetMatches")
+    @Serializable
+    data class IncreaseGenericIfAnyTargetMatches(
+        val amount: Int,
+        val filter: GameObjectFilter,
+    ) : CostModification {
+        override fun applyTextReplacement(replacer: TextReplacer): CostModification {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
 
     /**
      * Pay [amount] additional life as part of the casting cost (CR 601.2f).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AggressiveNegotiations.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AggressiveNegotiations.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aggressive Negotiations
+ * {2}{B}
+ * Sorcery
+ *
+ * Target opponent reveals their hand. You choose a nonland card from it and exile that card.
+ * Put a +1/+1 counter on up to one target creature you control.
+ *
+ * Composed entirely from existing primitives: the hand-strip half mirrors Cruelclaw's Heist /
+ * Tsabo's Decree (RevealHand → Gather nonland cards from the revealed hand → controller chooses
+ * one → exile it). The counter half targets "up to one" creature you control via an optional
+ * target; if the player declines the optional target, [Effects.AddCounters] resolves with no
+ * legal target and places no counter.
+ */
+val AggressiveNegotiations = card("Aggressive Negotiations") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You choose a nonland card from it and " +
+        "exile that card. Put a +1/+1 counter on up to one target creature you control."
+
+    spell {
+        val opponent = target("target opponent", Targets.Opponent)
+        val creature = target(
+            "creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl)
+        )
+
+        effect = CompositeEffect(
+            listOf(
+                RevealHandEffect(opponent),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.HAND,
+                        player = Player.ContextPlayer(0),
+                        filter = GameObjectFilter.Nonland,
+                    ),
+                    storeAs = "revealedNonland",
+                ),
+                SelectFromCollectionEffect(
+                    from = "revealedNonland",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    storeSelected = "chosenCard",
+                    prompt = "Choose a nonland card to exile",
+                ),
+                MoveCollectionEffect(
+                    from = "chosenCard",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0)),
+                ),
+            ),
+        ).then(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Ovidio Cartagena"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/993ade84-031f-4a3e-bd68-55f61b559248.jpg?1743204240"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonbackAssault.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonbackAssault.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dragonback Assault
+ * {3}{G}{U}{R}
+ * Enchantment
+ *
+ * When this enchantment enters, it deals 3 damage to each creature and each planeswalker.
+ * Landfall — Whenever a land you control enters, create a 4/4 red Dragon creature token
+ * with flying.
+ *
+ * The board-wipe ETB iterates the single combined group [GameObjectFilter.CreatureOrPlaneswalker]
+ * (the same primitive Goblin Chainwhirler-style sweeps use), dealing 3 damage from the
+ * enchantment to each member. The landfall half reuses [Triggers.LandYouControlEnters] +
+ * [Effects.CreateToken], mirroring Rampaging Baloths.
+ */
+val DragonbackAssault = card("Dragonback Assault") {
+    manaCost = "{3}{G}{U}{R}"
+    colorIdentity = "GUR"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, it deals 3 damage to each creature and each planeswalker.\n" +
+        "Landfall — Whenever a land you control enters, create a 4/4 red Dragon creature token with flying."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ForEachInGroupEffect(
+            GroupFilter(GameObjectFilter.CreatureOrPlaneswalker),
+            DealDamageEffect(3, EffectTarget.Self),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Dragon"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/4/3/434c2965-82b8-4e89-bf45-a8fc093f9a21.jpg?1743176601",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "179"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d54cc838-d79d-433a-99fb-d6e4d1c1431d.jpg?1743204697"
+        ruling("2025-04-04", "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control.")
+        ruling("2025-04-04", "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonsPrey.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonsPrey.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Dragon's Prey
+ * {2}{B}
+ * Instant
+ *
+ * This spell costs {2} more to cast if it targets a Dragon.
+ * Destroy target creature.
+ *
+ * The cost clause is modeled with [CostModification.IncreaseGenericIfAnyTargetMatches] on a
+ * [SpellCostTarget.SelfCast] static ability — the increase analogue of Dire Downdraft's
+ * "{1} less if it targets ..." reduction. The increase is locked in from the chosen target at
+ * cast time (CR 601.2f); the spell's only target is the destroyed creature, so it raises the
+ * cost exactly when that creature is a Dragon.
+ */
+val DragonsPrey = card("Dragon's Prey") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} more to cast if it targets a Dragon.\n" +
+        "Destroy target creature."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Destroy(creature)
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.IncreaseGenericIfAnyTargetMatches(
+                amount = 2,
+                filter = GameObjectFilter.Creature.withSubtype(Subtype.DRAGON),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "79"
+        artist = "Johann Bodin"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a6004ff-4180-4332-8b51-960f8c7521d9.jpg?1743204277"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -321,6 +321,13 @@ class CostCalculator(
                 val spellsCast = state.playerSpellsCastThisTurn[casterId] ?: 0
                 addGenericIncrease(spellsCast * modification.amountPerSpell)
             }
+            is CostModification.IncreaseGenericIfAnyTargetMatches -> {
+                if (chosenTargets.isNotEmpty() &&
+                    anyTargetMatchesFilter(state, casterId, chosenTargets, modification.filter)
+                ) {
+                    addGenericIncrease(modification.amount)
+                }
+            }
             is CostModification.IncreaseLife -> {
                 // Life is not part of the mana cost — collected separately via
                 // [calculateAdditionalLifeCost] and paid alongside mana in CastSpellHandler.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AggressiveNegotiationsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AggressiveNegotiationsScenarioTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Aggressive Negotiations (TDM #70).
+ *
+ * {2}{B} Sorcery.
+ *   "Target opponent reveals their hand. You choose a nonland card from it and exile that card.
+ *    Put a +1/+1 counter on up to one target creature you control."
+ *
+ * Composed from existing primitives (RevealHand → Gather nonland → Select one → exile, then
+ * AddCounters on an optional creature target). The two scenarios prove (1) the happy path where
+ * a nonland card is exiled and a counter is placed, and (2) declining the optional creature
+ * target still strips a card but places no counter.
+ */
+class AggressiveNegotiationsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("reveal, exile a nonland card, and put a +1/+1 counter") {
+
+            test("exiles the chosen nonland and buffs your creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Aggressive Negotiations")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardInHand(2, "Hill Giant") // nonland — the only legal exile choice
+                    .withCardInHand(2, "Swamp")       // land — not a legal choice
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myCreature = game.findPermanent("Glory Seeker")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Aggressive Negotiations"
+                }
+
+                // Target the opponent (index 0) and the optional creature you control (index 1).
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(
+                            ChosenTarget.Player(game.player2Id),
+                            ChosenTarget.Permanent(myCreature),
+                        ),
+                    ),
+                )
+                withClue("Casting Aggressive Negotiations should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // The controller chooses the only nonland card to exile.
+                if (game.hasPendingDecision()) {
+                    val giant = game.state.getHand(game.player2Id).first {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Hill Giant"
+                    }
+                    game.selectCards(listOf(giant))
+                    game.resolveStack()
+                }
+
+                withClue("Hill Giant is exiled from the opponent's hand") {
+                    game.state.getExile(game.player2Id).mapNotNull {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name
+                    } shouldBe listOf("Hill Giant")
+                }
+                withClue("The land stays in the opponent's hand") {
+                    game.state.getZone(game.player2Id, Zone.HAND).mapNotNull {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name
+                    } shouldBe listOf("Swamp")
+                }
+                withClue("Glory Seeker gets a +1/+1 counter") {
+                    val counters = game.state.getEntity(myCreature)
+                        ?.get<CountersComponent>()
+                        ?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 1
+                }
+            }
+
+            test("declining the optional creature target still exiles a card, places no counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Aggressive Negotiations")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardInHand(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myCreature = game.findPermanent("Glory Seeker")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Aggressive Negotiations"
+                }
+
+                // Provide only the mandatory opponent target — decline the "up to one" creature.
+                val cast = game.execute(
+                    CastSpell(game.player1Id, cardId, listOf(ChosenTarget.Player(game.player2Id))),
+                )
+                withClue("Declining the optional target is legal: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    val giant = game.state.getHand(game.player2Id).first {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Hill Giant"
+                    }
+                    game.selectCards(listOf(giant))
+                    game.resolveStack()
+                }
+
+                withClue("Hill Giant is still exiled") {
+                    game.state.getExile(game.player2Id).size shouldBe 1
+                }
+                withClue("No counter is placed when the optional target is declined") {
+                    val counters = game.state.getEntity(myCreature)
+                        ?.get<CountersComponent>()
+                        ?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragonbackAssaultScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragonbackAssaultScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Dragonback Assault (TDM #179).
+ *
+ * {3}{G}{U}{R} Enchantment, mythic.
+ *   "When this enchantment enters, it deals 3 damage to each creature and each planeswalker.
+ *    Landfall — Whenever a land you control enters, create a 4/4 red Dragon creature token
+ *    with flying."
+ *
+ * The ETB sweep iterates the combined GameObjectFilter.CreatureOrPlaneswalker group; the
+ * landfall half mirrors Rampaging Baloths (LandYouControlEnters → CreateToken).
+ */
+class DragonbackAssaultScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("enters-the-battlefield sweep") {
+
+            test("deals 3 damage to each creature and each planeswalker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dragonback Assault")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Glory Seeker")          // 2/2 — dies
+                    .withCardOnBattlefield(2, "Hill Giant")            // 3/3 — dies
+                    .withCardOnBattlefield(2, "Boulderborn Dragon")    // 3/3 — dies
+                    .withCardOnBattlefield(2, "Sorin, Solemn Visitor") // loyalty 4 → 1
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sorin = game.findPermanent("Sorin, Solemn Visitor")!!
+                // Seed the planeswalker's starting loyalty (the battlefield builder doesn't add
+                // loyalty counters automatically) so the 3-damage delta is observable.
+                game.state = game.state.updateEntity(sorin) { container ->
+                    container.with(CountersComponent().withAdded(CounterType.LOYALTY, 4))
+                }
+                game.castSpell(1, "Dragonback Assault").error shouldBe null
+                game.resolveStack()
+
+                withClue("Dragonback Assault resolves onto the battlefield") {
+                    game.isOnBattlefield("Dragonback Assault") shouldBe true
+                }
+                withClue("the 2/2 dies to 3 damage") {
+                    game.findPermanent("Glory Seeker") shouldBe null
+                }
+                withClue("both 3/3s die to 3 damage") {
+                    game.findPermanent("Hill Giant") shouldBe null
+                    game.findPermanent("Boulderborn Dragon") shouldBe null
+                }
+                withClue("the planeswalker loses 3 loyalty (4 → 1)") {
+                    val loyalty = game.state.getEntity(sorin)
+                        ?.get<CountersComponent>()
+                        ?.getCount(CounterType.LOYALTY) ?: 0
+                    loyalty shouldBe 1
+                }
+            }
+        }
+
+        context("landfall") {
+
+            test("creates a 4/4 red Dragon token with flying when a land you control enters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dragonback Assault")
+                    .withCardInHand(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val before = game.findPermanents("Dragon Token").size
+
+                val forest = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Forest"
+                }
+                game.execute(PlayLand(game.player1Id, forest)).error shouldBe null
+                game.resolveStack()
+
+                withClue("a Dragon token is created on landfall") {
+                    game.findPermanents("Dragon Token").size shouldBeGreaterThan before
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragonsPreyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragonsPreyScenarioTest.kt
@@ -1,0 +1,144 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Dragon's Prey (TDM #79) and the SDK primitive it introduces:
+ * [com.wingedsheep.sdk.scripting.CostModification.IncreaseGenericIfAnyTargetMatches].
+ *
+ * Dragon's Prey — {2}{B} Instant.
+ *   "This spell costs {2} more to cast if it targets a Dragon. Destroy target creature."
+ *
+ * The cost-increase variant mirrors Dire Downdraft's `FixedIfAnyTargetMatches` reduction, but
+ * in the increase direction: the tax applies at cast resolution exactly when a chosen target
+ * matches the Dragon filter, and is treated as not-applying for affordability enumeration (the
+ * minimum possible cost targets a non-Dragon).
+ */
+class DragonsPreyScenarioTest : ScenarioTestBase() {
+
+    private val calculator = CostCalculator(cardRegistry)
+
+    init {
+        context("cost increase if it targets a Dragon") {
+
+            test("base cost {2}{B} = 3 mana with no targets chosen (enumeration minimum)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dragon's Prey")
+                    .build()
+                val me = game.player1Id
+                val cost = calculator.calculateEffectiveCost(
+                    game.state, cardRegistry.requireCard("Dragon's Prey"), me,
+                )
+                cost.cmc shouldBe 3
+                cost.genericAmount shouldBe 2
+            }
+
+            test("targeting a non-Dragon creature does not raise the cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dragon's Prey")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+                val me = game.player1Id
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val cost = calculator.calculateEffectiveCost(
+                    game.state, cardRegistry.requireCard("Dragon's Prey"), me, listOf(giant),
+                )
+                withClue("Hill Giant is not a Dragon, so the {2} tax should not apply") {
+                    cost.cmc shouldBe 3
+                }
+            }
+
+            test("targeting a Dragon raises the cost by {2} → 5 mana") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dragon's Prey")
+                    .withCardOnBattlefield(2, "Boulderborn Dragon")
+                    .build()
+                val me = game.player1Id
+                val dragon = game.findPermanent("Boulderborn Dragon")!!
+
+                val cost = calculator.calculateEffectiveCost(
+                    game.state, cardRegistry.requireCard("Dragon's Prey"), me, listOf(dragon),
+                )
+                withClue("Boulderborn Dragon is a Dragon, so the {2} tax applies: {4}{B}") {
+                    cost.cmc shouldBe 5
+                    cost.genericAmount shouldBe 4
+                }
+            }
+        }
+
+        context("destroy target creature") {
+
+            test("destroys a non-Dragon when enough mana is available") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dragon's Prey")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                game.castSpell(1, "Dragon's Prey", giant).error shouldBe null
+                game.resolveStack()
+
+                game.findPermanent("Hill Giant") shouldBe null
+                game.findCardsInGraveyard(2, "Hill Giant").size shouldBe 1
+            }
+
+            test("destroys a Dragon when the {2} tax is paid (5 lands available)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dragon's Prey")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardOnBattlefield(2, "Boulderborn Dragon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dragon = game.findPermanent("Boulderborn Dragon")!!
+                game.castSpell(1, "Dragon's Prey", dragon).error shouldBe null
+                game.resolveStack()
+
+                game.findPermanent("Boulderborn Dragon") shouldBe null
+                game.findCardsInGraveyard(2, "Boulderborn Dragon").size shouldBe 1
+            }
+
+            test("casting against a Dragon with only 3 mana is rejected (tax unaffordable)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dragon's Prey")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(2, "Boulderborn Dragon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dragon = game.findPermanent("Boulderborn Dragon")!!
+                val playerId = game.player1Id
+                val cardId = game.state.getHand(playerId).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Dragon's Prey"
+                }
+                val result = game.execute(
+                    CastSpell(playerId, cardId, listOf(ChosenTarget.Permanent(dragon))),
+                )
+                withClue("5 mana required for a Dragon target, only 3 available") {
+                    (result.error != null) shouldBe true
+                }
+                game.findPermanent("Boulderborn Dragon") shouldBe dragon
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three Tarkir: Dragonstorm cards.

## Cards

### Aggressive Negotiations — {2}{B} Sorcery (common, #70)
> Target opponent reveals their hand. You choose a nonland card from it and exile that card. Put a +1/+1 counter on up to one target creature you control.

Composed entirely from existing primitives: `RevealHand` → `GatherCards` (nonland) → `SelectFromCollection` → exile, then `Effects.AddCounters` on an optional ("up to one") creature target.

### Dragon's Prey — {2}{B} Instant (common, #79)
> This spell costs {2} more to cast if it targets a Dragon. Destroy target creature.

Introduces one small, reuse-oriented SDK primitive: `CostModification.IncreaseGenericIfAnyTargetMatches(amount, filter)` — the increase analogue of the existing `CostReductionSource.FixedIfAnyTargetMatches` reduction (Dire Downdraft). The tax is locked in from the chosen target at cast time (CR 601.2f); for affordability enumeration the minimum cost targets a non-Dragon, so the increase is treated as not applying. Wired into `CostCalculator.applyToSpellCast`, mirroring the reduction path's projected-state target matching.

### Dragonback Assault — {3}{G}{U}{R} Enchantment (mythic, #179)
> When this enchantment enters, it deals 3 damage to each creature and each planeswalker.
> Landfall — Whenever a land you control enters, create a 4/4 red Dragon creature token with flying.

ETB sweep is a single `ForEachInGroupEffect` over `GameObjectFilter.CreatureOrPlaneswalker`; landfall reuses `Triggers.LandYouControlEnters` + `Effects.CreateToken`, mirroring Rampaging Baloths.

## Tests
- `DragonsPreyScenarioTest` — base cost, non-Dragon target (no tax), Dragon target (+{2}), destroy on both target kinds, and rejection when the Dragon tax is unaffordable.
- `AggressiveNegotiationsScenarioTest` — exile a nonland + counter on your creature; decline the optional creature target (card still exiled, no counter).
- `DragonbackAssaultScenarioTest` — ETB kills small creatures and drains 3 planeswalker loyalty; landfall creates a Dragon token.

All 10 new tests pass; `:mtg-sdk:test` and the serialization-registration hygiene tests are green. Updated `docs/card-sdk-language-reference.md` for the new `CostModification` variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)