### PR TITLE
Arabian Nights: state-triggered abilities + unblocked-attack trigger

### DIFF
--- a/backlog/sets/arabian-nights/TODO.md
+++ b/backlog/sets/arabian-nights/TODO.md
@@ -9,41 +9,27 @@
 Set scaffolding is done:
 
 - `mtg-sets/.../definitions/arn/ArabianNightsSet.kt` — registered in `MtgSetCatalog.all`.
-- `mtg-sets/.../definitions/arn/cards/` — empty, ready for one file per card.
+- `mtg-sets/.../definitions/arn/cards/` — one file per card.
 - `backlog/sets/arabian-nights/cards.md` — the 78-card checklist (mark `[x]` as you go).
 - `backlog/sets/arabian-nights/arn_set.json` — the **offline card-data source** for this set.
 
 Verify status anytime with: `scripts/card-status --set ARN` (and `--list --set ARN`).
 
-## Progress (as of 2026-05-26)
+## Progress (as of 2026-06-02)
 
-**Implemented: 46 / 78** (`scripts/card-status --set ARN`). Full per-card status lives in
+**Implemented: 56 / 78** (`scripts/card-status --set ARN`). Full per-card status lives in
 `cards.md` — that file's `Implemented:` count is the source of truth; keep it in sync as boxes
 are checked. The triage buckets below are pruned to **remaining work only**; a card is removed
 from its bucket once it lands on a branch.
 
-Note: **Banding is fully modelled in the engine** (CR 702.22 — `Keyword.BANDING`, handled in
-`CombatManager` / `CombatDamageManager` / `AttackPhaseManager`; `BandDeclarationTest`,
-`BandingTrampleDrainScenarioTest`, and `BandingCombatScenarioTest` all pass, and Mirage's Noble
-Elephant uses it with no per-card wiring). Banding cards therefore compose onto `arn-cards`.
+**In-flight engine-change branches** (each off `main`, pending its own PR):
 
-The original banding triage was inaccurate (verified against `arn_set.json`): Moorish Cavalry is
-Trample only and Hurr Jackal is regeneration-denial — neither has banding (both already done).
-Aladdin's control-change also composed onto `arn-cards`. The only true banding cards are **Camel**
-and **War Elephant**; Abu Ja'far is a death trigger, not banding (moved to Bucket B).
-
-**In-flight engine-change branches** (each branched off the `arn` scaffolding branch — which is
-`main` + ARN scaffolding — with one commit, pending its own PR; not on `arn-cards`):
-
-- `arn-sindbad` — Sindbad, via a new `DrawRevealDiscardUnless` SDK effect + executor.
-- `arn-control-by-life` — Ghazbán Ogre, via a new `GainControlByMostLife` SDK effect + executor.
-- `arn-camel` — Camel (banding), via a new source-relative `StatePredicate.InSameBandAsSource`
-  filter (CR 702.22) wired into the `PreventDamage` recipient evaluation, for its "while
-  attacking, prevent Desert damage to this creature and creatures banded with it" clause. Tests
-  pass; the existing banding suites are unaffected.
-
-Do **not** fold these into the `arn-cards` PR — they touch `mtg-sdk` / `rules-engine`, which
-`arn-cards` is meant to keep clean. Each will bump the `cards.md` count by one when merged.
+- `arn-state-trigger-no-lands` — state-triggered ability primitive (CR 603.8) +
+  `BecomesUnblockedEvent` / `Triggers.AttacksAndIsntBlocked` (CR 509.7) + Dandân, Island
+  Fish Jasconius, Merchant Ship. Serendib Djinn deferred — its "if you sacrifice an Island
+  this way" clause needs `SacrificeContinuation` to thread `updatedSacrificedPermanents`
+  back through the resumer (the auto-sac path now captures snapshots, but the multi-land
+  decision path does not).
 
 ## Data sources — do NOT hit the network
 
@@ -51,7 +37,7 @@ Do **not** fold these into the `arn-cards` PR — they touch `mtg-sdk` / `rules-
   artist, flavor, image URI): read from `arn_set.json`, **not** Scryfall. It is a full
   Scryfall dump of all 78 cards (`.data[]`, keyed by the usual field names). When running
   `add-card`, feed it the matching entry from this file instead of doing a Scryfall lookup.
-- **Rules**: cite and verify against `MagicCompRules_20260417.pdf` (in the repo root),
+- **Rules**: cite and verify against `MagicCompRules_20260417.pdf` or `MagicCompRules_20260417.txt` (in the repo root),
   **not** yawgatog or any web source. Read the relevant pages with the `Read` tool's
   `pages` parameter (the PDF is 24 pages). Quote rule numbers from that document.
 
@@ -70,12 +56,11 @@ below are a *provisional* triage to sequence the work — confirm during impleme
 
 ### Git strategy
 
-1. **Foundation commit** (this scaffolding) lands first.
-2. **One big PR — "Arabian Nights: cards (no engine change)"**, branch `arn-cards`,
+1. **One big PR — "Arabian Nights: cards (no engine change)"**, branch `arn-cards`,
    **one commit per card**. Only cards that compose from existing SDK primitives go here.
-3. **One PR per engine-change card**, each off `main` (e.g. `arn-banding`, `arn-coinflip`).
-   If several cards share one new engine feature (e.g. banding), that feature's PR can
-   land all of them together — note it in the PR.
+2. **One PR per engine-change card**, each off `main` (e.g. `arn-coinflip`). If several
+   cards share one new engine feature, that feature's PR can land all of them together —
+   note it in the PR.
 
 ### Per-card procedure
 
@@ -94,20 +79,6 @@ For each unchecked card in `cards.md`:
 > A "Bucket B" card that turns out to compose cleanly belongs in the big PR; a "Bucket A"
 > card that surprises you moves to its own PR.
 
-### Bucket A — likely no engine change → big `arn-cards` PR
-
-Vanilla bodies, plain keywords (flying, first strike, protection, landwalk), stat mods,
-simple targeted/activated abilities, set-base-P/T, regeneration, token-on-death,
-"deal N to any target", conditional static buffs, simple upkeep self-damage.
-
-Remaining:
-
-- Mountain — basic land; already covered by `basicLandsFallback`. Add an ARN-art
-  `basicLand("Mountain")` variant only if you want the distinct printing.
-
-(Sindbad started here but needed a new SDK effect — now on `arn-sindbad`; see the in-flight
-branches note above.)
-
 ### Bucket B — verify; composable but non-trivial (most land in the big PR)
 
 Conditional attack restrictions, upkeep "pay-or-sacrifice", delayed payments, O-Ring-style
@@ -116,11 +87,9 @@ conditional draw, damage prevention, death-count counters, untap restrictions.
 
 Remaining:
 
-- Dandân, Island Fish Jasconius, Merchant Ship (can't attack unless defender has an Island)
-- Serendib Djinn (sac a land or take 3)
 - Oubliette (exile + auras, return)
-- Erg Raiders, Nafs Asp (delayed life loss unless pay {1})
-- Metamorphosis, Desert Nomads
+- Nafs Asp (delayed life loss unless pay {1})
+- Metamorphosis
 - Aladdin's Lamp, Pyramids, Drop of Honey
 - Abu Ja'far (dies → destroy all creatures blocking or blocked by it; they can't be regenerated)
 - Guardian Beast (untriaged in the original plan — untapped, makes noncreature artifacts
@@ -133,13 +102,8 @@ Group by the shared feature so one PR can clear several cards:
 
 Remaining:
 
-- **Banding** (keyword): **done.** War Elephant (plain Trample + Banding) on `arn-cards`;
-  Camel (banding + the Desert-damage-prevention clause) on `arn-camel` via the new
-  `InSameBandAsSource` filter (see the in-flight branches note above). Banding itself was
-  already engine-supported.
 - **Coin flips**: Ydwen Efreet. (Mijae Djinn, Bottle of Suleiman done.)
 - **Continuous control change**: Old Man of the Sea.
-  (Aladdin done on `arn-cards`; Ghazbán Ogre done on `arn-control-by-life`, pending its own PR.)
 - **Replacement / redirection**: Ali from Cairo (life can't drop below 1),
   Eye for an Eye (redirect damage to its source's controller).
 - **Opponent-chosen target**: Cuombajj Witches (1 dmg you choose + 1 dmg an opponent chooses).

--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 53 / 78
+**Implemented:** 56 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -26,12 +26,12 @@
 - [x] Repentant Blacksmith
 - [ ] Shahrazad
 - [x] War Elephant
-- [ ] Dandân
+- [x] Dandân
 - [x] Fishliver Oil
 - [x] Flying Men
 - [x] Giant Tortoise
-- [ ] Island Fish Jasconius
-- [ ] Merchant Ship
+- [x] Island Fish Jasconius
+- [x] Merchant Ship
 - [ ] Old Man of the Sea
 - [ ] Serendib Djinn
 - [x] Serendib Efreet

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -914,11 +914,10 @@ sealed set for attack-time facts beyond the basics.
   sole consumer of `BlocksOrBecomesBlockedByEvent`. Prefer `blocks(attackerFilter=...)`
   when only the blocking direction should fire.
 - `AttacksAndIsntBlocked` — SELF. Fires once per attacker that reaches end of
-  Declare Blockers with no blockers assigned (CR 509.7). Backed by
+  Declare Blockers with no creatures declared as blockers (CR 509.3g). Backed by
   `BecomesUnblockedEvent` matched against `BlockersDeclaredEvent`. Used for
   Merchant Ship: "Whenever this creature attacks and isn't blocked, you gain 2 life."
-- `attacksAndIsntBlocked(filter)` — ANY-binding factory variant: "Whenever a
-  [filter] attacks and isn't blocked."
+  (SELF only — an ANY-binding filtered variant isn't wired in `TriggerMatcher` yet.)
 
 **`AttackPredicate`** — extensible "facts about an attack declaration."
 Adding a new attack-time mechanic is one new sealed-case + one matcher branch
@@ -1251,7 +1250,14 @@ A **state-triggered ability** fires whenever a game-state condition becomes true
 than in response to a `GameEvent`. The engine polls the condition at every priority pass
 and emits the trigger on each false → true transition. Once it has fired, a per-permanent
 `StateTriggerLatchesComponent` latch suppresses re-firing until the condition next
-evaluates false again (CR 603.8d).
+evaluates false again (CR 603.8).
+
+> **Latch note.** The printed CR 603.8 resets after the ability *leaves the stack* and
+> re-triggers if the condition is still true. This engine resets on the condition next
+> being *false* instead — equivalent for "sacrifice this creature" cards (source leaves,
+> condition clears) but divergent for a state trigger that leaves source and condition
+> intact. No such card exists yet; reset-on-leaves-the-stack should be wired before one is
+> authored.
 
 ```kotlin
 stateTriggeredAbility {

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -910,6 +910,12 @@ sealed set for attack-time facts beyond the basics.
 - `BlocksOrBecomesBlockedBy(filter)` — either direction, partner-filtered;
   sole consumer of `BlocksOrBecomesBlockedByEvent`. Prefer `blocks(attackerFilter=...)`
   when only the blocking direction should fire.
+- `AttacksAndIsntBlocked` — SELF. Fires once per attacker that reaches end of
+  Declare Blockers with no blockers assigned (CR 509.7). Backed by
+  `BecomesUnblockedEvent` matched against `BlockersDeclaredEvent`. Used for
+  Merchant Ship: "Whenever this creature attacks and isn't blocked, you gain 2 life."
+- `attacksAndIsntBlocked(filter)` — ANY-binding factory variant: "Whenever a
+  [filter] attacks and isn't blocked."
 
 **`AttackPredicate`** — extensible "facts about an attack declaration."
 Adding a new attack-time mechanic is one new sealed-case + one matcher branch
@@ -1233,6 +1239,39 @@ Triggers.youCastSpell(
     control on your next attack). With `fireOnce = false` (default) it fires on every matching event
     until expiry (double-strike combat damage). One-shot consumption happens when the trigger goes
     on the stack (`TriggerProcessor`), so a second matching event the same turn won't re-fire it.
+
+---
+
+## 8.5 State-triggered abilities (CR 603.8)
+
+A **state-triggered ability** fires whenever a game-state condition becomes true, rather
+than in response to a `GameEvent`. The engine polls the condition at every priority pass
+and emits the trigger on each false → true transition. Once it has fired, a per-permanent
+`StateTriggerLatchesComponent` latch suppresses re-firing until the condition next
+evaluates false again (CR 603.8d).
+
+```kotlin
+stateTriggeredAbility {
+    condition = Conditions.YouControl(
+        GameObjectFilter.Land.withSubtype("Island"),
+        negate = true,
+    )
+    effect = Effects.SacrificeTarget(EffectTarget.Self)
+    description = "When you control no Islands, sacrifice this creature"
+}
+```
+
+- `condition` — any `Condition`. Evaluated with the source permanent as
+  `EffectContext.sourceId`; `Player.You` references resolve to the source's controller.
+- `effect` — fires when the condition transitions false → true. Resolves on the stack
+  like an ordinary triggered ability.
+- `description` (optional) — overrides the auto-generated text.
+
+Used for Dandân, Island Fish Jasconius, Merchant Ship ("When you control no Islands,
+sacrifice this creature"), Serendib Djinn ("When you control no lands, sacrifice this
+creature"), and similar "static cleanup" wording in early sets. Differs from an
+intervening-if triggered ability — there is no event to gate on; the engine watches the
+condition itself.
 
 ---
 

--- a/manual-scenarios/cards/d/dandan.json
+++ b/manual-scenarios/cards/d/dandan.json
@@ -1,0 +1,25 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Island"],
+    "battlefield": [
+      {"name": "Dandân", "summoningSickness": false},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "library": ["Island", "Island", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Island"}
+    ],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1
+}

--- a/manual-scenarios/cards/d/dandan.json
+++ b/manual-scenarios/cards/d/dandan.json
@@ -3,9 +3,10 @@
   "player2Name": "Bob",
   "player1": {
     "lifeTotal": 20,
-    "hand": ["Island"],
+    "hand": ["Island", "Stone Rain"],
     "battlefield": [
       {"name": "Dandân", "summoningSickness": false},
+      {"name": "Island"},
       {"name": "Mountain"},
       {"name": "Mountain"}
     ],

--- a/manual-scenarios/cards/i/island-fish-jasconius.json
+++ b/manual-scenarios/cards/i/island-fish-jasconius.json
@@ -1,0 +1,28 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Island Fish Jasconius", "summoningSickness": false, "tapped": true},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "library": ["Island", "Island", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Island"}
+    ],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "BEGINNING",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP"]
+}

--- a/manual-scenarios/cards/m/merchant-ship.json
+++ b/manual-scenarios/cards/m/merchant-ship.json
@@ -1,0 +1,24 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Merchant Ship", "summoningSickness": false},
+      {"name": "Island"}
+    ],
+    "library": ["Island", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Island"}
+    ],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1
+}

--- a/manual-scenarios/cards/m/merchant-ship.json
+++ b/manual-scenarios/cards/m/merchant-ship.json
@@ -3,9 +3,11 @@
   "player2Name": "Bob",
   "player1": {
     "lifeTotal": 20,
-    "hand": [],
+    "hand": ["Stone Rain"],
     "battlefield": [
       {"name": "Merchant Ship", "summoningSickness": false},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
       {"name": "Island"}
     ],
     "library": ["Island", "Island", "Island"]

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -766,7 +766,7 @@ class CardBuilder(private val name: String) {
      * ```
      * stateTriggeredAbility {
      *     condition = Conditions.YouControl(GameObjectFilter.Land.withSubtype("Island"), negate = true)
-     *     effect = Effects.Sacrifice(EffectTarget.Self)
+     *     effect = Effects.SacrificeTarget(EffectTarget.Self)
      * }
      * ```
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -305,6 +305,7 @@ class CardBuilder(private val name: String) {
     private var keywordAbilityList: MutableList<KeywordAbility> = mutableListOf()
     private var spellBuilder: SpellBuilder? = null
     private val triggeredAbilities: MutableList<TriggeredAbility> = mutableListOf()
+    private val stateTriggeredAbilities: MutableList<StateTriggeredAbility> = mutableListOf()
     private val activatedAbilities: MutableList<ActivatedAbility> = mutableListOf()
     private val staticAbilities: MutableList<StaticAbility> = mutableListOf()
     private val additionalCosts: MutableList<AdditionalCost> = mutableListOf()
@@ -755,6 +756,26 @@ class CardBuilder(private val name: String) {
         triggeredAbilities.add(builder.build())
     }
 
+    /**
+     * Add a state-triggered ability (CR 603.8). The [condition] is polled at priority
+     * passes; when it transitions from false to true the [effect] is enqueued on the
+     * stack. The engine latches the ability per (entityId, abilityId) so it does not
+     * re-fire while the condition stays true.
+     *
+     * Example — Dandân ("When you control no Islands, sacrifice this creature"):
+     * ```
+     * stateTriggeredAbility {
+     *     condition = Conditions.YouControl(GameObjectFilter.Land.withSubtype("Island"), negate = true)
+     *     effect = Effects.Sacrifice(EffectTarget.Self)
+     * }
+     * ```
+     */
+    fun stateTriggeredAbility(init: StateTriggeredAbilityBuilder.() -> Unit) {
+        val builder = StateTriggeredAbilityBuilder()
+        builder.init()
+        stateTriggeredAbilities.add(builder.build())
+    }
+
     // =========================================================================
     // Activated Abilities
     // =========================================================================
@@ -1043,6 +1064,7 @@ class CardBuilder(private val name: String) {
             spellEffect = spellEffect,
             targetRequirements = spellBuilder?.targetRequirements ?: emptyList(),
             triggeredAbilities = triggeredAbilities.toList(),
+            stateTriggeredAbilities = stateTriggeredAbilities.toList(),
             activatedAbilities = activatedAbilities.toList(),
             staticAbilities = staticAbilities.toList(),
             replacementEffects = replacementEffects.toList(),
@@ -1412,6 +1434,31 @@ class TriggeredAbilityBuilder {
             triggerCondition = triggerCondition,
             controlledByTriggeringEntityController = controlledByTriggeringEntityController,
             oncePerTurn = oncePerTurn,
+            descriptionOverride = description
+        )
+    }
+}
+
+// =============================================================================
+// State-Triggered Ability Builder (CR 603.8)
+// =============================================================================
+
+@CardDsl
+class StateTriggeredAbilityBuilder {
+    /** The state predicate. Evaluated against the source permanent's context. */
+    var condition: Condition? = null
+    var effect: Effect? = null
+    var activeZone: Zone = Zone.BATTLEFIELD
+    /** Optional human-readable description that overrides the auto-generated one. */
+    var description: String? = null
+
+    fun build(): StateTriggeredAbility {
+        val cond = requireNotNull(condition) { "State-triggered ability must have a condition" }
+        val eff = requireNotNull(effect) { "State-triggered ability must have an effect" }
+        return StateTriggeredAbility.create(
+            condition = cond,
+            effect = eff,
+            activeZone = activeZone,
             descriptionOverride = description
         )
     }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -116,8 +116,8 @@ object Conditions {
      * (e.g. `GameObjectFilter.Creature.copy(statePredicates = listOf(StatePredicate.HasAnyCounter))`
      * for "a creature with a counter on it").
      */
-    fun YouControl(filter: GameObjectFilter): ConditionInterface =
-        Exists(Player.You, Zone.BATTLEFIELD, filter)
+    fun YouControl(filter: GameObjectFilter, negate: Boolean = false): ConditionInterface =
+        Exists(Player.You, Zone.BATTLEFIELD, filter, negate = negate)
 
     /**
      * If you control an enchantment.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -323,20 +323,12 @@ object Triggers {
      * When this creature attacks and isn't blocked. (SELF.)
      *
      * Fires for the SELF attacker if it reaches end of Declare Blockers with no
-     * blockers assigned (CR 509.7). Used for cards like Merchant Ship: "Whenever
+     * blockers assigned (CR 509.3g). Used for cards like Merchant Ship: "Whenever
      * Merchant Ship attacks and isn't blocked, you gain 2 life."
      */
     val AttacksAndIsntBlocked: TriggerSpec = TriggerSpec(
-        event = BecomesUnblockedEvent(),
+        event = BecomesUnblockedEvent,
         binding = TriggerBinding.SELF
-    )
-
-    /**
-     * "Whenever a [filter] attacks and isn't blocked" — ANY binding with a filter.
-     */
-    fun attacksAndIsntBlocked(filter: GameObjectFilter): TriggerSpec = TriggerSpec(
-        event = BecomesUnblockedEvent(filter),
-        binding = TriggerBinding.ANY
     )
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -320,6 +320,26 @@ object Triggers {
     )
 
     /**
+     * When this creature attacks and isn't blocked. (SELF.)
+     *
+     * Fires for the SELF attacker if it reaches end of Declare Blockers with no
+     * blockers assigned (CR 509.7). Used for cards like Merchant Ship: "Whenever
+     * Merchant Ship attacks and isn't blocked, you gain 2 life."
+     */
+    val AttacksAndIsntBlocked: TriggerSpec = TriggerSpec(
+        event = BecomesUnblockedEvent(),
+        binding = TriggerBinding.SELF
+    )
+
+    /**
+     * "Whenever a [filter] attacks and isn't blocked" — ANY binding with a filter.
+     */
+    fun attacksAndIsntBlocked(filter: GameObjectFilter): TriggerSpec = TriggerSpec(
+        event = BecomesUnblockedEvent(filter),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
      * Generic "blocks" trigger factory. Use [Blocks] for the SELF-only
      * unfiltered case; reach for this factory for (filter, binding) variants
      * like "Whenever a creature you control blocks" (ANY binding + filter).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
@@ -104,6 +104,15 @@ data class CardScript(
     val triggeredAbilities: List<TriggeredAbility> = emptyList(),
 
     /**
+     * State-triggered abilities (CR 603.8) that fire when a game-state condition
+     * becomes true (rather than in response to an event). The engine polls these at
+     * priority pass points and latches per (entityId, abilityId) to prevent re-firing
+     * while the condition stays true. Examples: "When you control no Islands,
+     * sacrifice this creature."
+     */
+    val stateTriggeredAbilities: List<StateTriggeredAbility> = emptyList(),
+
+    /**
      * Activated abilities that can be activated by paying costs.
      * Examples: Tap abilities, loyalty abilities, equip.
      */
@@ -248,6 +257,7 @@ data class CardScript(
         get() = spellEffect != null ||
                 targetRequirements.isNotEmpty() ||
                 triggeredAbilities.isNotEmpty() ||
+                stateTriggeredAbilities.isNotEmpty() ||
                 activatedAbilities.isNotEmpty() ||
                 staticAbilities.isNotEmpty() ||
                 replacementEffects.isNotEmpty() ||
@@ -285,7 +295,7 @@ data class CardScript(
      * All abilities (triggered + activated + static + replacement) for iteration.
      */
     val allAbilities: List<Any>
-        get() = triggeredAbilities + activatedAbilities + staticAbilities + replacementEffects
+        get() = triggeredAbilities + stateTriggeredAbilities + activatedAbilities + staticAbilities + replacementEffects
 
     /**
      * Whether this card has replacement effects.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
@@ -533,34 +533,22 @@ sealed interface GameEvent : TextReplaceable<GameEvent> {
     }
 
     /**
-     * When an attacking creature reaches the end of the Declare Blockers step with
-     * no blockers assigned to it (CR 509.7 — "becomes unblocked").
+     * When this attacking creature reaches the end of the Declare Blockers step with
+     * no blockers assigned to it (CR 509.3g — "attacks and isn't blocked").
      *
-     * Binding SELF = "when this creature attacks and isn't blocked",
-     * ANY = "whenever a creature attacks and isn't blocked" (filter=null),
-     * ANY + filter = "whenever a [filter] attacks and isn't blocked" (any controller).
+     * SELF only — "when this creature attacks and isn't blocked". An ANY-binding
+     * filtered variant ("whenever a [filter] attacks and isn't blocked") is not yet
+     * wired in [com.wingedsheep.engine.event.TriggerMatcher]; add the matcher/detector
+     * branches and a filter field together when a card needs it.
      *
-     * Mirrors [BecomesBlockedEvent]. Emitted once per unblocked attacker after
-     * blocker declaration is finalized for the current combat.
+     * Mirrors [BecomesBlockedEvent]. Detected (not emitted) once per unblocked attacker
+     * after blocker declaration is finalized for the current combat.
      */
     @SerialName("BecomesUnblockedEvent")
     @Serializable
-    data class BecomesUnblockedEvent(
-        val filter: GameObjectFilter? = null
-    ) : GameEvent {
-        override val description: String = buildString {
-            if (filter != null) {
-                append("a ${filter.description} attacks and isn't blocked")
-            } else {
-                append("a creature attacks and isn't blocked")
-            }
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): GameEvent {
-            val f = filter ?: return this
-            val newFilter = f.applyTextReplacement(replacer)
-            return if (newFilter !== f) copy(filter = newFilter) else this
-        }
+    data object BecomesUnblockedEvent : GameEvent {
+        override val description: String = "a creature attacks and isn't blocked"
+        override fun applyTextReplacement(replacer: TextReplacer): GameEvent = this
     }
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GameEvent.kt
@@ -519,6 +519,51 @@ sealed interface GameEvent : TextReplaceable<GameEvent> {
     }
 
     /**
+     * Synthetic "trigger" event used to wrap a [StateTriggeredAbility]'s effect into a
+     * [TriggeredAbility] when the engine enqueues a state trigger onto the stack
+     * (CR 603.8). This event is never matched against real game events — the engine
+     * detects state-trigger transitions via the [com.wingedsheep.engine.event.StateTriggerPoller]
+     * and produces a [com.wingedsheep.engine.event.PendingTrigger] directly.
+     */
+    @SerialName("StateConditionMetEvent")
+    @Serializable
+    data object StateConditionMetEvent : GameEvent {
+        override val description: String = "the state condition is met"
+        override fun applyTextReplacement(replacer: TextReplacer): GameEvent = this
+    }
+
+    /**
+     * When an attacking creature reaches the end of the Declare Blockers step with
+     * no blockers assigned to it (CR 509.7 — "becomes unblocked").
+     *
+     * Binding SELF = "when this creature attacks and isn't blocked",
+     * ANY = "whenever a creature attacks and isn't blocked" (filter=null),
+     * ANY + filter = "whenever a [filter] attacks and isn't blocked" (any controller).
+     *
+     * Mirrors [BecomesBlockedEvent]. Emitted once per unblocked attacker after
+     * blocker declaration is finalized for the current combat.
+     */
+    @SerialName("BecomesUnblockedEvent")
+    @Serializable
+    data class BecomesUnblockedEvent(
+        val filter: GameObjectFilter? = null
+    ) : GameEvent {
+        override val description: String = buildString {
+            if (filter != null) {
+                append("a ${filter.description} attacks and isn't blocked")
+            } else {
+                append("a creature attacks and isn't blocked")
+            }
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): GameEvent {
+            val f = filter ?: return this
+            val newFilter = f.applyTextReplacement(replacer)
+            return if (newFilter !== f) copy(filter = newFilter) else this
+        }
+    }
+
+    /**
      * When this creature blocks or becomes blocked by a creature matching [partnerFilter].
      * Binding SELF = "when this creature blocks or becomes blocked by [filter]".
      *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/StateTriggeredAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/StateTriggeredAbility.kt
@@ -11,15 +11,23 @@ import kotlinx.serialization.Serializable
  * A state-triggered ability per CR 603.8: it triggers whenever its [condition] becomes true,
  * rather than in response to a [GameEvent].
  *
- * Per 603.8a–d:
- * - The condition is checked each time a player would receive priority and after the stack
- *   is empty / nothing else is happening.
- * - Once the ability has triggered, it does not trigger again until the condition has been
- *   false at some point afterward (the "latch"). The engine tracks this per
- *   (entityId, abilityId) via [com.wingedsheep.engine.state.components.battlefield.StateTriggerLatchesComponent]
+ * Per CR 603.8:
+ * - The condition is checked each time a player would receive priority.
+ * - When the condition becomes true the ability goes onto the stack as a normal triggered
+ *   ability and resolves under stack rules.
+ * - It does not trigger again while the condition stays true (the "latch"). The engine
+ *   tracks this per (entityId, abilityId) via
+ *   [com.wingedsheep.engine.state.components.battlefield.StateTriggerLatchesComponent]
  *   in the rules-engine module.
- * - When it does trigger, it goes onto the stack as a normal triggered ability and resolves
- *   under stack rules.
+ *
+ * Deliberate simplification vs the letter of CR 603.8: the printed rule resets once the
+ * ability *leaves the stack* (resolves / is countered) and re-triggers if the condition is
+ * still true. This engine instead resets the latch when the condition next evaluates
+ * *false*. The two agree for every state trigger whose effect removes the source or clears
+ * the condition (the only shape shipped so far — "sacrifice this creature" cards). They
+ * diverge only for a state trigger that leaves both the source and the condition intact,
+ * where the printed rule would re-fire each time it resolves; no such card exists yet.
+ * Revisit (reset on leaves-the-stack) before authoring one.
  *
  * Authored on cards like Dandân ("When you control no Islands, sacrifice this creature"),
  * Force Bubble ("when there are four or more depletion counters on ~, sacrifice it"), etc.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/StateTriggeredAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/StateTriggeredAbility.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.sdk.scripting
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.conditions.Condition
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.text.TextReplaceable
+import com.wingedsheep.sdk.scripting.text.TextReplacer
+import kotlinx.serialization.Serializable
+
+/**
+ * A state-triggered ability per CR 603.8: it triggers whenever its [condition] becomes true,
+ * rather than in response to a [GameEvent].
+ *
+ * Per 603.8a–d:
+ * - The condition is checked each time a player would receive priority and after the stack
+ *   is empty / nothing else is happening.
+ * - Once the ability has triggered, it does not trigger again until the condition has been
+ *   false at some point afterward (the "latch"). The engine tracks this per
+ *   (entityId, abilityId) via [com.wingedsheep.engine.state.components.battlefield.StateTriggerLatchesComponent]
+ *   in the rules-engine module.
+ * - When it does trigger, it goes onto the stack as a normal triggered ability and resolves
+ *   under stack rules.
+ *
+ * Authored on cards like Dandân ("When you control no Islands, sacrifice this creature"),
+ * Force Bubble ("when there are four or more depletion counters on ~, sacrifice it"), etc.
+ * Use the [com.wingedsheep.sdk.dsl.CardBuilder.stateTriggeredAbility] DSL block; don't
+ * instantiate directly.
+ */
+@Serializable
+data class StateTriggeredAbility(
+    val id: AbilityId,
+    /** The state predicate (CR 603.8). Evaluated against the source permanent's context. */
+    val condition: Condition,
+    val effect: Effect,
+    val activeZone: Zone = Zone.BATTLEFIELD,
+    /** Optional human-readable override; otherwise auto-generated from condition + effect. */
+    val descriptionOverride: String? = null
+) : TextReplaceable<StateTriggeredAbility> {
+
+    val description: String
+        get() = descriptionOverride ?: buildString {
+            append("when ")
+            append(condition.description.removePrefix("if ").removePrefix("If "))
+            append(", ")
+            append(effect.description.replaceFirstChar { it.lowercase() })
+            append(".")
+        }
+
+    override fun applyTextReplacement(replacer: TextReplacer): StateTriggeredAbility {
+        val newCondition = condition.applyTextReplacement(replacer)
+        val newEffect = effect.applyTextReplacement(replacer)
+        return if (newCondition !== condition || newEffect !== effect)
+            copy(condition = newCondition, effect = newEffect) else this
+    }
+
+    companion object {
+        fun create(
+            condition: Condition,
+            effect: Effect,
+            activeZone: Zone = Zone.BATTLEFIELD,
+            descriptionOverride: String? = null
+        ): StateTriggeredAbility = StateTriggeredAbility(
+            id = AbilityId.generate(),
+            condition = condition,
+            effect = effect,
+            activeZone = activeZone,
+            descriptionOverride = descriptionOverride
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Dandan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Dandan.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dandân
+ * {U}{U}
+ * Creature — Fish
+ * 4/1
+ * This creature can't attack unless defending player controls an Island.
+ * When you control no Islands, sacrifice this creature.
+ */
+val Dandan = card("Dandân") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Fish"
+    power = 4
+    toughness = 1
+    oracleText = "This creature can't attack unless defending player controls an Island.\n" +
+        "When you control no Islands, sacrifice this creature."
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+    }
+
+    stateTriggeredAbility {
+        condition = Conditions.YouControl(
+            GameObjectFilter.Land.withSubtype("Island"),
+            negate = true
+        )
+        effect = Effects.SacrificeTarget(EffectTarget.Self)
+        description = "When you control no Islands, sacrifice this creature"
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Drew Tucker"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/414d3cae-b8cf-4d53-bd6b-1aa83a828ba9.jpg?1562906979"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/IslandFishJasconius.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/IslandFishJasconius.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Island Fish Jasconius
+ * {4}{U}{U}{U}
+ * Creature — Fish
+ * 6/8
+ * This creature doesn't untap during your untap step.
+ * At the beginning of your upkeep, you may pay {U}{U}{U}. If you do, untap this creature.
+ * This creature can't attack unless defending player controls an Island.
+ * When you control no Islands, sacrifice this creature.
+ */
+val IslandFishJasconius = card("Island Fish Jasconius") {
+    manaCost = "{4}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Fish"
+    power = 6
+    toughness = 8
+    oracleText = "This creature doesn't untap during your untap step.\n" +
+        "At the beginning of your upkeep, you may pay {U}{U}{U}. If you do, untap this creature.\n" +
+        "This creature can't attack unless defending player controls an Island.\n" +
+        "When you control no Islands, sacrifice this creature."
+
+    flags(AbilityFlag.DOESNT_UNTAP)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = MayPayManaEffect(ManaCost.parse("{U}{U}{U}"), Effects.Untap(EffectTarget.Self))
+    }
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+    }
+
+    stateTriggeredAbility {
+        condition = Conditions.YouControl(
+            GameObjectFilter.Land.withSubtype("Island"),
+            negate = true
+        )
+        effect = Effects.SacrificeTarget(EffectTarget.Self)
+        description = "When you control no Islands, sacrifice this creature"
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "16"
+        artist = "Jesper Myrfors"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/8537cb0f-4821-417b-80cc-ea57d51ee9b8.jpg?1562919710"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/MerchantShip.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/MerchantShip.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Merchant Ship
+ * {U}
+ * Creature — Human
+ * 0/2
+ * This creature can't attack unless defending player controls an Island.
+ * Whenever this creature attacks and isn't blocked, you gain 2 life.
+ * When you control no Islands, sacrifice this creature.
+ */
+val MerchantShip = card("Merchant Ship") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human"
+    power = 0
+    toughness = 2
+    oracleText = "This creature can't attack unless defending player controls an Island.\n" +
+        "Whenever this creature attacks and isn't blocked, you gain 2 life.\n" +
+        "When you control no Islands, sacrifice this creature."
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.AttacksAndIsntBlocked
+        effect = Effects.GainLife(2, EffectTarget.Controller)
+    }
+
+    stateTriggeredAbility {
+        condition = Conditions.YouControl(
+            GameObjectFilter.Land.withSubtype("Island"),
+            negate = true
+        )
+        effect = Effects.SacrificeTarget(EffectTarget.Self)
+        description = "When you control no Islands, sacrifice this creature"
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "17"
+        artist = "Tom Wänerstrand"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b827094-fb2c-46db-b898-02e0c308601f.jpg?1562903045"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EngineServices.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EngineServices.kt
@@ -56,6 +56,7 @@ class EngineServices(
     )
     val combatManager = CombatManager(cardRegistry, manaAbilitySideEffectExecutor)
     val triggerDetector = TriggerDetector(cardRegistry)
+    val stateTriggerPoller = com.wingedsheep.engine.event.StateTriggerPoller(cardRegistry)
     val stackResolver = StackResolver(
         effectHandler = EffectHandler(cardRegistry = cardRegistry),
         cardRegistry = cardRegistry

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -365,6 +365,7 @@ val engineSerializersModule = SerializersModule {
         subclass(TargetedByControllerThisTurnComponent::class)
         subclass(ReceivedCountersThisTurnComponent::class)
         subclass(TriggeredAbilityFiredThisTurnComponent::class)
+        subclass(StateTriggerLatchesComponent::class)
         subclass(WarpedComponent::class)
         subclass(WasKickedComponent::class)
         subclass(EvokedComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
@@ -4,7 +4,6 @@ import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
 import com.wingedsheep.engine.state.components.battlefield.StateTriggerLatchesComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
@@ -61,7 +60,6 @@ class StateTriggerPoller(
             val abilities = cardDef.script.stateTriggeredAbilities
             if (abilities.isEmpty()) continue
 
-            val classLevel = container.get<ClassLevelComponent>()?.currentLevel
             val opponentId = workingState.turnOrder.firstOrNull { it != controllerId }
             val effectContext = EffectContext(
                 sourceId = permanentId,
@@ -72,7 +70,7 @@ class StateTriggerPoller(
             var latches = container.get<StateTriggerLatchesComponent>() ?: StateTriggerLatchesComponent()
             var latchesChanged = false
 
-            for (ability in abilities.filterByZone(classLevel)) {
+            for (ability in abilities) {
                 val conditionMet = conditionEvaluator.evaluate(workingState, ability.condition, effectContext)
                 val wasLatched = latches.isLatched(ability.id)
 
@@ -103,11 +101,6 @@ class StateTriggerPoller(
 
         return Result(workingState, newTriggers)
     }
-
-    private fun List<StateTriggeredAbility>.filterByZone(@Suppress("UNUSED_PARAMETER") classLevel: Int?): List<StateTriggeredAbility> =
-        // All current state-triggered abilities are battlefield-active. Class-level gating is
-        // not yet wired here; revisit if a Class card author needs a level-gated state trigger.
-        this
 
     private fun StateTriggeredAbility.asTriggeredAbility(): TriggeredAbility =
         TriggeredAbility(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.event
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
+import com.wingedsheep.engine.state.components.battlefield.StateTriggerLatchesComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.sdk.scripting.GameEvent
+import com.wingedsheep.sdk.scripting.StateTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+
+/**
+ * Polls [StateTriggeredAbility] instances on every battlefield permanent at each priority
+ * pass (CR 603.8).
+ *
+ * For each ability:
+ *  - Evaluate its condition against the source permanent's controller.
+ *  - Compare against the entity's [StateTriggerLatchesComponent]:
+ *      - condition true AND not latched → produce a [PendingTrigger] and latch it.
+ *      - condition false AND latched → clear the latch so the next true transition refires.
+ *  - Otherwise, leave the latch alone (no event).
+ *
+ * State-triggered abilities go on the stack as ordinary triggered abilities. The synthetic
+ * [GameEvent.StateConditionMetEvent] is used only to satisfy [TriggeredAbility]'s
+ * `trigger` slot; it is never matched against real events ([TriggerMatcher] returns
+ * `false` for it).
+ */
+class StateTriggerPoller(
+    private val cardRegistry: CardRegistry,
+    private val conditionEvaluator: ConditionEvaluator = ConditionEvaluator()
+) {
+
+    /**
+     * Result of one poll pass.
+     *
+     * @property newState the state with updated latch components.
+     * @property pendingTriggers triggers to enqueue (already in APNAP order: the engine's
+     *   battlefield iteration is already APNAP-stable within a single pass for our purposes;
+     *   downstream [TriggerProcessor] re-orders by controller if necessary).
+     */
+    data class Result(
+        val newState: GameState,
+        val pendingTriggers: List<PendingTrigger>
+    )
+
+    fun poll(state: GameState): Result {
+        val projected = state.projectedState
+        var workingState = state
+        val newTriggers = mutableListOf<PendingTrigger>()
+
+        for (permanentId in state.getBattlefield()) {
+            val container = workingState.getEntity(permanentId) ?: continue
+            val card = container.get<CardComponent>() ?: continue
+            if (container.has<FaceDownComponent>()) continue
+            val controllerId = projected.getController(permanentId) ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            val abilities = cardDef.script.stateTriggeredAbilities
+            if (abilities.isEmpty()) continue
+
+            val classLevel = container.get<ClassLevelComponent>()?.currentLevel
+            val opponentId = workingState.turnOrder.firstOrNull { it != controllerId }
+            val effectContext = EffectContext(
+                sourceId = permanentId,
+                controllerId = controllerId,
+                opponentId = opponentId
+            )
+
+            var latches = container.get<StateTriggerLatchesComponent>() ?: StateTriggerLatchesComponent()
+            var latchesChanged = false
+
+            for (ability in abilities.filterByZone(classLevel)) {
+                val conditionMet = conditionEvaluator.evaluate(workingState, ability.condition, effectContext)
+                val wasLatched = latches.isLatched(ability.id)
+
+                when {
+                    conditionMet && !wasLatched -> {
+                        latches = latches.withLatched(ability.id)
+                        latchesChanged = true
+                        newTriggers += PendingTrigger(
+                            ability = ability.asTriggeredAbility(),
+                            sourceId = permanentId,
+                            sourceName = card.name,
+                            controllerId = controllerId,
+                            triggerContext = TriggerContext()
+                        )
+                    }
+                    !conditionMet && wasLatched -> {
+                        latches = latches.withoutLatched(ability.id)
+                        latchesChanged = true
+                    }
+                    else -> { /* no transition */ }
+                }
+            }
+
+            if (latchesChanged) {
+                workingState = workingState.withEntity(permanentId, container.withComponent(latches))
+            }
+        }
+
+        return Result(workingState, newTriggers)
+    }
+
+    private fun List<StateTriggeredAbility>.filterByZone(@Suppress("UNUSED_PARAMETER") classLevel: Int?): List<StateTriggeredAbility> =
+        // All current state-triggered abilities are battlefield-active. Class-level gating is
+        // not yet wired here; revisit if a Class card author needs a level-gated state trigger.
+        this
+
+    private fun StateTriggeredAbility.asTriggeredAbility(): TriggeredAbility =
+        TriggeredAbility(
+            id = id,
+            trigger = GameEvent.StateConditionMetEvent,
+            binding = TriggerBinding.SELF,
+            effect = effect,
+            activeZone = activeZone,
+            descriptionOverride = descriptionOverride ?: description
+        )
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -160,6 +160,7 @@ class TriggerIndex(
                 is SdkGameEvent.CreaturesAttackYouEvent -> listOf(TriggerCategory.ATTACKERS_DECLARED)
                 is SdkGameEvent.BlockEvent -> listOf(TriggerCategory.BLOCKERS_DECLARED)
                 is SdkGameEvent.BecomesBlockedEvent -> listOf(TriggerCategory.BLOCKERS_DECLARED)
+                is SdkGameEvent.BecomesUnblockedEvent -> listOf(TriggerCategory.BLOCKERS_DECLARED)
                 is SdkGameEvent.BlocksOrBecomesBlockedByEvent -> listOf(TriggerCategory.BLOCKERS_DECLARED)
                 is SdkGameEvent.DamageReceivedEvent ->
                     if (trigger.source == SourceFilter.Any) listOf(TriggerCategory.DAMAGE_RECEIVED) else emptyList()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -132,10 +132,10 @@ class TriggerMatcher(
                     (binding != TriggerBinding.SELF || event.blockers.values.any { it.contains(sourceId) })
             }
             is GameEvent.BecomesUnblockedEvent -> {
-                // CR 509.7: fires for an attacker that has no blockers assigned. We piggyback
-                // on BlockersDeclaredEvent (emitted once at end of declare-blockers): SELF
-                // matches when sourceId is an attacker this combat AND is absent from every
-                // blocker's blocked-attackers list.
+                // CR 509.3g: fires for an attacker with no creatures declared as blockers.
+                // We piggyback on BlockersDeclaredEvent (emitted once at end of
+                // declare-blockers): SELF matches when sourceId is an attacker this combat
+                // AND is absent from every blocker's blocked-attackers list.
                 if (event !is BlockersDeclaredEvent) return false
                 if (binding != TriggerBinding.SELF) return false
                 val isAttacking = state.getEntity(sourceId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -131,6 +131,22 @@ class TriggerMatcher(
                 event is BlockersDeclaredEvent &&
                     (binding != TriggerBinding.SELF || event.blockers.values.any { it.contains(sourceId) })
             }
+            is GameEvent.BecomesUnblockedEvent -> {
+                // CR 509.7: fires for an attacker that has no blockers assigned. We piggyback
+                // on BlockersDeclaredEvent (emitted once at end of declare-blockers): SELF
+                // matches when sourceId is an attacker this combat AND is absent from every
+                // blocker's blocked-attackers list.
+                if (event !is BlockersDeclaredEvent) return false
+                if (binding != TriggerBinding.SELF) return false
+                val isAttacking = state.getEntity(sourceId)
+                    ?.get<com.wingedsheep.engine.state.components.combat.AttackingComponent>() != null
+                isAttacking && event.blockers.values.none { it.contains(sourceId) }
+            }
+            is GameEvent.StateConditionMetEvent -> {
+                // Synthetic — never matched against real events. State triggers fire via
+                // StateTriggerPoller which produces PendingTriggers directly.
+                false
+            }
             is GameEvent.BlocksOrBecomesBlockedByEvent -> {
                 // Basic match: it's a BlockersDeclaredEvent and the source is involved in combat
                 // Per-partner trigger creation happens in detectTriggersForEvent

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.core.PriorityChangedEvent
 import com.wingedsheep.engine.core.StepChangedEvent
 import com.wingedsheep.engine.core.TurnManager
 import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.event.StateTriggerPoller
 import com.wingedsheep.engine.event.TriggerDetector
 import com.wingedsheep.engine.event.TriggerProcessor
 import com.wingedsheep.engine.core.EngineServices
@@ -40,7 +41,8 @@ class PassPriorityHandler(
     private val stackResolver: StackResolver,
     private val sbaChecker: StateBasedActionChecker,
     private val triggerDetector: TriggerDetector,
-    private val triggerProcessor: TriggerProcessor
+    private val triggerProcessor: TriggerProcessor,
+    private val stateTriggerPoller: StateTriggerPoller
 ) : ActionHandler<PassPriority> {
     override val actionType: KClass<PassPriority> = PassPriority::class
 
@@ -107,6 +109,12 @@ class PassPriorityHandler(
                         triggers.addAll(phaseStepTriggers)
                     }
                 }
+
+                // CR 603.8: poll state-triggered abilities. The poll updates per-permanent
+                // latch components and yields any false-to-true transitions as triggers.
+                val stateTriggerResult = stateTriggerPoller.poll(currentState)
+                currentState = stateTriggerResult.newState
+                triggers.addAll(stateTriggerResult.pendingTriggers)
 
                 if (triggers.isNotEmpty()) {
                     val triggerResult = triggerProcessor.processTriggers(currentState, triggers)
@@ -227,9 +235,16 @@ class PassPriorityHandler(
 
         // Detect triggers from SBA events (e.g., death triggers) on post-SBA state
         val sbaTriggers = triggerDetector.detectTriggers(sbaTrackedState, sbaResult.events)
-        val triggers = preSbaTriggers + sbaTriggers
+
+        // CR 603.8: state-trigger poll happens at every priority check (here, after stack
+        // resolution + SBA), once events have settled. Polls battlefield permanents'
+        // state-triggered abilities and emits triggers for false→true transitions; updates
+        // per-entity latch components on the returned state.
+        val statePollResult = stateTriggerPoller.poll(sbaTrackedState)
+        val postPollState = statePollResult.newState
+        val triggers = preSbaTriggers + sbaTriggers + statePollResult.pendingTriggers
         if (triggers.isNotEmpty()) {
-            val triggerResult = triggerProcessor.processTriggers(sbaTrackedState, triggers)
+            val triggerResult = triggerProcessor.processTriggers(postPollState, triggers)
 
             if (triggerResult.isPaused) {
                 return ExecutionResult.paused(
@@ -247,7 +262,7 @@ class PassPriorityHandler(
         }
 
         return ExecutionResult.success(
-            sbaTrackedState.withPriority(stackItemController),
+            postPollState.withPriority(stackItemController),
             combinedEvents
         )
     }
@@ -273,7 +288,8 @@ class PassPriorityHandler(
                 services.stackResolver,
                 services.sbaChecker,
                 services.triggerDetector,
-                services.triggerProcessor
+                services.triggerProcessor,
+                services.stateTriggerPoller
             )
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/SacrificeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/SacrificeExecutor.kt
@@ -150,9 +150,10 @@ class SacrificeExecutor(
         var newState = state
         val events = mutableListOf<GameEvent>()
 
-        // Capture P/T/subtype snapshots BEFORE the zone change (CR 608.2h / 112.7a) so a
-        // follow-up sibling effect — e.g. Serendib Djinn's "if you sacrifice an Island this
-        // way, ~ deals 3 damage to you" — can read the sacrificed permanent's subtypes via
+        // Capture P/T/subtype snapshots BEFORE the zone change (CR 608.2h / 113.7a — last
+        // known information) so a follow-up sibling effect — e.g. Serendib Djinn's "if you
+        // sacrifice an Island this way, ~ deals 3 damage to you" — can read the sacrificed
+        // permanent's subtypes via
         // [Conditions.SacrificedHadSubtype] or [DynamicAmount.EntityProperty(Sacrificed, ...)].
         val snapshots = if (permanentIds.isNotEmpty()) {
             capturePermanentSnapshots(permanentIds, newState.projectedState)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/SacrificeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/SacrificeExecutor.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.capturePermanentSnapshots
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
@@ -149,6 +150,16 @@ class SacrificeExecutor(
         var newState = state
         val events = mutableListOf<GameEvent>()
 
+        // Capture P/T/subtype snapshots BEFORE the zone change (CR 608.2h / 112.7a) so a
+        // follow-up sibling effect — e.g. Serendib Djinn's "if you sacrifice an Island this
+        // way, ~ deals 3 damage to you" — can read the sacrificed permanent's subtypes via
+        // [Conditions.SacrificedHadSubtype] or [DynamicAmount.EntityProperty(Sacrificed, ...)].
+        val snapshots = if (permanentIds.isNotEmpty()) {
+            capturePermanentSnapshots(permanentIds, newState.projectedState)
+        } else {
+            emptyList()
+        }
+
         if (permanentIds.isNotEmpty()) {
             val permanentNames = permanentIds.map { id ->
                 newState.getEntity(id)?.get<CardComponent>()?.name ?: "Unknown"
@@ -166,5 +177,6 @@ class SacrificeExecutor(
         }
 
         return EffectResult.success(newState, events)
+            .copy(updatedSacrificedPermanents = snapshots)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -339,9 +339,11 @@ data class TriggeredAbilityFiredThisTurnComponent(
 
 /**
  * Per-permanent latch state for [com.wingedsheep.sdk.scripting.StateTriggeredAbility]
- * instances (CR 603.8d). An [AbilityId] is in [latched] iff the engine has fired this
+ * instances (CR 603.8). An [AbilityId] is in [latched] iff the engine has fired this
  * state trigger and the condition has not yet become false again — preventing repeat
- * firings while the condition stays true. The [com.wingedsheep.engine.event.StateTriggerPoller]
+ * firings while the condition stays true. (See [com.wingedsheep.sdk.scripting.StateTriggeredAbility]
+ * for why this latch resets on condition-false rather than on leaves-the-stack.)
+ * The [com.wingedsheep.engine.event.StateTriggerPoller]
  * adds the id when emitting a [com.wingedsheep.engine.event.PendingTrigger] and removes
  * it as soon as the condition next evaluates false.
  *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -338,6 +338,31 @@ data class TriggeredAbilityFiredThisTurnComponent(
 }
 
 /**
+ * Per-permanent latch state for [com.wingedsheep.sdk.scripting.StateTriggeredAbility]
+ * instances (CR 603.8d). An [AbilityId] is in [latched] iff the engine has fired this
+ * state trigger and the condition has not yet become false again — preventing repeat
+ * firings while the condition stays true. The [com.wingedsheep.engine.event.StateTriggerPoller]
+ * adds the id when emitting a [com.wingedsheep.engine.event.PendingTrigger] and removes
+ * it as soon as the condition next evaluates false.
+ *
+ * NOT cleared at end of turn — the latch follows the permanent for as long as the
+ * condition stays true, possibly across turns. Removed automatically when the entity
+ * leaves the battlefield (component lives on the entity).
+ */
+@Serializable
+data class StateTriggerLatchesComponent(
+    val latched: Set<AbilityId> = emptySet()
+) : Component {
+    fun withLatched(abilityId: AbilityId): StateTriggerLatchesComponent =
+        copy(latched = latched + abilityId)
+
+    fun withoutLatched(abilityId: AbilityId): StateTriggerLatchesComponent =
+        copy(latched = latched - abilityId)
+
+    fun isLatched(abilityId: AbilityId): Boolean = abilityId in latched
+}
+
+/**
  * Tracks how many times abilities on this permanent have resolved this turn.
  * Used for cards like Harvestrite Host: "if this is the second time this ability has resolved this turn."
  * Cleared at end of turn by CleanupPhaseManager.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DandanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DandanScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Dandân — covers the new state-triggered ability primitive (CR 603.8).
+ *
+ * Oracle:
+ *  - This creature can't attack unless defending player controls an Island.
+ *  - When you control no Islands, sacrifice this creature.
+ *
+ * The second clause is a state-triggered ability: it fires whenever the controller transitions
+ * from "controls ≥1 Island" to "controls 0 Islands". The engine's [StateTriggerPoller] polls
+ * battlefield permanents at each priority pass and emits a [PendingTrigger] for the
+ * false→true transition; the per-entity [StateTriggerLatchesComponent] prevents the trigger
+ * from re-firing every priority pass while the condition stays true.
+ */
+class DandanScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dandân — state-triggered \"sacrifice if you control no Islands\"") {
+
+            test("does not fire when controller still controls at least one Island") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dandân", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.resolveStack()
+
+                withClue("Dandân should still be on the battlefield while controller has Islands") {
+                    game.isOnBattlefield("Dandân") shouldBe true
+                }
+            }
+
+            test("fires when controller has no Islands; Dandân is sacrificed at next priority pass") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dandân", summoningSickness = false)
+                    // No Islands controlled — the state trigger should fire immediately.
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Advance through priority passes. The first priority cycle invokes the
+                // state-trigger poller, the trigger goes on the stack, and Dandân is sacrificed
+                // when it resolves.
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("Dandân's state-triggered ability should sacrifice it") {
+                    game.isOnBattlefield("Dandân") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IslandFishJasconiusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IslandFishJasconiusScenarioTest.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Island Fish Jasconius's "When you control no Islands, sacrifice ~"
+ * state-triggered ability. The doesn't-untap + upkeep-pay-to-untap clauses follow the
+ * same shape as Brass Man (covered elsewhere); this test focuses on the new primitive.
+ */
+class IslandFishJasconiusScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Island Fish Jasconius — \"sacrifice when you control no Islands\"") {
+
+            test("is sacrificed at next priority pass when controller has no Islands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Island Fish Jasconius", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("Island Fish Jasconius should be sacrificed (no Islands controlled)") {
+                    game.isOnBattlefield("Island Fish Jasconius") shouldBe false
+                }
+            }
+
+            test("stays in play while controller still controls an Island") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Island Fish Jasconius", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("Island Fish Jasconius should still be on the battlefield") {
+                    game.isOnBattlefield("Island Fish Jasconius") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MerchantShipScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MerchantShipScenarioTest.kt
@@ -9,7 +9,7 @@ import io.kotest.matchers.shouldBe
 /**
  * Scenario tests for Merchant Ship — covers the new
  * [com.wingedsheep.sdk.scripting.GameEvent.BecomesUnblockedEvent] trigger detection
- * (CR 509.7), mapped behind [com.wingedsheep.sdk.dsl.Triggers.AttacksAndIsntBlocked].
+ * (CR 509.3g), mapped behind [com.wingedsheep.sdk.dsl.Triggers.AttacksAndIsntBlocked].
  *
  * Oracle:
  *  - This creature can't attack unless defending player controls an Island.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MerchantShipScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MerchantShipScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Merchant Ship — covers the new
+ * [com.wingedsheep.sdk.scripting.GameEvent.BecomesUnblockedEvent] trigger detection
+ * (CR 509.7), mapped behind [com.wingedsheep.sdk.dsl.Triggers.AttacksAndIsntBlocked].
+ *
+ * Oracle:
+ *  - This creature can't attack unless defending player controls an Island.
+ *  - Whenever this creature attacks and isn't blocked, you gain 2 life.
+ *  - When you control no Islands, sacrifice this creature.
+ *
+ * The unblocked trigger fires once per attacker that has no blockers assigned at the end of
+ * the Declare Blockers step. The matcher reads from [BlockersDeclaredEvent]: if Merchant
+ * Ship is attacking and its id never appears in any blocker's blocked-attackers list, it
+ * triggers exactly once.
+ */
+class MerchantShipScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Merchant Ship — attacks and isn't blocked → +2 life") {
+
+            test("gains 2 life when it attacks unblocked") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Merchant Ship", summoningSickness = false)
+                    // Defender controls an Island so the attack restriction is satisfied.
+                    .withLandsOnBattlefield(2, "Island", 1)
+                    // Controller keeps an Island so the "no Islands" state trigger doesn't
+                    // sacrifice the ship before combat resolves.
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .build()
+
+                val startLife = game.getLifeTotal(1)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Merchant Ship" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                // Defender declines to block — Merchant Ship is unblocked.
+                game.declareBlockers(emptyMap()).error shouldBe null
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Merchant Ship unblocked should gain controller 2 life") {
+                    game.getLifeTotal(1) shouldBe startLife + 2
+                }
+            }
+
+            test("does not gain life when Merchant Ship is blocked") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Merchant Ship", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(2, "Island", 1)
+                    .withActivePlayer(1)
+                    .build()
+
+                val startLife = game.getLifeTotal(1)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Merchant Ship" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Grizzly Bears" to listOf("Merchant Ship"))).error shouldBe null
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Merchant Ship was blocked → no life gain") {
+                    game.getLifeTotal(1) shouldBe startLife
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StateTriggerLatchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StateTriggerLatchScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Exercises the state-trigger latch (CR 603.8) on a source that survives resolution — the
+ * one behaviour the Dandân / Island Fish Jasconius / Merchant Ship tests can't cover, since
+ * those all sacrifice their source the instant the trigger resolves.
+ *
+ * The test card has a non-self-removing state-triggered ability ("When you control no
+ * Islands, you gain 1 life"). With the condition permanently true (the controller never
+ * holds an Island), the trigger must fire exactly once across many priority passes: the
+ * [com.wingedsheep.engine.state.components.battlefield.StateTriggerLatchesComponent] latch
+ * suppresses re-firing while the condition stays true. A broken latch would re-emit the
+ * trigger at every priority check and inflate the life total well past +1.
+ */
+class StateTriggerLatchScenarioTest : ScenarioTestBase() {
+
+    private val latchTestBeast = card("Latch Test Beast") {
+        manaCost = "{2}{U}"
+        typeLine = "Creature — Beast"
+        power = 2
+        toughness = 2
+
+        stateTriggeredAbility {
+            condition = Conditions.YouControl(
+                GameObjectFilter.Land.withSubtype("Island"),
+                negate = true,
+            )
+            effect = Effects.GainLife(1, EffectTarget.Controller)
+            description = "When you control no Islands, you gain 1 life"
+        }
+    }
+
+    init {
+        cardRegistry.register(latchTestBeast)
+
+        context("State-trigger latch — fires once while the condition stays true") {
+
+            test("gains exactly 1 life despite many priority passes with no Islands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Latch Test Beast", summoningSickness = false)
+                    // Controller holds only non-Islands, so "control no Islands" is true for
+                    // the whole turn and never resets the latch.
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startLife = game.getLifeTotal(1)
+
+                // Walk all the way to end of turn: dozens of priority checks, each polling
+                // the state trigger.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("latch must let the state trigger fire exactly once, not per priority pass") {
+                    game.getLifeTotal(1) shouldBe startLife + 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds two engine primitives needed by a cluster of early-set cards, and lands three
ARN cards that compose on top of them. Branch `arn-state-trigger-no-lands` off `main`.

### Engine
- **State-triggered abilities (CR 603.8)** — new `StateTriggeredAbility` SDK type +
  `CardBuilder.stateTriggeredAbility { }` block. Engine polls each battlefield
  permanent's conditions at every priority check via a new `StateTriggerPoller` and
  emits `PendingTrigger`s on false→true transitions; a per-entity
  `StateTriggerLatchesComponent` prevents re-firing while the condition stays true
  (603.8d). `Conditions.YouControl(filter, negate = true)` for "you control no X".
- **`Triggers.AttacksAndIsntBlocked` (CR 509.7)** — new `BecomesUnblockedEvent`;
  detection piggybacks on `BlockersDeclaredEvent` (SELF attacker not in any
  blocker's blocked-attackers list). Mirrors `BecomesBlockedEvent`.
- `SacrificeExecutor` now captures permanent snapshots on the auto-sac path so
  `Conditions.SacrificedHadSubtype` works after `EffectPatterns.sacrifice(...)`.

### Cards (3 / 4 from the original batch)
- **Dandân** · **Island Fish Jasconius** · **Merchant Ship** — each with a
  scenario test and a manual `DevScenarioController` JSON for live testing.
- **Serendib Djinn deferred** — its "if you sacrifice an Island this way" clause
  still needs `SacrificeContinuation` to thread `updatedSacrificedPermanents` for
  the multi-land decision path. Tracked in `backlog/sets/arabian-nights/TODO.md`.

ARN backlog: 53 → 56 / 78.