### PR TITLE
Add Xu-Ifit, Osteoharmonist with last-known-lost-abilities for dies t…

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 251 / 261
+**Implemented:** 252 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -262,7 +262,7 @@
 - [x] Weftstalker Ardent
 - [ ] Weftwalking
 - [x] Wurmwall Sweeper
-- [ ] Xu-Ifit, Osteoharmonist
+- [x] Xu-Ifit, Osteoharmonist
 - [x] Zealous Display
 - [ ] Zero Point Ballad
 - [x] Zookeeper Mechan

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -4,7 +4,7 @@ Engine features required to implement the remaining EOE cards. Each section list
 unblocks, the exact oracle clause that can't be expressed with current primitives, and a sketch of
 the engine/SDK work needed.
 
-As of the latest pass, **251 / 261** booster cards are implemented. The cards below remain
+As of the latest pass, **252 / 261** booster cards are implemented. The cards below remain
 blocked on the engine features listed here. Cards whose every clause maps to an existing primitive
 have already been implemented and are not listed. Section numbers are preserved from earlier
 revisions of this document so that [`problem-cards.md`](problem-cards.md) cross-references stay
@@ -115,18 +115,6 @@ its mana cost."
 **Plan:** Add a static that grants free-cast permission to the first spell each player casts on each
 of their own turns (per-player, per-turn gate). The ETB "shuffle hand and graveyard into library,
 then draw seven" is already expressible.
-
----
-
-## 21. Reanimate as a typed, ability-stripped permanent
-
-**Cards:** Xu-Ifit, Osteoharmonist.
-
-**Clause:** "Return target creature card from your graveyard to the battlefield. It's a Skeleton in
-addition to its other types and has no abilities."
-
-**Plan:** Add a continuous effect, tied to the reanimated permanent, that adds the Skeleton subtype
-(layer 4) and removes all abilities (layer 6). Plain reanimation already exists.
 
 ---
 

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,9 +3,9 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (10: 3 small + 7 large)
+## Status: cards still blocked on engine work (9: 2 small + 7 large)
 
-The booster set is at **251 / 261**. The cards below are the only unimplemented ones; each is
+The booster set is at **252 / 261**. The cards below are the only unimplemented ones; each is
 blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
 summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
 parentheses).
@@ -14,13 +14,12 @@ Cards are split by the scope of the engine work each one requires. "Small" = a s
 SDK/engine addition that composes with existing primitives. "Large" = multiple coupled features,
 a new subsystem, or work that reaches across several engine layers.
 
-### Small engine work (3)
+### Small engine work (2)
 
 | Card | Blocking clause | Engine change needed (missing-effects §) |
 |------|-----------------|-------------------------------------------|
 | Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Static that grants Warp (with cost) to filtered hand cards (§15) |
 | Weftwalking | "The first spell each player casts ... may be cast without paying its mana cost" | First-spell-each-turn free-cast static, per-player gate (§20) |
-| Xu-Ifit, Osteoharmonist | reanimate "It's a Skeleton ... and has no abilities" | Continuous layer-4 add-subtype + layer-6 strip-abilities tied to one permanent (§21) |
 
 ### Large engine work (7)
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/XuIfitOsteoharmonist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/XuIfitOsteoharmonist.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+
+/**
+ * Xu-Ifit, Osteoharmonist
+ * {1}{B}{B}
+ * Legendary Creature — Human Wizard
+ * 2/3
+ * {T}: Return target creature card from your graveyard to the battlefield. It's a Skeleton
+ *      in addition to its other types and has no abilities. Activate only as a sorcery.
+ *
+ * The rider is two `Duration.Permanent` floating effects keyed to the reanimated entity
+ * (layer-4 add-subtype + layer-6 strip-abilities), appended after `PutOntoBattlefield`.
+ * They expire when the entity leaves the battlefield, so a later return is a new object
+ * without the rider (CR 400.7). The engine separately suppresses the entity's own
+ * dies / leaves-battlefield triggers while the strip is in effect (CR 603.10a).
+ */
+val XuIfitOsteoharmonist = card("Xu-Ifit, Osteoharmonist") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "{T}: Return target creature card from your graveyard to the battlefield. " +
+        "It's a Skeleton in addition to its other types and has no abilities. " +
+        "Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = CompositeEffect(
+            listOf(
+                Effects.PutOntoBattlefield(creature),
+                Effects.AddCreatureType(Subtype.SKELETON.value, creature, Duration.Permanent),
+                Effects.RemoveAllAbilities(creature, Duration.Permanent),
+            )
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "127"
+        artist = "Michal Ivan"
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0838f25-2193-4305-b73a-bf0c0bb4981a.jpg?1752947068"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -65,6 +65,14 @@ data class ZoneChangeEvent(
     /** Last known projected keywords when leaving battlefield (for trigger filters needing keyword info after death) */
     val lastKnownKeywords: Set<String> = emptySet(),
     /**
+     * True if the leaving entity had its abilities stripped (via a layer-6 `RemoveAllAbilities`
+     * floating effect) at the moment it left the battlefield. CR 603.10a — leaves-the-battlefield
+     * triggers look back in time at the object's appearance immediately prior to the event — so
+     * the dies / leaves-battlefield detector reads this snapshot, not the (now-cleared) projected
+     * `lostAllAbilities` flag.
+     */
+    val lastKnownLostAllAbilities: Boolean = false,
+    /**
      * Last-known counter map (counter-type-string → count) when leaving the battlefield.
      * Used by triggers that move every counter (e.g., Essence Channeler), not just one
      * specific kind. Counter-type strings match the wire format used on counter effects

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
@@ -57,6 +57,12 @@ class DeathAndLeaveTriggerDetector(
         event: ZoneChangeEvent,
         triggers: MutableList<PendingTrigger>
     ) {
+        // The entity had its abilities stripped at leaving time (e.g. Xu-Ifit's
+        // "It's a Skeleton ... and has no abilities" rider). Its own dies triggers don't
+        // fire. Other creatures' "Whenever a creature dies" triggers are detected from
+        // their own sources elsewhere, so they're unaffected by this short-circuit.
+        if (event.lastKnownLostAllAbilities) return
+
         val entityId = event.entityId
         val info = resolveDyingEntity(state, event) ?: return
 
@@ -134,6 +140,11 @@ class DeathAndLeaveTriggerDetector(
             // Skip if this creature is still on the battlefield (already handled by main loop)
             if (deadEntityId in state.getBattlefield()) continue
 
+            // Skip creatures whose abilities were stripped at leaving time (Xu-Ifit's
+            // ability-stripped reanimate target contributes no triggers of its own even
+            // when it dies alongside other creatures).
+            if (deadEvent.lastKnownLostAllAbilities) continue
+
             val info = resolveDyingEntity(state, deadEvent) ?: continue
 
             val abilities = abilityResolver.getTriggeredAbilities(deadEntityId, info.cardDefinitionId, state)
@@ -172,6 +183,11 @@ class DeathAndLeaveTriggerDetector(
         event: ZoneChangeEvent,
         triggers: MutableList<PendingTrigger>
     ) {
+        // An aura whose abilities were stripped at leaving time (e.g. via a Xu-Ifit-shaped
+        // reanimate on an aura, or Humility-style suppression in effect at LTB) contributes
+        // no attached zone-change triggers.
+        if (event.lastKnownLostAllAbilities) return
+
         val attachedEntityId = event.lastKnownAttachedTo ?: return
 
         val auraEntityId = event.entityId
@@ -314,6 +330,10 @@ class DeathAndLeaveTriggerDetector(
         event: ZoneChangeEvent,
         triggers: MutableList<PendingTrigger>
     ) {
+        // See [detectDeathTriggers]: an entity that lost all its abilities at leaving time
+        // contributes no SELF/ANY leaves-battlefield triggers from itself.
+        if (event.lastKnownLostAllAbilities) return
+
         val entityId = event.entityId
         val info = resolveDyingEntity(state, event) ?: return
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -146,6 +146,7 @@ object ZoneTransitionService {
         var lastKnownToughness: Int? = null
         var lastKnownTypeLine: TypeLine? = null
         var lastKnownKeywords: Set<String> = emptySet()
+        var lastKnownLostAllAbilities = false
         var lastKnownAttachedTo = options.lastKnownAttachedTo
         var lastKnownWasToken = false
         var lastKnownDamageDealtByPlayers: Map<EntityId, Int> = emptyMap()
@@ -172,6 +173,10 @@ object ZoneTransitionService {
             // Capture projected keywords so dies/leaves triggers can check keyword filters
             // (e.g., Jackdaw Savior: "whenever a creature you control with flying dies").
             lastKnownKeywords = projected.getKeywords(entityId)
+            // Capture whether the entity had its abilities stripped at leaving time so the
+            // dies / leaves-battlefield detectors can suppress the entity's own triggers
+            // (e.g., Xu-Ifit reanimating Festering Goblin without its "When this dies" trigger).
+            lastKnownLostAllAbilities = projected.hasLostAllAbilities(entityId)
             if (lastKnownAttachedTo == null) {
                 lastKnownAttachedTo = container.get<AttachedToComponent>()?.targetId
             }
@@ -378,6 +383,7 @@ object ZoneTransitionService {
                 lastKnownToughness = lastKnownToughness,
                 lastKnownTypeLine = lastKnownTypeLine,
                 lastKnownKeywords = lastKnownKeywords,
+                lastKnownLostAllAbilities = lastKnownLostAllAbilities,
                 lastKnownAttachedTo = if (leavingBattlefield) lastKnownAttachedTo else null,
                 lastKnownCardDefinitionId = if (leavingBattlefield) cardComponent.cardDefinitionId else null,
                 lastKnownDamageDealtByPlayers = lastKnownDamageDealtByPlayers

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/XuIfitOsteoharmonistTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/XuIfitOsteoharmonistTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Xu-Ifit, Osteoharmonist (EOE).
+ *
+ * "{T}: Return target creature card from your graveyard to the battlefield. It's a Skeleton
+ *  in addition to its other types and has no abilities. Activate only as a sorcery."
+ *
+ * Pins two guarantees of the reanimate-with-ability-strip pattern:
+ *  1. The reanimated permanent gains the Skeleton subtype (layer 4) and loses all abilities
+ *     (layer 6), while keeping its other creature types.
+ *  2. Its OWN dies / leaves-battlefield triggers do NOT fire when it later leaves the
+ *     battlefield (CR 603.10a — leaves-the-battlefield triggers look back in time at the
+ *     object's appearance immediately prior to the event; with abilities stripped at LTB,
+ *     there are no triggered abilities to fire).
+ *
+ * Festering Goblin is the canonical case: a 1/1 with "When Festering Goblin dies, target
+ * creature gets -1/-1 until end of turn."
+ */
+class XuIfitOsteoharmonistTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Xu-Ifit, Osteoharmonist") {
+
+            test("reanimates a creature card as a Skeleton with no abilities") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Xu-Ifit, Osteoharmonist")
+                    .withCardInGraveyard(1, "Festering Goblin")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val xuIfit = game.findPermanent("Xu-Ifit, Osteoharmonist")!!
+                val festeringGoblin = game.state.getGraveyard(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Festering Goblin"
+                }
+                val abilityId = cardRegistry.getCard("Xu-Ifit, Osteoharmonist")!!
+                    .script.activatedAbilities.first().id
+
+                val activate = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = xuIfit,
+                        abilityId = abilityId,
+                        targets = listOf(
+                            ChosenTarget.Card(festeringGoblin, game.player1Id, Zone.GRAVEYARD)
+                        )
+                    )
+                )
+                withClue("Activating Xu-Ifit's reanimate ability should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                game.resolveStack()
+
+                game.isOnBattlefield("Festering Goblin") shouldBe true
+
+                val reanimated = game.findPermanent("Festering Goblin")!!
+                val projected = stateProjector.project(game.state)
+
+                withClue("reanimated creature is a Skeleton (layer 4 add-subtype)") {
+                    projected.hasSubtype(reanimated, Subtype.SKELETON.value) shouldBe true
+                }
+                withClue("reanimated creature retains its other creature types") {
+                    // Festering Goblin is printed as Zombie Goblin — both subtypes survive.
+                    projected.hasSubtype(reanimated, "Zombie") shouldBe true
+                    projected.hasSubtype(reanimated, "Goblin") shouldBe true
+                }
+                withClue("reanimated creature has no abilities (layer 6 strip)") {
+                    projected.hasLostAllAbilities(reanimated) shouldBe true
+                }
+            }
+
+            test("reanimated creature's own dies trigger does not fire (CR 603.10a)") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Xu-Ifit, Osteoharmonist")
+                    .withCardInGraveyard(1, "Festering Goblin")
+                    // Witness: Festering Goblin's dies trigger reads "target creature gets
+                    // -1/-1 until end of turn". If it fired against this 2/2 the projected
+                    // power would drop to 1.
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val xuIfit = game.findPermanent("Xu-Ifit, Osteoharmonist")!!
+                val grizzly = game.findPermanent("Grizzly Bears")!!
+                val festeringGoblin = game.state.getGraveyard(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Festering Goblin"
+                }
+                val abilityId = cardRegistry.getCard("Xu-Ifit, Osteoharmonist")!!
+                    .script.activatedAbilities.first().id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = xuIfit,
+                        abilityId = abilityId,
+                        targets = listOf(
+                            ChosenTarget.Card(festeringGoblin, game.player1Id, Zone.GRAVEYARD)
+                        )
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val reanimated = game.findPermanent("Festering Goblin")!!
+
+                // Lightning Bolt sends the reanimated 1/1 to the graveyard.
+                game.castSpell(1, "Lightning Bolt", reanimated).error shouldBe null
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Festering Goblin") shouldBe true
+
+                withClue(
+                    "Festering Goblin's 'When this dies' trigger must NOT fire — its abilities " +
+                        "were stripped at LTB, and CR 603.10a evaluates leaves-the-battlefield " +
+                        "triggers against the object's appearance immediately prior to the event."
+                ) {
+                    game.state.stack.isEmpty() shouldBe true
+                }
+                withClue("Grizzly Bears must not have been shrunk by a (suppressed) dies trigger") {
+                    val projected = stateProjector.project(game.state)
+                    projected.getPower(grizzly) shouldBe 2
+                    projected.getToughness(grizzly) shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…riggers

{T}: Reanimate a creature card from your graveyard; it's a Skeleton in addition to its other types and has no abilities; activate only as a sorcery. Composes PutOntoBattlefield → AddCreatureType(Skeleton, Permanent) → RemoveAllAbilities(Permanent).

The straight composition wasn't enough on its own: RemoveAllAbilities is a layer-6 floating effect, and ZoneTransitionService strips an entity's floating effects on the way out (CR 400.7), so dies/leaves-battlefield triggers were still firing for the reanimated permanent because the projected lostAllAbilities flag had already vanished by detection time.

This change captures `projected.hasLostAllAbilities(entityId)` before the move and surfaces it as `ZoneChangeEvent.lastKnownLostAllAbilities`. DeathAndLeaveTriggerDetector now short-circuits SELF/ANY triggers from the leaving entity (in detectDeathTriggers, detectLeavesBattlefieldTriggers, detectSimultaneousDeathTriggers, and detectDeadAuraAttachmentTriggers) when the flag is set, so Festering Goblin reanimated by Xu-Ifit no longer fires its "When this dies" trigger. The "look back in time" behavior this implements is CR 603.10a. Resolves missing-effects §21.

Scenario coverage: XuIfitOsteoharmonistTest pins (a) reanimation grants Skeleton + sets lostAllAbilities while keeping the original Zombie/Goblin subtypes, and (b) the reanimated Festering Goblin's dies trigger does not fire when killed (witnessed by a Grizzly Bears that stays 2/2).