### PR TITLE
Add Mox Jasper and Stormbeacon Blade to Tarkir: Dragonstorm

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1704,6 +1704,9 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
 ### Battlefield state
 
 - `YouControl(filter)` — you control ≥1 matching permanent.
+- `YouControlAtLeast(count, filter)` — you control `count` or more matching permanents (the
+  filtered-count generalization of `ControlCreaturesAtLeast`/`ControlLandsAtLeast`; e.g.
+  `YouControlAtLeast(3, GameObjectFilter.Creature.attacking())` for Stormbeacon Blade).
 - `ControlCreature` — you control any creature.
 - `ControlMoreCreatures` — you control more creatures than each opponent.
 - `OpponentControlsCreature` — at least one opponent has a creature.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -181,6 +181,21 @@ object Conditions {
         )
 
     /**
+     * If you control [count] or more permanents matching [filter].
+     *
+     * The general-purpose filtered-count form of [ControlCreaturesAtLeast] /
+     * [ControlLandsAtLeast] — pass any [GameObjectFilter] (e.g.
+     * `GameObjectFilter.Creature.attacking()` for "three or more attacking creatures",
+     * Stormbeacon Blade). [YouControl] checks mere existence; this counts the group.
+     */
+    fun YouControlAtLeast(count: Int, filter: GameObjectFilter): ConditionInterface =
+        Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, filter),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(count)
+        )
+
+    /**
      * If [count] or more different kinds of counters are among permanents you control matching
      * [filter] (default: creatures). Counts distinct counter kinds across the whole group — a
      * +1/+1 and a finality counter on two creatures is two kinds; the same kind on several

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MoxJasper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MoxJasper.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Mox Jasper — Tarkir: Dragonstorm #246
+ * {0} · Legendary Artifact
+ *
+ * {T}: Add one mana of any color. Activate only if you control a Dragon.
+ *
+ * A classic Mox shell with a Dragon-tribal gate: the tap-for-any-color mana ability via
+ * [Effects.AddAnyColorMana] is fenced behind an [ActivationRestriction.OnlyIfCondition]
+ * checking "you control a Dragon" — modeled with the general-purpose
+ * [Conditions.ControlCreatureOfType] existence check over Dragon permanents, so the gate
+ * re-evaluates each time the ability is offered (and disappears if the last Dragon leaves).
+ */
+val MoxJasper = card("Mox Jasper") {
+    manaCost = "{0}"
+    typeLine = "Legendary Artifact"
+    oracleText = "{T}: Add one mana of any color. Activate only if you control a Dragon."
+
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddAnyColorMana(1)
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.ControlCreatureOfType(Subtype.DRAGON)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "246"
+        artist = "Steven Belledin"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a851d2d3-7e93-4887-bee5-4d6c9aaf9419.jpg?1743204975"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormbeaconBlade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormbeaconBlade.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 
@@ -18,7 +19,7 @@ import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
  * Whenever equipped creature attacks, draw a card if you control three or more attacking creatures.
  * Equip {2}
  *
- * Standard Equipment shell: the +3/+0 is a [Effects.ModifyStats] static over
+ * Standard Equipment shell: the +3/+0 is a [ModifyStats] static over
  * [Filters.EquippedCreature]; equip via [card.equipAbility]. The attack trigger uses
  * `Triggers.attacks(binding = ATTACHED)` ("equipped creature attacks") and gates the draw
  * with an intervening-if condition — [Conditions.YouControlAtLeast] over attacking creatures
@@ -34,8 +35,7 @@ val StormbeaconBlade = card("Stormbeacon Blade") {
         "Equip {2}"
 
     staticAbility {
-        effect = Effects.ModifyStats(+3, 0)
-        filter = Filters.EquippedCreature
+        ability = ModifyStats(+3, 0, Filters.EquippedCreature)
     }
 
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormbeaconBlade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormbeaconBlade.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Stormbeacon Blade — Tarkir: Dragonstorm #27
+ * {1}{W} · Artifact — Equipment
+ *
+ * Equipped creature gets +3/+0.
+ * Whenever equipped creature attacks, draw a card if you control three or more attacking creatures.
+ * Equip {2}
+ *
+ * Standard Equipment shell: the +3/+0 is a [Effects.ModifyStats] static over
+ * [Filters.EquippedCreature]; equip via [card.equipAbility]. The attack trigger uses
+ * `Triggers.attacks(binding = ATTACHED)` ("equipped creature attacks") and gates the draw
+ * with an intervening-if condition — [Conditions.YouControlAtLeast] over attacking creatures
+ * — so the draw only happens when three or more of your creatures are attacking (evaluated as
+ * the triggered ability resolves, no `elseEffect`).
+ */
+val StormbeaconBlade = card("Stormbeacon Blade") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +3/+0.\n" +
+        "Whenever equipped creature attacks, draw a card if you control three or more attacking creatures.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        effect = Effects.ModifyStats(+3, 0)
+        filter = Filters.EquippedCreature
+    }
+
+    triggeredAbility {
+        trigger = Triggers.attacks(binding = TriggerBinding.ATTACHED)
+        effect = ConditionalEffect(
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Creature.attacking()),
+            effect = Effects.DrawCards(1)
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "27"
+        artist = "Jorge Jacinto"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2f12684-c80a-422b-9c3f-ed4f31742b9d.jpg?1743204061"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormbeaconBladeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormbeaconBladeScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.StormbeaconBlade
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Stormbeacon Blade.
+ *
+ * Stormbeacon Blade ({1}{W}): Artifact — Equipment
+ *   "Equipped creature gets +3/+0.
+ *    Whenever equipped creature attacks, draw a card if you control three or more attacking creatures.
+ *    Equip {2}"
+ *
+ * Exercises the new [com.wingedsheep.sdk.dsl.Conditions.YouControlAtLeast] filtered-count
+ * condition over attacking creatures: the attack trigger always fires, but the draw is gated on
+ * three or more of your creatures attacking when it resolves.
+ */
+class StormbeaconBladeScenarioTest : FunSpec({
+
+    val Bear = CardDefinition.creature(
+        name = "Stormbeacon Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2,
+        oracleText = ""
+    )
+
+    fun GameTestDriver.putEquipmentAttached(
+        playerId: EntityId,
+        cardName: String,
+        targetCreatureId: EntityId
+    ): EntityId {
+        val equipmentId = putPermanentOnBattlefield(playerId, cardName)
+        var newState = state.updateEntity(equipmentId) { c -> c.with(AttachedToComponent(targetCreatureId)) }
+        val existing = newState.getEntity(targetCreatureId)
+            ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(targetCreatureId) { c ->
+            c.with(AttachmentsComponent(existing + equipmentId))
+        }
+        replaceState(newState)
+        return equipmentId
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Bear, StormbeaconBlade))
+        return driver
+    }
+
+    val stateProjector = StateProjector()
+
+    test("equipped creature gets +3/+0") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(player, "Stormbeacon Bear")
+        driver.putEquipmentAttached(player, "Stormbeacon Blade", bear)
+
+        val projected = stateProjector.project(driver.state)
+        projected.getPower(bear) shouldBe 5   // 2 + 3
+        projected.getToughness(bear) shouldBe 2 // unchanged
+    }
+
+    test("draws a card when three or more creatures attack") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val defender = driver.getOpponent(player)
+
+        val equipped = driver.putCreatureOnBattlefield(player, "Stormbeacon Bear")
+        val bear2 = driver.putCreatureOnBattlefield(player, "Stormbeacon Bear")
+        val bear3 = driver.putCreatureOnBattlefield(player, "Stormbeacon Bear")
+        listOf(equipped, bear2, bear3).forEach { driver.removeSummoningSickness(it) }
+        driver.putEquipmentAttached(player, "Stormbeacon Blade", equipped)
+
+        val handBefore = driver.getHandSize(player)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(equipped, bear2, bear3), defender)
+        // Resolve the attack trigger.
+        repeat(8) { driver.bothPass() }
+
+        driver.getHandSize(player) shouldBe handBefore + 1
+    }
+
+    test("does not draw when fewer than three creatures attack") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val defender = driver.getOpponent(player)
+
+        val equipped = driver.putCreatureOnBattlefield(player, "Stormbeacon Bear")
+        val bear2 = driver.putCreatureOnBattlefield(player, "Stormbeacon Bear")
+        listOf(equipped, bear2).forEach { driver.removeSummoningSickness(it) }
+        driver.putEquipmentAttached(player, "Stormbeacon Blade", equipped)
+
+        val handBefore = driver.getHandSize(player)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(equipped, bear2), defender)
+        repeat(8) { driver.bothPass() }
+
+        // Only two attackers — the intervening-if fails, so no card is drawn.
+        driver.getHandSize(player) shouldBe handBefore
+    }
+})


### PR DESCRIPTION
Implements two TDM cards. (Two other assigned cards — Glacial Dragonhunt and Rite of Renewal — were already implemented and committed on `main` by other work, so they're omitted here.)

## Cards

### Mox Jasper — {0} Legendary Artifact (#246, mythic)
`{T}: Add one mana of any color. Activate only if you control a Dragon.`

A classic Mox shell with a Dragon-tribal gate. The tap-for-any-color mana ability (`Effects.AddAnyColorMana(1)`) is fenced behind `ActivationRestriction.OnlyIfCondition(Conditions.ControlCreatureOfType(DRAGON))`, so the gate re-evaluates each time the ability is offered and disappears if the last Dragon leaves. Composed entirely from existing primitives — no scenario test required.

### Stormbeacon Blade — {1}{W} Artifact — Equipment (#27, uncommon)
```
Equipped creature gets +3/+0.
Whenever equipped creature attacks, draw a card if you control three or more attacking creatures.
Equip {2}
```

- `+3/+0` via `Effects.ModifyStats` over `Filters.EquippedCreature`; equip `{2}`.
- The attack trigger uses `Triggers.attacks(binding = ATTACHED)` and gates the draw with an intervening-if condition evaluated at resolution.

## SDK addition
- `Conditions.YouControlAtLeast(count, filter)` — the filtered-count generalization of the existing `ControlCreaturesAtLeast` / `ControlLandsAtLeast`. Used here as `YouControlAtLeast(3, Creature.attacking())`. DSL reference updated in the same change.

## Tests
`StormbeaconBladeScenarioTest` (rules-engine) covers the +3/+0 buff, the draw firing with three attackers, and no draw with only two — exercising both sides of the new condition. All three pass; `SetLoaderTest` confirms both cards discover and serialize cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)