### PR TITLE
Add Craterhoof Behemoth and Magmatic Hellkite to Tarkir: Dragonstorm

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2377,12 +2377,15 @@ Counter effects live in §4 (`AddCounters`, `RemoveCounters`, `Proliferate`, `Mo
   rest"). Each restriction also exposes a boolean flag on `SelectCardsDecision` (`onePerBasicLandType`, …) so the UI
   can disable redundant picks.
   - `chooser` (`Chooser`, default `Controller`) — who makes the selection: `Controller`, `Opponent`, `TargetPlayer`
-    (`context.targets[0]`), `TriggeringPlayer`, `SourceController` (the source's controller, ignoring per-iteration
-    swaps), or `ControllerOfSelection` (the controller of the cards in `from` — resolved from the first card's
-    projected controller). Use `ControllerOfSelection` for "their controller chooses…" where the deciding player is
-    whoever controls the gathered cards and may be you or an opponent (Barrin's Spite: gather the two targeted
-    creatures, their controller sacrifices one, the other is returned to hand). The same `chooser` set is accepted by
-    `ChoosePileEffect`.
+    (`context.targets[0]` treated as the player), `TriggeringPlayer`, `SourceController` (the source's controller,
+    ignoring per-iteration swaps), `ControllerOfSelection` (the controller of the cards in `from` — resolved from the
+    first card's projected controller), or `ControllerOfTarget` (the controller of the targeted *permanent*,
+    `context.targets[0]`, falling back to its owner once it has left the battlefield). Use `ControllerOfSelection` for
+    "their controller chooses…" where the deciding player is whoever controls the gathered cards and may be you or an
+    opponent (Barrin's Spite: gather the two targeted creatures, their controller sacrifices one, the other is returned
+    to hand). Use `ControllerOfTarget` for "destroy target permanent. Its controller searches/chooses…" where the
+    targeted permanent's controller performs a follow-up (Magmatic Hellkite: destroy target nonbasic land, *its
+    controller* searches for a basic). The same `chooser` set is accepted by `ChoosePileEffect`.
 
 **Linked exile**
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -412,7 +412,18 @@ enum class Chooser {
      * first card in the source collection. Used by Barrin's Spite ("their controller
      * chooses and sacrifices one of them").
      */
-    ControllerOfSelection
+    ControllerOfSelection,
+
+    /**
+     * The controller of the targeted permanent (`context.targets[0]`) decides — distinct
+     * from [TargetPlayer], which treats the target itself as the deciding player. Resolves
+     * through the target's `ControllerComponent`, falling back to its owner when the
+     * permanent has already left the battlefield (e.g. it was destroyed earlier in the same
+     * resolution). Used by "destroy target permanent. Its controller searches their
+     * library…"-style effects (Magmatic Hellkite), where the destroyed permanent's
+     * controller performs a follow-up search/choice.
+     */
+    ControllerOfTarget
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CraterhoofBehemoth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CraterhoofBehemoth.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Craterhoof Behemoth — Avacyn Restored #172 (canonical printing)
+ * {5}{G}{G}{G} · Creature — Beast · Mythic
+ * 5/5
+ *
+ * Haste
+ * When this creature enters, creatures you control gain trample and get +X/+X until end of
+ * turn, where X is the number of creatures you control.
+ *
+ * X is locked in at resolution as the number of creatures you control (which already
+ * includes Craterhoof itself, since it is on the battlefield when the ability resolves).
+ * Both the keyword grant and the stat boost apply to every creature you control at that
+ * time via [EffectPatterns] group helpers (each iterates the projected battlefield), so a
+ * creature that enters after resolution is unaffected.
+ */
+val CraterhoofBehemoth = card("Craterhoof Behemoth") {
+    manaCost = "{5}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 5
+    oracleText = "Haste\n" +
+        "When this creature enters, creatures you control gain trample and get +X/+X until " +
+        "end of turn, where X is the number of creatures you control."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.grantKeywordToAll(Keyword.TRAMPLE, Filters.Group.creaturesYouControl)
+            .then(
+                EffectPatterns.modifyStatsForAll(
+                    DynamicAmounts.creaturesYouControl(),
+                    DynamicAmounts.creaturesYouControl(),
+                    Filters.Group.creaturesYouControl
+                )
+            )
+        description = "creatures you control gain trample and get +X/+X until end of turn, " +
+            "where X is the number of creatures you control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "172"
+        artist = "Chris Rahn"
+        flavorText = "Its footsteps of today are the lakes of tomorrow."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a249be17-73ed-4108-89c0-f7e87939beb8.jpg?1592709311"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/InnistradRemasteredSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/InnistradRemasteredSet.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.inr
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
 
 /**
  * Innistrad Remastered (2025)
@@ -19,6 +20,10 @@ object InnistradRemasteredSet : MtgSet {
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }
 
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.inr.cards"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CraterhoofBehemothReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CraterhoofBehemothReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Craterhoof Behemoth reprint in Innistrad Remastered (#480). Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Avacyn Restored set's `cards/`
+ * package; this file contributes only presentation data.
+ */
+val CraterhoofBehemothReprint = Printing(
+    oracleId = "8c52bd39-0586-48ca-b263-17210cf9feb6",
+    name = "Craterhoof Behemoth",
+    setCode = "INR",
+    collectorNumber = "480",
+    scryfallId = "777bb4ba-a821-4a83-a9e2-8827e7eff98f",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/777bb4ba-a821-4a83-a9e2-8827e7eff98f.jpg?1736551389",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CraterhoofBehemothReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CraterhoofBehemothReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Craterhoof Behemoth reprint in Tarkir: Dragonstorm (#138). Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Avacyn Restored set's `cards/`
+ * package; this file contributes only presentation data.
+ */
+val CraterhoofBehemothReprint = Printing(
+    oracleId = "8c52bd39-0586-48ca-b263-17210cf9feb6",
+    name = "Craterhoof Behemoth",
+    setCode = "TDM",
+    collectorNumber = "138",
+    scryfallId = "276f5cee-a501-4658-bd4d-7a044bf1ccbc",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/276f5cee-a501-4658-bd4d-7a044bf1ccbc.jpg?1743204520",
+    releaseDate = "2025-04-11",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MagmaticHellkite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MagmaticHellkite.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Magmatic Hellkite — Tarkir: Dragonstorm #111
+ * {2}{R}{R} · Creature — Dragon · Rare
+ * 4/5
+ *
+ * Flying
+ * When this creature enters, destroy target nonbasic land an opponent controls. Its
+ * controller searches their library for a basic land card, puts it onto the battlefield
+ * tapped with a stun counter on it, then shuffles.
+ *
+ * The "compensating ramp" is performed by the destroyed land's controller, not by the
+ * Hellkite's controller. Modeled as an atomic Gather -> Select -> Move pipeline scoped to
+ * that opponent via [Player.ControllerOf] / [Chooser.TargetPlayer] / [EffectTarget.TargetController]:
+ *  - Destroy the targeted land first.
+ *  - Gather basic lands from *the land controller's* library (after destruction the
+ *    relational player reference falls back to the land's owner, which for a land equals
+ *    its controller, so the correct opponent still searches).
+ *  - That player selects up to one (a search may always fail to find — CR 701.18c).
+ *  - The chosen basic enters *their* battlefield tapped with a stun counter via
+ *    [MoveCollectionEffect.addCounterType].
+ *  - Then that player shuffles.
+ */
+val MagmaticHellkite = card("Magmatic Hellkite") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When this creature enters, destroy target nonbasic land an opponent controls. Its " +
+        "controller searches their library for a basic land card, puts it onto the battlefield " +
+        "tapped with a stun counter on it, then shuffles."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val land = target(
+            "nonbasic land an opponent controls",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.IsLand,
+                            CardPredicate.Not(CardPredicate.IsBasicLand),
+                        )
+                    )
+                ).opponentControls()
+            )
+        )
+
+        // The land controller (target[0]'s controller) ramps a basic, tapped, stunned.
+        val landController = Player.ControllerOf("nonbasic land an opponent controls")
+
+        effect = Effects.Destroy(land)
+            .then(
+                CompositeEffect(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(Zone.LIBRARY, landController, GameObjectFilter.BasicLand),
+                            storeAs = "rampLands"
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "rampLands",
+                            selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                            chooser = Chooser.ControllerOfTarget,
+                            storeSelected = "rampChosen"
+                        ),
+                        MoveCollectionEffect(
+                            from = "rampChosen",
+                            destination = CardDestination.ToZone(
+                                Zone.BATTLEFIELD,
+                                landController,
+                                ZonePlacement.Tapped
+                            ),
+                            addCounterType = CounterType.STUN
+                        ),
+                        ShuffleLibraryEffect(target = EffectTarget.TargetController),
+                    )
+                )
+            )
+        description = "destroy target nonbasic land an opponent controls. Its controller searches " +
+            "their library for a basic land card, puts it onto the battlefield tapped with a stun " +
+            "counter on it, then shuffles."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "111"
+        artist = "Tyler Walpole"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3b3aec8-d931-4c7f-86b5-1e7dfb717b59.jpg?1743204407"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChoosePileExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChoosePileExecutor.kt
@@ -54,6 +54,14 @@ class ChoosePileExecutor : EffectExecutor<ChoosePileEffect> {
                     ?: state.getEntity(deriveFrom)?.get<ControllerComponent>()?.playerId
                     ?: return EffectResult.error(state, "Could not resolve controller for ChoosePile ControllerOfSelection chooser")
             }
+            Chooser.ControllerOfTarget -> {
+                val targetId = context.targets.firstOrNull()?.let {
+                    TargetResolutionUtils.run { it.toEntityId() }
+                } ?: return EffectResult.error(state, "No target for ChoosePile ControllerOfTarget chooser")
+                state.getEntity(targetId)?.get<ControllerComponent>()?.playerId
+                    ?: state.getEntity(targetId)?.get<CardComponent>()?.ownerId
+                    ?: return EffectResult.error(state, "Could not resolve controller for ChoosePile ControllerOfTarget chooser")
+            }
         }
 
         val sourceName = context.sourceId?.let { sourceId ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -105,6 +105,16 @@ class SelectFromCollectionExecutor : EffectExecutor<SelectFromCollectionEffect> 
                     ?: state.getEntity(deriveFrom)?.get<ControllerComponent>()?.playerId
                     ?: return EffectResult.error(state, "Could not resolve controller for ControllerOfSelection chooser")
             }
+            Chooser.ControllerOfTarget -> {
+                val targetId = context.targets.firstOrNull()?.let {
+                    TargetResolutionUtils.run { it.toEntityId() }
+                } ?: return EffectResult.error(state, "No target for ControllerOfTarget chooser")
+                // Controller of the targeted permanent; fall back to its owner once it has
+                // left the battlefield (e.g. destroyed earlier in the same resolution).
+                state.getEntity(targetId)?.get<ControllerComponent>()?.playerId
+                    ?: state.getEntity(targetId)?.get<CardComponent>()?.ownerId
+                    ?: return EffectResult.error(state, "Could not resolve controller for ControllerOfTarget chooser")
+            }
         }
 
         // OnePerColor(matchControllerPermanentColors = true) narrows eligibility to

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CraterhoofBehemothScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CraterhoofBehemothScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Craterhoof Behemoth (canonical printing: Avacyn Restored #172).
+ *
+ * {5}{G}{G}{G} · Creature — Beast · 5/5 · Haste
+ * "When this creature enters, creatures you control gain trample and get +X/+X until end
+ * of turn, where X is the number of creatures you control."
+ *
+ * Exercises the ETB trigger: every creature the controller has (including Craterhoof
+ * itself) gains trample and +X/+X, where X is locked in at resolution as the controller's
+ * creature count. Opponent creatures are untouched.
+ */
+class CraterhoofBehemothScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("ETB pumps all creatures you control by the creature count and grants trample") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            skipMulligans = true
+        )
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two of my creatures already in play, plus an opponent creature.
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val lions = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+        val theirBears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        // Cast Craterhoof Behemoth — once it resolves there are three of my creatures
+        // (Bears, Lions, Craterhoof), so X = 3.
+        val hoof = driver.putCardInHand(me, "Craterhoof Behemoth")
+        driver.giveMana(me, Color.GREEN, 8)
+        driver.castSpell(me, hoof)
+        driver.bothPass() // resolve the creature spell (ETB trigger goes on the stack)
+        driver.bothPass() // resolve the ETB trigger
+
+        val hoofId = driver.findPermanent(me, "Craterhoof Behemoth")!!
+
+        // X = 3: my creatures get +3/+3 and trample.
+        projector.getProjectedPower(driver.state, bears) shouldBe 5
+        projector.getProjectedToughness(driver.state, bears) shouldBe 5
+        projector.getProjectedPower(driver.state, lions) shouldBe 4
+        projector.getProjectedToughness(driver.state, lions) shouldBe 4
+        projector.getProjectedPower(driver.state, hoofId) shouldBe 8
+        projector.getProjectedToughness(driver.state, hoofId) shouldBe 8
+
+        projector.hasProjectedKeyword(driver.state, bears, Keyword.TRAMPLE) shouldBe true
+        projector.hasProjectedKeyword(driver.state, lions, Keyword.TRAMPLE) shouldBe true
+        projector.hasProjectedKeyword(driver.state, hoofId, Keyword.TRAMPLE) shouldBe true
+        // Haste is intrinsic to Craterhoof.
+        projector.hasProjectedKeyword(driver.state, hoofId, Keyword.HASTE) shouldBe true
+
+        // Opponent's creature is untouched.
+        projector.getProjectedPower(driver.state, theirBears) shouldBe 2
+        projector.getProjectedToughness(driver.state, theirBears) shouldBe 2
+        projector.hasProjectedKeyword(driver.state, theirBears, Keyword.TRAMPLE) shouldBe false
+    }
+
+    test("ETB with no other creatures still pumps Craterhoof itself by 1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            skipMulligans = true
+        )
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val hoof = driver.putCardInHand(me, "Craterhoof Behemoth")
+        driver.giveMana(me, Color.GREEN, 8)
+        driver.castSpell(me, hoof)
+        driver.bothPass()
+        driver.bothPass()
+
+        val hoofId = driver.findPermanent(me, "Craterhoof Behemoth")!!
+
+        // Only creature is Craterhoof, so X = 1: 5/5 -> 6/6 with trample.
+        projector.getProjectedPower(driver.state, hoofId) shouldBe 6
+        projector.getProjectedToughness(driver.state, hoofId) shouldBe 6
+        projector.hasProjectedKeyword(driver.state, hoofId, Keyword.TRAMPLE) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagmaticHellkiteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagmaticHellkiteScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Magmatic Hellkite (TDM #111).
+ *
+ * "Flying. When this creature enters, destroy target nonbasic land an opponent controls.
+ *  Its controller searches their library for a basic land card, puts it onto the battlefield
+ *  tapped with a stun counter on it, then shuffles."
+ *
+ * Verifies the opponent-scoped compensating-ramp pipeline:
+ *  - the targeted nonbasic land is destroyed,
+ *  - the land's controller (the opponent, not the Hellkite's controller) finds a basic and
+ *    puts it onto *their* battlefield tapped with a stun counter.
+ */
+class MagmaticHellkiteScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Magmatic Hellkite ETB") {
+
+            test("destroys opponent's nonbasic land and ramps them a tapped, stunned basic") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Magmatic Hellkite")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    // Opponent controls a nonbasic land + has a basic in their library to ramp.
+                    .withCardOnBattlefield(2, "Bloodfell Caves")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val me = game.player1Id
+                val opponent = game.player2Id
+                val nonbasic = game.findPermanent("Bloodfell Caves")!!
+
+                game.castSpell(1, "Magmatic Hellkite").error shouldBe null
+                game.resolveStack() // Hellkite enters → ETB trigger on stack, asks for a target land
+
+                withClue("ETB trigger should prompt to target the opponent's nonbasic land") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(nonbasic)).error shouldBe null
+                game.resolveStack() // trigger resolves: destroy + opponent search prompt
+
+                // The opponent now selects a basic from their library.
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision()
+                    val options = (decision as? com.wingedsheep.engine.core.SelectCardsDecision)?.options
+                        ?: emptyList()
+                    if (options.isNotEmpty()) {
+                        game.selectCards(listOf(options.first()))
+                    } else {
+                        game.skipSelection()
+                    }
+                    game.resolveStack()
+                }
+
+                withClue("The targeted nonbasic land should be destroyed") {
+                    game.findPermanent("Bloodfell Caves") shouldBe null
+                    game.findCardsInGraveyard(2, "Bloodfell Caves").size shouldBe 1
+                }
+
+                val forestId = game.findPermanents("Forest").singleOrNull()
+                withClue("The opponent should have searched up a Forest onto the battlefield") {
+                    (forestId != null) shouldBe true
+                }
+                withClue("The Forest enters under the opponent's control, not the caster's") {
+                    game.state.getEntity(forestId!!)?.get<ControllerComponent>()?.playerId shouldBe opponent
+                }
+                withClue("The Forest enters tapped") {
+                    (game.state.getEntity(forestId!!)?.get<TappedComponent>() != null) shouldBe true
+                }
+                withClue("The Forest enters with a stun counter") {
+                    game.state.getEntity(forestId!!)?.get<CountersComponent>()
+                        ?.getCount(CounterType.STUN) shouldBe 1
+                }
+                withClue("The Forest left the opponent's library") {
+                    game.findCardsInLibrary(2, "Forest").size shouldBe 0
+                }
+                // The Hellkite's controller gained nothing on their own battlefield.
+                withClue("No Forest under the caster's control") {
+                    game.findPermanents("Forest").none {
+                        game.state.getEntity(it)?.get<ControllerComponent>()?.playerId == me
+                    } shouldBe true
+                }
+            }
+
+            test("destroys the land even when the opponent has no basic to find") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Magmatic Hellkite")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardOnBattlefield(2, "Bloodfell Caves")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val nonbasic = game.findPermanent("Bloodfell Caves")!!
+
+                game.castSpell(1, "Magmatic Hellkite").error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(nonbasic)).error shouldBe null
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+
+                withClue("The land is destroyed regardless of whether a basic was found") {
+                    game.findPermanent("Bloodfell Caves") shouldBe null
+                }
+                withClue("No basic appeared since the library had none") {
+                    game.findPermanents("Forest").isEmpty() shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds two Tarkir: Dragonstorm cards.

## Craterhoof Behemoth
- `{5}{G}{G}{G}` 5/5 Beast, Haste. ETB: creatures you control gain trample and get +X/+X until end of turn, where X = creatures you control.
- Canonical `CardDefinition` placed in its earliest real printing, **Avacyn Restored** (#172), per the reprint rules. `Printing` rows added for the **Innistrad Remastered** (#480) and **Tarkir: Dragonstorm** (#138) reprints (and the INR set got its missing `printings` wiring).
- ETB composes existing atoms: `EffectPatterns.grantKeywordToAll(TRAMPLE, creaturesYouControl)` + `modifyStatsForAll(creaturesYouControl, creaturesYouControl)`. X is locked in at resolution (Craterhoof counts itself).
- Scenario tests cover the multi-creature pump+trample (including Craterhoof itself, opponent creatures untouched) and the lone-Craterhoof case (X=1).

## Magmatic Hellkite
- `{2}{R}{R}` 4/5 Dragon, Flying. ETB: destroy target nonbasic land an opponent controls; **its controller** searches their library for a basic land, puts it onto the battlefield tapped with a stun counter, then shuffles.
- Modeled as an atomic Gather -> Select -> Move pipeline scoped to the destroyed land's controller (the opponent) via `Player.ControllerOf` / `EffectTarget.TargetController`.
- Required one small, reusable SDK addition: **`Chooser.ControllerOfTarget`** — the controller of the targeted permanent makes the selection (distinct from `TargetPlayer`, which treats the target itself as the player; falls back to the owner once the permanent has left the battlefield). Wired into the `SelectFromCollection` and `ChoosePile` executors and documented in the SDK reference.
- Scenario tests cover the full ramp (land destroyed; opponent's basic enters tapped + stunned under the opponent's control, not the caster's) and the no-basic-to-find case (land still destroyed).

## Notes
- **Dragon's Prey** and **Winternight Stories** (also in the original assignment) were already implemented and committed on `main`, so no work was needed there.
- `just build` and the full `:rules-engine:test` suite pass; `just check-card-printing` is clean for both new cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)