### PR TITLE
Default deckbuilder to plain frame, not showcase/borderless variants

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/PrintingsController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/PrintingsController.kt
@@ -82,11 +82,15 @@ class PrintingsController(
     /**
      * Newest-first by release date — what a deckbuilder picker should show at the top.
      * Printings missing a release date sort last (matches [PrintingRegistry.defaultPrinting]).
-     * Tiebreaker on `(setCode, collectorNumber)` for a stable, deterministic order.
+     * Within a release date the plain (non-alternate-frame) printing sorts ahead of its
+     * showcase/borderless variants, so the set-filter art override picks the normal printing
+     * and the picker lists the standard frame first. Final tiebreaker on
+     * `(setCode, collectorNumber)` for a stable, deterministic order.
      */
     private val printingOrder: Comparator<Printing> =
         compareBy<Printing> { it.releaseDate == null }
             .thenByDescending { it.releaseDate ?: "" }
+            .thenBy { it.isAlternateFrame }
             .thenBy { it.setCode }
             .thenBy { it.collectorNumber }
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/controller/PrintingsControllerTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/controller/PrintingsControllerTest.kt
@@ -58,6 +58,46 @@ class PrintingsControllerTest : FunSpec({
         body.first().imageUri shouldBe "https://img/2x2.jpg"
     }
 
+    test("GET /api/cards/{name}/printings orders the plain frame ahead of same-set variants") {
+        // A set ships a normal printing plus showcase/borderless variants on the same release
+        // date. The plain printing must lead so the deckbuilder's set-filter art override picks
+        // it (it takes the first match for the set) and the picker lists the standard frame first.
+        val printings = PrintingRegistry().apply {
+            register(Printing(
+                oracleId = "bolt-oracle",
+                name = "Lightning Bolt",
+                setCode = "ECL",
+                collectorNumber = "300",
+                imageUri = "https://img/ecl-showcase.jpg",
+                releaseDate = "2026-01-23",
+                frameEffects = listOf("showcase"),
+            ))
+            register(Printing(
+                oracleId = "bolt-oracle",
+                name = "Lightning Bolt",
+                setCode = "ECL",
+                collectorNumber = "350",
+                imageUri = "https://img/ecl-borderless.jpg",
+                releaseDate = "2026-01-23",
+                borderColor = "borderless",
+            ))
+            register(Printing(
+                oracleId = "bolt-oracle",
+                name = "Lightning Bolt",
+                setCode = "ECL",
+                collectorNumber = "120",
+                imageUri = "https://img/ecl-plain.jpg",
+                releaseDate = "2026-01-23",
+            ))
+        }
+        val controller = PrintingsController(registry, printings)
+
+        val body = controller.getPrintingsForCard("Lightning Bolt").body.shouldNotBeNull()
+
+        body.first().collectorNumber shouldBe "120"
+        body.first().imageUri shouldBe "https://img/ecl-plain.jpg"
+    }
+
     test("GET /api/cards/{name}/printings falls back to a synthesised default when registry is empty") {
         // No printing rows wired — the controller has to derive one from the CardDefinition's
         // own setCode + metadata so the picker still surfaces a usable option.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/PrintingRegistry.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/PrintingRegistry.kt
@@ -91,18 +91,23 @@ class PrintingRegistry {
 
     /**
      * Default printing for a card name. Newest by `releaseDate` (lexicographic ISO date),
-     * with printings missing a release date sorted last. When all candidates lack a date,
-     * the first-registered one wins. Returns null if no printings are known for that name.
+     * with printings missing a release date sorted last. Within the same release date, the
+     * plain (non-alternate-frame) printing wins so the deckbuilder catalog never defaults to
+     * a showcase/borderless variant — players still reach those through the printing picker.
+     * When all candidates lack a date, the first-registered one wins. Returns null if no
+     * printings are known for that name.
      */
     fun defaultPrinting(name: String): Printing? {
         val candidates = byName[name] ?: return null
         if (candidates.isEmpty()) return null
-        // Sort: dated entries first by descending date, undated last in registration order.
+        // Sort: dated entries first by descending date, plain frames before alternate frames,
+        // undated last in registration order.
         return candidates
             .withIndex()
             .sortedWith(
                 compareBy<IndexedValue<Printing>> { it.value.releaseDate == null }
                     .thenByDescending { it.value.releaseDate ?: "" }
+                    .thenBy { it.value.isAlternateFrame }
                     .thenBy { it.index }
             )
             .first()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/registry/PrintingRegistryTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/registry/PrintingRegistryTest.kt
@@ -59,6 +59,30 @@ class PrintingRegistryTest : FunSpec({
         registry.defaultPrinting("Lightning Bolt")?.setCode shouldBe "2X2"
     }
 
+    test("defaultPrinting prefers the plain frame over a same-set alternate-frame variant") {
+        val registry = PrintingRegistry()
+        // Showcase variant registered first to prove order doesn't decide it.
+        val showcase = bolt("ECL", "300", releaseDate = "2026-01-23")
+            .copy(frameEffects = listOf("showcase"))
+        val borderless = bolt("ECL", "350", releaseDate = "2026-01-23")
+            .copy(borderColor = "borderless")
+        val plain = bolt("ECL", "120", releaseDate = "2026-01-23")
+        registry.register(listOf(showcase, borderless, plain))
+
+        registry.defaultPrinting("Lightning Bolt") shouldBe plain
+    }
+
+    test("defaultPrinting still picks the newest set even when only its variant is alternate-frame") {
+        val registry = PrintingRegistry()
+        val oldPlain = bolt("M10", "146", releaseDate = "2009-07-17")
+        val newShowcase = bolt("ECL", "300", releaseDate = "2026-01-23")
+            .copy(frameEffects = listOf("showcase"))
+        registry.register(listOf(oldPlain, newShowcase))
+
+        // Release date dominates the alternate-frame tiebreaker: the newer set still wins.
+        registry.defaultPrinting("Lightning Bolt") shouldBe newShowcase
+    }
+
     test("defaultPrinting falls back to first-registered when dates are missing") {
         val registry = PrintingRegistry()
         val first = bolt("M10", "146")


### PR DESCRIPTION
## Problem

The recent showcase/borderless booster-variant work registers alternate-frame printings alongside each card's normal printing. In the deckbuilder, those variants could surface as the **default** — both as the catalog grid thumbnail and as the art chosen by the `s:`/`set:` filter override. Players expect the standard printing by default and to reach showcase/borderless versions deliberately through the printing picker.

## Fix

Add `Printing.isAlternateFrame` as a sort tiebreaker in the two places that decide a card's default printing — positioned **after** release date but **before** the existing registration-order / `(setCode, collectorNumber)` fallbacks:

- `PrintingRegistry.defaultPrinting` — the catalog grid thumbnail.
- `PrintingsController.printingOrder` — drives the set-filter art override's first-match `.find()` and the picker's list order (so the picker now lists the standard frame first; all variants remain selectable).

Release date still dominates, so the newest set wins even when only its variant is alternate-frame; the new tiebreaker only separates printings sharing a release date. No frontend change needed — the override and picker both consume server ordering.

## Tests

- `PrintingRegistryTest`: plain frame beats same-set showcase/borderless; newer set still wins when only its printing is a variant.
- `PrintingsControllerTest`: `/api/cards/{name}/printings` lists the plain frame first across same-set variants.

`./gradlew :rules-engine:test --tests PrintingRegistryTest :game-server:test --tests PrintingsControllerTest` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)