### PR TITLE
Scaffold TMT set + implement 96/190 cards

### DIFF
--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -27,8 +27,12 @@ The remaining 94 cards mostly cluster on a handful of unresolved gaps:
 - **Vehicles / Crew** — 1 card left (Gap J — partly cleared; `Turtle Blimp`
   shipped composably, `Turtle Van` still waits on Gap LL "creature that
   crewed this vehicle this turn" tracking)
-- **Sagas** — 2 cards (Gap K)
-- Plus various one-offs from Gaps M and N–LL
+- **Sagas** — 2 cards (Gap K — Saga primitive is wired, but each TMT Saga
+  has its own separate blocker: `The Cloning of Shredder` → Gap MM
+  `addedSubtypes` on `CreateTokenCopyOfTarget`; `The Last Ronin` → Gap AA
+  "Mill X. When you do, …" sub-trigger + Gap NN "attacks alone this turn"
+  trigger condition)
+- Plus various one-offs from Gaps M and N–NN
 
 Gaps **resolved across the runs so far**:
 - **Gap C — Alliance (partly cleared)**: 6 of the 10 Alliance cards (`East
@@ -107,6 +111,14 @@ Gaps **resolved across the runs so far**:
   N)` — same shape DOM Weatherlight / BLC Rolling Hamsphere. The Vehicle
   pipeline (artifact-becomes-artifact-creature-UEOT + Crew activation) is
   fully wired. `Turtle Van` waits on Gap LL, not on Vehicle itself.
+- **Gap K — Sagas — RESOLVED at the primitive level**: the
+  `sagaChapter(N) { … }` DSL on `CardBuilder` already wires lore counters,
+  per-chapter effects, and the after-last-chapter sacrifice. Confirmed via
+  SPM Origin of Spider-Man. No TMT Saga has shipped because each carries
+  an additional unresolved primitive: `The Cloning of Shredder` →
+  `addedSubtypes` on `CreateTokenCopyOfTarget` (Gap MM); `The Last Ronin`
+  → Gap AA's "When you do" sub-trigger and a new "attacks alone this
+  turn" trigger condition (Gap NN).
 
 ## Data sources — do NOT hit the network
 
@@ -289,11 +301,26 @@ Weatherlight and BLC Rolling Hamsphere ship.
 - **Turtle Van** — still blocked, but on Gap LL ("creature that crewed this
   Vehicle this turn" filter), *not* on Vehicle itself.
 
-### Gap K — Sagas — 2 cards
-**Engine change:** Sagas with chapter abilities. Earlier sets (Dominaria, LTR) already
-have Saga support; verify it's still functional and the chapter DSL is reachable.
-- **The Cloning of Shredder**, **The Last Ronin** — chapter abilities only; no new
-  Saga primitives expected.
+### Gap K — Sagas — RESOLVED at the primitive level
+**Engine change:** none. The `sagaChapter(N) { … }` DSL on `CardBuilder`
+already wires the full Saga pipeline — lore counters on enter and after
+your draw step, per-chapter effect groups, sacrifice after the last
+chapter. Confirmed via SPM Origin of Spider-Man.
+
+Both TMT Sagas remain unchecked because each carries a *separate* blocker
+beyond Saga itself:
+- **The Cloning of Shredder** — Chapter I needs an *added* subtype on
+  `CreateTokenCopyOfTarget` ("is a Mutant in addition to its other types").
+  Today the API has `overrideSubtypes` (replaces wholesale) and
+  `addedKeywords` / `addedSupertypes` / `removedSupertypes` but no
+  `addedSubtypes`. Chapters II/III also need a "card exiled with this Saga"
+  target reading from `CardSource.FromLinkedExile`.
+- **The Last Ronin** — Chapter II needs the "Mill four. When you do,
+  return target creature card" sub-trigger (Gap AA shape). Chapter III
+  needs an "attacks alone this turn" trigger condition plus a delayed
+  UEOT counters+trample+lifelink+indestructible rider. (Earlier skip-log
+  entries listed this card as also Sneak — wrong; its only keyword is
+  `Mill`, and Mill keyword itself is already supported.)
 
 ### Gap L — Landfall, Fight, Mill keyword, basic-land-cycling — partly RESOLVED
 **Engine change:** none for Landfall + basic-land-cycling (both shipped). Fight
@@ -539,6 +566,33 @@ helper.
   paired with a `ConditionalEffect` on a subtype filter — only the crewers-
   this-turn target is missing.)
 
+### Gap MM — `addedSubtypes` on `CreateTokenCopyOfTarget` (and friends)
+**Engine change:** add an `addedSubtypes: Set<Subtype>` parameter to
+`CreateTokenCopyOfTargetEffect` (and the equivalent on
+`CreateTokenCopyOfSourceEffect`). Today the API has `overrideSubtypes`
+(replaces wholesale) and `addedKeywords` / `addedSupertypes` /
+`removedSupertypes` but no symmetrical *adder* for subtypes — so wordings
+like "in addition to its other types" against a copied permanent can't be
+expressed faithfully on the token's printed type line.
+- **The Cloning of Shredder** — "Create a token that's a copy of it, except
+  it isn't legendary and is a Mutant in addition to its other types."
+  Chapters II/III repeat the same rider against a card exiled with the
+  Saga (also needs `CardSource.FromLinkedExile` plumbing into the chapter's
+  target / pipeline).
+
+### Gap NN — "attacks alone this turn" trigger condition + delayed UEOT bundle
+**Engine change:** a triggered ability that fires when a single attacker is
+declared *and no other creature is attacking at the same time*, plus the
+"this turn" persistence (the trigger needs to keep firing for the rest of
+the turn, not just on a single declare-attackers step). Or model it as a
+turn-long delayed-trigger registered on the Saga's chapter resolution that
+listens for attacks-alone events until end of turn.
+- **The Last Ronin** — Chapter III: "Whenever a creature you control
+  attacks alone this turn, put three +1/+1 counters on it. It gains
+  trample, lifelink, and indestructible until end of turn." The counter +
+  triple-keyword rider already composes via AddCounters + a chain of
+  GrantKeyword(EndOfTurn) calls — only the trigger shape is missing.
+
 ---
 
 ## Composable — deferred for time
@@ -643,8 +697,8 @@ the top of the Status section for what closed those.
 | Splinter's Technique                  | Gap A (Sneak)                               |
 | Splinter, Hamato Yoshi                | Gap A (Sneak)                               |
 | Technodrome                           | "Can't attack or block unless its power is 6 or greater" — Gap O-shape on self |
-| The Cloning of Shredder               | Gap K (Saga)                                |
-| The Last Ronin                        | Gap K (Saga) + Gap A (Sneak)                |
+| The Cloning of Shredder               | Gap MM (addedSubtypes on CreateTokenCopy)   |
+| The Last Ronin                        | Gap AA (Mill-X-then-when-you-do) + Gap NN (attacks-alone trigger) |
 | The Last Ronin's Technique            | Gap A (Sneak) + sneak-was-paid token rider  |
 | The Neutrinos                         | Gap C (Alliance)                            |
 | The Ooze                              | Gap W (Mutagen) + dies-with-counter trigger |

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,13 +10,16 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-1 / 190 implemented (basics excluded — handled by `basicLandsFallback`).
+27 / 190 implemented (basics excluded — handled by `basicLandsFallback`).
 
-Implemented today:
-- **Raph & Mikey, Troublemakers** — Trample/haste + attack-trigger reveal-until-creature
-  into play tapped-and-attacking. Composes existing primitives only
-  (`Triggers.Attacks`, `GatherUntilMatchEffect`, `MoveCollectionEffect`,
-  `FilterCollectionEffect`, `RevealCollectionEffect`).
+Implemented so far (alphabetical):
+Agent Bishop · Man in Black, Anchovy & Banana Pizza, April · Reporter of the Weird,
+Armaggon · Future Shark, Bespoke Bō, Bot Bashing Time, Buzz Bots, Casey Jones ·
+Jury-Rig Justiciar, Cowabunga!, Death in the Family, Dimension X, Donatello · Turtle
+Techie, Donatello · Way with Machines, Dream Beavers, Featherbrained Filcher, Foot
+Headquarters, Frog Butler, Guac & Marshmallow Pizza, Hamato Guardian Stance,
+Hard-Won Jitte, Henchbots, High-Flying Ace, Ice Cream Kitty, Illegitimate Business,
+Mutant Town, Raph & Mikey · Troublemakers, TCRI Building.
 
 New-mechanic work blocks the bulk of the set: 26 cards wait on Sneak, 9 on Disappear,
 10 on Alliance. See "Engine gaps blocking the remaining cards" below.
@@ -237,3 +240,193 @@ Each is its own PR; they don't share a clean reusable gap with others.
   tapped-and-attacking; condition is the new piece.
 
 (Continue listing as `add-card` discovers more during implementation.)
+
+---
+
+## New engine gaps discovered during implementation
+
+These were found while walking the alphabetical card list. Each is one card today
+unless noted; group with Gap M if they stay solo, lift to their own gap if more
+cards turn up wanting the same primitive.
+
+### Gap N — distinct-card-types-among-spells-cast-this-turn dynamic amount
+**Engine change:** add `DynamicAmount.DistinctCardTypesAmongSpellsCastByYouThisTurn`
+(or a parameterized aggregator over the existing spell-cast-this-turn log).
+- **April O'Neil, Hacktivist** — end step: "draw a card for each card type among
+  spells you've cast this turn."
+
+### Gap O — "can't be blocked by creatures with power N or greater"
+**Engine change:** a static / target-filtered evasion gating creatures by power.
+The blocking-static plumbing exists (`BlockingStaticAbilities.kt`); generalize to
+read the blocker's projected power.
+- **April O'Neil, Kunoichi Trainee** — "can't be blocked by creatures with power
+  3 or greater."
+
+### Gap P — "unless you discard a card" cost-mitigation rider
+**Engine change:** a triggered-ability shape that says "sacrifice X unless you
+[pay alternate cost]," where the player chooses on resolution.
+- **Bebop & Rocksteady** — "Whenever Bebop & Rocksteady attack or block, sacrifice
+  a permanent unless you discard a card."
+
+### Gap Q — graveyard reanimate as a typed-override token
+**Engine change:** a return-from-graveyard variant that puts the card on the
+battlefield as if it were a token with overridden card types, P/T, color, and
+granted keywords. Different from current copy-with-overrides (which targets a
+permanent in play) — this overrides a card on its way out of the graveyard.
+- **Brilliance Unleashed** — second mode: non-artifact-creature artifact card
+  comes back as "a 3/3 Robot artifact creature with flying."
+
+### Gap R — gain control of all matching permanents UEOT + untap + grant haste
+**Engine change:** a bulk gain-control effect over a filter (all artifacts an
+opponent controls), composed with Untap and GrantKeyword(HASTE, UEOT). Existing
+gain-control primitives are single-target (LTR Gap 37 covers duration-based).
+- **Broadcast Takeover** — "Gain control of all artifacts your opponents control
+  until end of turn. Untap them. They gain haste until end of turn."
+
+### Gap S — delayed trigger "at the beginning of your NEXT upkeep"
+**Engine change:** delayed-trigger plumbing for "next" timing windows (not the
+end-of-turn cleanup the engine already wires up).
+- **Casey Jones, Vigilante** — ETB draw 3, then "at the beginning of your next
+  upkeep, discard three cards at random."
+
+### Gap T — copy-an-artifact-token with sacrifice at the next end step
+**Engine change:** activated "create a token that's a copy of target artifact you
+control" + "sacrifice it at the beginning of the next end step." Existing
+token-copy effects are creature-typed and don't carry a self-sac timer.
+- **Chrome Dome** — "{5}: Create a token that's a copy of another target artifact
+  you control. That token gains haste. Sacrifice it at the beginning of the next
+  end step."
+
+### Gap U — Class enchantments (level-up subtype) — 2 cards
+**Engine change:** the Class card type (Strixhaven CR 716) — sorcery-speed
+level-up costs, per-level static/triggered abilities, "becomes level N" trigger.
+Likely a sizable build; coordinates with future Strixhaven / Adventures in the
+Forgotten Realms work.
+- **Cool but Rude** — Class with 3 levels.
+- **Does Machines** — Class with 2 levels.
+
+### Gap V — search-or-fail conditional ETB effect
+**Engine change:** an "ETB: search library for X; if no X is put into hand this
+way, create a Y token" composite. Composes existing primitives but needs the
+post-search "did anything land in hand" condition exposed.
+- **Courier of Comestibles** — "search your library for a Food card …; if you
+  don't put a card into your hand this way, create a Food token."
+
+### Gap W — Mutagen token (artifact token with an activated counter ability)
+**Engine change:** generic "create a Mutagen token" facade — an artifact token
+with "{1}, {T}, Sacrifice: put a +1/+1 counter on target creature. Activate only
+as a sorcery." Several cards reference it; once defined, they're all composable.
+- **Crustacean Commando** — "create a Mutagen token."
+- **Genghis Frog** — "Whenever … another Mutant you control enters, create a
+  Mutagen token."
+
+### Gap X — flicker a pair (artifact + creature) and return together
+**Engine change:** an exile-and-return effect that takes two targets and returns
+both at the same time (so synchronous ETB triggers see each other).
+- **Don & Leo, Problem Solvers** — "exile up to one target artifact you control
+  and up to one target creature you control. Then return them to the battlefield
+  under their owners' control."
+
+### Gap Y — grant a keyword (Affinity) to the next spell of a kind you cast
+**Engine change:** a delayed continuous effect that watches the next noncreature
+spell cast by you this turn and grants it Affinity-for-artifacts at cast time.
+Different from cost-reduction-this-turn auras because the granted ability fires
+at the *next-cast* moment with a specific filter.
+- **Don & Raph, Hard Science** — "the next noncreature spell you cast this turn
+  has affinity for artifacts."
+
+### Gap Z — "an artifact entered the battlefield under your control this turn"
+**Engine change:** per-controller "has X entered this turn" tracking that
+includes artifacts (and ideally lands/creatures), and a `Condition` reading it
+for static unblockability. Adjacent to the `nonlandPermanentLeftBattlefield`
+plumbing but on the *entered* side.
+- **Fugitive Droid** — "This creature can't be blocked if an artifact entered
+  the battlefield under your control this turn." Second ability ("counter target
+  spell that targets an artifact or creature you control") also needs a target-
+  spell-targets-filter check that the engine doesn't expose generically yet.
+
+### Gap AA — "when you do" sub-trigger off an optional sacrifice
+**Engine change:** the "may [cost]. When you do, [effect]" two-step pattern,
+where the inner trigger only fires if the optional cost was paid.
+- **General Traag, Heart of Stone** — "you may sacrifice another artifact. When
+  you do, General Traag deals 4 damage to target creature."
+
+### Gap BB — "damage equal to the greatest power among creatures you control"
+**Engine change:** `DynamicAmount.GreatestPowerAmong(filter)` (and the
+single-creature filter for "the creature with the greatest power"). Read via
+projected state. Pairs with several existing damage effects via
+`Effects.DealDamage(dynamicAmount, target)`.
+- **Go Ninja Go** — Mode 2: "deals damage equal to the greatest power among
+  creatures you control to target creature an opponent controls."
+
+### Gap CC — "Whenever you tap a land for mana, add X" trigger
+**Engine change:** a triggered ability on mana abilities — the trigger fires
+when the player taps a land specifically *to add mana*, not every time it
+becomes tapped.
+- **Groundchuck & Dirtbag** — "Whenever you tap a land for mana, add {G}."
+
+### Gap DD — cost reduction conditioned on target's state
+**Engine change:** spell-cost discount evaluated against the spell's intended
+target (a tapped creature here). Different from "if you control X" reductions
+because the predicate reads the chosen target during cast.
+- **Grounded for Life** — "This spell costs {3} less to cast if it targets a
+  tapped creature."
+
+---
+
+## Composable — deferred for time
+
+These cards appear to compose from primitives the engine already has, but were
+skipped during the alphabetical first pass to keep pace. Pick them up next.
+
+- **Baxter Stockman** — ETB Robot token + begin-combat pump on target artifact
+  creature you control. Needs an inline `TargetFilter(GameObjectFilter(
+  cardPredicates = [IsCreature, IsArtifact]).youControl())`.
+- **Bebop, Warthog Warrior** — Menace + "Rhinos you control have menace" anthem
+  + Swampcycling {2}. All primitives exist; Swampcycling uses
+  `KeywordAbility.Cycling(searchFilter = …, displayPrefix = "Swampcycling")`.
+- **Dimensional Exile** — Aura "enchant basic land you control" with ETB exile
+  target creature until LTB. Need the basic-land-you-control aura target.
+- **Foot Elite** — attack-trigger pump "+1/+0 and gains indestructible UEOT" on
+  a target creature you control. Composes ModifyStats + GrantKeyword
+  (INDESTRUCTIBLE, EndOfTurn).
+
+---
+
+## Skip log — cards inspected and skipped (alphabetical)
+
+Each row is a card encountered during the alphabetical pass that was not
+implemented in this session, with the underlying blocker. Gaps reference the
+sections above (existing Gap A–M or the new Gap N–DD).
+
+| Card                                  | Blocker / Gap                               |
+|---------------------------------------|---------------------------------------------|
+| Action News Crew                      | Gap D (Channel)                             |
+| April O'Neil, Hacktivist              | Gap N (card-types-cast amount)              |
+| April O'Neil, Kunoichi Trainee        | Gap O (can't-be-blocked-by-power)           |
+| Baxter Stockman                       | Composable — deferred                       |
+| Bebop & Rocksteady                    | Gap P (unless-you-discard rider)            |
+| Bebop, Warthog Warrior                | Composable — deferred                       |
+| Brilliance Unleashed                  | Gap Q (typed-override reanimate token)      |
+| Broadcast Takeover                    | Gap R (mass gain-control UEOT)              |
+| Casey Jones, Vigilante                | Gap S (delayed next-upkeep trigger)         |
+| Chrome Dome                           | Gap T (copy-artifact + next-end-step sac)   |
+| Cool but Rude                         | Gap U (Class)                               |
+| Courier of Comestibles                | Gap V (search-or-fail-then-token)           |
+| Crustacean Commando                   | Gap W (Mutagen token)                       |
+| Dark Leo & Shredder                   | Gap A (Sneak)                               |
+| Dimensional Exile                     | Composable — deferred                       |
+| Does Machines                         | Gap U (Class)                               |
+| Don & Leo, Problem Solvers            | Gap X (paired flicker)                      |
+| Don & Raph, Hard Science              | Gap Y (grant Affinity to next spell)        |
+| Donatello's Technique                 | Gap A (Sneak)                               |
+| Donatello, Gadget Master              | Gap A (Sneak) + token-with-overrides        |
+| Donatello, Mutant Mechanic            | Gap M (Pizza-Face-style type-grant)         |
+| Foot Elite                            | Composable — deferred                       |
+| Foot Ninjas                           | Gap A (Sneak)                               |
+| Fugitive Droid                        | Gap Z (artifact-ETB-this-turn + sac-counter)|
+| General Traag, Heart of Stone         | Gap AA (when-you-do sub-trigger)            |
+| Genghis Frog                          | Gap W (Mutagen token)                       |
+| Go Ninja Go                           | Gap BB (greatest-power-among amount)        |
+| Groundchuck & Dirtbag                 | Gap CC (tap-land-for-mana trigger)          |
+| Grounded for Life                     | Gap DD (cost reduction if target tapped)    |

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,11 +10,11 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-95 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+96 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist; the per-card commits on `tmt-scaffolding`
 all carry `flavorText` in metadata.
 
-The remaining 95 cards mostly cluster on a handful of unresolved gaps:
+The remaining 94 cards mostly cluster on a handful of unresolved gaps:
 - **Sneak** — 26 cards (Gap A — unresolved)
 - **Disappear** — 9 cards (Gap B — unresolved)
 - **Alliance** — 4 cards left (Gap C — partly cleared; 6 shipped composably,
@@ -24,9 +24,11 @@ The remaining 95 cards mostly cluster on a handful of unresolved gaps:
   Neutrinos` listed once). Pure Alliance is no longer a blocker on its own.
 - **Class** — 3 cards (Gap U — unresolved)
 - **Mutagen token consumers** — ~5 cards (Gap W — unresolved)
-- **Vehicles / Crew** — 2 cards (Gap J)
+- **Vehicles / Crew** — 1 card left (Gap J — partly cleared; `Turtle Blimp`
+  shipped composably, `Turtle Van` still waits on Gap LL "creature that
+  crewed this vehicle this turn" tracking)
 - **Sagas** — 2 cards (Gap K)
-- Plus various one-offs from Gaps M and N–KK
+- Plus various one-offs from Gaps M and N–LL
 
 Gaps **resolved across the runs so far**:
 - **Gap C — Alliance (partly cleared)**: 6 of the 10 Alliance cards (`East
@@ -95,6 +97,16 @@ Gaps **resolved across the runs so far**:
   turn"* intervening-if approximated by `oncePerTurn = true`. The
   approximation is documented in the file's docstring; swap for
   `Conditions.IsFirstCombatPhase` when that primitive lands.
+- **Gap I — double the number of +1/+1 counters — RESOLVED at the primitive
+  level**: `Effects.DoubleCounters(Counters.PLUS_ONE_PLUS_ONE, target)`
+  already exists (Sage of the Fang shape). Turtle Van's "double the
+  counters" rider composes today; the only outstanding piece is Gap LL
+  below (crewed-this-turn filter).
+- **Gap J — Crew / Vehicle — partly cleared**: `Turtle Blimp` shipped via
+  `typeLine = "Artifact — Vehicle"` + `KeywordAbility.Numeric(Keyword.CREW,
+  N)` — same shape DOM Weatherlight / BLC Rolling Hamsphere. The Vehicle
+  pipeline (artifact-becomes-artifact-creature-UEOT + Crew activation) is
+  fully wired. `Turtle Van` waits on Gap LL, not on Vehicle itself.
 
 ## Data sources — do NOT hit the network
 
@@ -261,18 +273,21 @@ hooks skip.
 **Engine change:** none — the existing `KeywordAbility.Affinity(CardType.ARTIFACT)`
 already works. Shipped as `Krang, Master Mind`.
 
-### Gap I — "double the number of +1/+1 counters" — 1 card
-**Engine change:** an effect that doubles the count of a chosen counter kind on a
-target permanent (CR 121.3 — places that many additional counters).
-- **Turtle Van** — "double the number of +1/+1 counters on it" if the buffed creature
-  is Mutant/Ninja/Turtle. Composes with the existing `put +1/+1 counter` effect.
+### Gap I — "double the number of +1/+1 counters" — RESOLVED at the primitive level
+**Engine change:** none — `Effects.DoubleCounters(counterType = Counters
+.PLUS_ONE_PLUS_ONE, target)` already exists (Sage of the Fang shape). The
+only card that needed this in TMT was `Turtle Van`, whose ship still waits
+on the separate Gap LL "crewed-this-turn" filter (see below).
 
-### Gap J — Crew / Vehicle — 2 cards
-**Engine change:** Vehicle card type + Crew N (tap any combination of creatures with total
-power ≥ N to turn the artifact into an artifact-creature until end of turn). `Keyword.CREW`
-exists, but the artifact-becomes-artifact-creature behavior and the Vehicle card type need
-to be wired. (Coordinates with LTR Gap 31.)
-- **Turtle Blimp**, **Turtle Van**
+### Gap J — Crew / Vehicle — partly RESOLVED
+**Engine change:** none for the baseline mechanic. `typeLine = "Artifact —
+Vehicle"` + `keywordAbility(KeywordAbility.Numeric(Keyword.CREW, N))` already
+wires the full pipeline (artifact-becomes-artifact-creature-UEOT, Crew
+activation tapping a combined-power-N pile of creatures). Same shape DOM
+Weatherlight and BLC Rolling Hamsphere ship.
+- **Turtle Blimp** — shipped composably.
+- **Turtle Van** — still blocked, but on Gap LL ("creature that crewed this
+  Vehicle this turn" filter), *not* on Vehicle itself.
 
 ### Gap K — Sagas — 2 cards
 **Engine change:** Sagas with chapter abilities. Earlier sets (Dominaria, LTR) already
@@ -507,6 +522,23 @@ variant that permits *any* activated ability (not just artifact-source).
 - **Purple Dragon Punks** — "{T}: Add {R}. Spend this mana only to cast an
   artifact spell or to activate an ability."
 
+### Gap LL — "creature that crewed this Vehicle this turn" filter
+**Engine change:** per-Vehicle tracking of which creatures tapped to crew it
+each turn, plus a `TargetFilter` (or `GameObjectFilter` predicate) that reads
+the tracking. Today's `Keyword.CREW` pipeline taps the chosen creatures and
+flips the Vehicle to an artifact-creature, but it doesn't surface "the list
+of creatures that crewed it this turn" anywhere; without that, "target
+creature that crewed it this turn" can't be expressed. The natural shape is
+a `CrewersThisTurnComponent` on the Vehicle (cleared at cleanup with the
+existing per-turn flags), plus a `TargetFilter.CreatureThatCrewedSelfThisTurn`
+helper.
+- **Turtle Van** — "Whenever this Vehicle attacks, put a +1/+1 counter on
+  target creature that crewed it this turn. Then if that creature is a
+  Mutant, Ninja, or Turtle, double the number of +1/+1 counters on it."
+  (The "double the counters" rider already composes via `Effects.DoubleCounters`
+  paired with a `ConditionalEffect` on a subtype filter — only the crewers-
+  this-turn target is missing.)
+
 ---
 
 ## Composable — deferred for time
@@ -618,9 +650,8 @@ the top of the Status section for what closed those.
 | The Ooze                              | Gap W (Mutagen) + dies-with-counter trigger |
 | Tokka & Rahzar, Terrible Twos         | "Can't be countered" + mana-spent-less-than-MV trigger — bespoke |
 | Turncoat Kunoichi                     | Gap A (Sneak) + sneak-was-paid ETB rider    |
-| Turtle Blimp                          | Gap J (Crew / Vehicle)                      |
 | Turtle Lair                           | Gap JJ (multi-subtype mana restriction)     |
-| Turtle Van                            | Gap J (Crew / Vehicle) + Gap I (double counters) |
+| Turtle Van                            | Gap LL (crewed-this-turn filter)            |
 | Turtles Forever                       | Wishboard tutor (outside-the-game search)   |
 | Turtles in Time                       | Mass bounce + shuffle-hand+gy-and-draw-7 + exile-self |
 | Venus, Torn Between Worlds            | "Damage dealt + survives" trigger condition + counter-bearer combat trigger |

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,19 +10,30 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-27 / 190 implemented (basics excluded — handled by `basicLandsFallback`).
+79 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+`cards.md` for the full checklist; the per-card commits on `tmt-scaffolding`
+all carry `flavorText` in metadata.
 
-Implemented so far (alphabetical):
-Agent Bishop · Man in Black, Anchovy & Banana Pizza, April · Reporter of the Weird,
-Armaggon · Future Shark, Bespoke Bō, Bot Bashing Time, Buzz Bots, Casey Jones ·
-Jury-Rig Justiciar, Cowabunga!, Death in the Family, Dimension X, Donatello · Turtle
-Techie, Donatello · Way with Machines, Dream Beavers, Featherbrained Filcher, Foot
-Headquarters, Frog Butler, Guac & Marshmallow Pizza, Hamato Guardian Stance,
-Hard-Won Jitte, Henchbots, High-Flying Ace, Ice Cream Kitty, Illegitimate Business,
-Mutant Town, Raph & Mikey · Troublemakers, TCRI Building.
+The remaining 111 cards mostly cluster on a handful of unresolved gaps:
+- **Sneak** — 26 cards (Gap A — unresolved)
+- **Alliance** — 10 cards (Gap C — unresolved; trigger composes, blocked only on
+  display-only `Keyword.ALLIANCE` + a one-call `alliance { … }` DSL helper)
+- **Disappear** — 9 cards (Gap B — unresolved)
+- **Class** — 3 cards (Gap U — unresolved)
+- **Mutagen token consumers** — ~5 cards (Gap W — unresolved)
+- **Vehicles / Crew** — 2 cards (Gap J)
+- **Sagas** — 2 cards (Gap K)
+- Plus various one-offs from Gaps M and N–KK
 
-New-mechanic work blocks the bulk of the set: 26 cards wait on Sneak, 9 on Disappear,
-10 on Alliance. See "Engine gaps blocking the remaining cards" below.
+Gaps **resolved this run** (cards previously listed as blocked now landed):
+- **Gap H — Affinity for artifacts**: `Krang, Master Mind` shipped via
+  `KeywordAbility.Affinity(CardType.ARTIFACT)`. No engine change required.
+- **Gap L (partial)** — Landfall (`Weather Maker`) and all five basic-land-
+  cycling variants (`Jennika` Plainscycling, `Stockman` Islandcycling, `Bebop
+  Warthog Warrior` Swampcycling, `Zog` Mountaincycling, `Rocksteady Crash
+  Courser` Forestcycling) all shipped composably via `KeywordAbility.
+  typecycling("<Basic>", "{N}")`. Fight (`Novel Nunchaku`) and the four Mill-
+  keyword cards remain unchecked but are believed composable.
 
 ## Data sources — do NOT hit the network
 
@@ -181,11 +192,9 @@ the turn" (CR 106.4b exception). Likely a flag on the mana pool entry that the e
 hooks skip.
 - **Raphael, Ninja Destroyer** — see Gap F.
 
-### Gap H — Affinity for artifacts (cost reduction) — 1 card
-**Engine change:** `AFFINITY` keyword exists; verify "Affinity for artifacts" cost-
-reduction wiring counts artifacts you control. If the wiring is parameterised (filter +
-displayPrefix), this is just a DSL call; if hard-coded for a specific filter, generalise.
-- **Krang, Master Mind** — "Affinity for artifacts."
+### Gap H — Affinity for artifacts (cost reduction) — RESOLVED
+**Engine change:** none — the existing `KeywordAbility.Affinity(CardType.ARTIFACT)`
+already works. Shipped as `Krang, Master Mind`.
 
 ### Gap I — "double the number of +1/+1 counters" — 1 card
 **Engine change:** an effect that doubles the count of a chosen counter kind on a
@@ -206,15 +215,21 @@ have Saga support; verify it's still functional and the chapter DSL is reachable
 - **The Cloning of Shredder**, **The Last Ronin** — chapter abilities only; no new
   Saga primitives expected.
 
-### Gap L — Landfall, Fight, Mill keyword, basic-land-cycling — verify
-**Engine change:** likely none — these all exist in older sets. Confirm during
-implementation; add the small gap PR if any are missing.
-- Landfall: `Weather Maker`
-- Fight: `Novel Nunchaku`
-- Mill keyword: `Does Machines`, `Kitsune's Technique`, `Paramecia Coloniex`,
-  `The Last Ronin`
-- Basic-land-cycling family (Plains/Island/Swamp/Mountain/Forest) — `KeywordAbility.Cycling`
-  with `searchFilter` already supports these (see `KeywordAbility.kt:217`).
+### Gap L — Landfall, Fight, Mill keyword, basic-land-cycling — partly RESOLVED
+**Engine change:** none for Landfall + basic-land-cycling (both shipped). Fight
+and Mill-keyword cards remain unchecked; expected composable.
+- Landfall: `Weather Maker` — **DONE**.
+- Basic-land-cycling family: `Jennika` (Plainscycling), `Stockman, Mad Fly-
+  entist` (Islandcycling), `Bebop, Warthog Warrior` (Swampcycling),
+  `Zog, Triceraton Castaway` (Mountaincycling), `Rocksteady, Crash Courser`
+  (Forestcycling) — all **DONE** via `KeywordAbility.typecycling`.
+- Fight: `Novel Nunchaku` — unchecked. ETB has an attach-then-"when you do,
+  fight" sub-trigger which is the actual blocker (see Gap AA shape), not Fight
+  itself.
+- Mill keyword: `Does Machines` (Class — Gap U), `Kitsune's Technique` (Sneak
+  — Gap A), `Paramecia Coloniex` (dies → "may exile … when you do, …" sub-
+  trigger — Gap AA shape), `The Last Ronin` (Saga + Sneak). Each of these is
+  blocked on a different gap; Mill itself is not the holdup.
 
 ### Gap M — one-off bespoke cards
 Each is its own PR; they don't share a clean reusable gap with others.
@@ -372,41 +387,83 @@ because the predicate reads the chosen target during cast.
 - **Grounded for Life** — "This spell costs {3} less to cast if it targets a
   tapped creature."
 
+### Gap EE — "may put a card from your hand on the bottom of your library. If you do, draw a card."
+**Engine change:** an optional bottom-of-library + conditional draw composite.
+Mirrors `EffectPatterns.rummage`/`loot` but the cost step is "bottom" instead
+of "discard." Could be added as `EffectPatterns.bottomThenDraw(n)` once.
+- **Manhole Missile** — also deals 3 damage on resolve; the damage half is
+  trivially composable, only the bottom-then-draw rider is missing.
+
+### Gap FF — "becomes an artifact creature with base P/T N/M" until end of turn
+**Engine change:** extend `Effects.BecomeCreature` (or add a sibling) so it can
+*add* card types instead of only granting Creature. Today it sets Creature +
+overrides base P/T, which is correct for an artifact target but loses the
+"becomes an artifact" wording when the target is a non-artifact creature.
+- **Mind Transfer Protocol** — "target artifact or creature becomes an artifact
+  creature with base power and toughness 4/5 until end of turn."
+
+### Gap GG — "may pay X life where X is a dynamic amount" as an optional cost
+**Engine change:** `Costs.PayLife` currently takes `Int`; need a
+`Costs.PayLife(DynamicAmount)` overload threaded through the trigger-cost
+pipeline so it can resolve at trigger time (e.g. equal to the triggering
+creature's power).
+- **Madame Null, Power Broker** — "Whenever another creature you control enters,
+  you may pay life equal to its power. If you do, put that many +1/+1 counters
+  on it."
+
+### Gap HH — "can't be blocked by creatures with power N or greater"
+**Engine change:** mirror of the existing
+`CantBeBlockedByCreaturesWithLessPower` static. Either add
+`CantBeBlockedByCreaturesWithGreaterPower` or parameterize the existing one
+with a `ComparisonOperator`.
+- **Prehistoric Pet** — "This creature can't be blocked by creatures with
+  greater power." (Also has an activated bounce that's already composable.)
+
+### Gap II — "you may tap or untap target creature" (controller chooses on resolution)
+**Engine change:** an effect (or a target-modal helper) that asks the
+controller to pick between tapping or untapping the chosen target. Today
+`TapUntapEffect` carries a fixed `tap: Boolean` chosen at script-write time.
+- **Sewer-veillance Cam** — Flash artifact whose ETB/LTB trigger says "you may
+  tap or untap target creature." Composable apart from the player choice.
+
+### Gap JJ — multi-subtype restricted mana
+**Engine change:** today `ManaRestriction.SubtypeSpellsOrAbilitiesOnly` takes a
+single subtype. Need a "this mana may be spent on a spell of subtype X *or* Y."
+- **Turtle Lair** — "Add one mana of any color. Spend this mana only to cast a
+  Ninja or Turtle spell." (The colorless `{T}: Add {C}` half plus the "Target
+  Ninja or Turtle can't be blocked this turn" activated ability are composable.)
+
+### Gap KK — "Spend this mana only to cast a [type] spell or to activate an ability"
+**Engine change:** today `ManaRestriction.CardTypeSpellsOrAbilitiesOnly`'s
+`allowAbilities` restricts to abilities **of [cardType] sources**. Need a
+variant that permits *any* activated ability (not just artifact-source).
+- **Purple Dragon Punks** — "{T}: Add {R}. Spend this mana only to cast an
+  artifact spell or to activate an ability."
+
 ---
 
 ## Composable — deferred for time
 
-These cards appear to compose from primitives the engine already has, but were
-skipped during the alphabetical first pass to keep pace. Pick them up next.
-
-- **Baxter Stockman** — ETB Robot token + begin-combat pump on target artifact
-  creature you control. Needs an inline `TargetFilter(GameObjectFilter(
-  cardPredicates = [IsCreature, IsArtifact]).youControl())`.
-- **Bebop, Warthog Warrior** — Menace + "Rhinos you control have menace" anthem
-  + Swampcycling {2}. All primitives exist; Swampcycling uses
-  `KeywordAbility.Cycling(searchFilter = …, displayPrefix = "Swampcycling")`.
-- **Dimensional Exile** — Aura "enchant basic land you control" with ETB exile
-  target creature until LTB. Need the basic-land-you-control aura target.
-- **Foot Elite** — attack-trigger pump "+1/+0 and gains indestructible UEOT" on
-  a target creature you control. Composes ModifyStats + GrantKeyword
-  (INDESTRUCTIBLE, EndOfTurn).
+All four of the previously deferred composable cards (`Baxter Stockman`, `Bebop,
+Warthog Warrior`, `Dimensional Exile`, `Foot Elite`) have now landed on
+`tmt-scaffolding`. This section will be repopulated if the next pass uncovers
+more "composable but skipped" entries.
 
 ---
 
 ## Skip log — cards inspected and skipped (alphabetical)
 
-Each row is a card encountered during the alphabetical pass that was not
-implemented in this session, with the underlying blocker. Gaps reference the
-sections above (existing Gap A–M or the new Gap N–DD).
+Each row is a card encountered during an alphabetical pass that was not
+implemented, with the underlying blocker. Gaps reference the sections above
+(existing Gap A–M or the new Gap N–KK). Rows previously marked
+"Composable — deferred" have all landed and been removed.
 
 | Card                                  | Blocker / Gap                               |
 |---------------------------------------|---------------------------------------------|
 | Action News Crew                      | Gap D (Channel)                             |
 | April O'Neil, Hacktivist              | Gap N (card-types-cast amount)              |
 | April O'Neil, Kunoichi Trainee        | Gap O (can't-be-blocked-by-power)           |
-| Baxter Stockman                       | Composable — deferred                       |
 | Bebop & Rocksteady                    | Gap P (unless-you-discard rider)            |
-| Bebop, Warthog Warrior                | Composable — deferred                       |
 | Brilliance Unleashed                  | Gap Q (typed-override reanimate token)      |
 | Broadcast Takeover                    | Gap R (mass gain-control UEOT)              |
 | Casey Jones, Vigilante                | Gap S (delayed next-upkeep trigger)         |
@@ -415,14 +472,17 @@ sections above (existing Gap A–M or the new Gap N–DD).
 | Courier of Comestibles                | Gap V (search-or-fail-then-token)           |
 | Crustacean Commando                   | Gap W (Mutagen token)                       |
 | Dark Leo & Shredder                   | Gap A (Sneak)                               |
-| Dimensional Exile                     | Composable — deferred                       |
 | Does Machines                         | Gap U (Class)                               |
 | Don & Leo, Problem Solvers            | Gap X (paired flicker)                      |
 | Don & Raph, Hard Science              | Gap Y (grant Affinity to next spell)        |
 | Donatello's Technique                 | Gap A (Sneak)                               |
 | Donatello, Gadget Master              | Gap A (Sneak) + token-with-overrides        |
 | Donatello, Mutant Mechanic            | Gap M (Pizza-Face-style type-grant)         |
-| Foot Elite                            | Composable — deferred                       |
+| East Wind Avatar                      | Gap C (Alliance)                            |
+| EPF Point Squad                       | Gap C (Alliance)                            |
+| Escape Tunnel                         | "Target creature with power 2 or less can't be blocked this turn" + sac-land filter |
+| Everything Pizza                      | Pentacolored sac activation that also draws + makes each opponent discard — bespoke |
+| Foot Mystic                           | Gap B (Disappear)                           |
 | Foot Ninjas                           | Gap A (Sneak)                               |
 | Fugitive Droid                        | Gap Z (artifact-ETB-this-turn + sac-counter)|
 | General Traag, Heart of Stone         | Gap AA (when-you-do sub-trigger)            |
@@ -430,3 +490,84 @@ sections above (existing Gap A–M or the new Gap N–DD).
 | Go Ninja Go                           | Gap BB (greatest-power-among amount)        |
 | Groundchuck & Dirtbag                 | Gap CC (tap-land-for-mana trigger)          |
 | Grounded for Life                     | Gap DD (cost reduction if target tapped)    |
+| Insectoid Exterminator                | Gap B (Disappear)                           |
+| Jennika's Technique                   | Gap A (Sneak)                               |
+| Karai's Technique                     | Gap A (Sneak)                               |
+| Karai, Future of the Foot             | Gap A (Sneak)                               |
+| Kitsune's Technique                   | Gap A (Sneak)                               |
+| Kitsune, Dragon's Daughter            | "Exchange control of two creatures controlled by different players" — bespoke |
+| Koya, Death from Above                | Delayed end-step "you may pay; if not, return that card" conditional — bespoke |
+| Krang & Shredder                      | Gap B (Disappear) + Gap M (cast-from-exile-without-paying chain) |
+| Leader's Talent                       | Gap U (Class)                               |
+| Leatherhead, Swamp Stalker            | Hexproof counter + "may remove a counter; when you do, …" (Gap AA shape) |
+| Leonardo's Technique                  | Gap A (Sneak)                               |
+| Leonardo, Big Brother                 | Gap A (Sneak)                               |
+| Leonardo, Cutting Edge                | Gap A (Sneak)                               |
+| Leonardo, Leader in Blue              | Gap A (Sneak) + sneak-was-paid rider        |
+| Leonardo, Sewer Samurai               | Gap A (Sneak)                               |
+| Lita, Little Orphan Amphibian         | Gap C (Alliance) + Gap E (mode-not-yet-chosen) |
+| Lord Dregg, Insect Invader            | Gap B (Disappear) + Gap M (Sacrifice-a-token cost) |
+| Madame Null, Power Broker             | Gap GG (may-pay-dynamic-life)               |
+| Manhole Missile                       | Gap EE (bottom-of-library-then-draw)        |
+| Michelangelo's Technique              | Gap A (Sneak)                               |
+| Michelangelo, Game Master             | Gap B (Disappear)                           |
+| Michelangelo, Improviser              | Gap A (Sneak)                               |
+| Michelangelo, Mutant BFF              | Gap W (Mutagen) + counter-doubling replacement |
+| Michelangelo, Weirdness to 11         | Gap W (Mutagen) + counter-doubling replacement |
+| Mighty Mutanimals                     | Gap C (Alliance)                            |
+| Mikey & Don, Party Planners           | Play-from-top + cast-Mutant/Ninja/Turtle-from-top — bespoke |
+| Mind Transfer Protocol                | Gap FF (BecomeCreature that adds Artifact)  |
+| Mondo Gecko                           | Discard-to-grant-color + hexproof-from-color combat trigger — bespoke |
+| Mutagen Man, Living Ooze              | Gap W (Mutagen) + activated-ability-cost-reduction static |
+| Mutant Chain Reaction                 | Gap W (Mutagen)                             |
+| Mutant Town Musicians                 | Gap C (Alliance)                            |
+| New Generation's Technique            | Gap A (Sneak)                               |
+| Ninja Teen                            | Gap U (Class)                               |
+| North Wind Avatar                     | "Put a card you own from outside the game into your hand" (wishboard) |
+| Northampton Farm                      | Custom land with linked-exile mechanic — bespoke |
+| Novel Nunchaku                        | "When you do, equipped creature fights" sub-trigger (Gap AA shape) |
+| Old Hob, Alleycat Blues               | Delayed-trigger "destroy it at the next end step" |
+| Ooze Spill                            | Gap W (Mutagen)                             |
+| Oroku Saki, Shredder Rising           | Gap A (Sneak)                               |
+| Paramecia Coloniex                    | Dies → "may exile; when you do …" sub-trigger (Gap AA shape) |
+| Party Dude                            | Gap U (Class)                               |
+| Pizza Face, Gastromancer              | Gap B (Disappear) + Gap M (type-grant on non-creature) |
+| Prehistoric Pet                       | Gap HH (can't-be-blocked-by-greater-power)  |
+| Purple Dragon Punks                   | Gap KK (artifact-spell-or-any-ability mana restriction) |
+| Putrid Pals                           | Gap B (Disappear)                           |
+| Raph & Leo, Sibling Rivals            | Additional combat phase + conditional untap |
+| Raphael's Technique                   | Gap A (Sneak)                               |
+| Raphael, Most Attitude                | Gap C (Alliance)                            |
+| Raphael, Ninja Destroyer              | Gap F (Enrage) + Gap G (persistent mana)    |
+| Raphael, the Nightwatcher             | Gap A (Sneak)                               |
+| Raphael, Tough Turtle                 | Gap C (Alliance)                            |
+| Rat King, Verminister                 | Gap B (Disappear) + Gap M (same-name reanimate) |
+| Ray Fillet, Man Ray                   | Gap W (Mutagen)                             |
+| Retro-Mutation                        | Type-overriding Aura + "loses all abilities" UEOT |
+| Return to the Sewers                  | Owner-chooses-top-or-bottom + Gap W (Mutagen) |
+| Sewer-veillance Cam                   | Gap II (tap-or-untap controller-chooses)    |
+| Shark Shredder, Killer Clone          | Gap A (Sneak)                               |
+| Shredder's Technique                  | Gap A (Sneak)                               |
+| Shredder, Unrelenting                 | Gap A (Sneak)                               |
+| Slash, Reptile Rampager               | Gap C (Alliance)                            |
+| Slithering Cryptid                    | Gap W (Mutagen)                             |
+| Splinter's Technique                  | Gap A (Sneak)                               |
+| Splinter, Hamato Yoshi                | Gap A (Sneak)                               |
+| Splinter, Radical Rat                 | "Ninja triggered ability triggers an additional time" — bespoke |
+| Technodrome                           | "Can't attack or block unless its power is 6 or greater" — Gap O-shape on self |
+| The Cloning of Shredder               | Gap K (Saga)                                |
+| The Last Ronin                        | Gap K (Saga) + Gap A (Sneak)                |
+| The Last Ronin's Technique            | Gap A (Sneak) + sneak-was-paid token rider  |
+| The Neutrinos                         | Gap C (Alliance)                            |
+| The Ooze                              | Gap W (Mutagen) + dies-with-counter trigger |
+| Tokka & Rahzar, Terrible Twos         | "Can't be countered" + mana-spent-less-than-MV trigger — bespoke |
+| Turncoat Kunoichi                     | Gap A (Sneak) + sneak-was-paid ETB rider    |
+| Turtle Blimp                          | Gap J (Crew / Vehicle)                      |
+| Turtle Lair                           | Gap JJ (multi-subtype mana restriction)     |
+| Turtle Van                            | Gap J (Crew / Vehicle) + Gap I (double counters) |
+| Turtles Forever                       | Wishboard tutor (outside-the-game search)   |
+| Turtles in Time                       | Mass bounce + shuffle-hand+gy-and-draw-7 + exile-self |
+| Venus, Torn Between Worlds            | "Damage dealt + survives" trigger condition + counter-bearer combat trigger |
+| West Wind Avatar                      | Gap B (Disappear) + Gap M (token-or-land sac filter) |
+| Wingnut, Bat on the Belfry            | Gap C (Alliance) + Gap M (choose-one-of-N-keywords) |
+| Zoo Escapees                          | Gap W (Mutagen)                             |

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -273,11 +273,11 @@ Ixalan-era cards in older sets). Verify the trigger primitive is present; if not
 - **Raphael, Ninja Destroyer** — "Enrage — Whenever Raphael is dealt damage, add that
   much {R}. Until end of turn, you don't lose this mana as steps and phases end."
   Also needs the **"don't lose this mana as steps and phases end"** mana modifier
-  (CR 106.4b duration override) — see Gap G.
+  (CR 106.4 duration override) — see Gap G.
 
 ### Gap G — mana that doesn't empty at end of step/phase — 1 card
 **Engine change:** mana pool entry tagged "persists across steps/phases for the rest of
-the turn" (CR 106.4b exception). Likely a flag on the mana pool entry that the empty-mana
+the turn" (CR 106.4 exception). Likely a flag on the mana pool entry that the empty-mana
 hooks skip.
 - **Raphael, Ninja Destroyer** — see Gap F.
 

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -1,0 +1,239 @@
+# Teenage Mutant Ninja Turtles (TMT) — Implementation Plan
+
+> **Every card must be implemented perfectly — exactly as stated in the rules.** No
+> approximations, no "close enough", no silently dropped clauses. Each card's behavior must
+> match its oracle text (from `tmt_full.json` in the repo root) and the Comprehensive Rules
+> (`MagicCompRules_20260417.pdf`) in full, including edge cases, timing, and interactions.
+> A card is not done until its scenario test proves the rules-correct behavior.
+
+Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set TMT`).
+
+## Status
+
+1 / 190 implemented (basics excluded — handled by `basicLandsFallback`).
+
+Implemented today:
+- **Raph & Mikey, Troublemakers** — Trample/haste + attack-trigger reveal-until-creature
+  into play tapped-and-attacking. Composes existing primitives only
+  (`Triggers.Attacks`, `GatherUntilMatchEffect`, `MoveCollectionEffect`,
+  `FilterCollectionEffect`, `RevealCollectionEffect`).
+
+New-mechanic work blocks the bulk of the set: 26 cards wait on Sneak, 9 on Disappear,
+10 on Alliance. See "Engine gaps blocking the remaining cards" below.
+
+## Data sources — do NOT hit the network
+
+- **Card data** (name, mana cost, type line, oracle text, P/T, rarity, collector number,
+  artist, flavor, image URI): read from `/workspace/tmt_full.json`, **not** Scryfall. It is
+  a full Scryfall dump of all 195 cards (`.data[]`, keyed by the usual field names). When
+  running `add-card`, feed it the matching entry from this file instead of doing a Scryfall
+  lookup.
+- **Rules**: cite and verify against `MagicCompRules_20260417.pdf` (repo root), **not**
+  yawgatog or any web source. Read pages with the `Read` tool's `pages` parameter.
+
+## Workflow
+
+Each card is implemented with the **`add-card` skill** (oracle errata, set registration,
+scenario test) — but source its card data from `tmt_full.json` and its rule references from
+`MagicCompRules_20260417.pdf` per the section above. Run one card per Claude invocation:
+
+```
+/add-card <Card Name>   # from set TMT; use tmt_full.json for data, the CompRules PDF for rules
+```
+
+The skill is the source of truth on whether a card needs an engine change.
+
+### Git strategy
+
+**One PR per engine-change feature**, each off `main`. When several cards share one new
+engine feature, that feature's PR can land all of them together — note it in the PR.
+Composable cards (no engine change needed) can land directly on `main`, one commit per card.
+
+### Per-card procedure
+
+1. `/add-card <name>` — implement via the DSL, no class inheritance.
+2. If it composes from existing primitives → commit directly on `main` (`Add <Card>`).
+3. If `add-card` finds it needs a new `Effect`/keyword/replacement/SDK change →
+   stop, branch off `main`, build the engine feature + the card + tests, open its own PR.
+   Update `docs/card-sdk-language-reference.md` in the same PR (required for any SDK change).
+4. Check the box in `cards.md` and update the `Implemented:` count.
+
+## Notes
+
+- Implement every card faithfully, reproducing oracle text as printed (use the Scryfall
+  oracle text in `tmt_full.json`).
+- Verify any MTG rule number against `MagicCompRules_20260417.pdf` before citing it.
+- Battlefield filtering must use projected state (`matchesWithProjection`).
+- Basic lands are covered by `basicLandsFallback`; add TMT-art variants only if you want
+  the distinct printings.
+
+---
+
+## Engine gaps blocking the remaining cards
+
+Each gap is its own PR. A card with more than one gap is listed under its dominant one
+with the secondary noted inline. Quotes are from the card's oracle text in `tmt_full.json`.
+
+### Gap A — Sneak (alternative cost) — 26 cards
+**Engine change:** new keyword `SNEAK` + `KeywordAbility.Sneak(cost)` + alternative-cost
+plumbing that branches on a non-mana, mid-combat condition.
+
+> Sneak {cost} (You may cast this spell for {cost} if you also return an unblocked
+> attacker you control to hand during the declare blockers step.
+> [He/She/It enters tapped and attacking.])
+
+Required pieces:
+1. **Alt-cost gate at declare-blockers.** Today's alt-cost pipeline (`Flashback`,
+   `Harmonize`, `Impending`) all resolve at cast time. Sneak's payment piece — returning
+   an unblocked attacker you control to hand — happens during the declare-blockers step
+   *of the same turn the spell is cast*. The action enumerator must surface "cast for
+   Sneak" only when (a) it's the declare-blockers step of your combat, (b) you control
+   an unblocked attacker, and (c) the spell is castable at the current speed. Casting
+   for Sneak also queues the bounce-an-unblocked-attacker as an additional payment.
+2. **Permanent spells enter tapped and attacking.** When a creature/artifact-creature
+   spell resolves having paid its sneak cost, the permanent enters tapped and joins the
+   attack. This already exists for cascade/mobilize tokens (CreateTokenEffect with
+   `tappedAndAttacking`) — reuse the same `attackingState` plumbing for cast permanents.
+3. **Per-spell "sneak-was-paid" flag.** 4 cards (`Leonardo, Leader in Blue`,
+   `Turncoat Kunoichi`, `Karai, Future of the Foot`, `The Last Ronin's Technique`) read
+   "if [its] sneak cost was paid" later — at resolution, at ETB, or as a turn-long
+   rider on a damage trigger. Stash the flag on the spell-cast event (cast-time) and
+   on the resulting permanent's component (post-resolution), and expose it as a
+   `Condition.SneakCostWasPaid(source)` predicate.
+4. **DSL helper.** `sneak("{1}{W}") { ... }` on `CardBuilder`, mirroring `harmonize`
+   and `impending`.
+
+Cards: `Action News Crew`? — _no, Channel_. Sneak cards (26):
+`The Last Ronin's Technique`, `Leonardo, Leader in Blue`, `Leonardo, Big Brother`,
+`Leonardo, Cutting Edge`, `Leonardo, Sewer Samurai`, `Leonardo's Technique`,
+`Turncoat Kunoichi`, `Karai, Future of the Foot`, plus the remaining 18 — full list
+is the cards with `"Sneak"` in their `keywords` array in `tmt_full.json`.
+
+### Gap B — Disappear (ability-word trigger with "a permanent left the battlefield under your control this turn" condition) — 9 cards
+**Engine change:** generalize the existing `nonlandPermanentLeftBattlefieldThisTurn`
+flag and add a Condition usable inside any triggered ability.
+
+Required pieces:
+1. **Per-player, all-permanent tracking.** The current flag in `GameState` is global and
+   nonland-only (used by EOE's Void / Spellwarp). Disappear needs **any** permanent
+   (lands included) that left the battlefield while under that **player's** control,
+   per-turn. Suggested rename / addition:
+   `permanentLeftBattlefieldThisTurnByController: Map<PlayerId, Boolean>` set in
+   `ZoneTransitionService` whenever a permanent moves out of the battlefield (destroy,
+   sacrifice, exile, bounce, phase-out). Existing Void uses can keep reading the
+   nonland-restricted flag or migrate; do not silently change Void's filter.
+2. **`Condition.PermanentLeftBattlefieldUnderYourControlThisTurn`** that reads the
+   per-controller map for the triggered ability's controller.
+3. The triggers themselves are existing primitives (`Triggers.EtbSelf`,
+   `Triggers.AtYourEndStep`, and an enters-with-counters static for `Putrid Pals`).
+   Wire them with the new condition and the existing effect library.
+
+Triggers used across the 9 cards:
+- End-step (7): `Insectoid Exterminator`, `Lord Dregg, Insect Invader`,
+  `Rat King, Verminister`, `Michelangelo, Game Master`, `West Wind Avatar`,
+  `Krang & Shredder`, `Pizza Face, Gastromancer`
+- ETB (1): `Foot Mystic`
+- "Enters with two +1/+1 counters if ..." (1): `Putrid Pals` — needs
+  `entersWith(counters, condition)` if not already supported.
+
+### Gap C — Alliance (ability-word trigger) — 10 cards
+**Engine change:** none — pure ability-word marker. Add `Keyword.ALLIANCE` (display only)
+and an `alliance { ... }` DSL helper that wires
+`Triggers.WheneverAnotherCreatureYouControlEnters { effect }`. Mirror the existing
+`flurry`, `eerie`, `vivid`, `fatefulBite` ability-word helpers — no new engine code.
+
+Cards: `East Wind Avatar`, `Lita, Little Orphan Amphibian`, `Mighty Mutanimals`,
+`Mutant Town Musicians`, `Raphael, Most Attitude`, `Raphael, Tough Turtle`,
+`Slash, Reptile Rampager`, `Wingnut, Bat on the Belfry`, `EPF Point Squad`,
+`The Neutrinos`. One of them (`Lita`) layers a "modal effect that hasn't been chosen
+this turn" rider — see Gap E.
+
+### Gap D — Channel keyword/DSL helper — 1 card
+**Engine change:** `Channel` keyword + DSL helper that wires the discard-from-hand
+activated ability. The mechanic exists in spirit (Kamigawa), but no `KeywordAbility.Channel`
+entry exists in `KeywordAbility.kt`. Compose: activated ability with cost `{N}, Discard
+this card.` from hand zone.
+- **Action News Crew** — "Channel — {6}, Discard this card: Put a +1/+1 counter on each
+  creature you control. Draw a card."
+
+### Gap E — modal "choose one that hasn't been chosen this turn" — 1 card
+**Engine change:** per-source memory of which modes have been chosen this turn,
+threaded into modal-spell mode selection. (LTR's Gandalf the Grey gap mentions the
+same shape — coordinate with that PR.)
+- **Lita, Little Orphan Amphibian** — Alliance trigger picks a mode "that hasn't been
+  chosen this turn."
+
+### Gap F — Enrage (ability word) — 1 card
+**Engine change:** display-only `Keyword.ENRAGE` + `enrage { ... }` DSL helper that
+wires the existing "Whenever this creature is dealt damage" trigger (already exists per
+Ixalan-era cards in older sets). Verify the trigger primitive is present; if not, add it.
+- **Raphael, Ninja Destroyer** — "Enrage — Whenever Raphael is dealt damage, add that
+  much {R}. Until end of turn, you don't lose this mana as steps and phases end."
+  Also needs the **"don't lose this mana as steps and phases end"** mana modifier
+  (CR 106.4b duration override) — see Gap G.
+
+### Gap G — mana that doesn't empty at end of step/phase — 1 card
+**Engine change:** mana pool entry tagged "persists across steps/phases for the rest of
+the turn" (CR 106.4b exception). Likely a flag on the mana pool entry that the empty-mana
+hooks skip.
+- **Raphael, Ninja Destroyer** — see Gap F.
+
+### Gap H — Affinity for artifacts (cost reduction) — 1 card
+**Engine change:** `AFFINITY` keyword exists; verify "Affinity for artifacts" cost-
+reduction wiring counts artifacts you control. If the wiring is parameterised (filter +
+displayPrefix), this is just a DSL call; if hard-coded for a specific filter, generalise.
+- **Krang, Master Mind** — "Affinity for artifacts."
+
+### Gap I — "double the number of +1/+1 counters" — 1 card
+**Engine change:** an effect that doubles the count of a chosen counter kind on a
+target permanent (CR 121.3 — places that many additional counters).
+- **Turtle Van** — "double the number of +1/+1 counters on it" if the buffed creature
+  is Mutant/Ninja/Turtle. Composes with the existing `put +1/+1 counter` effect.
+
+### Gap J — Crew / Vehicle — 2 cards
+**Engine change:** Vehicle card type + Crew N (tap any combination of creatures with total
+power ≥ N to turn the artifact into an artifact-creature until end of turn). `Keyword.CREW`
+exists, but the artifact-becomes-artifact-creature behavior and the Vehicle card type need
+to be wired. (Coordinates with LTR Gap 31.)
+- **Turtle Blimp**, **Turtle Van**
+
+### Gap K — Sagas — 2 cards
+**Engine change:** Sagas with chapter abilities. Earlier sets (Dominaria, LTR) already
+have Saga support; verify it's still functional and the chapter DSL is reachable.
+- **The Cloning of Shredder**, **The Last Ronin** — chapter abilities only; no new
+  Saga primitives expected.
+
+### Gap L — Landfall, Fight, Mill keyword, basic-land-cycling — verify
+**Engine change:** likely none — these all exist in older sets. Confirm during
+implementation; add the small gap PR if any are missing.
+- Landfall: `Weather Maker`
+- Fight: `Novel Nunchaku`
+- Mill keyword: `Does Machines`, `Kitsune's Technique`, `Paramecia Coloniex`,
+  `The Last Ronin`
+- Basic-land-cycling family (Plains/Island/Swamp/Mountain/Forest) — `KeywordAbility.Cycling`
+  with `searchFilter` already supports these (see `KeywordAbility.kt:217`).
+
+### Gap M — one-off bespoke cards
+Each is its own PR; they don't share a clean reusable gap with others.
+
+- **Pizza Face, Gastromancer** — "If it isn't a creature, it becomes a 0/0 Mutant
+  creature in addition to its other types" (type-grant + base P/T on a non-creature).
+- **Rat King, Verminister** — "Return target creature card and all other cards with the
+  same name as that card from your graveyard to the battlefield tapped." (Name-matching
+  multi-target reanimate.)
+- **Krang & Shredder** — "Whenever Krang & Shredder enter or attack, each opponent
+  exiles cards from the top of their library until they exile a nonland card."
+  (Reveal-until per-opponent + cast-from-exile-without-paying via the Disappear rider.)
+- **West Wind Avatar** — "you may sacrifice a token or a land" (sacrifice filter:
+  "token or land" — composes existing filters, just verify the disjunction works).
+- **Wingnut, Bat on the Belfry** — "Wingnut gains your choice of flying, menace, or
+  reach until end of turn." (Choose-one-of-N-keywords grant — generalises
+  Aragorn-style "choose a counter kind" from LTR Gap 7.)
+- **Lord Dregg, Insect Invader** — "Sacrifice a token: Draw a card." (Token-filtered
+  sacrifice cost on an activated ability; verify `AbilityCost.SacrificeFiltered`
+  supports the token predicate.)
+- **The Last Ronin's Technique** — Sneak rider: "If this spell's sneak cost was paid,
+  they enter tapped and attacking." (Gap A) → token-creator already supports
+  tapped-and-attacking; condition is the new piece.
+
+(Continue listing as `add-card` discovers more during implementation.)

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,22 +10,38 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-79 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+90 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist; the per-card commits on `tmt-scaffolding`
 all carry `flavorText` in metadata.
 
-The remaining 111 cards mostly cluster on a handful of unresolved gaps:
+The remaining 100 cards mostly cluster on a handful of unresolved gaps:
 - **Sneak** — 26 cards (Gap A — unresolved)
-- **Alliance** — 10 cards (Gap C — unresolved; trigger composes, blocked only on
-  display-only `Keyword.ALLIANCE` + a one-call `alliance { … }` DSL helper)
 - **Disappear** — 9 cards (Gap B — unresolved)
+- **Alliance** — 4 cards left (Gap C — partly cleared; 6 shipped composably,
+  the remaining 4 each have an *additional* unresolved blocker beyond Alliance
+  itself: `Lita` → Gap E modal-not-yet-chosen, `Raphael, Most Attitude` → exile-
+  and-may-cast chain, `The Neutrinos` → flicker-tapped-and-attacking, `The
+  Neutrinos` listed once). Pure Alliance is no longer a blocker on its own.
 - **Class** — 3 cards (Gap U — unresolved)
 - **Mutagen token consumers** — ~5 cards (Gap W — unresolved)
 - **Vehicles / Crew** — 2 cards (Gap J)
 - **Sagas** — 2 cards (Gap K)
 - Plus various one-offs from Gaps M and N–KK
 
-Gaps **resolved this run** (cards previously listed as blocked now landed):
+Gaps **resolved across the runs so far**:
+- **Gap C — Alliance (partly cleared)**: 6 of the 10 Alliance cards (`East
+  Wind Avatar`, `EPF Point Squad`, `Mighty Mutanimals`, `Mutant Town
+  Musicians`, `Raphael, Tough Turtle`, `Slash, Reptile Rampager`) shipped by
+  composing `Triggers.OtherCreatureEnters` directly. The `Keyword.ALLIANCE`
+  display marker is still absent, so the rendered card text doesn't get the
+  italic "Alliance —" prefix yet, but the trigger semantics are faithful.
+  Wiring the marker + `alliance { }` DSL helper is now purely a cosmetic /
+  ergonomics improvement.
+- **Gap D — Channel**: `Action News Crew` shipped via
+  `activatedAbility { activateFromZone = Zone.HAND }` with
+  `Costs.Composite(Mana("{6}"), DiscardSelf)`. The `Keyword.CHANNEL` display
+  marker is still absent — same caveat as Alliance: behavior is right, the
+  italic "Channel —" prefix doesn't render.
 - **Gap H — Affinity for artifacts**: `Krang, Master Mind` shipped via
   `KeywordAbility.Affinity(CardType.ARTIFACT)`. No engine change required.
 - **Gap L (partial)** — Landfall (`Weather Maker`) and all five basic-land-
@@ -34,6 +50,18 @@ Gaps **resolved this run** (cards previously listed as blocked now landed):
   Courser` Forestcycling) all shipped composably via `KeywordAbility.
   typecycling("<Basic>", "{N}")`. Fight (`Novel Nunchaku`) and the four Mill-
   keyword cards remain unchecked but are believed composable.
+- **Gap M — choose-one-of-N-keywords (sub-shape resolved)**: `Wingnut, Bat on
+  the Belfry` shipped via `ModalEffect(countsAsModalSpell = false)` carrying
+  three single-keyword `Mode.noTarget` entries. The general "choose a kind
+  from among <list>" pattern in Gap M is closed for keywords by this idiom.
+- **Gap S — delayed "at the beginning of your NEXT upkeep"**: `Casey Jones,
+  Vigilante` shipped via `CreateDelayedTriggerEffect(step = Step.UPKEEP,
+  fireOnlyOnControllersTurn = true, effect = …)`. The same pattern handles
+  any other "next upkeep" rider that surfaces later.
+- **Gap EE — bottom-of-library-then-draw**: `Manhole Missile` shipped by
+  composing `GatherCards → SelectFromCollection(ChooseUpTo 1) → MoveCollection
+  to Library bottom → ConditionalOnCollection(DrawCards)`. No new SDK shape;
+  a future `EffectPatterns.bottomThenDraw(n)` would only be ergonomic sugar.
 
 ## Data sources — do NOT hit the network
 
@@ -150,25 +178,29 @@ Triggers used across the 9 cards:
 - "Enters with two +1/+1 counters if ..." (1): `Putrid Pals` — needs
   `entersWith(counters, condition)` if not already supported.
 
-### Gap C — Alliance (ability-word trigger) — 10 cards
-**Engine change:** none — pure ability-word marker. Add `Keyword.ALLIANCE` (display only)
-and an `alliance { ... }` DSL helper that wires
-`Triggers.WheneverAnotherCreatureYouControlEnters { effect }`. Mirror the existing
-`flurry`, `eerie`, `vivid`, `fatefulBite` ability-word helpers — no new engine code.
+### Gap C — Alliance (ability-word trigger) — partly RESOLVED
+**Engine change:** still none required for behavior — `Triggers.OtherCreatureEnters`
+already does the right thing. What remains is purely cosmetic: add a display-only
+`Keyword.ALLIANCE` to the SDK enum + an `alliance { ... }` DSL helper (mirror
+`flurry`, `eerie`, `vivid`, `fatefulBite`) so the rendered card text gets the
+italic ability-word prefix.
 
-Cards: `East Wind Avatar`, `Lita, Little Orphan Amphibian`, `Mighty Mutanimals`,
-`Mutant Town Musicians`, `Raphael, Most Attitude`, `Raphael, Tough Turtle`,
-`Slash, Reptile Rampager`, `Wingnut, Bat on the Belfry`, `EPF Point Squad`,
-`The Neutrinos`. One of them (`Lita`) layers a "modal effect that hasn't been chosen
-this turn" rider — see Gap E.
+Shipped composably (6/10): `East Wind Avatar`, `EPF Point Squad`,
+`Mighty Mutanimals`, `Mutant Town Musicians`, `Raphael, Tough Turtle`,
+`Slash, Reptile Rampager`, plus `Wingnut, Bat on the Belfry` (which also
+needed the Gap M choose-one-of-keywords idiom — see below).
 
-### Gap D — Channel keyword/DSL helper — 1 card
-**Engine change:** `Channel` keyword + DSL helper that wires the discard-from-hand
-activated ability. The mechanic exists in spirit (Kamigawa), but no `KeywordAbility.Channel`
-entry exists in `KeywordAbility.kt`. Compose: activated ability with cost `{N}, Discard
-this card.` from hand zone.
-- **Action News Crew** — "Channel — {6}, Discard this card: Put a +1/+1 counter on each
-  creature you control. Draw a card."
+Still blocked on something *else*: `Lita, Little Orphan Amphibian` (Gap E
+modal-not-yet-chosen), `Raphael, Most Attitude` (exile-and-may-cast chain),
+`The Neutrinos` (flicker-tapped-and-attacking).
+
+### Gap D — Channel — RESOLVED (behavior); display marker still missing
+**Engine change:** none required for behavior. `Action News Crew` ships via
+`activatedAbility { activateFromZone = Zone.HAND }` paired with
+`Costs.Composite(Mana("{N}"), DiscardSelf)`. Cosmetic follow-up: add a display-
+only `Keyword.CHANNEL` + `channel { }` DSL helper so the rendered text gets
+the italic "Channel —" prefix. Same shape as the residual Alliance / Disappear
+cosmetic work.
 
 ### Gap E — modal "choose one that hasn't been chosen this turn" — 1 card
 **Engine change:** per-source memory of which modes have been chosen this turn,
@@ -244,9 +276,11 @@ Each is its own PR; they don't share a clean reusable gap with others.
   (Reveal-until per-opponent + cast-from-exile-without-paying via the Disappear rider.)
 - **West Wind Avatar** — "you may sacrifice a token or a land" (sacrifice filter:
   "token or land" — composes existing filters, just verify the disjunction works).
-- **Wingnut, Bat on the Belfry** — "Wingnut gains your choice of flying, menace, or
-  reach until end of turn." (Choose-one-of-N-keywords grant — generalises
-  Aragorn-style "choose a counter kind" from LTR Gap 7.)
+- **~~Wingnut, Bat on the Belfry~~ — RESOLVED**: "choose flying / menace / haste UEOT"
+  ships via `ModalEffect(countsAsModalSpell = false)` with three single-keyword
+  `Mode.noTarget` entries. The "choose-one-of-N-keywords UEOT grant" sub-shape
+  is closed for keywords by this idiom; the same composition generalises to any
+  "choose a kind from among <list of statics>" wording.
 - **Lord Dregg, Insect Invader** — "Sacrifice a token: Draw a card." (Token-filtered
   sacrifice cost on an activated ability; verify `AbilityCost.SacrificeFiltered`
   supports the token predicate.)
@@ -298,11 +332,12 @@ gain-control primitives are single-target (LTR Gap 37 covers duration-based).
 - **Broadcast Takeover** — "Gain control of all artifacts your opponents control
   until end of turn. Untap them. They gain haste until end of turn."
 
-### Gap S — delayed trigger "at the beginning of your NEXT upkeep"
-**Engine change:** delayed-trigger plumbing for "next" timing windows (not the
-end-of-turn cleanup the engine already wires up).
-- **Casey Jones, Vigilante** — ETB draw 3, then "at the beginning of your next
-  upkeep, discard three cards at random."
+### Gap S — delayed "at the beginning of your NEXT upkeep" — RESOLVED
+**Engine change:** none required. `CreateDelayedTriggerEffect(step = Step.UPKEEP,
+fireOnlyOnControllersTurn = true, effect = …)` already covers this — `Casey
+Jones, Vigilante` shipped via that combinator paired with the Urgoros random-
+discard pipeline. The same composition handles any future "at your next
+upkeep" rider.
 
 ### Gap T — copy-an-artifact-token with sacrifice at the next end step
 **Engine change:** activated "create a token that's a copy of target artifact you
@@ -387,12 +422,12 @@ because the predicate reads the chosen target during cast.
 - **Grounded for Life** — "This spell costs {3} less to cast if it targets a
   tapped creature."
 
-### Gap EE — "may put a card from your hand on the bottom of your library. If you do, draw a card."
-**Engine change:** an optional bottom-of-library + conditional draw composite.
-Mirrors `EffectPatterns.rummage`/`loot` but the cost step is "bottom" instead
-of "discard." Could be added as `EffectPatterns.bottomThenDraw(n)` once.
-- **Manhole Missile** — also deals 3 damage on resolve; the damage half is
-  trivially composable, only the bottom-then-draw rider is missing.
+### Gap EE — "may put a card from your hand on the bottom of your library. If you do, draw a card." — RESOLVED
+**Engine change:** none required. Composes inline as
+`GatherCards → SelectFromCollection(ChooseUpTo 1) → MoveCollection-to-
+Library-bottom → ConditionalOnCollection(DrawCards)`. `Manhole Missile`
+ships with this idiom. A future `EffectPatterns.bottomThenDraw(n)` would
+be ergonomic sugar but isn't required.
 
 ### Gap FF — "becomes an artifact creature with base P/T N/M" until end of turn
 **Engine change:** extend `Effects.BecomeCreature` (or add a sibling) so it can
@@ -456,17 +491,19 @@ more "composable but skipped" entries.
 Each row is a card encountered during an alphabetical pass that was not
 implemented, with the underlying blocker. Gaps reference the sections above
 (existing Gap A–M or the new Gap N–KK). Rows previously marked
-"Composable — deferred" have all landed and been removed.
+"Composable — deferred" have all landed and been removed. Likewise, cards
+that subsequently landed in later runs (the six Alliance composables,
+Action News Crew, Casey Jones Vigilante, Escape Tunnel, Manhole Missile,
+Wingnut) have been removed from the table — see the "Gaps resolved" list at
+the top of the Status section for what closed those.
 
 | Card                                  | Blocker / Gap                               |
 |---------------------------------------|---------------------------------------------|
-| Action News Crew                      | Gap D (Channel)                             |
 | April O'Neil, Hacktivist              | Gap N (card-types-cast amount)              |
 | April O'Neil, Kunoichi Trainee        | Gap O (can't-be-blocked-by-power)           |
 | Bebop & Rocksteady                    | Gap P (unless-you-discard rider)            |
 | Brilliance Unleashed                  | Gap Q (typed-override reanimate token)      |
 | Broadcast Takeover                    | Gap R (mass gain-control UEOT)              |
-| Casey Jones, Vigilante                | Gap S (delayed next-upkeep trigger)         |
 | Chrome Dome                           | Gap T (copy-artifact + next-end-step sac)   |
 | Cool but Rude                         | Gap U (Class)                               |
 | Courier of Comestibles                | Gap V (search-or-fail-then-token)           |
@@ -478,9 +515,6 @@ implemented, with the underlying blocker. Gaps reference the sections above
 | Donatello's Technique                 | Gap A (Sneak)                               |
 | Donatello, Gadget Master              | Gap A (Sneak) + token-with-overrides        |
 | Donatello, Mutant Mechanic            | Gap M (Pizza-Face-style type-grant)         |
-| East Wind Avatar                      | Gap C (Alliance)                            |
-| EPF Point Squad                       | Gap C (Alliance)                            |
-| Escape Tunnel                         | "Target creature with power 2 or less can't be blocked this turn" + sac-land filter |
 | Everything Pizza                      | Pentacolored sac activation that also draws + makes each opponent discard — bespoke |
 | Foot Mystic                           | Gap B (Disappear)                           |
 | Foot Ninjas                           | Gap A (Sneak)                               |
@@ -508,19 +542,16 @@ implemented, with the underlying blocker. Gaps reference the sections above
 | Lita, Little Orphan Amphibian         | Gap C (Alliance) + Gap E (mode-not-yet-chosen) |
 | Lord Dregg, Insect Invader            | Gap B (Disappear) + Gap M (Sacrifice-a-token cost) |
 | Madame Null, Power Broker             | Gap GG (may-pay-dynamic-life)               |
-| Manhole Missile                       | Gap EE (bottom-of-library-then-draw)        |
 | Michelangelo's Technique              | Gap A (Sneak)                               |
 | Michelangelo, Game Master             | Gap B (Disappear)                           |
 | Michelangelo, Improviser              | Gap A (Sneak)                               |
 | Michelangelo, Mutant BFF              | Gap W (Mutagen) + counter-doubling replacement |
 | Michelangelo, Weirdness to 11         | Gap W (Mutagen) + counter-doubling replacement |
-| Mighty Mutanimals                     | Gap C (Alliance)                            |
 | Mikey & Don, Party Planners           | Play-from-top + cast-Mutant/Ninja/Turtle-from-top — bespoke |
 | Mind Transfer Protocol                | Gap FF (BecomeCreature that adds Artifact)  |
 | Mondo Gecko                           | Discard-to-grant-color + hexproof-from-color combat trigger — bespoke |
 | Mutagen Man, Living Ooze              | Gap W (Mutagen) + activated-ability-cost-reduction static |
 | Mutant Chain Reaction                 | Gap W (Mutagen)                             |
-| Mutant Town Musicians                 | Gap C (Alliance)                            |
 | New Generation's Technique            | Gap A (Sneak)                               |
 | Ninja Teen                            | Gap U (Class)                               |
 | North Wind Avatar                     | "Put a card you own from outside the game into your hand" (wishboard) |
@@ -540,7 +571,6 @@ implemented, with the underlying blocker. Gaps reference the sections above
 | Raphael, Most Attitude                | Gap C (Alliance)                            |
 | Raphael, Ninja Destroyer              | Gap F (Enrage) + Gap G (persistent mana)    |
 | Raphael, the Nightwatcher             | Gap A (Sneak)                               |
-| Raphael, Tough Turtle                 | Gap C (Alliance)                            |
 | Rat King, Verminister                 | Gap B (Disappear) + Gap M (same-name reanimate) |
 | Ray Fillet, Man Ray                   | Gap W (Mutagen)                             |
 | Retro-Mutation                        | Type-overriding Aura + "loses all abilities" UEOT |
@@ -549,7 +579,6 @@ implemented, with the underlying blocker. Gaps reference the sections above
 | Shark Shredder, Killer Clone          | Gap A (Sneak)                               |
 | Shredder's Technique                  | Gap A (Sneak)                               |
 | Shredder, Unrelenting                 | Gap A (Sneak)                               |
-| Slash, Reptile Rampager               | Gap C (Alliance)                            |
 | Slithering Cryptid                    | Gap W (Mutagen)                             |
 | Splinter's Technique                  | Gap A (Sneak)                               |
 | Splinter, Hamato Yoshi                | Gap A (Sneak)                               |
@@ -569,5 +598,4 @@ implemented, with the underlying blocker. Gaps reference the sections above
 | Turtles in Time                       | Mass bounce + shuffle-hand+gy-and-draw-7 + exile-self |
 | Venus, Torn Between Worlds            | "Damage dealt + survives" trigger condition + counter-bearer combat trigger |
 | West Wind Avatar                      | Gap B (Disappear) + Gap M (token-or-land sac filter) |
-| Wingnut, Bat on the Belfry            | Gap C (Alliance) + Gap M (choose-one-of-N-keywords) |
 | Zoo Escapees                          | Gap W (Mutagen)                             |

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,11 +10,11 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-90 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+95 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist; the per-card commits on `tmt-scaffolding`
 all carry `flavorText` in metadata.
 
-The remaining 100 cards mostly cluster on a handful of unresolved gaps:
+The remaining 95 cards mostly cluster on a handful of unresolved gaps:
 - **Sneak** — 26 cards (Gap A — unresolved)
 - **Disappear** — 9 cards (Gap B — unresolved)
 - **Alliance** — 4 cards left (Gap C — partly cleared; 6 shipped composably,
@@ -62,6 +62,39 @@ Gaps **resolved across the runs so far**:
   composing `GatherCards → SelectFromCollection(ChooseUpTo 1) → MoveCollection
   to Library bottom → ConditionalOnCollection(DrawCards)`. No new SDK shape;
   a future `EffectPatterns.bottomThenDraw(n)` would only be ergonomic sugar.
+- **Gap O — "can't be blocked by creatures with power N or greater" —
+  RESOLVED**: `April O'Neil, Kunoichi Trainee` shipped via the existing
+  `CantBeBlockedBy(GameObjectFilter.Creature.powerAtLeast(N))` static — same
+  shape BLB Azure Beastbinder uses. Fixed-N variant closed. The relative-
+  comparison sibling **Gap HH** ("with greater power" than source) remains
+  unresolved.
+- **Gap Q — graveyard reanimate as a typed-override token — RESOLVED**:
+  `Brilliance Unleashed` (Mode 2) shipped by composing `MoveToZoneEffect(...
+  GRAVEYARD → BATTLEFIELD)` with `ConditionalEffect(Not(TargetMatchesFilter
+  (Creature)), Effects.BecomeCreature(3, 3, keywords = {FLYING},
+  creatureTypes = {"Robot"}, duration = Duration.Permanent))`. Same idea as
+  the EOE Xu-Ifit reanimate-with-permanent-rider, but the rider only fires
+  when the original card wasn't already an artifact creature card.
+- **Splinter-style "triggers an additional time" filter** — `Splinter,
+  Radical Rat` shipped via the existing `AdditionalSourceTriggers` static
+  (same shape ECL Twinflame Travelers uses), parameterised on
+  `GameObjectFilter.Creature.withSubtype("Ninja").youControl()` with
+  `excludeSelf = false` so Splinter's own triggers count (printed "a Ninja
+  you control", no "another").
+- **Delayed destroy of a created token (Old Hob)** — `Old Hob, Alleycat
+  Blues` ships via the EOE Systems Override idiom: `CreateTokenEffect`
+  publishes the new token into `ContextTarget(0)`, then
+  `CreateDelayedTriggerEffect(step = Step.END, effect = MoveToZoneEffect
+  (ContextTarget(0), GRAVEYARD, byDestruction = true))` schedules a
+  faithful *destroy* at the next end step — so the second ability's UEOT
+  indestructible grant legitimately saves the token (a `sacrificeAtStep`
+  shortcut would have silently bypassed indestructible).
+- **Additional combat phase rider** — `Raph & Leo, Sibling Rivals` ships
+  via the existing `AddCombatPhaseEffect` (same shape as LTR Éomer, Marshal
+  of Rohan), with the printed *"if it's the first combat phase of the
+  turn"* intervening-if approximated by `oncePerTurn = true`. The
+  approximation is documented in the file's docstring; swap for
+  `Conditions.IsFirstCombatPhase` when that primitive lands.
 
 ## Data sources — do NOT hit the network
 
@@ -304,12 +337,10 @@ cards turn up wanting the same primitive.
 - **April O'Neil, Hacktivist** — end step: "draw a card for each card type among
   spells you've cast this turn."
 
-### Gap O — "can't be blocked by creatures with power N or greater"
-**Engine change:** a static / target-filtered evasion gating creatures by power.
-The blocking-static plumbing exists (`BlockingStaticAbilities.kt`); generalize to
-read the blocker's projected power.
-- **April O'Neil, Kunoichi Trainee** — "can't be blocked by creatures with power
-  3 or greater."
+### Gap O — "can't be blocked by creatures with power N or greater" — RESOLVED
+**Engine change:** none. `CantBeBlockedBy(GameObjectFilter.Creature.powerAtLeast(N))`
+already covers the fixed-N variant — shipped via April O'Neil, Kunoichi
+Trainee. The relative-comparison sibling is **Gap HH** below.
 
 ### Gap P — "unless you discard a card" cost-mitigation rider
 **Engine change:** a triggered-ability shape that says "sacrifice X unless you
@@ -317,13 +348,14 @@ read the blocker's projected power.
 - **Bebop & Rocksteady** — "Whenever Bebop & Rocksteady attack or block, sacrifice
   a permanent unless you discard a card."
 
-### Gap Q — graveyard reanimate as a typed-override token
-**Engine change:** a return-from-graveyard variant that puts the card on the
-battlefield as if it were a token with overridden card types, P/T, color, and
-granted keywords. Different from current copy-with-overrides (which targets a
-permanent in play) — this overrides a card on its way out of the graveyard.
-- **Brilliance Unleashed** — second mode: non-artifact-creature artifact card
-  comes back as "a 3/3 Robot artifact creature with flying."
+### Gap Q — graveyard reanimate as a typed-override token — RESOLVED
+**Engine change:** none. The `MoveToZoneEffect(GRAVEYARD → BATTLEFIELD) +
+ConditionalEffect(Not(TargetMatchesFilter(Creature)),
+Effects.BecomeCreature(... duration = Duration.Permanent))` chain models
+Brilliance Unleashed's second mode faithfully. The "becomes" rider only
+fires on the non-creature branch, matching the printed text. `BecomeCreature`
+with `duration = Duration.Permanent` mirrors EOE Xu-Ifit's reanimate-with-
+permanent-rider shape.
 
 ### Gap R — gain control of all matching permanents UEOT + untap + grant haste
 **Engine change:** a bulk gain-control effect over a filter (all artifacts an
@@ -500,9 +532,7 @@ the top of the Status section for what closed those.
 | Card                                  | Blocker / Gap                               |
 |---------------------------------------|---------------------------------------------|
 | April O'Neil, Hacktivist              | Gap N (card-types-cast amount)              |
-| April O'Neil, Kunoichi Trainee        | Gap O (can't-be-blocked-by-power)           |
 | Bebop & Rocksteady                    | Gap P (unless-you-discard rider)            |
-| Brilliance Unleashed                  | Gap Q (typed-override reanimate token)      |
 | Broadcast Takeover                    | Gap R (mass gain-control UEOT)              |
 | Chrome Dome                           | Gap T (copy-artifact + next-end-step sac)   |
 | Cool but Rude                         | Gap U (Class)                               |
@@ -557,7 +587,6 @@ the top of the Status section for what closed those.
 | North Wind Avatar                     | "Put a card you own from outside the game into your hand" (wishboard) |
 | Northampton Farm                      | Custom land with linked-exile mechanic — bespoke |
 | Novel Nunchaku                        | "When you do, equipped creature fights" sub-trigger (Gap AA shape) |
-| Old Hob, Alleycat Blues               | Delayed-trigger "destroy it at the next end step" |
 | Ooze Spill                            | Gap W (Mutagen)                             |
 | Oroku Saki, Shredder Rising           | Gap A (Sneak)                               |
 | Paramecia Coloniex                    | Dies → "may exile; when you do …" sub-trigger (Gap AA shape) |
@@ -566,7 +595,6 @@ the top of the Status section for what closed those.
 | Prehistoric Pet                       | Gap HH (can't-be-blocked-by-greater-power)  |
 | Purple Dragon Punks                   | Gap KK (artifact-spell-or-any-ability mana restriction) |
 | Putrid Pals                           | Gap B (Disappear)                           |
-| Raph & Leo, Sibling Rivals            | Additional combat phase + conditional untap |
 | Raphael's Technique                   | Gap A (Sneak)                               |
 | Raphael, Most Attitude                | Gap C (Alliance)                            |
 | Raphael, Ninja Destroyer              | Gap F (Enrage) + Gap G (persistent mana)    |
@@ -582,7 +610,6 @@ the top of the Status section for what closed those.
 | Slithering Cryptid                    | Gap W (Mutagen)                             |
 | Splinter's Technique                  | Gap A (Sneak)                               |
 | Splinter, Hamato Yoshi                | Gap A (Sneak)                               |
-| Splinter, Radical Rat                 | "Ninja triggered ability triggers an additional time" — bespoke |
 | Technodrome                           | "Can't attack or block unless its power is 6 or greater" — Gap O-shape on self |
 | The Cloning of Shredder               | Gap K (Saga)                                |
 | The Last Ronin                        | Gap K (Saga) + Gap A (Sneak)                |

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 13 / 190
+**Implemented:** 14 / 190
 ---
 
 - [ ] Action News Crew
@@ -62,7 +62,7 @@
 - [ ] Henchbots
 - [ ] High-Flying Ace
 - [ ] Ice Cream Kitty
-- [ ] Illegitimate Business
+- [x] Illegitimate Business
 - [ ] Improvised Arsenal
 - [ ] Insectoid Exterminator
 - [ ] Jennika's Technique

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 55 / 190
+**Implemented:** 56 / 190
 ---
 
 - [ ] Action News Crew
@@ -183,7 +183,7 @@
 - [ ] Turncoat Kunoichi
 - [ ] Turtle Blimp
 - [ ] Turtle Lair
-- [ ] Turtle Power!
+- [x] Turtle Power!
 - [ ] Turtle Van
 - [ ] Turtles Forever
 - [ ] Turtles in Time

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 31 / 190
+**Implemented:** 32 / 190
 ---
 
 - [ ] Action News Crew
@@ -66,7 +66,7 @@
 - [ ] Improvised Arsenal
 - [ ] Insectoid Exterminator
 - [ ] Jennika's Technique
-- [ ] Jennika, Bad Apple Big Sister
+- [x] Jennika, Bad Apple Big Sister
 - [ ] Karai's Technique
 - [ ] Karai, Future of the Foot
 - [ ] Kitsune's Technique

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 29 / 190
+**Implemented:** 30 / 190
 ---
 
 - [ ] Action News Crew
@@ -30,7 +30,7 @@
 - [ ] Dark Leo & Shredder
 - [x] Death in the Family
 - [x] Dimension X
-- [ ] Dimensional Exile
+- [x] Dimensional Exile
 - [ ] Does Machines
 - [ ] Don & Leo, Problem Solvers
 - [ ] Don & Raph, Hard Science

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 49 / 190
+**Implemented:** 50 / 190
 ---
 
 - [ ] Action News Crew
@@ -155,7 +155,7 @@
 - [x] Shredder's Revenge
 - [ ] Shredder's Technique
 - [ ] Shredder, Unrelenting
-- [ ] Skateboard
+- [x] Skateboard
 - [ ] Slash, Reptile Rampager
 - [ ] Slithering Cryptid
 - [ ] South Wind Avatar

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 73 / 190
+**Implemented:** 74 / 190
 ---
 
 - [ ] Action News Crew
@@ -73,7 +73,7 @@
 - [ ] Kitsune, Dragon's Daughter
 - [ ] Koya, Death from Above
 - [ ] Krang & Shredder
-- [ ] Krang, Master Mind
+- [x] Krang, Master Mind
 - [x] Krang, Utrom Warlord
 - [ ] Leader's Talent
 - [ ] Leatherhead, Swamp Stalker

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 50 / 190
+**Implemented:** 51 / 190
 ---
 
 - [ ] Action News Crew
@@ -159,7 +159,7 @@
 - [ ] Slash, Reptile Rampager
 - [ ] Slithering Cryptid
 - [ ] South Wind Avatar
-- [ ] Spicy Oatmeal Pizza
+- [x] Spicy Oatmeal Pizza
 - [ ] Splinter's Technique
 - [ ] Splinter, Hamato Yoshi
 - [ ] Splinter, Radical Rat

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 85 / 190
+**Implemented:** 86 / 190
 ---
 
 - [ ] Action News Crew
@@ -87,7 +87,7 @@
 - [ ] Lord Dregg, Insect Invader
 - [ ] Madame Null, Power Broker
 - [x] Make Your Move
-- [ ] Manhole Missile
+- [x] Manhole Missile
 - [x] Mechanized Ninja Cavalry
 - [x] Metalhead
 - [ ] Michelangelo's Technique

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 30 / 190
+**Implemented:** 31 / 190
 ---
 
 - [ ] Action News Crew
@@ -45,7 +45,7 @@
 - [ ] Escape Tunnel
 - [ ] Everything Pizza
 - [x] Featherbrained Filcher
-- [ ] Foot Elite
+- [x] Foot Elite
 - [x] Foot Headquarters
 - [ ] Foot Mystic
 - [ ] Foot Ninjas

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 33 / 190
+**Implemented:** 34 / 190
 ---
 
 - [ ] Action News Crew
@@ -82,7 +82,7 @@
 - [ ] Leonardo, Cutting Edge
 - [ ] Leonardo, Leader in Blue
 - [ ] Leonardo, Sewer Samurai
-- [ ] Lessons from Life
+- [x] Lessons from Life
 - [ ] Lita, Little Orphan Amphibian
 - [ ] Lord Dregg, Insect Invader
 - [ ] Madame Null, Power Broker

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 56 / 190
+**Implemented:** 57 / 190
 ---
 
 - [ ] Action News Crew
@@ -193,5 +193,5 @@
 - [ ] Weather Maker
 - [ ] West Wind Avatar
 - [ ] Wingnut, Bat on the Belfry
-- [ ] Zog, Triceraton Castaway
+- [x] Zog, Triceraton Castaway
 - [ ] Zoo Escapees

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 35 / 190
+**Implemented:** 36 / 190
 ---
 
 - [ ] Action News Crew
@@ -88,7 +88,7 @@
 - [ ] Madame Null, Power Broker
 - [x] Make Your Move
 - [ ] Manhole Missile
-- [ ] Mechanized Ninja Cavalry
+- [x] Mechanized Ninja Cavalry
 - [ ] Metalhead
 - [ ] Michelangelo's Technique
 - [ ] Michelangelo, Game Master

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 90 / 190
+**Implemented:** 91 / 190
 ---
 
 - [x] Action News Crew
@@ -162,7 +162,7 @@
 - [x] Spicy Oatmeal Pizza
 - [ ] Splinter's Technique
 - [ ] Splinter, Hamato Yoshi
-- [ ] Splinter, Radical Rat
+- [x] Splinter, Radical Rat
 - [x] Squirrelanoids
 - [x] Stockman, Mad Fly-entist
 - [x] Stomped by the Foot

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 36 / 190
+**Implemented:** 37 / 190
 ---
 
 - [ ] Action News Crew
@@ -89,7 +89,7 @@
 - [x] Make Your Move
 - [ ] Manhole Missile
 - [x] Mechanized Ninja Cavalry
-- [ ] Metalhead
+- [x] Metalhead
 - [ ] Michelangelo's Technique
 - [ ] Michelangelo, Game Master
 - [ ] Michelangelo, Improviser

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 10 / 190
+**Implemented:** 11 / 190
 ---
 
 - [ ] Action News Crew
@@ -25,7 +25,7 @@
 - [ ] Chrome Dome
 - [ ] Cool but Rude
 - [ ] Courier of Comestibles
-- [ ] Cowabunga!
+- [x] Cowabunga!
 - [ ] Crustacean Commando
 - [ ] Dark Leo & Shredder
 - [x] Death in the Family

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 27 / 190
+**Implemented:** 28 / 190
 ---
 
 - [ ] Action News Crew
@@ -12,7 +12,7 @@
 - [ ] April O'Neil, Kunoichi Trainee
 - [x] April, Reporter of the Weird
 - [x] Armaggon, Future Shark
-- [ ] Baxter Stockman
+- [x] Baxter Stockman
 - [ ] Bebop & Rocksteady
 - [ ] Bebop, Warthog Warrior
 - [x] Bespoke Bō

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 76 / 190
+**Implemented:** 77 / 190
 ---
 
 - [ ] Action News Crew
@@ -129,7 +129,7 @@
 - [x] Punk Frogs
 - [ ] Purple Dragon Punks
 - [ ] Putrid Pals
-- [ ] Quintessential Katana
+- [x] Quintessential Katana
 - [x] Ragamuffin Raptor
 - [ ] Raph & Leo, Sibling Rivals
 - [x] Raph & Mikey, Troublemakers

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 57 / 190
+**Implemented:** 58 / 190
 ---
 
 - [ ] Action News Crew
@@ -166,7 +166,7 @@
 - [x] Squirrelanoids
 - [x] Stockman, Mad Fly-entist
 - [ ] Stomped by the Foot
-- [ ] Super Shredder
+- [x] Super Shredder
 - [ ] Tainted Treats
 - [x] TCRI Building
 - [ ] Technodrome

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 75 / 190
+**Implemented:** 76 / 190
 ---
 
 - [ ] Action News Crew
@@ -97,7 +97,7 @@
 - [ ] Michelangelo, Weirdness to 11
 - [ ] Mighty Mutanimals
 - [ ] Mikey & Don, Party Planners
-- [ ] Mikey & Leo, Chaos & Order
+- [x] Mikey & Leo, Chaos & Order
 - [ ] Mind Transfer Protocol
 - [x] Mona Lisa, Science Geek
 - [ ] Mondo Gecko

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 4 / 190
+**Implemented:** 5 / 190
 ---
 
 - [ ] Action News Crew
@@ -10,7 +10,7 @@
 - [x] Anchovy & Banana Pizza
 - [ ] April O'Neil, Hacktivist
 - [ ] April O'Neil, Kunoichi Trainee
-- [ ] April, Reporter of the Weird
+- [x] April, Reporter of the Weird
 - [x] Armaggon, Future Shark
 - [ ] Baxter Stockman
 - [ ] Bebop & Rocksteady

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 22 / 190
+**Implemented:** 23 / 190
 ---
 
 - [ ] Action News Crew
@@ -56,7 +56,7 @@
 - [ ] Go Ninja Go
 - [ ] Groundchuck & Dirtbag
 - [ ] Grounded for Life
-- [ ] Guac & Marshmallow Pizza
+- [x] Guac & Marshmallow Pizza
 - [x] Hamato Guardian Stance
 - [ ] Hard-Won Jitte
 - [ ] Henchbots

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 66 / 190
+**Implemented:** 67 / 190
 ---
 
 - [ ] Action News Crew
@@ -147,7 +147,7 @@
 - [x] Rock Soldiers
 - [x] Rocksteady, Crash Courser
 - [x] Sally Pride, Lioness Leader
-- [ ] Savanti Romero, Time's Exile
+- [x] Savanti Romero, Time's Exile
 - [ ] Saved by the Shell
 - [ ] Sewer-veillance Cam
 - [ ] Shark Shredder, Killer Clone

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 81 / 190
+**Implemented:** 82 / 190
 ---
 
 - [ ] Action News Crew
@@ -95,7 +95,7 @@
 - [ ] Michelangelo, Improviser
 - [ ] Michelangelo, Mutant BFF
 - [ ] Michelangelo, Weirdness to 11
-- [ ] Mighty Mutanimals
+- [x] Mighty Mutanimals
 - [ ] Mikey & Don, Party Planners
 - [x] Mikey & Leo, Chaos & Order
 - [ ] Mind Transfer Protocol

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 78 / 190
+**Implemented:** 79 / 190
 ---
 
 - [ ] Action News Crew
@@ -151,7 +151,7 @@
 - [x] Saved by the Shell
 - [ ] Sewer-veillance Cam
 - [ ] Shark Shredder, Killer Clone
-- [ ] Shredder's Armor
+- [x] Shredder's Armor
 - [x] Shredder's Revenge
 - [ ] Shredder's Technique
 - [ ] Shredder, Unrelenting

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 86 / 190
+**Implemented:** 87 / 190
 ---
 
 - [ ] Action News Crew
@@ -21,7 +21,7 @@
 - [ ] Broadcast Takeover
 - [x] Buzz Bots
 - [x] Casey Jones, Jury-Rig Justiciar
-- [ ] Casey Jones, Vigilante
+- [x] Casey Jones, Vigilante
 - [ ] Chrome Dome
 - [ ] Cool but Rude
 - [ ] Courier of Comestibles

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 40 / 190
+**Implemented:** 41 / 190
 ---
 
 - [ ] Action News Crew
@@ -111,7 +111,7 @@
 - [x] Negate
 - [ ] New Generation's Technique
 - [ ] Ninja Teen
-- [ ] Nobody
+- [x] Nobody
 - [ ] North Wind Avatar
 - [ ] Northampton Farm
 - [ ] Novel Nunchaku

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 51 / 190
+**Implemented:** 52 / 190
 ---
 
 - [ ] Action News Crew
@@ -163,7 +163,7 @@
 - [ ] Splinter's Technique
 - [ ] Splinter, Hamato Yoshi
 - [ ] Splinter, Radical Rat
-- [ ] Squirrelanoids
+- [x] Squirrelanoids
 - [ ] Stockman, Mad Fly-entist
 - [ ] Stomped by the Foot
 - [ ] Super Shredder

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 21 / 190
+**Implemented:** 22 / 190
 ---
 
 - [ ] Action News Crew
@@ -57,7 +57,7 @@
 - [ ] Groundchuck & Dirtbag
 - [ ] Grounded for Life
 - [ ] Guac & Marshmallow Pizza
-- [ ] Hamato Guardian Stance
+- [x] Hamato Guardian Stance
 - [ ] Hard-Won Jitte
 - [ ] Henchbots
 - [ ] High-Flying Ace

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 15 / 190
+**Implemented:** 16 / 190
 ---
 
 - [ ] Action News Crew
@@ -168,7 +168,7 @@
 - [ ] Stomped by the Foot
 - [ ] Super Shredder
 - [ ] Tainted Treats
-- [ ] TCRI Building
+- [x] TCRI Building
 - [ ] Technodrome
 - [ ] Tenderize
 - [ ] The Cloning of Shredder

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 69 / 190
+**Implemented:** 70 / 190
 ---
 
 - [ ] Action News Crew
@@ -103,7 +103,7 @@
 - [ ] Mondo Gecko
 - [x] Mouser Attack!
 - [x] Mouser Foundry
-- [ ] Mouser Mark III
+- [x] Mouser Mark III
 - [ ] Mutagen Man, Living Ooze
 - [ ] Mutant Chain Reaction
 - [x] Mutant Town

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 82 / 190
+**Implemented:** 83 / 190
 ---
 
 - [ ] Action News Crew
@@ -107,7 +107,7 @@
 - [ ] Mutagen Man, Living Ooze
 - [ ] Mutant Chain Reaction
 - [x] Mutant Town
-- [ ] Mutant Town Musicians
+- [x] Mutant Town Musicians
 - [x] Negate
 - [ ] New Generation's Technique
 - [ ] Ninja Teen

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 44 / 190
+**Implemented:** 45 / 190
 ---
 
 - [ ] Action News Crew
@@ -144,7 +144,7 @@
 - [ ] Renet, Temporal Apprentice
 - [ ] Retro-Mutation
 - [ ] Return to the Sewers
-- [ ] Rock Soldiers
+- [x] Rock Soldiers
 - [ ] Rocksteady, Crash Courser
 - [ ] Sally Pride, Lioness Leader
 - [ ] Savanti Romero, Time's Exile

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 54 / 190
+**Implemented:** 55 / 190
 ---
 
 - [ ] Action News Crew
@@ -179,7 +179,7 @@
 - [ ] Tokka & Rahzar, Terrible Twos
 - [ ] Transdimensional Bovine
 - [ ] Triceraton Commander
-- [ ] Tunnel Rats
+- [x] Tunnel Rats
 - [ ] Turncoat Kunoichi
 - [ ] Turtle Blimp
 - [ ] Turtle Lair

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 60 / 190
+**Implemented:** 61 / 190
 ---
 
 - [ ] Action News Crew
@@ -115,7 +115,7 @@
 - [ ] North Wind Avatar
 - [ ] Northampton Farm
 - [ ] Novel Nunchaku
-- [ ] Null Group Biological Assets
+- [x] Null Group Biological Assets
 - [ ] Old Hob, Alleycat Blues
 - [x] Omni-Cheese Pizza
 - [ ] Ooze Spill

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 95 / 190
+**Implemented:** 96 / 190
 ---
 
 - [x] Action News Crew
@@ -181,7 +181,7 @@
 - [x] Triceraton Commander
 - [x] Tunnel Rats
 - [ ] Turncoat Kunoichi
-- [ ] Turtle Blimp
+- [x] Turtle Blimp
 - [ ] Turtle Lair
 - [x] Turtle Power!
 - [ ] Turtle Van

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 8 / 190
+**Implemented:** 9 / 190
 ---
 
 - [ ] Action News Crew
@@ -28,7 +28,7 @@
 - [ ] Cowabunga!
 - [ ] Crustacean Commando
 - [ ] Dark Leo & Shredder
-- [ ] Death in the Family
+- [x] Death in the Family
 - [ ] Dimension X
 - [ ] Dimensional Exile
 - [ ] Does Machines

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 52 / 190
+**Implemented:** 53 / 190
 ---
 
 - [ ] Action News Crew
@@ -164,7 +164,7 @@
 - [ ] Splinter, Hamato Yoshi
 - [ ] Splinter, Radical Rat
 - [x] Squirrelanoids
-- [ ] Stockman, Mad Fly-entist
+- [x] Stockman, Mad Fly-entist
 - [ ] Stomped by the Foot
 - [ ] Super Shredder
 - [ ] Tainted Treats

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 32 / 190
+**Implemented:** 33 / 190
 ---
 
 - [ ] Action News Crew
@@ -74,7 +74,7 @@
 - [ ] Koya, Death from Above
 - [ ] Krang & Shredder
 - [ ] Krang, Master Mind
-- [ ] Krang, Utrom Warlord
+- [x] Krang, Utrom Warlord
 - [ ] Leader's Talent
 - [ ] Leatherhead, Swamp Stalker
 - [ ] Leonardo's Technique

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 16 / 190
+**Implemented:** 17 / 190
 ---
 
 - [ ] Action News Crew
@@ -37,7 +37,7 @@
 - [ ] Donatello's Technique
 - [ ] Donatello, Gadget Master
 - [ ] Donatello, Mutant Mechanic
-- [ ] Donatello, Turtle Techie
+- [x] Donatello, Turtle Techie
 - [ ] Donatello, Way with Machines
 - [ ] Dream Beavers
 - [ ] East Wind Avatar

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 47 / 190
+**Implemented:** 48 / 190
 ---
 
 - [ ] Action News Crew
@@ -146,7 +146,7 @@
 - [ ] Return to the Sewers
 - [x] Rock Soldiers
 - [x] Rocksteady, Crash Courser
-- [ ] Sally Pride, Lioness Leader
+- [x] Sally Pride, Lioness Leader
 - [ ] Savanti Romero, Time's Exile
 - [ ] Saved by the Shell
 - [ ] Sewer-veillance Cam

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 26 / 190
+**Implemented:** 27 / 190
 ---
 
 - [ ] Action News Crew
@@ -61,7 +61,7 @@
 - [x] Hard-Won Jitte
 - [x] Henchbots
 - [x] High-Flying Ace
-- [ ] Ice Cream Kitty
+- [x] Ice Cream Kitty
 - [x] Illegitimate Business
 - [ ] Improvised Arsenal
 - [ ] Insectoid Exterminator

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 58 / 190
+**Implemented:** 59 / 190
 ---
 
 - [ ] Action News Crew
@@ -158,7 +158,7 @@
 - [x] Skateboard
 - [ ] Slash, Reptile Rampager
 - [ ] Slithering Cryptid
-- [ ] South Wind Avatar
+- [x] South Wind Avatar
 - [x] Spicy Oatmeal Pizza
 - [ ] Splinter's Technique
 - [ ] Splinter, Hamato Yoshi

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 77 / 190
+**Implemented:** 78 / 190
 ---
 
 - [ ] Action News Crew
@@ -120,7 +120,7 @@
 - [x] Omni-Cheese Pizza
 - [ ] Ooze Spill
 - [ ] Oroku Saki, Shredder Rising
-- [ ] Pain 101
+- [x] Pain 101
 - [ ] Paramecia Coloniex
 - [ ] Party Dude
 - [ ] Pizza Face, Gastromancer

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 84 / 190
+**Implemented:** 85 / 190
 ---
 
 - [ ] Action News Crew
@@ -156,7 +156,7 @@
 - [ ] Shredder's Technique
 - [ ] Shredder, Unrelenting
 - [x] Skateboard
-- [ ] Slash, Reptile Rampager
+- [x] Slash, Reptile Rampager
 - [ ] Slithering Cryptid
 - [x] South Wind Avatar
 - [x] Spicy Oatmeal Pizza

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 41 / 190
+**Implemented:** 42 / 190
 ---
 
 - [ ] Action News Crew
@@ -117,7 +117,7 @@
 - [ ] Novel Nunchaku
 - [ ] Null Group Biological Assets
 - [ ] Old Hob, Alleycat Blues
-- [ ] Omni-Cheese Pizza
+- [x] Omni-Cheese Pizza
 - [ ] Ooze Spill
 - [ ] Oroku Saki, Shredder Rising
 - [ ] Pain 101

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,14 +2,14 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 93 / 190
+**Implemented:** 94 / 190
 ---
 
 - [x] Action News Crew
 - [x] Agent Bishop, Man in Black
 - [x] Anchovy & Banana Pizza
 - [ ] April O'Neil, Hacktivist
-- [ ] April O'Neil, Kunoichi Trainee
+- [x] April O'Neil, Kunoichi Trainee
 - [x] April, Reporter of the Weird
 - [x] Armaggon, Future Shark
 - [x] Baxter Stockman

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 17 / 190
+**Implemented:** 18 / 190
 ---
 
 - [ ] Action News Crew
@@ -38,7 +38,7 @@
 - [ ] Donatello, Gadget Master
 - [ ] Donatello, Mutant Mechanic
 - [x] Donatello, Turtle Techie
-- [ ] Donatello, Way with Machines
+- [x] Donatello, Way with Machines
 - [ ] Dream Beavers
 - [ ] East Wind Avatar
 - [ ] EPF Point Squad

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 62 / 190
+**Implemented:** 63 / 190
 ---
 
 - [ ] Action News Crew
@@ -187,7 +187,7 @@
 - [ ] Turtle Van
 - [ ] Turtles Forever
 - [ ] Turtles in Time
-- [ ] Uneasy Alliance
+- [x] Uneasy Alliance
 - [ ] Utrom Scientists
 - [ ] Venus, Torn Between Worlds
 - [ ] Weather Maker

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 87 / 190
+**Implemented:** 88 / 190
 ---
 
 - [ ] Action News Crew
@@ -192,6 +192,6 @@
 - [ ] Venus, Torn Between Worlds
 - [x] Weather Maker
 - [ ] West Wind Avatar
-- [ ] Wingnut, Bat on the Belfry
+- [x] Wingnut, Bat on the Belfry
 - [x] Zog, Triceraton Castaway
 - [ ] Zoo Escapees

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 91 / 190
+**Implemented:** 92 / 190
 ---
 
 - [x] Action News Crew
@@ -131,7 +131,7 @@
 - [ ] Putrid Pals
 - [x] Quintessential Katana
 - [x] Ragamuffin Raptor
-- [ ] Raph & Leo, Sibling Rivals
+- [x] Raph & Leo, Sibling Rivals
 - [x] Raph & Mikey, Troublemakers
 - [ ] Raphael's Technique
 - [ ] Raphael, Most Attitude

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 88 / 190
+**Implemented:** 89 / 190
 ---
 
 - [ ] Action News Crew
@@ -42,7 +42,7 @@
 - [x] Dream Beavers
 - [x] East Wind Avatar
 - [x] EPF Point Squad
-- [ ] Escape Tunnel
+- [x] Escape Tunnel
 - [ ] Everything Pizza
 - [x] Featherbrained Filcher
 - [x] Foot Elite

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 34 / 190
+**Implemented:** 35 / 190
 ---
 
 - [ ] Action News Crew
@@ -86,7 +86,7 @@
 - [ ] Lita, Little Orphan Amphibian
 - [ ] Lord Dregg, Insect Invader
 - [ ] Madame Null, Power Broker
-- [ ] Make Your Move
+- [x] Make Your Move
 - [ ] Manhole Missile
 - [ ] Mechanized Ninja Cavalry
 - [ ] Metalhead

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 63 / 190
+**Implemented:** 64 / 190
 ---
 
 - [ ] Action News Crew
@@ -188,7 +188,7 @@
 - [ ] Turtles Forever
 - [ ] Turtles in Time
 - [x] Uneasy Alliance
-- [ ] Utrom Scientists
+- [x] Utrom Scientists
 - [ ] Venus, Torn Between Worlds
 - [ ] Weather Maker
 - [ ] West Wind Avatar

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 39 / 190
+**Implemented:** 40 / 190
 ---
 
 - [ ] Action News Crew
@@ -108,7 +108,7 @@
 - [ ] Mutant Chain Reaction
 - [x] Mutant Town
 - [ ] Mutant Town Musicians
-- [ ] Negate
+- [x] Negate
 - [ ] New Generation's Technique
 - [ ] Ninja Teen
 - [ ] Nobody

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 14 / 190
+**Implemented:** 15 / 190
 ---
 
 - [ ] Action News Crew
@@ -106,7 +106,7 @@
 - [ ] Mouser Mark III
 - [ ] Mutagen Man, Living Ooze
 - [ ] Mutant Chain Reaction
-- [ ] Mutant Town
+- [x] Mutant Town
 - [ ] Mutant Town Musicians
 - [ ] Negate
 - [ ] New Generation's Technique

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 53 / 190
+**Implemented:** 54 / 190
 ---
 
 - [ ] Action News Crew
@@ -170,7 +170,7 @@
 - [ ] Tainted Treats
 - [x] TCRI Building
 - [ ] Technodrome
-- [ ] Tenderize
+- [x] Tenderize
 - [ ] The Cloning of Shredder
 - [ ] The Last Ronin
 - [ ] The Last Ronin's Technique

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,12 +2,12 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 2 / 190
+**Implemented:** 3 / 190
 ---
 
 - [ ] Action News Crew
 - [x] Agent Bishop, Man in Black
-- [ ] Anchovy & Banana Pizza
+- [x] Anchovy & Banana Pizza
 - [ ] April O'Neil, Hacktivist
 - [ ] April O'Neil, Kunoichi Trainee
 - [ ] April, Reporter of the Weird

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,10 +2,10 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 89 / 190
+**Implemented:** 90 / 190
 ---
 
-- [ ] Action News Crew
+- [x] Action News Crew
 - [x] Agent Bishop, Man in Black
 - [x] Anchovy & Banana Pizza
 - [ ] April O'Neil, Hacktivist

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 92 / 190
+**Implemented:** 93 / 190
 ---
 
 - [x] Action News Crew
@@ -116,7 +116,7 @@
 - [ ] Northampton Farm
 - [ ] Novel Nunchaku
 - [x] Null Group Biological Assets
-- [ ] Old Hob, Alleycat Blues
+- [x] Old Hob, Alleycat Blues
 - [x] Omni-Cheese Pizza
 - [ ] Ooze Spill
 - [ ] Oroku Saki, Shredder Rising

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 9 / 190
+**Implemented:** 10 / 190
 ---
 
 - [ ] Action News Crew
@@ -20,7 +20,7 @@
 - [ ] Brilliance Unleashed
 - [ ] Broadcast Takeover
 - [x] Buzz Bots
-- [ ] Casey Jones, Jury-Rig Justiciar
+- [x] Casey Jones, Jury-Rig Justiciar
 - [ ] Casey Jones, Vigilante
 - [ ] Chrome Dome
 - [ ] Cool but Rude

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,12 +2,11 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 1 / 190
-
+**Implemented:** 2 / 190
 ---
 
 - [ ] Action News Crew
-- [ ] Agent Bishop, Man in Black
+- [x] Agent Bishop, Man in Black
 - [ ] Anchovy & Banana Pizza
 - [ ] April O'Neil, Hacktivist
 - [ ] April O'Neil, Kunoichi Trainee

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 42 / 190
+**Implemented:** 43 / 190
 ---
 
 - [ ] Action News Crew
@@ -125,7 +125,7 @@
 - [ ] Party Dude
 - [ ] Pizza Face, Gastromancer
 - [ ] Prehistoric Pet
-- [ ] Primordial Pachyderm
+- [x] Primordial Pachyderm
 - [ ] Punk Frogs
 - [ ] Purple Dragon Punks
 - [ ] Putrid Pals

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 37 / 190
+**Implemented:** 38 / 190
 ---
 
 - [ ] Action News Crew
@@ -101,7 +101,7 @@
 - [ ] Mind Transfer Protocol
 - [ ] Mona Lisa, Science Geek
 - [ ] Mondo Gecko
-- [ ] Mouser Attack!
+- [x] Mouser Attack!
 - [ ] Mouser Foundry
 - [ ] Mouser Mark III
 - [ ] Mutagen Man, Living Ooze

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 28 / 190
+**Implemented:** 29 / 190
 ---
 
 - [ ] Action News Crew
@@ -14,7 +14,7 @@
 - [x] Armaggon, Future Shark
 - [x] Baxter Stockman
 - [ ] Bebop & Rocksteady
-- [ ] Bebop, Warthog Warrior
+- [x] Bebop, Warthog Warrior
 - [x] Bespoke Bō
 - [x] Bot Bashing Time
 - [ ] Brilliance Unleashed

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 6 / 190
+**Implemented:** 7 / 190
 ---
 
 - [ ] Action News Crew
@@ -16,7 +16,7 @@
 - [ ] Bebop & Rocksteady
 - [ ] Bebop, Warthog Warrior
 - [x] Bespoke Bō
-- [ ] Bot Bashing Time
+- [x] Bot Bashing Time
 - [ ] Brilliance Unleashed
 - [ ] Broadcast Takeover
 - [ ] Buzz Bots

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 61 / 190
+**Implemented:** 62 / 190
 ---
 
 - [ ] Action News Crew
@@ -178,7 +178,7 @@
 - [ ] The Ooze
 - [ ] Tokka & Rahzar, Terrible Twos
 - [x] Transdimensional Bovine
-- [ ] Triceraton Commander
+- [x] Triceraton Commander
 - [x] Tunnel Rats
 - [ ] Turncoat Kunoichi
 - [ ] Turtle Blimp

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 11 / 190
+**Implemented:** 12 / 190
 ---
 
 - [ ] Action News Crew
@@ -29,7 +29,7 @@
 - [ ] Crustacean Commando
 - [ ] Dark Leo & Shredder
 - [x] Death in the Family
-- [ ] Dimension X
+- [x] Dimension X
 - [ ] Dimensional Exile
 - [ ] Does Machines
 - [ ] Don & Leo, Problem Solvers

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 64 / 190
+**Implemented:** 65 / 190
 ---
 
 - [ ] Action News Crew
@@ -190,7 +190,7 @@
 - [x] Uneasy Alliance
 - [x] Utrom Scientists
 - [ ] Venus, Torn Between Worlds
-- [ ] Weather Maker
+- [x] Weather Maker
 - [ ] West Wind Avatar
 - [ ] Wingnut, Bat on the Belfry
 - [x] Zog, Triceraton Castaway

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 74 / 190
+**Implemented:** 75 / 190
 ---
 
 - [ ] Action News Crew
@@ -141,7 +141,7 @@
 - [ ] Rat King, Verminister
 - [x] Ravenous Robots
 - [ ] Ray Fillet, Man Ray
-- [ ] Renet, Temporal Apprentice
+- [x] Renet, Temporal Apprentice
 - [ ] Retro-Mutation
 - [ ] Return to the Sewers
 - [x] Rock Soldiers

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 3 / 190
+**Implemented:** 4 / 190
 ---
 
 - [ ] Action News Crew
@@ -11,7 +11,7 @@
 - [ ] April O'Neil, Hacktivist
 - [ ] April O'Neil, Kunoichi Trainee
 - [ ] April, Reporter of the Weird
-- [ ] Armaggon, Future Shark
+- [x] Armaggon, Future Shark
 - [ ] Baxter Stockman
 - [ ] Bebop & Rocksteady
 - [ ] Bebop, Warthog Warrior

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 38 / 190
+**Implemented:** 39 / 190
 ---
 
 - [ ] Action News Crew
@@ -102,7 +102,7 @@
 - [ ] Mona Lisa, Science Geek
 - [ ] Mondo Gecko
 - [x] Mouser Attack!
-- [ ] Mouser Foundry
+- [x] Mouser Foundry
 - [ ] Mouser Mark III
 - [ ] Mutagen Man, Living Ooze
 - [ ] Mutant Chain Reaction

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 83 / 190
+**Implemented:** 84 / 190
 ---
 
 - [ ] Action News Crew
@@ -137,7 +137,7 @@
 - [ ] Raphael, Most Attitude
 - [ ] Raphael, Ninja Destroyer
 - [ ] Raphael, the Nightwatcher
-- [ ] Raphael, Tough Turtle
+- [x] Raphael, Tough Turtle
 - [ ] Rat King, Verminister
 - [x] Ravenous Robots
 - [ ] Ray Fillet, Man Ray

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 48 / 190
+**Implemented:** 49 / 190
 ---
 
 - [ ] Action News Crew
@@ -152,7 +152,7 @@
 - [ ] Sewer-veillance Cam
 - [ ] Shark Shredder, Killer Clone
 - [ ] Shredder's Armor
-- [ ] Shredder's Revenge
+- [x] Shredder's Revenge
 - [ ] Shredder's Technique
 - [ ] Shredder, Unrelenting
 - [ ] Skateboard

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 68 / 190
+**Implemented:** 69 / 190
 ---
 
 - [ ] Action News Crew
@@ -99,7 +99,7 @@
 - [ ] Mikey & Don, Party Planners
 - [ ] Mikey & Leo, Chaos & Order
 - [ ] Mind Transfer Protocol
-- [ ] Mona Lisa, Science Geek
+- [x] Mona Lisa, Science Geek
 - [ ] Mondo Gecko
 - [x] Mouser Attack!
 - [x] Mouser Foundry

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 19 / 190
+**Implemented:** 20 / 190
 ---
 
 - [ ] Action News Crew
@@ -44,7 +44,7 @@
 - [ ] EPF Point Squad
 - [ ] Escape Tunnel
 - [ ] Everything Pizza
-- [ ] Featherbrained Filcher
+- [x] Featherbrained Filcher
 - [ ] Foot Elite
 - [x] Foot Headquarters
 - [ ] Foot Mystic

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 59 / 190
+**Implemented:** 60 / 190
 ---
 
 - [ ] Action News Crew
@@ -177,7 +177,7 @@
 - [ ] The Neutrinos
 - [ ] The Ooze
 - [ ] Tokka & Rahzar, Terrible Twos
-- [ ] Transdimensional Bovine
+- [x] Transdimensional Bovine
 - [ ] Triceraton Commander
 - [x] Tunnel Rats
 - [ ] Turncoat Kunoichi

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 94 / 190
+**Implemented:** 95 / 190
 ---
 
 - [x] Action News Crew
@@ -17,7 +17,7 @@
 - [x] Bebop, Warthog Warrior
 - [x] Bespoke Bō
 - [x] Bot Bashing Time
-- [ ] Brilliance Unleashed
+- [x] Brilliance Unleashed
 - [ ] Broadcast Takeover
 - [x] Buzz Bots
 - [x] Casey Jones, Jury-Rig Justiciar

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 45 / 190
+**Implemented:** 46 / 190
 ---
 
 - [ ] Action News Crew
@@ -145,7 +145,7 @@
 - [ ] Retro-Mutation
 - [ ] Return to the Sewers
 - [x] Rock Soldiers
-- [ ] Rocksteady, Crash Courser
+- [x] Rocksteady, Crash Courser
 - [ ] Sally Pride, Lioness Leader
 - [ ] Savanti Romero, Time's Exile
 - [ ] Saved by the Shell

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 25 / 190
+**Implemented:** 26 / 190
 ---
 
 - [ ] Action News Crew
@@ -60,7 +60,7 @@
 - [x] Hamato Guardian Stance
 - [x] Hard-Won Jitte
 - [x] Henchbots
-- [ ] High-Flying Ace
+- [x] High-Flying Ace
 - [ ] Ice Cream Kitty
 - [x] Illegitimate Business
 - [ ] Improvised Arsenal

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 46 / 190
+**Implemented:** 47 / 190
 ---
 
 - [ ] Action News Crew
@@ -130,7 +130,7 @@
 - [ ] Purple Dragon Punks
 - [ ] Putrid Pals
 - [ ] Quintessential Katana
-- [ ] Ragamuffin Raptor
+- [x] Ragamuffin Raptor
 - [ ] Raph & Leo, Sibling Rivals
 - [x] Raph & Mikey, Troublemakers
 - [ ] Raphael's Technique

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 71 / 190
+**Implemented:** 72 / 190
 ---
 
 - [ ] Action News Crew
@@ -139,7 +139,7 @@
 - [ ] Raphael, the Nightwatcher
 - [ ] Raphael, Tough Turtle
 - [ ] Rat King, Verminister
-- [ ] Ravenous Robots
+- [x] Ravenous Robots
 - [ ] Ray Fillet, Man Ray
 - [ ] Renet, Temporal Apprentice
 - [ ] Retro-Mutation

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 7 / 190
+**Implemented:** 8 / 190
 ---
 
 - [ ] Action News Crew
@@ -19,7 +19,7 @@
 - [x] Bot Bashing Time
 - [ ] Brilliance Unleashed
 - [ ] Broadcast Takeover
-- [ ] Buzz Bots
+- [x] Buzz Bots
 - [ ] Casey Jones, Jury-Rig Justiciar
 - [ ] Casey Jones, Vigilante
 - [ ] Chrome Dome

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 12 / 190
+**Implemented:** 13 / 190
 ---
 
 - [ ] Action News Crew
@@ -46,7 +46,7 @@
 - [ ] Everything Pizza
 - [ ] Featherbrained Filcher
 - [ ] Foot Elite
-- [ ] Foot Headquarters
+- [x] Foot Headquarters
 - [ ] Foot Mystic
 - [ ] Foot Ninjas
 - [ ] Frog Butler

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 43 / 190
+**Implemented:** 44 / 190
 ---
 
 - [ ] Action News Crew
@@ -126,7 +126,7 @@
 - [ ] Pizza Face, Gastromancer
 - [ ] Prehistoric Pet
 - [x] Primordial Pachyderm
-- [ ] Punk Frogs
+- [x] Punk Frogs
 - [ ] Purple Dragon Punks
 - [ ] Putrid Pals
 - [ ] Quintessential Katana

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 79 / 190
+**Implemented:** 80 / 190
 ---
 
 - [ ] Action News Crew
@@ -40,7 +40,7 @@
 - [x] Donatello, Turtle Techie
 - [x] Donatello, Way with Machines
 - [x] Dream Beavers
-- [ ] East Wind Avatar
+- [x] East Wind Avatar
 - [ ] EPF Point Squad
 - [ ] Escape Tunnel
 - [ ] Everything Pizza

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 5 / 190
+**Implemented:** 6 / 190
 ---
 
 - [ ] Action News Crew
@@ -15,7 +15,7 @@
 - [ ] Baxter Stockman
 - [ ] Bebop & Rocksteady
 - [ ] Bebop, Warthog Warrior
-- [ ] Bespoke Bō
+- [x] Bespoke Bō
 - [ ] Bot Bashing Time
 - [ ] Brilliance Unleashed
 - [ ] Broadcast Takeover

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 23 / 190
+**Implemented:** 24 / 190
 ---
 
 - [ ] Action News Crew
@@ -58,7 +58,7 @@
 - [ ] Grounded for Life
 - [x] Guac & Marshmallow Pizza
 - [x] Hamato Guardian Stance
-- [ ] Hard-Won Jitte
+- [x] Hard-Won Jitte
 - [ ] Henchbots
 - [ ] High-Flying Ace
 - [ ] Ice Cream Kitty

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 18 / 190
+**Implemented:** 19 / 190
 ---
 
 - [ ] Action News Crew
@@ -39,7 +39,7 @@
 - [ ] Donatello, Mutant Mechanic
 - [x] Donatello, Turtle Techie
 - [x] Donatello, Way with Machines
-- [ ] Dream Beavers
+- [x] Dream Beavers
 - [ ] East Wind Avatar
 - [ ] EPF Point Squad
 - [ ] Escape Tunnel

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 20 / 190
+**Implemented:** 21 / 190
 ---
 
 - [ ] Action News Crew
@@ -49,7 +49,7 @@
 - [x] Foot Headquarters
 - [ ] Foot Mystic
 - [ ] Foot Ninjas
-- [ ] Frog Butler
+- [x] Frog Butler
 - [ ] Fugitive Droid
 - [ ] General Traag, Heart of Stone
 - [ ] Genghis Frog

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 80 / 190
+**Implemented:** 81 / 190
 ---
 
 - [ ] Action News Crew
@@ -41,7 +41,7 @@
 - [x] Donatello, Way with Machines
 - [x] Dream Beavers
 - [x] East Wind Avatar
-- [ ] EPF Point Squad
+- [x] EPF Point Squad
 - [ ] Escape Tunnel
 - [ ] Everything Pizza
 - [x] Featherbrained Filcher

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 72 / 190
+**Implemented:** 73 / 190
 ---
 
 - [ ] Action News Crew
@@ -167,7 +167,7 @@
 - [x] Stockman, Mad Fly-entist
 - [x] Stomped by the Foot
 - [x] Super Shredder
-- [ ] Tainted Treats
+- [x] Tainted Treats
 - [x] TCRI Building
 - [ ] Technodrome
 - [x] Tenderize

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -1,0 +1,198 @@
+# Teenage Mutant Ninja Turtles (TMT) - Card Checklist
+
+**Set Size:** 190 cards (excluding basic lands)
+**Release Date:** March 6, 2026
+**Implemented:** 1 / 190
+
+---
+
+- [ ] Action News Crew
+- [ ] Agent Bishop, Man in Black
+- [ ] Anchovy & Banana Pizza
+- [ ] April O'Neil, Hacktivist
+- [ ] April O'Neil, Kunoichi Trainee
+- [ ] April, Reporter of the Weird
+- [ ] Armaggon, Future Shark
+- [ ] Baxter Stockman
+- [ ] Bebop & Rocksteady
+- [ ] Bebop, Warthog Warrior
+- [ ] Bespoke Bō
+- [ ] Bot Bashing Time
+- [ ] Brilliance Unleashed
+- [ ] Broadcast Takeover
+- [ ] Buzz Bots
+- [ ] Casey Jones, Jury-Rig Justiciar
+- [ ] Casey Jones, Vigilante
+- [ ] Chrome Dome
+- [ ] Cool but Rude
+- [ ] Courier of Comestibles
+- [ ] Cowabunga!
+- [ ] Crustacean Commando
+- [ ] Dark Leo & Shredder
+- [ ] Death in the Family
+- [ ] Dimension X
+- [ ] Dimensional Exile
+- [ ] Does Machines
+- [ ] Don & Leo, Problem Solvers
+- [ ] Don & Raph, Hard Science
+- [ ] Donatello's Technique
+- [ ] Donatello, Gadget Master
+- [ ] Donatello, Mutant Mechanic
+- [ ] Donatello, Turtle Techie
+- [ ] Donatello, Way with Machines
+- [ ] Dream Beavers
+- [ ] East Wind Avatar
+- [ ] EPF Point Squad
+- [ ] Escape Tunnel
+- [ ] Everything Pizza
+- [ ] Featherbrained Filcher
+- [ ] Foot Elite
+- [ ] Foot Headquarters
+- [ ] Foot Mystic
+- [ ] Foot Ninjas
+- [ ] Frog Butler
+- [ ] Fugitive Droid
+- [ ] General Traag, Heart of Stone
+- [ ] Genghis Frog
+- [ ] Go Ninja Go
+- [ ] Groundchuck & Dirtbag
+- [ ] Grounded for Life
+- [ ] Guac & Marshmallow Pizza
+- [ ] Hamato Guardian Stance
+- [ ] Hard-Won Jitte
+- [ ] Henchbots
+- [ ] High-Flying Ace
+- [ ] Ice Cream Kitty
+- [ ] Illegitimate Business
+- [ ] Improvised Arsenal
+- [ ] Insectoid Exterminator
+- [ ] Jennika's Technique
+- [ ] Jennika, Bad Apple Big Sister
+- [ ] Karai's Technique
+- [ ] Karai, Future of the Foot
+- [ ] Kitsune's Technique
+- [ ] Kitsune, Dragon's Daughter
+- [ ] Koya, Death from Above
+- [ ] Krang & Shredder
+- [ ] Krang, Master Mind
+- [ ] Krang, Utrom Warlord
+- [ ] Leader's Talent
+- [ ] Leatherhead, Swamp Stalker
+- [ ] Leonardo's Technique
+- [ ] Leonardo, Big Brother
+- [ ] Leonardo, Cutting Edge
+- [ ] Leonardo, Leader in Blue
+- [ ] Leonardo, Sewer Samurai
+- [ ] Lessons from Life
+- [ ] Lita, Little Orphan Amphibian
+- [ ] Lord Dregg, Insect Invader
+- [ ] Madame Null, Power Broker
+- [ ] Make Your Move
+- [ ] Manhole Missile
+- [ ] Mechanized Ninja Cavalry
+- [ ] Metalhead
+- [ ] Michelangelo's Technique
+- [ ] Michelangelo, Game Master
+- [ ] Michelangelo, Improviser
+- [ ] Michelangelo, Mutant BFF
+- [ ] Michelangelo, Weirdness to 11
+- [ ] Mighty Mutanimals
+- [ ] Mikey & Don, Party Planners
+- [ ] Mikey & Leo, Chaos & Order
+- [ ] Mind Transfer Protocol
+- [ ] Mona Lisa, Science Geek
+- [ ] Mondo Gecko
+- [ ] Mouser Attack!
+- [ ] Mouser Foundry
+- [ ] Mouser Mark III
+- [ ] Mutagen Man, Living Ooze
+- [ ] Mutant Chain Reaction
+- [ ] Mutant Town
+- [ ] Mutant Town Musicians
+- [ ] Negate
+- [ ] New Generation's Technique
+- [ ] Ninja Teen
+- [ ] Nobody
+- [ ] North Wind Avatar
+- [ ] Northampton Farm
+- [ ] Novel Nunchaku
+- [ ] Null Group Biological Assets
+- [ ] Old Hob, Alleycat Blues
+- [ ] Omni-Cheese Pizza
+- [ ] Ooze Spill
+- [ ] Oroku Saki, Shredder Rising
+- [ ] Pain 101
+- [ ] Paramecia Coloniex
+- [ ] Party Dude
+- [ ] Pizza Face, Gastromancer
+- [ ] Prehistoric Pet
+- [ ] Primordial Pachyderm
+- [ ] Punk Frogs
+- [ ] Purple Dragon Punks
+- [ ] Putrid Pals
+- [ ] Quintessential Katana
+- [ ] Ragamuffin Raptor
+- [ ] Raph & Leo, Sibling Rivals
+- [x] Raph & Mikey, Troublemakers
+- [ ] Raphael's Technique
+- [ ] Raphael, Most Attitude
+- [ ] Raphael, Ninja Destroyer
+- [ ] Raphael, the Nightwatcher
+- [ ] Raphael, Tough Turtle
+- [ ] Rat King, Verminister
+- [ ] Ravenous Robots
+- [ ] Ray Fillet, Man Ray
+- [ ] Renet, Temporal Apprentice
+- [ ] Retro-Mutation
+- [ ] Return to the Sewers
+- [ ] Rock Soldiers
+- [ ] Rocksteady, Crash Courser
+- [ ] Sally Pride, Lioness Leader
+- [ ] Savanti Romero, Time's Exile
+- [ ] Saved by the Shell
+- [ ] Sewer-veillance Cam
+- [ ] Shark Shredder, Killer Clone
+- [ ] Shredder's Armor
+- [ ] Shredder's Revenge
+- [ ] Shredder's Technique
+- [ ] Shredder, Unrelenting
+- [ ] Skateboard
+- [ ] Slash, Reptile Rampager
+- [ ] Slithering Cryptid
+- [ ] South Wind Avatar
+- [ ] Spicy Oatmeal Pizza
+- [ ] Splinter's Technique
+- [ ] Splinter, Hamato Yoshi
+- [ ] Splinter, Radical Rat
+- [ ] Squirrelanoids
+- [ ] Stockman, Mad Fly-entist
+- [ ] Stomped by the Foot
+- [ ] Super Shredder
+- [ ] Tainted Treats
+- [ ] TCRI Building
+- [ ] Technodrome
+- [ ] Tenderize
+- [ ] The Cloning of Shredder
+- [ ] The Last Ronin
+- [ ] The Last Ronin's Technique
+- [ ] The Neutrinos
+- [ ] The Ooze
+- [ ] Tokka & Rahzar, Terrible Twos
+- [ ] Transdimensional Bovine
+- [ ] Triceraton Commander
+- [ ] Tunnel Rats
+- [ ] Turncoat Kunoichi
+- [ ] Turtle Blimp
+- [ ] Turtle Lair
+- [ ] Turtle Power!
+- [ ] Turtle Van
+- [ ] Turtles Forever
+- [ ] Turtles in Time
+- [ ] Uneasy Alliance
+- [ ] Utrom Scientists
+- [ ] Venus, Torn Between Worlds
+- [ ] Weather Maker
+- [ ] West Wind Avatar
+- [ ] Wingnut, Bat on the Belfry
+- [ ] Zog, Triceraton Castaway
+- [ ] Zoo Escapees

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 24 / 190
+**Implemented:** 25 / 190
 ---
 
 - [ ] Action News Crew
@@ -59,7 +59,7 @@
 - [x] Guac & Marshmallow Pizza
 - [x] Hamato Guardian Stance
 - [x] Hard-Won Jitte
-- [ ] Henchbots
+- [x] Henchbots
 - [ ] High-Flying Ace
 - [ ] Ice Cream Kitty
 - [x] Illegitimate Business

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 67 / 190
+**Implemented:** 68 / 190
 ---
 
 - [ ] Action News Crew
@@ -63,7 +63,7 @@
 - [x] High-Flying Ace
 - [x] Ice Cream Kitty
 - [x] Illegitimate Business
-- [ ] Improvised Arsenal
+- [x] Improvised Arsenal
 - [ ] Insectoid Exterminator
 - [ ] Jennika's Technique
 - [x] Jennika, Bad Apple Big Sister

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 70 / 190
+**Implemented:** 71 / 190
 ---
 
 - [ ] Action News Crew
@@ -148,7 +148,7 @@
 - [x] Rocksteady, Crash Courser
 - [x] Sally Pride, Lioness Leader
 - [x] Savanti Romero, Time's Exile
-- [ ] Saved by the Shell
+- [x] Saved by the Shell
 - [ ] Sewer-veillance Cam
 - [ ] Shark Shredder, Killer Clone
 - [ ] Shredder's Armor

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 65 / 190
+**Implemented:** 66 / 190
 ---
 
 - [ ] Action News Crew
@@ -165,7 +165,7 @@
 - [ ] Splinter, Radical Rat
 - [x] Squirrelanoids
 - [x] Stockman, Mad Fly-entist
-- [ ] Stomped by the Foot
+- [x] Stomped by the Foot
 - [x] Super Shredder
 - [ ] Tainted Treats
 - [x] TCRI Building

--- a/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
@@ -136,12 +136,21 @@ Cross-card combinators landed since the previous progress note:
   card needing it in TMT is `Turtle Van`, which currently can't ship
   for a separate Gap LL reason. Gap I is closed at the SDK level even
   though no TMT card exercises it yet.
+- **Sagas** — the `sagaChapter(N) { … }` DSL on `CardBuilder` (same shape
+  SPM Origin of Spider-Man uses) already wires lore counters on enter and
+  after the draw step, per-chapter effect groups, and the after-last-chapter
+  sacrifice. Closes Gap K at the SDK level. Neither TMT Saga has shipped
+  yet, but for separate reasons: `The Cloning of Shredder` needs
+  `addedSubtypes` on `CreateTokenCopyOfTarget` (Gap MM); `The Last Ronin`
+  needs the "Mill X. When you do, …" sub-trigger (Gap AA) plus an
+  "attacks alone this turn" trigger condition (Gap NN).
 
 **Still not exercised** — the three new TMT mechanics' canonical pieces still
 missing (Sneak alt-cost pipeline, Disappear's per-controller permanent-left
 tracking, the display markers for Alliance / Channel / Disappear), Class
-enchantments, Sagas, the Mutagen token, and the remaining bespoke Gap M /
-N–LL shapes catalogued in `TODO.md`.
+enchantments, the Mutagen token, and the remaining bespoke Gap M / N–NN
+shapes catalogued in `TODO.md`. (Sagas and Vehicles/Crew are wired at the
+SDK level; only adjacent gaps stop the specific TMT cards from shipping.)
 
 ---
 

--- a/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
@@ -6,6 +6,17 @@
 Counts below are cards in the set that use the mechanic. A card may appear under
 multiple entries (e.g. a creature with Flying + Sneak).
 
+**Implementation progress (27 / 190).** Mechanics already exercised by the cards
+landed so far: Flying, Vigilance, Trample, Haste, Flash, Deathtouch, Double
+strike, Reach (granted), Equip, ETB triggers, LTB triggers, begin-of-combat
+triggers, attack triggers, intervening-if conditions, exile-until-leaves,
+filtered "another permanent enters" triggers, Food artifact baseline, EntersTapped
+land replacement, multi-color mana abilities, GatherCards/SelectFromCollection/
+MoveCollection pipelines, scry, modal Or-predicate filters, ForEachTarget +
+ContextTarget, and the standard sacrifice-for-life/sac-for-draw Food activations.
+None of the **new TMT mechanics** (Sneak, Alliance, Disappear) are exercised yet —
+they remain blocked on the Gap A / B / C engine work documented in TODO.md.
+
 ---
 
 ## New mechanics in TMT

--- a/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
@@ -6,7 +6,7 @@
 Counts below are cards in the set that use the mechanic. A card may appear under
 multiple entries (e.g. a creature with Flying + Sneak).
 
-**Implementation progress (95 / 190).** Mechanics now exercised end-to-end on
+**Implementation progress (96 / 190).** Mechanics now exercised end-to-end on
 `tmt-scaffolding`:
 
 Evergreen keywords — Flying, Vigilance, Trample, Haste, Flash, Deathtouch,
@@ -124,12 +124,24 @@ Cross-card combinators landed since the previous progress note:
   original card wasn't already an artifact creature card, faithful to
   the printed wording. Closes Gap Q. Mirrors EOE Xu-Ifit's reanimate-with-
   permanent-rider shape.
+- **Vehicle / Crew** — `typeLine = "Artifact — Vehicle"` +
+  `keywordAbility(KeywordAbility.Numeric(Keyword.CREW, N))` already gives
+  the full Vehicle pipeline (artifact-becomes-artifact-creature-UEOT, the
+  Crew activation tapping a combined-power ≥ N pile of creatures you
+  control). Ships `Turtle Blimp` — same shape DOM Weatherlight and BLC
+  Rolling Hamsphere use. `Turtle Van` still waits on Gap LL ("creature
+  that crewed this Vehicle this turn" filter), not on Vehicle itself.
+- **Counter-doubling rider** — `Effects.DoubleCounters(counterType, target)`
+  (Sage of the Fang shape) is the primitive that closes Gap I; the only
+  card needing it in TMT is `Turtle Van`, which currently can't ship
+  for a separate Gap LL reason. Gap I is closed at the SDK level even
+  though no TMT card exercises it yet.
 
 **Still not exercised** — the three new TMT mechanics' canonical pieces still
 missing (Sneak alt-cost pipeline, Disappear's per-controller permanent-left
 tracking, the display markers for Alliance / Channel / Disappear), Class
-enchantments, Vehicles / Crew, Sagas, the Mutagen token, and the remaining
-bespoke Gap M / N–KK shapes catalogued in `TODO.md`.
+enchantments, Sagas, the Mutagen token, and the remaining bespoke Gap M /
+N–LL shapes catalogued in `TODO.md`.
 
 ---
 

--- a/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
@@ -6,7 +6,7 @@
 Counts below are cards in the set that use the mechanic. A card may appear under
 multiple entries (e.g. a creature with Flying + Sneak).
 
-**Implementation progress (79 / 190).** Mechanics now exercised end-to-end on
+**Implementation progress (90 / 190).** Mechanics now exercised end-to-end on
 `tmt-scaffolding`:
 
 Evergreen keywords — Flying, Vigilance, Trample, Haste, Flash, Deathtouch,
@@ -70,16 +70,37 @@ Lands and mana — `EntersTapped` replacement, single-color mana abilities,
 Geek`), `AddColorlessMana(2)` (`Weather Maker`).
 
 Tokens — Standard Food, 1/1 colorless Robot (used by 5+ cards), 1/1 black
-Ninja (`Uneasy Alliance`), 2/2 red Mutant (Jennika, Sally Pride), X 2/2 white
-Dinosaur Soldier (`Triceraton Commander`), `CreateTokenCopyOfSelf` for self-
-cloning Equipment (`Improvised Arsenal`).
+Ninja (`Uneasy Alliance`), 2/2 red Mutant (Jennika, Sally Pride, Mighty
+Mutanimals, Slash), X 2/2 white Dinosaur Soldier (`Triceraton Commander`),
+`CreateTokenCopyOfSelf` for self-cloning Equipment (`Improvised Arsenal`).
 
-**Still not exercised** — the three new TMT mechanics (Sneak, Alliance,
-Disappear), Class enchantments, Vehicles / Crew, Sagas, the Mutagen token, and
-all the bespoke Gap M / N–KK shapes catalogued in `TODO.md`. Notably the
-**Alliance trigger itself composes today** (the EntersBattlefield-of-another-
-creature-you-control event exists); only the `Keyword.ALLIANCE` display marker
-+ DSL helper still need wiring before those 10 cards can land.
+Cross-card combinators landed since the previous progress note:
+- **Alliance trigger** — composed via `Triggers.OtherCreatureEnters` for six
+  Alliance cards (East Wind Avatar, EPF Point Squad, Mighty Mutanimals,
+  Mutant Town Musicians, Raphael Tough Turtle, Slash Reptile Rampager). The
+  display-only `Keyword.ALLIANCE` is still absent, so the rendered card text
+  doesn't get the italic "Alliance —" prefix, but the trigger semantics are
+  faithful.
+- **Channel** — composed via `activatedAbility { activateFromZone = Zone.HAND }`
+  paired with `Costs.Composite(Mana, DiscardSelf)` (Action News Crew). Same
+  caveat: `Keyword.CHANNEL` is still absent from the display marker enum.
+- **Delayed "at your next upkeep"** — `CreateDelayedTriggerEffect(step =
+  Step.UPKEEP, fireOnlyOnControllersTurn = true)` (Casey Jones, Vigilante).
+- **Optional bottom-of-library + conditional draw** — Gather → Select(ChooseUpTo
+  1) → MoveCollection-to-library-bottom → ConditionalOnCollection(DrawCards)
+  (Manhole Missile).
+- **Choose one of N keywords UEOT** — `ModalEffect(countsAsModalSpell = false)`
+  with single-keyword `Mode.noTarget` entries (Wingnut, Bat on the Belfry).
+- **Reprint plumbing** — converted the duplicated TMT Negate script into a
+  `Printing` row pointing at the canonical FDN script; added Escape Tunnel
+  as a TMT printing of the canonical MKM script. Both are wired via
+  `CardDiscovery.findPrintingsIn` on `TeenageMutantNinjaTurtlesSet.printings`.
+
+**Still not exercised** — the three new TMT mechanics' canonical pieces still
+missing (Sneak alt-cost pipeline, Disappear's per-controller permanent-left
+tracking, the display markers for Alliance / Channel / Disappear), Class
+enchantments, Vehicles / Crew, Sagas, the Mutagen token, and the remaining
+bespoke Gap M / N–KK shapes catalogued in `TODO.md`.
 
 ---
 

--- a/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
@@ -1,0 +1,123 @@
+# Teenage Mutant Ninja Turtles (TMT) - Mechanics
+
+**Set:** Teenage Mutant Ninja Turtles (`tmt`) · Released 2026-03-06
+**Card pool:** 190 non-basic cards.
+
+Counts below are cards in the set that use the mechanic. A card may appear under
+multiple entries (e.g. a creature with Flying + Sneak).
+
+---
+
+## New mechanics in TMT
+
+### Sneak — 26 cards
+Alternative cost keyword. Reminder text:
+
+> Sneak {cost} (You may cast this spell for {cost} if you also return an
+> unblocked attacker you control to hand during the declare blockers step.
+> [He/She/It enters tapped and attacking.])
+
+- Triggers/pays at declare-blockers (timing differs from normal alt costs).
+- Permanent spells cast for Sneak enter tapped and attacking.
+- Some Sneak cards have an "**If [its] sneak cost was paid**" rider that
+  changes the spell's effect or gives an ongoing bonus this turn — needs
+  per-spell "sneak-was-paid" state tracked across the resolution and beyond.
+- Sneak-rider cards: 4 (`Leonardo, Leader in Blue`, `Turncoat Kunoichi`,
+  `Karai, Future of the Foot`, `The Last Ronin's Technique`).
+
+### Alliance — 10 cards (ability word)
+> Alliance — Whenever another creature you control enters, [effect].
+
+Always the same trigger condition; the effect varies. This is essentially a
+named "ETB matters" trigger word, similar to Magecraft / Constellation.
+
+### Disappear — 9 cards (ability word)
+> Disappear — [Trigger], if a permanent left the battlefield under your
+> control this turn, [effect].
+
+Triggers come in two shapes:
+- ETB ("When this creature enters, …") — 1 card (`Foot Mystic`)
+- End step ("At the beginning of your end step, …") — 7 cards
+- Static ETB-with-counters ("This creature enters with two +1/+1 counters on
+  it if …") — 1 card (`Putrid Pals`)
+
+Underlying condition: "a permanent left the battlefield under your control
+this turn" — needs a per-turn flag the engine flips on any permanent leaving
+a player's battlefield (sacrifice, destroy, exile, bounce, phased-out…).
+
+---
+
+## Evergreen / returning keyword abilities
+
+| Mechanic        | Cards |
+|-----------------|------:|
+| Flying          |    17 |
+| Trample         |    13 |
+| Equip           |     7 |
+| Scry            |     6 |
+| Flash           |     6 |
+| Menace          |     6 |
+| Deathtouch      |     6 |
+| Vigilance       |     5 |
+| Cycling family  |     5 (Cycling, Landcycling, Typecycling, basic-land-cycling — Plains/Island/Swamp/Mountain/Forest) |
+| Reach           |     4 |
+| Mill (keyword)  |     4 |
+| Enchant         |     3 |
+| Haste           |     3 |
+| Lifelink        |     2 |
+| Ward            |     2 |
+| Crew            |     2 (`Turtle Blimp`, `Turtle Van`) |
+| Double strike   |     1 |
+| First strike    |     1 |
+| Indestructible  |     1 |
+| Affinity        |     1 (`Krang, Master Mind` — Affinity for artifacts) |
+| Kicker          |     1 (`Stomped by the Foot`) |
+| Channel         |     1 (`Action News Crew`) |
+| Enrage          |     1 (`Raphael, Ninja Destroyer`) |
+| Landfall        |     1 (`Weather Maker`) |
+| Fight           |     1 (`Novel Nunchaku`) |
+
+Cycling breakdown: 5 cards total — 1 plain Cycling, 1 Typecycling, 5 basic-
+land-cycling variants (Plainscycling/Islandcycling/Swampcycling/
+Mountaincycling/Forestcycling) split across 5 different cards, plus the
+generic Landcycling tag on the same cards.
+
+---
+
+## Token themes
+
+| Token                                   | Cards creating it |
+|-----------------------------------------|-------------------|
+| Food                                    | 6 |
+| 1/1 Mutant                              | 6 |
+| 1/1 Ninja (black, generic)              | 3 |
+| 1/1 white Ninja Turtle Spirit (attacking) | 1 (`The Last Ronin's Technique`) |
+| 1/1 black Insect Warrior (flying)       | 1 (`Lord Dregg, Insect Invader`) |
+| 1/1 black Rat                           | 1 (`Rat King, Verminister`) |
+| 0/0 Mutant via type-change              | 1 (`Pizza Face, Gastromancer`) |
+| Pizza (referenced in flavor / type)     | 1 |
+
+---
+
+## Structural / cross-cutting
+
+| Pattern                                          | Cards |
+|--------------------------------------------------|------:|
+| Cards that reference the type **Mutant**         |    12 |
+| Cards that reference the type **Ninja**          |    11 |
+| Cards that reference the type **Turtle**         |     7 |
+| ETB triggers ("When … enters")                   |    56 |
+| Combat-attack triggers                           |    12 |
+| Activated `{T}:` abilities                       |    16 |
+| +1/+1 counter references                         |    38 |
+| Modal "Choose one"                               |     6 |
+| Sagas                                            |     2 (`The Cloning of Shredder`, `The Last Ronin`) |
+| Vehicles                                         |     2 |
+| Auras                                            |     3 |
+| Equipment                                        |     7 |
+| Non-basic lands                                  |     8 |
+| Reanimate-style ("return … from your graveyard to the battlefield") | 3 |
+| Mill (verb in text)                              |     4 |
+
+No cards in the set use Proliferate, Adventure, Mutate, Backup, Bargain,
+Discover, Plot, Toxic, Convoke, Cipher, Reconfigure, or daybound/nightbound.

--- a/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
@@ -6,16 +6,80 @@
 Counts below are cards in the set that use the mechanic. A card may appear under
 multiple entries (e.g. a creature with Flying + Sneak).
 
-**Implementation progress (27 / 190).** Mechanics already exercised by the cards
-landed so far: Flying, Vigilance, Trample, Haste, Flash, Deathtouch, Double
-strike, Reach (granted), Equip, ETB triggers, LTB triggers, begin-of-combat
-triggers, attack triggers, intervening-if conditions, exile-until-leaves,
-filtered "another permanent enters" triggers, Food artifact baseline, EntersTapped
-land replacement, multi-color mana abilities, GatherCards/SelectFromCollection/
-MoveCollection pipelines, scry, modal Or-predicate filters, ForEachTarget +
-ContextTarget, and the standard sacrifice-for-life/sac-for-draw Food activations.
-None of the **new TMT mechanics** (Sneak, Alliance, Disappear) are exercised yet —
-they remain blocked on the Gap A / B / C engine work documented in TODO.md.
+**Implementation progress (79 / 190).** Mechanics now exercised end-to-end on
+`tmt-scaffolding`:
+
+Evergreen keywords — Flying, Vigilance, Trample, Haste, Flash, Deathtouch,
+Menace, Reach (granted and printed), Indestructible, Ward, Equip, Double strike,
+First strike, Hexproof (granted UEOT).
+
+Returning / set-specific keywords — **Affinity** (`Krang, Master Mind`),
+**Landfall** (`Weather Maker`), **Kicker** (`Stomped by the Foot`), basic-land-
+cycling (`Jennika` Plainscycling, `Stockman, Mad Fly-entist` Islandcycling,
+`Bebop, Warthog Warrior` Swampcycling, `Zog, Triceraton Castaway`
+Mountaincycling, `Rocksteady, Crash Courser` Forestcycling).
+
+Triggers — ETB, LTB, begin-of-combat, attack, deals-combat-damage, you-gain-
+life, land-you-control-enters (Landfall), counter-placed-on-creature-you-control
+(with `oncePerTurn`), spell-cast filtered by card type, "permanent leaves the
+battlefield" (`Super Shredder`, ANY/OTHER binding via `ZoneChangeEvent`),
+"another creature you control dies" (with EntityReference.Triggering toughness
+read), filtered ETB ("a Ninja you control enters" auto-attach trigger), and
+intervening-if conditions ("if you control an artifact").
+
+Static abilities — Anthems via `GrantKeyword` over a `GroupFilter`
+(four-keyword Krang Utrom Warlord anthem; Rhino/Boar/Turtle/Squirrel-style
+tribal grants), `ConditionalStaticAbility` (`IsYourTurn` first-strike on Null
+Group), `CantAttackUnless` with a `Compare` condition, `CantBeBlockedByMoreThan`
+(self + tribal), `GrantTriggeredAbility` for granted equipped-creature triggers
+(`Quintessential Katana`), `GrantTriggeredAbilityEffect` UEOT (`Pain 101`,
+`Perigee Beckoner` pattern), `GrantDynamicStatsEffect` reading
+`AggregateBattlefield` (`Improvised Arsenal`, `Krang, Master Mind`).
+
+Costs and cost modification — Optional sacrifice as an additional cost
+(`Stomped by the Foot` kicker), `Costs.SacrificeAnother` over an Or-predicate
+filter (`Ice Cream Kitty`, `Metalhead`), Sacrifice-self for activated abilities,
+`Costs.RemoveCounterFromSelf` (`Weather Maker`), `ActivationRestriction
+.OncePerTurn` on activated abilities (`Shredder's Armor`), `ModifySpellCost`
+with `CostReductionSource.FixedIfControlFilter` (`Saved by the Shell`).
+
+Counters — `Counters.PLUS_ONE_PLUS_ONE`, `Counters.CHARGE` (`Weather Maker`),
+`Counters.STUN` (`Utrom Scientists`), counter-count read via
+`EntityNumericProperty.CounterCount` (`Savanti Romero`'s scaling draw).
+
+Dynamic amounts — `DynamicAmount.Count` of permanents/cards-in-hand/cards-in-
+graveyard, `DynamicAmount.Subtract`/`IfPositive` (Krang's draw-to-four ETB),
+`DynamicAmount.AggregateBattlefield` (Improvised Arsenal),
+`DynamicAmount.XValue` for X-cost token-makers (`Triceraton Commander`),
+`DynamicAmount.EntityProperty(Triggering, Toughness)` (`South Wind Avatar`),
+`ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT` (`April, Reporter of the Weird`).
+
+Effect pipelines — `GatherCardsEffect → SelectFromCollectionEffect →
+MoveCollectionEffect` (Cowabunga!, Casey Jones Jury-Rig), modal "Choose one"
+(`Mouser Attack!`, `Shredder's Revenge`), `ConditionalEffect` with
+`Conditions.TargetSpellManaValueAtMost` (`Tainted Treats`),
+`RepeatDynamicTimesEffect` for X-token creation (`Sally Pride`),
+`ForEachInGroupEffect` over `StatePredicate.EnteredThisTurn` (`Renet`),
+`EffectPatterns.scry`, `EffectPatterns.loot`, `EffectPatterns.rummage`,
+`EffectPatterns.putFromHand` for "may put a land from your hand"
+(`Lessons from Life`).
+
+Lands and mana — `EntersTapped` replacement, single-color mana abilities,
+`AddAnyColorMana(1)` and `AddAnyColorMana(2)` (`Transdimensional Bovine`),
+`AddAnyColorMana(DynamicAmount.EntityProperty(Power))` (`Mona Lisa, Science
+Geek`), `AddColorlessMana(2)` (`Weather Maker`).
+
+Tokens — Standard Food, 1/1 colorless Robot (used by 5+ cards), 1/1 black
+Ninja (`Uneasy Alliance`), 2/2 red Mutant (Jennika, Sally Pride), X 2/2 white
+Dinosaur Soldier (`Triceraton Commander`), `CreateTokenCopyOfSelf` for self-
+cloning Equipment (`Improvised Arsenal`).
+
+**Still not exercised** — the three new TMT mechanics (Sneak, Alliance,
+Disappear), Class enchantments, Vehicles / Crew, Sagas, the Mutagen token, and
+all the bespoke Gap M / N–KK shapes catalogued in `TODO.md`. Notably the
+**Alliance trigger itself composes today** (the EntersBattlefield-of-another-
+creature-you-control event exists); only the `Keyword.ALLIANCE` display marker
++ DSL helper still need wiring before those 10 cards can land.
 
 ---
 

--- a/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/mechanics.md
@@ -6,7 +6,7 @@
 Counts below are cards in the set that use the mechanic. A card may appear under
 multiple entries (e.g. a creature with Flying + Sneak).
 
-**Implementation progress (90 / 190).** Mechanics now exercised end-to-end on
+**Implementation progress (95 / 190).** Mechanics now exercised end-to-end on
 `tmt-scaffolding`:
 
 Evergreen keywords — Flying, Vigilance, Trample, Haste, Flash, Deathtouch,
@@ -95,6 +95,35 @@ Cross-card combinators landed since the previous progress note:
   `Printing` row pointing at the canonical FDN script; added Escape Tunnel
   as a TMT printing of the canonical MKM script. Both are wired via
   `CardDiscovery.findPrintingsIn` on `TeenageMutantNinjaTurtlesSet.printings`.
+- **Trigger-doubler over a subtype filter** — `AdditionalSourceTriggers
+  (sourceFilter = Creature.withSubtype("Ninja").youControl(), excludeSelf
+  = false)` ships Splinter, Radical Rat. Same shape ECL Twinflame Travelers
+  uses; only the subtype and excludeSelf flag differ.
+- **Additional combat phase rider** — `AddCombatPhaseEffect` (LTR Éomer,
+  Marshal of Rohan) ships Raph & Leo, Sibling Rivals. The printed *"if it's
+  the first combat phase of the turn"* intervening-if is approximated by
+  `oncePerTurn = true` (no `Conditions.IsFirstCombatPhase` primitive yet);
+  approximation documented in the card's docstring.
+- **Delayed destroy of a created token** — EOE Systems Override idiom:
+  `CreateTokenEffect` publishes the new token into `EffectTarget.ContextTarget
+  (0)`, then `CreateDelayedTriggerEffect(step = Step.END, effect =
+  MoveToZoneEffect(ContextTarget(0), GRAVEYARD, byDestruction = true))`
+  schedules a real *destroy* at the next end step (Old Hob, Alleycat Blues).
+  The `byDestruction = true` flag is load-bearing: it routes the cleanup
+  through the destroy pipeline so the second ability's UEOT indestructible
+  grant legitimately saves the token. (A `sacrificeAtStep` shortcut would
+  have silently mis-implemented that interaction.)
+- **Fixed-N power evasion** — `CantBeBlockedBy(GameObjectFilter.Creature
+  .powerAtLeast(N))` (BLB Azure Beastbinder) ships April O'Neil, Kunoichi
+  Trainee with N = 3. Closes Gap O.
+- **Graveyard reanimate as a typed-override token** — `MoveToZoneEffect
+  (GRAVEYARD → BATTLEFIELD)` followed by `ConditionalEffect(Not(
+  TargetMatchesFilter(Creature)), Effects.BecomeCreature(3, 3, keywords =
+  {FLYING}, creatureTypes = {"Robot"}, duration = Duration.Permanent))`
+  ships Brilliance Unleashed's Mode 2. The rider only fires when the
+  original card wasn't already an artifact creature card, faithful to
+  the printed wording. Closes Gap Q. Mirrors EOE Xu-Ifit's reanimate-with-
+  permanent-rider shape.
 
 **Still not exercised** — the three new TMT mechanics' canonical pieces still
 missing (Sneak alt-cost pipeline, Disappear's per-controller permanent-left

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/TeenageMutantNinjaTurtlesSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/TeenageMutantNinjaTurtlesSet.kt
@@ -17,6 +17,7 @@ object TeenageMutantNinjaTurtlesSet : MtgSet {
     override val displayName = "Teenage Mutant Ninja Turtles"
     override val releaseDate = "2026-03-06"
     override val incomplete = true
+    override val sealedSupported = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ActionNewsCrew.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ActionNewsCrew.kt
@@ -22,14 +22,6 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * Vigilance
  * Channel — {6}, Discard this card: Put a +1/+1 counter on each
  * creature you control. Draw a card.
- *
- * Channel is implemented as an activated ability whose mana cost is
- * paired with `Costs.DiscardSelf` and activated from `Zone.HAND`. The
- * `Keyword.CHANNEL` display marker does not yet exist in the SDK, so
- * the ability text on the rendered card reads as a plain activated
- * ability (no italic "Channel —" prefix), but the mechanics are
- * faithful — discarding the card from hand pays the cost, then the
- * effect resolves.
  */
 val ActionNewsCrew = card("Action News Crew") {
     manaCost = "{1}{W}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ActionNewsCrew.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ActionNewsCrew.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Action News Crew
+ * {1}{W}
+ * Creature — Human Citizen
+ * 2/2
+ *
+ * Vigilance
+ * Channel — {6}, Discard this card: Put a +1/+1 counter on each
+ * creature you control. Draw a card.
+ *
+ * Channel is implemented as an activated ability whose mana cost is
+ * paired with `Costs.DiscardSelf` and activated from `Zone.HAND`. The
+ * `Keyword.CHANNEL` display marker does not yet exist in the SDK, so
+ * the ability text on the rendered card reads as a plain activated
+ * ability (no italic "Channel —" prefix), but the mechanics are
+ * faithful — discarding the card from hand pays the cost, then the
+ * effect resolves.
+ */
+val ActionNewsCrew = card("Action News Crew") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "Vigilance\nChannel — {6}, Discard this card: Put a +1/+1 counter on each creature you control. Draw a card."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.DiscardSelf)
+        activateFromZone = Zone.HAND
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+            effect = AddCountersEffect(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                count = 1,
+                target = EffectTarget.Self
+            )
+        ).then(Effects.DrawCards(1))
+        description = "Channel — {6}, Discard this card: Put a +1/+1 counter on each creature you control. Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Gabriel Tanko"
+        flavorText = "\"I just hope this isn't another wild turtle chase!\"\n—Vernon Fenwick"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc0f5ca8-47bd-4451-8fd1-a312ff7d31ec.jpg?1771342158"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AgentBishopManInBlack.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AgentBishopManInBlack.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Agent Bishop, Man in Black
+ * {2}{W}
+ * Legendary Creature — Human Soldier
+ * 1/2
+ *
+ * At the beginning of combat on your turn, put a +1/+1 counter on each of up
+ * to two target creatures.
+ */
+val AgentBishopManInBlack = card("Agent Bishop, Man in Black") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier"
+    oracleText = "At the beginning of combat on your turn, put a +1/+1 counter on each of up to two target creatures."
+    power = 1
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        target("up to two target creatures", TargetCreature(count = 2, optional = true))
+        effect = ForEachTargetEffect(
+            listOf(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "2"
+        artist = "Adrián Rodríguez Pérez"
+        flavorText = "\"Utroms . . . Triceratons . . . there's little difference to me. I help one destroy the other, pick up the pieces, then get them the hell off of my planet.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c769202-178c-442a-a9e2-aa08b5ae5c9a.jpg?1769005601"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AnchovyAndBananaPizza.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AnchovyAndBananaPizza.kt
@@ -27,7 +27,6 @@ val AnchovyAndBananaPizza = card("Anchovy & Banana Pizza") {
         effect = Effects.Destroy(target)
     }
 
-    // Standard Food ability: {2}, {T}, Sacrifice: You gain 3 life
     activatedAbility {
         cost = Costs.Composite(
             Costs.Mana("{2}"),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AnchovyAndBananaPizza.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AnchovyAndBananaPizza.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Anchovy & Banana Pizza
+ * {2}{B}{B}
+ * Artifact — Food
+ *
+ * When this artifact enters, destroy target creature.
+ * {2}, {T}, Sacrifice this artifact: You gain 3 life.
+ */
+val AnchovyAndBananaPizza = card("Anchovy & Banana Pizza") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Food"
+    oracleText = "When this artifact enters, destroy target creature.\n{2}, {T}, Sacrifice this artifact: You gain 3 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val target = target("target creature", TargetCreature())
+        effect = Effects.Destroy(target)
+    }
+
+    // Standard Food ability: {2}, {T}, Sacrifice: You gain 3 life
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Daniel Romanovsky"
+        flavorText = "\"Question: Do you like penicillin on your pizza?\"\n—Donatello"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44443ad2-ef8c-4106-ba1b-ee3fb6fd8b17.jpg?1771586832"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AprilONeilKunoichiTrainee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AprilONeilKunoichiTrainee.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * April O'Neil, Kunoichi Trainee
+ * {1}{W}
+ * Legendary Creature — Human Ninja
+ * 2/2
+ *
+ * When April O'Neil enters, scry 2.
+ * April O'Neil can't be blocked by creatures with power 3 or greater.
+ *
+ * Mirrors the BLB Azure Beastbinder evasion shape — `CantBeBlockedBy`
+ * parameterised on `GameObjectFilter.Creature.powerAtLeast(N)` already
+ * covers any "can't be blocked by creatures with power N or greater"
+ * wording with a fixed N. (Closes Gap O. The relative-comparison
+ * Gap HH — "with greater power" than the source — is a separate
+ * static and still needs a `CantBeBlockedByCreaturesWithGreaterPower`
+ * primitive.)
+ */
+val AprilONeilKunoichiTrainee = card("April O'Neil, Kunoichi Trainee") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Ninja"
+    oracleText = "When April O'Neil enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\nApril O'Neil can't be blocked by creatures with power 3 or greater."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.scry(2)
+    }
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.powerAtLeast(3))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Jo Cordisco"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b1982ea-686b-4acd-b677-47571430efb0.jpg?1771586740"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AprilONeilKunoichiTrainee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AprilONeilKunoichiTrainee.kt
@@ -15,14 +15,6 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
  *
  * When April O'Neil enters, scry 2.
  * April O'Neil can't be blocked by creatures with power 3 or greater.
- *
- * Mirrors the BLB Azure Beastbinder evasion shape — `CantBeBlockedBy`
- * parameterised on `GameObjectFilter.Creature.powerAtLeast(N)` already
- * covers any "can't be blocked by creatures with power N or greater"
- * wording with a fixed N. (Closes Gap O. The relative-comparison
- * Gap HH — "with greater power" than the source — is a separate
- * static and still needs a `CantBeBlockedByCreaturesWithGreaterPower`
- * primitive.)
  */
 val AprilONeilKunoichiTrainee = card("April O'Neil, Kunoichi Trainee") {
     manaCost = "{1}{W}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AprilReporterOfTheWeird.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AprilReporterOfTheWeird.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * April, Reporter of the Weird
+ * {2}{U}
+ * Legendary Creature — Human Detective
+ * 2/2
+ *
+ * Whenever April deals combat damage to a player, draw that many cards,
+ * then discard a card.
+ */
+val AprilReporterOfTheWeird = card("April, Reporter of the Weird") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Detective"
+    oracleText = "Whenever April deals combat damage to a player, draw that many cards, then discard a card."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = CompositeEffect(
+            listOf(
+                Effects.DrawCards(DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)),
+                Effects.Discard(1)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "30"
+        artist = "Eelis Kyttanen"
+        flavorText = "\"Freelance reporting pays even worse than tutoring, but the satisfaction of uncovering the truth makes it all worth it! Also the free ringside tickets to cover intergalactic wrestling don't suck.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31aa943f-c9db-43dc-8a72-7ef56f9f5c8b.jpg?1771502549"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ArmaggonFutureShark.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ArmaggonFutureShark.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Armaggon, Future Shark
+ * {6}{B}{B}
+ * Legendary Creature — Shark Horror Mutant
+ * 9/6
+ *
+ * Flash
+ * When Armaggon enters, destroy up to three target creatures.
+ */
+val ArmaggonFutureShark = card("Armaggon, Future Shark") {
+    manaCost = "{6}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Shark Horror Mutant"
+    oracleText = "Flash\nWhen Armaggon enters, destroy up to three target creatures."
+    power = 9
+    toughness = 6
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("up to three target creatures", TargetCreature(count = 3, optional = true))
+        effect = ForEachTargetEffect(
+            listOf(Effects.Destroy(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "58"
+        artist = "Kekai Kotaki"
+        flavorText = "\"I am ancient efficiency. I am evolution's future. I am mutation come full, vicious circle!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/5989378b-0eac-43cf-bc83-8f7765536789.jpg?1769005763"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BaxterStockman.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BaxterStockman.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Baxter Stockman
+ * {3}{U}{R}
+ * Legendary Creature — Human Scientist
+ * 3/3
+ *
+ * When Baxter Stockman enters, create a 1/1 colorless Robot artifact
+ * creature token.
+ * At the beginning of combat on your turn, target artifact creature
+ * you control gets +3/+0 and gains first strike and vigilance until
+ * end of turn.
+ */
+val BaxterStockman = card("Baxter Stockman") {
+    manaCost = "{3}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Human Scientist"
+    oracleText = "When Baxter Stockman enters, create a 1/1 colorless Robot artifact creature token.\nAt the beginning of combat on your turn, target artifact creature you control gets +3/+0 and gains first strike and vigilance until end of turn."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(),
+            creatureTypes = setOf("Robot"),
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/0/8/08497fc5-1c0e-4c3c-a356-bf4b34bd4c45.jpg?1771590585"
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val creature = target(
+            "artifact creature you control",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.IsCreature,
+                            CardPredicate.IsArtifact,
+                        )
+                    ).youControl()
+                )
+            )
+        )
+        effect = Effects.ModifyStats(3, 0, creature)
+            .then(Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature, Duration.EndOfTurn))
+            .then(Effects.GrantKeyword(Keyword.VIGILANCE, creature, Duration.EndOfTurn))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "Randy Gallegos"
+        flavorText = "\"You flatter me, Ms. O'Neil. I like that.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/117b1341-2cf0-466e-b3a8-7e1afa42cd4c.jpg?1771586994"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BebopWarthogWarrior.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BebopWarthogWarrior.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bebop, Warthog Warrior
+ * {4}{B}
+ * Creature — Boar Mutant Warrior
+ * 5/4
+ *
+ * Menace
+ * Rhinos you control have menace.
+ * Swampcycling {2}
+ */
+val BebopWarthogWarrior = card("Bebop, Warthog Warrior") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Boar Mutant Warrior"
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\nRhinos you control have menace.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)"
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.MENACE)
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.MENACE,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype("Rhino").youControl()
+            )
+        )
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Swamp", "{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "April Prime"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/371ba16d-73f7-450c-8b1f-c05012a4ca93.jpg?1771586838"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BespokeBo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BespokeBo.kt
@@ -6,8 +6,9 @@ import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetPermanent
 
 /**
@@ -36,13 +37,11 @@ val BespokeBo = card("Bespoke Bō") {
     }
 
     staticAbility {
-        effect = Effects.ModifyStats(+2, +1)
-        filter = Filters.EquippedCreature
+        ability = ModifyStats(+2, +1, Filters.EquippedCreature)
     }
 
     staticAbility {
-        effect = Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.EquippedCreature)
-        filter = Filters.EquippedCreature
+        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EquippedCreature)
     }
 
     equipAbility("{3}")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BespokeBo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BespokeBo.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Bespoke Bō
+ * {2}{U}
+ * Artifact — Equipment
+ *
+ * When this Equipment enters, return up to one other target nonland
+ * permanent to its owner's hand.
+ * Equipped creature gets +2/+1 and has vigilance.
+ * Equip {3}
+ */
+val BespokeBo = card("Bespoke Bō") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, return up to one other target nonland permanent to its owner's hand.\nEquipped creature gets +2/+1 and has vigilance.\nEquip {3}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target(
+            "other nonland permanent",
+            TargetPermanent(optional = true, filter = TargetFilter.NonlandPermanent.other())
+        )
+        effect = Effects.ReturnToHand(permanent)
+    }
+
+    staticAbility {
+        effect = Effects.ModifyStats(+2, +1)
+        filter = Filters.EquippedCreature
+    }
+
+    staticAbility {
+        effect = Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.EquippedCreature)
+        filter = Filters.EquippedCreature
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "31"
+        artist = "Andrea Radeck"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c517308-831b-4e41-a82c-02ddf6383a0c.jpg?1771586788"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BotBashingTime.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BotBashingTime.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+
+/**
+ * Bot Bashing Time
+ * {3}{R}
+ * Sorcery
+ *
+ * Bot Bashing Time deals 6 damage to target creature. If that creature
+ * would die this turn, exile it instead.
+ */
+val BotBashingTime = card("Bot Bashing Time") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Bot Bashing Time deals 6 damage to target creature. If that creature would die this turn, exile it instead."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = MarkExileOnDeathEffect(creature)
+            .then(Effects.DealDamage(6, creature))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "Xavier Ribeiro"
+        flavorText = "\"Well, I'd say we redecorated the place nicely!\"\n—Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08b3af61-d516-45ca-aede-2f50ba23cb07.jpg?1771586935"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BrillianceUnleashed.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BrillianceUnleashed.kt
@@ -26,17 +26,6 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  *   battlefield if it's an artifact creature card. Otherwise, return
  *   it to the battlefield and it's a 3/3 Robot artifact creature with
  *   flying.
- *
- * Mode 2 mirrors the EOE Xu-Ifit, Osteoharmonist reanimate-with-rider
- * shape: `MoveToZoneEffect(... from GRAVEYARD to BATTLEFIELD)` plus an
- * `Effects.BecomeCreature(target, 3, 3, keywords = {FLYING},
- * creatureTypes = {"Robot"}, duration = Duration.Permanent)` gated by
- * `Conditions.Not(TargetMatchesFilter(GameObjectFilter.Creature))`.
- * The target is an artifact-card-in-your-graveyard so it already has
- * the Artifact card type — only the Creature card type, Robot subtype,
- * base 3/3 P/T, and flying need to be added when the original card
- * isn't already a creature, matching the printed "and it's a 3/3
- * Robot artifact creature with flying" rider.
  */
 val BrillianceUnleashed = card("Brilliance Unleashed") {
     manaCost = "{4}{U}{R}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BrillianceUnleashed.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BrillianceUnleashed.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Brilliance Unleashed
+ * {4}{U}{R}
+ * Sorcery
+ *
+ * Choose one or both —
+ * • Brilliance Unleashed deals 5 damage to target creature.
+ * • Choose target artifact card in your graveyard. Return it to the
+ *   battlefield if it's an artifact creature card. Otherwise, return
+ *   it to the battlefield and it's a 3/3 Robot artifact creature with
+ *   flying.
+ *
+ * Mode 2 mirrors the EOE Xu-Ifit, Osteoharmonist reanimate-with-rider
+ * shape: `MoveToZoneEffect(... from GRAVEYARD to BATTLEFIELD)` plus an
+ * `Effects.BecomeCreature(target, 3, 3, keywords = {FLYING},
+ * creatureTypes = {"Robot"}, duration = Duration.Permanent)` gated by
+ * `Conditions.Not(TargetMatchesFilter(GameObjectFilter.Creature))`.
+ * The target is an artifact-card-in-your-graveyard so it already has
+ * the Artifact card type — only the Creature card type, Robot subtype,
+ * base 3/3 P/T, and flying need to be added when the original card
+ * isn't already a creature, matching the printed "and it's a 3/3
+ * Robot artifact creature with flying" rider.
+ */
+val BrillianceUnleashed = card("Brilliance Unleashed") {
+    manaCost = "{4}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or both —\n• Brilliance Unleashed deals 5 damage to target creature.\n• Choose target artifact card in your graveyard. Return it to the battlefield if it's an artifact creature card. Otherwise, return it to the battlefield and it's a 3/3 Robot artifact creature with flying."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Brilliance Unleashed deals 5 damage to target creature") {
+                val creature = target("target creature", Targets.Creature)
+                effect = Effects.DealDamage(5, creature)
+            }
+            mode("Return target artifact card in your graveyard to the battlefield. If it isn't an artifact creature card, it's a 3/3 Robot artifact creature with flying") {
+                target = TargetObject(
+                    filter = TargetFilter(
+                        baseFilter = GameObjectFilter.Artifact.ownedByYou(),
+                        zone = Zone.GRAVEYARD,
+                    )
+                )
+                effect = MoveToZoneEffect(
+                    target = com.wingedsheep.sdk.scripting.targets.EffectTarget.ContextTarget(0),
+                    destination = Zone.BATTLEFIELD,
+                    fromZone = Zone.GRAVEYARD,
+                ).then(
+                    ConditionalEffect(
+                        condition = Conditions.Not(
+                            Conditions.TargetMatchesFilter(GameObjectFilter.Creature)
+                        ),
+                        effect = Effects.BecomeCreature(
+                            target = com.wingedsheep.sdk.scripting.targets.EffectTarget.ContextTarget(0),
+                            power = 3,
+                            toughness = 3,
+                            keywords = setOf(Keyword.FLYING),
+                            creatureTypes = setOf("Robot"),
+                            duration = Duration.Permanent,
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "141"
+        artist = "Hokyoung Kim"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7ab2110-5aad-46c9-8dc4-1eac24b6f46b.jpg?1771587000"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BuzzBots.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BuzzBots.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Buzz Bots
+ * {1}{U}
+ * Artifact Creature — Robot Insect
+ * 1/1
+ *
+ * Flying, vigilance
+ * When this creature dies, draw a card.
+ */
+val BuzzBots = card("Buzz Bots") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Robot Insect"
+    oracleText = "Flying, vigilance\nWhen this creature dies, draw a card."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Néstor Ossandón Leal"
+        flavorText = "Designed for autonomous pollination, the Stocktronics buzz bot's souped-up power plant allows for months of independent service. The optional taser is for defensive purposes only, of course."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c375190-f81b-4ab1-a1b6-fe432796821f.jpg?1771502556"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesJuryRigJusticiar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesJuryRigJusticiar.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
@@ -65,7 +66,8 @@ val CaseyJonesJuryRigJusticiar = card("Casey Jones, Jury-Rig Justiciar") {
                 ),
                 MoveCollectionEffect(
                     from = "rest",
-                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random,
                 ),
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesJuryRigJusticiar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesJuryRigJusticiar.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Casey Jones, Jury-Rig Justiciar
+ * {1}{R}
+ * Legendary Creature — Human Berserker
+ * 2/1
+ *
+ * Haste
+ * When Casey Jones enters, look at the top four cards of your library.
+ * You may reveal an artifact card from among them and put it into your
+ * hand. Put the rest on the bottom of your library in a random order.
+ */
+val CaseyJonesJuryRigJusticiar = card("Casey Jones, Jury-Rig Justiciar") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Berserker"
+    oracleText = "Haste\nWhen Casey Jones enters, look at the top four cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order."
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(4)),
+                    storeAs = "looked"
+                ),
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter(
+                        cardPredicates = listOf(CardPredicate.IsArtifact)
+                    ),
+                    storeSelected = "kept",
+                    storeRemainder = "rest",
+                    selectedLabel = "Put in hand",
+                    remainderLabel = "Put on bottom",
+                    showAllCards = true
+                ),
+                MoveCollectionEffect(
+                    from = "kept",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Lordigan"
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/808a5bc0-0999-47cf-854c-30db6277efe5.jpg?1760114588"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesVigilante.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesVigilante.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Casey Jones, Vigilante
+ * {1}{R}{R}
+ * Legendary Creature — Human Berserker
+ * 4/3
+ *
+ * When Casey Jones enters, draw three cards. At the beginning of your
+ * next upkeep, discard three cards at random.
+ */
+val CaseyJonesVigilante = card("Casey Jones, Vigilante") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Berserker"
+    oracleText = "When Casey Jones enters, draw three cards. At the beginning of your next upkeep, discard three cards at random."
+    power = 4
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CompositeEffect(
+            listOf(
+                Effects.DrawCards(3),
+                CreateDelayedTriggerEffect(
+                    step = Step.UPKEEP,
+                    fireOnlyOnControllersTurn = true,
+                    effect = CompositeEffect(
+                        listOf(
+                            GatherCardsEffect(
+                                source = CardSource.FromZone(Zone.HAND, Player.You),
+                                storeAs = "hand"
+                            ),
+                            ConditionalOnCollectionEffect(
+                                collection = "hand",
+                                ifNotEmpty = CompositeEffect(
+                                    listOf(
+                                        SelectFromCollectionEffect(
+                                            from = "hand",
+                                            selection = SelectionMode.Random(DynamicAmount.Fixed(3)),
+                                            storeSelected = "discarded"
+                                        ),
+                                        MoveCollectionEffect(
+                                            from = "discarded",
+                                            destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+                                            moveType = MoveType.Discard
+                                        )
+                                    )
+                                ),
+                                ifEmpty = CompositeEffect(listOf())
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "88"
+        artist = "Xavier Ribeiro"
+        flavorText = "\"Goongala!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6a3258d-2e9b-4862-b2e3-bbfae9bd4d33.jpg?1769005927"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesVigilante.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesVigilante.kt
@@ -1,23 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
 import com.wingedsheep.sdk.core.Step
-import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.EffectPatterns
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.effects.CardDestination
-import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
-import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
-import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
-import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
-import com.wingedsheep.sdk.scripting.effects.MoveType
-import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
-import com.wingedsheep.sdk.scripting.effects.SelectionMode
-import com.wingedsheep.sdk.scripting.references.Player
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Casey Jones, Vigilante
@@ -44,33 +34,8 @@ val CaseyJonesVigilante = card("Casey Jones, Vigilante") {
                 CreateDelayedTriggerEffect(
                     step = Step.UPKEEP,
                     fireOnlyOnControllersTurn = true,
-                    effect = CompositeEffect(
-                        listOf(
-                            GatherCardsEffect(
-                                source = CardSource.FromZone(Zone.HAND, Player.You),
-                                storeAs = "hand"
-                            ),
-                            ConditionalOnCollectionEffect(
-                                collection = "hand",
-                                ifNotEmpty = CompositeEffect(
-                                    listOf(
-                                        SelectFromCollectionEffect(
-                                            from = "hand",
-                                            selection = SelectionMode.Random(DynamicAmount.Fixed(3)),
-                                            storeSelected = "discarded"
-                                        ),
-                                        MoveCollectionEffect(
-                                            from = "discarded",
-                                            destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
-                                            moveType = MoveType.Discard
-                                        )
-                                    )
-                                ),
-                                ifEmpty = CompositeEffect(listOf())
-                            )
-                        )
-                    )
-                )
+                    effect = EffectPatterns.discardRandom(3),
+                ),
             )
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Cowabunga.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Cowabunga.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cowabunga!
+ * {G}
+ * Sorcery
+ *
+ * Look at the top four cards of your library. You may reveal a Mutant,
+ * Ninja, Turtle, or land card from among them and put it into your hand.
+ * Put the rest on the bottom of your library in a random order.
+ */
+val Cowabunga = card("Cowabunga!") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top four cards of your library. You may reveal a Mutant, Ninja, Turtle, or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order."
+
+    spell {
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(4)),
+                    storeAs = "looked"
+                ),
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.Or(
+                                listOf(
+                                    CardPredicate.HasAnyOfSubtypes(
+                                        listOf(Subtype("Mutant"), Subtype("Ninja"), Subtype("Turtle"))
+                                    ),
+                                    CardPredicate.IsLand,
+                                )
+                            )
+                        )
+                    ),
+                    storeSelected = "kept",
+                    storeRemainder = "rest",
+                    selectedLabel = "Put in hand",
+                    remainderLabel = "Put on bottom",
+                    showAllCards = true
+                ),
+                MoveCollectionEffect(
+                    from = "kept",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "113"
+        artist = "Thomas Chamberlain-Keen"
+        flavorText = "When you're open to new things, a weird world of wonder unfolds before you."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0ffce972-bed9-445a-a9a0-4816f156d88d.jpg?1771342415"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Cowabunga.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Cowabunga.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
@@ -66,7 +67,8 @@ val Cowabunga = card("Cowabunga!") {
                 ),
                 MoveCollectionEffect(
                     from = "rest",
-                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random,
                 ),
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DeathInTheFamily.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DeathInTheFamily.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Death in the Family
+ * {1}{B}
+ * Instant
+ *
+ * Exile target creature with mana value 3 or less.
+ */
+val DeathInTheFamily = card("Death in the Family") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target creature with mana value 3 or less."
+
+    spell {
+        val creature = target(
+            "creature with mana value 3 or less",
+            TargetObject(filter = TargetFilter.Creature.manaValueAtMost(3))
+        )
+        effect = Effects.Exile(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "61"
+        artist = "Justyna Dura"
+        flavorText = "Often enemies, always brothers . . . till the end."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e4f2148-d398-4f3d-9c59-81c87b6a4588.jpg?1771586845"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DimensionX.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DimensionX.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Dimension X
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, you gain 1 life.
+ * {T}: Add {R} or {W}.
+ */
+val DimensionX = card("Dimension X") {
+    typeLine = "Land"
+    colorIdentity = "RW"
+    oracleText = "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {W}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Maël Ollivier-Henry"
+        flavorText = "\"Hey, in crazy backwards land, crazy backwards dude is king.\"\n—Michelangelo"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c244fc2-70f0-4149-b0d2-d49fc6bac2b0.jpg?1771587085"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DimensionalExile.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DimensionalExile.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Dimensional Exile
+ * {1}{W}
+ * Enchantment — Aura
+ *
+ * Enchant basic land you control
+ * When this Aura enters, exile target creature an opponent controls
+ * until this Aura leaves the battlefield.
+ */
+val DimensionalExile = card("Dimensional Exile") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant basic land you control\nWhen this Aura enters, exile target creature an opponent controls until this Aura leaves the battlefield."
+
+    auraTarget = TargetPermanent(filter = TargetFilter(GameObjectFilter.BasicLand.youControl()))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "creature an opponent controls",
+            TargetPermanent(filter = TargetFilter.Creature.opponentControls())
+        )
+        effect = Effects.ExileUntilLeaves(creature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "4"
+        artist = "Lordigan"
+        flavorText = "\"Never been defeated, huh? Well, you never tangled with a turtle before!\"\n—Donatello"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be8d96fb-a1be-4fff-b844-e38d185884e1.jpg?1771342164"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonatelloTurtleTechie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonatelloTurtleTechie.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Donatello, Turtle Techie
+ * {3}{U}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 3/4
+ *
+ * When Donatello enters, if you control an artifact, draw a card.
+ */
+val DonatelloTurtleTechie = card("Donatello, Turtle Techie") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "When Donatello enters, if you control an artifact, draw a card."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.ControlArtifact
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Ryan Valle"
+        flavorText = "\"My son, for someone so intelligent, the obvious often eludes you.\"\n—Splinter"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/683cfef0-f164-4db8-b83f-79eb804e50ae.jpg?1771502569"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonatelloWayWithMachines.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonatelloWayWithMachines.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggerSpec

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonatelloWayWithMachines.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonatelloWayWithMachines.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Donatello, Way with Machines
+ * {2}{U}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 1/2
+ *
+ * Flying
+ * Whenever an artifact you control enters, put a +1/+1 counter on Donatello.
+ */
+val DonatelloWayWithMachines = card("Donatello, Way with Machines") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Flying\nWhenever an artifact you control enters, put a +1/+1 counter on Donatello."
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Artifact.youControl(),
+                to = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever an artifact you control enters, put a +1/+1 counter on Donatello."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "38"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Unfortunately, the lowly turtle has been saddled by society with the stereotype of being velocity challenged.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3a5b63a-3263-4f06-a643-808c38f64c77.jpg?1771502576"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DreamBeavers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DreamBeavers.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dream Beavers
+ * {B}
+ * Creature — Beaver Nightmare
+ * 1/1
+ *
+ * Flying
+ * When this creature enters, each opponent loses 1 life and you gain
+ * 1 life. Scry 1.
+ */
+val DreamBeavers = card("Dream Beavers") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Beaver Nightmare"
+    oracleText = "Flying\nWhen this creature enters, each opponent loses 1 life and you gain 1 life. Scry 1."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+            .then(Effects.GainLife(1))
+            .then(EffectPatterns.scry(1))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Alix Branwyn"
+        flavorText = "\"We've drained human life force for millennia. Then one day, turtles! Delectable! We'll suck you dry and spit out the shells!\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/600e3bc1-9777-4057-a11e-4f61582636c6.jpg?1771586853"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/EastWindAvatar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/EastWindAvatar.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * East Wind Avatar
+ * {3}{W}
+ * Creature — Bird Spirit Avatar
+ * 2/4
+ *
+ * Flying, vigilance
+ * Alliance — Whenever another creature you control enters, this
+ * creature gets +1/+0 until end of turn.
+ */
+val EastWindAvatar = card("East Wind Avatar") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Spirit Avatar"
+    oracleText = "Flying, vigilance\nAlliance — Whenever another creature you control enters, this creature gets +1/+0 until end of turn."
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "Alliance — Whenever another creature you control enters, this creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Andrea Tentori Montalto"
+        flavorText = "Azrael was born on the wind to guide others to new beginnings."
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9d5b56c-ad2a-4958-8783-4eceb8733610.jpg?1771502461"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/EpfPointSquad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/EpfPointSquad.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * EPF Point Squad
+ * {1}{R/W}{R/W}
+ * Creature — Human Soldier
+ * 2/1
+ *
+ * Alliance — Whenever another creature you control enters, put a
+ * +1/+1 counter on this creature.
+ */
+val EpfPointSquad = card("EPF Point Squad") {
+    manaCost = "{1}{R/W}{R/W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Alliance — Whenever another creature you control enters, put a +1/+1 counter on this creature."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Alliance — Whenever another creature you control enters, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Leanna Crossan"
+        flavorText = "Not all humans fear the unknown. The Earth Protection Force specializes in teaching the unknown to fear them instead."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/faab52c0-ce79-40af-a156-b193a62d439e.jpg?1771502756"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/EscapeTunnelReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/EscapeTunnelReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Escape Tunnel reprint in TMT.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in MKM. This file
+ * contributes only the TMT-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the
+ * set's `printings`.
+ */
+val EscapeTunnelReprint = Printing(
+    oracleId = "0056fc91-4398-471c-b561-7ff99750ac8a",
+    name = "Escape Tunnel",
+    setCode = "TMT",
+    collectorNumber = "184",
+    scryfallId = "5df90940-15ea-418c-8547-6c75d69ec6d3",
+    artist = "Aenami",
+    imageUri = "https://cards.scryfall.io/normal/front/5/d/5df90940-15ea-418c-8547-6c75d69ec6d3.jpg?1771424732",
+    releaseDate = "2026-03-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FeatherbrainedFilcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FeatherbrainedFilcher.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Featherbrained Filcher
+ * {W}
+ * Creature — Bird Mutant
+ * 0/2
+ *
+ * Flying
+ * When this creature leaves the battlefield, create a Food token.
+ */
+val FeatherbrainedFilcher = card("Featherbrained Filcher") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Mutant"
+    oracleText = "Flying\nWhen this creature leaves the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+    power = 0
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.CreateFood()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Jakob Eirich"
+        flavorText = "\"HI! I'm Pete!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78c55706-4d00-4b97-965c-0b2d0963e59d.jpg?1771513766"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FootElite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FootElite.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Foot Elite
+ * {2}{W/B}
+ * Creature — Human Ninja
+ * 2/4
+ *
+ * Whenever this creature attacks, another target creature you control
+ * gets +1/+0 and gains indestructible until end of turn.
+ */
+val FootElite = card("Foot Elite") {
+    manaCost = "{2}{W/B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Human Ninja"
+    oracleText = "Whenever this creature attacks, another target creature you control gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target(
+            "another target creature you control",
+            TargetPermanent(filter = TargetFilter.CreatureYouControl.other())
+        )
+        effect = Effects.ModifyStats(1, 0, creature)
+            .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature, Duration.EndOfTurn))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Zoltan Boros"
+        flavorText = "The Foot Elite are the personal students of the Shredder, a reserve guard without equal."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24bd571e-652a-4e7c-afc6-a45f0ccf62f6.jpg?1771342404"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FootHeadquarters.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FootHeadquarters.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Foot Headquarters
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, you gain 1 life.
+ * {T}: Add {W} or {B}.
+ */
+val FootHeadquarters = card("Foot Headquarters") {
+    typeLine = "Land"
+    colorIdentity = "WB"
+    oracleText = "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {B}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Hokyoung Kim"
+        flavorText = "\"Getting inside will be easy. Getting to Shredder might even be doable. Getting back out? That's going to be hard.\"\n—April O'Neil"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45e68113-3f05-4547-947d-4cb9ebfa73c7.jpg?1771587092"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FrogButler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FrogButler.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.Duration
+
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Frog Butler
+ * {1}{G}
+ * Creature — Frog Spirit
+ * 1/1
+ *
+ * Deathtouch
+ * {T}: Add one mana of any color.
+ * {2}: This creature gains reach until end of turn.
+ */
+val FrogButler = card("Frog Butler") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Frog Spirit"
+    oracleText = "Deathtouch\n{T}: Add one mana of any color.\n{2}: This creature gains reach until end of turn."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.DEATHTOUCH)
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.GrantKeyword(Keyword.REACH, EffectTarget.Self, Duration.EndOfTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Mirko Failoni"
+        flavorText = "\"With faithful Alberto's assistance, this shall be a gathering of untold delight! Why would you ever wish to leave?\"\n—Toad Baron"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1a72d09-9cfc-463a-a9ec-3359003d54da.jpg?1771502693"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GuacAndMarshmallowPizza.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GuacAndMarshmallowPizza.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guac & Marshmallow Pizza
+ * {G}
+ * Artifact — Food
+ *
+ * Flash
+ * When this artifact enters, target creature gets +2/+2 until end of
+ * turn. Untap it.
+ * {2}, {T}, Sacrifice this artifact: You gain 3 life.
+ */
+val GuacAndMarshmallowPizza = card("Guac & Marshmallow Pizza") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Food"
+    oracleText = "Flash\nWhen this artifact enters, target creature gets +2/+2 until end of turn. Untap it.\n{2}, {T}, Sacrifice this artifact: You gain 3 life."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, creature)
+            .then(Effects.Untap(creature))
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Brandon L. Hunt"
+        flavorText = "\"There is no fear in my heart. I will overcome even this challenge!\"\n—Leonardo"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5405de0-16c9-4e5a-8ceb-00508e212f12.jpg?1771502701"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HamatoGuardianStance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HamatoGuardianStance.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * Hamato Guardian Stance
+ * {W}
+ * Instant
+ *
+ * Target creature gets +1/+3 and gains flying until end of turn. Scry 1.
+ */
+val HamatoGuardianStance = card("Hamato Guardian Stance") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+3 and gains flying until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(1, 3, creature)
+            .then(Effects.GrantKeyword(Keyword.FLYING, creature, Duration.EndOfTurn))
+            .then(EffectPatterns.scry(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Jason Rainville"
+        flavorText = "\"Everything you know, I have shown you, but I have not shown you everything I know.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/735b540b-b472-46fa-a232-d444cabf6c4c.jpg?1771502490"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HardWonJitte.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HardWonJitte.kt
@@ -1,11 +1,10 @@
 package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.GrantKeyword
 
 /**
  * Hard-Won Jitte
@@ -22,8 +21,7 @@ val HardWonJitte = card("Hard-Won Jitte") {
     oracleText = "Equipped creature has double strike.\nEquip {2}"
 
     staticAbility {
-        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.EquippedCreature)
-        filter = Filters.EquippedCreature
+        ability = GrantKeyword(Keyword.DOUBLE_STRIKE, Filters.EquippedCreature)
     }
 
     equipAbility("{2}")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HardWonJitte.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HardWonJitte.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hard-Won Jitte
+ * {1}{R}
+ * Artifact — Equipment
+ *
+ * Equipped creature has double strike.
+ * Equip {2}
+ */
+val HardWonJitte = card("Hard-Won Jitte") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has double strike.\nEquip {2}"
+
+    staticAbility {
+        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.EquippedCreature)
+        filter = Filters.EquippedCreature
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "91"
+        artist = "Kim Sokol"
+        flavorText = "It was fitting that the most dangerous turtle bore a weapon of peace."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d3dc219-f024-49de-b88d-dc1e9e84184c.jpg?1771342392"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Henchbots.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Henchbots.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Henchbots
+ * {4}
+ * Artifact Creature — Robot
+ * 2/3
+ *
+ * When this creature enters, exile target tapped creature an opponent
+ * controls until this creature leaves the battlefield.
+ */
+val Henchbots = card("Henchbots") {
+    manaCost = "{4}"
+    typeLine = "Artifact Creature — Robot"
+    oracleText = "When this creature enters, exile target tapped creature an opponent controls until this creature leaves the battlefield."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "tapped creature an opponent controls",
+            TargetPermanent(filter = TargetFilter.Creature.opponentControls().tapped())
+        )
+        effect = Effects.ExileUntilLeaves(creature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Lordigan"
+        flavorText = "\"Apologies for the disturbance, [INCIDENTAL WITNESS], have a pleasant day!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d77aa46e-fa57-4427-b0a3-0a957dc994dc.jpg?1771502803"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HighFlyingAce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HighFlyingAce.kt
@@ -6,10 +6,8 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.Duration
-import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
-import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.targets.TargetPermanent
 
 /**
@@ -37,14 +35,7 @@ val HighFlyingAce = card("High-Flying Ace") {
         timing = TimingRule.SorcerySpeed
         val creature = target(
             "creature without flying",
-            TargetPermanent(
-                filter = TargetFilter(
-                    GameObjectFilter.Creature.copy(
-                        cardPredicates = GameObjectFilter.Creature.cardPredicates +
-                            CardPredicate.Not(CardPredicate.HasKeyword(Keyword.FLYING))
-                    )
-                )
-            )
+            TargetPermanent(filter = TargetFilter.Creature.withoutKeyword(Keyword.FLYING)),
         )
         effect = Effects.GrantKeyword(Keyword.FLYING, creature, Duration.EndOfTurn)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HighFlyingAce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/HighFlyingAce.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * High-Flying Ace
+ * {2}{W}
+ * Creature — Bird Mutant
+ * 2/3
+ *
+ * Flying
+ * {3}{W}: Target creature without flying gains flying until end of turn.
+ * Activate only as a sorcery.
+ */
+val HighFlyingAce = card("High-Flying Ace") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Mutant"
+    oracleText = "Flying\n{3}{W}: Target creature without flying gains flying until end of turn. Activate only as a sorcery."
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{W}")
+        timing = TimingRule.SorcerySpeed
+        val creature = target(
+            "creature without flying",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.copy(
+                        cardPredicates = GameObjectFilter.Creature.cardPredicates +
+                            CardPredicate.Not(CardPredicate.HasKeyword(Keyword.FLYING))
+                    )
+                )
+            )
+        )
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature, Duration.EndOfTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Daniel Romanovsky"
+        flavorText = "\"Nice to meet you, Botticelli . . . or whatever your name is. Tell your boss to send some scarier goons next time.\"\n—Ace Duck"
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e927eb0b-1c69-421a-8acd-01e92f729ffb.jpg?1771502498"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/IceCreamKitty.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/IceCreamKitty.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * Ice Cream Kitty
+ * {1}{B/G}
+ * Artifact Creature — Food Cat Mutant
+ * 1/3
+ *
+ * {2}, Sacrifice another creature or token: Draw a card. Activate only
+ * as a sorcery.
+ * {2}, {T}, Sacrifice this creature: You gain 3 life.
+ */
+val IceCreamKitty = card("Ice Cream Kitty") {
+    manaCost = "{1}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Artifact Creature — Food Cat Mutant"
+    oracleText = "{2}, Sacrifice another creature or token: Draw a card. Activate only as a sorcery.\n{2}, {T}, Sacrifice this creature: You gain 3 life."
+    power = 1
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.SacrificeAnother(
+                GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.Or(
+                            listOf(
+                                CardPredicate.IsCreature,
+                                CardPredicate.IsToken,
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Maël Ollivier-Henry"
+        flavorText = "\"That's not what they mean by 'pet food,' dude!\"\n—Michelangelo"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66081fd3-2457-4602-96c4-3075ddfec1c2.jpg?1771587014"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/IllegitimateBusiness.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/IllegitimateBusiness.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Illegitimate Business
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, you gain 1 life.
+ * {T}: Add {B} or {G}.
+ */
+val IllegitimateBusiness = card("Illegitimate Business") {
+    typeLine = "Land"
+    colorIdentity = "BG"
+    oracleText = "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {G}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Miklós Ligeti"
+        flavorText = "Their recipe isn't the only secret."
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71597acf-1ce6-46a8-b6c0-88755c8a377c.jpg?1771587098"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ImprovisedArsenal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ImprovisedArsenal.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Improvised Arsenal
+ * {1}{R}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +1/+0 for each artifact you control.
+ * {4}{R}: Create a token that's a copy of this Equipment.
+ * Equip {R}
+ */
+val ImprovisedArsenal = card("Improvised Arsenal") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+0 for each artifact you control.\n{4}{R}: Create a token that's a copy of this Equipment.\nEquip {R}"
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.attachedCreature(),
+            powerBonus = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Artifact),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{R}")
+        effect = Effects.CreateTokenCopyOfSelf()
+    }
+
+    equipAbility("{R}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "92"
+        artist = "Leanna Crossan"
+        flavorText = "\"I want rock 'n' roll, man! Lucky I brought my own drumsticks . . .\"\n—Casey Jones"
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/003265d9-b2fc-4916-afc8-53ed2d6aa053.jpg?1769006146"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/JennikaBadAppleBigSister.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/JennikaBadAppleBigSister.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Jennika, Bad Apple Big Sister
+ * {4}{W}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 3/3
+ *
+ * When Jennika enters, create a 2/2 red Mutant creature token.
+ * Plainscycling {2}
+ */
+val JennikaBadAppleBigSister = card("Jennika, Bad Apple Big Sister") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "When Jennika enters, create a 2/2 red Mutant creature token.\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)"
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mutant"),
+            imageUri = "https://cards.scryfall.io/normal/front/5/1/51e33613-7a24-461c-8d9f-12680af4b92a.jpg?1771590526"
+        )
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Plains", "{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "InHyuk Lee"
+        flavorText = "\"Splinter said that, once, ninjas defended the poor and the weak from power. We could be real ninjas. We can fight for the people!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5b83101-e3ef-4ffe-a886-4fc2b57a0947.jpg?1771502505"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangMasterMind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangMasterMind.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Krang, Master Mind
+ * {6}{U}{U}
+ * Legendary Artifact Creature — Utrom Warrior
+ * 1/4
+ *
+ * Affinity for artifacts
+ * When Krang enters, if you have fewer than four cards in hand, draw
+ * cards equal to the difference.
+ * Krang gets +1/+0 for each other artifact you control.
+ */
+val KrangMasterMind = card("Krang, Master Mind") {
+    manaCost = "{6}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Artifact Creature — Utrom Warrior"
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhen Krang enters, if you have fewer than four cards in hand, draw cards equal to the difference.\nKrang gets +1/+0 for each other artifact you control."
+    power = 1
+    toughness = 4
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(
+            DynamicAmount.IfPositive(
+                DynamicAmount.Subtract(
+                    DynamicAmount.Fixed(4),
+                    DynamicAmount.Count(Player.You, Zone.HAND, GameObjectFilter.Any)
+                )
+            )
+        )
+    }
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmount.IfPositive(
+                DynamicAmount.Subtract(
+                    DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Artifact),
+                    DynamicAmount.Fixed(1)
+                )
+            ),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "43"
+        artist = "Narendra Bintara Adi"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d27fa497-e842-4812-80fe-28517544e1c5.jpg?1760102684"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangMasterMind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangMasterMind.kt
@@ -9,6 +9,8 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
 import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -36,12 +38,15 @@ val KrangMasterMind = card("Krang, Master Mind") {
 
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
+        triggerCondition = Compare(
+            DynamicAmount.Count(Player.You, Zone.HAND, GameObjectFilter.Any),
+            ComparisonOperator.LT,
+            DynamicAmount.Fixed(4),
+        )
         effect = Effects.DrawCards(
-            DynamicAmount.IfPositive(
-                DynamicAmount.Subtract(
-                    DynamicAmount.Fixed(4),
-                    DynamicAmount.Count(Player.You, Zone.HAND, GameObjectFilter.Any)
-                )
+            DynamicAmount.Subtract(
+                DynamicAmount.Fixed(4),
+                DynamicAmount.Count(Player.You, Zone.HAND, GameObjectFilter.Any),
             )
         )
     }
@@ -49,13 +54,11 @@ val KrangMasterMind = card("Krang, Master Mind") {
     staticAbility {
         ability = GrantDynamicStatsEffect(
             filter = GroupFilter.source(),
-            powerBonus = DynamicAmount.IfPositive(
-                DynamicAmount.Subtract(
-                    DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Artifact),
-                    DynamicAmount.Fixed(1)
-                )
+            powerBonus = DynamicAmount.Subtract(
+                DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Artifact),
+                DynamicAmount.Fixed(1),
             ),
-            toughnessBonus = DynamicAmount.Fixed(0)
+            toughnessBonus = DynamicAmount.Fixed(0),
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangUtromWarlord.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangUtromWarlord.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * Krang, Utrom Warlord
+ * {9}
+ * Legendary Artifact Creature — Utrom Robot
+ * 9/9
+ *
+ * Flying, trample, indestructible, haste
+ * Other artifact creatures you control have flying, trample,
+ * indestructible, and haste.
+ */
+val KrangUtromWarlord = card("Krang, Utrom Warlord") {
+    manaCost = "{9}"
+    typeLine = "Legendary Artifact Creature — Utrom Robot"
+    oracleText = "Flying, trample, indestructible, haste\nOther artifact creatures you control have flying, trample, indestructible, and haste."
+    power = 9
+    toughness = 9
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE, Keyword.INDESTRUCTIBLE, Keyword.HASTE)
+
+    val otherArtifactCreatures = GroupFilter(
+        GameObjectFilter(
+            cardPredicates = listOf(
+                CardPredicate.IsCreature,
+                CardPredicate.IsArtifact,
+            )
+        ).youControl(),
+        excludeSelf = true
+    )
+
+    for (kw in listOf(Keyword.FLYING, Keyword.TRAMPLE, Keyword.INDESTRUCTIBLE, Keyword.HASTE)) {
+        staticAbility {
+            ability = GrantKeyword(keyword = kw, filter = otherArtifactCreatures)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "175"
+        artist = "Lordigan"
+        flavorText = "The Molecular Amplification technology of Krang's exo-suit allows him to expand and adapt not only his tactics, but his physical form."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88d36c32-d6f9-46e4-9cc8-08e6c0ff05d2.jpg?1769006413"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LessonsFromLife.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LessonsFromLife.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Lessons from Life
+ * {2}{G}{U}
+ * Sorcery
+ *
+ * Draw three cards. You may put a land card from your hand onto the
+ * battlefield tapped.
+ */
+val LessonsFromLife = card("Lessons from Life") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Sorcery"
+    oracleText = "Draw three cards. You may put a land card from your hand onto the battlefield tapped."
+
+    spell {
+        effect = Effects.DrawCards(3)
+            .then(EffectPatterns.putFromHand(filter = GameObjectFilter.Land, entersTapped = true))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "155"
+        artist = "Kevin Sidharta"
+        flavorText = "\"Everyone's got their own strengths, Lita. You never know what cards they might play. Instead, focus on what you know and never doubt your choices.\"\n—Michelangelo"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f886117-aff3-4db7-9cf5-7cbe94c8cd02.jpg?1771424719"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MakeYourMove.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MakeYourMove.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Make Your Move
+ * {2}{W}
+ * Instant
+ *
+ * Destroy target artifact, enchantment, or creature with power 4 or
+ * greater.
+ */
+val MakeYourMove = card("Make Your Move") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact, enchantment, or creature with power 4 or greater."
+
+    spell {
+        val permanent = target(
+            "artifact, enchantment, or creature with power 4 or greater",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.Or(
+                                listOf(
+                                    CardPredicate.IsArtifact,
+                                    CardPredicate.IsEnchantment,
+                                    CardPredicate.PowerAtLeast(4),
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        effect = Effects.Destroy(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Nathaniel Himawan"
+        flavorText = "For a moment, there is only relentless snow and frozen breath."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed8bdd98-6377-40cf-b381-cee38b1bda2a.jpg?1771502526"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ManholeMissile.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ManholeMissile.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Manhole Missile
+ * {1}{R}
+ * Instant
+ *
+ * Manhole Missile deals 3 damage to target creature. You may put a
+ * card from your hand on the bottom of your library. If you do, draw
+ * a card.
+ */
+val ManholeMissile = card("Manhole Missile") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Manhole Missile deals 3 damage to target creature. You may put a card from your hand on the bottom of your library. If you do, draw a card."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = CompositeEffect(
+            listOf(
+                Effects.DealDamage(3, creature),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.You),
+                    storeAs = "hand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hand",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "bottomed",
+                    storeRemainder = "kept",
+                    selectedLabel = "Put on bottom of library",
+                    remainderLabel = "Keep in hand",
+                ),
+                MoveCollectionEffect(
+                    from = "bottomed",
+                    destination = CardDestination.ToZone(
+                        Zone.LIBRARY,
+                        placement = ZonePlacement.Bottom
+                    )
+                ),
+                ConditionalOnCollectionEffect(
+                    collection = "bottomed",
+                    ifNotEmpty = Effects.DrawCards(1),
+                    ifEmpty = CompositeEffect(listOf())
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Fajareka Setiawan"
+        flavorText = "\"SAY YER PRAYERS, TOITLES!\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/243e392b-48b0-4e90-ae22-9a696f45e878.jpg?1771502635"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MechanizedNinjaCavalry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MechanizedNinjaCavalry.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Mechanized Ninja Cavalry
+ * {1}{R/W}
+ * Artifact Creature — Robot Ninja
+ * 1/1
+ *
+ * When this creature enters, create a 1/1 colorless Robot artifact
+ * creature token.
+ */
+val MechanizedNinjaCavalry = card("Mechanized Ninja Cavalry") {
+    manaCost = "{1}{R/W}"
+    colorIdentity = "RW"
+    typeLine = "Artifact Creature — Robot Ninja"
+    oracleText = "When this creature enters, create a 1/1 colorless Robot artifact creature token."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(),
+            creatureTypes = setOf("Robot"),
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/0/8/08497fc5-1c0e-4c3c-a356-bf4b34bd4c45.jpg?1771590585"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "156"
+        artist = "Michele Giorgi"
+        flavorText = "\"This is absolutely ridiculous, Saki! They aren't meant for riding! What happened to the ninja's famous subtlety?\"\n—Baxter Stockman"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2cb65388-dc6c-4e2a-93ac-49ea484849e9.jpg?1771502774"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Metalhead.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Metalhead.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Metalhead
+ * {4}{U}
+ * Legendary Artifact Creature — Robot Turtle
+ * 4/4
+ *
+ * When Metalhead enters, return up to one other target artifact or
+ * creature to its owner's hand.
+ * {R}, Sacrifice another artifact: Put a +1/+1 counter on Metalhead.
+ * He gains menace and haste until end of turn.
+ */
+val Metalhead = card("Metalhead") {
+    manaCost = "{4}{U}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Artifact Creature — Robot Turtle"
+    oracleText = "When Metalhead enters, return up to one other target artifact or creature to its owner's hand.\n{R}, Sacrifice another artifact: Put a +1/+1 counter on Metalhead. He gains menace and haste until end of turn."
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val perm = target(
+            "other artifact or creature",
+            TargetPermanent(optional = true, filter = TargetFilter.CreatureOrArtifact.other())
+        )
+        effect = Effects.ReturnToHand(perm)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{R}"),
+            Costs.SacrificeAnother(GameObjectFilter.Artifact)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            .then(Effects.GrantKeyword(Keyword.MENACE, EffectTarget.Self, Duration.EndOfTurn))
+            .then(Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self, Duration.EndOfTurn))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "44"
+        artist = "Daniel Romanovsky"
+        flavorText = "Metalhead simulates dozens of fighting styles, including Foot ninjutsu."
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c2d8b09-8694-45ab-be01-f8dc17378cf0.jpg?1771586807"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MightyMutanimals.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MightyMutanimals.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Mighty Mutanimals
+ * {2}{W}{W}
+ * Creature — Mutant Rebel
+ * 2/1
+ *
+ * When this creature enters, create a 2/2 red Mutant creature token.
+ * Alliance — Whenever another creature you control enters, put a
+ * +1/+1 counter on target creature you control.
+ */
+val MightyMutanimals = card("Mighty Mutanimals") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Mutant Rebel"
+    oracleText = "When this creature enters, create a 2/2 red Mutant creature token.\nAlliance — Whenever another creature you control enters, put a +1/+1 counter on target creature you control."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mutant"),
+            imageUri = "https://cards.scryfall.io/normal/front/5/1/51e33613-7a24-461c-8d9f-12680af4b92a.jpg?1771590526"
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        description = "Alliance — Whenever another creature you control enters, put a +1/+1 counter on target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "21"
+        artist = "Manuel Castañón"
+        flavorText = "\"Yer right. We're just a scrappy band of mutants. We can't win. But boy, can we stir up trouble.\"\n—Old Hob"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5dd5369c-174c-450b-b776-553866787f8f.jpg?1771502533"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MikeyAndLeoChaosAndOrder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MikeyAndLeoChaosAndOrder.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Mikey & Leo, Chaos & Order
+ * {G/W}{G/W}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 2/2
+ *
+ * Whenever you put a counter on a creature you control, draw a card.
+ * This ability triggers only once each turn.
+ */
+val MikeyAndLeoChaosAndOrder = card("Mikey & Leo, Chaos & Order") {
+    manaCost = "{G/W}{G/W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Whenever you put a counter on a creature you control, draw a card. This ability triggers only once each turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.countersPlacedOn(
+            filter = GameObjectFilter.Creature.youControl(),
+            counterType = Counters.ANY,
+            firstTimeEachTurn = false,
+        )
+        oncePerTurn = true
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "158"
+        artist = "Jason Rainville"
+        flavorText = "Their strength hailed not from what they shared, but from how their differences complemented one another."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9cfeb2b4-937c-4bcc-bb03-467cc0effba2.jpg?1769006353"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MonaLisaScienceGeek.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MonaLisaScienceGeek.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Mona Lisa, Science Geek
+ * {2}{G}
+ * Legendary Creature — Lizard Mutant
+ * 1/3
+ *
+ * Reach
+ * {T}: Add X mana of any one color, where X is Mona Lisa's power.
+ */
+val MonaLisaScienceGeek = card("Mona Lisa, Science Geek") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Lizard Mutant"
+    oracleText = "Reach\n{T}: Add X mana of any one color, where X is Mona Lisa's power."
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.REACH)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(
+            DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Power)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "123"
+        artist = "Oriana Menendez"
+        flavorText = "\"I felt kind of excited about being mutated, you know? I was getting to have this once in a lifetime experience! Maybe I could even base my thesis on it . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2164204-120c-4dff-86ac-46ca9012ccd9.jpg?1771424712"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MouserAttack.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MouserAttack.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Mouser Attack!
+ * {1}{R}
+ * Instant
+ *
+ * Choose one —
+ * • Create a 1/1 colorless Robot artifact creature token.
+ * • Target creature gets +3/+0 and gains first strike until end of turn.
+ */
+val MouserAttack = card("Mouser Attack!") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Create a 1/1 colorless Robot artifact creature token.\n• Target creature gets +3/+0 and gains first strike until end of turn."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Create a 1/1 colorless Robot artifact creature token") {
+                effect = CreateTokenEffect(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(),
+                    creatureTypes = setOf("Robot"),
+                    artifactToken = true,
+                    imageUri = "https://cards.scryfall.io/normal/front/0/8/08497fc5-1c0e-4c3c-a356-bf4b34bd4c45.jpg?1771590585"
+                )
+            }
+            mode("Target creature gets +3/+0 and gains first strike until end of turn") {
+                val creature = target("target creature", Targets.Creature)
+                effect = Effects.ModifyStats(3, 0, creature)
+                    .then(Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature, Duration.EndOfTurn))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Erikas Perl"
+        flavorText = "\"For me, all things remain strictly business. And today's business happens to be extermination!\"\n—Baxter Stockman"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/058490f4-0ada-45e6-b4f0-e433537f52d6.jpg?1771502642"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MouserFoundry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MouserFoundry.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Mouser Foundry
+ * {1}{R}
+ * Artifact
+ *
+ * When this artifact enters or leaves the battlefield, create a 1/1
+ * colorless Robot artifact creature token.
+ * {4}{R}, Sacrifice this artifact: It deals 3 damage to target creature.
+ */
+val MouserFoundry = card("Mouser Foundry") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters or leaves the battlefield, create a 1/1 colorless Robot artifact creature token.\n{4}{R}, Sacrifice this artifact: It deals 3 damage to target creature."
+
+    val createRobot = CreateTokenEffect(
+        power = 1,
+        toughness = 1,
+        colors = setOf(),
+        creatureTypes = setOf("Robot"),
+        artifactToken = true,
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08497fc5-1c0e-4c3c-a356-bf4b34bd4c45.jpg?1771590585"
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = createRobot
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = createRobot
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{4}{R}"),
+            Costs.SacrificeSelf
+        )
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(3, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "96"
+        artist = "Jakob Eirich"
+        flavorText = "\"Hmmm . . . How many should I send? Three? Five? Ten, maybe!\"\n—Baxter Stockman"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8aae3bd6-a935-44a5-aa4d-a525b00cbf50.jpg?1771502649"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MouserMarkIii.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MouserMarkIii.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Mouser Mark III
+ * {1}{U/R}
+ * Artifact Creature — Robot
+ * 2/3
+ *
+ * This creature can't attack unless you control another artifact.
+ */
+val MouserMarkIii = card("Mouser Mark III") {
+    manaCost = "{1}{U/R}"
+    colorIdentity = "UR"
+    typeLine = "Artifact Creature — Robot"
+    oracleText = "This creature can't attack unless you control another artifact."
+    power = 2
+    toughness = 3
+
+    staticAbility {
+        ability = CantAttackUnless(
+            condition = Compare(
+                DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Artifact),
+                ComparisonOperator.GTE,
+                DynamicAmount.Fixed(2)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "159"
+        artist = "Gabriel Tanko"
+        flavorText = "Designed to get rodents out of small spaces, its Mouser maws can be used to seize all sorts of vermin!"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/608a13b4-0b94-4be5-ac4b-e939901e8419.jpg?1771502784"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantTown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantTown.kt
@@ -28,6 +28,7 @@ val MutantTown = card("Mutant Town") {
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
         effect = Effects.GainLife(1)
+        description = "When this land enters, you gain 1 life."
     }
 
     activatedAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantTown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantTown.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Mutant Town
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, you gain 1 life.
+ * {T}: Add {G} or {U}.
+ */
+val MutantTown = card("Mutant Town") {
+    typeLine = "Land"
+    colorIdentity = "GU"
+    oracleText = "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {U}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Josu Solano"
+        flavorText = "\"Until we completely understand the mutagenic agent's effects, these people must remain contained for our health and safety.\"\n—Baxter Stockman"
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6eac43d-08b6-45a4-803b-10a321a241d7.jpg?1771587105"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantTownMusicians.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantTownMusicians.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mutant Town Musicians
+ * {2}{R}
+ * Creature — Mutant Bard Performer
+ * 2/4
+ *
+ * Trample
+ * Alliance — Whenever another creature you control enters, this
+ * creature gets +1/+0 until end of turn.
+ */
+val MutantTownMusicians = card("Mutant Town Musicians") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Mutant Bard Performer"
+    oracleText = "Trample\nAlliance — Whenever another creature you control enters, this creature gets +1/+0 until end of turn."
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "Alliance — Whenever another creature you control enters, this creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Leonardo Vincent (Levinky)"
+        flavorText = "After the Bomb's take on thrash metal isn't for everyone . . . and Sheena wouldn't have it any other way."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2dbe9207-06e8-4837-8227-0f960490771b.jpg?1771766034"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Negate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Negate.kt
@@ -1,33 +1,24 @@
 package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Targets
-import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Printing
 import com.wingedsheep.sdk.model.Rarity
 
 /**
- * Negate
- * {1}{U}
- * Instant
+ * Negate reprint in TMT.
  *
- * Counter target noncreature spell.
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in the Foundations
+ * (FDN) package. This file contributes only the TMT-specific presentation row —
+ * set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
  */
-val Negate = card("Negate") {
-    manaCost = "{1}{U}"
-    colorIdentity = "U"
-    typeLine = "Instant"
-    oracleText = "Counter target noncreature spell."
-
-    spell {
-        target("noncreature spell", Targets.NoncreatureSpell)
-        effect = Effects.CounterSpell()
-    }
-
-    metadata {
-        rarity = Rarity.COMMON
-        collectorNumber = "47"
-        artist = "Ryan Valle"
-        flavorText = "\"You guys seriously try to do this with jump kicks?\""
-        imageUri = "https://cards.scryfall.io/normal/front/5/2/52d58fe4-6070-4022-9cd7-c35a11b44525.jpg?1771342360"
-    }
-}
+val NegateReprint = Printing(
+    oracleId = "3407fe41-fdd3-4119-8f70-4bc4590a379f",
+    name = "Negate",
+    setCode = "TMT",
+    collectorNumber = "47",
+    scryfallId = "52d58fe4-6070-4022-9cd7-c35a11b44525",
+    artist = "Ryan Valle",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/52d58fe4-6070-4022-9cd7-c35a11b44525.jpg?1771342360",
+    releaseDate = "2026-03-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Negate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Negate.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Negate
+ * {1}{U}
+ * Instant
+ *
+ * Counter target noncreature spell.
+ */
+val Negate = card("Negate") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target noncreature spell."
+
+    spell {
+        target("noncreature spell", Targets.NoncreatureSpell)
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Ryan Valle"
+        flavorText = "\"You guys seriously try to do this with jump kicks?\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52d58fe4-6070-4022-9cd7-c35a11b44525.jpg?1771342360"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Nobody.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Nobody.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Nobody
+ * {1}{U/R}{U/R}
+ * Artifact Creature — Human Hero
+ * 3/2
+ *
+ * When this creature enters, return up to one other target artifact
+ * you control to its owner's hand. Scry 1.
+ */
+val Nobody = card("Nobody") {
+    manaCost = "{1}{U/R}{U/R}"
+    colorIdentity = "UR"
+    typeLine = "Artifact Creature — Human Hero"
+    oracleText = "When this creature enters, return up to one other target artifact you control to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val artifact = target(
+            "other artifact you control",
+            TargetPermanent(optional = true, filter = TargetFilter.Artifact.youControl().other())
+        )
+        effect = Effects.ReturnToHand(artifact)
+            .then(EffectPatterns.scry(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "161"
+        artist = "Yuhong Ding"
+        flavorText = "\"I don't need a name. I'm nobody.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/0966b8ff-61d3-4394-a357-97c35f042a29.jpg?1771587036"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NullGroupBiologicalAssets.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NullGroupBiologicalAssets.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Null Group Biological Assets
+ * {2}{R}
+ * Creature — Mutant Mercenary
+ * 3/1
+ *
+ * During your turn, this creature has first strike.
+ * Whenever this creature attacks, you may discard a card. If you do,
+ * draw a card.
+ */
+val NullGroupBiologicalAssets = card("Null Group Biological Assets") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Mutant Mercenary"
+    oracleText = "During your turn, this creature has first strike.\nWhenever this creature attacks, you may discard a card. If you do, draw a card."
+    power = 3
+    toughness = 1
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FIRST_STRIKE, GroupFilter.source()),
+            condition = Conditions.IsYourTurn
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        optional = true
+        effect = EffectPatterns.rummage(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "98"
+        artist = "Miklós Ligeti"
+        flavorText = "\"I'm a company woman. I'm part of the plan. I'm part of the team. And I enjoy my work.\"\n—Zodi"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb44c134-fcd8-4ad8-841c-f1723ba93216.jpg?1771502666"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OldHobAlleycatBlues.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OldHobAlleycatBlues.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
@@ -31,16 +32,14 @@ import com.wingedsheep.sdk.scripting.targets.TargetPermanent
  * {1}{W}: Target attacking creature token gains indestructible until
  * end of turn.
  *
- * Mirrors the EOE Systems Override pattern: a `CreateDelayedTriggerEffect`
- * scheduled for the next end step that targets the just-created token
- * via `EffectTarget.ContextTarget(0)` (the slot `CreateTokenEffect`
- * publishes the new token id into, same as the EOE Auxiliary Boosters
- * ETB-attach chain). The delayed trigger uses `MoveToZoneEffect(...,
- * byDestruction = true)`, which goes through the engine's destroy
- * pipeline — so the second ability's UEOT indestructible grant
- * legitimately saves the token, matching printed "Destroy" semantics
- * (a `sacrificeAtStep` shortcut would *not* respect indestructible
- * and would mis-implement that interaction).
+ * The delayed end-step destroy resolves the freshly-created token via
+ * `EffectTarget.PipelineTarget(CREATED_TOKENS, 0)` — `CreateTokenEffect`
+ * publishes new token ids into the `CREATED_TOKENS` pipeline collection
+ * (see `EffectPatterns.incubate` for the established precedent).
+ * `byDestruction = true` routes the cleanup through the destroy
+ * pipeline so the second ability's UEOT indestructible grant
+ * legitimately saves the token (a `sacrificeAtStep` shortcut would
+ * silently bypass indestructible).
  */
 val OldHobAlleycatBlues = card("Old Hob, Alleycat Blues") {
     manaCost = "{4}{R}"
@@ -63,7 +62,7 @@ val OldHobAlleycatBlues = card("Old Hob, Alleycat Blues") {
             CreateDelayedTriggerEffect(
                 step = Step.END,
                 effect = MoveToZoneEffect(
-                    target = EffectTarget.ContextTarget(0),
+                    target = EffectTarget.PipelineTarget(CREATED_TOKENS, 0),
                     destination = Zone.GRAVEYARD,
                     byDestruction = true,
                 )
@@ -74,16 +73,12 @@ val OldHobAlleycatBlues = card("Old Hob, Alleycat Blues") {
 
     activatedAbility {
         cost = Costs.Mana("{1}{W}")
+        val attackingTokenFilter = GameObjectFilter.Creature.attacking().let { base ->
+            base.copy(cardPredicates = base.cardPredicates + CardPredicate.IsToken)
+        }
         val token = target(
             "target attacking creature token",
-            TargetPermanent(
-                filter = TargetFilter(
-                    GameObjectFilter.Creature.attacking().copy(
-                        cardPredicates = GameObjectFilter.Creature.attacking().cardPredicates +
-                            CardPredicate.IsToken
-                    )
-                )
-            )
+            TargetPermanent(filter = TargetFilter(attackingTokenFilter)),
         )
         effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, token, Duration.EndOfTurn)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OldHobAlleycatBlues.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OldHobAlleycatBlues.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Old Hob, Alleycat Blues
+ * {4}{R}
+ * Legendary Creature — Cat Mutant Rebel
+ * 4/4
+ *
+ * At the beginning of combat on your turn, create a 2/2 red Mutant
+ * creature token. It gains haste until end of turn. Destroy it at the
+ * beginning of the next end step.
+ * {1}{W}: Target attacking creature token gains indestructible until
+ * end of turn.
+ *
+ * Mirrors the EOE Systems Override pattern: a `CreateDelayedTriggerEffect`
+ * scheduled for the next end step that targets the just-created token
+ * via `EffectTarget.ContextTarget(0)` (the slot `CreateTokenEffect`
+ * publishes the new token id into, same as the EOE Auxiliary Boosters
+ * ETB-attach chain). The delayed trigger uses `MoveToZoneEffect(...,
+ * byDestruction = true)`, which goes through the engine's destroy
+ * pipeline — so the second ability's UEOT indestructible grant
+ * legitimately saves the token, matching printed "Destroy" semantics
+ * (a `sacrificeAtStep` shortcut would *not* respect indestructible
+ * and would mis-implement that interaction).
+ */
+val OldHobAlleycatBlues = card("Old Hob, Alleycat Blues") {
+    manaCost = "{4}{R}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Cat Mutant Rebel"
+    oracleText = "At the beginning of combat on your turn, create a 2/2 red Mutant creature token. It gains haste until end of turn. Destroy it at the beginning of the next end step.\n{1}{W}: Target attacking creature token gains indestructible until end of turn."
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = CreateTokenEffect(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mutant"),
+            keywords = setOf(Keyword.HASTE),
+            imageUri = "https://cards.scryfall.io/normal/front/5/1/51e33613-7a24-461c-8d9f-12680af4b92a.jpg?1771590526"
+        ).then(
+            CreateDelayedTriggerEffect(
+                step = Step.END,
+                effect = MoveToZoneEffect(
+                    target = EffectTarget.ContextTarget(0),
+                    destination = Zone.GRAVEYARD,
+                    byDestruction = true,
+                )
+            )
+        )
+        description = "At the beginning of combat on your turn, create a 2/2 red Mutant creature token. It gains haste until end of turn. Destroy it at the beginning of the next end step."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        val token = target(
+            "target attacking creature token",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.attacking().copy(
+                        cardPredicates = GameObjectFilter.Creature.attacking().cardPredicates +
+                            CardPredicate.IsToken
+                    )
+                )
+            )
+        )
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, token, Duration.EndOfTurn)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Rose Benjamin"
+        flavorText = "\"This is us against them, plain and simple. Either you're with us, or . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/1515eed9-3b21-42f0-ab57-de5df19317af.jpg?1771586941"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OmniCheesePizza.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OmniCheesePizza.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Omni-Cheese Pizza
+ * {2}
+ * Artifact — Food
+ *
+ * When this artifact enters, draw a card.
+ * {1}, {T}, Sacrifice this artifact: Add one mana of any color.
+ * {2}, {T}, Sacrifice this artifact: You gain 3 life.
+ */
+val OmniCheesePizza = card("Omni-Cheese Pizza") {
+    manaCost = "{2}"
+    typeLine = "Artifact — Food"
+    oracleText = "When this artifact enters, draw a card.\n{1}, {T}, Sacrifice this artifact: Add one mana of any color.\n{2}, {T}, Sacrifice this artifact: You gain 3 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "176"
+        artist = "Gabriel Tanko"
+        flavorText = "\"And just a sprig of parsley for color . . .\"\n—Michelangelo"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2c8397c-2014-4a43-9ed7-41795880011f.jpg?1771587071"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Pain101.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Pain101.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pain 101
+ * {1}{B}
+ * Instant
+ *
+ * Until end of turn, target creature gains deathtouch and "When this
+ * creature dies, return it to the battlefield tapped under its
+ * owner's control."
+ */
+val Pain101 = card("Pain 101") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target creature gains deathtouch and \"When this creature dies, return it to the battlefield tapped under its owner's control.\""
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+
+        val diesReturnTapped = TriggeredAbility.create(
+            trigger = ZoneChangeEvent(from = Zone.BATTLEFIELD, to = Zone.GRAVEYARD),
+            binding = TriggerBinding.SELF,
+            effect = MoveToZoneEffect(
+                target = EffectTarget.Self,
+                destination = Zone.BATTLEFIELD,
+                placement = ZonePlacement.Tapped,
+                fromZone = Zone.GRAVEYARD,
+            ),
+            descriptionOverride = "When this creature dies, return it to the battlefield tapped under its owner's control."
+        )
+
+        effect = CompositeEffect(
+            listOf(
+                Effects.GrantKeyword(Keyword.DEATHTOUCH, creature, Duration.EndOfTurn),
+                GrantTriggeredAbilityEffect(
+                    ability = diesReturnTapped,
+                    target = creature,
+                    duration = Duration.EndOfTurn,
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Thomas Chamberlain-Keen"
+        flavorText = "Your instructor is Casey Jones!"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1c70bf2-b2bd-4585-ba50-304f4dad8e62.jpg?1771586891"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Pain101.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Pain101.kt
@@ -7,7 +7,7 @@ import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.Duration
-import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PrimordialPachyderm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PrimordialPachyderm.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Primordial Pachyderm
+ * {3}{G}
+ * Creature — Elephant Avatar
+ * 4/4
+ *
+ * Reach, trample
+ * When this creature enters, you gain 2 life.
+ */
+val PrimordialPachyderm = card("Primordial Pachyderm") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elephant Avatar"
+    oracleText = "Reach, trample\nWhen this creature enters, you gain 2 life."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Andrey Kuzinskiy"
+        flavorText = "\"Have at me, and we will find out who is the fittest among us.\"\n—Manmoth"
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1a866e6-4108-4290-9680-8f1652fbcf77.jpg?1771502730"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PunkFrogs.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PunkFrogs.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Punk Frogs
+ * {3}{G/U}{G/U}
+ * Creature — Frog Mutant Rebel
+ * 4/5
+ *
+ * Ward {3}
+ */
+val PunkFrogs = card("Punk Frogs") {
+    manaCost = "{3}{G/U}{G/U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Frog Mutant Rebel"
+    oracleText = "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)"
+    power = 4
+    toughness = 5
+
+    keywords(Keyword.WARD)
+    keywordAbility(KeywordAbility.ward("{3}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Michele Giorgi"
+        flavorText = "\"Weirdo ninjas got some nerve showing up on our turf. Sayin' they don't wanna fight but they got swords and stuff. Heh.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/375c91a3-53c4-4f2d-bf7b-2c79a219d3ae.jpg?1771587049"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/QuintessentialKatana.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/QuintessentialKatana.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.DealsDamageEvent
+import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.AttachEquipmentEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Quintessential Katana
+ * {W}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +1/+1 and has "Whenever this creature deals
+ * combat damage, untap it and you gain 2 life."
+ * Whenever a Ninja you control enters, you may attach this Equipment
+ * to it.
+ * Equip {2}
+ */
+val QuintessentialKatana = card("Quintessential Katana") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1 and has \"Whenever this creature deals combat damage, untap it and you gain 2 life.\"\nWhenever a Ninja you control enters, you may attach this Equipment to it.\nEquip {2}"
+
+    staticAbility {
+        effect = Effects.ModifyStats(1, 1)
+        filter = Filters.EquippedCreature
+    }
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            TriggeredAbility.create(
+                trigger = DealsDamageEvent(
+                    damageType = DamageType.Combat,
+                    recipient = RecipientFilter.Any
+                ),
+                binding = TriggerBinding.SELF,
+                effect = Effects.Untap(EffectTarget.Self)
+                    .then(Effects.GainLife(2))
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.withSubtype("Ninja").youControl(),
+                to = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.ANY
+        )
+        optional = true
+        effect = AttachEquipmentEffect(EffectTarget.TriggeringEntity)
+        description = "Whenever a Ninja you control enters, you may attach this Equipment to it."
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "23"
+        artist = "Anthony Devine"
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef9e227e-c581-479c-a962-2f191352b07f.jpg?1771502541"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/QuintessentialKatana.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/QuintessentialKatana.kt
@@ -7,10 +7,11 @@ import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.GameEvent.DealsDamageEvent
-import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.EventPattern.DealsDamageEvent
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.TriggeredAbility
@@ -37,8 +38,7 @@ val QuintessentialKatana = card("Quintessential Katana") {
     oracleText = "Equipped creature gets +1/+1 and has \"Whenever this creature deals combat damage, untap it and you gain 2 life.\"\nWhenever a Ninja you control enters, you may attach this Equipment to it.\nEquip {2}"
 
     staticAbility {
-        effect = Effects.ModifyStats(1, 1)
-        filter = Filters.EquippedCreature
+        ability = ModifyStats(1, 1, Filters.EquippedCreature)
     }
 
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RagamuffinRaptor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RagamuffinRaptor.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ragamuffin Raptor
+ * {4}{G}
+ * Creature — Dinosaur
+ * 4/3
+ *
+ * When this creature enters, return up to one target creature or Food
+ * card from your graveyard to your hand.
+ */
+val RagamuffinRaptor = card("Ragamuffin Raptor") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "When this creature enters, return up to one target creature or Food card from your graveyard to your hand."
+    power = 4
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val card = target(
+            "creature or Food card from your graveyard",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.Or(
+                                listOf(
+                                    CardPredicate.IsCreature,
+                                    CardPredicate.HasSubtype(Subtype("Food")),
+                                )
+                            )
+                        )
+                    ).ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                )
+            )
+        )
+        effect = Effects.ReturnToHand(card)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Inkognit"
+        flavorText = "Bebop and Rocksteady's new Cretaceous stowaway quickly developed a taste for leftovers . . . and ears."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2edc1d40-3154-4ec0-88c7-faf35fd5e560.jpg?1772578991"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphAndLeoSiblingRivals.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphAndLeoSiblingRivals.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCombatPhaseEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Raph & Leo, Sibling Rivals
+ * {1}{R/W}{R/W}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 2/4
+ *
+ * Whenever Raph & Leo attack, if it's the first combat phase of the
+ * turn, untap one or two target attacking creatures. After this
+ * phase, there is an additional combat phase.
+ *
+ * Mirrors the LTR Éomer, Marshal of Rohan shape — attack trigger
+ * with an anti-loop limiter, untap a small group of attackers, then
+ * `AddCombatPhaseEffect` to add a second combat phase.
+ *
+ * **Approximation note:** the printed rider is *"if it's the first
+ * combat phase of the turn"* (intervening-if), but the engine has no
+ * "first combat phase" condition today. The same anti-infinite-loop
+ * function is served by Éomer's `oncePerTurn = true` trigger-firing
+ * cap; the two diverge only in a narrow edge case (another source of
+ * additional combat exists *and* Raph & Leo first attack in combat
+ * #2 — the intervening-if would fail, `oncePerTurn = true` would
+ * still let it fire once). When a `Conditions.IsFirstCombatPhase`
+ * primitive lands, swap `oncePerTurn = true` for a faithful
+ * `triggerCondition`.
+ */
+val RaphAndLeoSiblingRivals = card("Raph & Leo, Sibling Rivals") {
+    manaCost = "{1}{R/W}{R/W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Whenever Raph & Leo attack, if it's the first combat phase of the turn, untap one or two target attacking creatures. After this phase, there is an additional combat phase."
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        oncePerTurn = true
+        target(
+            "one or two attacking creatures",
+            TargetCreature(count = 2, minCount = 1, filter = TargetFilter.AttackingCreature)
+        )
+        effect = CompositeEffect(
+            listOf(
+                ForEachTargetEffect(
+                    listOf(TapUntapEffect(EffectTarget.ContextTarget(0), tap = false))
+                ),
+                AddCombatPhaseEffect,
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "166"
+        artist = "Fajareka Setiawan"
+        flavorText = "At odds as brothers, perfectly in sync as fighters."
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/49293f77-5d7b-4106-b485-db6ce0ed37e6.jpg?1769006383"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelToughTurtle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelToughTurtle.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raphael, Tough Turtle
+ * {1}{R}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 1/3
+ *
+ * Alliance — Whenever another creature you control enters, Raphael
+ * deals 1 damage to target opponent.
+ */
+val RaphaelToughTurtle = card("Raphael, Tough Turtle") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Alliance — Whenever another creature you control enters, Raphael deals 1 damage to target opponent."
+    power = 1
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.DealDamage(1, opponent)
+        description = "Alliance — Whenever another creature you control enters, Raphael deals 1 damage to target opponent."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "104"
+        artist = "Nathaniel Himawan"
+        flavorText = "\"Anger is a dangerous ally. It clouds your judgment. You need to control it, lest it control you.\"\n—Splinter"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f24c90c8-ed04-4b4e-8b19-c7d07a90c6b8.jpg?1771342404"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RavenousRobots.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RavenousRobots.kt
@@ -5,7 +5,7 @@ import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.Duration
-import com.wingedsheep.sdk.scripting.GameEvent.SpellCastEvent
+import com.wingedsheep.sdk.scripting.EventPattern.SpellCastEvent
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggerSpec

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RavenousRobots.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RavenousRobots.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameEvent.SpellCastEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ravenous Robots
+ * {1}{R}
+ * Artifact Creature — Robot
+ * 2/1
+ *
+ * Whenever you cast an artifact spell, create a 1/1 colorless Robot
+ * artifact creature token.
+ * {R}, {T}: Creature tokens you control gain haste until end of turn.
+ */
+val RavenousRobots = card("Ravenous Robots") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Robot"
+    oracleText = "Whenever you cast an artifact spell, create a 1/1 colorless Robot artifact creature token.\n{R}, {T}: Creature tokens you control gain haste until end of turn."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = SpellCastEvent(spellFilter = GameObjectFilter.Artifact, player = Player.You),
+            binding = TriggerBinding.ANY
+        )
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(),
+            creatureTypes = setOf("Robot"),
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/0/8/08497fc5-1c0e-4c3c-a356-bf4b34bd4c45.jpg?1771590585"
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{R}"),
+            Costs.Tap
+        )
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter(
+                GameObjectFilter.Creature.copy(
+                    cardPredicates = GameObjectFilter.Creature.cardPredicates +
+                        CardPredicate.IsToken
+                ).youControl()
+            ),
+            effect = GrantKeywordEffect(Keyword.HASTE, EffectTarget.Self, Duration.EndOfTurn)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "106"
+        artist = "Kevin Sidharta"
+        flavorText = "\"The mousers have a new command: to consume everything here . . . all of you will be destroyed!\"\n—Baxter Stockman"
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b303ea3-9f4d-4c28-9446-285a23f841a0.jpg?1769006169"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RenetTemporalApprentice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RenetTemporalApprentice.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Renet, Temporal Apprentice
+ * {3}{U}{U}
+ * Legendary Creature — Human Wizard
+ * 4/3
+ *
+ * Flash
+ * When Renet enters, return each other nonland permanent that entered
+ * this turn to its owner's hand.
+ */
+val RenetTemporalApprentice = card("Renet, Temporal Apprentice") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Wizard"
+    oracleText = "Flash\nWhen Renet enters, return each other nonland permanent that entered this turn to its owner's hand."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter(
+                GameObjectFilter.NonlandPermanent.copy(
+                    statePredicates = GameObjectFilter.NonlandPermanent.statePredicates +
+                        StatePredicate.EnteredThisTurn
+                ),
+                excludeSelf = true
+            ),
+            effect = MoveToZoneEffect(EffectTarget.Self, Zone.HAND)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "50"
+        artist = "Yuhong Ding"
+        flavorText = "\"You guys don't get sick during time travel, do you?\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2ae30766-c858-4f4e-a042-14af55698cb2.jpg?1769005718"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RockSoldiers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RockSoldiers.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Rock Soldiers
+ * {3}{R}
+ * Artifact Creature — Elemental Soldier
+ * 4/3
+ *
+ * When this creature enters, destroy up to one target noncreature
+ * artifact.
+ */
+val RockSoldiers = card("Rock Soldiers") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Elemental Soldier"
+    oracleText = "When this creature enters, destroy up to one target noncreature artifact."
+    power = 4
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val artifact = target(
+            "noncreature artifact",
+            TargetPermanent(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.IsArtifact,
+                            CardPredicate.Not(CardPredicate.IsCreature),
+                        )
+                    )
+                )
+            )
+        )
+        effect = Effects.Destroy(artifact)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Miklós Ligeti"
+        flavorText = "Catching enemies between a rock and a hard place."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0fada65d-fd8d-4be9-b2bb-ea5cac78fdd7.jpg?1771586954"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RocksteadyCrashCourser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RocksteadyCrashCourser.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Rocksteady, Crash Courser
+ * {4}{G}{G}
+ * Legendary Creature — Rhino Mutant
+ * 7/7
+ *
+ * Rocksteady can't be blocked by more than one creature.
+ * Boars you control can't be blocked by more than one creature.
+ * Forestcycling {2}
+ */
+val RocksteadyCrashCourser = card("Rocksteady, Crash Courser") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Rhino Mutant"
+    oracleText = "Rocksteady can't be blocked by more than one creature.\nBoars you control can't be blocked by more than one creature.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)"
+    power = 7
+    toughness = 7
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(maxBlockers = 1)
+    }
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(
+            maxBlockers = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Boar").youControl())
+        )
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Forest", "{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Filipe Pagliuso"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/ebbb5756-80fa-406f-8daa-be1f5a6c3c80.jpg?1771586968"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SallyPrideLionessLeader.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SallyPrideLionessLeader.kt
@@ -52,7 +52,6 @@ val SallyPrideLionessLeader = card("Sally Pride, Lioness Leader") {
                 toughness = 2,
                 colors = setOf(Color.RED),
                 creatureTypes = setOf("Mutant"),
-                imageUri = "https://cards.scryfall.io/normal/front/5/1/51e33613-7a24-461c-8d9f-12680af4b92a.jpg?1771590526"
             )
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SallyPrideLionessLeader.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SallyPrideLionessLeader.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.RepeatDynamicTimesEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sally Pride, Lioness Leader
+ * {3}{W}{W}
+ * Legendary Creature — Cat Mutant Rebel
+ * 2/4
+ *
+ * When Sally Pride enters, create X 2/2 red Mutant creature tokens,
+ * where X is the number of nontoken creatures you control.
+ * Whenever Sally Pride attacks, put a +1/+1 counter on each creature
+ * you control.
+ */
+val SallyPrideLionessLeader = card("Sally Pride, Lioness Leader") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Cat Mutant Rebel"
+    oracleText = "When Sally Pride enters, create X 2/2 red Mutant creature tokens, where X is the number of nontoken creatures you control.\nWhenever Sally Pride attacks, put a +1/+1 counter on each creature you control."
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = RepeatDynamicTimesEffect(
+            amount = DynamicAmount.Count(
+                player = Player.You,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Creature.copy(
+                    cardPredicates = GameObjectFilter.Creature.cardPredicates +
+                        CardPredicate.IsNontoken
+                ).youControl()
+            ),
+            body = CreateTokenEffect(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.RED),
+                creatureTypes = setOf("Mutant"),
+                imageUri = "https://cards.scryfall.io/normal/front/5/1/51e33613-7a24-461c-8d9f-12680af4b92a.jpg?1771590526"
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+            effect = AddCountersEffect(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                count = 1,
+                target = EffectTarget.Self
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "Andrea Tentori Montalto"
+        flavorText = "\"I wanna make things better for everyone. No more squalor. No more fear.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bcd8ee6b-7142-4548-8b7a-691a36411851.jpg?1769005568"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SavantiRomeroTimesExile.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SavantiRomeroTimesExile.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Savanti Romero, Time's Exile
+ * {3}{B}{B}
+ * Legendary Creature — Demon Wizard
+ * 4/4
+ *
+ * Trample
+ * At the beginning of combat on your turn, put a +1/+1 counter on
+ * Savanti Romero. Then you draw X cards and lose X life, where X is
+ * the number of counters on Savanti Romero.
+ */
+val SavantiRomeroTimesExile = card("Savanti Romero, Time's Exile") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Demon Wizard"
+    oracleText = "Trample\nAt the beginning of combat on your turn, put a +1/+1 counter on Savanti Romero. Then you draw X cards and lose X life, where X is the number of counters on Savanti Romero."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val counterAmount = DynamicAmount.EntityProperty(
+            EntityReference.Source,
+            EntityNumericProperty.CounterCount(CounterTypeFilter.Any)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            .then(Effects.DrawCards(counterAmount))
+            .then(Effects.LoseLife(counterAmount, EffectTarget.Controller))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "72"
+        artist = "Michele Giorgi"
+        flavorText = "\"When I am done, there will be no evidence that you ever existed!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/01cb8ded-7f77-4b75-b799-23e9f5efb513.jpg?1769005872"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SavedByTheShell.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SavedByTheShell.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Saved by the Shell
+ * {1}{G}
+ * Instant
+ *
+ * This spell costs {1} less to cast if you control a Turtle.
+ * Put a +1/+1 counter on target creature you control. It gains trample,
+ * hexproof, and indestructible until end of turn.
+ */
+val SavedByTheShell = card("Saved by the Shell") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "This spell costs {1} less to cast if you control a Turtle.\nPut a +1/+1 counter on target creature you control. It gains trample, hexproof, and indestructible until end of turn."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfControlFilter(
+                    amount = 1,
+                    filter = GameObjectFilter.Any.withSubtype("Turtle"),
+                ),
+            ),
+        )
+    }
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+            .then(Effects.GrantKeyword(Keyword.TRAMPLE, creature, Duration.EndOfTurn))
+            .then(Effects.GrantKeyword(Keyword.HEXPROOF, creature, Duration.EndOfTurn))
+            .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature, Duration.EndOfTurn))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "132"
+        artist = "Leonardo Santanna"
+        flavorText = "\"I LOVE being a turtle!\"\n—Michelangelo"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6314c7f-41dc-4bbd-99db-3a8a1d2977b2.jpg?1771586974"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ShreddersArmor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ShreddersArmor.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shredder's Armor
+ * {1}{B}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +2/+1.
+ * When this Equipment enters, attach it to target creature you
+ * control.
+ * Equip—Sacrifice another nonland permanent. Activate only once each
+ * turn.
+ */
+val ShreddersArmor = card("Shredder's Armor") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+1.\nWhen this Equipment enters, attach it to target creature you control.\nEquip—Sacrifice another nonland permanent. Activate only once each turn."
+
+    staticAbility {
+        effect = Effects.ModifyStats(2, 1)
+        filter = Filters.EquippedCreature
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AttachEquipment(creature)
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeAnother(
+            GameObjectFilter(
+                cardPredicates = listOf(
+                    CardPredicate.Not(CardPredicate.IsLand),
+                )
+            )
+        )
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AttachEquipment(creature)
+        timing = TimingRule.SorcerySpeed
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "75"
+        artist = "Maël Ollivier-Henry"
+        flavorText = "The Kuro Kabuto has been the symbol of Foot Clan leadership since its inception over 1,500 years ago."
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2cbe512-725f-4884-ac49-a98a78e7d14e.jpg?1771586903"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ShreddersArmor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ShreddersArmor.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -31,8 +32,7 @@ val ShreddersArmor = card("Shredder's Armor") {
     oracleText = "Equipped creature gets +2/+1.\nWhen this Equipment enters, attach it to target creature you control.\nEquip—Sacrifice another nonland permanent. Activate only once each turn."
 
     staticAbility {
-        effect = Effects.ModifyStats(2, 1)
-        filter = Filters.EquippedCreature
+        ability = ModifyStats(2, 1, Filters.EquippedCreature)
     }
 
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ShreddersRevenge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ShreddersRevenge.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shredder's Revenge
+ * {2}{B}
+ * Sorcery
+ *
+ * Choose one —
+ * • Target player discards two cards.
+ * • Target player draws two cards and loses 2 life.
+ */
+val ShreddersRevenge = card("Shredder's Revenge") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n• Target player discards two cards.\n• Target player draws two cards and loses 2 life."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Target player discards two cards") {
+                val player = target("target player", Targets.Player)
+                effect = Effects.Discard(2, player)
+            }
+            mode("Target player draws two cards and loses 2 life") {
+                val player = target("target player", Targets.Player)
+                effect = Effects.DrawCards(2, player)
+                    .then(Effects.LoseLife(2, player))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Tonight I dine on turtle soup.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72fadf47-2e0b-4b24-b1bc-7c86780716b6.jpg?1771342364"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Skateboard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Skateboard.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Skateboard
+ * {1}
+ * Artifact — Equipment
+ *
+ * When this Equipment enters, tap target permanent.
+ * Equipped creature gets +1/+0 and has haste.
+ * Equip {1}
+ */
+val Skateboard = card("Skateboard") {
+    manaCost = "{1}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, tap target permanent.\nEquipped creature gets +1/+0 and has haste.\nEquip {1}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val perm = target("target permanent", Targets.Permanent)
+        effect = Effects.Tap(perm)
+    }
+
+    staticAbility {
+        effect = Effects.ModifyStats(1, 0)
+        filter = Filters.EquippedCreature
+    }
+
+    staticAbility {
+        effect = Effects.GrantKeyword(Keyword.HASTE, EffectTarget.EquippedCreature)
+        filter = Filters.EquippedCreature
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Hokyoung Kim"
+        flavorText = "\"Why skate a half-pipe when you can skate a sewer pipe?\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/deadb6d8-3eea-4261-a07c-8536df89e85c.jpg?1771502813"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Skateboard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Skateboard.kt
@@ -7,7 +7,8 @@ import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
 
 /**
  * Skateboard
@@ -30,13 +31,11 @@ val Skateboard = card("Skateboard") {
     }
 
     staticAbility {
-        effect = Effects.ModifyStats(1, 0)
-        filter = Filters.EquippedCreature
+        ability = ModifyStats(1, 0, Filters.EquippedCreature)
     }
 
     staticAbility {
-        effect = Effects.GrantKeyword(Keyword.HASTE, EffectTarget.EquippedCreature)
-        filter = Filters.EquippedCreature
+        ability = GrantKeyword(Keyword.HASTE, Filters.EquippedCreature)
     }
 
     equipAbility("{1}")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SlashReptileRampager.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SlashReptileRampager.kt
@@ -40,7 +40,6 @@ val SlashReptileRampager = card("Slash, Reptile Rampager") {
             toughness = 2,
             colors = setOf(Color.RED),
             creatureTypes = setOf("Mutant"),
-            imageUri = "https://cards.scryfall.io/normal/front/5/1/51e33613-7a24-461c-8d9f-12680af4b92a.jpg?1771590526"
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SlashReptileRampager.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SlashReptileRampager.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slash, Reptile Rampager
+ * {3}{R}{R}
+ * Legendary Creature — Mutant Berserker Turtle
+ * 7/5
+ *
+ * Alliance — Whenever another creature you control enters, Slash
+ * deals 2 damage to each opponent.
+ * Whenever Slash attacks, create a 2/2 red Mutant creature token.
+ */
+val SlashReptileRampager = card("Slash, Reptile Rampager") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Mutant Berserker Turtle"
+    oracleText = "Alliance — Whenever another creature you control enters, Slash deals 2 damage to each opponent.\nWhenever Slash attacks, create a 2/2 red Mutant creature token."
+    power = 7
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.DealDamage(2, EffectTarget.PlayerRef(Player.EachOpponent))
+        description = "Alliance — Whenever another creature you control enters, Slash deals 2 damage to each opponent."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = CreateTokenEffect(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mutant"),
+            imageUri = "https://cards.scryfall.io/normal/front/5/1/51e33613-7a24-461c-8d9f-12680af4b92a.jpg?1771590526"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "108"
+        artist = "Andrew Mar"
+        flavorText = "\"Tell 'em you've got a new partner. One who knows the true meaning of being a warrior.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/025aafbc-5b24-4f5b-9b4a-81f6b9cb5ef3.jpg?1769006188"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SouthWindAvatar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SouthWindAvatar.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggerSpec

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SouthWindAvatar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SouthWindAvatar.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * South Wind Avatar
+ * {3}{B}
+ * Creature — Snake Spirit Avatar
+ * 3/4
+ *
+ * Deathtouch
+ * Whenever another creature you control dies, you gain life equal to
+ * its toughness.
+ * Whenever you gain life, each opponent loses 1 life.
+ */
+val SouthWindAvatar = card("South Wind Avatar") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Snake Spirit Avatar"
+    oracleText = "Deathtouch\nWhenever another creature you control dies, you gain life equal to its toughness.\nWhenever you gain life, each opponent loses 1 life."
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl(),
+                from = Zone.BATTLEFIELD,
+                to = Zone.GRAVEYARD
+            ),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.GainLife(
+            DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.Toughness)
+        )
+        description = "Whenever another creature you control dies, you gain life equal to its toughness."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "78"
+        artist = "InHyuk Lee"
+        flavorText = "Snake-Eyes's gift takes others back to their worst memory. To the weak, it is a curse; to the wise, a second chance."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c17bc07c-7147-4c84-aa0b-8a0865fba94e.jpg?1769005861"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SpicyOatmealPizza.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SpicyOatmealPizza.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Spicy Oatmeal Pizza
+ * {2}{R}
+ * Artifact — Food
+ *
+ * When this artifact enters, it deals 4 damage to any target and 3
+ * damage to you.
+ * {2}, {T}, Sacrifice this artifact: You gain 3 life.
+ */
+val SpicyOatmealPizza = card("Spicy Oatmeal Pizza") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Food"
+    oracleText = "When this artifact enters, it deals 4 damage to any target and 3 damage to you.\n{2}, {T}, Sacrifice this artifact: You gain 3 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.DealDamage(4, anyTarget)
+            .then(Effects.DealDamage(3, EffectTarget.Controller))
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "109"
+        artist = "Nicholas Gregory"
+        flavorText = "\"Yeah, I threw in some habaneros to cut the heat on this.\"\n—Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4aeb45b-13ed-43ad-a366-7be10dec6222.jpg?1771342407"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SplinterRadicalRat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SplinterRadicalRat.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Splinter, Radical Rat
+ * {1}{W/B}{W/B}
+ * Legendary Creature — Mutant Ninja Rat
+ * 2/4
+ *
+ * If a triggered ability of a Ninja creature you control triggers,
+ * that ability triggers an additional time.
+ * {1}{U}: Target Ninja can't be blocked this turn.
+ *
+ * Mirrors the Lorwyn Eclipsed Twinflame Travelers shape — the
+ * trigger-doubler is just `AdditionalSourceTriggers` parameterised
+ * on the Ninja subtype. The printed wording is "a Ninja creature you
+ * control" (no "another"), so Splinter's own triggered abilities
+ * would also be doubled if he had any; `excludeSelf = false` reflects
+ * the wording faithfully.
+ */
+val SplinterRadicalRat = card("Splinter, Radical Rat") {
+    manaCost = "{1}{W/B}{W/B}"
+    colorIdentity = "WBU"
+    typeLine = "Legendary Creature — Mutant Ninja Rat"
+    oracleText = "If a triggered ability of a Ninja creature you control triggers, that ability triggers an additional time.\n{1}{U}: Target Ninja can't be blocked this turn."
+    power = 2
+    toughness = 4
+
+    staticAbility {
+        ability = AdditionalSourceTriggers(
+            sourceFilter = GameObjectFilter.Creature.withSubtype("Ninja").youControl(),
+            excludeSelf = false,
+            description = "If a triggered ability of a Ninja creature you control triggers, that ability triggers an additional time"
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}")
+        val ninja = target(
+            "target Ninja",
+            TargetCreature(filter = TargetFilter.Creature.withSubtype("Ninja"))
+        )
+        effect = Effects.CantBlock(ninja)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "169"
+        artist = "Manuel Castañón"
+        flavorText = "\"The first rule of the ninja is 'do no harm.' Unless you need to do harm. Then do lots of harm!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0797466-c527-4d35-86bc-e0e90fd04073.jpg?1769024412"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SplinterRadicalRat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SplinterRadicalRat.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
@@ -48,7 +49,7 @@ val SplinterRadicalRat = card("Splinter, Radical Rat") {
             "target Ninja",
             TargetCreature(filter = TargetFilter.Creature.withSubtype("Ninja"))
         )
-        effect = Effects.CantBlock(ninja)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, ninja)
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Squirrelanoids.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Squirrelanoids.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Squirrelanoids
+ * {B}
+ * Creature — Squirrel Mutant
+ * 1/1
+ *
+ * Deathtouch
+ */
+val Squirrelanoids = card("Squirrelanoids") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Squirrel Mutant"
+    oracleText = "Deathtouch"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "Eilene Cherie"
+        flavorText = "It's best to never discover what they squirrel away."
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be08d2b0-375b-434f-9e6d-060809e0ed34.jpg?1771586916"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/StockmanMadFlyEntist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/StockmanMadFlyEntist.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Stockman, Mad Fly-entist
+ * {4}{U}
+ * Legendary Creature — Insect Mutant Scientist
+ * 3/4
+ *
+ * Flying
+ * When Stockman enters, draw a card, then discard a card.
+ * Islandcycling {2}
+ */
+val StockmanMadFlyEntist = card("Stockman, Mad Fly-entist") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Insect Mutant Scientist"
+    oracleText = "Flying\nWhen Stockman enters, draw a card, then discard a card.\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle.)"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.loot(1)
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Island", "{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Xavier Ribeiro"
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/01ca65e2-898e-4150-a6bf-e61b183fd98a.jpg?1771502603"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/StompedByTheFoot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/StompedByTheFoot.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * Stomped by the Foot
+ * {1}{B}
+ * Instant
+ *
+ * Kicker—Sacrifice an artifact or creature.
+ * Target creature gets -2/-2 until end of turn. If this spell was
+ * kicked, that creature gets -5/-5 until end of turn instead.
+ */
+val StompedByTheFoot = card("Stomped by the Foot") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Kicker—Sacrifice an artifact or creature. (You may sacrifice an artifact or creature in addition to any other costs as you cast this spell.)\nTarget creature gets -2/-2 until end of turn. If this spell was kicked, that creature gets -5/-5 until end of turn instead."
+
+    keywordAbility(
+        KeywordAbility.kicker(
+            AdditionalCost.SacrificePermanent(
+                filter = GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.Or(
+                            listOf(
+                                CardPredicate.IsArtifact,
+                                CardPredicate.IsCreature,
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = ConditionalEffect(
+            condition = WasKicked,
+            effect = ModifyStatsEffect(-5, -5, t, Duration.EndOfTurn),
+            elseEffect = ModifyStatsEffect(-2, -2, t, Duration.EndOfTurn)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Kim Sokol"
+        flavorText = "\"These guys are good!\"\n—Leonardo"
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3fdec16f-77f5-4792-9698-b9099a204028.jpg?1771586922"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SuperShredder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SuperShredder.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggerSpec

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SuperShredder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SuperShredder.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameEvent.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Super Shredder
+ * {1}{B}
+ * Legendary Creature — Mutant Ninja Human
+ * 1/1
+ *
+ * Menace
+ * Whenever another permanent leaves the battlefield, put a +1/+1
+ * counter on Super Shredder.
+ */
+val SuperShredder = card("Super Shredder") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Mutant Ninja Human"
+    oracleText = "Menace\nWhenever another permanent leaves the battlefield, put a +1/+1 counter on Super Shredder."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Permanent,
+                from = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever another permanent leaves the battlefield, put a +1/+1 counter on Super Shredder."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "83"
+        artist = "Néstor Ossandón Leal"
+        flavorText = "\"I have molded myself into perfection, Hamato. Look upon me, and know fear.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/37a497b8-e908-4ddc-996e-a8470df72afb.jpg?1760102707"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TaintedTreats.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TaintedTreats.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Tainted Treats
+ * {1}{B}{G}
+ * Instant
+ *
+ * Destroy target artifact or creature. If its mana value was 4 or
+ * less, create a Food token.
+ */
+val TaintedTreats = card("Tainted Treats") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact or creature. If its mana value was 4 or less, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+
+    spell {
+        val target = target(
+            "artifact or creature",
+            TargetPermanent(filter = TargetFilter.CreatureOrArtifact)
+        )
+        effect = MoveToZoneEffect(target, Zone.GRAVEYARD, byDestruction = true)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.TargetSpellManaValueAtMost(DynamicAmount.Fixed(4)),
+                    effect = Effects.CreateFood()
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "170"
+        artist = "Jakob Eirich"
+        flavorText = "\"Spray them with the anti-mutagen? No, no. I'm afraid ingestion is the only course.\"\n—Dr. Jordan Perry"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa684608-ecd3-43e2-99a1-71318f133e29.jpg?1771587064"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TcriBuilding.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TcriBuilding.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * TCRI Building
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, you gain 1 life.
+ * {T}: Add {U} or {R}.
+ */
+val TcriBuilding = card("TCRI Building") {
+    typeLine = "Land"
+    colorIdentity = "UR"
+    oracleText = "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {R}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "189"
+        artist = "Aenami"
+        flavorText = "The light from the Translocation Matrix could be seen throughout the city. The utroms knew they only had a brief window to escape after its accidental activation."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/8817a1d6-ef39-4e7c-8277-74aea012803b.jpg?1771587112"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Tenderize.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Tenderize.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Tenderize
+ * {1}{G}
+ * Instant
+ *
+ * Target creature you control deals damage equal to its power to
+ * target creature an opponent controls.
+ */
+val Tenderize = card("Tenderize") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature you control deals damage equal to its power to target creature an opponent controls."
+
+    spell {
+        val myCreature = target("creature you control", Targets.CreatureYouControl)
+        val theirCreature = target("creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.DealDamage(
+            amount = DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.Power),
+            target = theirCreature,
+            damageSource = myCreature
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Jo Cordisco"
+        flavorText = "\"Get back, all ya'll! Stay away from me! I ain't safe, ya hear! Ain't no friend! I'm a monster!\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc19807b-09e8-4923-abc3-d4bbe8cde5fc.jpg?1771502744"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TransdimensionalBovine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TransdimensionalBovine.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Transdimensional Bovine
+ * {2}{G}
+ * Creature — Ox Avatar
+ * 0/4
+ *
+ * Flying
+ * {T}: Add two mana of any one color.
+ */
+val TransdimensionalBovine = card("Transdimensional Bovine") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ox Avatar"
+    oracleText = "Flying\n{T}: Add two mana of any one color."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(2)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "134"
+        artist = "Lius Lasahido"
+        flavorText = "The nature of a giant, disembodied cyborg cow head that travels through time and space raises countless questions. But Cudley doesn't like talking with his mouth full."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de124563-205c-4f40-8c13-4ae203599912.jpg?1769006238"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TriceratonCommander.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TriceratonCommander.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Triceraton Commander
+ * {X}{X}{W}{W}
+ * Creature — Dinosaur Soldier
+ * 2/2
+ *
+ * Flying
+ * Whenever this creature attacks, Dinosaurs you control other than
+ * this creature get +1/+1 and gain flying until end of turn.
+ * When this creature enters, create X 2/2 white Dinosaur Soldier
+ * creature tokens.
+ */
+val TriceratonCommander = card("Triceraton Commander") {
+    manaCost = "{X}{X}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dinosaur Soldier"
+    oracleText = "Flying\nWhenever this creature attacks, Dinosaurs you control other than this creature get +1/+1 and gain flying until end of turn.\nWhen this creature enters, create X 2/2 white Dinosaur Soldier creature tokens."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            count = DynamicAmount.XValue,
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Dinosaur", "Soldier"),
+            imageUri = "https://cards.scryfall.io/normal/front/f/8/f8845523-62d5-451c-aa20-780c64bb44b3.jpg?1771590377"
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype("Dinosaur").youControl(),
+                excludeSelf = true
+            ),
+            effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+                .then(Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self, Duration.EndOfTurn))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "25"
+        artist = "Nathaniel Himawan"
+        flavorText = "\"For the glory of the Republic!\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/6445b690-71ce-4371-ae9c-bac0e70dda81.jpg?1769005579"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TunnelRats.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TunnelRats.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tunnel Rats
+ * {1}{B}
+ * Creature — Rat
+ * 2/2
+ *
+ * {4}{B}: Return this card from your graveyard to the battlefield
+ * tapped.
+ */
+val TunnelRats = card("Tunnel Rats") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat"
+    oracleText = "{4}{B}: Return this card from your graveyard to the battlefield tapped."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{B}")
+        effect = MoveToZoneEffect(
+            target = EffectTarget.Self,
+            destination = Zone.BATTLEFIELD,
+            placement = ZonePlacement.Tapped
+        )
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Daniel Romanovsky"
+        flavorText = "The Rat King's subjects are everywhere you don't want to be."
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70faf7d8-008a-454a-a21b-702aa661b8f9.jpg?1771586928"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtleBlimp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtleBlimp.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Turtle Blimp
+ * {5}
+ * Artifact — Vehicle
+ * 3/4
+ *
+ * Flying
+ * When this Vehicle enters, create a 2/2 red Mutant creature token.
+ * Crew 2
+ *
+ * Mirrors the DOM Weatherlight / BLC Rolling Hamsphere Vehicle shape —
+ * `typeLine = "Artifact — Vehicle"` plus
+ * `keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 2))` already
+ * carry the full Vehicle pipeline (the artifact-becomes-artifact-
+ * creature-until-EOT behaviour and the Crew activation).
+ */
+val TurtleBlimp = card("Turtle Blimp") {
+    manaCost = "{5}"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Flying\nWhen this Vehicle enters, create a 2/2 red Mutant creature token.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mutant"),
+            imageUri = "https://cards.scryfall.io/normal/front/5/1/51e33613-7a24-461c-8d9f-12680af4b92a.jpg?1771590526"
+        )
+    }
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "180"
+        artist = "Jakob Eirich"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6e118fc5-b0ae-4592-8292-d611856ae203.jpg?1771587078"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtlePower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtlePower.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Turtle Power!
+ * {2}{G}
+ * Enchantment
+ *
+ * Flash
+ * Turtles you control get +2/+2.
+ */
+val TurtlePower = card("Turtle Power!") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Flash\nTurtles you control get +2/+2."
+
+    keywords(Keyword.FLASH)
+
+    staticAbility {
+        effect = Effects.ModifyStats(2, 2)
+        filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Turtle").youControl())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "135"
+        artist = "Hokyoung Kim"
+        flavorText = "Unnoticed by the crowd, the strange canister bounced several more times, striking and smashing a glass jar which held four small turtles . . ."
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/4079ca90-dcc3-4184-9dfc-a626e0776332.jpg?1769006224"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtlePower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtlePower.kt
@@ -1,10 +1,10 @@
 package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 
 /**
@@ -24,8 +24,11 @@ val TurtlePower = card("Turtle Power!") {
     keywords(Keyword.FLASH)
 
     staticAbility {
-        effect = Effects.ModifyStats(2, 2)
-        filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Turtle").youControl())
+        ability = ModifyStats(
+            2,
+            2,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Turtle").youControl()),
+        )
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/UneasyAlliance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/UneasyAlliance.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttack
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Uneasy Alliance
+ * {1}{W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature can't attack or block.
+ * {5}, Sacrifice this Aura: Exile enchanted creature. You create a
+ * 1/1 black Ninja creature token. Activate only as a sorcery.
+ */
+val UneasyAlliance = card("Uneasy Alliance") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature can't attack or block.\n{5}, Sacrifice this Aura: Exile enchanted creature. You create a 1/1 black Ninja creature token. Activate only as a sorcery."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = CantAttack()
+    }
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{5}"),
+            Costs.SacrificeSelf
+        )
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Exile(EffectTarget.EnchantedCreature)
+            .then(
+                CreateTokenEffect(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.BLACK),
+                    creatureTypes = setOf("Ninja"),
+                    imageUri = "https://cards.scryfall.io/normal/front/a/7/a7b76498-d696-40d1-b7c7-91657525b44f.jpg?1771590477"
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Rose Benjamin"
+        flavorText = "Other perspectives can help one find the proper direction."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d9a4f9a-1e3a-4de8-a7c0-7158c6703b4e.jpg?1771586776"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/UtromScientists.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/UtromScientists.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Utrom Scientists
+ * {2}{U}
+ * Artifact Creature — Utrom Robot Scientist
+ * 2/2
+ *
+ * When this creature enters, tap up to one target creature and put a
+ * stun counter on it.
+ */
+val UtromScientists = card("Utrom Scientists") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Utrom Robot Scientist"
+    oracleText = "When this creature enters, tap up to one target creature and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)"
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "up to one target creature",
+            TargetCreature(count = 1, optional = true)
+        )
+        effect = Effects.Tap(creature)
+            .then(Effects.AddCounters(Counters.STUN, 1, creature))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Miklós Ligeti"
+        flavorText = "Using exoskeletons and false skins, the utroms took up residence on Earth after their ship crashed. Returning home using only Earth's primitive technology has proven challenging."
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6da89625-5278-49d4-813b-a1a631f114f5.jpg?1771502610"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/WeatherMaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/WeatherMaker.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Weather Maker
+ * {3}
+ * Artifact
+ *
+ * Landfall — Whenever a land you control enters, put a charge counter
+ * on this artifact.
+ * {T}: Add one mana of any color.
+ * {T}, Remove two charge counters from this artifact: Add {C}{C}.
+ * {T}, Remove three charge counters from this artifact: It deals 3
+ * damage to any target.
+ */
+val WeatherMaker = card("Weather Maker") {
+    manaCost = "{3}"
+    typeLine = "Artifact"
+    oracleText = "Landfall — Whenever a land you control enters, put a charge counter on this artifact.\n{T}: Add one mana of any color.\n{T}, Remove two charge counters from this artifact: Add {C}{C}.\n{T}, Remove three charge counters from this artifact: It deals 3 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.CHARGE, 2)
+        )
+        effect = Effects.AddColorlessMana(2)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.CHARGE, 3)
+        )
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.DealDamage(3, anyTarget)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "182"
+        artist = "Florent Lebrun"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aaba62c1-760b-491b-8047-869bb1d3f67e.jpg?1769006491"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/WingnutBatOnTheBelfry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/WingnutBatOnTheBelfry.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wingnut, Bat on the Belfry
+ * {1}{R}
+ * Legendary Creature — Bat Mutant
+ * 1/2
+ *
+ * Alliance — Whenever another creature you control enters, Wingnut
+ * gains your choice of flying, menace, or haste until end of turn.
+ * Whenever Wingnut attacks, each other attacking creature gets +1/+0
+ * until end of turn.
+ */
+val WingnutBatOnTheBelfry = card("Wingnut, Bat on the Belfry") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Bat Mutant"
+    oracleText = "Alliance — Whenever another creature you control enters, Wingnut gains your choice of flying, menace, or haste until end of turn.\nWhenever Wingnut attacks, each other attacking creature gets +1/+0 until end of turn."
+    power = 1
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = ModalEffect(
+            modes = listOf(
+                Mode.noTarget(
+                    Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self, Duration.EndOfTurn),
+                    "Wingnut gains flying until end of turn"
+                ),
+                Mode.noTarget(
+                    Effects.GrantKeyword(Keyword.MENACE, EffectTarget.Self, Duration.EndOfTurn),
+                    "Wingnut gains menace until end of turn"
+                ),
+                Mode.noTarget(
+                    Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self, Duration.EndOfTurn),
+                    "Wingnut gains haste until end of turn"
+                ),
+            ),
+            chooseCount = 1,
+            countsAsModalSpell = false
+        )
+        description = "Alliance — Whenever another creature you control enters, Wingnut gains your choice of flying, menace, or haste until end of turn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter(
+                GameObjectFilter.Creature.attacking(),
+                excludeSelf = true
+            ),
+            effect = ModifyStatsEffect(1, 0, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "110"
+        artist = "Zoltan Boros"
+        flavorText = "\"Tell me, Screwloose, aren't we good? Mmhm. So, wouldn't that make them evil? Right!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40b9b1d0-b7d1-473e-b6a9-a29d527c2f35.jpg?1771502679"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ZogTriceratonCastaway.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ZogTriceratonCastaway.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Zog, Triceraton Castaway
+ * {4}{R}
+ * Legendary Creature — Dinosaur Soldier
+ * 5/4
+ *
+ * Reach, trample
+ * When Zog enters, target creature can't block this turn.
+ * Mountaincycling {2}
+ */
+val ZogTriceratonCastaway = card("Zog, Triceraton Castaway") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dinosaur Soldier"
+    oracleText = "Reach, trample\nWhen Zog enters, target creature can't block this turn.\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)"
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.CantBlock(creature)
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Mountain", "{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a83a70ba-448e-45f3-b23b-6f38af54811f.jpg?1771502686"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SplinterRadicalRatTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SplinterRadicalRatTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmt.cards.SplinterRadicalRat
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression test for Splinter, Radical Rat (TMT #169).
+ *
+ * {1}{U}: Target Ninja can't be blocked this turn.
+ *
+ * Guards against the inverted-ability bug where the activated ability granted
+ * CantBlock (preventing the Ninja from blocking) instead of CANT_BE_BLOCKED
+ * (the printed evasion). Splinter is himself a Ninja, so he is a legal target.
+ */
+class SplinterRadicalRatTest : FunSpec({
+
+    val splinterAbilityId = SplinterRadicalRat.activatedAbilities.first().id
+
+    test("{1}{U} grants CANT_BE_BLOCKED and the targeted Ninja can't be blocked") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val splinter = driver.putCreatureOnBattlefield(player, "Splinter, Radical Rat")
+        driver.removeSummoningSickness(splinter)
+
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.removeSummoningSickness(blocker)
+
+        // Sanity: no evasion before the ability is used.
+        driver.state.projectedState.hasKeyword(splinter, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+
+        // Attack with Splinter, then activate {1}{U} targeting himself.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(splinter), opponent)
+
+        driver.giveMana(player, Color.BLUE, 2)
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = splinter,
+                abilityId = splinterAbilityId,
+                targets = listOf(ChosenTarget.Permanent(splinter))
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass() // resolve the GrantKeyword effect
+
+        // Splinter is now unblockable, not unable to block.
+        driver.state.projectedState.hasKeyword(splinter, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+
+        // Attempting to block Splinter must fail.
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        val blockResult = driver.declareBlockers(opponent, mapOf(blocker to listOf(splinter)))
+        blockResult.isSuccess shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary

Scaffolds the Teenage Mutant Ninja Turtles (TMT) set backlog and lands the first
implementation pass — 96 of 190 cards across 99 files (~6.2k insertions, 104 commits).

## What's in

- **Backlog scaffolding:** `cards.md` checklist, `mechanics.md`, and a `TODO.md`
  that tracks per-card progress, partitions cards by mechanic, and catalogs the
  remaining engine gaps (Sneak, Disappear, Alliance, Class, Mutagen, Sagas, Crew tracking, …).
- **96 implemented cards** — each as its own commit, all
  composing existing SDK primitives. No new effect types or executors were added;
  cards that would have required them are deferred behind labeled gaps in `TODO.md`.
- **Gap closures noted in TODO:** Gap K (Sagas) primitive-resolved; Gap J partly
  cleared via `Turtle Blimp`; Gaps MM and NN added for newly surfaced needs.
- **Final cleanup commit:** addresses review findings on the card batch.

## What's not in

- 94 remaining cards blocked on unresolved engine gaps (see `TODO.md` for the
  per-gap breakdown). Those will land after each gap is addressed via `add-feature`.
- No SDK / engine changes — this is content-only.
