### PR TITLE
Add four Tarkir: Dragonstorm cards (Fleeting Effigy, Fire-Rim Form, Lightfoot Technique, Riverwalk Technique)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FireRimForm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FireRimForm.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fire-Rim Form
+ * {1}{R}
+ * Enchantment — Aura
+ * Flash
+ * Enchant creature
+ * When this Aura enters, enchanted creature gains first strike until end of turn.
+ * Enchanted creature gets +2/+0.
+ */
+val FireRimForm = card("Fire-Rim Form") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "When this Aura enters, enchanted creature gains first strike until end of turn.\n" +
+        "Enchanted creature gets +2/+0."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.EnchantedCreature)
+    }
+
+    staticAbility {
+        ability = ModifyStats(2, 0)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Filipe Pagliuso"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32dc1bf4-a135-449f-848f-361a5360fae1.jpg?1743204392"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FleetingEffigy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FleetingEffigy.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fleeting Effigy
+ * {R}
+ * Creature — Elemental
+ * 2/2
+ * Haste
+ * At the beginning of your end step, return this creature to its owner's hand.
+ * {2}{R}: This creature gets +2/+0 until end of turn.
+ */
+val FleetingEffigy = card("Fleeting Effigy") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 2
+    toughness = 2
+    oracleText = "Haste\n" +
+        "At the beginning of your end step, return this creature to its owner's hand. " +
+        "(Return it only if it's on the battlefield.)\n" +
+        "{2}{R}: This creature gets +2/+0 until end of turn."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.ReturnToHand(EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "108"
+        artist = "Darren Tan"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/1971fd6c-0a1c-41b2-93a6-886a176fbb73.jpg?1743697583"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LightfootTechnique.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LightfootTechnique.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightfoot Technique
+ * {1}{W}
+ * Instant
+ * Put a +1/+1 counter on target creature. It gains flying and indestructible until end of turn.
+ */
+val LightfootTechnique = card("Lightfoot Technique") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Put a +1/+1 counter on target creature. It gains flying and indestructible until end of turn. " +
+        "(Damage and effects that say \"destroy\" don't destroy it.)"
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+            .then(Effects.GrantKeyword(Keyword.FLYING, t))
+            .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Craig J Spearing"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/baac1a41-d44d-4184-9147-b4233e73de65.jpg?1743204007"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RiverwalkTechnique.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RiverwalkTechnique.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Riverwalk Technique
+ * {3}{U}
+ * Instant
+ *
+ * Choose one —
+ * • The owner of target nonland permanent puts it on their choice of the top or bottom of their library.
+ * • Counter target noncreature spell.
+ */
+val RiverwalkTechnique = card("Riverwalk Technique") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• The owner of target nonland permanent puts it on their choice of the top or bottom of their library.\n" +
+        "• Counter target noncreature spell."
+
+    spell {
+        effect = ModalEffect.chooseOne(
+            // Owner of target nonland permanent puts it on top or bottom of their library.
+            Mode(
+                effect = Effects.PutOnTopOrBottomOfLibrary(EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(Targets.NonlandPermanent),
+                description = "The owner of target nonland permanent puts it on their choice of the top or bottom of their library"
+            ),
+            // Counter target noncreature spell.
+            Mode(
+                effect = Effects.CounterSpell(),
+                targetRequirements = listOf(Targets.NoncreatureSpell),
+                description = "Counter target noncreature spell"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Julia Metzger"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/043c25d5-13ee-4cab-98d5-fb89db9cf6e3.jpg?1743204178"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmGroupAScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmGroupAScenarioTest.kt
@@ -1,0 +1,245 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the TDM "group A" cards:
+ *  - Fleeting Effigy (#108): {R} Elemental 2/2, Haste; returns to hand at your end step;
+ *    {2}{R}: +2/+0 until end of turn.
+ *  - Fire-Rim Form (#107): {1}{R} Aura, Flash, Enchant creature; ETB grants first strike
+ *    until end of turn; enchanted creature gets +2/+0.
+ *  - Lightfoot Technique (#14): {1}{W} Instant; +1/+1 counter on target creature, it gains
+ *    flying and indestructible until end of turn.
+ *  - Riverwalk Technique (#54): {3}{U} Instant; choose one — put target nonland permanent on
+ *    top/bottom of library, or counter target noncreature spell.
+ */
+class TdmGroupAScenarioTest : ScenarioTestBase() {
+
+    private val effigyPumpAbilityId =
+        cardRegistry.getCard("Fleeting Effigy")!!.activatedAbilities.first().id
+
+    init {
+        context("Fleeting Effigy") {
+            test("has haste and its {2}{R} ability gives +2/+0 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Fleeting Effigy", tapped = false, summoningSickness = true)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val effigy = game.findPermanent("Fleeting Effigy")!!
+                withClue("Fleeting Effigy has haste") {
+                    game.state.projectedState.hasKeyword(effigy, Keyword.HASTE) shouldBe true
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = effigy,
+                        abilityId = effigyPumpAbilityId,
+                    )
+                )
+                withClue("Activating the pump ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Fleeting Effigy is a 4/2 after the pump") {
+                    game.state.projectedState.getPower(effigy) shouldBe 4
+                    game.state.projectedState.getToughness(effigy) shouldBe 2
+                }
+            }
+
+            test("returns to its owner's hand at the beginning of its controller's end step") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Fleeting Effigy", tapped = false, summoningSickness = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Fleeting Effigy left the battlefield") {
+                    game.findPermanent("Fleeting Effigy") shouldBe null
+                }
+                withClue("Fleeting Effigy is back in its owner's hand") {
+                    game.isInHand(1, "Fleeting Effigy") shouldBe true
+                }
+            }
+        }
+
+        context("Fire-Rim Form") {
+            test("flashes onto a creature, grants first strike (EOT) and a static +2/+0") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Fire-Rim Form")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 to enchant
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Casting Fire-Rim Form on the Bear should succeed") {
+                    game.castSpell(1, "Fire-Rim Form", targetId = bear).error shouldBe null
+                }
+                game.resolveStack() // aura enters → ETB trigger
+                game.resolveStack() // resolve the first-strike trigger
+
+                withClue("Enchanted Bear is a 4/2 from the static +2/+0") {
+                    game.state.projectedState.getPower(bear) shouldBe 4
+                    game.state.projectedState.getToughness(bear) shouldBe 2
+                }
+                withClue("Enchanted Bear has first strike until end of turn") {
+                    game.state.projectedState.hasKeyword(bear, Keyword.FIRST_STRIKE) shouldBe true
+                }
+            }
+        }
+
+        context("Lightfoot Technique") {
+            test("puts a +1/+1 counter on target creature and grants flying + indestructible EOT") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lightfoot Technique")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 target
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Casting Lightfoot Technique targeting the Bear should succeed") {
+                    game.castSpell(1, "Lightfoot Technique", targetId = bear).error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Bear has a +1/+1 counter") {
+                    game.state.getEntity(bear)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+                withClue("Bear is a 3/3 with the counter") {
+                    game.state.projectedState.getPower(bear) shouldBe 3
+                    game.state.projectedState.getToughness(bear) shouldBe 3
+                }
+                withClue("Bear has flying and indestructible until end of turn") {
+                    game.state.projectedState.hasKeyword(bear, Keyword.FLYING) shouldBe true
+                    game.state.projectedState.hasKeyword(bear, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+            }
+        }
+
+        context("Riverwalk Technique") {
+            test("mode 1 puts a target nonland permanent on top of its owner's library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Riverwalk Technique")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(2, "Grizzly Bears") // opponent's nonland permanent
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Casting Riverwalk Technique (mode 1) on the Bear should succeed") {
+                    game.castSpellWithMode(1, "Riverwalk Technique", modeIndex = 0, targetId = bear)
+                        .error shouldBe null
+                }
+                game.resolveStack()
+
+                // The owner (Player2) chooses top or bottom of library.
+                val decision = game.getPendingDecision()
+                withClue("Owner faces a top-or-bottom library choice") {
+                    (decision is ChooseOptionDecision) shouldBe true
+                }
+                decision as ChooseOptionDecision
+                withClue("The Bear's owner makes the choice") {
+                    decision.playerId shouldBe game.player2Id
+                }
+                game.submitDecision(OptionChosenResponse(decision.id, 0)) // top of library
+                game.resolveStack()
+
+                withClue("Bear left the battlefield") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                withClue("Bear is on top of Player2's library") {
+                    game.state.getLibrary(game.player2Id).first().let { top ->
+                        game.state.getEntity(top)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name
+                    } shouldBe "Grizzly Bears"
+                }
+            }
+
+            test("mode 2 counters a target noncreature spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Riverwalk Technique")
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // Bolt's target
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Player2 casts Lightning Bolt at the Bear") {
+                    game.castSpell(2, "Lightning Bolt", targetId = bear).error shouldBe null
+                }
+                // Active player (Player2) passes priority so Player1 can respond.
+                game.execute(PassPriority(game.player2Id))
+
+                val bolt = game.state.stack.first { id ->
+                    game.state.getEntity(id)
+                        ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Lightning Bolt"
+                }
+                withClue("Player1 counters the Bolt with Riverwalk Technique (mode 2)") {
+                    game.execute(
+                        CastSpell(
+                            playerId = game.player1Id,
+                            cardId = game.findCardsInHand(1, "Riverwalk Technique").first(),
+                            targets = listOf(ChosenTarget.Spell(bolt)),
+                            chosenModes = listOf(1),
+                            modeTargetsOrdered = listOf(listOf(ChosenTarget.Spell(bolt))),
+                        )
+                    ).error shouldBe null
+                }
+
+                // Drain the stack via priority passes.
+                var iterations = 0
+                while (game.state.stack.isNotEmpty() && iterations < 20) {
+                    val priorityPlayer = game.state.priorityPlayerId ?: break
+                    val r = game.execute(PassPriority(priorityPlayer))
+                    if (r.error != null) break
+                    iterations++
+                }
+
+                withClue("Lightning Bolt was countered — Bear survives") {
+                    game.findPermanent("Grizzly Bears") shouldBe bear
+                }
+                withClue("Lightning Bolt is in Player2's graveyard") {
+                    game.isInGraveyard(2, "Lightning Bolt") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Tarkir: Dragonstorm (TDM) cards, all using existing SDK facades (no new engine mechanics):

| Card | Cost | Type | Implementation |
|------|------|------|----------------|
| **Fleeting Effigy** (#108) | {R} | Elemental 2/2 | Haste; `Triggers.YourEndStep` → `ReturnToHand(Self)`; `{2}{R}: ModifyStats(+2/+0)` |
| **Fire-Rim Form** (#107) | {1}{R} | Aura | Flash; `EntersBattlefield` → grant first strike (EOT) to enchanted creature; static `ModifyStats(+2/+0)` |
| **Lightfoot Technique** (#14) | {1}{W} | Instant | `AddCounters(+1/+1)` on target creature → grant flying + indestructible (EOT) |
| **Riverwalk Technique** (#54) | {3}{U} | Instant | `ModalEffect.chooseOne`: put a nonland permanent on top/bottom of library, **or** counter a noncreature spell |

### Testing
- New `TdmGroupAScenarioTest` (6 tests, all passing) exercises each card's behavior, including both Riverwalk Technique modes (library bounce with owner's top/bottom choice, and countering a noncreature spell in response).
- `just check-card-printing` confirms TDM is the canonical (and only) printing for each card.
- Existing TDM scenario suites still green.

All card fields (mana cost, type line, oracle text, P/T, rarity, collector number, artist, image URI) verified against the Scryfall TDM printing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)