### PR TITLE
Save the drafted printing when saving a draft/sealed deck

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -619,7 +619,9 @@ class ConnectionHandler(
                 backFaceTypeLine = backFace?.typeLine?.toString(),
                 backFaceOracleText = backFace?.oracleText?.takeIf { it.isNotBlank() },
                 backFaceImageUri = backFace?.metadata?.imageUri,
-                colorIdentity = card.colorIdentity.map { it.name }
+                colorIdentity = card.colorIdentity.map { it.name },
+                setCode = card.setCode,
+                collectorNumber = card.metadata.collectorNumber
             )
         }
     }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -299,7 +299,13 @@ sealed interface ServerMessage {
         // archetype matcher. Parsing the printed mana cost would miss off-color activation
         // costs (e.g., a green-cost card with a {B}: ability has identity GB) and lands whose
         // basic-land subtypes contribute color.
-        val colorIdentity: List<String> = emptyList()
+        val colorIdentity: List<String> = emptyList(),
+        // Specific printing this pool card was opened/drafted as — `(setCode, collectorNumber)`,
+        // Scryfall's unique printing key. Lets the client preserve the exact printing when the
+        // player saves a drafted/sealed deck to their library (otherwise the save falls back to
+        // the card's default printing). Either may be null for test cards lacking metadata.
+        val setCode: String? = null,
+        val collectorNumber: String? = null
     )
 
     /**

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -9,7 +9,7 @@ import { randomBackground } from '@/utils/background.ts'
 import { ReplayViewer, type GameSummary } from '../admin/ReplayViewer'
 import type { ReplayData } from '@/replay/reconstructSnapshots.ts'
 import { QuickGameLobbyOverlay } from './QuickGameLobbyOverlay'
-import { useDeckLibrary } from '@/store/deckLibrary'
+import { useDeckLibrary, buildDraftedDeckSave, type SavedDeckEntry } from '@/store/deckLibrary'
 import { DeckPicker } from './DeckPicker'
 import { labelForFormat } from '@/utils/deckLegality'
 import styles from './GameUI.module.css'
@@ -1641,16 +1641,14 @@ function TournamentOverlay({
   const saveDeckToLibrary = useDeckLibrary((s) => s.saveDeck)
   useEffect(() => { hydrateDeckLibrary() }, [hydrateDeckLibrary])
 
-  const buildCardsFromDraftedDeck = (): Record<string, number> | null => {
+  const buildDeckSave = (): { cards: Record<string, number>; entries: SavedDeckEntry[] | undefined } | null => {
     if (!deckBuildingState) return null
-    const cards: Record<string, number> = {}
-    for (const name of deckBuildingState.deck) {
-      cards[name] = (cards[name] ?? 0) + 1
-    }
-    for (const [name, count] of Object.entries(deckBuildingState.landCounts)) {
-      if (count > 0) cards[name] = (cards[name] ?? 0) + count
-    }
-    return Object.keys(cards).length === 0 ? null : cards
+    const built = buildDraftedDeckSave(
+      deckBuildingState.deck,
+      deckBuildingState.landCounts,
+      [...deckBuildingState.cardPool, ...deckBuildingState.basicLands],
+    )
+    return Object.keys(built.cards).length === 0 ? null : built
   }
 
   const openSaveDeckDialog = () => {
@@ -1663,10 +1661,10 @@ function TournamentOverlay({
 
   const confirmSaveDeck = () => {
     if (!saveDeckDialog) return
-    const cards = buildCardsFromDraftedDeck()
-    if (!cards) return
+    const built = buildDeckSave()
+    if (!built) return
     const name = saveDeckDialog.name.trim() || `Drafted deck – ${new Date().toLocaleDateString()}`
-    saveDeckToLibrary({ name, cards })
+    saveDeckToLibrary({ name, cards: built.cards, ...(built.entries ? { entries: built.entries } : {}) })
     setSaveDeckDialog(null)
     setDeckSavedAt(Date.now())
     setTimeout(() => setDeckSavedAt(null), 2000)
@@ -2388,15 +2386,14 @@ function DeckViewerModal({
           <button
             type="button"
             onClick={() => {
-              // Combine non-basic deck cards with basic-land counts. The picker accepts the same shape.
-              const cards: Record<string, number> = {}
-              for (const name of deckBuildingState.deck) {
-                cards[name] = (cards[name] ?? 0) + 1
-              }
-              for (const [name, count] of Object.entries(deckBuildingState.landCounts)) {
-                if (count > 0) cards[name] = (cards[name] ?? 0) + count
-              }
-              saveDeck({ name: saveName.trim() || defaultDeckName, cards })
+              // Combine non-basic deck cards with basic-land counts, pinning each to the
+              // printing it was drafted as so the saved deck keeps the exact art/printing.
+              const { cards, entries } = buildDraftedDeckSave(
+                deckBuildingState.deck,
+                deckBuildingState.landCounts,
+                [...deckBuildingState.cardPool, ...deckBuildingState.basicLands],
+              )
+              saveDeck({ name: saveName.trim() || defaultDeckName, cards, ...(entries ? { entries } : {}) })
               setSavedAt(Date.now())
               setTimeout(() => setSavedAt(null), 2000)
             }}

--- a/web-client/src/store/deckLibrary.test.ts
+++ b/web-client/src/store/deckLibrary.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { buildDraftedDeckSave, type PoolCardPrinting } from './deckLibrary'
+
+const card = (name: string, setCode?: string, collectorNumber?: string): PoolCardPrinting => ({
+  name,
+  setCode: setCode ?? null,
+  collectorNumber: collectorNumber ?? null,
+})
+
+describe('buildDraftedDeckSave', () => {
+  it('pins each drafted card to the printing it was opened as', () => {
+    const pool = [card('Lightning Bolt', 'M10', '146'), card('Llanowar Elves', 'M10', '189')]
+    const { cards, entries } = buildDraftedDeckSave(['Lightning Bolt', 'Lightning Bolt', 'Llanowar Elves'], {}, pool)
+
+    expect(cards).toEqual({ 'Lightning Bolt': 2, 'Llanowar Elves': 1 })
+    expect(entries).toEqual([
+      { name: 'Lightning Bolt', count: 2, printing: { setCode: 'M10', collectorNumber: '146' } },
+      { name: 'Llanowar Elves', count: 1, printing: { setCode: 'M10', collectorNumber: '189' } },
+    ])
+  })
+
+  it('folds basic-land counts into the same cards/entries, preserving their printing', () => {
+    const pool = [card('Grizzly Bears', 'LEA', '195')]
+    const basics = [card('Forest', 'BLB', '280')]
+    const { cards, entries } = buildDraftedDeckSave(['Grizzly Bears'], { Forest: 7 }, [...pool, ...basics])
+
+    expect(cards).toEqual({ 'Grizzly Bears': 1, Forest: 7 })
+    expect(entries).toContainEqual({ name: 'Forest', count: 7, printing: { setCode: 'BLB', collectorNumber: '280' } })
+  })
+
+  it('keeps a card without a printing as a name-only entry', () => {
+    const pool = [card('Real Card', 'BLB', '1'), card('Test Card')]
+    const { entries } = buildDraftedDeckSave(['Real Card', 'Test Card'], {}, pool)
+
+    expect(entries).toEqual([
+      { name: 'Real Card', count: 1, printing: { setCode: 'BLB', collectorNumber: '1' } },
+      { name: 'Test Card', count: 1 },
+    ])
+  })
+
+  it('returns undefined entries when no card resolves to a printing (stays name-only)', () => {
+    const pool = [card('Test A'), card('Test B')]
+    const { cards, entries } = buildDraftedDeckSave(['Test A', 'Test B'], {}, pool)
+
+    expect(cards).toEqual({ 'Test A': 1, 'Test B': 1 })
+    expect(entries).toBeUndefined()
+  })
+
+  it('takes the first printing seen when the pool holds the same name twice', () => {
+    const pool = [card('Plains', 'BLB', '270'), card('Plains', 'M10', '232')]
+    const { entries } = buildDraftedDeckSave([], { Plains: 3 }, pool)
+
+    expect(entries).toEqual([{ name: 'Plains', count: 3, printing: { setCode: 'BLB', collectorNumber: '270' } }])
+  })
+})

--- a/web-client/src/store/deckLibrary.ts
+++ b/web-client/src/store/deckLibrary.ts
@@ -173,6 +173,58 @@ export function toCardEntries(
   return out
 }
 
+/** Minimal pool-card shape needed to recover a card's drafted printing. */
+export interface PoolCardPrinting {
+  readonly name: string
+  readonly setCode?: string | null
+  readonly collectorNumber?: string | null
+}
+
+/**
+ * Build the `{ cards, entries }` pair for saving a drafted/sealed deck to the library,
+ * pinning each card to the exact printing it was opened/drafted as.
+ *
+ * A drafted/sealed deck is tracked only by card name (the spell list plus basic-land
+ * counts), so the printing has to be recovered from the original pool — each pool card
+ * carries the `(setCode, collectorNumber)` it was opened as. We look each deck card up by
+ * name and attach that printing; without this the save falls back to the card's default
+ * printing and the player loses (e.g.) the specific art they drafted.
+ *
+ * `entries` is returned only when at least one card resolved to a printing — otherwise the
+ * save stays name-only (identical to the legacy path), avoiding noise for pools whose cards
+ * lack printing metadata (e.g. test cards).
+ */
+export function buildDraftedDeckSave(
+  deckCardNames: readonly string[],
+  landCounts: Record<string, number>,
+  pool: readonly PoolCardPrinting[],
+): { cards: Record<string, number>; entries: SavedDeckEntry[] | undefined } {
+  const printingByName = new Map<string, PrintingRef>()
+  for (const card of pool) {
+    if (card.setCode && card.collectorNumber && !printingByName.has(card.name)) {
+      printingByName.set(card.name, { setCode: card.setCode, collectorNumber: card.collectorNumber })
+    }
+  }
+
+  const counts = new Map<string, number>()
+  for (const name of deckCardNames) counts.set(name, (counts.get(name) ?? 0) + 1)
+  for (const [name, count] of Object.entries(landCounts)) {
+    if (count > 0) counts.set(name, (counts.get(name) ?? 0) + count)
+  }
+
+  const cards: Record<string, number> = {}
+  const entries: SavedDeckEntry[] = []
+  let anyPrinting = false
+  for (const [name, count] of counts) {
+    cards[name] = count
+    const printing = printingByName.get(name)
+    if (printing) anyPrinting = true
+    entries.push(printing ? { name, count, printing } : { name, count })
+  }
+
+  return { cards, entries: anyPrinting ? entries : undefined }
+}
+
 export const useDeckLibrary = create<DeckLibraryState>((set, get) => ({
   decks: [],
   hydrated: false,

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -978,6 +978,14 @@ export interface SealedCardInfo {
    * this from the authoritative Scryfall override when one exists.
    */
   readonly colorIdentity?: readonly string[]
+  /**
+   * Specific printing this pool card was opened/drafted as — Scryfall's unique
+   * `(setCode, collectorNumber)` key. Lets the deckbuilder save a drafted/sealed deck
+   * to the library while preserving the exact printing the player drafted, instead of
+   * falling back to the card's default printing. Absent for test cards lacking metadata.
+   */
+  readonly setCode?: string | null
+  readonly collectorNumber?: string | null
 }
 
 /**


### PR DESCRIPTION
## Problem

Saving a deck built from a **draft or sealed pool** to the deck library lost each card's printing. After saving, the deck rendered/loaded with each card's *default* printing instead of the specific art the player actually drafted.

Two gaps caused this:
1. The two "Save to My Decks" actions in the tournament UI (`GameUI.tsx`) collected **card names only** — no printing.
2. Even if they tried, the server's `SealedCardInfo` pool payload never included the printing, so the client had nothing to pin to.

The deck library already supports per-card printings (v2 `SavedDeckEntry.printing`); the drafted-deck save path just never populated it.

## Fix

Thread the printing end-to-end:

- **`SealedCardInfo`** (server `ServerMessage` DTO + client `messages.ts` type) now carries the `(setCode, collectorNumber)` the pool card was opened/drafted as — Scryfall's unique printing key.
- **`ConnectionHandler.cardToSealedCardInfo`** stamps it from the `CardDefinition` (`card.setCode` + `card.metadata.collectorNumber`), so every pool/pack/picked-card payload includes it.
- New **`buildDraftedDeckSave()`** in `deckLibrary.ts` recovers each deck card's printing from the pool by name and builds the v2 `SavedDeckEntry` list (folding in basic-land counts). Both save sites in `GameUI` (tournament overlay dialog + deck viewer modal) use it.
- Falls back to a **name-only save** (identical to the previous behaviour) when no pool card carries printing metadata, so test cards / printingless pools are unaffected.

The store handlers (`onSealedPoolGenerated`, `onDraftComplete`) already pass `SealedCardInfo` through verbatim, so the new fields reach `deckBuildingState.cardPool` / `basicLands` without further wiring.

## Tests

- New `web-client/src/store/deckLibrary.test.ts` covers `buildDraftedDeckSave`: printing pinning, basic-land folding, name-only fallback for printingless cards, all-printingless → `undefined` entries, and first-printing-wins on duplicate names.
- Full web-client suite green (116 tests); `tsc --noEmit` clean; `:game-server:compileKotlin` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)