### PR TITLE
Add YouChoseOtherCreatureAsRingBearer condition + fix CR 701.54a cont…

### DIFF
--- a/backlog/sets/lord-of-the-rings/TODO.md
+++ b/backlog/sets/lord-of-the-rings/TODO.md
@@ -94,14 +94,15 @@ in its own PR, then attach all of its cards.
 - **Stalwarts of Osgiliath** — same trigger (ETB Ring tempts half is already composable).
 
 ### Gap 3 — "the Ring tempted you and you chose a creature other than this" condition
-**Engine change:** a condition usable with `Triggers.RingTemptsYou` meaning "you chose a
-creature other than {source} as your Ring-bearer" (CR 701.52d).
-- **Aragorn, Company Leader** — "…if you chose a creature other than Aragorn as your
-  Ring-bearer…" (also Gap 7 keyword counters).
-- **Faramir, Field Commander** — "…if you chose a creature other than Faramir…, create a token."
-- **Gandalf, Friend of the Shire** — "…if you chose a creature other than Gandalf…, draw a card."
-  (also Gap 4 cast-as-flash).
-- **Galadriel of Lothlórien** — chapter-one half.
+**Status:** LANDED as `Conditions.YouChoseOtherCreatureAsRingBearer` (PR
+`ltr-gap3-ring-bearer-other-than`). Same PR fixed CR 701.54a — control-change executors now strip
+`RingBearerComponent` eagerly via `clearRingBearerOnControlChange`, so a temporary Threaten-style
+steal no longer silently restores the designation when control reverts at end of turn.
+- **Faramir, Field Commander** — ✅ implemented.
+- **Aragorn, Company Leader** — still blocked on Gap 7 (keyword counters).
+- **Gandalf, Friend of the Shire** — still blocked on Gap 4 (cast-as-flash for sorcery spells).
+- **Galadriel of Lothlórien** — Ring-tempt half composes via this condition; second ability still
+  needs a "Whenever you scry" trigger + "reveal top; if land, put onto battlefield tapped".
 
 ### Gap 4 — "cast [filter] spells as though they had flash" permission
 **Engine change:** a static/one-shot permission granting flash-timing to a filtered set of

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 190 / 291
+**Implemented:** 191 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -38,7 +38,7 @@ starter-deck/special cards and basic lands.
 - [x] Errand-Rider of Gondor
 - [x] Escape from Orthanc
 - [x] Esquire of the King
-- [ ] Faramir, Field Commander
+- [x] Faramir, Field Commander
 - [x] Flowering of the White Tree
 - [x] Fog on the Barrow-Downs
 - [ ] Forge Anew

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1186,7 +1186,7 @@ Triggers.youCastSpell(
 
 ### The Ring
 
-- `RingTemptsYou` — whenever the Ring tempts you (CR 701.52d). Paired with `Effects.TheRingTemptsYou()`.
+- `RingTemptsYou` — whenever the Ring tempts you (CR 701.54d). Paired with `Effects.TheRingTemptsYou()`.
 
 ### Scry
 
@@ -1793,7 +1793,13 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
   trigger resolver for conditionally-granted abilities). Used by Essence Leak ("as long as enchanted
   permanent is red or green…", `GameObjectFilter.Permanent.withAnyColor(Color.RED, Color.GREEN)`).
 - `YouHaveCitysBlessing` — you have City's Blessing (10+ permanents).
-- `SourceIsRingBearer` — the source permanent is your Ring-bearer (CR 701.52e).
+- `SourceIsRingBearer` — the source permanent is your Ring-bearer (CR 701.54e).
+- `YouChoseOtherCreatureAsRingBearer` — intervening-if for `Triggers.RingTemptsYou` payoffs that fire
+  only when the controller chose a Ring-bearer other than the source (CR 701.54a). True iff the
+  controller currently has a Ring-bearer designated AND that bearer isn't the source — so it's false
+  both when the source itself was chosen and when the controller had no creature to choose. Used by
+  Aragorn (Company Leader), Faramir (Field Commander), Gandalf (Friend of the Shire), and Galadriel
+  of Lothlórien.
 
 ### Life & damage
 
@@ -2467,7 +2473,7 @@ Counter effects live in §4 (`AddCounters`, `RemoveCounters`, `Proliferate`, `Mo
 ### Player
 
 - `PlayerCitysBlessingComponent` — you have City's Blessing.
-- `TheRingComponent` — you have the Ring emblem; `temptCount` gates its four abilities (CR 701.52).
+- `TheRingComponent` — you have the Ring emblem; `temptCount` gates its four abilities (CR 701.54).
 - `RingBearerComponent` — designates a creature as a player's Ring-bearer (on the creature, not the player).
 - `SpellsCantBeCounteredComponent` — your matching spells can't be countered.
 - `LifeGainedAmountThisTurnComponent` — accumulator for life gained.
@@ -2530,13 +2536,18 @@ Card authors rarely reference these directly; they are created/updated by the ma
 - **Player-scoped uncounterable grant** — `Effects.GrantSpellsCantBeCountered(target, filter, duration)` +
   `SpellsCantBeCounteredComponent`.
 - **Static emblems** — `Effects.CreatePermanentEmblem(...)` for planeswalker emblems with static abilities.
-- **The Ring / the Ring tempts you (CR 701.52)** — `Effects.TheRingTemptsYou(target = Controller)`: the player gets
+- **The Ring / the Ring tempts you (CR 701.54)** — `Effects.TheRingTemptsYou(target = Controller)`: the player gets
   the Ring emblem (`TheRingComponent`, tempt-count tracked) and chooses a creature they control to become their
   Ring-bearer (`RingBearerComponent` designation). The emblem's four cumulative abilities are resolved by the engine,
   not card data: the bearer is made legendary in `StateProjector` and can't be blocked by greater power via
   `RingBearerCantBeBlockedByGreaterPowerRule`; the ≥2/≥3/≥4 triggered abilities are appended to the bearer by
   `TriggerAbilityResolver` (see `TheRingAbilities`). For card triggers/checks use `Triggers.RingTemptsYou`
-  ("Whenever the Ring tempts you") and `Conditions.SourceIsRingBearer` ("if this is your Ring-bearer").
+  ("Whenever the Ring tempts you"), `Conditions.SourceIsRingBearer` ("if this is your Ring-bearer"), and
+  `Conditions.YouChoseOtherCreatureAsRingBearer` ("if you chose a creature other than this as your
+  Ring-bearer" — pairs with `Triggers.RingTemptsYou` for the Aragorn/Faramir/Gandalf/Galadriel cycle).
+  CR 701.54a: the designation ends permanently when another player gains control of the bearer —
+  every control-change executor strips `RingBearerComponent` via `clearRingBearerOnControlChange`, so a
+  temporary steal (Threaten) does not silently restore the designation when control reverts.
 - **Amass [subtype] N (CR 701.47)** — `Effects.Amass(count, subtype)` (fixed) or
   `Effects.Amass(amount, subtype)` (a `DynamicAmount`, for "amass Orcs X"). `subtype` is required (no default) —
   the amassed Army's type is printed on each card (Orcs for the LTR cards). If the controller controls no Army

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -21,6 +21,7 @@ import com.wingedsheep.sdk.scripting.conditions.WasKicked as WasKickedCondition
 import com.wingedsheep.sdk.scripting.conditions.BlightWasPaid as BlightWasPaidCondition
 import com.wingedsheep.sdk.scripting.conditions.SourceMatches
 import com.wingedsheep.sdk.scripting.conditions.SourceIsRingBearer as SourceIsRingBearerCondition
+import com.wingedsheep.sdk.scripting.conditions.YouChoseOtherCreatureAsRingBearer as YouChoseOtherCreatureAsRingBearerCondition
 import com.wingedsheep.sdk.scripting.predicates.StatePredicate
 import com.wingedsheep.sdk.scripting.conditions.IsYourTurn as IsYourTurnCondition
 import com.wingedsheep.sdk.scripting.conditions.IsNotYourTurn as IsNotYourTurnCondition
@@ -48,13 +49,19 @@ import com.wingedsheep.sdk.scripting.conditions.Condition as ConditionInterface
 object Conditions {
 
     // =========================================================================
-    // The Ring (CR 701.52)
+    // The Ring (CR 701.54)
     // =========================================================================
 
     /**
-     * If the source permanent is your Ring-bearer (CR 701.52e).
+     * If the source permanent is your Ring-bearer (CR 701.54e).
      */
     val SourceIsRingBearer: ConditionInterface = SourceIsRingBearerCondition
+
+    /**
+     * If you chose a creature other than this as your Ring-bearer (CR 701.54a). Intervening-if
+     * for `Triggers.RingTemptsYou` payoffs that fire only when the player picked someone else.
+     */
+    val YouChoseOtherCreatureAsRingBearer: ConditionInterface = YouChoseOtherCreatureAsRingBearerCondition
 
     // =========================================================================
     // Battlefield Conditions (via Exists / Compare)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -567,7 +567,7 @@ object Effects {
         com.wingedsheep.sdk.scripting.effects.GainCitysBlessingEffect(target)
 
     /**
-     * "The Ring tempts you" (CR 701.52). The target player gets the Ring emblem (if they don't have
+     * "The Ring tempts you" (CR 701.54). The target player gets the Ring emblem (if they don't have
      * one), then chooses a creature they control to become their Ring-bearer. Defaults to the
      * controller. Tempting still happens even if the player controls no creatures.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1324,11 +1324,11 @@ object Triggers {
     )
 
     // =========================================================================
-    // The Ring Triggers (CR 701.52)
+    // The Ring Triggers (CR 701.54)
     // =========================================================================
 
     /**
-     * Whenever the Ring tempts you (CR 701.52d). Fires when this ability's controller is tempted,
+     * Whenever the Ring tempts you (CR 701.54d). Fires when this ability's controller is tempted,
      * even if some or all of the tempt actions were impossible.
      */
     val RingTemptsYou: TriggerSpec = TriggerSpec(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -258,7 +258,7 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
-     * Whenever the Ring tempts a player (CR 701.52d). Fires after the temptee completes
+     * Whenever the Ring tempts a player (CR 701.54d). Fires after the temptee completes
      * the "the Ring tempts you" action, even if some or all of it was impossible.
      * Used by cards with "Whenever the Ring tempts you, ...".
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
@@ -102,7 +102,7 @@ data class ControllerTurnsTakenAtMost(val threshold: Int) : Condition {
 }
 
 /**
- * Condition: "if this creature is your Ring-bearer" (CR 701.52e).
+ * Condition: "if this creature is your Ring-bearer" (CR 701.54e).
  *
  * True when the source permanent is on the battlefield under the ability's controller and has the
  * Ring-bearer designation for that player. Used by cards whose effects key off "your Ring-bearer".
@@ -111,6 +111,22 @@ data class ControllerTurnsTakenAtMost(val threshold: Int) : Condition {
 @Serializable
 data object SourceIsRingBearer : Condition {
     override val description: String = "if this creature is your Ring-bearer"
+}
+
+/**
+ * Condition: "if you chose a creature other than this as your Ring-bearer" (CR 701.54a).
+ *
+ * Pairs with `Triggers.RingTemptsYou` as an intervening-if on cards whose payoff fires only when
+ * the player picked someone other than the source — Aragorn (Company Leader), Faramir (Field
+ * Commander), Gandalf (Friend of the Shire), Galadriel of Lothlórien. True when the ability's
+ * controller currently has a Ring-bearer AND that Ring-bearer isn't the source permanent. If the
+ * controller had no creatures to choose from (no bearer exists), the condition is false — they
+ * didn't choose any creature, so they didn't choose one other than the source.
+ */
+@SerialName("YouChoseOtherCreatureAsRingBearer")
+@Serializable
+data object YouChoseOtherCreatureAsRingBearer : Condition {
+    override val description: String = "if you chose a creature other than this as your Ring-bearer"
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -463,7 +463,7 @@ data class GainCitysBlessingEffect(
 }
 
 /**
- * "The Ring tempts you" (CR 701.52). The target player gets an emblem named The Ring (if they
+ * "The Ring tempts you" (CR 701.54). The target player gets an emblem named The Ring (if they
  * don't have one) and chooses a creature they control to become their Ring-bearer. The emblem's
  * four cumulative abilities are gated by how many times that player has been tempted.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FaramirFieldCommander.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/FaramirFieldCommander.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faramir, Field Commander
+ * {3}{W}
+ * Legendary Creature — Human Soldier
+ * 3/3
+ *
+ * At the beginning of your end step, if a creature died under your control this turn, draw a card.
+ * Whenever the Ring tempts you, if you chose a creature other than Faramir as your Ring-bearer,
+ * create a 1/1 white Human Soldier creature token.
+ */
+val FaramirFieldCommander = card("Faramir, Field Commander") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "At the beginning of your end step, if a creature died under your control this turn, draw a card.\n" +
+        "Whenever the Ring tempts you, if you chose a creature other than Faramir as your Ring-bearer, create a 1/1 white Human Soldier creature token."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.ControlledCreatureDiedThisTurn
+        effect = Effects.DrawCards(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.RingTemptsYou
+        triggerCondition = Conditions.YouChoseOtherCreatureAsRingBearer
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Human", "Soldier"),
+            imageUri = "https://cards.scryfall.io/normal/front/a/6/a6181330-7521-4ec6-be6c-b35487c2d2d4.jpg?1699974464"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "14"
+        artist = "Sidharth Chaturvedi"
+        flavorText = "\"A chance for Faramir, Captain of Gondor, to show his quality.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/17c2250a-9af1-40de-9f09-7e8c7daec520.jpg?1686967763"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -189,7 +189,7 @@ data class ProliferateContinuation(
 ) : ContinuationFrame
 
 /**
- * Resume after a tempted player chooses which creature becomes their Ring-bearer (CR 701.52a).
+ * Resume after a tempted player chooses which creature becomes their Ring-bearer (CR 701.54a).
  *
  * The emblem and tempt-count increment are applied before the decision; this continuation only
  * moves the Ring-bearer designation to the chosen creature and announces the temptation.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -216,7 +216,7 @@ data class CitysBlessingGainedEvent(
 ) : GameEvent
 
 /**
- * The Ring tempted a player (CR 701.52d). Emitted after the "the Ring tempts you" action
+ * The Ring tempted a player (CR 701.54d). Emitted after the "the Ring tempts you" action
  * completes (even if some or all of it was impossible). Drives "Whenever the Ring tempts you"
  * triggers; see [com.wingedsheep.sdk.scripting.EventPattern.RingTemptedEvent].
  *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TheRingAbilities.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TheRingAbilities.kt
@@ -13,7 +13,7 @@ import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
- * The Ring emblem's cumulative triggered abilities (CR 701.52c).
+ * The Ring emblem's cumulative triggered abilities (CR 701.54c).
  *
  * The emblem is a per-player object, but its triggered abilities reference "your Ring-bearer", so
  * they are modeled as SELF-bound triggered abilities living on the Ring-bearer creature.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -209,7 +209,7 @@ class TriggerAbilityResolver(
             else getWardTriggeredAbilities(entityId, cardDefinitionId, state)
 
         // The Ring emblem's abilities belong to the emblem (a player object), not the creature, so
-        // they survive "loses all abilities" effects on the Ring-bearer (CR 701.52c).
+        // they survive "loses all abilities" effects on the Ring-bearer (CR 701.54c).
         val ringBearerAbilities = getRingBearerAbilities(entityId, state)
 
         val suspendAbilities = getSuspendTriggeredAbilities(entityId, state)
@@ -227,14 +227,14 @@ class TriggerAbilityResolver(
     }
 
     /**
-     * The Ring emblem's cumulative triggered abilities (CR 701.52c) for [entityId] when it is a
+     * The Ring emblem's cumulative triggered abilities (CR 701.54c) for [entityId] when it is a
      * player's Ring-bearer. "Is your Ring-bearer" requires the creature to be under that owner's
-     * control (CR 701.52e), so a Ring-bearer that changed controllers contributes nothing. The
+     * control (CR 701.54e), so a Ring-bearer that changed controllers contributes nothing. The
      * subset of abilities is gated by the owner's tempt count (see [TheRingAbilities]).
      */
     private fun getRingBearerAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> {
         val bearer = state.getEntity(entityId)?.get<RingBearerComponent>() ?: return emptyList()
-        // CR 701.52e: read the *projected* controller — a Ring-bearer stolen by a control-changing
+        // CR 701.54e: read the *projected* controller — a Ring-bearer stolen by a control-changing
         // effect is no longer "your Ring-bearer," so it stops contributing the emblem's abilities.
         if (state.projectedState.getController(entityId) != bearer.ownerId) return emptyList()
         val temptCount = state.getEntity(bearer.ownerId)?.get<TheRingComponent>()?.temptCount ?: return emptyList()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -84,6 +84,7 @@ import com.wingedsheep.sdk.scripting.conditions.ManaSpentToCastIncludes
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
 import com.wingedsheep.sdk.scripting.conditions.BlightWasPaid
 import com.wingedsheep.sdk.scripting.conditions.SourceIsRingBearer
+import com.wingedsheep.sdk.scripting.conditions.YouChoseOtherCreatureAsRingBearer
 import com.wingedsheep.sdk.scripting.conditions.YouControlSource
 import com.wingedsheep.sdk.scripting.conditions.PlayerAttackedWithCreaturesThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PermanentTypeEnteredBattlefieldThisTurn
@@ -177,7 +178,7 @@ class ConditionEvaluator(
             // Generic source-state primitive — predicate-evaluator against the source entity.
             is SourceMatches -> evaluateSourceMatchesCtx(state, condition, ctx)
 
-            // CR 701.52e: the source is your Ring-bearer — it carries your Ring-bearer designation
+            // CR 701.54e: the source is your Ring-bearer — it carries your Ring-bearer designation
             // and you still control it. The control half reads the projected controller so a
             // control-changing effect correctly ends the designation.
             is SourceIsRingBearer -> {
@@ -187,6 +188,26 @@ class ConditionEvaluator(
                 bearer != null && controllerId != null &&
                     bearer.ownerId == controllerId &&
                     state.projectedState.getController(sourceId) == controllerId
+            }
+
+            // CR 701.54a: intervening-if for "Whenever the Ring tempts you" payoffs that only
+            // fire when the player chose someone other than the source. True iff the controller
+            // currently has a Ring-bearer AND that bearer isn't the source. Reads the same
+            // controller/projected-controller pair as SourceIsRingBearer so a designation that's
+            // been suspended by a control change correctly fails to count as "a bearer".
+            is YouChoseOtherCreatureAsRingBearer -> {
+                val sourceId = ctx.sourceId
+                val controllerId = ctx.controllerId
+                if (sourceId == null || controllerId == null) {
+                    false
+                } else {
+                    val bearerId = state.getBattlefield().firstOrNull { id ->
+                        val bearer = state.getEntity(id)?.get<RingBearerComponent>() ?: return@firstOrNull false
+                        bearer.ownerId == controllerId &&
+                            state.projectedState.getController(id) == controllerId
+                    }
+                    bearerId != null && bearerId != sourceId
+                }
             }
 
             // Aura-controller-aware modified check (CR 700.4) — distinct enough from the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/RingTemptContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/RingTemptContinuationResumer.kt
@@ -11,7 +11,7 @@ import com.wingedsheep.engine.state.components.identity.RingBearerComponent
 import com.wingedsheep.sdk.model.EntityId
 
 /**
- * Resumes "the Ring tempts you" after the tempted player picks their Ring-bearer (CR 701.52a).
+ * Resumes "the Ring tempts you" after the tempted player picks their Ring-bearer (CR 701.54a).
  *
  * The Ring-bearer designation is unique per owner, so this moves it: any creature currently
  * carrying [RingBearerComponent] for the tempted player loses it, and the chosen creature gains it.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/ExchangeControlExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/ExchangeControlExecutor.kt
@@ -89,6 +89,8 @@ class ExchangeControlExecutor : EffectExecutor<ExchangeControlEffect> {
         newState = newState
             .updateEntity(target1Id) { it.with(SummoningSicknessComponent) }
             .updateEntity(target2Id) { it.with(SummoningSicknessComponent) }
+            .let { clearRingBearerOnControlChange(it, target1Id, controller2) }
+            .let { clearRingBearerOnControlChange(it, target2Id, controller1) }
 
         val events = listOf(
             ControlChangedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByActivePlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByActivePlayerExecutor.kt
@@ -68,6 +68,7 @@ class GainControlByActivePlayerExecutor : EffectExecutor<GainControlByActivePlay
                 context = controlContext
             )
             .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
+            .let { clearRingBearerOnControlChange(it, targetId, newControllerId) }
 
         val events = listOf(
             ControlChangedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlByMostExecutor.kt
@@ -85,6 +85,7 @@ class GainControlByMostExecutor : EffectExecutor<GainControlByMostEffect> {
                 context = controlContext
             )
             .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
+            .let { clearRingBearerOnControlChange(it, targetId, newControllerId) }
 
         val events = listOf(
             ControlChangedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GainControlExecutor.kt
@@ -63,6 +63,7 @@ class GainControlExecutor : EffectExecutor<GainControlEffect> {
                 context = context
             )
             .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
+            .let { clearRingBearerOnControlChange(it, targetId, newControllerId) }
 
         val events = listOf(
             ControlChangedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
@@ -68,6 +68,7 @@ class GiveControlToTargetPlayerExecutor : EffectExecutor<GiveControlToTargetPlay
                     context = controlContext
                 )
                 .updateEntity(targetId) { it.with(SummoningSicknessComponent) }
+                .let { clearRingBearerOnControlChange(it, targetId, newControllerId) }
         }
 
         val events = listOf(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/RingBearerControlChangeCleanup.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/RingBearerControlChangeCleanup.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.engine.handlers.effects.permanent.control
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.RingBearerComponent
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * CR 701.54a: "That creature becomes your Ring-bearer until another creature becomes your
+ * Ring-bearer or another player gains control of it." When control of a Ring-bearer actually
+ * moves to a different player, the designation ends — permanently, not just for the duration of
+ * the control change. So we strip [RingBearerComponent] eagerly here.
+ *
+ * Without this, a temporary control change (e.g. Threaten — "gain control until end of turn")
+ * would suspend the designation while the bearer was under the opponent and then silently
+ * resurrect it when control reverted at cleanup, which contradicts the rule.
+ *
+ * Call this from every executor that emits a [com.wingedsheep.engine.core.ControlChangedEvent]
+ * after the floating effect is added and before returning the [com.wingedsheep.engine.core.EffectResult].
+ */
+internal fun clearRingBearerOnControlChange(
+    state: GameState,
+    permanentId: EntityId,
+    newControllerId: EntityId
+): GameState {
+    val bearer = state.getEntity(permanentId)?.get<RingBearerComponent>() ?: return state
+    if (bearer.ownerId == newControllerId) return state
+    return state.updateEntity(permanentId) { it.without<RingBearerComponent>() }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/TheRingTemptsYouExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/TheRingTemptsYouExecutor.kt
@@ -19,13 +19,13 @@ import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
- * Resolves [TheRingTemptsYouEffect] — "the Ring tempts you" (CR 701.52).
+ * Resolves [TheRingTemptsYouEffect] — "the Ring tempts you" (CR 701.54).
  *
  * 1. Ensure the tempted player has the Ring emblem ([TheRingComponent]) and increment its tempt
- *    count (CR 701.52c — the emblem and its leveling happen *before* choosing a Ring-bearer).
+ *    count (CR 701.54c — the emblem and its leveling happen *before* choosing a Ring-bearer).
  * 2. If the player controls one or more creatures, pause to let them choose one to become their
  *    Ring-bearer; [RingTemptContinuation] applies the designation and announces the temptation.
- * 3. If the player controls no creature, the temptation still happens (CR 701.52a/d): the count is
+ * 3. If the player controls no creature, the temptation still happens (CR 701.54a/d): the count is
  *    incremented and [RingTemptedEvent] fires with no bearer chosen.
  */
 class TheRingTemptsYouExecutor : EffectExecutor<TheRingTemptsYouEffect> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
@@ -499,10 +499,10 @@ class CantBeBlockedIfCastSpellTypeRule(
 }
 
 /**
- * Ring-bearer evasion (CR 701.52c): a player's Ring-bearer can't be blocked by creatures with
+ * Ring-bearer evasion (CR 701.54c): a player's Ring-bearer can't be blocked by creatures with
  * power greater than the Ring-bearer's power. Driven by the [RingBearerComponent] designation
  * rather than a card static ability, and only while the bearer is still controlled by its
- * designator (CR 701.52e). The dual of [CantBlockCreaturesWithGreaterPowerRule].
+ * designator (CR 701.54e). The dual of [CantBlockCreaturesWithGreaterPowerRule].
  */
 class RingBearerCantBeBlockedByGreaterPowerRule : BlockEvasionRule {
     override fun check(ctx: BlockCheckContext): String? {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -176,10 +176,10 @@ class StateProjector(
             effectApplicator.applyEffect(effect, state, projectedValues)
         }
 
-        // CR 701.52c: a player's Ring-bearer is legendary (the Ring emblem's first ability).
+        // CR 701.54c: a player's Ring-bearer is legendary (the Ring emblem's first ability).
         // Applied here as a type-changing (Layer 4) effect, after Layer 2 control is established, so
         // it reads the *projected* controller: "is your Ring-bearer" requires the creature to still
-        // be under its designator's control (CR 701.52e), so a Ring-bearer stolen by a control-
+        // be under its designator's control (CR 701.54e), so a Ring-bearer stolen by a control-
         // changing effect stops being legendary. isLegendary() reads the projected type set, so
         // adding "LEGENDARY" suffices, and it follows whichever creature currently holds the
         // designation.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/RingBearerComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/RingBearerComponent.kt
@@ -5,11 +5,11 @@ import com.wingedsheep.sdk.model.EntityId
 import kotlinx.serialization.Serializable
 
 /**
- * Marks a creature as a player's **Ring-bearer** (CR 701.52a–e).
+ * Marks a creature as a player's **Ring-bearer** (CR 701.54a–e).
  *
- * Being a Ring-bearer is a designation, not a copiable value (701.52b). A creature "is [ownerId]'s
+ * Being a Ring-bearer is a designation, not a copiable value (701.54b). A creature "is [ownerId]'s
  * Ring-bearer" only while it has this component **and** is on the battlefield under [ownerId]'s
- * control (701.52e) — so losing control of the creature ends the designation's effects without the
+ * control (701.54e) — so losing control of the creature ends the designation's effects without the
  * component having to be eagerly removed. The designation moves to a new creature each time that
  * player is tempted (handled by the tempt executor), and at most one creature carries this component
  * per owner.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/RingBearerComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/RingBearerComponent.kt
@@ -9,10 +9,14 @@ import kotlinx.serialization.Serializable
  *
  * Being a Ring-bearer is a designation, not a copiable value (701.54b). A creature "is [ownerId]'s
  * Ring-bearer" only while it has this component **and** is on the battlefield under [ownerId]'s
- * control (701.54e) — so losing control of the creature ends the designation's effects without the
- * component having to be eagerly removed. The designation moves to a new creature each time that
- * player is tempted (handled by the tempt executor), and at most one creature carries this component
- * per owner.
+ * control (701.54e) — so a *transient* loss of control (e.g. a projected/continuous control effect)
+ * suspends the designation's effects without the component having to be touched, and they resume if
+ * control reverts. A control change that actually transfers the permanent to another player ends the
+ * designation *permanently* (701.54a), so the control-change executors strip this component eagerly
+ * via `clearRingBearerOnControlChange` — otherwise a temporary steal (Threaten) would silently
+ * restore the designation when control reverted. The designation moves to a new creature each time
+ * that player is tempted (handled by the tempt executor), and at most one creature carries this
+ * component per owner.
  *
  * @property ownerId The player who designated this creature (whose Ring emblem grants its abilities).
  */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -363,7 +363,7 @@ data class PlayerHexproofComponent(
 data object PlayerCitysBlessingComponent : Component
 
 /**
- * Tracks a player's emblem named **The Ring** (CR 701.52c).
+ * Tracks a player's emblem named **The Ring** (CR 701.54c).
  *
  * Presence of this component means the player has the Ring emblem. [temptCount] is how many times
  * the Ring has tempted that player, gating the emblem's four cumulative abilities:

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1774,7 +1774,7 @@ class ClientStateTransformer(
             )
         }
 
-        // The Ring emblem (CR 701.52). Surface the tempt count so the player can see which of the
+        // The Ring emblem (CR 701.54). Surface the tempt count so the player can see which of the
         // emblem's four cumulative abilities are active and which creature is their Ring-bearer.
         container.get<TheRingComponent>()?.let { ring ->
             val bearerName = state.getBattlefield()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaramirFieldCommanderTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaramirFieldCommanderTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.FaramirFieldCommander
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Faramir, Field Commander — exercises the `YouChoseOtherCreatureAsRingBearer` intervening-if
+ * (Gap 3, CR 701.54a). The card-level test confirms the new condition fires the token trigger
+ * only when the player picked a Ring-bearer other than Faramir, while the end-step draw half
+ * (composed from existing `Conditions.ControlledCreatureDiedThisTurn`) is covered by the
+ * companion mechanic test suite.
+ */
+class FaramirFieldCommanderTest : FunSpec({
+
+    val RingTempter = card("Ring Tempter") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "The Ring tempts you."
+        spell { effect = Effects.TheRingTemptsYou() }
+    }
+
+    val Bear = CardDefinition.creature("Ring Bear", ManaCost.parse("{2}"), emptySet(), 2, 2)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RingTempter, Bear, FaramirFieldCommander))
+        return driver
+    }
+
+    fun GameTestDriver.tempt(player: EntityId, bearerId: EntityId?) {
+        val cardId = putCardInHand(player, "Ring Tempter")
+        castSpell(player, cardId)
+        bothPass()
+        val decision = pendingDecision
+        if (decision is SelectCardsDecision && bearerId != null) {
+            submitDecision(player, CardsSelectedResponse(decision.id, listOf(bearerId)))
+        }
+    }
+
+    fun GameTestDriver.countSoldierTokens(playerId: EntityId): Int {
+        val projected = state.projectedState
+        return state.getBattlefield().count { id ->
+            projected.getController(id) == playerId &&
+                projected.isCreature(id) &&
+                projected.hasSubtype(id, "Soldier")
+        }
+    }
+
+    test("triggers and creates a Soldier when you choose a creature other than Faramir") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(active, "Faramir, Field Commander")
+        val bear = driver.putCreatureOnBattlefield(active, "Ring Bear")
+        val before = driver.countSoldierTokens(active)
+
+        driver.tempt(active, bear)
+        driver.bothPass() // resolve Faramir's "Whenever the Ring tempts you" trigger
+
+        driver.countSoldierTokens(active) shouldBe before + 1
+    }
+
+    test("does NOT trigger when you choose Faramir as your Ring-bearer") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val faramir = driver.putCreatureOnBattlefield(active, "Faramir, Field Commander")
+        driver.putCreatureOnBattlefield(active, "Ring Bear") // another option, but we pick Faramir
+        val before = driver.countSoldierTokens(active)
+
+        driver.tempt(active, faramir)
+        driver.bothPass()
+
+        driver.countSoldierTokens(active) shouldBe before
+    }
+
+    test("does NOT trigger when Faramir is your only creature, so you must choose him") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val faramir = driver.putCreatureOnBattlefield(active, "Faramir, Field Commander")
+        val before = driver.countSoldierTokens(active)
+
+        // Faramir is the only creature, so the only Ring-bearer choice is Faramir himself.
+        driver.tempt(active, faramir)
+        driver.bothPass()
+
+        driver.countSoldierTokens(active) shouldBe before
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRingScenarioTest.kt
@@ -11,17 +11,19 @@ import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
 /**
- * Substrate tests for The Ring mechanic (CR 701.52): the "the Ring tempts you" effect, the
+ * Substrate tests for The Ring mechanic (CR 701.54): the "the Ring tempts you" effect, the
  * Ring-bearer designation, the legendary + can't-be-blocked-by-greater-power static abilities,
  * the "Whenever the Ring tempts you" trigger, and the tempt-count-gated combat ability.
  */
@@ -55,9 +57,23 @@ class TheRingScenarioTest : FunSpec({
     // it's still around to be sacrificed at end of combat).
     val StoutBlocker = CardDefinition.creature("Stout Blocker", ManaCost.parse("{3}"), emptySet(), 2, 4)
 
+    // {0} sorcery: "Gain control of target creature until end of turn." — Threaten in miniature,
+    // used to exercise CR 701.54a (Ring-bearer designation ends when another player gains control).
+    val ThreatenTest = card("Threaten Test") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Gain control of target creature until end of turn."
+        spell {
+            val t = target("creature", Targets.Creature)
+            effect = Effects.GainControl(t, Duration.EndOfTurn)
+        }
+    }
+
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(RingTempter, RingWatcher, Bear, BigOgre, SmallGoblin, StoutBlocker))
+        driver.registerCards(
+            TestCards.all + listOf(RingTempter, RingWatcher, Bear, BigOgre, SmallGoblin, StoutBlocker, ThreatenTest)
+        )
         return driver
     }
 
@@ -84,6 +100,47 @@ class TheRingScenarioTest : FunSpec({
         driver.state.getEntity(active)?.get<TheRingComponent>()?.temptCount shouldBe 1
         driver.state.getEntity(bear)?.get<RingBearerComponent>()?.ownerId shouldBe active
         projector.project(driver.state).isLegendary(bear) shouldBe true
+    }
+
+    test("CR 701.54a: another player gaining control ends the Ring-bearer designation permanently") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val owner = driver.activePlayer!!                  // bear's owner — tempts themselves first
+        val thief = driver.getOpponent(owner)              // will steal the bear on their next turn
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(owner, "Ring Bear")
+        driver.tempt(owner, bear)
+        driver.state.getEntity(bear)?.get<RingBearerComponent>()?.ownerId shouldBe owner
+
+        // Hand the turn to the would-be thief and arrive at their main phase. UNTAP /
+        // CLEANUP don't get priority, so we wait on DRAW (which does) instead.
+        driver.passPriorityUntil(Step.DRAW, maxPasses = 200)
+        if (driver.activePlayer != thief) driver.passPriorityUntil(Step.DRAW, maxPasses = 200)
+        driver.activePlayer shouldBe thief
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 200)
+
+        // Thief steals the bear with a Threaten-style spell.
+        val threaten = driver.putCardInHand(thief, "Threaten Test")
+        driver.castSpell(thief, threaten, listOf(bear))
+        driver.bothPass()
+        projector.project(driver.state).getController(bear) shouldBe thief
+
+        // The designation ended the moment control changed (CR 701.54a) — the component
+        // is stripped eagerly so that when control reverts the bear stays not-the-bearer.
+        driver.state.getEntity(bear)?.get<RingBearerComponent>() shouldBe null
+
+        // Advance to the owner's next draw step so the EndOfTurn floating control effect has
+        // expired and control has reverted.
+        driver.passPriorityUntil(Step.DRAW, maxPasses = 200)
+        if (driver.activePlayer != owner) driver.passPriorityUntil(Step.DRAW, maxPasses = 200)
+        driver.activePlayer shouldBe owner
+
+        projector.project(driver.state).getController(bear) shouldBe owner
+        driver.state.getEntity(bear)?.get<RingBearerComponent>() shouldBe null
+        driver.state.getBattlefield().any {
+            driver.state.getEntity(it)?.get<RingBearerComponent>()?.ownerId == owner
+        } shouldBe false
     }
 
     test("tempting again moves the Ring-bearer designation to the new creature") {
@@ -146,7 +203,7 @@ class TheRingScenarioTest : FunSpec({
         driver.getLifeTotal(active) shouldBe lifeBefore + 2
     }
 
-    test("tempting with no creatures still tempts: count increments and the trigger fires (CR 701.52a/d)") {
+    test("tempting with no creatures still tempts: count increments and the trigger fires (CR 701.54a/d)") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
         val active = driver.activePlayer!!
@@ -249,7 +306,7 @@ class TheRingScenarioTest : FunSpec({
             }
         }
 
-        // The blocker survived combat damage but is sacrificed at end of combat (CR 701.52c, ≥3).
+        // The blocker survived combat damage but is sacrificed at end of combat (CR 701.54c, ≥3).
         driver.findPermanent(opponent, "Stout Blocker") shouldBe null
     }
 })


### PR DESCRIPTION
…rol change

Closes LTR Gap 3: ring-tempt triggers like Aragorn/Faramir/Gandalf/Galadriel gate their payoff on "if you chose a creature other than this as your Ring-bearer." The new `Conditions.YouChoseOtherCreatureAsRingBearer` is true when the controller currently has a Ring-bearer designated and that bearer isn't the source — so it's false both when the source was chosen and when no creature was available to choose. Lands Faramir, Field Commander as the demo card; the other three Gap-3 cards remain blocked on Gaps 4/7 for their second abilities.

Also fixes CR 701.54a: "until another player gains control of it." Today the designation hangs around as `RingBearerComponent` on the entity, suspended while another player controls it. When control reverts (Threaten end-of-turn) the projection re-activates the designation, contradicting the rule. Every control-change executor now calls `clearRingBearerOnControlChange` to strip the component eagerly the moment the new controller differs from the bearer's owner, so the revert keeps the bear bearer-less.

Drive-by: renames the Ring rules from CR 701.52 to 701.54 across the codebase. The CR shuffled these subrules (a–e map 1:1) between LTR's 2023 release and the 2026-04-17 rules; verified against the local MagicCompRules_20260417.txt.