### PR TITLE
Default deckbuilder to plain frame for sets with variant printings (Lorwyn Eclipsed)

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
@@ -34,7 +34,7 @@ class GameBeansConfig(
         // cards from all sets, even those gated out of sealed/draft via game.sets.disabled-by-default.
         // Booster/sealed/draft generation still respects the active-set filter via boosterGenerator.
         for (set in MtgSetCatalog.all) {
-            register(set.cards.stamp(set.code).withLegalities())
+            register(set.cards.stamp(set).withLegalities())
             register(set.basicLands.withLegalities())
             set.basicLandsFallback?.let { register(it.basicLands.withLegalities()) }
         }
@@ -89,8 +89,28 @@ class GameBeansConfig(
     }
 }
 
-private fun List<CardDefinition>.stamp(setCode: String): List<CardDefinition> =
-    map { if (it.setCode == null) it.copy(setCode = setCode) else it }
+/**
+ * Stamp each card with its [set]'s identity that the bare `CardDefinition` doesn't carry:
+ * `setCode` (so the deckbuilder can resolve a default printing) and `metadata.releaseDate`
+ * (so the synthesised default printing dates from the set, not `null`).
+ *
+ * The release-date stamp is what keeps the deckbuilder defaulting to the *plain* frame: a set's
+ * showcase/borderless variant printings ship explicit release dates, but the canonical printing
+ * is synthesised from this metadata. Without the stamp it dates to `null` and sorts *after* the
+ * dated variants, so the catalog defaults to a showcase/borderless art. Stamping the set date
+ * ties the canonical printing with its variants, letting the `isAlternateFrame` tiebreaker in
+ * `PrintingRegistry.defaultPrinting` pick the plain one. Only fills gaps — never overwrites a
+ * value a card already declares.
+ */
+private fun List<CardDefinition>.stamp(set: MtgSet): List<CardDefinition> =
+    map { card ->
+        val withSet = if (card.setCode == null) card.copy(setCode = set.code) else card
+        if (withSet.metadata.releaseDate == null && set.releaseDate != null) {
+            withSet.copy(metadata = withSet.metadata.copy(releaseDate = set.releaseDate))
+        } else {
+            withSet
+        }
+    }
 
 private fun List<CardDefinition>.withLegalities(): List<CardDefinition> =
     map { LegalityData.stamp(it) }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/config/GameBeansConfigPrintingTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/config/GameBeansConfigPrintingTest.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.gameserver.config
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Guards the deckbuilder default-printing wiring against the regression where a set that ships
+ * showcase/borderless variant printings (e.g. Lorwyn Eclipsed) had its catalog default to a
+ * variant art instead of the standard frame.
+ *
+ * The canonical printing of a card is *synthesised* from its `CardDefinition` metadata, while
+ * the variants are explicit `Printing` rows carrying their set's release date. `GameBeansConfig`
+ * must stamp the same release date onto the canonical printing so the two tie on date and the
+ * `isAlternateFrame` tiebreaker can pick the plain one — otherwise the canonical printing dates
+ * to `null`, sorts last, and a showcase/borderless variant wins the default slot.
+ */
+class GameBeansConfigPrintingTest : FunSpec({
+
+    val config = GameBeansConfig(GameProperties())
+    val cardRegistry = config.cardRegistry()
+    val printingRegistry = config.printingRegistry(cardRegistry)
+
+    test("ECL canonical printing is stamped with the set release date") {
+        // Dawnhand Dissident ships a plain printing (#98) plus a showcase/borderless variant.
+        // The synthesised canonical printing must inherit ECL's release date from the stamp.
+        val plain = printingRegistry.getPrinting("ECL", "98").shouldNotBeNull()
+        plain.releaseDate shouldBe "2026-01-23"
+        plain.isAlternateFrame shouldBe false
+    }
+
+    test("ECL deckbuilder default is the plain frame, not the showcase/borderless variant") {
+        val default = printingRegistry.defaultPrinting("Dawnhand Dissident").shouldNotBeNull()
+        default.collectorNumber shouldBe "98"
+        default.isAlternateFrame shouldBe false
+    }
+})


### PR DESCRIPTION
## Problem

In the deckbuilder, Lorwyn Eclipsed (ECL) cards still default to their **showcase / borderless** art instead of the standard printing — e.g. *Dawnhand Dissident* shows the borderless #311 rather than the plain #98.

This persisted despite PR #450, which added an `isAlternateFrame` tiebreaker to the default-printing selection (`PrintingRegistry.defaultPrinting` and `PrintingsController.printingOrder`).

## Root cause

That tiebreaker only fires **after** release date:

```
compareBy { releaseDate == null }      // null sorts last
  .thenByDescending { releaseDate }
  .thenBy { isAlternateFrame }          // ← never reached when dates differ
```

A card's canonical printing is *synthesised* from its `CardDefinition` metadata. But cards only get `setCode` stamped at registration — **not** `releaseDate`. So:

- canonical plain printing (#98) → `releaseDate = null` → sorts **last**
- curated variant rows (#311, showcase/borderless) → explicit `releaseDate = "2026-01-23"` → sorts **first**

Release date decided the order before the frame tiebreaker ever ran, so the variant won the default slot. PR #450's logic was correct; it just assumed the canonical and variant printings shared a release date, which they didn't.

## Fix

Stamp the set's `releaseDate` onto each card alongside `setCode` in `GameBeansConfig`. The canonical printing now ties with its variants on date, and the existing `isAlternateFrame` tiebreaker picks the plain frame. Only fills gaps — a card that declares its own release date is left untouched. Benefits both synthesis paths (`PrintingRegistry` and `PrintingsController`), since both read `card.metadata.releaseDate`.

## Test

New `GameBeansConfigPrintingTest` drives the **real** `GameBeansConfig` wiring against the real Lorwyn Eclipsed set:

- the synthesised ECL canonical printing is now dated `2026-01-23` (was `null`)
- the deckbuilder default for *Dawnhand Dissident* is the plain **#98**, not the showcase/borderless **#311**

Both new tests and all existing `PrintingsControllerTest` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)