### PR TITLE
Add TDM cards (group A)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AleshasLegacy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/AleshasLegacy.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+
+/**
+ * Alesha's Legacy
+ * {1}{B}
+ * Instant
+ * Target creature you control gains deathtouch and indestructible until end of turn.
+ */
+val AleshasLegacy = card("Alesha's Legacy") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature you control gains deathtouch and indestructible until end of turn. " +
+        "(Damage and effects that say \"destroy\" don't destroy it.)"
+
+    spell {
+        val target = target("target creature you control", Targets.CreatureYouControl)
+        effect = CompositeEffect(listOf(
+            Effects.GrantKeyword(Keyword.DEATHTOUCH, target),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, target),
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Craig J Spearing"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9262bf6-df6a-446c-ba70-18270a09842d.jpg?1743204249"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BloomvineRegent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BloomvineRegent.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Bloomvine Regent // Claim Territory
+ * {3}{G}{G} // {2}{G}
+ * Creature — Dragon // Sorcery — Omen
+ * 4/5
+ *
+ * Bloomvine Regent:
+ *   Flying
+ *   Whenever this creature or another Dragon you control enters, you gain 3 life.
+ *
+ * Claim Territory — {2}{G}, Sorcery — Omen:
+ *   Search your library for up to two basic Forest cards, reveal them, put one onto the
+ *   battlefield tapped and the other into your hand, then shuffle. (Also shuffle this card.)
+ *
+ * The ETB life-gain uses an ANY binding so it fires for the Regent itself as well as for any
+ * other Dragon you control entering. Claim Territory is a Cultivate-style "search up to two
+ * basics" split (one to battlefield tapped, one to hand) — the [SelectionMode.ChooseExactly]
+ * split step auto-selects the only card when one basic is found. The "(Also shuffle this card.)"
+ * reminder is handled by the Omen/Adventure exile-and-recast flow.
+ */
+val BloomvineRegent = card("Bloomvine Regent") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 5
+    oracleText = "Flying\n" +
+        "Whenever this creature or another Dragon you control enters, you gain 3 life."
+
+    keywords(Keyword.FLYING)
+
+    // Whenever this creature or another Dragon you control enters, you gain 3 life.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl().withSubtype(Subtype.DRAGON),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.GainLife(3)
+        description = "Whenever this creature or another Dragon you control enters, you gain 3 life."
+    }
+
+    // Claim Territory — Omen. Search your library for up to two basic Forest cards, reveal them,
+    // put one onto the battlefield tapped and the other into your hand, then shuffle.
+    adventure("Claim Territory") {
+        manaCost = "{2}{G}"
+        typeLine = "Sorcery — Omen"
+        oracleText = "Search your library for up to two basic Forest cards, reveal them, put one " +
+            "onto the battlefield tapped and the other into your hand, then shuffle. " +
+            "(Also shuffle this card.)"
+        spell {
+            effect = CompositeEffect(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.FromZone(
+                            Zone.LIBRARY,
+                            Player.You,
+                            GameObjectFilter.BasicLand.withSubtype(Subtype.FOREST)
+                        ),
+                        storeAs = "searchable"
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "searchable",
+                        selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                        storeSelected = "found",
+                        prompt = "Search your library for up to two basic Forest cards"
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "found",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                        storeSelected = "toBattlefield",
+                        storeRemainder = "toHand",
+                        selectedLabel = "Onto the battlefield tapped",
+                        remainderLabel = "Into your hand",
+                        prompt = "Choose which basic Forest enters the battlefield tapped; the other goes to your hand."
+                    ),
+                    MoveCollectionEffect(
+                        from = "toBattlefield",
+                        destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped),
+                        revealed = true
+                    ),
+                    MoveCollectionEffect(
+                        from = "toHand",
+                        destination = CardDestination.ToZone(Zone.HAND),
+                        revealed = true
+                    ),
+                    ShuffleLibraryEffect()
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "136"
+        artist = "Johann Bodin"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg?1754359377"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CoriMountainMonastery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CoriMountainMonastery.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cori Mountain Monastery
+ * Land
+ *
+ * This land enters tapped unless you control a Plains or an Island.
+ * {T}: Add {R}.
+ * {3}{R}, {T}: Exile the top card of your library. Until the end of your next turn, you may
+ * play that card.
+ */
+val CoriMountainMonastery = card("Cori Mountain Monastery") {
+    typeLine = "Land"
+    colorIdentity = "R"
+    oracleText = "This land enters tapped unless you control a Plains or an Island.\n" +
+        "{T}: Add {R}.\n" +
+        "{3}{R}, {T}: Exile the top card of your library. Until the end of your next turn, you " +
+        "may play that card."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.Any(
+                Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Plains")),
+                Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Island"))
+            )
+        )
+    )
+
+    // {T}: Add {R}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {3}{R}, {T}: Exile the top card of your library. Until the end of your next turn, you may
+    // play that card.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{R}"), Costs.Tap)
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                    storeAs = "exiledCard"
+                ),
+                MoveCollectionEffect(
+                    from = "exiledCard",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                ),
+                GrantMayPlayFromExileEffect("exiledCard", MayPlayExpiry.UntilEndOfNextTurn)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "252"
+        artist = "Arthur Yuan"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/9312821a-2059-4f44-9b20-c9522b827e38.jpg?1743204997"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DeathBegetsLife.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DeathBegetsLife.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Death Begets Life
+ * {5}{B}{G}{U}
+ * Sorcery
+ *
+ * Destroy all creatures and enchantments. Draw a card for each permanent destroyed this way.
+ *
+ * Uses the [Effects.DestroyAll] pipeline with the shared [GameObjectFilter.CreatureOrEnchantment]
+ * filter (a single Or card-predicate, so an enchantment creature is matched and counted once),
+ * storing the destroyed count and drawing that many cards via [DynamicAmount.VariableReference].
+ */
+val DeathBegetsLife = card("Death Begets Life") {
+    manaCost = "{5}{B}{G}{U}"
+    colorIdentity = "BGU"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all creatures and enchantments. Draw a card for each permanent destroyed this way."
+
+    spell {
+        effect = Effects.DestroyAll(
+            filter = GameObjectFilter.CreatureOrEnchantment,
+            storeDestroyedAs = "destroyed"
+        ).then(
+            Effects.DrawCards(DynamicAmount.VariableReference("destroyed_count"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "176"
+        artist = "Justin Hernandez & Alexis Hernandez"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1faab43d-587d-44f6-9516-c8e3965bbc20.jpg?1743204680"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonbroodsRelic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonbroodsRelic.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dragonbroods' Relic
+ * {1}{G}
+ * Artifact
+ *
+ * {T}, Tap an untapped creature you control: Add one mana of any color.
+ * {3}{W}{U}{B}{R}{G}, Sacrifice this artifact: Create a 4/4 Dragon creature token named
+ * Reliquary Dragon that's all colors. It has flying, lifelink, and "When this token enters, it
+ * deals 3 damage to any target." Activate only as a sorcery.
+ *
+ * The mana ability taps both this artifact ({T}) and an untapped creature you control
+ * ([Costs.TapPermanents] count = 1) as its cost, then adds one mana of any color. The Dragon
+ * token is created all-colors (all five [Color] values) with flying + lifelink and an
+ * any-target ETB-damage [TriggeredAbility].
+ */
+val DragonbroodsRelic = card("Dragonbroods' Relic") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact"
+    oracleText = "{T}, Tap an untapped creature you control: Add one mana of any color.\n" +
+        "{3}{W}{U}{B}{R}{G}, Sacrifice this artifact: Create a 4/4 Dragon creature token named " +
+        "Reliquary Dragon that's all colors. It has flying, lifelink, and \"When this token " +
+        "enters, it deals 3 damage to any target.\" Activate only as a sorcery."
+
+    // {T}, Tap an untapped creature you control: Add one mana of any color.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.TapPermanents(count = 1, filter = GameObjectFilter.Creature.youControl())
+        )
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {3}{W}{U}{B}{R}{G}, Sacrifice this artifact: Create the Reliquary Dragon token.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{W}{U}{B}{R}{G}"), Costs.SacrificeSelf)
+        timing = TimingRule.SorcerySpeed
+        effect = CreateTokenEffect(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.WHITE, Color.BLUE, Color.BLACK, Color.RED, Color.GREEN),
+            creatureTypes = setOf("Dragon"),
+            keywords = setOf(Keyword.FLYING, Keyword.LIFELINK),
+            name = "Reliquary Dragon",
+            triggeredAbilities = listOf(
+                TriggeredAbility.create(
+                    trigger = Triggers.EntersBattlefield.event,
+                    binding = Triggers.EntersBattlefield.binding,
+                    effect = Effects.DealDamage(3, EffectTarget.ContextTarget(0)),
+                    targetRequirement = Targets.Any,
+                    descriptionOverride = "When this token enters, it deals 3 damage to any target."
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/4/4/44465924-8cc2-49a4-bc07-8dbae7570af6.jpg?1743176691"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "140"
+        artist = "Racrufi"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d634087-77ba-4543-aa7a-8a3774d69cd7.jpg?1743204527"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmCardsGroupAScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmCardsGroupAScenarioTest.kt
@@ -1,0 +1,250 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.TimingRule
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the TDM "group A" batch:
+ *  - Alesha's Legacy (#72): {1}{B} Instant — target creature you control gains deathtouch and
+ *    indestructible until end of turn.
+ *  - Bloomvine Regent // Claim Territory (#136): {3}{G}{G} Dragon 4/5 Flying; ETB (this or another
+ *    Dragon you control) you gain 3 life. Omen Claim Territory searches up to two basic Forests,
+ *    one to battlefield tapped and one to hand.
+ *  - Cori Mountain Monastery (#252): Land — enters tapped unless you control a Plains or Island;
+ *    {T}: Add {R}; {3}{R},{T}: impulse the top card of your library.
+ *  - Death Begets Life (#176): {5}{B}{G}{U} Sorcery — destroy all creatures and enchantments,
+ *    draw a card for each permanent destroyed this way.
+ *  - Dragonbroods' Relic (#140): {1}{G} Artifact — mana ability; {3}{W}{U}{B}{R}{G}, Sacrifice:
+ *    create the all-colors Reliquary Dragon token that deals 3 damage to any target on ETB.
+ */
+class TdmCardsGroupAScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Alesha's Legacy") {
+            test("grants deathtouch and indestructible until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Alesha's Legacy")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Casting Alesha's Legacy targeting the Bear should succeed") {
+                    game.castSpell(1, "Alesha's Legacy", targetId = bear).error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Bear has deathtouch and indestructible until end of turn") {
+                    game.state.projectedState.hasKeyword(bear, Keyword.DEATHTOUCH) shouldBe true
+                    game.state.projectedState.hasKeyword(bear, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+            }
+        }
+
+        context("Bloomvine Regent") {
+            test("enters as a 4/5 flier and gains its controller 3 life on its own ETB") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Bloomvine Regent")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startingLife = game.getLifeTotal(1)
+
+                withClue("Casting the creature face should succeed") {
+                    game.castSpell(1, "Bloomvine Regent").error shouldBe null
+                }
+                game.resolveStack() // resolve the creature
+                game.resolveStack() // resolve the ETB life-gain trigger
+
+                val regent = game.findPermanent("Bloomvine Regent")!!
+                withClue("Bloomvine Regent is a 4/5 with flying") {
+                    game.state.projectedState.getPower(regent) shouldBe 4
+                    game.state.projectedState.getToughness(regent) shouldBe 5
+                    game.state.projectedState.hasKeyword(regent, Keyword.FLYING) shouldBe true
+                }
+                withClue("Controller gained 3 life from its own ETB") {
+                    game.getLifeTotal(1) shouldBe startingLife + 3
+                }
+            }
+
+            test("ETB also triggers when another Dragon you control enters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bloomvine Regent")
+                    .withCardInHand(1, "Sagu Wildling") // another Dragon
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startingLife = game.getLifeTotal(1)
+
+                withClue("Casting Sagu Wildling should succeed") {
+                    game.castSpell(1, "Sagu Wildling").error shouldBe null
+                }
+                game.resolveStack() // Sagu Wildling enters
+                game.resolveStack() // resolve triggers (Sagu's own +3, Bloomvine's +3)
+
+                withClue("Both Dragon ETB triggers gained 3 life each (Sagu's own + Bloomvine's)") {
+                    game.getLifeTotal(1) shouldBe startingLife + 6
+                }
+            }
+        }
+
+        context("Cori Mountain Monastery") {
+            test("enters tapped when you control no Plains or Island") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cori Mountain Monastery")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val landCard = game.findCardsInHand(1, "Cori Mountain Monastery").first()
+                withClue("Playing the land should succeed") {
+                    game.execute(PlayLand(game.player1Id, landCard)).error shouldBe null
+                }
+
+                val land = game.findPermanent("Cori Mountain Monastery")!!
+                withClue("It enters tapped with no Plains/Island in play") {
+                    game.state.getEntity(land)?.get<TappedComponent>() shouldNotBe null
+                }
+            }
+
+            test("enters untapped when you control a Plains") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cori Mountain Monastery")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val landCard = game.findCardsInHand(1, "Cori Mountain Monastery").first()
+                withClue("Playing the land should succeed") {
+                    game.execute(PlayLand(game.player1Id, landCard)).error shouldBe null
+                }
+
+                val land = game.findPermanent("Cori Mountain Monastery")!!
+                withClue("It enters untapped because a Plains is controlled") {
+                    game.state.getEntity(land)?.get<TappedComponent>() shouldBe null
+                }
+            }
+        }
+
+        context("Death Begets Life") {
+            test("destroys all creatures and enchantments and draws one card per permanent destroyed") {
+                // Three creatures + one global enchantment = four permanents destroyed; the
+                // shared GameObjectFilter.CreatureOrEnchantment covers the "and enchantments"
+                // clause (Divine Presence is a plain static Enchantment with no ETB).
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Death Begets Life")
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardOnBattlefield(1, "Grizzly Bears")     // creature
+                    .withCardOnBattlefield(2, "Grizzly Bears")     // creature
+                    .withCardOnBattlefield(2, "Grizzly Bears")     // creature
+                    .withCardOnBattlefield(1, "Divine Presence")   // global enchantment
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                withClue("Casting Death Begets Life should succeed") {
+                    game.castSpell(1, "Death Begets Life").error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("All creatures were destroyed") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 0
+                }
+                withClue("The enchantment was destroyed") {
+                    game.findPermanent("Divine Presence") shouldBe null
+                }
+                val destroyed = 4 // 3 Grizzly Bears + 1 Divine Presence
+                withClue("Drew a card for each permanent destroyed this way") {
+                    game.handSize(1) shouldBe (handBefore - 1 /* the spell */ + destroyed)
+                }
+            }
+        }
+
+        context("Dragonbroods' Relic") {
+            test("sacrifice ability creates the all-colors Reliquary Dragon that deals 3 damage on ETB") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dragonbroods' Relic")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val relic = game.findPermanent("Dragonbroods' Relic")!!
+                val sacAbility = cardRegistry.getCard("Dragonbroods' Relic")!!
+                    .activatedAbilities.first { it.timing is TimingRule.SorcerySpeed }
+
+                val opponentStartLife = game.getLifeTotal(2)
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = relic,
+                        abilityId = sacAbility.id,
+                    )
+                )
+                withClue("Activating the sacrifice ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack() // ability resolves → token created → ETB trigger goes on stack
+
+                withClue("Reliquary Dragon token was created") {
+                    game.findPermanent("Reliquary Dragon") shouldNotBe null
+                }
+                val token = game.findPermanent("Reliquary Dragon")!!
+                withClue("Token is a 4/4 with flying and lifelink") {
+                    game.state.projectedState.getPower(token) shouldBe 4
+                    game.state.projectedState.getToughness(token) shouldBe 4
+                    game.state.projectedState.hasKeyword(token, Keyword.FLYING) shouldBe true
+                    game.state.projectedState.hasKeyword(token, Keyword.LIFELINK) shouldBe true
+                }
+
+                // The ETB trigger needs a target — aim 3 damage at the opponent.
+                game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+
+                withClue("Reliquary Dragon dealt 3 damage to the opponent on ETB") {
+                    game.getLifeTotal(2) shouldBe opponentStartLife - 3
+                }
+                withClue("The relic was sacrificed") {
+                    game.findPermanent("Dragonbroods' Relic") shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds five Tarkir: Dragonstorm cards. All reuse existing SDK primitives — no new effect/trigger/condition/keyword types were introduced.

## Implemented
- **Alesha's Legacy** (#72) — {1}{B} Instant. Target creature you control gains deathtouch and indestructible until end of turn. (`Effects.GrantKeyword`)
- **Bloomvine Regent // Claim Territory** (#136) — {3}{G}{G} Dragon 4/5 Flying; ETB (this or another Dragon you control, ANY binding) gain 3 life. Omen Claim Territory searches up to two basic Forests, one onto the battlefield tapped and one to hand (Cultivate-style gather→select→move split).
- **Cori Mountain Monastery** (#252) — Land. Enters tapped unless you control a Plains or an Island (`EntersTapped` + `Conditions.Any` of two `Exists`); {T}: Add {R}; {3}{R},{T}: impulse the top card of your library (`GrantMayPlayFromExileEffect` with `UntilEndOfNextTurn`).
- **Death Begets Life** (#176) — {5}{B}{G}{U} Sorcery. Destroy all creatures and enchantments, draw a card for each permanent destroyed this way (`Effects.DestroyAll(CreatureOrEnchantment)` + `DynamicAmount.VariableReference`).
- **Dragonbroods' Relic** (#140) — {1}{G} Artifact. Mana ability: {T}, tap an untapped creature you control → add one mana of any color. {3}{W}{U}{B}{R}{G}, Sacrifice: create the all-colors 4/4 Reliquary Dragon token (flying, lifelink, "When this token enters, it deals 3 damage to any target.").

## Skipped
None.

## Tests
`TdmCardsGroupAScenarioTest` — 7 tests, all passing (deathtouch/indestructible grant, Bloomvine 4/5 flier + own-ETB and other-Dragon-ETB life gain, Cori enters tapped/untapped, Death Begets Life destroy-and-draw count over creatures + an enchantment, Dragonbroods' Relic sac → all-colors token → 3 ETB damage).

Note: the existing `feat/tdm-cards-group-a` branch is held by a different agent's worktree for a different group-A batch, so this PR uses `feat/tdm-cards-group-a-batch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)