### PR TITLE
Add TDM cards (group C)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiBrushmaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiBrushmaster.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jeskai Brushmaster — Tarkir: Dragonstorm #195
+ * {1}{U}{R}{W} · Creature — Orc Monk · 2/4
+ *
+ * Double strike
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ *
+ * Both abilities are plain keywords: [Keyword.DOUBLE_STRIKE] and the [prowess] helper.
+ */
+val JeskaiBrushmaster = card("Jeskai Brushmaster") {
+    manaCost = "{1}{U}{R}{W}"
+    colorIdentity = "URW"
+    typeLine = "Creature — Orc Monk"
+    power = 2
+    toughness = 4
+    oracleText = "Double strike\n" +
+        "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)"
+
+    keywords(Keyword.DOUBLE_STRIKE)
+    prowess()
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "195"
+        artist = "Nino Vecia"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2eb06c36-cf7e-47a9-819e-adfc54284153.jpg?1743204763"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LotuslightDancers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/LotuslightDancers.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Lotuslight Dancers — Tarkir: Dragonstorm #204
+ * {2}{B}{G}{U} · Creature — Zombie Bard · 3/6
+ *
+ * Lifelink
+ * When this creature enters, search your library for a black card, a green card, and a blue card.
+ * Put those cards into your graveyard, then shuffle.
+ *
+ * The ETB is modelled as three sequential single-card library searches — one per color filter —
+ * each via the atomic [EffectPatterns.searchLibrary] gather→select→move pipeline to the graveyard.
+ * Only the final search shuffles, matching the single "then shuffle" at the end of the oracle text.
+ * Each search removes its found card from the library before the next runs, so a card cannot be
+ * chosen twice; a multicolor card (e.g. black-green) can satisfy whichever single color search the
+ * player picks it for.
+ */
+val LotuslightDancers = card("Lotuslight Dancers") {
+    manaCost = "{2}{B}{G}{U}"
+    colorIdentity = "BGU"
+    typeLine = "Creature — Zombie Bard"
+    power = 3
+    toughness = 6
+    oracleText = "Lifelink\n" +
+        "When this creature enters, search your library for a black card, a green card, and a blue " +
+        "card. Put those cards into your graveyard, then shuffle."
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.Any.withColor(Color.BLACK),
+            count = 1,
+            destination = SearchDestination.GRAVEYARD,
+            shuffleAfter = false
+        ).then(
+            EffectPatterns.searchLibrary(
+                filter = GameObjectFilter.Any.withColor(Color.GREEN),
+                count = 1,
+                destination = SearchDestination.GRAVEYARD,
+                shuffleAfter = false
+            )
+        ).then(
+            EffectPatterns.searchLibrary(
+                filter = GameObjectFilter.Any.withColor(Color.BLUE),
+                count = 1,
+                destination = SearchDestination.GRAVEYARD,
+                shuffleAfter = true
+            )
+        )
+        description = "When this creature enters, search your library for a black card, a green card, " +
+            "and a blue card. Put those cards into your graveyard, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "204"
+        artist = "Jodie Muir"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82aa2593-4a79-46f1-a2bd-b71fb504d0ab.jpg?1743204801"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarangRiverRegent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MarangRiverRegent.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Marang River Regent // Coil and Catch — Tarkir: Dragonstorm #51
+ * {4}{U}{U} · Creature — Dragon · 6/7
+ *
+ * Flying
+ * When this creature enters, return up to two other target nonland permanents to their owners' hands.
+ *
+ * Omen: Coil and Catch — {3}{U}, Instant — Omen
+ * Draw three cards, then discard a card.
+ *
+ * The ETB returns up to two OTHER target nonland permanents (excludeSelf via
+ * [TargetFilter.NonlandPermanent.other]) — optional, so a cast with zero or one legal target still
+ * resolves. (Omen, Tarkir: Dragonstorm: casting the Omen face shuffles this card into its owner's
+ * library on resolution instead of going to the graveyard — see
+ * [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ */
+val MarangRiverRegent = card("Marang River Regent") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Dragon"
+    power = 6
+    toughness = 7
+    oracleText = "Flying\n" +
+        "When this creature enters, return up to two other target nonland permanents to their owners' hands."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to two other target nonland permanents",
+            TargetPermanent(count = 2, optional = true, filter = TargetFilter.NonlandPermanent.other())
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "marangRiverRegent_targets"),
+            MoveCollectionEffect(
+                from = "marangRiverRegent_targets",
+                destination = CardDestination.ToZone(Zone.HAND),
+            ),
+        )
+        description = "When this creature enters, return up to two other target nonland permanents to " +
+            "their owners' hands."
+    }
+
+    // Omen: Coil and Catch — Instant. Draw three cards, then discard a card.
+    omen("Coil and Catch") {
+        manaCost = "{3}{U}"
+        typeLine = "Instant — Omen"
+        oracleText = "Draw three cards, then discard a card. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            effect = Effects.DrawCards(3).then(Effects.Discard(1))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "51"
+        artist = "John Tedrick"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg?1764062994"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RilingDawnbreaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RilingDawnbreaker.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Riling Dawnbreaker // Signaling Roar — Tarkir: Dragonstorm #21
+ * {4}{W} · Creature — Dragon · 3/4
+ *
+ * Flying, vigilance
+ * At the beginning of combat on your turn, another target creature you control gets +1/+0 until end of turn.
+ *
+ * Omen: Signaling Roar — {1}{W}, Sorcery — Omen
+ * Create a 2/2 white Soldier creature token.
+ *
+ * The combat trigger buffs ANOTHER target creature you control ([TargetFilter.OtherCreatureYouControl])
+ * via [Effects.ModifyStats] (+1/+0, default until-end-of-turn duration). (Omen, Tarkir: Dragonstorm:
+ * casting the Omen face shuffles this card into its owner's library on resolution — see
+ * [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ */
+val RilingDawnbreaker = card("Riling Dawnbreaker") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dragon"
+    power = 3
+    toughness = 4
+    oracleText = "Flying, vigilance\n" +
+        "At the beginning of combat on your turn, another target creature you control gets +1/+0 until end of turn."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val t = target(
+            "another target creature you control",
+            TargetCreature(filter = TargetFilter.OtherCreatureYouControl)
+        )
+        effect = Effects.ModifyStats(1, 0, t)
+        description = "At the beginning of combat on your turn, another target creature you control " +
+            "gets +1/+0 until end of turn."
+    }
+
+    // Omen: Signaling Roar — Sorcery. Create a 2/2 white Soldier creature token.
+    omen("Signaling Roar") {
+        manaCost = "{1}{W}"
+        typeLine = "Sorcery — Omen"
+        oracleText = "Create a 2/2 white Soldier creature token. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            effect = Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Soldier"),
+                imageUri = "https://cards.scryfall.io/normal/front/7/d/7ddd5153-2d16-4a4e-b9bc-f20313d322da.jpg?1743176203"
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Tuan Duong Chu"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg?1743204036"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JeskaiBrushmasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JeskaiBrushmasterScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Jeskai Brushmaster (TDM #195).
+ *
+ * {1}{U}{R}{W} Creature — Orc Monk, 2/4. Double strike + Prowess.
+ *
+ * Both abilities are well-covered keywords; this confirms the card wires them up: it enters as a
+ * 2/4 with double strike, and casting a noncreature spell pumps it +1/+1 via prowess.
+ */
+class JeskaiBrushmasterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Jeskai Brushmaster keywords") {
+
+            test("enters as a 2/4 with double strike") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Jeskai Brushmaster")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val brushmaster = game.findPermanent("Jeskai Brushmaster")!!
+                val projected = StateProjector().project(game.state)
+
+                projected.getPower(brushmaster) shouldBe 2
+                projected.getToughness(brushmaster) shouldBe 4
+                withClue("Jeskai Brushmaster has double strike") {
+                    projected.hasKeyword(brushmaster, Keyword.DOUBLE_STRIKE) shouldBe true
+                }
+            }
+
+            test("prowess pumps it when a noncreature spell is cast") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Jeskai Brushmaster")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val brushmaster = game.findPermanent("Jeskai Brushmaster")!!
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack() // prowess trigger + bolt resolve
+
+                val projected = StateProjector().project(game.state)
+                withClue("Prowess: Jeskai Brushmaster is 3/5 after a noncreature spell") {
+                    projected.getPower(brushmaster) shouldBe 3
+                    projected.getToughness(brushmaster) shouldBe 5
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightfootTechniqueScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightfootTechniqueScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Lightfoot Technique (TDM #14).
+ *
+ * {1}{W} Instant.
+ *   "Put a +1/+1 counter on target creature. It gains flying and indestructible until end of turn."
+ */
+class LightfootTechniqueScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lightfoot Technique") {
+
+            test("adds a +1/+1 counter and grants flying + indestructible until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lightfoot Technique")
+                    .withCardOnBattlefield(1, "Centaur Courser") // 3/3, no flying
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val creature = game.findPermanent("Centaur Courser")!!
+
+                game.castSpell(1, "Lightfoot Technique", targetId = creature).error shouldBe null
+                game.resolveStack()
+
+                withClue("Centaur Courser gets a +1/+1 counter") {
+                    val counters = game.state.getEntity(creature)
+                        ?.get<CountersComponent>()
+                        ?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 1
+                }
+
+                val projected = StateProjector().project(game.state)
+                withClue("It is now a 4/4 (3/3 + counter)") {
+                    projected.getPower(creature) shouldBe 4
+                    projected.getToughness(creature) shouldBe 4
+                }
+                withClue("It gains flying and indestructible") {
+                    projected.hasKeyword(creature, Keyword.FLYING) shouldBe true
+                    projected.hasKeyword(creature, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LotuslightDancersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LotuslightDancersScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Lotuslight Dancers (TDM #204).
+ *
+ * {2}{B}{G}{U} Creature — Zombie Bard, 3/6, Lifelink.
+ *   "When this creature enters, search your library for a black card, a green card, and a blue
+ *    card. Put those cards into your graveyard, then shuffle."
+ *
+ * The ETB is three sequential single-card searches (one per color), each routed to the graveyard.
+ * We confirm lifelink is present and that all three colored cards end up in the graveyard.
+ */
+class LotuslightDancersScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lotuslight Dancers") {
+
+            test("enters with lifelink and tutors a black, green, and blue card to the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lotuslight Dancers")
+                    // {2}{B}{G}{U}: one source of each color plus two generic.
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    // Library: one card of each required color plus a decoy.
+                    .withCardInLibrary(1, "Black Creature")    // {1}{B}
+                    .withCardInLibrary(1, "Centaur Courser")   // {2}{G}
+                    .withCardInLibrary(1, "Phantom Warrior")   // {1}{U}{U}
+                    .withCardInLibrary(1, "Mountain")          // colorless decoy
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Lotuslight Dancers").error shouldBe null
+                game.resolveStack() // creature enters → first (black) search prompt
+
+                // Three sequential search selections: black, then green, then blue.
+                repeat(3) {
+                    val decision = game.getPendingDecision()
+                    decision.shouldBeInstanceOf<SelectCardsDecision>()
+                    // Exactly one eligible card per color search.
+                    game.selectCards(listOf(decision.options.first()))
+                    game.resolveStack()
+                }
+
+                val dancers = game.findPermanent("Lotuslight Dancers")!!
+                val projected = StateProjector().project(game.state)
+                withClue("Lotuslight Dancers has lifelink") {
+                    projected.hasKeyword(dancers, Keyword.LIFELINK) shouldBe true
+                }
+
+                val graveyardNames = game.state.getGraveyard(game.player1Id).mapNotNull { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name
+                }
+                withClue("All three colored cards are in the graveyard: $graveyardNames") {
+                    graveyardNames.contains("Black Creature") shouldBe true
+                    graveyardNames.contains("Centaur Courser") shouldBe true
+                    graveyardNames.contains("Phantom Warrior") shouldBe true
+                }
+                withClue("The colorless decoy stays in the library") {
+                    game.findCardsInLibrary(1, "Mountain").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarangRiverRegentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarangRiverRegentScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Marang River Regent // Coil and Catch (TDM #51).
+ *
+ * Marang River Regent — {4}{U}{U} Dragon, 6/7, Flying.
+ *   "When this creature enters, return up to two other target nonland permanents to their owners' hands."
+ * Coil and Catch — {3}{U} Instant — Omen.
+ *   "Draw three cards, then discard a card."
+ */
+class MarangRiverRegentScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Marang River Regent creature face") {
+
+            test("ETB returns up to two other nonland permanents to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Marang River Regent")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardOnBattlefield(1, "Centaur Courser") // own nonland permanent
+                    .withCardOnBattlefield(2, "Phantom Warrior")  // opponent nonland permanent
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Marang River Regent").error shouldBe null
+                game.resolveStack() // creature enters → ETB asks for up to two targets
+
+                val mine = game.findPermanent("Centaur Courser")!!
+                val theirs = game.findPermanent("Phantom Warrior")!!
+                val result = game.selectTargets(listOf(mine, theirs))
+                withClue("Two other nonland permanents is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Both targeted permanents are bounced to their owners' hands") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                    game.isOnBattlefield("Phantom Warrior") shouldBe false
+                    game.findCardsInHand(1, "Centaur Courser").size shouldBe 1
+                    game.findCardsInHand(2, "Phantom Warrior").size shouldBe 1
+                }
+                withClue("Marang River Regent (the source) is still on the battlefield — \"other\"") {
+                    game.isOnBattlefield("Marang River Regent") shouldBe true
+                }
+            }
+        }
+
+        context("Coil and Catch Omen face") {
+
+            test("draw three, discard one, then shuffle the Omen back into the library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Marang River Regent")
+                    .withLandsOnBattlefield(1, "Island", 4) // {3}{U}
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Marang River Regent"
+                }
+                val libraryBefore = game.librarySize(1) // 4
+
+                // Cast the Omen face (faceIndex = 0).
+                val cast = game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = cardId, faceIndex = 0)
+                )
+                withClue("Casting Coil and Catch should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack() // draw three, then discard prompt
+
+                if (game.hasPendingDecision()) {
+                    val discard = game.state.getHand(game.player1Id).first {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Island"
+                    }
+                    game.selectCards(listOf(discard))
+                    game.resolveStack()
+                }
+
+                withClue("One card was discarded to the graveyard") {
+                    game.graveyardSize(1) shouldBe 1
+                }
+                // Library: started at 4, drew 3, then Marang River Regent shuffles back → 4 - 3 + 1 = 2.
+                withClue("Drew three and shuffled the Omen back into the library") {
+                    game.librarySize(1) shouldBe libraryBefore - 3 + 1
+                }
+                withClue("Coil and Catch resolved to the library, not the battlefield") {
+                    game.findCardsInLibrary(1, "Marang River Regent").size shouldBe 1
+                    game.isOnBattlefield("Marang River Regent") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RilingDawnbreakerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RilingDawnbreakerScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Riling Dawnbreaker // Signaling Roar (TDM #21).
+ *
+ * Riling Dawnbreaker — {4}{W} Dragon, 3/4, Flying, vigilance.
+ *   "At the beginning of combat on your turn, another target creature you control gets +1/+0 until end of turn."
+ * Signaling Roar — {1}{W} Sorcery — Omen.
+ *   "Create a 2/2 white Soldier creature token."
+ */
+class RilingDawnbreakerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Riling Dawnbreaker creature face") {
+
+            test("begin-combat trigger pumps another target creature you control +1/+0") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Riling Dawnbreaker")
+                    .withCardOnBattlefield(1, "Centaur Courser") // 3/3 ally to pump
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ally = game.findPermanent("Centaur Courser")!!
+
+                // Pass priority through the precombat main into the begin-combat step. The
+                // turn-based trigger surfaces a target-selection decision; choose the ally
+                // (the Dragon excludes itself via "another"), then let the trigger resolve.
+                var guard = 0
+                while (game.state.step != Step.BEGIN_COMBAT && guard++ < 30) {
+                    if (game.hasPendingDecision()) {
+                        game.selectTargets(listOf(ally))
+                    } else {
+                        game.passPriority()
+                    }
+                }
+                // The trigger may still be on the stack awaiting its target / resolution.
+                guard = 0
+                while ((game.hasPendingDecision() || game.state.stack.isNotEmpty()) && guard++ < 30) {
+                    if (game.hasPendingDecision()) {
+                        game.selectTargets(listOf(ally))
+                    } else {
+                        game.passPriority()
+                    }
+                }
+
+                val projected = StateProjector().project(game.state)
+                withClue("Centaur Courser is pumped to 4/3 by the begin-combat trigger") {
+                    projected.getPower(ally) shouldBe 4
+                    projected.getToughness(ally) shouldBe 3
+                }
+            }
+        }
+
+        context("Signaling Roar Omen face") {
+
+            test("creates a 2/2 white Soldier, then shuffles the Omen back into the library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Riling Dawnbreaker")
+                    .withLandsOnBattlefield(1, "Plains", 2) // {1}{W}
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Riling Dawnbreaker"
+                }
+                val libraryBefore = game.librarySize(1) // 1
+
+                val cast = game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = cardId, faceIndex = 0)
+                )
+                withClue("Casting Signaling Roar should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val token = game.findPermanent("Soldier Token") ?: game.findPermanent("Soldier")
+                withClue("A 2/2 white Soldier token is created") {
+                    val id = token!!
+                    val projected = StateProjector().project(game.state)
+                    projected.getPower(id) shouldBe 2
+                    projected.getToughness(id) shouldBe 2
+                }
+                // Library: started at 1, +1 from the Omen shuffling back = 2.
+                withClue("Signaling Roar shuffles back into the library") {
+                    game.librarySize(1) shouldBe libraryBefore + 1
+                    game.findCardsInLibrary(1, "Riling Dawnbreaker").size shouldBe 1
+                    game.isOnBattlefield("Riling Dawnbreaker") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds five Tarkir: Dragonstorm (TDM) cards. All compose existing SDK primitives — no new effects, triggers, conditions, or keywords were introduced. Each card has a passing Kotest scenario test in `rules-engine`.

## Implemented
- **Jeskai Brushmaster** (#195) — `{1}{U}{R}{W}` Orc Monk 2/4 with Double strike + Prowess (both existing keywords).
- **Lightfoot Technique** (#14) — `{1}{W}` Instant: +1/+1 counter, grant flying + indestructible until end of turn. The card definition already existed in the repo; this PR adds its scenario test.
- **Lotuslight Dancers** (#204) — `{2}{B}{G}{U}` Zombie Bard 3/6, Lifelink. ETB composes three sequential single-card library searches (black / green / blue), each routed to the graveyard, shuffling only after the last.
- **Marang River Regent // Coil and Catch** (#51) — `{4}{U}{U}` Dragon 6/7, Flying. ETB returns up to two *other* target nonland permanents to hand (gather→move pipeline, excludeSelf). Omen face: draw three, then discard a card.
- **Riling Dawnbreaker // Signaling Roar** (#21) — `{4}{W}` Dragon 3/4, Flying + Vigilance. Begin-combat trigger pumps another target creature you control +1/+0. Omen face: create a 2/2 white Soldier token.

## Skipped
None.

## Tests
All 8 scenario tests pass (`:rules-engine:test`). `mtg-sets` discovery/printing tests pass; `check-card-printing` confirms TDM is the correct canonical set for the Omen cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)