### PR TITLE
Add TDM cards: Ureni's Rebuff, Sarkhan's Resolve, Rally the Monastery…

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RallyTheMonastery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RallyTheMonastery.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Rally the Monastery — Tarkir: Dragonstorm #19
+ * {3}{W} · Instant
+ *
+ * This spell costs {2} less to cast if you've cast another spell this turn.
+ * Choose one —
+ * • Create two 1/1 white Monk creature tokens with prowess.
+ * • Up to two target creatures you control each get +2/+2 until end of turn.
+ * • Destroy target creature with power 4 or greater.
+ *
+ * The cost reduction is evaluated at cast time, before this spell is counted, so
+ * `YouCastSpellsThisTurn(atLeast = 1)` means "you've cast another spell this turn".
+ */
+val RallyTheMonastery = card("Rally the Monastery") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} less to cast if you've cast another spell this turn.\n" +
+        "Choose one —\n" +
+        "• Create two 1/1 white Monk creature tokens with prowess.\n" +
+        "• Up to two target creatures you control each get +2/+2 until end of turn.\n" +
+        "• Destroy target creature with power 4 or greater."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.YouCastSpellsThisTurn(atLeast = 1)),
+        )
+    }
+
+    spell {
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                effect = CreateTokenEffect(
+                    count = 2,
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.WHITE),
+                    creatureTypes = setOf("Monk"),
+                    keywords = setOf(Keyword.PROWESS),
+                    name = "Monk",
+                    imageUri = "https://cards.scryfall.io/normal/front/6/3/633d2d10-def7-426f-8496-ed6b45684299.jpg?1742421122"
+                ),
+                description = "Create two 1/1 white Monk creature tokens with prowess"
+            ),
+            Mode.withTarget(
+                effect = ForEachTargetEffect(
+                    listOf(Effects.ModifyStats(power = 2, toughness = 2, target = EffectTarget.ContextTarget(0)))
+                ),
+                target = TargetCreature(count = 2, minCount = 0, filter = TargetFilter.CreatureYouControl),
+                description = "Up to two target creatures you control each get +2/+2 until end of turn"
+            ),
+            Mode.withTarget(
+                effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                target = TargetCreature(filter = TargetFilter.Creature.powerAtLeast(4)),
+                description = "Destroy target creature with power 4 or greater"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "David Astruga"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b56e0037-8143-4c13-83e1-0c3f44e685ea.jpg?1743204029"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RilingDawnbreaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RilingDawnbreaker.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Riling Dawnbreaker // Signaling Roar — Tarkir: Dragonstorm #21
+ * {4}{W} · Creature — Dragon · 3/4
+ *
+ * Flying, vigilance
+ * At the beginning of combat on your turn, another target creature you control gets +1/+0
+ * until end of turn.
+ *
+ * Omen: Signaling Roar — {1}{W}, Sorcery — Omen
+ * Create a 2/2 white Soldier creature token. (Then shuffle this card into its owner's library.)
+ *
+ * (Omen, Tarkir: Dragonstorm: casting the Omen face shuffles this card into its owner's library
+ * on resolution instead of putting it in the graveyard. From every zone other than the stack the
+ * card is just the Dragon — see [com.wingedsheep.sdk.model.CardLayout.OMEN].)
+ */
+val RilingDawnbreaker = card("Riling Dawnbreaker") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dragon"
+    power = 3
+    toughness = 4
+    oracleText = "Flying, vigilance\n" +
+        "At the beginning of combat on your turn, another target creature you control gets +1/+0 until end of turn."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val t = target(
+            "another target creature you control",
+            TargetCreature(filter = TargetFilter.OtherCreatureYouControl)
+        )
+        effect = Effects.ModifyStats(power = 1, toughness = 0, target = t)
+    }
+
+    // Omen: Signaling Roar — Sorcery. Create a 2/2 white Soldier creature token.
+    omen("Signaling Roar") {
+        manaCost = "{1}{W}"
+        typeLine = "Sorcery — Omen"
+        oracleText = "Create a 2/2 white Soldier creature token. (Then shuffle this card into its owner's library.)"
+        spell {
+            effect = CreateTokenEffect(
+                count = 1,
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Soldier"),
+                name = "Soldier",
+                imageUri = "https://cards.scryfall.io/normal/front/7/d/7ddd5153-2d16-4a4e-b9bc-f20313d322da.jpg?1743176203"
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Tuan Duong Chu"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg?1743204036"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SarkhansResolve.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SarkhansResolve.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sarkhan's Resolve — Tarkir: Dragonstorm #158
+ * {1}{G} · Instant
+ *
+ * Choose one —
+ * • Target creature gets +3/+3 until end of turn.
+ * • Destroy target creature with flying.
+ */
+val SarkhansResolve = card("Sarkhan's Resolve") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Target creature gets +3/+3 until end of turn.\n" +
+        "• Destroy target creature with flying."
+
+    spell {
+        effect = ModalEffect.chooseOne(
+            Mode(
+                effect = Effects.ModifyStats(power = 3, toughness = 3, target = EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(TargetCreature()),
+                description = "Target creature gets +3/+3 until end of turn"
+            ),
+            Mode(
+                effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(TargetCreature(filter = TargetFilter.Creature.withKeyword(Keyword.FLYING))),
+                description = "Destroy target creature with flying"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Billy Christian"
+        flavorText = "With Taigam whispering encouragement in his ear, Sarkhan threw aside his misgivings. The ritual would return him to his former glory. All he needed was a dragon's heart."
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/cae56fef-b661-4bc5-b9a1-3871ae06e491.jpg?1743204600"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/UrenisRebuff.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/UrenisRebuff.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Ureni's Rebuff — Tarkir: Dragonstorm #63
+ * {1}{U} · Sorcery
+ *
+ * Return target creature to its owner's hand.
+ * Harmonize {5}{U} (You may cast this card from your graveyard for its harmonize cost. You may
+ * tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this
+ * spell.)
+ */
+val UrenisRebuff = card("Ureni's Rebuff") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature to its owner's hand.\n" +
+        "Harmonize {5}{U} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature " +
+        "you control to reduce that cost by {X}, where X is its power. Then exile this spell.)"
+
+    spell {
+        target = TargetCreature()
+        effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0))
+    }
+
+    keywordAbility(KeywordAbility.harmonize("{5}{U}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "63"
+        artist = "Sergio Cosmai"
+        flavorText = "\"You say you come in peace. That you come here at all is an act of war.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/722716df-9cea-40a7-924b-c28497e227e6.jpg?1743204214"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmCardsGroupCExtraScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmCardsGroupCExtraScenarioTest.kt
@@ -1,0 +1,199 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the Tarkir: Dragonstorm cards:
+ *   Ureni's Rebuff (#63), Sarkhan's Resolve (#158),
+ *   Rally the Monastery (#19), Riling Dawnbreaker // Signaling Roar (#21).
+ *
+ * Each card composes existing engine mechanics; these tests prove the composed
+ * behaviour end-to-end (bounce, modal pump/destroy, conditional cost reduction,
+ * prowess token creation, and the Omen token face).
+ *
+ * Named with an "Extra" suffix to avoid colliding with another agent's
+ * TdmGroupCScenarioTest (a different batch of TDM spells).
+ */
+class TdmCardsGroupCExtraScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Ureni's Rebuff") {
+            test("returns target creature to its owner's hand") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Ureni's Rebuff")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spell = game.findCardsInHand(1, "Ureni's Rebuff").first()
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = spell,
+                        targets = listOf(ChosenTarget.Permanent(bear))
+                    )
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+                game.findCardsInHand(2, "Grizzly Bears").size shouldBe 1
+            }
+        }
+
+        context("Sarkhan's Resolve") {
+            test("mode 0 gives +3/+3 until end of turn") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Sarkhan's Resolve")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spell = game.findCardsInHand(1, "Sarkhan's Resolve").first()
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = spell,
+                        targets = listOf(ChosenTarget.Permanent(bear)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(bear)))
+                    )
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                projector.getProjectedPower(game.state, bear) shouldBe 5
+                projector.getProjectedToughness(game.state, bear) shouldBe 5
+            }
+
+            test("mode 1 destroys a creature with flying") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Sarkhan's Resolve")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(2, "Wind Drake") // 2/2 flyer
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spell = game.findCardsInHand(1, "Sarkhan's Resolve").first()
+                val drake = game.findPermanent("Wind Drake")!!
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = spell,
+                        targets = listOf(ChosenTarget.Permanent(drake)),
+                        chosenModes = listOf(1),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(drake)))
+                    )
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                game.isOnBattlefield("Wind Drake") shouldBe false
+                game.graveyardSize(2) shouldBe 1
+            }
+        }
+
+        context("Rally the Monastery") {
+            test("mode 0 creates two 1/1 Monk tokens with prowess") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Rally the Monastery")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spell = game.findCardsInHand(1, "Rally the Monastery").first()
+                val cast = game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = spell, chosenModes = listOf(0))
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                game.findPermanents("Monk").size shouldBe 2
+            }
+
+            test("cost reduction applies after casting another spell this turn") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Rally the Monastery")
+                    .withCardInHand(1, "Armored Pegasus") // a vanilla {1}{W} spell cast earlier this turn
+                    .withLandsOnBattlefield(1, "Plains", 4) // {1}{W} for Pegasus + {1}{W} for the reduced Rally
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast a vanilla creature first so "you've cast another spell this turn" is true.
+                val pegasus = game.findCardsInHand(1, "Armored Pegasus").first()
+                val firstCast = game.execute(CastSpell(playerId = game.player1Id, cardId = pegasus))
+                withClue("Pegasus should cast: ${firstCast.error}") { firstCast.error shouldBe null }
+                game.resolveStack()
+
+                val spell = game.findCardsInHand(1, "Rally the Monastery").first()
+                // {3}{W} reduced by {2} → {1}{W}; only two Plains remain after Pegasus.
+                val cast = game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = spell, chosenModes = listOf(0))
+                )
+                withClue("Reduced spell should be castable with the remaining Plains: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+                game.findPermanents("Monk").size shouldBe 2
+            }
+        }
+
+        context("Riling Dawnbreaker // Signaling Roar") {
+            test("Omen face creates a 2/2 Soldier token and shuffles back into the library") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Riling Dawnbreaker")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.findCardsInHand(1, "Riling Dawnbreaker").first()
+                val libraryBefore = game.librarySize(1)
+
+                // Omen face is faceIndex = 0.
+                val cast = game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = cardId, faceIndex = 0)
+                )
+                withClue("Casting Signaling Roar should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                game.findPermanents("Soldier").size shouldBe 1
+                withClue("Omen shuffles back into the library, not the graveyard/battlefield") {
+                    game.findCardsInLibrary(1, "Riling Dawnbreaker").size shouldBe 1
+                    game.librarySize(1) shouldBe libraryBefore + 1
+                    game.isOnBattlefield("Riling Dawnbreaker") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…, Riling Dawnbreaker

Implements four Tarkir: Dragonstorm cards, all composed from existing SDK mechanics (no new effect/trigger/condition types):

- Ureni's Rebuff (#63): {1}{U} sorcery — bounce + Harmonize {5}{U}.
- Sarkhan's Resolve (#158): {1}{G} instant — modal choose one (+3/+3, or destroy a creature with flying).
- Rally the Monastery (#19): {3}{W} instant — costs {2} less if you've cast another spell this turn; modal choose one (two 1/1 Monk tokens with prowess / up to two creatures you control +2/+2 / destroy a creature with power 4+).
- Riling Dawnbreaker // Signaling Roar (#21): {4}{W} 3/4 Dragon, flying, vigilance, begin-of-combat +1/+0 to another target creature; Omen face creates a 2/2 white Soldier token.

Adds TdmCardsGroupCExtraScenarioTest covering bounce, both modal modes, the cost reduction, the prowess token mode, and the Omen token/shuffle-back.