### PR TITLE
Add Old Man of the Sea to Arabian Nights; implement CR 506.4

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 56 / 78
+**Implemented:** 57 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -32,7 +32,7 @@
 - [x] Giant Tortoise
 - [x] Island Fish Jasconius
 - [x] Merchant Ship
-- [ ] Old Man of the Sea
+- [x] Old Man of the Sea
 - [ ] Serendib Djinn
 - [x] Serendib Efreet
 - [x] Sindbad

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -450,8 +450,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `Duration.WhileSourceTapped` (Callous Oppressor) or
   `Duration.WhileSourceTappedAndAffectedPowerAtMostSource` (Old Man of the Sea) for the classic
   "for as long as this creature remains tapped [and the stolen creature's power stays ≤ source's
-  power]" steal pattern; both durations are gated per-frame by `StateProjector` and cleaned up
-  at the next untap step.
+  power]" steal pattern. `StateProjector` gates these per-frame for the instantaneous view; the
+  one-way half of CR 611.2b ("for as long as" durations don't restart) is enforced by the
+  `EndedDurationExpiryCheck` state-based action, which physically removes the effect the moment
+  the condition fails — so a pump that wears off (or a re-tap) never re-grabs the creature.
 - `ExchangeControlEffect(target1, target2)` — swap control of two permanents.
 - `GainControlByMostEffect(metric, target?)` — the player with strictly the most of a `PlayerRankMetric` takes it (tie = no change). Metrics: `PlayerRankMetric.LifeTotal` (Ghazbán Ogre), `PlayerRankMetric.CreaturesOfSubtype(subtype)` (Thoughtbound Primoc). Facades: `Effects.GainControlByMostLife()`, `Effects.GainControlByMostOfSubtype(subtype)`.
 - `GiftGivenEffect(target)` — "gift" temporary control.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -446,7 +446,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 ### Control & combat
 
-- `GainControlEffect(target, duration)` — gain control until end of turn (default).
+- `GainControlEffect(target, duration)` — gain control until end of turn (default). Pair with
+  `Duration.WhileSourceTapped` (Callous Oppressor) or
+  `Duration.WhileSourceTappedAndAffectedPowerAtMostSource` (Old Man of the Sea) for the classic
+  "for as long as this creature remains tapped [and the stolen creature's power stays ≤ source's
+  power]" steal pattern; both durations are gated per-frame by `StateProjector` and cleaned up
+  at the next untap step.
 - `ExchangeControlEffect(target1, target2)` — swap control of two permanents.
 - `GainControlByMostEffect(metric, target?)` — the player with strictly the most of a `PlayerRankMetric` takes it (tie = no change). Metrics: `PlayerRankMetric.LifeTotal` (Ghazbán Ogre), `PlayerRankMetric.CreaturesOfSubtype(subtype)` (Thoughtbound Primoc). Facades: `Effects.GainControlByMostLife()`, `Effects.GainControlByMostOfSubtype(subtype)`.
 - `GiftGivenEffect(target)` — "gift" temporary control.
@@ -789,6 +794,9 @@ Every `TargetRequirement` carries count semantics (defaults shown):
 - `.powerGreaterThanEntity(ref)` — power strictly greater than a referenced entity's projected power. Used by
   Éowyn, Fearless Knight ("exile target creature an opponent controls with greater power") — combine
   with `EntityReference.Source` to express "greater power than the ability's source".
+- `.powerAtMostEntity(ref)` — power ≤ a referenced entity's projected power. Inverse of
+  `.powerGreaterThanEntity`; used by Old Man of the Sea ("target creature with power less than or equal
+  to this creature's power") with `EntityReference.Source`.
 - `.manaValueAtMostEntityManaSpent(ref)` — mana value ≤ the mana **actually spent** to cast a referenced
   entity. Reads the live `SpellOnStackComponent` buckets while the entity is still a spell, or the
   `CastRecordComponent` snapshot once it has resolved onto the battlefield (0 if it was never cast).

--- a/manual-scenarios/cards/o/old-man-of-the-sea.json
+++ b/manual-scenarios/cards/o/old-man-of-the-sea.json
@@ -1,0 +1,53 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Grub's Command", "Aggressive Urge"],
+    "battlefield": [
+      {"name": "Old Man of the Sea"},
+      {"name": "Surly Farrier"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Mountain"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Wingspan Stride", "Aggressive Urge"],
+    "battlefield": [
+      {"name": "Bird Maiden"},
+      {"name": "Elvish Warrior"},
+      {"name": "Hasran Ogress"},
+      {"name": "Bird Maiden", "counters": {"PLUS_ONE_PLUS_ONE": 2}},
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UNTAP"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Duration.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Duration.kt
@@ -133,6 +133,30 @@ sealed interface Duration {
     }
 
     /**
+     * Effect lasts while the source permanent remains tapped AND each affected entity's
+     * projected power stays less than or equal to the source's projected power. Gated
+     * per-frame by `StateProjector`: the source-tapped half is enforced when the floating
+     * effect is collected; the affected-power half is a post-Layer-7 fix-up that compares
+     * each affected entity's final projected power to the source's final projected power
+     * and reverts the controller for any entity that's stronger. The fix-up runs after
+     * Layer 7, so it picks up every pump source — base printed power, +1/+1 / -1/-1
+     * counters, Layer-7 floating pumps (Giant Growth, Aggressive Urge), and lord-style
+     * anthems. The floating effect entry is physically removed at the next untap-step
+     * cleanup, mirroring [WhileSourceTapped].
+     *
+     * Example: Old Man of the Sea — "for as long as Old Man of the Sea remains tapped
+     * and that creature's power remains less than or equal to Old Man of the Sea's power".
+     */
+    @SerialName("WhileSourceTappedAndAffectedPowerAtMostSource")
+    @Serializable
+    data class WhileSourceTappedAndAffectedPowerAtMostSource(
+        val sourceDescription: String = "this creature"
+    ) : Duration {
+        override val description =
+            "for as long as $sourceDescription remains tapped and that creature's power remains less than or equal to $sourceDescription's power"
+    }
+
+    /**
      * Effect lasts for as long as the effect's controller controls the affected object —
      * it ends the moment that object's controller becomes a different player ("for as long
      * as you control it"). Evaluated against the *projected* controller, so it responds to

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Duration.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Duration.kt
@@ -121,7 +121,9 @@ sealed interface Duration {
     }
 
     /**
-     * Effect lasts while the source permanent remains tapped.
+     * Effect lasts while the source permanent remains tapped. One-way (CR 611.2b): once the
+     * source untaps or leaves the battlefield the effect ends for good — `EndedDurationExpiryCheck`
+     * removes it, so a later re-tap does not restart it.
      * Example: Everglove Courier "for as long as Everglove Courier remains tapped"
      */
     @SerialName("WhileSourceTapped")
@@ -141,8 +143,13 @@ sealed interface Duration {
      * and reverts the controller for any entity that's stronger. The fix-up runs after
      * Layer 7, so it picks up every pump source — base printed power, +1/+1 / -1/-1
      * counters, Layer-7 floating pumps (Giant Growth, Aggressive Urge), and lord-style
-     * anthems. The floating effect entry is physically removed at the next untap-step
-     * cleanup, mirroring [WhileSourceTapped].
+     * anthems.
+     *
+     * Like every "for as long as …" duration this is one-way (CR 611.2b): once the source
+     * untaps or an affected entity's power exceeds the source's, `EndedDurationExpiryCheck`
+     * (a state-based action) physically removes the effect, so a pump that later wears off —
+     * or a re-tap — does NOT restart it. The projection gate is the instantaneous view; the
+     * SBA makes the end permanent.
      *
      * Example: Old Man of the Sea — "for as long as Old Man of the Sea remains tapped
      * and that creature's power remains less than or equal to Old Man of the Sea's power".
@@ -161,7 +168,9 @@ sealed interface Duration {
      * it ends the moment that object's controller becomes a different player ("for as long
      * as you control it"). Evaluated against the *projected* controller, so it responds to
      * every kind of control-changing effect (one-shot steals, Threaten, and static control
-     * Auras alike).
+     * Auras alike). One-way (CR 611.2b): the instant the controller loses the object the effect
+     * ends for good — `EndedDurationExpiryCheck` removes it, so regaining control does not
+     * restart it.
      *
      * Example: Suspend (CR 702.62g) — a creature played via suspend "gains haste until you
      * lose control of the spell or the permanent it becomes."

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -284,6 +284,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.PowerGreaterThanEntity(reference)
     )
 
+    /** Power less than or equal to the projected power of a referenced entity (source, triggering, etc.) */
+    fun powerAtMostEntity(reference: EntityReference) = copy(
+        cardPredicates = cardPredicates + CardPredicate.PowerAtMostEntity(reference)
+    )
+
     /** Toughness at most */
     fun toughnessAtMost(max: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.ToughnessAtMost(max)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -259,6 +259,10 @@ data class TargetFilter(
     fun powerGreaterThanEntity(reference: com.wingedsheep.sdk.scripting.values.EntityReference) =
         copy(baseFilter = baseFilter.powerGreaterThanEntity(reference))
 
+    /** Power less than or equal to the projected power of a referenced entity (source, triggering, etc.) */
+    fun powerAtMostEntity(reference: com.wingedsheep.sdk.scripting.values.EntityReference) =
+        copy(baseFilter = baseFilter.powerAtMostEntity(reference))
+
     /** Toughness at most */
     fun toughnessAtMost(max: Int) = copy(baseFilter = baseFilter.toughnessAtMost(max))
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -445,6 +445,23 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
     }
 
+    /**
+     * Power less than or equal to the projected power of a referenced entity. Mirror of
+     * [PowerGreaterThanEntity]; the entity is looked up via [PredicateContext]
+     * (Source / Triggering / AffectedEntity) and the comparison reads its
+     * [com.wingedsheep.sdk.model.CardComponent] power (projected when available).
+     *
+     * Used by Old Man of the Sea: "target creature with power less than or equal to this
+     * creature's power" — the candidate's power is compared against the Old Man's
+     * ([EntityReference.Source]) at target choice and at resolution-time legality re-check.
+     */
+    @SerialName("PowerAtMostEntity")
+    @Serializable
+    data class PowerAtMostEntity(val reference: EntityReference) : CardPredicate {
+        override val description: String = "with power less than or equal to ${reference.description}"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate = this
+    }
+
     // =============================================================================
     // Context-relative Predicates (Pipeline Variable References)
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/OldManOfTheSea.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/OldManOfTheSea.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.GainControlEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Old Man of the Sea
+ * {1}{U}{U}
+ * Creature — Djinn
+ * 2/3
+ * You may choose not to untap this creature during your untap step.
+ * {T}: Gain control of target creature with power less than or equal to this creature's
+ * power for as long as this creature remains tapped and that creature's power remains
+ * less than or equal to this creature's power.
+ *
+ * Both halves of the duration are gated by [com.wingedsheep.engine.mechanics.layers.StateProjector]:
+ * the projector skips the floating control effect when the source isn't tapped, and reverts
+ * the target's controller in a post-Layer-7 fix-up the moment its projected power exceeds the
+ * Old Man's projected power (counters, +X/+Y floating effects, lord-style anthems). The cleanup
+ * pass at the next untap step physically removes the floating effect entry when the source is
+ * no longer tapped, mirroring [Duration.WhileSourceTapped].
+ */
+val OldManOfTheSea = card("Old Man of the Sea") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Djinn"
+    power = 2
+    toughness = 3
+    oracleText = "You may choose not to untap this creature during your untap step.\n" +
+        "{T}: Gain control of target creature with power less than or equal to this creature's " +
+        "power for as long as this creature remains tapped and that creature's power remains " +
+        "less than or equal to this creature's power."
+
+    flags(AbilityFlag.MAY_NOT_UNTAP)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", TargetCreature(
+            filter = TargetFilter(GameObjectFilter.Creature.powerAtMostEntity(EntityReference.Source))
+        ))
+        effect = GainControlEffect(
+            t,
+            Duration.WhileSourceTappedAndAffectedPowerAtMostSource("Old Man of the Sea")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "18"
+        artist = "Susan Van Camp"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d10f8a05-78b0-42a7-adcd-83f6bafe5417.jpg?1562934067"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/OldManOfTheSea.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/OldManOfTheSea.kt
@@ -21,12 +21,14 @@ import com.wingedsheep.sdk.scripting.values.EntityReference
  * power for as long as this creature remains tapped and that creature's power remains
  * less than or equal to this creature's power.
  *
- * Both halves of the duration are gated by [com.wingedsheep.engine.mechanics.layers.StateProjector]:
- * the projector skips the floating control effect when the source isn't tapped, and reverts
- * the target's controller in a post-Layer-7 fix-up the moment its projected power exceeds the
- * Old Man's projected power (counters, +X/+Y floating effects, lord-style anthems). The cleanup
- * pass at the next untap step physically removes the floating effect entry when the source is
- * no longer tapped, mirroring [Duration.WhileSourceTapped].
+ * Both halves of the duration are gated by [com.wingedsheep.engine.mechanics.layers.StateProjector]
+ * for the instantaneous view: the projector skips the floating control effect when the source
+ * isn't tapped, and reverts the target's controller in a post-Layer-7 fix-up the moment its
+ * projected power exceeds the Old Man's projected power (counters, +X/+Y floating effects,
+ * lord-style anthems). Per CR 611.2b the duration is one-way: once either half fails,
+ * [com.wingedsheep.engine.mechanics.sba.permanent.EndedDurationExpiryCheck] physically removes
+ * the floating effect, so a pump that later wears off — or a re-tap — does not re-steal the
+ * creature.
  */
 val OldManOfTheSea = card("Old Man of the Sea") {
     manaCost = "{1}{U}{U}"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -204,15 +204,21 @@ class CleanupPhaseManager(
     /**
      * Remove WhileSourceTapped floating effects whose source is no longer tapped.
      * Called during untap step to prevent stale effects from accumulating.
+     *
+     * Also handles [Duration.WhileSourceTappedAndAffectedPowerAtMostSource] (Old Man of
+     * the Sea); the power-comparison half is gated per-frame by [StateProjector], so
+     * cleanup here only enforces the source-tapped half — same rule as [Duration.WhileSourceTapped].
      */
     fun cleanupWhileSourceTappedEffects(state: GameState): GameState {
         val remaining = state.floatingEffects.filter { floatingEffect ->
-            if (floatingEffect.duration is Duration.WhileSourceTapped) {
-                val sourceId = floatingEffect.sourceId
-                sourceId != null && state.getBattlefield().contains(sourceId) &&
-                    state.getEntity(sourceId)?.has<TappedComponent>() == true
-            } else {
-                true
+            when (floatingEffect.duration) {
+                is Duration.WhileSourceTapped,
+                is Duration.WhileSourceTappedAndAffectedPowerAtMostSource -> {
+                    val sourceId = floatingEffect.sourceId
+                    sourceId != null && state.getBattlefield().contains(sourceId) &&
+                        state.getEntity(sourceId)?.has<TappedComponent>() == true
+                }
+                else -> true
             }
         }
         return if (remaining.size != state.floatingEffects.size) {
@@ -279,8 +285,11 @@ class CleanupPhaseManager(
                     val sourceId = floatingEffect.sourceId
                     sourceId != null && newState.getBattlefield().contains(sourceId)
                 }
-                is Duration.WhileSourceTapped -> {
-                    // Keep if source is still on battlefield AND tapped
+                is Duration.WhileSourceTapped,
+                is Duration.WhileSourceTappedAndAffectedPowerAtMostSource -> {
+                    // Keep if source is still on battlefield AND tapped. The power-comparison
+                    // half of WhileSourceTappedAndAffectedPowerAtMostSource is gated per-frame
+                    // by StateProjector, so cleanup only enforces the source-tapped condition.
                     val sourceId = floatingEffect.sourceId
                     sourceId != null && newState.getBattlefield().contains(sourceId) &&
                         newState.getEntity(sourceId)?.has<TappedComponent>() == true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -638,6 +638,7 @@ class TriggerMatcher(
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostEntity -> false
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostEntityManaSpent -> false
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.PowerGreaterThanEntity -> false
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.PowerAtMostEntity -> false
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueEquals -> {
                 val cmc = if (isFaceDown) 0 else cardComponent.manaValue
                 cmc == predicate.value

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -361,6 +361,16 @@ class PredicateEvaluator {
                 candidatePower > refPower
             }
 
+            is CardPredicate.PowerAtMostEntity -> {
+                val refEntityId = resolveEntityReference(predicate.reference, context) ?: return false
+                val refContainer = state.getEntity(refEntityId) ?: return false
+                val refPower = state.projectedState.getPower(refEntityId)
+                    ?: refContainer.get<CardComponent>()?.baseStats?.basePower
+                    ?: return false
+                val candidatePower = projectedValues?.power ?: card.baseStats?.basePower ?: 0
+                candidatePower <= refPower
+            }
+
             // Source-relative predicates
             CardPredicate.NotOfSourceChosenType -> {
                 val sourceId = context?.sourceId ?: return true
@@ -862,6 +872,7 @@ class PredicateEvaluator {
             is CardPredicate.PowerOrToughnessAtLeast,
             is CardPredicate.TotalPowerAndToughnessAtMost,
             is CardPredicate.PowerGreaterThanEntity,
+            is CardPredicate.PowerAtMostEntity,
             CardPredicate.ToughnessGreaterThanPower -> false
 
             // Name predicates — not stored in record

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -768,15 +768,19 @@ class SacrificeAndPayContinuationResumer(
             if (event != null) events.add(event)
         }
 
-        // Remove WhileSourceTapped floating effects whose source is no longer tapped
+        // Remove WhileSourceTapped (and the power-gated variant) floating effects whose
+        // source is no longer tapped. The power-comparison half of the variant duration is
+        // gated per-frame by StateProjector; cleanup only enforces the tapped condition.
         newState = newState.copy(
             floatingEffects = newState.floatingEffects.filter { floatingEffect ->
-                if (floatingEffect.duration is Duration.WhileSourceTapped) {
-                    val sourceId = floatingEffect.sourceId
-                    sourceId != null && newState.getBattlefield().contains(sourceId) &&
-                        newState.getEntity(sourceId)?.has<TappedComponent>() == true
-                } else {
-                    true
+                when (floatingEffect.duration) {
+                    is Duration.WhileSourceTapped,
+                    is Duration.WhileSourceTappedAndAffectedPowerAtMostSource -> {
+                        val sourceId = floatingEffect.sourceId
+                        sourceId != null && newState.getBattlefield().contains(sourceId) &&
+                            newState.getEntity(sourceId)?.has<TappedComponent>() == true
+                    }
+                    else -> true
                 }
             }
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/RemoveFromCombatExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/RemoveFromCombatExecutor.kt
@@ -3,18 +3,16 @@ package com.wingedsheep.engine.handlers.effects.combat
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.mechanics.combat.CombatRemovalHelper
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.combat.*
 import com.wingedsheep.sdk.scripting.effects.RemoveFromCombatEffect
 import kotlin.reflect.KClass
 
 /**
- * Executor for RemoveFromCombatEffect.
- * "Remove [target] from combat."
+ * Executor for RemoveFromCombatEffect ("Remove [target] from combat.").
  *
- * Removes all combat-related components from the target creature.
- * Also cleans up any blockers that were blocking the removed attacker
- * by removing its ID from their BlockingComponent.
+ * Cleanup is delegated to [CombatRemovalHelper] so the CR 506.4 state-based check shares
+ * the same logic.
  */
 class RemoveFromCombatExecutor : EffectExecutor<RemoveFromCombatEffect> {
 
@@ -27,70 +25,6 @@ class RemoveFromCombatExecutor : EffectExecutor<RemoveFromCombatEffect> {
     ): EffectResult {
         val targetId = context.resolveTarget(effect.target)
             ?: return EffectResult.success(state)
-
-        val entity = state.getEntity(targetId)
-            ?: return EffectResult.success(state)
-
-        // Check if this creature is actually in combat
-        val isAttacking = entity.has<AttackingComponent>()
-        val isBlocking = entity.has<BlockingComponent>()
-        if (!isAttacking && !isBlocking) {
-            return EffectResult.success(state)
-        }
-
-        // Remove combat components from the target
-        var newState = state.updateEntity(targetId) { container ->
-            container
-                .without<AttackingComponent>()
-                .without<BlockingComponent>()
-                .without<BlockedComponent>()
-                .without<DamageAssignmentComponent>()
-                .without<DamageAssignmentOrderComponent>()
-                .without<AttackerOrderComponent>()
-                .without<RequiresManualDamageAssignmentComponent>()
-        }
-
-        // If the removed creature was an attacker, clean up blockers that were blocking it
-        if (isAttacking) {
-            for ((entityId, components) in newState.entities) {
-                val blockingComponent = components.get<BlockingComponent>() ?: continue
-                if (targetId in blockingComponent.blockedAttackerIds) {
-                    val updatedIds = blockingComponent.blockedAttackerIds - targetId
-                    newState = if (updatedIds.isEmpty()) {
-                        newState.updateEntity(entityId) { container ->
-                            container.without<BlockingComponent>().without<AttackerOrderComponent>()
-                        }
-                    } else {
-                        newState.updateEntity(entityId) { container ->
-                            var updated = container.with(BlockingComponent(updatedIds))
-                            val attackerOrder = updated.get<AttackerOrderComponent>()
-                            if (attackerOrder != null) {
-                                updated = updated.with(AttackerOrderComponent(
-                                    attackerOrder.orderedAttackers.filter { it != targetId }
-                                ))
-                            }
-                            updated
-                        }
-                    }
-                }
-            }
-        }
-
-        // If the removed creature was a blocker, clean up the attacker's BlockedComponent.
-        // Keep BlockedComponent even if empty — a blocked creature stays blocked per MTG rules
-        // (it just deals no combat damage without trample).
-        if (isBlocking) {
-            val blockedAttackerIds = entity.get<BlockingComponent>()?.blockedAttackerIds ?: emptyList()
-            for (attackerId in blockedAttackerIds) {
-                val attackerEntity = newState.getEntity(attackerId) ?: continue
-                val blockedComponent = attackerEntity.get<BlockedComponent>() ?: continue
-                val updatedBlockerIds = blockedComponent.blockerIds - targetId
-                newState = newState.updateEntity(attackerId) { container ->
-                    container.with(BlockedComponent(updatedBlockerIds))
-                }
-            }
-        }
-
-        return EffectResult.success(newState)
+        return EffectResult.success(CombatRemovalHelper.removeFromCombat(state, targetId))
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatRemovalHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatRemovalHelper.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.mechanics.combat
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.AttackerOrderComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.combat.BlockedComponent
+import com.wingedsheep.engine.state.components.combat.BlockingComponent
+import com.wingedsheep.engine.state.components.combat.DamageAssignmentComponent
+import com.wingedsheep.engine.state.components.combat.DamageAssignmentOrderComponent
+import com.wingedsheep.engine.state.components.combat.RequiresManualDamageAssignmentComponent
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Strips all combat components from [targetId] and propagates the removal to any creatures
+ * that were blocking it (if it was an attacker) or any attackers it was blocking (if it was
+ * a blocker). Mirrors the cleanup formerly inlined in
+ * [com.wingedsheep.engine.handlers.effects.combat.RemoveFromCombatExecutor]; extracted so the
+ * CR 506.4 state-based check (controller-changed → removed from combat) can share it.
+ */
+object CombatRemovalHelper {
+
+    /**
+     * Remove [targetId] from combat in [state]. Returns the new state, or [state] unchanged
+     * if the entity wasn't in combat. Idempotent.
+     */
+    fun removeFromCombat(state: GameState, targetId: EntityId): GameState {
+        val entity = state.getEntity(targetId) ?: return state
+        val isAttacking = entity.has<AttackingComponent>()
+        val isBlocking = entity.has<BlockingComponent>()
+        if (!isAttacking && !isBlocking) return state
+
+        var newState = state.updateEntity(targetId) { container ->
+            container
+                .without<AttackingComponent>()
+                .without<BlockingComponent>()
+                .without<BlockedComponent>()
+                .without<DamageAssignmentComponent>()
+                .without<DamageAssignmentOrderComponent>()
+                .without<AttackerOrderComponent>()
+                .without<RequiresManualDamageAssignmentComponent>()
+        }
+
+        if (isAttacking) {
+            for ((entityId, components) in newState.entities) {
+                val blockingComponent = components.get<BlockingComponent>() ?: continue
+                if (targetId in blockingComponent.blockedAttackerIds) {
+                    val updatedIds = blockingComponent.blockedAttackerIds - targetId
+                    newState = if (updatedIds.isEmpty()) {
+                        newState.updateEntity(entityId) { container ->
+                            container.without<BlockingComponent>().without<AttackerOrderComponent>()
+                        }
+                    } else {
+                        newState.updateEntity(entityId) { container ->
+                            var updated = container.with(BlockingComponent(updatedIds))
+                            val attackerOrder = updated.get<AttackerOrderComponent>()
+                            if (attackerOrder != null) {
+                                updated = updated.with(AttackerOrderComponent(
+                                    attackerOrder.orderedAttackers.filter { it != targetId }
+                                ))
+                            }
+                            updated
+                        }
+                    }
+                }
+            }
+        }
+
+        if (isBlocking) {
+            val blockedAttackerIds = entity.get<BlockingComponent>()?.blockedAttackerIds ?: emptyList()
+            for (attackerId in blockedAttackerIds) {
+                val attackerEntity = newState.getEntity(attackerId) ?: continue
+                val blockedComponent = attackerEntity.get<BlockedComponent>() ?: continue
+                val updatedBlockerIds = blockedComponent.blockerIds - targetId
+                newState = newState.updateEntity(attackerId) { container ->
+                    container.with(BlockedComponent(updatedBlockerIds))
+                }
+            }
+        }
+
+        return newState
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -465,6 +465,7 @@ internal class AffectsFilterResolver {
         is CardPredicate.ManaValueAtMostEntity -> false
         is CardPredicate.ManaValueAtMostEntityManaSpent -> false
         is CardPredicate.PowerGreaterThanEntity -> false
+        is CardPredicate.PowerAtMostEntity -> false
         CardPredicate.ManaValueIsEven -> card.manaValue % 2 == 0
         CardPredicate.ManaValueIsOdd -> card.manaValue % 2 != 0
         is CardPredicate.NameEquals -> card.name == predicate.name

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -533,6 +533,12 @@ class StateProjector(
      * controller) is correct for the single-control-changer case Old Man of the Sea covers;
      * if another control effect targets the same entity simultaneously, this gate hides it,
      * which is acceptable for the current SDK surface.
+     *
+     * This gate is the *instantaneous* view only — it hides the effect while the condition is
+     * false but would re-apply it if power dropped back. The one-way half of CR 611.2b is
+     * supplied by [com.wingedsheep.engine.mechanics.sba.permanent.EndedDurationExpiryCheck],
+     * which physically removes the floating effect the moment the gate fails so it can never
+     * restart.
      */
     private fun applyAffectedPowerAtMostSourceGate(
         state: GameState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -281,6 +281,16 @@ class StateProjector(
         // Must happen after all P/T layers so projected power/toughness is final.
         applyGrantCantBeBlockedToSmallCreatures(state, projectedValues)
 
+        // Post-layer pass: enforce the affected-power half of
+        // [Duration.WhileSourceTappedAndAffectedPowerAtMostSource] (Old Man of the Sea).
+        // We could only apply the source-tapped half during Layer 2 collection because Layer 7
+        // hadn't projected power yet. Now that final projected power is known, walk the floating
+        // effects with this Duration and revert the controller change for any affected entity
+        // whose projected power exceeds the source's projected power. This catches every pump
+        // source — base printed power, +1/+1 / -1/-1 counters, Layer-7 floating pumps (Giant
+        // Growth, Aggressive Urge), and lord-style anthems alike.
+        applyAffectedPowerAtMostSourceGate(state, projectedValues)
+
         // Convert to immutable
         val finalValues = projectedValues.mapValues { (_, v) ->
             ProjectedValues(
@@ -452,6 +462,13 @@ class StateProjector(
                     continue
                 }
             }
+            if (floating.duration is Duration.WhileSourceTappedAndAffectedPowerAtMostSource) {
+                val sourceId = floating.sourceId
+                if (sourceId == null || !state.getBattlefield().contains(sourceId) ||
+                    state.getEntity(sourceId)?.has<TappedComponent>() != true) {
+                    continue
+                }
+            }
             if (floating.duration is Duration.WhileSourceOnBattlefield) {
                 val sourceId = floating.sourceId
                 if (sourceId == null || !state.getBattlefield().contains(sourceId)) {
@@ -459,7 +476,7 @@ class StateProjector(
                 }
             }
 
-            val validAffectedEntities = if (floating.effect.dynamicGroupFilter != null) {
+            var validAffectedEntities = if (floating.effect.dynamicGroupFilter != null) {
                 // Rule 611.2c: re-evaluate filter dynamically to include entities that entered later
                 filterResolver.resolveAffectedEntities(
                     state,
@@ -476,6 +493,13 @@ class StateProjector(
                     state.getBattlefield().contains(entityId) || state.stack.contains(entityId)
                 }.toSet()
             }
+
+            // The per-affected-entity power gate for
+            // [Duration.WhileSourceTappedAndAffectedPowerAtMostSource] is deferred to a
+            // post-Layer-7 fix-up in [project] — we can't compare projected power here
+            // because Layer 7 hasn't run yet (and reading `state.projectedState` would
+            // recurse). Include the effect now; the fix-up reverts control for any affected
+            // entity whose final projected power exceeds the source's final projected power.
 
             if (validAffectedEntities.isNotEmpty()) {
                 effects.add(
@@ -498,6 +522,41 @@ class StateProjector(
         }
 
         return effects
+    }
+
+    /**
+     * Post-Layer-7 gate for [Duration.WhileSourceTappedAndAffectedPowerAtMostSource]:
+     * walk the floating effects with this duration, compare each affected entity's
+     * final projected power to the source's final projected power, and revert the
+     * controller to the entity's base [ControllerComponent] if the affected entity is
+     * now stronger. Reverting to the base controller (rather than the previously-projected
+     * controller) is correct for the single-control-changer case Old Man of the Sea covers;
+     * if another control effect targets the same entity simultaneously, this gate hides it,
+     * which is acceptable for the current SDK surface.
+     */
+    private fun applyAffectedPowerAtMostSourceGate(
+        state: GameState,
+        projectedValues: MutableMap<EntityId, MutableProjectedValues>
+    ) {
+        for (floating in state.floatingEffects) {
+            if (floating.duration !is Duration.WhileSourceTappedAndAffectedPowerAtMostSource) continue
+            val sourceId = floating.sourceId ?: continue
+            if (!state.getBattlefield().contains(sourceId)) continue
+            if (state.getEntity(sourceId)?.has<TappedComponent>() != true) continue
+
+            val sourcePower = projectedValues[sourceId]?.power ?: continue
+
+            for (affectedId in floating.effect.affectedEntities) {
+                if (!state.getBattlefield().contains(affectedId)) continue
+                val affectedPower = projectedValues[affectedId]?.power ?: continue
+                if (affectedPower > sourcePower) {
+                    val baseController = state.getEntity(affectedId)
+                        ?.get<ControllerComponent>()
+                        ?.playerId
+                    projectedValues[affectedId]?.controllerId = baseController
+                }
+            }
+        }
     }
 
     private fun resolveCDAs(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -893,6 +893,7 @@ class CostCalculator(
             is CardPredicate.ManaValueAtMostEntity -> false
             is CardPredicate.ManaValueAtMostEntityManaSpent -> false
             is CardPredicate.PowerGreaterThanEntity -> false
+            is CardPredicate.PowerAtMostEntity -> false
             CardPredicate.ManaValueIsEven -> cardDef.manaCost.cmc % 2 == 0
             CardPredicate.ManaValueIsOdd -> cardDef.manaCost.cmc % 2 != 0
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
@@ -8,6 +8,7 @@ object SbaOrder {
     const val PLAYER_LIFE_LOSS = 100        // 704.5a
     const val COMMANDER_DAMAGE_LOSS = 150   // 704.5c (Commander format)
     const val POISON_LOSS = 200             // 704.5b
+    const val CONTROL_CHANGED_COMBAT = 250  // 506.4 (controller change removes from combat)
     const val ZERO_TOUGHNESS = 300          // 704.5f
     const val LETHAL_DAMAGE = 400           // 704.5g/h
     const val PLANESWALKER_LOYALTY = 500    // 704.5i

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
@@ -8,6 +8,7 @@ object SbaOrder {
     const val PLAYER_LIFE_LOSS = 100        // 704.5a
     const val COMMANDER_DAMAGE_LOSS = 150   // 704.5c (Commander format)
     const val POISON_LOSS = 200             // 704.5b
+    const val DURATION_EXPIRY = 240         // 611.2b ("for as long as" durations end one-way)
     const val CONTROL_CHANGED_COMBAT = 250  // 506.4 (controller change removes from combat)
     const val ZERO_TOUGHNESS = 300          // 704.5f
     const val LETHAL_DAMAGE = 400           // 704.5g/h

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/ControlChangedRemovesFromCombatCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/ControlChangedRemovesFromCombatCheck.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.combat.BlockingComponent
+import com.wingedsheep.sdk.model.EntityId
 
 /**
  * CR 506.4 — "A permanent is removed from combat if … its controller changes …".
@@ -33,7 +34,7 @@ class ControlChangedRemovesFromCombatCheck : StateBasedActionCheck {
         val activePlayerId = state.activePlayerId
         val projected = state.projectedState
 
-        val toRemove = mutableListOf<com.wingedsheep.sdk.model.EntityId>()
+        val toRemove = mutableListOf<EntityId>()
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val isAttacking = container.has<AttackingComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/ControlChangedRemovesFromCombatCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/ControlChangedRemovesFromCombatCheck.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.mechanics.sba.creature
+
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.mechanics.combat.CombatRemovalHelper
+import com.wingedsheep.engine.mechanics.sba.SbaOrder
+import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.combat.BlockingComponent
+
+/**
+ * CR 506.4 — "A permanent is removed from combat if … its controller changes …".
+ *
+ * Walks every creature with [AttackingComponent] or [BlockingComponent] and compares its
+ * projected controller (which already reflects every Layer 2 control-changing effect, plus
+ * Old Man of the Sea's post-Layer-7 power gate) to the player it should be fighting for:
+ *
+ * - Attackers must remain controlled by the active player (the only player who has
+ *   declared attackers this turn). A projected controller that is no longer the active
+ *   player → removed from combat.
+ * - Blockers must remain controlled by a non-active player (the defender who declared
+ *   them). A projected controller that has become the active player → removed from combat.
+ *
+ * The two-player approximation is sufficient for current scope; multi-player formats
+ * can extend this once they're modelled. Removal uses [CombatRemovalHelper] so dependent
+ * `BlockedComponent` / `BlockingComponent` references stay consistent.
+ */
+class ControlChangedRemovesFromCombatCheck : StateBasedActionCheck {
+    override val name = "506.4 Controller-Changed Combat Removal"
+    override val order = SbaOrder.CONTROL_CHANGED_COMBAT
+
+    override fun check(state: GameState): ExecutionResult {
+        val activePlayerId = state.activePlayerId
+        val projected = state.projectedState
+
+        val toRemove = mutableListOf<com.wingedsheep.sdk.model.EntityId>()
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val isAttacking = container.has<AttackingComponent>()
+            val isBlocking = container.has<BlockingComponent>()
+            if (!isAttacking && !isBlocking) continue
+
+            val controllerId = projected.getController(entityId) ?: continue
+            val mismatched = when {
+                isAttacking -> controllerId != activePlayerId
+                isBlocking -> controllerId == activePlayerId
+                else -> false
+            }
+            if (mismatched) toRemove.add(entityId)
+        }
+
+        if (toRemove.isEmpty()) return ExecutionResult.success(state)
+
+        var newState = state
+        for (entityId in toRemove) {
+            newState = CombatRemovalHelper.removeFromCombat(newState, entityId)
+        }
+        return ExecutionResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/CreatureSbaModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/CreatureSbaModule.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.mechanics.sba.StateBasedActionModule
 
 class CreatureSbaModule : StateBasedActionModule {
     override fun checks(): List<StateBasedActionCheck> = listOf(
+        ControlChangedRemovesFromCombatCheck(),
         ZeroToughnessCheck(),
         LethalDamageCheck()
     )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/EndedDurationExpiryCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/EndedDurationExpiryCheck.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.engine.mechanics.sba.permanent
+
+import com.wingedsheep.engine.core.ControlChangedEvent
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.sba.SbaOrder
+import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * CR 611.2b — a continuous effect with a "for as long as …" duration ends the moment its
+ * condition stops being true and does NOT restart if the condition later becomes true again
+ * ("It doesn't start and immediately stop again, and it doesn't last forever").
+ *
+ * [com.wingedsheep.engine.mechanics.layers.StateProjector] already enforces these conditions
+ * per projection frame, which gives the correct *instantaneous* view: the effect simply stops
+ * applying while the condition is false. That half is reversible on its own — if the condition
+ * flips back to true the gate re-applies the effect. This state-based check supplies the missing
+ * half: once the condition has failed, the floating effect is physically removed from
+ * [GameState.floatingEffects] (latched off), so no later projection can resurrect it.
+ *
+ * Concretely this fixes Old Man of the Sea: when the stolen creature is pumped past Old Man's
+ * power its control reverts, and a temporary pump that later wears off must NOT re-steal it.
+ *
+ * Conditions handled — mirrors the gates in [com.wingedsheep.engine.mechanics.layers.StateProjector]:
+ * - [Duration.WhileSourceTapped] / [Duration.WhileSourceTappedAndAffectedPowerAtMostSource]:
+ *   ends when the source leaves the battlefield or untaps. The power variant additionally drops
+ *   any affected creature whose projected power exceeds the source's projected power.
+ * - [Duration.WhileSourceOnBattlefield]: ends when the source leaves the battlefield.
+ * - [Duration.WhileControlledByController]: drops any affected object the effect's controller no
+ *   longer controls.
+ *
+ * Affected entities no longer on the battlefield are left untouched: the effect as a whole is
+ * reaped by the untap-step cleanup / zone-change handling, and we must not emit spurious
+ * control-change events for permanents that merely left.
+ *
+ * Ordered ([SbaOrder.DURATION_EXPIRY]) before [ControlChangedRemovesFromCombatCheck] and the
+ * lethal-damage / zero-toughness checks so that, within the same SBA pass, combat removal sees
+ * the reverted controller and the death checks see any toughness boost that has now ended.
+ */
+class EndedDurationExpiryCheck : StateBasedActionCheck {
+    override val name = "611.2b Ended-Duration Effect Expiry"
+    override val order = SbaOrder.DURATION_EXPIRY
+
+    override fun check(state: GameState): ExecutionResult {
+        if (state.floatingEffects.isEmpty()) return ExecutionResult.success(state)
+
+        val events = mutableListOf<GameEvent>()
+        var current = state
+
+        // Internal fixpoint: pruning one effect can change the projected power/controller that
+        // gates another, so re-evaluate until the floating-effect set stops shrinking. Each pass
+        // only removes entities/effects, so this converges in at most one pass per effect.
+        while (true) {
+            val projected = current.projectedState
+            val pruned = ArrayList<ActiveFloatingEffect>(current.floatingEffects.size)
+            var changed = false
+
+            for (floating in current.floatingEffects) {
+                val active = activeAffectedEntities(current, projected, floating)
+                if (active.size == floating.effect.affectedEntities.size) {
+                    pruned.add(floating)
+                    continue
+                }
+                changed = true
+                emitControlReversions(current, floating, floating.effect.affectedEntities - active, events)
+                if (active.isNotEmpty()) {
+                    pruned.add(floating.copy(effect = floating.effect.copy(affectedEntities = active)))
+                }
+            }
+
+            if (!changed) break
+            current = current.copy(floatingEffects = pruned)
+        }
+
+        return if (current === state) ExecutionResult.success(state)
+        else ExecutionResult.success(current, events)
+    }
+
+    /**
+     * The subset of [ActiveFloatingEffect.effect]'s affected entities for which the effect's
+     * "for as long as" condition still holds. Returns the full set unchanged for non-conditional
+     * durations. The returned set is always a subset of the input (the affected set only shrinks),
+     * which is what makes the latch one-way.
+     */
+    private fun activeAffectedEntities(
+        state: GameState,
+        projected: ProjectedState,
+        floating: ActiveFloatingEffect
+    ): Set<EntityId> {
+        val all = floating.effect.affectedEntities
+        return when (floating.duration) {
+            is Duration.WhileSourceTapped ->
+                if (sourceTapped(state, floating.sourceId)) all else emptySet()
+
+            is Duration.WhileSourceTappedAndAffectedPowerAtMostSource -> {
+                if (!sourceTapped(state, floating.sourceId)) {
+                    emptySet()
+                } else {
+                    val sourcePower = projected.getPower(floating.sourceId!!) ?: return all
+                    all.filterTo(LinkedHashSet()) { id ->
+                        !state.getBattlefield().contains(id) ||
+                            (projected.getPower(id) ?: 0) <= sourcePower
+                    }
+                }
+            }
+
+            is Duration.WhileSourceOnBattlefield ->
+                if (floating.sourceId != null && state.getBattlefield().contains(floating.sourceId)) all
+                else emptySet()
+
+            Duration.WhileControlledByController ->
+                all.filterTo(LinkedHashSet()) { id ->
+                    !state.getBattlefield().contains(id) || projected.getController(id) == floating.controllerId
+                }
+
+            else -> all
+        }
+    }
+
+    private fun sourceTapped(state: GameState, sourceId: EntityId?): Boolean =
+        sourceId != null && state.getBattlefield().contains(sourceId) &&
+            state.getEntity(sourceId)?.has<TappedComponent>() == true
+
+    /**
+     * Emit a [ControlChangedEvent] for each dropped entity of a control effect, reverting from the
+     * thief ([SerializableModification.ChangeController.newControllerId]) back to the permanent's
+     * base controller. Only control effects produce a visible control change worth an event.
+     */
+    private fun emitControlReversions(
+        state: GameState,
+        floating: ActiveFloatingEffect,
+        dropped: Set<EntityId>,
+        events: MutableList<GameEvent>
+    ) {
+        val modification = floating.effect.modification
+        if (modification !is SerializableModification.ChangeController) return
+        for (id in dropped) {
+            val container = state.getEntity(id) ?: continue
+            val baseController = container.get<ControllerComponent>()?.playerId ?: continue
+            if (baseController == modification.newControllerId) continue
+            events.add(
+                ControlChangedEvent(
+                    permanentId = id,
+                    permanentName = container.get<CardComponent>()?.name ?: "",
+                    oldControllerId = modification.newControllerId,
+                    newControllerId = baseController
+                )
+            )
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/PermanentSbaModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/PermanentSbaModule.kt
@@ -10,6 +10,7 @@ class PermanentSbaModule(
     private val cardRegistry: CardRegistry
 ) : StateBasedActionModule {
     override fun checks(): List<StateBasedActionCheck> = listOf(
+        EndedDurationExpiryCheck(),
         PlaneswalkerLoyaltyCheck(),
         LegendRuleCheck(decisionHandler),
         CounterAnnihilationCheck(),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OldManOfTheSeaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OldManOfTheSeaScenarioTest.kt
@@ -235,6 +235,67 @@ class OldManOfTheSeaScenarioTest : FunSpec({
         projector.project(driver.state).getController(target) shouldBe opponent
     }
 
+    test("CR 611.2b — control does NOT return after a temporary pump wears off (one-way latch)") {
+        // The reversible projection gate alone would re-steal the creature once its power drops
+        // back to ≤ Old Man's. CR 611.2b: a "for as long as" duration ends permanently once its
+        // condition fails. EndedDurationExpiryCheck physically removes the control effect the
+        // moment power is exceeded, so the pump wearing off must NOT bring control back.
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oldMan = driver.putCreatureOnBattlefield(activePlayer, "Old Man of the Sea")
+        driver.removeSummoningSickness(oldMan)
+        val target = driver.putCreatureOnBattlefield(opponent, "Elvish Warrior")  // 2/3
+
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = oldMan,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        driver.bothPass()
+        projector.project(driver.state).getController(target) shouldBe activePlayer
+
+        val sbaChecker = com.wingedsheep.engine.mechanics.StateBasedActionChecker(
+            cardRegistry = driver.cardRegistry
+        )
+
+        // Temporary +2/+0 pump: power 2 → 4 > Old Man's 2. SBAs latch the steal off for good.
+        val ctx = EffectContext(sourceId = oldMan, controllerId = opponent, opponentId = activePlayer)
+        driver.replaceState(
+            driver.state.addFloatingEffect(
+                layer = Layer.POWER_TOUGHNESS,
+                modification = SerializableModification.ModifyPowerToughness(powerMod = 2, toughnessMod = 0),
+                affectedEntities = setOf(target),
+                duration = Duration.EndOfTurn,
+                context = ctx,
+            )
+        )
+        driver.replaceState(sbaChecker.checkAndApply(driver.state).newState)
+        projector.project(driver.state).getController(target) shouldBe opponent
+
+        // The control effect must be gone — not merely hidden by the power gate.
+        driver.state.floatingEffects.none {
+            it.duration is Duration.WhileSourceTappedAndAffectedPowerAtMostSource
+        } shouldBe true
+
+        // The pump wears off (remove the EndOfTurn effect); Old Man is still tapped and the
+        // Warrior is back to power 2 ≤ 2 — but control must stay with its owner.
+        driver.replaceState(
+            driver.state.copy(
+                floatingEffects = driver.state.floatingEffects.filterNot { it.duration == Duration.EndOfTurn }
+            )
+        )
+        driver.replaceState(sbaChecker.checkAndApply(driver.state).newState)
+        projector.project(driver.state).getController(target) shouldBe opponent
+    }
+
     test("CR 506.4 — stolen attacker is removed from combat when control reverts mid-attack") {
         // Alice steals Bob's Elvish Warrior with Old Man and attacks Bob with it. Bob plays
         // an Aggressive-Urge-style pump on the Warrior, pushing its power past Old Man's.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OldManOfTheSeaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OldManOfTheSeaScenarioTest.kt
@@ -1,0 +1,344 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.arn.cards.OldManOfTheSea
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.Duration
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Old Man of the Sea (Arabian Nights).
+ *
+ * Old Man of the Sea: {1}{U}{U}
+ * Creature — Djinn
+ * 2/3
+ * You may choose not to untap this creature during your untap step.
+ * {T}: Gain control of target creature with power less than or equal to this creature's
+ * power for as long as this creature remains tapped and that creature's power remains
+ * less than or equal to this creature's power.
+ */
+class OldManOfTheSeaScenarioTest : FunSpec({
+
+    val abilityId = OldManOfTheSea.activatedAbilities.first().id
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("Tap to steal a creature with power equal to source's power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oldMan = driver.putCreatureOnBattlefield(activePlayer, "Old Man of the Sea")
+        driver.removeSummoningSickness(oldMan)
+
+        // Elvish Warrior is 2/3 — power 2 equals Old Man's 2, so it's a legal target.
+        val target = driver.putCreatureOnBattlefield(opponent, "Elvish Warrior")
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = oldMan,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        val projected = projector.project(driver.state)
+        projected.getController(target) shouldBe activePlayer
+    }
+
+    test("Cannot target a creature with power greater than source's power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oldMan = driver.putCreatureOnBattlefield(activePlayer, "Old Man of the Sea")
+        driver.removeSummoningSickness(oldMan)
+
+        // Centaur Courser is 3/3 — power 3 exceeds Old Man's 2.
+        val target = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = oldMan,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("Control returns when Old Man of the Sea is untapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oldMan = driver.putCreatureOnBattlefield(activePlayer, "Old Man of the Sea")
+        driver.removeSummoningSickness(oldMan)
+        val target = driver.putCreatureOnBattlefield(opponent, "Elvish Warrior")
+
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = oldMan,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        driver.bothPass()
+        projector.project(driver.state).getController(target) shouldBe activePlayer
+
+        // Next untap step — decline the MAY_NOT_UNTAP option (select empty list).
+        driver.passPriorityUntil(Step.UNTAP)
+        driver.submitCardSelection(activePlayer, emptyList())
+
+        driver.state.getEntity(oldMan)?.has<TappedComponent>() shouldBe false
+        projector.project(driver.state).getController(target) shouldBe opponent
+    }
+
+    test("Control persists while Old Man of the Sea remains tapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oldMan = driver.putCreatureOnBattlefield(activePlayer, "Old Man of the Sea")
+        driver.removeSummoningSickness(oldMan)
+        val target = driver.putCreatureOnBattlefield(opponent, "Elvish Warrior")
+
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = oldMan,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        driver.bothPass()
+
+        // Next untap step — choose to keep Old Man tapped.
+        driver.passPriorityUntil(Step.UNTAP)
+        driver.submitCardSelection(activePlayer, listOf(oldMan))
+
+        driver.state.getEntity(oldMan)?.has<TappedComponent>() shouldBe true
+        projector.project(driver.state).getController(target) shouldBe activePlayer
+    }
+
+    test("Control reverts when stolen creature gains +1/+1 counters past source's power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oldMan = driver.putCreatureOnBattlefield(activePlayer, "Old Man of the Sea")
+        driver.removeSummoningSickness(oldMan)
+        val target = driver.putCreatureOnBattlefield(opponent, "Elvish Warrior")  // 2/3
+
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = oldMan,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        driver.bothPass()
+        projector.project(driver.state).getController(target) shouldBe activePlayer
+
+        // Two +1/+1 counters push the stolen creature's power 2 → 4, exceeding Old Man's 2.
+        // The per-entity gate should drop the control effect for that target.
+        driver.replaceState(driver.state.updateEntity(target) { c ->
+            c.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2)))
+        })
+
+        projector.project(driver.state).getController(target) shouldBe opponent
+    }
+
+    test("Control reverts when stolen creature is pumped by a Layer-7 floating effect") {
+        // Aggressive-Urge-style: a temporary +1/+1 floating effect (NOT a counter) on the
+        // stolen creature. The post-Layer-7 fix-up must see the projected power and revert
+        // control even though the pump never touches CountersComponent.
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oldMan = driver.putCreatureOnBattlefield(activePlayer, "Old Man of the Sea")
+        driver.removeSummoningSickness(oldMan)
+        val target = driver.putCreatureOnBattlefield(opponent, "Elvish Warrior")  // 2/3
+
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = oldMan,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        driver.bothPass()
+        projector.project(driver.state).getController(target) shouldBe activePlayer
+
+        // Layer-7 +2/+0 floating effect on the stolen creature (Giant Growth-style).
+        // Power goes 2 → 4, exceeding Old Man's 2. The post-Layer-7 fix-up must catch this.
+        val ctx = EffectContext(
+            sourceId = oldMan,
+            controllerId = opponent,
+            opponentId = activePlayer,
+        )
+        driver.replaceState(
+            driver.state.addFloatingEffect(
+                layer = Layer.POWER_TOUGHNESS,
+                modification = SerializableModification.ModifyPowerToughness(powerMod = 2, toughnessMod = 0),
+                affectedEntities = setOf(target),
+                duration = Duration.EndOfTurn,
+                context = ctx,
+            )
+        )
+
+        projector.project(driver.state).getController(target) shouldBe opponent
+    }
+
+    test("CR 506.4 — stolen attacker is removed from combat when control reverts mid-attack") {
+        // Alice steals Bob's Elvish Warrior with Old Man and attacks Bob with it. Bob plays
+        // an Aggressive-Urge-style pump on the Warrior, pushing its power past Old Man's.
+        // The post-Layer-7 power gate reverts the controller to Bob; the CR 506.4 SBA then
+        // removes the Warrior from combat so it deals zero damage during combat damage.
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oldMan = driver.putCreatureOnBattlefield(activePlayer, "Old Man of the Sea")
+        driver.removeSummoningSickness(oldMan)
+        val target = driver.putCreatureOnBattlefield(opponent, "Elvish Warrior")  // 2/3
+
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = oldMan,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        driver.bothPass()
+        projector.project(driver.state).getController(target) shouldBe activePlayer
+
+        // The stolen Warrior is no longer summoning-sick once Alice controls it. Clear it
+        // explicitly to mirror what a real "since your last turn began" check would say.
+        driver.removeSummoningSickness(target)
+
+        // Advance to declare attackers and attack with the stolen Warrior.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val opponentLifeBefore = driver.state.getEntity(opponent)
+            ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 20
+        driver.declareAttackers(activePlayer, listOf(target), opponent)
+        driver.state.getEntity(target)
+            ?.has<com.wingedsheep.engine.state.components.combat.AttackingComponent>() shouldBe true
+
+        // Bob pumps the (stolen) Warrior with a +2/+0 floating effect. Power becomes 4 > Old
+        // Man's 2 → power-gate reverts control to Bob → CR 506.4 removes Warrior from combat.
+        val ctx = EffectContext(
+            sourceId = oldMan,
+            controllerId = opponent,
+            opponentId = activePlayer,
+        )
+        driver.replaceState(
+            driver.state.addFloatingEffect(
+                layer = Layer.POWER_TOUGHNESS,
+                modification = SerializableModification.ModifyPowerToughness(powerMod = 2, toughnessMod = 0),
+                affectedEntities = setOf(target),
+                duration = Duration.EndOfTurn,
+                context = ctx,
+            )
+        )
+
+        // Run state-based actions and verify the Warrior is no longer attacking.
+        val sbaChecker = com.wingedsheep.engine.mechanics.StateBasedActionChecker(
+            cardRegistry = driver.cardRegistry
+        )
+        val sbaResult = sbaChecker.checkAndApply(driver.state)
+        sbaResult.isSuccess shouldBe true
+        driver.replaceState(sbaResult.newState)
+
+        driver.state.getEntity(target)
+            ?.has<com.wingedsheep.engine.state.components.combat.AttackingComponent>() shouldBe false
+        projector.project(driver.state).getController(target) shouldBe opponent
+
+        // Bob's life total is unchanged once we finish out combat damage.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        val opponentLifeAfter = driver.state.getEntity(opponent)
+            ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>()?.life ?: 20
+        opponentLifeAfter shouldBe opponentLifeBefore
+    }
+
+    test("Pumping Old Man of the Sea with counters expands its valid-target range") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oldMan = driver.putCreatureOnBattlefield(activePlayer, "Old Man of the Sea")
+        driver.removeSummoningSickness(oldMan)
+        val target = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")  // 3/3
+
+        // Without a pump, targeting a 3-power creature is illegal (verified by an earlier test).
+        // With two +1/+1 counters, Old Man's power becomes 4 — the Centaur (3) is now in range.
+        driver.replaceState(driver.state.updateEntity(oldMan) { c ->
+            c.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2)))
+        })
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = oldMan,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+        projector.project(driver.state).getController(target) shouldBe activePlayer
+    }
+})


### PR DESCRIPTION
Adds the {1}{U}{U} 2/3 Djinn with its "for as long as this creature remains tapped and that creature's power remains less than or equal to this creature's power" steal duration, plus the engine work needed to make the second half of that duration actually fire.

SDK additions:
- `Duration.WhileSourceTappedAndAffectedPowerAtMostSource` — variant of WhileSourceTapped that also gates per-affected-entity on power ≤ source's power.
- `CardPredicate.PowerAtMostEntity(reference)` + `.powerAtMostEntity(ref)` DSL on ObjectFilter / TargetFilter — inverse of PowerGreaterThanEntity, used by the target requirement.

Engine wiring:
- StateProjector collects the duration's floating effects gated only on source-tapped; a post-Layer-7 fix-up (`applyAffectedPowerAtMostSourceGate`) compares each affected entity's final projected power to the source's final projected power and reverts the controller for any entity that's stronger. The post-Layer-7 timing is what makes the gate see every pump source — printed power, +1/+1 / -1/-1 counters, Layer-7 floating pumps (Giant Growth, Aggressive Urge), and lord-style anthems.
- CR 506.4 — "A permanent is removed from combat if its controller changes." New SBA `ControlChangedRemovesFromCombatCheck` walks every `AttackingComponent` / `BlockingComponent` entity and removes it from combat if its projected controller no longer matches the player whose role it's filling (attackers must be the active player; blockers must not). `RemoveFromCombatExecutor`'s cleanup is extracted into `CombatRemovalHelper` so the SBA and the explicit `RemoveFromCombatEffect` share the same removal logic.
- CleanupPhaseManager + SacrificeAndPayContinuationResumer drop the new duration's floating effect at untap-step cleanup the same way they handle WhileSourceTapped.
- PredicateEvaluator implements PowerAtMostEntity; the other entity-relative-predicate stubs (TriggerMatcher, AffectsFilterResolver, CostCalculator) mirror PowerGreaterThanEntity.

Eight scenario tests cover the activation flow, the predicate's target-validity gate, the untap-returns-control / stays-tapped fork, the per-entity power gate via +1/+1 counters AND Layer-7 floating pumps, and the CR 506.4 mid-attack removal — a stolen attacker pumped past Old Man's power loses control, leaves combat, and deals zero damage.