### PR TITLE
Add Weftwalking with composable free-cast SDK primitive

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 254 / 261
+**Implemented:** 255 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -260,7 +260,7 @@
 - [x] Wedgelight Rammer
 - [x] Weftblade Enhancer
 - [x] Weftstalker Ardent
-- [ ] Weftwalking
+- [x] Weftwalking
 - [x] Wurmwall Sweeper
 - [x] Xu-Ifit, Osteoharmonist
 - [x] Zealous Display

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1527,18 +1527,23 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   Yawgmoth's Agenda (`MayCastFromGraveyard(Nonland)`); `lifeCost = 1, duringYourTurnOnly = true` for
   Festival of Embers. Pair with `MayPlayLandsFromGraveyard` for "play lands and cast spells from
   your graveyard". Lands are *played*, not cast, so they need the lands permission separately.
-- `MayCastFirstSpellOfTurnWithoutPayingMana(controllerOnly = false)` — the first spell each
-  player casts during each of their **own** turns may be cast without paying its mana cost
-  (Weftwalking). Gated at cast time by `CostCalculator.hasFirstSpellOfTurnFreeCast`: requires the
-  active player to be the caster, requires the caster to have cast zero spells this turn, and
-  requires a battlefield source with this static (the source's controller may be anyone unless
-  `controllerOnly = true`). Surfaces as an alt-cost entry (`{0}`) in
-  `EnumerationContext.alternativeCastingCosts`; `CastSpellHandler.isFirstSpellOfTurnFreeCastChosen`
-  resolves the priority chain so the static only wins when no keyword alt (flashback / harmonize /
-  warp / evoke / impending), no `selfAlternativeCost`, and no Jodah-style `GrantAlternativeCastingCost`
-  applies — when it does win the cast is treated as `playForFree` (cost zeroed, kicker / blight /
-  behold / runtime tax skipped, matching the existing `PlayWithoutPayingCostComponent` flow used
-  by Cascade and Omniscience).
+- `MayCastWithoutPayingManaCost(controllerOnly = false, firstSpellOfTurnOnly = false)` — a
+  battlefield permission to cast a spell without paying its mana cost (CR 118.9). Composable
+  gates: `controllerOnly = true` restricts the benefit to the source's controller ("you" wording);
+  `firstSpellOfTurnOnly = true` requires the caster to be the active player and to have cast
+  zero spells this turn. Weftwalking is `MayCastWithoutPayingManaCost(firstSpellOfTurnOnly = true)`;
+  a future "you may cast the first spell you cast each turn …" composes via both gates true.
+  Cast-legality is checked by `CostCalculator.hasFreeCastPermission`. Surfaced as a dedicated
+  `CastWithoutPayingManaCost` `LegalAction` variant routed through
+  `CastSpell.useWithoutPayingManaCost = true` — emitted **alongside** Jodah-style
+  `GrantAlternativeCastingCost`, flashback, harmonize, warp, evoke, impending, and
+  `selfAlternativeCost` variants so the player explicitly picks one (CR 118.9a — only one
+  alternative cost may apply to a cast, and which one is the player's choice, not handler
+  priority). `CastSpellHandler.validate` rejects combining the flag with `useAlternativeCost`.
+  When chosen, the cast is treated as `playForFree` (cost zeroed, X = 0 per CR 107.3b, kicker
+  / blight / behold / runtime tax skipped; mandatory additional costs like Embrace Oblivion's
+  sacrifice are still enforced), matching the existing `PlayWithoutPayingCostComponent` flow
+  used by Cascade and Omniscience.
 
 **Top-of-library reveal & play** (reveal the top card of a library, optionally with permission to
 play it from there). Visibility (public reveal to all players) and play permission are separate

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1527,6 +1527,18 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   Yawgmoth's Agenda (`MayCastFromGraveyard(Nonland)`); `lifeCost = 1, duringYourTurnOnly = true` for
   Festival of Embers. Pair with `MayPlayLandsFromGraveyard` for "play lands and cast spells from
   your graveyard". Lands are *played*, not cast, so they need the lands permission separately.
+- `MayCastFirstSpellOfTurnWithoutPayingMana(controllerOnly = false)` — the first spell each
+  player casts during each of their **own** turns may be cast without paying its mana cost
+  (Weftwalking). Gated at cast time by `CostCalculator.hasFirstSpellOfTurnFreeCast`: requires the
+  active player to be the caster, requires the caster to have cast zero spells this turn, and
+  requires a battlefield source with this static (the source's controller may be anyone unless
+  `controllerOnly = true`). Surfaces as an alt-cost entry (`{0}`) in
+  `EnumerationContext.alternativeCastingCosts`; `CastSpellHandler.isFirstSpellOfTurnFreeCastChosen`
+  resolves the priority chain so the static only wins when no keyword alt (flashback / harmonize /
+  warp / evoke / impending), no `selfAlternativeCost`, and no Jodah-style `GrantAlternativeCastingCost`
+  applies — when it does win the cast is treated as `playForFree` (cost zeroed, kicker / blight /
+  behold / runtime tax skipped, matching the existing `PlayWithoutPayingCostComponent` flow used
+  by Cascade and Omniscience).
 
 **Top-of-library reveal & play** (reveal the top card of a library, optionally with permission to
 play it from there). Visibility (public reveal to all players) and play permission are separate

--- a/manual-scenarios/cards/w/weftwalking-etb.json
+++ b/manual-scenarios/cards/w/weftwalking-etb.json
@@ -5,8 +5,8 @@
     "lifeTotal": 20,
     "hand": [
       "Weftwalking",
-      "Lightning Bolt",
-      "Counterspell",
+      "Shock",
+      "Unravel",
       "Grizzly Bears"
     ],
     "battlefield": [
@@ -19,32 +19,34 @@
     ],
     "graveyard": [
       "Opt",
-      "Counterspell",
-      "Doom Blade",
+      "Unravel",
+      "Smother",
       "Wrath of God"
     ],
     "library": [
       "Serra Angel",
-      "Lightning Bolt",
-      "Doom Blade",
-      "Counterspell",
+      "Shock",
+      "Smother",
+      "Unravel",
       "Opt",
       "Plains",
       "Island",
       "Forest",
       "Grizzly Bears",
-      "Sengir Vampire"
+      "Serra Angel"
     ]
   },
   "player2": {
     "lifeTotal": 20,
-    "hand": [],
+    "hand": ["Glamer Gifter"],
     "battlefield": [
       {"name": "Mountain", "tapped": false},
       {"name": "Mountain", "tapped": false}
     ],
     "graveyard": [],
     "library": [
+      "Serra Angel",
+      "Grizzly Bears",
       "Mountain",
       "Mountain",
       "Mountain",

--- a/manual-scenarios/cards/w/weftwalking-etb.json
+++ b/manual-scenarios/cards/w/weftwalking-etb.json
@@ -1,0 +1,62 @@
+{
+  "player1Name": "Weftwalker",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Weftwalking",
+      "Lightning Bolt",
+      "Counterspell",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false}
+    ],
+    "graveyard": [
+      "Opt",
+      "Counterspell",
+      "Doom Blade",
+      "Wrath of God"
+    ],
+    "library": [
+      "Serra Angel",
+      "Lightning Bolt",
+      "Doom Blade",
+      "Counterspell",
+      "Opt",
+      "Plains",
+      "Island",
+      "Forest",
+      "Grizzly Bears",
+      "Sengir Vampire"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/w/weftwalking-free-cast.json
+++ b/manual-scenarios/cards/w/weftwalking-free-cast.json
@@ -22,7 +22,7 @@
       {"name": "Island", "tapped": false},
       {"name": "Island", "tapped": false}
     ],
-    "graveyard": [],
+    "graveyard": ["Memory Deluge"],
     "library": [
       "Opt",
       "Unravel",

--- a/manual-scenarios/cards/w/weftwalking-free-cast.json
+++ b/manual-scenarios/cards/w/weftwalking-free-cast.json
@@ -6,18 +6,27 @@
     "hand": [
       "Serra Angel",
       "Wrath of God",
-      "Counterspell"
+      "End-Blaze Epiphany",
+      "Academy Drake",
+      "Unravel"
     ],
     "battlefield": [
       {"name": "Weftwalking"},
+      {"name": "Grizzly Bears"},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false},
       {"name": "Island", "tapped": false},
       {"name": "Island", "tapped": false}
     ],
     "graveyard": [],
     "library": [
       "Opt",
-      "Counterspell",
-      "Lightning Bolt",
+      "Unravel",
+      "Shock",
       "Island",
       "Plains"
     ]
@@ -26,9 +35,12 @@
     "lifeTotal": 20,
     "hand": [
       "Grizzly Bears",
-      "Sengir Vampire"
+      "Shock",
+      "Smother",
+      "Serra Angel"
     ],
     "battlefield": [
+      {"name": "Grizzly Bears"},
       {"name": "Mountain", "tapped": false},
       {"name": "Swamp", "tapped": false}
     ],

--- a/manual-scenarios/cards/w/weftwalking-free-cast.json
+++ b/manual-scenarios/cards/w/weftwalking-free-cast.json
@@ -1,0 +1,51 @@
+{
+  "player1Name": "Weftwalker",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Serra Angel",
+      "Wrath of God",
+      "Counterspell"
+    ],
+    "battlefield": [
+      {"name": "Weftwalking"},
+      {"name": "Island", "tapped": false},
+      {"name": "Island", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": [
+      "Opt",
+      "Counterspell",
+      "Lightning Bolt",
+      "Island",
+      "Plains"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears",
+      "Sengir Vampire"
+    ],
+    "battlefield": [
+      {"name": "Mountain", "tapped": false},
+      {"name": "Swamp", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Swamp",
+      "Mountain",
+      "Swamp",
+      "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -259,32 +259,6 @@ data object CantCastSpellsSharingColorWithLastCast : StaticAbility {
 }
 
 /**
- * A continuous prohibition on casting spells, scoped along three independent axes — each a
- * reused SDK primitive, so one type covers a whole family of "can't cast" cards:
- *
- *  - **who** — [affected], a [Player] reference interpreted *relative to this permanent's
- *    controller*: `EachOpponent` / `Opponent` (your opponents), `You` (the controller), `Each`
- *    (everyone).
- *  - **which** — [spellFilter], matched against the card being cast (card predicates work in any
- *    zone). Defaults to every spell.
- *  - **when** — [condition], evaluated in the controller's context, so `IsYourTurn` reads as
- *    "during your turn" and `IsNotYourTurn` as "during an opponent's turn". `null` = always.
- *
- * Read at cast-legality time (never on the stack), so it composes with every casting path —
- * hand, graveyard flashback/harmonize, exile, top of library. Control is read from projected
- * state, so a control-changing effect flips who is restricted.
- *
- *  - Voice of Victory: `PlayersCantCastSpells(Player.EachOpponent, condition = IsYourTurn)`
- *    ("Your opponents can't cast spells during your turn.")
- *  - Grand Abolisher's cast clause: `PlayersCantCastSpells(Player.EachOpponent)` (every turn).
- *  - Void Winnower: `PlayersCantCastSpells(Player.EachOpponent, spellFilter =
- *    GameObjectFilter(cardPredicates = listOf(CardPredicate.ManaValueIsEven)))`.
- *
- * @property affected Who is forbidden, relative to the source's controller.
- * @property spellFilter Which spells are forbidden (matched against the card being cast).
- * @property condition Optional timing/state gate, evaluated in the controller's context; null = always.
- */
-/**
  * Generic "may cast a spell without paying its mana cost" battlefield permission. The static is
  * read at cast-legality time on every permanent on the battlefield; when its gates are open it
  * surfaces a `CastWithoutPayingManaCost` [com.wingedsheep.engine.legalactions.LegalAction]
@@ -335,6 +309,32 @@ data class MayCastWithoutPayingManaCost(
     }
 }
 
+/**
+ * A continuous prohibition on casting spells, scoped along three independent axes — each a
+ * reused SDK primitive, so one type covers a whole family of "can't cast" cards:
+ *
+ *  - **who** — [affected], a [Player] reference interpreted *relative to this permanent's
+ *    controller*: `EachOpponent` / `Opponent` (your opponents), `You` (the controller), `Each`
+ *    (everyone).
+ *  - **which** — [spellFilter], matched against the card being cast (card predicates work in any
+ *    zone). Defaults to every spell.
+ *  - **when** — [condition], evaluated in the controller's context, so `IsYourTurn` reads as
+ *    "during your turn" and `IsNotYourTurn` as "during an opponent's turn". `null` = always.
+ *
+ * Read at cast-legality time (never on the stack), so it composes with every casting path —
+ * hand, graveyard flashback/harmonize, exile, top of library. Control is read from projected
+ * state, so a control-changing effect flips who is restricted.
+ *
+ *  - Voice of Victory: `PlayersCantCastSpells(Player.EachOpponent, condition = IsYourTurn)`
+ *    ("Your opponents can't cast spells during your turn.")
+ *  - Grand Abolisher's cast clause: `PlayersCantCastSpells(Player.EachOpponent)` (every turn).
+ *  - Void Winnower: `PlayersCantCastSpells(Player.EachOpponent, spellFilter =
+ *    GameObjectFilter(cardPredicates = listOf(CardPredicate.ManaValueIsEven)))`.
+ *
+ * @property affected Who is forbidden, relative to the source's controller.
+ * @property spellFilter Which spells are forbidden (matched against the card being cast).
+ * @property condition Optional timing/state gate, evaluated in the controller's context; null = always.
+ */
 @SerialName("PlayersCantCastSpells")
 @Serializable
 data class PlayersCantCastSpells(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -285,39 +285,53 @@ data object CantCastSpellsSharingColorWithLastCast : StaticAbility {
  * @property condition Optional timing/state gate, evaluated in the controller's context; null = always.
  */
 /**
- * The first spell each player casts during each of their own turns may be cast without paying
- * its mana cost. Used by Weftwalking ({4}{U}{U} Enchantment, Edge of Eternities): "The first
- * spell each player casts during each of their turns may be cast without paying its mana cost."
+ * Generic "may cast a spell without paying its mana cost" battlefield permission. The static is
+ * read at cast-legality time on every permanent on the battlefield; when its gates are open it
+ * surfaces a `CastWithoutPayingManaCost` [com.wingedsheep.engine.legalactions.LegalAction]
+ * variant routing through `CastSpell.useWithoutPayingManaCost`.
  *
- * Per Rule 117.9 / 118.9b, "without paying its mana cost" means:
- *  - the spell's mana cost is not paid (X = 0 for X spells),
- *  - other mandatory additional costs still apply (kicker, behold, blight, etc.),
- *  - alternative costs cannot be combined (so this can't be chained with flashback, etc.).
+ * Per CR 118.9, "without paying its mana cost" is itself an alternative cost; mandatory
+ * additional costs (kicker, blight, behold, etc.) still apply, and per CR 107.3b X is treated
+ * as 0 for X-cost spells cast this way. Per CR 118.9a only one alternative cost can apply to
+ * a given cast, so the variant is **mutually exclusive** with `useAlternativeCost`
+ * (validated in `CastSpellHandler`).
  *
- * The free-cast permission is **optional** ("may"), surfaced to the player as an alternative cost
- * variant during cast-action enumeration. Gating, applied at cast time:
- *  - it must currently be the casting player's turn (the spell is being cast on one of *their*
- *    own turns, not on an opponent's turn via flash),
- *  - the casting player must have cast no spells yet this turn (the "first spell" clause —
- *    `GameState.spellsCastThisTurnByPlayer[caster]` is null or empty),
- *  - when [controllerOnly] is true, only the source permanent's controller benefits.
+ * The variant is emitted **alongside** Jodah-style [GrantAlternativeCastingCost], flashback,
+ * harmonize, warp, evoke, impending, and `selfAlternativeCost` variants so the player picks
+ * one explicitly — CR 118.9a leaves the choice to the player, not handler priority.
  *
- * Modelled as a static ability on a permanent so that the permission tracks the permanent's
- * presence on the battlefield — removing the permanent in response to the cast offer
- * immediately revokes it.
+ * Composable gates:
+ *  - [controllerOnly] — if true, only the source permanent's controller benefits ("you cast"
+ *    wording). Default false = any player benefits ("each player casts" wording).
+ *  - [firstSpellOfTurnOnly] — if true, the caster must be the active player and must have cast
+ *    no spells yet this turn. Default false = no first-spell gate.
  *
- * @property controllerOnly If true, only the source permanent's controller benefits (default:
- *           false = each player on each of their own turns, the Weftwalking wording).
+ * Composes for Weftwalking ({4}{U}{U}, EOE: "The first spell each player casts during each of
+ * their turns may be cast without paying its mana cost.") via
+ * `MayCastWithoutPayingManaCost(firstSpellOfTurnOnly = true)`. A future "you may cast the first
+ * spell you cast each turn without paying its mana cost" composes via
+ * `MayCastWithoutPayingManaCost(controllerOnly = true, firstSpellOfTurnOnly = true)`. An
+ * always-on Omniscience-style static would set both gates false (though Omniscience itself is
+ * modelled via `PlayWithoutPayingCostComponent` on the spell rather than this static).
+ *
+ * Modelled as a static ability on a permanent so the permission tracks the permanent's
+ * presence on the battlefield — removing the source in response to the cast offer immediately
+ * revokes it.
  */
-@SerialName("MayCastFirstSpellOfTurnWithoutPayingMana")
+@SerialName("MayCastWithoutPayingManaCost")
 @Serializable
-data class MayCastFirstSpellOfTurnWithoutPayingMana(
-    val controllerOnly: Boolean = false
+data class MayCastWithoutPayingManaCost(
+    val controllerOnly: Boolean = false,
+    val firstSpellOfTurnOnly: Boolean = false
 ) : StaticAbility {
-    override val description: String = if (controllerOnly) {
-        "The first spell you cast each turn may be cast without paying its mana cost"
-    } else {
-        "The first spell each player casts during each of their turns may be cast without paying its mana cost"
+    override val description: String = buildString {
+        if (firstSpellOfTurnOnly) {
+            if (controllerOnly) append("The first spell you cast each turn may be cast without paying its mana cost")
+            else append("The first spell each player casts during each of their turns may be cast without paying its mana cost")
+        } else {
+            if (controllerOnly) append("You may cast spells without paying their mana costs")
+            else append("Each player may cast spells without paying their mana costs")
+        }
     }
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -284,6 +284,43 @@ data object CantCastSpellsSharingColorWithLastCast : StaticAbility {
  * @property spellFilter Which spells are forbidden (matched against the card being cast).
  * @property condition Optional timing/state gate, evaluated in the controller's context; null = always.
  */
+/**
+ * The first spell each player casts during each of their own turns may be cast without paying
+ * its mana cost. Used by Weftwalking ({4}{U}{U} Enchantment, Edge of Eternities): "The first
+ * spell each player casts during each of their turns may be cast without paying its mana cost."
+ *
+ * Per Rule 117.9 / 118.9b, "without paying its mana cost" means:
+ *  - the spell's mana cost is not paid (X = 0 for X spells),
+ *  - other mandatory additional costs still apply (kicker, behold, blight, etc.),
+ *  - alternative costs cannot be combined (so this can't be chained with flashback, etc.).
+ *
+ * The free-cast permission is **optional** ("may"), surfaced to the player as an alternative cost
+ * variant during cast-action enumeration. Gating, applied at cast time:
+ *  - it must currently be the casting player's turn (the spell is being cast on one of *their*
+ *    own turns, not on an opponent's turn via flash),
+ *  - the casting player must have cast no spells yet this turn (the "first spell" clause —
+ *    `GameState.spellsCastThisTurnByPlayer[caster]` is null or empty),
+ *  - when [controllerOnly] is true, only the source permanent's controller benefits.
+ *
+ * Modelled as a static ability on a permanent so that the permission tracks the permanent's
+ * presence on the battlefield — removing the permanent in response to the cast offer
+ * immediately revokes it.
+ *
+ * @property controllerOnly If true, only the source permanent's controller benefits (default:
+ *           false = each player on each of their own turns, the Weftwalking wording).
+ */
+@SerialName("MayCastFirstSpellOfTurnWithoutPayingMana")
+@Serializable
+data class MayCastFirstSpellOfTurnWithoutPayingMana(
+    val controllerOnly: Boolean = false
+) : StaticAbility {
+    override val description: String = if (controllerOnly) {
+        "The first spell you cast each turn may be cast without paying its mana cost"
+    } else {
+        "The first spell each player casts during each of their turns may be cast without paying its mana cost"
+    }
+}
+
 @SerialName("PlayersCantCastSpells")
 @Serializable
 data class PlayersCantCastSpells(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Weftwalking.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Weftwalking.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.MayCastFirstSpellOfTurnWithoutPayingMana
+import com.wingedsheep.sdk.scripting.MayCastWithoutPayingManaCost
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
@@ -25,8 +25,9 @@ import com.wingedsheep.sdk.scripting.references.Player
  * - The ETB is an intervening-if trigger ([Conditions.WasCast]) — only fires when Weftwalking is cast,
  *   not when put onto the battlefield by reanimation or similar non-cast means.
  * - The static grants every player a "may cast without paying its mana cost" alternative on the first
- *   spell they cast during each of their own turns. Engine wiring lives in [CostCalculator] (gate
- *   check) + [CastSpellHandler] (`isFirstSpellOfTurnFreeCastChosen` priority chain).
+ *   spell they cast during each of their own turns. Engine wiring lives in
+ *   [CostCalculator.hasFreeCastPermission] (gate check) and [CastSpellHandler] (free-cast resolution
+ *   via [CastSpell.useWithoutPayingManaCost]).
  */
 val Weftwalking = card("Weftwalking") {
     manaCost = "{4}{U}{U}"
@@ -57,7 +58,7 @@ val Weftwalking = card("Weftwalking") {
     }
 
     staticAbility {
-        ability = MayCastFirstSpellOfTurnWithoutPayingMana()
+        ability = MayCastWithoutPayingManaCost(firstSpellOfTurnOnly = true)
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Weftwalking.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Weftwalking.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.MayCastFirstSpellOfTurnWithoutPayingMana
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Weftwalking — Edge of Eternities #86
+ * {4}{U}{U} · Enchantment · Mythic
+ *
+ * When this enchantment enters, if you cast it, shuffle your hand and graveyard into your library,
+ * then draw seven cards.
+ * The first spell each player casts during each of their turns may be cast without paying its mana cost.
+ *
+ * - The ETB is an intervening-if trigger ([Conditions.WasCast]) — only fires when Weftwalking is cast,
+ *   not when put onto the battlefield by reanimation or similar non-cast means.
+ * - The static grants every player a "may cast without paying its mana cost" alternative on the first
+ *   spell they cast during each of their own turns. Engine wiring lives in [CostCalculator] (gate
+ *   check) + [CastSpellHandler] (`isFirstSpellOfTurnFreeCastChosen` priority chain).
+ */
+val Weftwalking = card("Weftwalking") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, if you cast it, shuffle your hand and graveyard into your library, then draw seven cards.\n" +
+        "The first spell each player casts during each of their turns may be cast without paying its mana cost."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        effect = Effects.Composite(
+            // Gather hand + graveyard in a single pass (one combined "shuffle ... into your library"
+            // event per oracle text) and shuffle the result into the controller's library.
+            GatherCardsEffect(
+                source = CardSource.FromMultipleZones(
+                    zones = listOf(Zone.HAND, Zone.GRAVEYARD),
+                    player = Player.You
+                ),
+                storeAs = "weftwalkingShuffleCards"
+            ),
+            MoveCollectionEffect(
+                from = "weftwalkingShuffleCards",
+                destination = CardDestination.ToZone(Zone.LIBRARY, Player.You, ZonePlacement.Shuffled)
+            ),
+            Effects.DrawCards(7)
+        )
+    }
+
+    staticAbility {
+        ability = MayCastFirstSpellOfTurnWithoutPayingMana()
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "86"
+        artist = "Rovina Cai"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39d48ddd-4529-4284-9da3-5272ad362b9b.jpg?1752946899"
+        ruling(
+            "2025-07-25",
+            "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for any alternative costs. " +
+                "You can, however, pay additional costs, such as kicker costs. If the spell has any mandatory additional costs, " +
+                "such as that of Embrace Oblivion, those must be paid to cast the spell."
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
@@ -86,7 +86,17 @@ data class CastSpell(
      * the face's mana cost and the resulting permanent enters the battlefield with that
      * face's door unlocked (CR 709.5d).
      */
-    val faceIndex: Int? = null
+    val faceIndex: Int? = null,
+    /**
+     * Invokes a `MayCastWithoutPayingManaCost` battlefield permission (e.g. Weftwalking): cast
+     * the spell for {0} via the "without paying its mana cost" alternative cost. Per CR 118.9a
+     * only one alternative cost can apply to a cast, so this is mutually exclusive with
+     * [useAlternativeCost]; distinguishing the two via separate flags is what lets the player
+     * choose between this free cast and any other alt cost (Jodah's `GrantAlternativeCastingCost`,
+     * flashback, harmonize, warp, evoke, impending, `selfAlternativeCost`) when both are legal.
+     * The enumerator emits a separate `CastWithoutPayingManaCost` action per granted permission.
+     */
+    val useWithoutPayingManaCost: Boolean = false
 ) : GameAction
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -74,7 +74,6 @@ import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.sdk.scripting.effects.StormCopyEffect
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
-import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
 import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
@@ -316,11 +315,19 @@ class CastSpellHandler(
             if (conspireError != null) return conspireError
         }
 
-        // Calculate effective cost (free if PlayWithoutPayingCostComponent is present, or if the
-        // MayCastFirstSpellOfTurnWithoutPayingMana static (e.g. Weftwalking) is the chosen alt).
+        // Calculate effective cost (free if PlayWithoutPayingCostComponent is present, or if a
+        // MayCastWithoutPayingManaCost battlefield source (e.g. Weftwalking) is the chosen alt).
         val playForFreeFromComponent = zoneResolver.hasPlayWithoutPayingCost(state, action.playerId, action.cardId)
-        val playForFree = playForFreeFromComponent ||
-            isFirstSpellOfTurnFreeCastChosen(state, action, cardDef, playForFreeFromComponent)
+        if (action.useWithoutPayingManaCost) {
+            // CR 118.9a — only one alternative cost can apply to a given cast.
+            if (action.useAlternativeCost) {
+                return "Cannot combine 'without paying its mana cost' with another alternative cost"
+            }
+            if (!costCalculator.hasFreeCastPermission(state, action.playerId)) {
+                return "'Without paying its mana cost' is not available (gate closed or no source on the battlefield)"
+            }
+        }
+        val playForFree = playForFreeFromComponent || action.useWithoutPayingManaCost
         // Split-layout (CR 709.3a) — only the chosen half is evaluated for legality. When
         // `faceIndex` is set, the cost is the face's printed mana cost passed through the
         // standard battlefield cost-modifier pipeline (CR 118.9a applies cost modifiers to
@@ -722,40 +729,6 @@ class CastSpellHandler(
 
     private fun isCastFromExile(state: GameState, cardId: EntityId): Boolean =
         state.turnOrder.any { ownerId -> cardId in state.getZone(ZoneKey(ownerId, Zone.EXILE)) }
-
-    /**
-     * Detects whether [action.useAlternativeCost] is the caster invoking the
-     * `MayCastFirstSpellOfTurnWithoutPayingMana` static (Weftwalking). True only when no
-     * higher-priority alt cost path applies (flashback / harmonize / warp / evoke / impending /
-     * selfAlt / Jodah-style `GrantAlternativeCastingCost`) and the gate is open (active player +
-     * zero spells cast this turn + a battlefield source granting the permission). When true, the
-     * cast is treated as `playForFree`: cost is {0} and downstream kicker / blight / behold /
-     * runtime-cost-increase guards are skipped — mirroring [PlayWithoutPayingCostComponent]
-     * semantics for the rest of the cast pipeline (matching how Cascade/Omniscience-style free
-     * casts already resolve in this engine).
-     */
-    private fun isFirstSpellOfTurnFreeCastChosen(
-        state: GameState,
-        action: CastSpell,
-        cardDef: CardDefinition?,
-        playForFreeFromComponent: Boolean,
-    ): Boolean {
-        if (!action.useAlternativeCost || playForFreeFromComponent || cardDef == null) return false
-        val hasFlashback = cardDef.keywordAbilities.any { it is KeywordAbility.Flashback } &&
-            zoneResolver.hasFlashbackPermission(state, action.playerId, action.cardId)
-        if (hasFlashback) return false
-        val hasHarmonize = HarmonizeGrants.effectiveHarmonize(state, action.cardId, cardDef) != null &&
-            zoneResolver.hasHarmonizePermission(state, action.playerId, action.cardId)
-        if (hasHarmonize) return false
-        val hasWarp = cardDef.keywordAbilities.any { it is KeywordAbility.Warp } &&
-            zoneResolver.hasWarpPermission(state, action.playerId, action.cardId)
-        if (hasWarp) return false
-        if (cardDef.keywordAbilities.any { it is KeywordAbility.Evoke }) return false
-        if (cardDef.keywordAbilities.any { it is KeywordAbility.Impending }) return false
-        if (cardDef.script.selfAlternativeCost != null) return false
-        if (costCalculator.findAlternativeCastingCosts(state, action.playerId).isNotEmpty()) return false
-        return costCalculator.hasFirstSpellOfTurnFreeCast(state, action.playerId)
-    }
 
     private fun validateConspire(
         state: GameState,
@@ -1343,11 +1316,11 @@ class CastSpellHandler(
         // successful cast.
         val linkedExileGranterEntry = zoneResolver.findLinkedExileGranterEntry(currentState, action.playerId, action.cardId)
 
-        // Calculate effective cost (free if PlayWithoutPayingCostComponent is present, or if the
-        // MayCastFirstSpellOfTurnWithoutPayingMana static (e.g. Weftwalking) is the chosen alt).
+        // Calculate effective cost (free if PlayWithoutPayingCostComponent is present, or if a
+        // MayCastWithoutPayingManaCost battlefield source (e.g. Weftwalking) is the chosen alt).
+        // Mutual-exclusion + gate already enforced in validate().
         val playForFreeFromComponentExecute = zoneResolver.hasPlayWithoutPayingCost(currentState, action.playerId, action.cardId)
-        val playForFreeInExecute = playForFreeFromComponentExecute ||
-            isFirstSpellOfTurnFreeCastChosen(currentState, action, cardDef, playForFreeFromComponentExecute)
+        val playForFreeInExecute = playForFreeFromComponentExecute || action.useWithoutPayingManaCost
         // Split-layout (CR 709.3a) — see validate() for the rationale. Mirror the override here.
         val faceManaCostOverrideExecute: ManaCost? = action.faceIndex?.let { idx ->
             cardDef?.cardFaces?.getOrNull(idx)?.manaCost

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -74,6 +74,7 @@ import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.sdk.scripting.effects.StormCopyEffect
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
 import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
@@ -315,8 +316,11 @@ class CastSpellHandler(
             if (conspireError != null) return conspireError
         }
 
-        // Calculate effective cost (free if PlayWithoutPayingCostComponent is present)
-        val playForFree = zoneResolver.hasPlayWithoutPayingCost(state, action.playerId, action.cardId)
+        // Calculate effective cost (free if PlayWithoutPayingCostComponent is present, or if the
+        // MayCastFirstSpellOfTurnWithoutPayingMana static (e.g. Weftwalking) is the chosen alt).
+        val playForFreeFromComponent = zoneResolver.hasPlayWithoutPayingCost(state, action.playerId, action.cardId)
+        val playForFree = playForFreeFromComponent ||
+            isFirstSpellOfTurnFreeCastChosen(state, action, cardDef, playForFreeFromComponent)
         // Split-layout (CR 709.3a) — only the chosen half is evaluated for legality. When
         // `faceIndex` is set, the cost is the face's printed mana cost passed through the
         // standard battlefield cost-modifier pipeline (CR 118.9a applies cost modifiers to
@@ -718,6 +722,40 @@ class CastSpellHandler(
 
     private fun isCastFromExile(state: GameState, cardId: EntityId): Boolean =
         state.turnOrder.any { ownerId -> cardId in state.getZone(ZoneKey(ownerId, Zone.EXILE)) }
+
+    /**
+     * Detects whether [action.useAlternativeCost] is the caster invoking the
+     * `MayCastFirstSpellOfTurnWithoutPayingMana` static (Weftwalking). True only when no
+     * higher-priority alt cost path applies (flashback / harmonize / warp / evoke / impending /
+     * selfAlt / Jodah-style `GrantAlternativeCastingCost`) and the gate is open (active player +
+     * zero spells cast this turn + a battlefield source granting the permission). When true, the
+     * cast is treated as `playForFree`: cost is {0} and downstream kicker / blight / behold /
+     * runtime-cost-increase guards are skipped — mirroring [PlayWithoutPayingCostComponent]
+     * semantics for the rest of the cast pipeline (matching how Cascade/Omniscience-style free
+     * casts already resolve in this engine).
+     */
+    private fun isFirstSpellOfTurnFreeCastChosen(
+        state: GameState,
+        action: CastSpell,
+        cardDef: CardDefinition?,
+        playForFreeFromComponent: Boolean,
+    ): Boolean {
+        if (!action.useAlternativeCost || playForFreeFromComponent || cardDef == null) return false
+        val hasFlashback = cardDef.keywordAbilities.any { it is KeywordAbility.Flashback } &&
+            zoneResolver.hasFlashbackPermission(state, action.playerId, action.cardId)
+        if (hasFlashback) return false
+        val hasHarmonize = HarmonizeGrants.effectiveHarmonize(state, action.cardId, cardDef) != null &&
+            zoneResolver.hasHarmonizePermission(state, action.playerId, action.cardId)
+        if (hasHarmonize) return false
+        val hasWarp = cardDef.keywordAbilities.any { it is KeywordAbility.Warp } &&
+            zoneResolver.hasWarpPermission(state, action.playerId, action.cardId)
+        if (hasWarp) return false
+        if (cardDef.keywordAbilities.any { it is KeywordAbility.Evoke }) return false
+        if (cardDef.keywordAbilities.any { it is KeywordAbility.Impending }) return false
+        if (cardDef.script.selfAlternativeCost != null) return false
+        if (costCalculator.findAlternativeCastingCosts(state, action.playerId).isNotEmpty()) return false
+        return costCalculator.hasFirstSpellOfTurnFreeCast(state, action.playerId)
+    }
 
     private fun validateConspire(
         state: GameState,
@@ -1305,8 +1343,11 @@ class CastSpellHandler(
         // successful cast.
         val linkedExileGranterEntry = zoneResolver.findLinkedExileGranterEntry(currentState, action.playerId, action.cardId)
 
-        // Calculate effective cost (free if PlayWithoutPayingCostComponent is present)
-        val playForFreeInExecute = zoneResolver.hasPlayWithoutPayingCost(currentState, action.playerId, action.cardId)
+        // Calculate effective cost (free if PlayWithoutPayingCostComponent is present, or if the
+        // MayCastFirstSpellOfTurnWithoutPayingMana static (e.g. Weftwalking) is the chosen alt).
+        val playForFreeFromComponentExecute = zoneResolver.hasPlayWithoutPayingCost(currentState, action.playerId, action.cardId)
+        val playForFreeInExecute = playForFreeFromComponentExecute ||
+            isFirstSpellOfTurnFreeCastChosen(currentState, action, cardDef, playForFreeFromComponentExecute)
         // Split-layout (CR 709.3a) — see validate() for the rationale. Mirror the override here.
         val faceManaCostOverrideExecute: ManaCost? = action.faceIndex?.let { idx ->
             cardDef?.cardFaces?.getOrNull(idx)?.manaCost

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -111,17 +111,19 @@ class EnumerationContext(
             (perSpellCastRestrictionPresent &&
                 castPermissionUtils.spellSpecificallyRestricted(state, playerId, cardId))
 
-    // First spell of own turn may be cast without paying its mana cost (e.g., Weftwalking).
-    // Gated to the active player AND zero spells cast this turn — see CostCalculator.
-    val firstSpellOfTurnFreeCast: Boolean by lazy {
-        costCalculator.hasFirstSpellOfTurnFreeCast(state, playerId)
+    // A battlefield [MayCastWithoutPayingManaCost] source is granting the player permission to
+    // cast a spell without paying its mana cost (e.g., Weftwalking on the first spell of the
+    // player's own turn). Surfaced as its own [CastSpell.useWithoutPayingManaCost] action
+    // variant in CastSpellEnumerator, distinct from [alternativeCastingCosts] so the player can
+    // choose between this free cast and any Jodah-style alternative (CR 118.9a — only one
+    // alternative cost can apply to a cast, and which one is the player's choice).
+    val freeCastPermissionAvailable: Boolean by lazy {
+        costCalculator.hasFreeCastPermission(state, playerId)
     }
 
-    // Alternative casting costs from battlefield permanents (e.g., Jodah, plus a {0} entry for
-    // Weftwalking's first-spell-of-turn free cast when the gate is open).
+    // Alternative casting costs from battlefield permanents (e.g., Jodah's WUBRG).
     val alternativeCastingCosts: List<ManaCost> by lazy {
-        val base = costCalculator.findAlternativeCastingCosts(state, playerId)
-        if (firstSpellOfTurnFreeCast) base + ManaCost.ZERO else base
+        costCalculator.findAlternativeCastingCosts(state, playerId)
     }
 
     // Cycling prevention

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbilitiesComponent
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.EntityId
 
 /**
@@ -110,9 +111,17 @@ class EnumerationContext(
             (perSpellCastRestrictionPresent &&
                 castPermissionUtils.spellSpecificallyRestricted(state, playerId, cardId))
 
-    // Alternative casting costs from battlefield permanents (e.g., Jodah)
-    val alternativeCastingCosts by lazy {
-        costCalculator.findAlternativeCastingCosts(state, playerId)
+    // First spell of own turn may be cast without paying its mana cost (e.g., Weftwalking).
+    // Gated to the active player AND zero spells cast this turn — see CostCalculator.
+    val firstSpellOfTurnFreeCast: Boolean by lazy {
+        costCalculator.hasFirstSpellOfTurnFreeCast(state, playerId)
+    }
+
+    // Alternative casting costs from battlefield permanents (e.g., Jodah, plus a {0} entry for
+    // Weftwalking's first-spell-of-turn free cast when the gate is open).
+    val alternativeCastingCosts: List<ManaCost> by lazy {
+        val base = costCalculator.findAlternativeCastingCosts(state, playerId)
+        if (firstSpellOfTurnFreeCast) base + ManaCost.ZERO else base
     }
 
     // Cycling prevention

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -868,7 +868,7 @@ class CastSpellEnumerator : ActionEnumerator {
                         if (freeCastResult != null) {
                             result.add(LegalAction(
                                 actionType = "CastWithoutPayingManaCost",
-                                description = "Cast ${cardComponent.name}",
+                                description = "Cast ${cardComponent.name} (Free)",
                                 action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useWithoutPayingManaCost = true),
                                 manaCostString = freeCastResult.manaCostString,
                                 requiresDamageDistribution = requiresDamageDistribution,
@@ -1010,7 +1010,7 @@ class CastSpellEnumerator : ActionEnumerator {
                         if (freeCastResult != null) {
                             result.add(LegalAction(
                                 actionType = "CastWithoutPayingManaCost",
-                                description = "Cast ${cardComponent.name}",
+                                description = "Cast ${cardComponent.name} (Free)",
                                 action = CastSpell(playerId, cardId, useWithoutPayingManaCost = true),
                                 validTargets = firstReqInfo.validTargets,
                                 requiresTargets = true,
@@ -1130,7 +1130,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 if (freeCastResult != null) {
                     result.add(LegalAction(
                         actionType = "CastWithoutPayingManaCost",
-                        description = "Cast ${cardComponent.name}",
+                        description = "Cast ${cardComponent.name} (Free)",
                         action = CastSpell(playerId, cardId, useWithoutPayingManaCost = true),
                         manaCostString = freeCastResult.manaCostString,
                         autoTapPreview = freeCastResult.autoTapPreview

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -390,7 +390,11 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, beholdBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
-            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordBlightPath && !canAffordBeholdPath) {
+            // A `MayCastWithoutPayingManaCost` battlefield permission (e.g. Weftwalking) makes the
+            // spell affordable for {0} when its gates are open. Emitted by its own branch below;
+            // don't continue out before reaching it.
+            val canAffordFreeCast = context.freeCastPermissionAvailable
+            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordBlightPath && !canAffordBeholdPath && !canAffordFreeCast) {
                 // The primary face can't be paid for by any path. Normally we skip it entirely.
                 // But if this is an Adventure/Omen/modal-DFC card whose *secondary* face is
                 // affordable, surface a grayed-out placeholder for the primary face so the
@@ -496,7 +500,7 @@ class CastSpellEnumerator : ActionEnumerator {
             val totalDamageToDistribute = dividedDamageEffect?.totalDamage
             val minDamagePerTarget = if (dividedDamageEffect != null) 1 else null
 
-            // Compute alternative cost info for this spell
+            // Compute alternative cost info for this spell (Jodah-style GrantAlternativeCastingCost).
             val altCostInfo = if (canAffordAlternative) {
                 val altCost = context.alternativeCastingCosts.first()
                 val altEffective = context.costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altCost)
@@ -504,21 +508,8 @@ class CastSpellEnumerator : ActionEnumerator {
                     context.manaSolver.solve(state, playerId, altEffective, precomputedSources = cachedSources)
                         ?.sources?.map { it.entityId }
                 }
-                // Render an empty mana cost (e.g. Weftwalking's first-spell-of-turn free cast)
-                // as "{0}" — `ManaCost.ZERO.toString()` is "" by default, which leaves the UI
-                // showing "Cast X () {1}{G}" (empty parens + the spell's printed cost).
-                val altCostDisplay = if (altEffective.symbols.isEmpty()) "{0}" else altEffective.toString()
-                Triple(altCostDisplay, altPreview, context.manaSolver.canPay(state, playerId, altEffective, precomputedSources = cachedSources))
+                Triple(altEffective.toString(), altPreview, context.manaSolver.canPay(state, playerId, altEffective, precomputedSources = cachedSources))
             } else null
-
-            // Cast-button label for the alternative-cost variant. For a non-zero alt (Jodah's
-            // {W}{U}{B}{R}{G}, etc.) we keep the cost-in-parens hint so the player can tell
-            // the variant apart from the normal cast. For a zero alt (Weftwalking's free cast)
-            // the parens collapse and the cost icon ("{0}") carries the meaning by itself —
-            // otherwise the label reads "Cast Grizzly Bears ({0})", awkward in the UI.
-            val altCastLabel: String? = altCostInfo?.let {
-                if (it.first == "{0}") "Cast ${cardComponent.name}" else "Cast ${cardComponent.name} (${it.first})"
-            }
 
             // Compute self-alternative cost info (e.g., Zahid)
             val selfAltCostResult = if (canAffordSelfAlternative && selfAltCost != null) {
@@ -569,6 +560,20 @@ class CastSpellEnumerator : ActionEnumerator {
                 SelfAltCostResult(
                     manaCostString = impendingMana.toString(),
                     autoTapPreview = impendingPreview,
+                    additionalCostInfo = null
+                )
+            } else null
+
+            // Free cast via `MayCastWithoutPayingManaCost` (e.g. Weftwalking) — its own variant,
+            // parallel to [altCostInfo], so the player can pick it over Jodah-style
+            // `GrantAlternativeCastingCost` and over any keyword alt (flashback, harmonize, warp,
+            // evoke, impending) when both are legal (CR 118.9a — only one alternative cost may
+            // apply to a cast, and which one is the player's choice). Routes through
+            // [CastSpell.useWithoutPayingManaCost].
+            val freeCastResult = if (context.freeCastPermissionAvailable) {
+                SelfAltCostResult(
+                    manaCostString = "{0}",
+                    autoTapPreview = if (context.skipAutoTapPreview) null else emptyList(),
                     additionalCostInfo = null
                 )
             } else null
@@ -820,7 +825,7 @@ class CastSpellEnumerator : ActionEnumerator {
                         if (altCostInfo?.third == true) {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
-                                description = altCastLabel!!,
+                                description = "Cast ${cardComponent.name} (${altCostInfo.first})",
                                 action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true),
                                 manaCostString = altCostInfo.first,
                                 requiresDamageDistribution = requiresDamageDistribution,
@@ -858,6 +863,18 @@ class CastSpellEnumerator : ActionEnumerator {
                                 action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true),
                                 manaCostString = impendingCostResult.manaCostString,
                                 autoTapPreview = impendingCostResult.autoTapPreview
+                            ))
+                        }
+                        if (freeCastResult != null) {
+                            result.add(LegalAction(
+                                actionType = "CastWithoutPayingManaCost",
+                                description = "Cast ${cardComponent.name}",
+                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useWithoutPayingManaCost = true),
+                                manaCostString = freeCastResult.manaCostString,
+                                requiresDamageDistribution = requiresDamageDistribution,
+                                totalDamageToDistribute = totalDamageToDistribute,
+                                minDamagePerTarget = minDamagePerTarget,
+                                autoTapPreview = freeCastResult.autoTapPreview
                             ))
                         }
                         if (blightPathInfo != null) {
@@ -918,7 +935,7 @@ class CastSpellEnumerator : ActionEnumerator {
                         if (altCostInfo?.third == true) {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
-                                description = altCastLabel!!,
+                                description = "Cast ${cardComponent.name} (${altCostInfo.first})",
                                 action = CastSpell(playerId, cardId, useAlternativeCost = true),
                                 validTargets = firstReqInfo.validTargets,
                                 requiresTargets = true,
@@ -988,6 +1005,26 @@ class CastSpellEnumerator : ActionEnumerator {
                                 xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
                                 manaCostString = impendingCostResult.manaCostString,
                                 autoTapPreview = impendingCostResult.autoTapPreview
+                            ))
+                        }
+                        if (freeCastResult != null) {
+                            result.add(LegalAction(
+                                actionType = "CastWithoutPayingManaCost",
+                                description = "Cast ${cardComponent.name}",
+                                action = CastSpell(playerId, cardId, useWithoutPayingManaCost = true),
+                                validTargets = firstReqInfo.validTargets,
+                                requiresTargets = true,
+                                targetCount = firstReq.count,
+                                minTargets = firstReq.effectiveMinCount,
+                                targetDescription = firstReq.description,
+                                targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
+                                xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
+                                xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
+                                manaCostString = freeCastResult.manaCostString,
+                                requiresDamageDistribution = requiresDamageDistribution,
+                                totalDamageToDistribute = totalDamageToDistribute,
+                                minDamagePerTarget = minDamagePerTarget,
+                                autoTapPreview = freeCastResult.autoTapPreview
                             ))
                         }
                         if (blightPathInfo != null) {
@@ -1056,7 +1093,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 if (altCostInfo?.third == true) {
                     result.add(LegalAction(
                         actionType = "CastWithAlternativeCost",
-                        description = altCastLabel!!,
+                        description = "Cast ${cardComponent.name} (${altCostInfo.first})",
                         action = CastSpell(playerId, cardId, useAlternativeCost = true),
                         manaCostString = altCostInfo.first,
                         autoTapPreview = altCostInfo.second
@@ -1088,6 +1125,15 @@ class CastSpellEnumerator : ActionEnumerator {
                         action = CastSpell(playerId, cardId, useAlternativeCost = true),
                         manaCostString = impendingCostResult.manaCostString,
                         autoTapPreview = impendingCostResult.autoTapPreview
+                    ))
+                }
+                if (freeCastResult != null) {
+                    result.add(LegalAction(
+                        actionType = "CastWithoutPayingManaCost",
+                        description = "Cast ${cardComponent.name}",
+                        action = CastSpell(playerId, cardId, useWithoutPayingManaCost = true),
+                        manaCostString = freeCastResult.manaCostString,
+                        autoTapPreview = freeCastResult.autoTapPreview
                     ))
                 }
                 if (blightPathInfo != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -504,8 +504,21 @@ class CastSpellEnumerator : ActionEnumerator {
                     context.manaSolver.solve(state, playerId, altEffective, precomputedSources = cachedSources)
                         ?.sources?.map { it.entityId }
                 }
-                Triple(altEffective.toString(), altPreview, context.manaSolver.canPay(state, playerId, altEffective, precomputedSources = cachedSources))
+                // Render an empty mana cost (e.g. Weftwalking's first-spell-of-turn free cast)
+                // as "{0}" — `ManaCost.ZERO.toString()` is "" by default, which leaves the UI
+                // showing "Cast X () {1}{G}" (empty parens + the spell's printed cost).
+                val altCostDisplay = if (altEffective.symbols.isEmpty()) "{0}" else altEffective.toString()
+                Triple(altCostDisplay, altPreview, context.manaSolver.canPay(state, playerId, altEffective, precomputedSources = cachedSources))
             } else null
+
+            // Cast-button label for the alternative-cost variant. For a non-zero alt (Jodah's
+            // {W}{U}{B}{R}{G}, etc.) we keep the cost-in-parens hint so the player can tell
+            // the variant apart from the normal cast. For a zero alt (Weftwalking's free cast)
+            // the parens collapse and the cost icon ("{0}") carries the meaning by itself —
+            // otherwise the label reads "Cast Grizzly Bears ({0})", awkward in the UI.
+            val altCastLabel: String? = altCostInfo?.let {
+                if (it.first == "{0}") "Cast ${cardComponent.name}" else "Cast ${cardComponent.name} (${it.first})"
+            }
 
             // Compute self-alternative cost info (e.g., Zahid)
             val selfAltCostResult = if (canAffordSelfAlternative && selfAltCost != null) {
@@ -807,7 +820,7 @@ class CastSpellEnumerator : ActionEnumerator {
                         if (altCostInfo?.third == true) {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
-                                description = "Cast ${cardComponent.name} (${altCostInfo.first})",
+                                description = altCastLabel!!,
                                 action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true),
                                 manaCostString = altCostInfo.first,
                                 requiresDamageDistribution = requiresDamageDistribution,
@@ -905,7 +918,7 @@ class CastSpellEnumerator : ActionEnumerator {
                         if (altCostInfo?.third == true) {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
-                                description = "Cast ${cardComponent.name} (${altCostInfo.first})",
+                                description = altCastLabel!!,
                                 action = CastSpell(playerId, cardId, useAlternativeCost = true),
                                 validTargets = firstReqInfo.validTargets,
                                 requiresTargets = true,
@@ -1043,7 +1056,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 if (altCostInfo?.third == true) {
                     result.add(LegalAction(
                         actionType = "CastWithAlternativeCost",
-                        description = "Cast ${cardComponent.name} (${altCostInfo.first})",
+                        description = altCastLabel!!,
                         action = CastSpell(playerId, cardId, useAlternativeCost = true),
                         manaCostString = altCostInfo.first,
                         autoTapPreview = altCostInfo.second

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -21,7 +21,7 @@ import com.wingedsheep.sdk.scripting.CostModification
 import com.wingedsheep.sdk.scripting.CostReductionSource
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantAlternativeCastingCost
-import com.wingedsheep.sdk.scripting.MayCastFirstSpellOfTurnWithoutPayingMana
+import com.wingedsheep.sdk.scripting.MayCastWithoutPayingManaCost
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.SpellCostTarget
@@ -1070,34 +1070,35 @@ class CostCalculator(
     }
 
     /**
-     * Whether any battlefield permanent is currently granting [casterId] permission to cast
-     * their first spell of this turn without paying its mana cost
-     * ([MayCastFirstSpellOfTurnWithoutPayingMana], e.g. Weftwalking).
+     * Whether any battlefield permanent is currently granting [casterId] a
+     * [MayCastWithoutPayingManaCost] permission whose gates are all open
+     * (e.g. Weftwalking's `firstSpellOfTurnOnly = true`).
      *
-     * Gating rules:
-     *  - It must currently be [casterId]'s turn — the static keys off "each of their own turns",
-     *    so casting on an opponent's turn (e.g. via flash) does not qualify.
-     *  - [casterId] must have cast no spells yet this turn.
-     *  - When `controllerOnly` is set on the source ability, the source's controller must be
-     *    [casterId]. The default (`false`) is the Weftwalking wording — every player on each of
-     *    their own turns, regardless of who controls the source.
+     * Gates honored per source:
+     *  - `controllerOnly` — when true, the source's controller (read from projected state) must
+     *    be [casterId].
+     *  - `firstSpellOfTurnOnly` — when true, [casterId] must be the active player and must have
+     *    cast no spells yet this turn.
      *
-     * Scans every battlefield zone (not just the caster's) so that an opponent's Weftwalking can
-     * still grant the caster their free first-spell-of-the-turn cast.
+     * Scans every battlefield zone (not just the caster's) so that an opponent's source can
+     * still grant the caster their free cast when the source's wording doesn't require
+     * controller-only.
      */
-    fun hasFirstSpellOfTurnFreeCast(state: GameState, casterId: EntityId): Boolean {
-        if (state.activePlayerId != casterId) return false
-        if ((state.playerSpellsCastThisTurn[casterId] ?: 0) > 0) return false
+    fun hasFreeCastPermission(state: GameState, casterId: EntityId): Boolean {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val card = container.get<CardComponent>() ?: continue
             val permanentDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
             val classLevel = container.get<ClassLevelComponent>()?.currentLevel
             for (ability in permanentDef.script.effectiveStaticAbilities(classLevel)) {
-                if (ability !is MayCastFirstSpellOfTurnWithoutPayingMana) continue
+                if (ability !is MayCastWithoutPayingManaCost) continue
                 if (ability.controllerOnly) {
                     val controllerId = state.projectedState.getController(entityId) ?: continue
                     if (controllerId != casterId) continue
+                }
+                if (ability.firstSpellOfTurnOnly) {
+                    if (state.activePlayerId != casterId) continue
+                    if ((state.playerSpellsCastThisTurn[casterId] ?: 0) > 0) continue
                 }
                 return true
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -21,6 +21,7 @@ import com.wingedsheep.sdk.scripting.CostModification
 import com.wingedsheep.sdk.scripting.CostReductionSource
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantAlternativeCastingCost
+import com.wingedsheep.sdk.scripting.MayCastFirstSpellOfTurnWithoutPayingMana
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.SpellCostTarget
@@ -1066,6 +1067,42 @@ class CostCalculator(
             }
         }
         return costs
+    }
+
+    /**
+     * Whether any battlefield permanent is currently granting [casterId] permission to cast
+     * their first spell of this turn without paying its mana cost
+     * ([MayCastFirstSpellOfTurnWithoutPayingMana], e.g. Weftwalking).
+     *
+     * Gating rules:
+     *  - It must currently be [casterId]'s turn — the static keys off "each of their own turns",
+     *    so casting on an opponent's turn (e.g. via flash) does not qualify.
+     *  - [casterId] must have cast no spells yet this turn.
+     *  - When `controllerOnly` is set on the source ability, the source's controller must be
+     *    [casterId]. The default (`false`) is the Weftwalking wording — every player on each of
+     *    their own turns, regardless of who controls the source.
+     *
+     * Scans every battlefield zone (not just the caster's) so that an opponent's Weftwalking can
+     * still grant the caster their free first-spell-of-the-turn cast.
+     */
+    fun hasFirstSpellOfTurnFreeCast(state: GameState, casterId: EntityId): Boolean {
+        if (state.activePlayerId != casterId) return false
+        if ((state.playerSpellsCastThisTurn[casterId] ?: 0) > 0) return false
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val card = container.get<CardComponent>() ?: continue
+            val permanentDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            val classLevel = container.get<ClassLevelComponent>()?.currentLevel
+            for (ability in permanentDef.script.effectiveStaticAbilities(classLevel)) {
+                if (ability !is MayCastFirstSpellOfTurnWithoutPayingMana) continue
+                if (ability.controllerOnly) {
+                    val controllerId = state.projectedState.getController(entityId) ?: continue
+                    if (controllerId != casterId) continue
+                }
+                return true
+            }
+        }
+        return false
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeftwalkingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeftwalkingScenarioTest.kt
@@ -131,7 +131,7 @@ class WeftwalkingScenarioTest : FunSpec({
         ).isSuccess shouldBe false
     }
 
-    test("legal-action label for the free-cast variant reads 'Cast X' with actionType 'CastWithoutPayingManaCost' and manaCostString '{0}'") {
+    test("legal-action label for the free-cast variant reads 'Cast X (Free)' with actionType 'CastWithoutPayingManaCost' and manaCostString '{0}'") {
         val driver = createDriver()
         val player = driver.activePlayer!!
 
@@ -146,7 +146,7 @@ class WeftwalkingScenarioTest : FunSpec({
                 (la.action as? CastSpell)?.cardId == bears
         }
         freeCast shouldNotBe null
-        freeCast!!.description shouldBe "Cast Grizzly Bears"
+        freeCast!!.description shouldBe "Cast Grizzly Bears (Free)"
         freeCast.manaCostString shouldBe "{0}"
         (freeCast.action as CastSpell).useWithoutPayingManaCost shouldBe true
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeftwalkingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeftwalkingScenarioTest.kt
@@ -2,6 +2,8 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.support.GameTestDriver
@@ -12,6 +14,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Weftwalking — Edge of Eternities mythic enchantment, {4}{U}{U}.
@@ -124,6 +127,25 @@ class WeftwalkingScenarioTest : FunSpec({
         driver.submit(
             CastSpell(player, second, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
         ).isSuccess shouldBe false
+    }
+
+    test("legal-action label for the free-cast variant reads 'Cast X' (no empty parens) with manaCostString '{0}'") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(player, "Weftwalking")
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+
+        val freeCast = actions.firstOrNull { la ->
+            la.actionType == "CastWithAlternativeCost" &&
+                (la.action as? CastSpell)?.cardId == bears
+        }
+        freeCast shouldNotBe null
+        freeCast!!.description shouldBe "Cast Grizzly Bears"
+        freeCast.manaCostString shouldBe "{0}"
     }
 
     test("free-cast variant is not offered on opponent's turn (gate keys on active player)") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeftwalkingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeftwalkingScenarioTest.kt
@@ -6,12 +6,14 @@ import com.wingedsheep.engine.legalactions.EnumerationMode
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
 import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -30,9 +32,9 @@ import io.kotest.matchers.shouldNotBe
  *    cast, not when it enters via another path (verified by checking the cast path triggers the
  *    library reshuffle and a 7-card draw).
  *
- * 2. **First-spell-of-turn free-cast static** ([MayCastFirstSpellOfTurnWithoutPayingMana]) — the
- *    caster's first spell during each of their own turns gets a `{0}` alternative cost; once the
- *    caster has cast a spell this turn the gate closes.
+ * 2. **Free-cast static** ([MayCastWithoutPayingManaCost] with `firstSpellOfTurnOnly = true`) —
+ *    the caster's first spell during each of their own turns gets a `{0}` alternative cost; once
+ *    the caster has cast a spell this turn the gate closes.
  */
 class WeftwalkingScenarioTest : FunSpec({
 
@@ -83,7 +85,7 @@ class WeftwalkingScenarioTest : FunSpec({
         libraryAfter shouldBe libraryBefore + (handBefore - 1) + graveyardBefore - 7
     }
 
-    test("with Weftwalking on the battlefield, first spell may be cast for free via useAlternativeCost") {
+    test("with Weftwalking on the battlefield, first spell may be cast for free via useWithoutPayingManaCost") {
         val driver = createDriver()
         val player = driver.activePlayer!!
 
@@ -93,19 +95,19 @@ class WeftwalkingScenarioTest : FunSpec({
         // this turn — the cost calculator should expose the {0} free-cast alternative.
         (driver.state.playerSpellsCastThisTurn[player] ?: 0) shouldBe 0
         val costCalculator = CostCalculator(driver.cardRegistry)
-        costCalculator.hasFirstSpellOfTurnFreeCast(driver.state, player) shouldBe true
+        costCalculator.hasFreeCastPermission(driver.state, player) shouldBe true
 
-        // Cast Grizzly Bears using the alternative cost — pool is empty, paid nothing.
+        // Cast Grizzly Bears for free via the dedicated flag — pool is empty, paid nothing.
         val bears = driver.putCardInHand(player, "Grizzly Bears")
         driver.submit(
-            CastSpell(player, bears, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
+            CastSpell(player, bears, useWithoutPayingManaCost = true, paymentStrategy = PaymentStrategy.FromPool)
         ).isSuccess shouldBe true
         driver.bothPass()
 
         driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(bears) shouldBe true
     }
 
-    test("the free-cast gate closes after the first spell — second spell can't useAlternativeCost") {
+    test("the free-cast gate closes after the first spell — useWithoutPayingManaCost fails on the second cast") {
         val driver = createDriver()
         val player = driver.activePlayer!!
 
@@ -113,23 +115,23 @@ class WeftwalkingScenarioTest : FunSpec({
 
         val first = driver.putCardInHand(player, "Grizzly Bears")
         driver.submit(
-            CastSpell(player, first, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
+            CastSpell(player, first, useWithoutPayingManaCost = true, paymentStrategy = PaymentStrategy.FromPool)
         ).isSuccess shouldBe true
         driver.bothPass()
 
         // After one spell has resolved this turn, the gate is shut.
         ((driver.state.playerSpellsCastThisTurn[player] ?: 0) >= 1) shouldBe true
         val costCalculator = CostCalculator(driver.cardRegistry)
-        costCalculator.hasFirstSpellOfTurnFreeCast(driver.state, player) shouldBe false
+        costCalculator.hasFreeCastPermission(driver.state, player) shouldBe false
 
-        // A second cast attempt with useAlternativeCost = true fails — no alternative is available.
+        // A second free-cast attempt fails — the gate is closed.
         val second = driver.putCardInHand(player, "Grizzly Bears")
         driver.submit(
-            CastSpell(player, second, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
+            CastSpell(player, second, useWithoutPayingManaCost = true, paymentStrategy = PaymentStrategy.FromPool)
         ).isSuccess shouldBe false
     }
 
-    test("legal-action label for the free-cast variant reads 'Cast X' (no empty parens) with manaCostString '{0}'") {
+    test("legal-action label for the free-cast variant reads 'Cast X' with actionType 'CastWithoutPayingManaCost' and manaCostString '{0}'") {
         val driver = createDriver()
         val player = driver.activePlayer!!
 
@@ -140,12 +142,13 @@ class WeftwalkingScenarioTest : FunSpec({
         val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
 
         val freeCast = actions.firstOrNull { la ->
-            la.actionType == "CastWithAlternativeCost" &&
+            la.actionType == "CastWithoutPayingManaCost" &&
                 (la.action as? CastSpell)?.cardId == bears
         }
         freeCast shouldNotBe null
         freeCast!!.description shouldBe "Cast Grizzly Bears"
         freeCast.manaCostString shouldBe "{0}"
+        (freeCast.action as CastSpell).useWithoutPayingManaCost shouldBe true
     }
 
     test("free-cast variant is not offered on opponent's turn (gate keys on active player)") {
@@ -160,6 +163,158 @@ class WeftwalkingScenarioTest : FunSpec({
         // turn it actually is. The simplest way is to verify the cost-calculator predicate
         // returns false when queried for a non-active player.
         val costCalculator = CostCalculator(driver.cardRegistry)
-        costCalculator.hasFirstSpellOfTurnFreeCast(driver.state, opponent) shouldBe false
+        costCalculator.hasFreeCastPermission(driver.state, opponent) shouldBe false
+    }
+
+    test("Weftwalking entering via non-cast means (intervening-if 'if you cast it') does NOT shuffle/draw") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        // Seed graveyard so a shuffle would be detectable.
+        repeat(3) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+        val graveyardBefore = driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).size
+        val handBefore = driver.state.getZone(ZoneKey(player, Zone.HAND)).size
+
+        // Drop Weftwalking directly onto the battlefield (simulates reanimation / Show and Tell / etc.).
+        driver.putPermanentOnBattlefield(player, "Weftwalking")
+        driver.bothPass()
+        driver.bothPass()
+
+        // The ETB's intervening-if (Conditions.WasCast) didn't fire — hand and graveyard are untouched.
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).size shouldBe handBefore
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).size shouldBe graveyardBefore
+    }
+
+    test("opponent's Weftwalking grants the active player a free first-spell cast (controllerOnly = false)") {
+        val driver = createDriver()
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        // The wording is "each player ... during each of their own turns" — the source's controller
+        // is irrelevant when controllerOnly = false. Opponent's Weftwalking still benefits us.
+        driver.putPermanentOnBattlefield(opponent, "Weftwalking")
+
+        val costCalculator = CostCalculator(driver.cardRegistry)
+        costCalculator.hasFreeCastPermission(driver.state, activePlayer) shouldBe true
+
+        val bears = driver.putCardInHand(activePlayer, "Grizzly Bears")
+        driver.submit(
+            CastSpell(activePlayer, bears, useWithoutPayingManaCost = true, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(activePlayer, Zone.BATTLEFIELD)).contains(bears) shouldBe true
+    }
+
+    test("Jodah + Weftwalking on the battlefield: the player picks which alternative cost — both are offered as distinct LegalActions") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(player, "Weftwalking")
+        driver.putPermanentOnBattlefield(player, "Jodah, Archmage Eternal")
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+        // Give Jodah's full {W}{U}{B}{R}{G} so the Jodah variant is affordable; without it the
+        // enumerator wouldn't emit the Jodah action at all and the test would degenerate.
+        driver.giveMana(player, Color.WHITE)
+        driver.giveMana(player, Color.BLUE)
+        driver.giveMana(player, Color.BLACK)
+        driver.giveMana(player, Color.RED)
+        driver.giveMana(player, Color.GREEN)
+
+        // Both Jodah's GrantAlternativeCastingCost ({W}{U}{B}{R}{G}) and Weftwalking's free
+        // cast ({0}) must surface — the enumerator emits them as distinct legal actions so the
+        // player can choose (CR 118.9a — alternative costs don't combine, but which one to use
+        // is the player's call).
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+            .filter { (it.action as? CastSpell)?.cardId == bears }
+
+        val freeCast = actions.firstOrNull { it.actionType == "CastWithoutPayingManaCost" }
+        val jodahCast = actions.firstOrNull {
+            it.actionType == "CastWithAlternativeCost" &&
+                (it.action as CastSpell).useAlternativeCost
+        }
+        freeCast shouldNotBe null
+        jodahCast shouldNotBe null
+        freeCast!!.manaCostString shouldBe "{0}"
+        jodahCast!!.manaCostString shouldBe "{W}{U}{B}{R}{G}"
+
+        // The player picks the free cast — and it works at {0}, the WUBRG pool stays untouched.
+        driver.submit(
+            CastSpell(player, bears, useWithoutPayingManaCost = true, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(bears) shouldBe true
+    }
+
+    test("combining useWithoutPayingManaCost with useAlternativeCost is rejected (CR 118.9a — alt costs don't combine)") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(player, "Weftwalking")
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+
+        val result = driver.submit(
+            CastSpell(
+                player, bears,
+                useWithoutPayingManaCost = true,
+                useAlternativeCost = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("free-casting Embrace Oblivion still requires sacrificing an artifact or creature (mandatory additional cost survives 'without paying its mana cost')") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        driver.putPermanentOnBattlefield(player, "Weftwalking")
+        // Two creatures: one to sacrifice for the mandatory cost, one to destroy with the spell.
+        val sacFodder = driver.putPermanentOnBattlefield(player, "Grizzly Bears")
+        val victim = driver.putPermanentOnBattlefield(opponent, "Grizzly Bears")
+        val embrace = driver.putCardInHand(player, "Embrace Oblivion")
+
+        // Free-cast Embrace Oblivion — its `{B}` is waived, but the printed "As an additional
+        // cost ... sacrifice an artifact or creature" must still be paid (CR 118.9 ruling cited
+        // on Weftwalking itself).
+        val result = driver.submit(
+            CastSpell(
+                player, embrace,
+                useWithoutPayingManaCost = true,
+                targets = listOf(ChosenTarget.Permanent(victim)),
+                additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(sacFodder)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        // The sacrifice resolved (fodder is in the graveyard) and Embrace Oblivion destroyed the victim.
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(sacFodder) shouldBe true
+        driver.state.getZone(ZoneKey(opponent, Zone.GRAVEYARD)).contains(victim) shouldBe true
+    }
+
+    test("free-casting Embrace Oblivion without nominating a sacrifice fails — the mandatory additional cost is enforced even at {0}") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        driver.putPermanentOnBattlefield(player, "Weftwalking")
+        driver.putPermanentOnBattlefield(player, "Grizzly Bears")  // legal sacrifice exists
+        val victim = driver.putPermanentOnBattlefield(opponent, "Grizzly Bears")
+        val embrace = driver.putCardInHand(player, "Embrace Oblivion")
+
+        val result = driver.submit(
+            CastSpell(
+                player, embrace,
+                useWithoutPayingManaCost = true,
+                targets = listOf(ChosenTarget.Permanent(victim)),
+                // additionalCostPayment intentionally null — no sacrifice nominated
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe false
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeftwalkingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeftwalkingScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Weftwalking — Edge of Eternities mythic enchantment, {4}{U}{U}.
+ *
+ *   When this enchantment enters, if you cast it, shuffle your hand and graveyard into your
+ *   library, then draw seven cards.
+ *   The first spell each player casts during each of their turns may be cast without paying
+ *   its mana cost.
+ *
+ * Two new pieces of behaviour are exercised here:
+ *
+ * 1. **ETB-if-cast** ([Conditions.WasCast]) — the shuffle-and-draw fires only when Weftwalking is
+ *    cast, not when it enters via another path (verified by checking the cast path triggers the
+ *    library reshuffle and a 7-card draw).
+ *
+ * 2. **First-spell-of-turn free-cast static** ([MayCastFirstSpellOfTurnWithoutPayingMana]) — the
+ *    caster's first spell during each of their own turns gets a `{0}` alternative cost; once the
+ *    caster has cast a spell this turn the gate closes.
+ */
+class WeftwalkingScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 30, "Island" to 30),
+            startingLife = 20
+        )
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("casting Weftwalking shuffles hand and graveyard into the library and draws seven") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        // Seed the graveyard with three cards and the hand with two extra non-Weftwalking cards
+        // so we can verify both zones get shuffled away.
+        repeat(3) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+        driver.putCardInHand(player, "Grizzly Bears")
+        driver.putCardInHand(player, "Grizzly Bears")
+
+        val weftwalking = driver.putCardInHand(player, "Weftwalking")
+        driver.giveMana(player, Color.BLUE, 6) // {4}{U}{U}
+
+        val handBefore = driver.state.getZone(ZoneKey(player, Zone.HAND)).size
+        val graveyardBefore = driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).size
+        val libraryBefore = driver.state.getZone(ZoneKey(player, Zone.LIBRARY)).size
+
+        driver.submit(
+            CastSpell(player, weftwalking, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        // Spell resolves on first pair of passes; the ETB trigger goes onto the stack and needs
+        // a second pair to resolve.
+        driver.bothPass()
+        driver.bothPass()
+
+        // After resolution: Weftwalking sits on the battlefield, the rest of the hand and the
+        // graveyard have been shuffled into the library, and the controller has drawn seven.
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(weftwalking) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).size shouldBe 0
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).size shouldBe 7
+
+        // Library net change: + (handBefore - 1 [Weftwalking itself stays out]) + graveyardBefore - 7 drawn.
+        val libraryAfter = driver.state.getZone(ZoneKey(player, Zone.LIBRARY)).size
+        libraryAfter shouldBe libraryBefore + (handBefore - 1) + graveyardBefore - 7
+    }
+
+    test("with Weftwalking on the battlefield, first spell may be cast for free via useAlternativeCost") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(player, "Weftwalking")
+
+        // Pre-cast sanity: the static is detected, and the active player has cast zero spells
+        // this turn — the cost calculator should expose the {0} free-cast alternative.
+        (driver.state.playerSpellsCastThisTurn[player] ?: 0) shouldBe 0
+        val costCalculator = CostCalculator(driver.cardRegistry)
+        costCalculator.hasFirstSpellOfTurnFreeCast(driver.state, player) shouldBe true
+
+        // Cast Grizzly Bears using the alternative cost — pool is empty, paid nothing.
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+        driver.submit(
+            CastSpell(player, bears, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(bears) shouldBe true
+    }
+
+    test("the free-cast gate closes after the first spell — second spell can't useAlternativeCost") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(player, "Weftwalking")
+
+        val first = driver.putCardInHand(player, "Grizzly Bears")
+        driver.submit(
+            CastSpell(player, first, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // After one spell has resolved this turn, the gate is shut.
+        ((driver.state.playerSpellsCastThisTurn[player] ?: 0) >= 1) shouldBe true
+        val costCalculator = CostCalculator(driver.cardRegistry)
+        costCalculator.hasFirstSpellOfTurnFreeCast(driver.state, player) shouldBe false
+
+        // A second cast attempt with useAlternativeCost = true fails — no alternative is available.
+        val second = driver.putCardInHand(player, "Grizzly Bears")
+        driver.submit(
+            CastSpell(player, second, useAlternativeCost = true, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe false
+    }
+
+    test("free-cast variant is not offered on opponent's turn (gate keys on active player)") {
+        val driver = createDriver()
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.putPermanentOnBattlefield(controller, "Weftwalking")
+        driver.putCardInHand(controller, "Grizzly Bears")
+
+        // Active player is still `controller` here — flip to confirm the gate keys to whose
+        // turn it actually is. The simplest way is to verify the cost-calculator predicate
+        // returns false when queried for a non-active player.
+        val costCalculator = CostCalculator(driver.cardRegistry)
+        costCalculator.hasFirstSpellOfTurnFreeCast(driver.state, opponent) shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary
- Adds Weftwalking (Edge of Eternities #86, {4}{U}{U} mythic enchantment): ETB-if-cast shuffles hand + graveyard into library and draws 7; static lets each player free-cast their first spell each of their own
turns.
- Introduces `MayCastWithoutPayingManaCost(controllerOnly, firstSpellOfTurnOnly)` — a composable battlefield "may cast without paying its mana cost" SDK type. Future cards in this family compose by flipping
flags instead of growing a sibling type.
- Wires the free-cast through a dedicated `CastWithoutPayingManaCost` LegalAction routing via `CastSpell.useWithoutPayingManaCost`, emitted **alongside** Jodah / flashback / harmonize / warp / evoke / impending
  / `selfAlternativeCost`. The player picks which alternative cost to apply (CR 118.9a — alt costs don't combine, and the choice is the player's, not handler priority). Mutually exclusive with
`useAlternativeCost`, validated at cast time.
- Cost calculator gate (`hasFreeCastPermission`) scans the full battlefield so an opponent's source still grants the active player their free cast unless `controllerOnly = true`. `firstSpellOfTurnOnly` enforces
  active-player + zero-spells-cast-this-turn.
- Mandatory additional costs (Embrace Oblivion sacrifice, etc.) still apply; kicker / blight / behold / runtime tax are skipped; X = 0 per CR 107.3b — matching the existing `PlayWithoutPayingCostComponent` flow
  used by Cascade / Omniscience.
- Updates the SDK reference doc, EOE backlog (254 → 255 implemented), and two manual scenarios.

## Test plan
- [x] `:rules-engine:test --tests WeftwalkingScenarioTest` — 11 scenarios green (shuffle+draw on cast, no shuffle on reanimate, free-cast happy path, gate close after first spell, opponent's-turn rejection,
opponent-controls-source, Jodah+Weftwalking dual LegalActions, mutex rejection, Embrace Oblivion mandatory sacrifice both with and without).
- [x] `:rules-engine:test`, `:mtg-sdk:test`, `:mtg-sets:test` — no regressions.
- [ ] Manual: load `manual-scenarios/cards/w/weftwalking-etb.json` and `weftwalking-free-cast.json` in the dev scenario UI; confirm both cast paths render and the cost-{0} button shows up alongside Jodah's alt
cost when both are legal.