### PR TITLE
Add AI opponent to dev scenarios

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -84,6 +84,13 @@ class AiGameManager(
     }
 
     /**
+     * Master AI toggle, ignoring the LLM-key gate that [isEnabled] also applies. Use this
+     * for code paths that force engine mode (e.g. dev scenarios) and so don't need a key
+     * even when the server's global config is LLM.
+     */
+    val aiEnabledToggle: Boolean get() = gameProperties.ai.enabled
+
+    /**
      * Look up the LLM model override for an AI player by querying its identity in the SessionRegistry.
      * The override is stored on `PlayerIdentity.aiModelOverride` so it survives server restart.
      */
@@ -134,6 +141,57 @@ class AiGameManager(
     )
 
     /**
+     * Wire the AI plumbing common to every bring-up path: synthetic [AiWebSocketSession],
+     * its [PlayerSession]/[PlayerIdentity], registration with [SessionRegistry] +
+     * [activeSessions] + [aiPlayerIds].
+     *
+     * Each caller is responsible for the game-state side (deck list, [GameSession.addPlayer]
+     * vs [GameSession.associatePlayer], persistence info) since those vary per flow.
+     */
+    private fun registerAiSession(
+        gameSession: GameSession,
+        aiPlayerId: EntityId,
+        playerName: String,
+        controller: AiPlayerController,
+        modelOverride: String? = null,
+        onActionReady: (EntityId, GameAction) -> Unit,
+        onMulliganKeep: (EntityId) -> Unit,
+        onMulliganTake: (EntityId) -> Unit,
+        onBottomCards: (EntityId, List<EntityId>) -> Unit,
+    ): Pair<PlayerSession, PlayerIdentity> {
+        val aiSession = AiWebSocketSession(
+            aiPlayerId = aiPlayerId,
+            controller = controller,
+            thinkingDelayMs = gameProperties.ai.thinkingDelayMs,
+            onActionReady = onActionReady,
+            onMulliganKeep = onMulliganKeep,
+            onMulliganTake = onMulliganTake,
+            onBottomCards = onBottomCards
+        )
+
+        val playerSession = PlayerSession(
+            webSocketSession = aiSession,
+            playerId = aiPlayerId,
+            playerName = playerName
+        )
+
+        val identity = PlayerIdentity(
+            token = "ai-token-${UUID.randomUUID().toString().take(8)}",
+            playerId = aiPlayerId,
+            playerName = playerName,
+            isAi = true,
+            aiModelOverride = modelOverride
+        )
+        identity.webSocketSession = aiSession
+        identity.currentGameSessionId = gameSession.sessionId
+        sessionRegistry.register(identity, aiSession, playerSession)
+
+        activeSessions[gameSession.sessionId] = aiSession
+        aiPlayerIds.add(aiPlayerId)
+        return playerSession to identity
+    }
+
+    /**
      * Create an AI opponent and add it to the game session.
      *
      * @param gameSession The game session to add the AI to.
@@ -155,36 +213,20 @@ class AiGameManager(
         require(isEnabled) { "AI is not enabled. Set game.ai.enabled=true." }
 
         val aiPlayerId = EntityId("ai-${UUID.randomUUID().toString().take(8)}")
-        val aiProperties = gameProperties.ai
         val aiName = randomAiName()
 
         val controller = createController(aiPlayerId, gameSession)
 
-        val aiSession = AiWebSocketSession(
+        val (playerSession, identity) = registerAiSession(
+            gameSession = gameSession,
             aiPlayerId = aiPlayerId,
+            playerName = aiName,
             controller = controller,
-            thinkingDelayMs = aiProperties.thinkingDelayMs,
             onActionReady = onActionReady,
             onMulliganKeep = onMulliganKeep,
             onMulliganTake = onMulliganTake,
-            onBottomCards = onBottomCards
+            onBottomCards = onBottomCards,
         )
-
-        val playerSession = PlayerSession(
-            webSocketSession = aiSession,
-            playerId = aiPlayerId,
-            playerName = aiName
-        )
-
-        // Register a fake identity and session so MessageSender can find the lock
-        val identity = com.wingedsheep.gameserver.session.PlayerIdentity(
-            token = "ai-token-${UUID.randomUUID().toString().take(8)}",
-            playerId = aiPlayerId,
-            playerName = aiName,
-            isAi = true
-        )
-        identity.webSocketSession = aiSession
-        sessionRegistry.register(identity, aiSession, playerSession)
 
         // Quick games use a sealed deck — use same set as human player if provided
         val aiDeck = if (setCode != null) deckGenerator.generate(setCode) else deckGenerator.generate()
@@ -195,12 +237,64 @@ class AiGameManager(
 
         // Store persistence info
         gameSession.setPlayerPersistenceInfo(aiPlayerId, aiName, identity.token, isAi = true)
-        identity.currentGameSessionId = gameSession.sessionId
-
-        activeSessions[gameSession.sessionId] = aiSession
 
         logger.info("Created AI opponent ({}) for game {} [mode={}]",
-            aiPlayerId.value, gameSession.sessionId, aiProperties.mode)
+            aiPlayerId.value, gameSession.sessionId, gameProperties.ai.mode)
+        return playerSession
+    }
+
+    /**
+     * Wire an AI opponent into an existing dev-scenario seat.
+     *
+     * Unlike [createAiOpponent], this does NOT generate a fresh `ai-<uuid>` entity or call
+     * `gameSession.addPlayer(...)` — the player entity (with all its zones and life total) was
+     * already built by [com.wingedsheep.gameserver.controller.DevScenarioController]'s
+     * `ScenarioBuilder` and lives in the injected GameState under the supplied [aiPlayerId].
+     *
+     * Dev scenarios always use the in-process engine AI, never the LLM controller: scenarios
+     * have no deck list to ground prompts against, the engine AI reads zones straight from
+     * GameState, and we don't want test runs to need API keys or burn LLM tokens.
+     *
+     * @return the AI's [PlayerSession] (also added to [GameSession.players]).
+     */
+    fun wireAiForDevScenario(
+        gameSession: GameSession,
+        aiPlayerId: EntityId,
+        playerName: String,
+        onActionReady: (EntityId, GameAction) -> Unit,
+        onMulliganKeep: (EntityId) -> Unit,
+        onMulliganTake: (EntityId) -> Unit,
+        onBottomCards: (EntityId, List<EntityId>) -> Unit
+    ): PlayerSession {
+        // Only check the master toggle — engine AI doesn't need the LLM API key that
+        // [isEnabled] also gates on, so dev scenarios run even when the server is
+        // configured for LLM mode without a key.
+        require(gameProperties.ai.enabled) { "AI is not enabled. Set game.ai.enabled=true." }
+
+        val controller = EngineAiPlayerController(
+            cardRegistry = cardRegistry,
+            playerId = aiPlayerId,
+            gameStateProvider = { gameSession.getStateSnapshot() }
+        )
+
+        val (playerSession, identity) = registerAiSession(
+            gameSession = gameSession,
+            aiPlayerId = aiPlayerId,
+            playerName = playerName,
+            controller = controller,
+            onActionReady = onActionReady,
+            onMulliganKeep = onMulliganKeep,
+            onMulliganTake = onMulliganTake,
+            onBottomCards = onBottomCards,
+        )
+
+        // Add the AI to gameSession.players so player1/player2 accessors and broadcastStateUpdate see it.
+        // (No addPlayer — that requires a deck list, but the dev scenario already injected the full state.)
+        gameSession.associatePlayer(playerSession)
+        gameSession.setPlayerPersistenceInfo(aiPlayerId, playerName, identity.token, isAi = true)
+
+        logger.info("Wired AI ({}) into dev scenario {} [engine mode forced]",
+            aiPlayerId.value, gameSession.sessionId)
         return playerSession
     }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/DevScenarioController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/DevScenarioController.kt
@@ -19,6 +19,8 @@ import com.wingedsheep.sdk.scripting.ProtectionScope
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.gameserver.ai.AiGameManager
+import com.wingedsheep.gameserver.handler.GamePlayHandler
 import com.wingedsheep.gameserver.repository.GameRepository
 import com.wingedsheep.gameserver.session.GameSession
 import com.wingedsheep.gameserver.session.PlayerIdentity
@@ -59,7 +61,9 @@ class DevScenarioController(
     private val cardRegistry: CardRegistry,
     private val printingRegistry: com.wingedsheep.engine.registry.PrintingRegistry,
     private val gameRepository: GameRepository,
-    private val sessionRegistry: SessionRegistry
+    private val sessionRegistry: SessionRegistry,
+    private val aiGameManager: AiGameManager,
+    private val gamePlayHandler: GamePlayHandler,
 ) {
     private val stateTransformer = ClientStateTransformer(cardRegistry)
 
@@ -401,7 +405,24 @@ class DevScenarioController(
         @RequestParam(required = false) player1Token: String?,
         @RequestParam(required = false) player2Token: String?
     ): ResponseEntity<ScenarioResponse> {
-        logger.info("Creating dev scenario: player1=${request.player1Name}, player2=${request.player2Name}")
+        logger.info("Creating dev scenario: player1=${request.player1Name}, player2=${request.player2Name}, aiPlayer=${request.aiPlayer}")
+
+        if (request.aiPlayer != null && request.aiPlayer !in setOf(1, 2)) {
+            return ResponseEntity.badRequest().body(ScenarioResponse(
+                sessionId = "",
+                player1 = PlayerInfo("", "", ""),
+                player2 = PlayerInfo("", "", ""),
+                message = "aiPlayer must be 1 or 2 (got ${request.aiPlayer})"
+            ))
+        }
+        if (request.aiPlayer != null && !aiGameManager.aiEnabledToggle) {
+            return ResponseEntity.badRequest().body(ScenarioResponse(
+                sessionId = "",
+                player1 = PlayerInfo("", "", ""),
+                player2 = PlayerInfo("", "", ""),
+                message = "AI is not enabled on this server. Set game.ai.enabled=true to play scenarios against the AI."
+            ))
+        }
 
         try {
             val builder = ScenarioBuilder(cardRegistry)
@@ -489,46 +510,90 @@ class DevScenarioController(
             // Save the session
             gameRepository.save(gameSession)
 
-            // Create player identities with matching player IDs from the scenario
-            // Default to stable tokens "p1"/"p2" for easy dev workflow (bookmark browser tabs)
+            // Create player identities with matching player IDs from the scenario.
+            // Default to stable tokens "p1"/"p2" for easy dev workflow (bookmark browser tabs).
+            // When [aiPlayer] is set, that seat is filled by AiGameManager.wireAiForDevScenario
+            // (which registers its own AI identity) — we only pre-register the human seat.
             val p1Name = request.player1Name ?: "Player1"
             val p2Name = request.player2Name ?: "Player2"
 
-            val identity1 = PlayerIdentity(
-                token = player1Token ?: "p1",
-                playerId = player1Id,
-                playerName = p1Name
-            ).apply {
-                currentGameSessionId = gameSession.sessionId
-            }
+            val humanIdentity1 = if (request.aiPlayer != 1) {
+                PlayerIdentity(
+                    token = player1Token ?: "p1",
+                    playerId = player1Id,
+                    playerName = p1Name
+                ).apply { currentGameSessionId = gameSession.sessionId }
+                    .also { sessionRegistry.preRegisterIdentity(it) }
+            } else null
 
-            val identity2 = PlayerIdentity(
-                token = player2Token ?: "p2",
-                playerId = player2Id,
-                playerName = p2Name
-            ).apply {
-                currentGameSessionId = gameSession.sessionId
-            }
+            val humanIdentity2 = if (request.aiPlayer != 2) {
+                PlayerIdentity(
+                    token = player2Token ?: "p2",
+                    playerId = player2Id,
+                    playerName = p2Name
+                ).apply { currentGameSessionId = gameSession.sessionId }
+                    .also { sessionRegistry.preRegisterIdentity(it) }
+            } else null
 
-            // Pre-register identities so players can connect with their tokens
-            sessionRegistry.preRegisterIdentity(identity1)
-            sessionRegistry.preRegisterIdentity(identity2)
+            // Wire the AI seat (if any). This associates the AI's PlayerSession with the
+            // GameSession so subsequent broadcastStateUpdate calls reach the AI controller.
+            if (request.aiPlayer != null) {
+                val (aiSeatId, aiSeatName) = if (request.aiPlayer == 1) {
+                    player1Id to p1Name
+                } else {
+                    player2Id to p2Name
+                }
+                aiGameManager.wireAiForDevScenario(
+                    gameSession = gameSession,
+                    aiPlayerId = aiSeatId,
+                    playerName = aiSeatName,
+                    onActionReady = { id, action -> gamePlayHandler.handleAiAction(gameSession, id, action) },
+                    onMulliganKeep = { id -> gamePlayHandler.handleAiMulliganKeep(gameSession, id) },
+                    onMulliganTake = { id -> gamePlayHandler.handleAiMulliganTake(gameSession, id) },
+                    onBottomCards = { id, cardIds -> gamePlayHandler.handleAiBottomCards(gameSession, id, cardIds) }
+                )
+                // Kick off the AI: if it holds priority in the injected state, this triggers
+                // its first action. If the human has priority, the AI receives state and waits.
+                gamePlayHandler.broadcastStateUpdate(gameSession, emptyList())
+            }
 
             logger.info("Created scenario session ${gameSession.sessionId}")
 
+            val player1Info = PlayerInfo(
+                name = p1Name,
+                token = humanIdentity1?.token ?: "(AI)",
+                playerId = player1Id.value
+            )
+            val player2Info = PlayerInfo(
+                name = p2Name,
+                token = humanIdentity2?.token ?: "(AI)",
+                playerId = player2Id.value
+            )
+
+            // Exactly one human identity is null iff [aiPlayer] selected that seat — assert
+            // the invariant so a future reordering of the pre-registration block fails
+            // loudly here rather than producing a malformed URL.
+            val openMessage = when (request.aiPlayer) {
+                1 -> {
+                    val token = checkNotNull(humanIdentity2) { "humanIdentity2 must be non-null when aiPlayer=1" }.token
+                    "Scenario created vs AI. Open http://localhost:5173/?token=$token (you are Player 2)"
+                }
+                2 -> {
+                    val token = checkNotNull(humanIdentity1) { "humanIdentity1 must be non-null when aiPlayer=2" }.token
+                    "Scenario created vs AI. Open http://localhost:5173/?token=$token (you are Player 1)"
+                }
+                else -> {
+                    val t1 = checkNotNull(humanIdentity1) { "humanIdentity1 must be non-null when aiPlayer is null" }.token
+                    val t2 = checkNotNull(humanIdentity2) { "humanIdentity2 must be non-null when aiPlayer is null" }.token
+                    "Scenario created. Open http://localhost:5173/?token=$t1 (Player 1) or http://localhost:5173/?token=$t2 (Player 2)"
+                }
+            }
+
             return ResponseEntity.ok(ScenarioResponse(
                 sessionId = gameSession.sessionId,
-                player1 = PlayerInfo(
-                    name = p1Name,
-                    token = identity1.token,
-                    playerId = player1Id.value
-                ),
-                player2 = PlayerInfo(
-                    name = p2Name,
-                    token = identity2.token,
-                    playerId = player2Id.value
-                ),
-                message = "Scenario created. Open http://localhost:5173/?token=${identity1.token} (Player 1) or http://localhost:5173/?token=${identity2.token} (Player 2)"
+                player1 = player1Info,
+                player2 = player2Info,
+                message = openMessage
             ))
         } catch (e: Exception) {
             logger.error("Failed to create scenario", e)
@@ -888,7 +953,14 @@ data class ScenarioRequest(
     /** Steps where player 1 should stop on opponent's turn (prevents auto-pass) */
     val player1OpponentStopAtSteps: List<Step>? = null,
     /** Steps where player 2 should stop on opponent's turn (prevents auto-pass) */
-    val player2OpponentStopAtSteps: List<Step>? = null
+    val player2OpponentStopAtSteps: List<Step>? = null,
+    /**
+     * If set to 1 or 2, that seat is played by the built-in engine AI opponent (driven by
+     * [com.wingedsheep.gameserver.ai.AiGameManager]). Requires `game.ai.enabled=true`.
+     * The other seat is connected normally over WebSocket with the returned token. Dev
+     * scenarios always use the in-process engine AI — no LLM, no API key.
+     */
+    val aiPlayer: Int? = null
 )
 
 data class PlayerConfig(

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/controller/DevScenarioAiTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/controller/DevScenarioAiTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.gameserver.controller
+
+import com.wingedsheep.gameserver.ai.AiGameManager
+import com.wingedsheep.gameserver.repository.GameRepository
+import com.wingedsheep.gameserver.session.SessionRegistry
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+/**
+ * Verifies that `POST /api/dev/scenarios` with `aiPlayer = 2` wires the AI seat correctly:
+ *
+ *  - response advertises only the human's token, the AI's token is hidden behind "(AI)"
+ *  - both seats end up in `GameSession.players` (so `broadcastStateUpdate` reaches the AI)
+ *  - `AiGameManager.isAiPlayer(...)` reports the AI seat
+ *
+ * Dev scenarios always run with the in-process engine AI — no LLM, no API key needed.
+ *
+ * Uses raw JSON + kotlinx `JsonElement` parsing instead of Spring's `TestRestTemplate` /
+ * `AutoConfigureMockMvc`, both of which were dropped in Spring Boot 4.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "game.dev-endpoints.enabled=true",
+        "game.ai.enabled=true",
+        "game.ai.mode=engine",
+    ],
+)
+class DevScenarioAiTest(
+    @Autowired private val gameRepository: GameRepository,
+    @Autowired private val sessionRegistry: SessionRegistry,
+    @Autowired private val aiGameManager: AiGameManager,
+    @LocalServerPort private val port: Int,
+) : FunSpec({
+
+    val http = HttpClient.newHttpClient()
+    val json = Json { ignoreUnknownKeys = true }
+
+    fun post(body: String): HttpResponse<String> {
+        val req = HttpRequest.newBuilder(URI.create("http://localhost:$port/api/dev/scenarios"))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build()
+        return http.send(req, HttpResponse.BodyHandlers.ofString())
+    }
+
+    fun JsonObject.s(key: String): String = this[key]!!.jsonPrimitive.content
+
+    test("aiPlayer=2 fills seat 2 with engine AI and registers it everywhere downstream") {
+        val response = post(
+            """
+            {
+              "player1Name": "Human",
+              "player2Name": "Bot",
+              "player1": {
+                "lifeTotal": 20,
+                "battlefield": [{"name": "Forest"}],
+                "library": ["Forest", "Forest"]
+              },
+              "player2": {
+                "lifeTotal": 20,
+                "battlefield": [{"name": "Mountain"}],
+                "library": ["Mountain", "Mountain"]
+              },
+              "aiPlayer": 2
+            }
+            """.trimIndent()
+        )
+        response.statusCode() shouldBe 200
+
+        val body = json.parseToJsonElement(response.body()).jsonObject
+        val sessionId = body.s("sessionId")
+        val player1 = body["player1"]!!.jsonObject
+        val player2 = body["player2"]!!.jsonObject
+
+        player1.s("token") shouldBe "p1"
+        player2.s("token") shouldBe "(AI)"
+        body.s("message") shouldContain "you are Player 1"
+        body.s("message") shouldStartWith "Scenario created vs AI."
+
+        val player1Id = EntityId.of(player1.s("playerId"))
+        val player2Id = EntityId.of(player2.s("playerId"))
+
+        // AI is associated into GameSession.players right away (so broadcastStateUpdate
+        // reaches it); the human seat only enters players when their WebSocket connects.
+        val gameSession = gameRepository.findById(sessionId).shouldNotBeNull()
+        gameSession.player1?.playerId shouldBe player2Id
+        gameSession.player2?.playerId shouldBe null
+
+        // Human identity is pre-registered with its returned token so the WS handshake
+        // resolves it; the AI has its own synthetic token registered via SessionRegistry.register.
+        sessionRegistry.getIdentityByToken("p1")?.playerId shouldBe player1Id
+        sessionRegistry.getAllIdentities()
+            .singleOrNull { it.isAi && it.playerId == player2Id }
+            .shouldNotBeNull()
+
+        // The AI seat is tracked by AiGameManager so isAiPlayer + cleanupGame work.
+        aiGameManager.isAiPlayer(player2Id) shouldBe true
+        aiGameManager.isAiPlayer(player1Id) shouldBe false
+        aiGameManager.hasAiPlayer(sessionId) shouldBe true
+    }
+
+    test("aiPlayer=5 is rejected with a 400") {
+        val response = post("""{"aiPlayer": 5}""")
+        response.statusCode() shouldBe 400
+        val body = json.parseToJsonElement(response.body()).jsonObject
+        body.s("message") shouldContain "aiPlayer must be 1 or 2"
+    }
+})


### PR DESCRIPTION
Dev scenarios (POST /api/dev/scenarios) accept a new aiPlayer field set to 1 or 2 — that seat is filled by the in-process engine AI and the other seat is connected normally over WebSocket with the returned token. Lets you bookmark a scenario URL and immediately play it solo against the AI instead of needing two browser tabs.

New AiGameManager.wireAiForDevScenario takes a pre-built dev-scenario state and an existing player entity ID (the ScenarioBuilder has already created the player with all zones and life total) and:
  - builds a synthetic AiWebSocketSession + PlayerIdentity for the seat,
  - associates it into GameSession.players (no addPlayer — that requires a deck list, which the injected state replaces),
  - registers it in SessionRegistry so message routing works,
  - tracks it in aiPlayerIds so isAiPlayer / hasAiPlayer / cleanupGame behave the same as for tournament and quick-game AIs.

The bring-up plumbing common to createAiOpponent, wireAiForDevScenario and the tournament path is now a single registerAiSession helper. As a side effect createAiOpponent also tracks its AI in aiPlayerIds, fixing a pre-existing inconsistency where isAiPlayer() returned false for quick- game AIs while reporting true everywhere else.

Dev scenarios always use the engine AI, never the LLM controller: scenarios have no deck list to ground prompts against, the engine reads zones from GameState directly, and tests shouldn't need API keys. wireAiForDevScenario constructs an EngineAiPlayerController unconditionally and gates on a new aiEnabledToggle that ignores the LLM-key requirement in isEnabled, so dev scenarios still work when the server's global mode is configured for LLM without a key.

DevScenarioController:
  - aiPlayer/aiModel parameters wired into ScenarioRequest (aiModel later removed when dropping LLM support).
  - human seats are pre-registered with stable "p1"/"p2" tokens, the AI seat returns "(AI)" in the response.
  - the response message links only the human token(s); uses checkNotNull with explicit messages so a future reorder of the pre-registration block fails loudly rather than producing a malformed URL.
  - broadcasts an initial state update after wiring so the AI starts acting if it holds priority.

DevScenarioAiTest covers POST /api/dev/scenarios with aiPlayer=2: token shape ("p1" / "(AI)"), AI seat in gameSession.players, human identity pre-registered against its token, AiGameManager.isAiPlayer/hasAiPlayer tracking, plus the aiPlayer=5 rejection path.