### PR TITLE
Add TDM red/dragon cards (batch C)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NerivHeartOfTheStorm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NerivHeartOfTheStorm.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DoubleDamage
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * Neriv, Heart of the Storm — Tarkir: Dragonstorm #210
+ * {1}{R}{W}{B} · Legendary Creature — Spirit Dragon · 4/5
+ *
+ * Flying
+ * If a creature you control that entered this turn would deal damage, it deals twice
+ * that much damage instead.
+ *
+ * The damage-doubling clause is a damage replacement effect ([DoubleDamage]) gated on the
+ * damage source: a creature controlled by Neriv's controller that has the
+ * [com.wingedsheep.sdk.scripting.predicates.StatePredicate.EnteredThisTurn] state predicate
+ * (tracked by `EnteredThisTurnComponent`, cleared at the start of each turn). This covers any
+ * damage the creature deals — combat or ability — and applies to Neriv itself if it entered
+ * this turn. `youControl()` resolves against the replacement source's controller.
+ */
+val NerivHeartOfTheStorm = card("Neriv, Heart of the Storm") {
+    manaCost = "{1}{R}{W}{B}"
+    colorIdentity = "RWB"
+    typeLine = "Legendary Creature — Spirit Dragon"
+    power = 4
+    toughness = 5
+    oracleText = "Flying\n" +
+        "If a creature you control that entered this turn would deal damage, it deals twice " +
+        "that much damage instead."
+
+    keywords(Keyword.FLYING)
+
+    replacementEffect(
+        DoubleDamage(
+            appliesTo = EventPattern.DamageEvent(
+                source = SourceFilter.Matching(
+                    GameObjectFilter.Creature.youControl().enteredThisTurn()
+                )
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "210"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b58112b0-a05c-4b98-b650-fd27ad97789f.jpg?1743204826"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SarkhansResolve.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SarkhansResolve.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sarkhan's Resolve — Tarkir: Dragonstorm #158
+ * {1}{G} · Instant · Common
+ *
+ * Choose one —
+ * • Target creature gets +3/+3 until end of turn.
+ * • Destroy target creature with flying.
+ */
+val SarkhansResolve = card("Sarkhan's Resolve") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Target creature gets +3/+3 until end of turn.\n" +
+        "• Destroy target creature with flying."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Target creature gets +3/+3 until end of turn") {
+                val t = target("target creature", Targets.Creature)
+                effect = Effects.ModifyStats(3, 3, t)
+            }
+            mode("Destroy target creature with flying") {
+                val t = target("target creature with flying", Targets.CreatureWithKeyword(Keyword.FLYING))
+                effect = Effects.Destroy(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Billy Christian"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/cae56fef-b661-4bc5-b9a1-3871ae06e491.jpg?1743204600"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormscaleScion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StormscaleScion.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Stormscale Scion — Tarkir: Dragonstorm #123
+ * {4}{R}{R} · Creature — Dragon · 4/4
+ *
+ * Flying
+ * Other Dragons you control get +1/+1.
+ * Storm (When you cast this spell, copy it for each spell cast before it this turn.
+ * Copies become tokens.)
+ */
+val StormscaleScion = card("Stormscale Scion") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Other Dragons you control get +1/+1.\n" +
+        "Storm (When you cast this spell, copy it for each spell cast before it this turn. " +
+        "Copies become tokens.)"
+
+    keywords(Keyword.FLYING, Keyword.STORM)
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype("Dragon").youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "123"
+        artist = "Andrew Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0ac43386-bd32-425c-8776-cec00b064cbc.jpg?1743204459"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SummitIntimidator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SummitIntimidator.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Summit Intimidator — Tarkir: Dragonstorm #125
+ * {3}{R} · Creature — Yeti · 4/3
+ *
+ * Reach
+ * When this creature enters, target creature can't block this turn.
+ */
+val SummitIntimidator = card("Summit Intimidator") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Yeti"
+    power = 4
+    toughness = 3
+    oracleText = "Reach\nWhen this creature enters, target creature can't block this turn."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = Targets.Creature
+        effect = Effects.CantBlock()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Diego Gisbert"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3cba0b1-7c22-4e51-b9cf-5bf01e67a222.jpg?1743204466"
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NerivHeartOfTheStormScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NerivHeartOfTheStormScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Neriv, Heart of the Storm (TDM #210).
+ *
+ * "Flying
+ *  If a creature you control that entered this turn would deal damage, it deals twice
+ *  that much damage instead."
+ *
+ * Verifies the damage-doubling replacement effect:
+ *  - a creature you control that entered this turn (Raging Goblin, cast this turn with
+ *    haste) deals double combat damage,
+ *  - a creature you control that did NOT enter this turn deals normal damage,
+ *  - an opponent's creature is unaffected.
+ */
+class NerivHeartOfTheStormScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Neriv, Heart of the Storm") {
+
+            test("has flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Neriv, Heart of the Storm")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val neriv = game.findPermanent("Neriv, Heart of the Storm")!!
+                game.state.projectedState.hasKeyword(neriv, Keyword.FLYING) shouldBe true
+            }
+
+            test("a creature that entered this turn deals double combat damage") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Neriv, Heart of the Storm")
+                    .withCardInHand(1, "Raging Goblin")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startLife = game.getLifeTotal(2)
+
+                // Cast Raging Goblin (1/1 haste) — it has entered this turn.
+                game.castSpell(1, "Raging Goblin").error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Raging Goblin" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Raging Goblin (1 power) entered this turn → 2 combat damage doubled") {
+                    game.getLifeTotal(2) shouldBe startLife - 2
+                }
+            }
+
+            test("a creature that did not enter this turn deals normal damage") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Neriv, Heart of the Storm")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // placed pre-game, did not enter this turn
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startLife = game.getLifeTotal(2)
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Grizzly Bears did not enter this turn → normal 2 combat damage") {
+                    game.getLifeTotal(2) shouldBe startLife - 2
+                }
+            }
+
+            test("an opponent's creature that entered this turn is unaffected") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Neriv, Heart of the Storm")
+                    .withCardInHand(2, "Raging Goblin")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startLife = game.getLifeTotal(1)
+
+                // Opponent (player 2) casts Raging Goblin this turn and attacks player 1.
+                game.castSpell(2, "Raging Goblin").error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Raging Goblin" to 1)).error shouldBe null
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Opponent's Goblin is not 'a creature you control' for Neriv → normal 1 damage") {
+                    game.getLifeTotal(1) shouldBe startLife - 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarkhansResolveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarkhansResolveScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sarkhan's Resolve (TDM #158).
+ *
+ * "Choose one —
+ *  • Target creature gets +3/+3 until end of turn.
+ *  • Destroy target creature with flying."
+ *
+ * Verifies both modes: the pump on any creature, and the flying-restricted destroy.
+ */
+class SarkhansResolveScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sarkhan's Resolve") {
+
+            test("mode 1 gives target creature +3/+3 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sarkhan's Resolve")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpellWithMode(1, "Sarkhan's Resolve", modeIndex = 0, targetId = bears)
+                withClue("Casting mode 1 should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears (2/2) should become 5/5") {
+                    game.state.projectedState.getPower(bears) shouldBe 5
+                    game.state.projectedState.getToughness(bears) shouldBe 5
+                }
+            }
+
+            test("mode 2 destroys a creature with flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sarkhan's Resolve")
+                    .withCardOnBattlefield(2, "Wind Drake")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val drake = game.findPermanent("Wind Drake")!!
+
+                val cast = game.castSpellWithMode(1, "Sarkhan's Resolve", modeIndex = 1, targetId = drake)
+                withClue("Casting mode 2 against a flyer should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Wind Drake should be destroyed") {
+                    game.isOnBattlefield("Wind Drake") shouldBe false
+                }
+                withClue("Wind Drake should be in its owner's graveyard") {
+                    game.findCardsInGraveyard(2, "Wind Drake").size shouldBe 1
+                }
+            }
+
+            test("mode 2 cannot target a creature without flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sarkhan's Resolve")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpellWithMode(1, "Sarkhan's Resolve", modeIndex = 1, targetId = bears)
+                withClue("Destroy mode should reject a non-flying creature target") {
+                    (cast.error != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormscaleScionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormscaleScionScenarioTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Stormscale Scion (TDM #123).
+ *
+ * "Flying
+ *  Other Dragons you control get +1/+1.
+ *  Storm (...)"
+ *
+ * Verifies the flying keyword and the you-control Dragon lord buff (other Dragons only,
+ * not the Scion itself, and not opponents' Dragons). Storm is exercised by the shared
+ * keyword machinery and is not re-verified here.
+ */
+class StormscaleScionScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Stormscale Scion") {
+
+            test("has flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stormscale Scion")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val scion = game.findPermanent("Stormscale Scion")!!
+                game.state.projectedState.hasKeyword(scion, Keyword.FLYING) shouldBe true
+            }
+
+            test("buffs other Dragons you control but not itself or non-Dragons") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stormscale Scion")
+                    .withCardOnBattlefield(1, "Grizzly Bears")    // non-Dragon you control
+                    .withCardOnBattlefield(1, "Volcanic Dragon")  // another Dragon you control
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val scion = game.findPermanent("Stormscale Scion")!!
+                val dragon = game.findPermanent("Volcanic Dragon")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = game.state.projectedState
+
+                withClue("Volcanic Dragon (4/4) should be buffed to 5/5 by the Scion") {
+                    projected.getPower(dragon) shouldBe 5
+                    projected.getToughness(dragon) shouldBe 5
+                }
+                withClue("Stormscale Scion should not buff itself (stays 4/4)") {
+                    projected.getPower(scion) shouldBe 4
+                    projected.getToughness(scion) shouldBe 4
+                }
+                withClue("Non-Dragon Grizzly Bears should stay 2/2") {
+                    projected.getPower(bears) shouldBe 2
+                    projected.getToughness(bears) shouldBe 2
+                }
+            }
+
+            test("does not buff opponent's Dragons") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stormscale Scion")
+                    .withCardOnBattlefield(2, "Volcanic Dragon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dragon = game.findPermanent("Volcanic Dragon")!!
+                withClue("Opponent's Volcanic Dragon should stay 4/4") {
+                    game.state.projectedState.getPower(dragon) shouldBe 4
+                    game.state.projectedState.getToughness(dragon) shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummitIntimidatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummitIntimidatorScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Summit Intimidator (TDM #125).
+ *
+ * "Reach
+ *  When this creature enters, target creature can't block this turn."
+ */
+class SummitIntimidatorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Summit Intimidator") {
+
+            test("has reach") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Summit Intimidator")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val intimidator = game.findPermanent("Summit Intimidator")!!
+                game.state.projectedState.hasKeyword(intimidator, Keyword.REACH) shouldBe true
+            }
+
+            test("ETB makes target creature unable to block this turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Summit Intimidator")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpell(1, "Summit Intimidator")
+                withClue("Casting Summit Intimidator should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // ETB targets the opponent's creature.
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(bears))
+                    game.resolveStack()
+                }
+
+                withClue("Targeted Grizzly Bears should not be able to block this turn") {
+                    game.state.projectedState.cantBlock(bears) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements four **Tarkir: Dragonstorm (TDM)** cards, all composed from existing SDK primitives (no new effects/triggers/conditions/keywords), each with a `rules-engine` scenario test.

| Card | Cost / Type | Mechanics |
|------|-------------|-----------|
| **Sarkhan's Resolve** | `{1}{G}` Instant | Modal: +3/+3, or destroy target creature with flying |
| **Summit Intimidator** | `{3}{R}` 4/3 Yeti | Reach; ETB "target creature can't block this turn" |
| **Stormscale Scion** | `{4}{R}{R}` 4/4 Dragon | Flying, Storm, you-control Dragon lord (+1/+1 to other Dragons you control) |
| **Neriv, Heart of the Storm** | `{1}{R}{W}{B}` 4/5 Spirit Dragon | Flying; `DoubleDamage` replacement gated on a creature you control with the `EnteredThisTurn` state predicate |

### Notable implementation detail
Neriv's "creature you control that entered this turn deals twice that much damage" reuses the existing `DoubleDamage` replacement effect with a source filter of `GameObjectFilter.Creature.youControl().enteredThisTurn()`. The `applyStaticDamageAmplification` path already runs the source filter through `predicateEvaluator.matches`, which evaluates `EnteredThisTurn` via `EnteredThisTurnComponent` — so no engine change was needed.

## Skipped: Dracogenesis
`{6}{R}{R}` Enchantment — "You may cast Dragon spells without paying their mana costs."

Intentionally skipped. There is no Omniscience-style static permission to cast spells **from hand by filter without paying**, and `GrantAlternativeCastingCost` is unfiltered with no free-cast path. A faithful implementation needs a new cross-layer SDK feature (cast-legality enumeration + alternative payment + the "you may" cast-time choice), which is out of scope for the add-card flow. Reported rather than shipped as a fragile one-off.

## Tests
All 12 scenario tests pass:
- `SarkhansResolveScenarioTest` (3) — both modes + flying-restriction enforcement
- `SummitIntimidatorScenarioTest` (2) — reach + ETB can't-block
- `StormscaleScionScenarioTest` (3) — flying, you-control lord (excludes self/non-Dragons), no opponent buff
- `NerivHeartOfTheStormScenarioTest` (4) — flying, entered-this-turn doubling, non-entered normal damage, opponent's creature unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)