### PR TITLE
Fix summoning sickness for Vehicles and animated permanents

### DIFF
--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -254,7 +254,14 @@ class ObservationBuilder(
             power = if (onBattlefield) projected.getPower(entityId) else null,
             toughness = if (onBattlefield) projected.getToughness(entityId) else null,
             tapped = onBattlefield && container.get<TappedComponent>() != null,
-            summoningSick = onBattlefield && container.get<SummoningSicknessComponent>() != null,
+            // Only creatures meaningfully suffer summoning sickness — the engine attaches the
+            // marker to every entering permanent so Vehicles / animated lands inherit the
+            // restriction when they become creatures, but for non-creatures the marker is a
+            // no-op (all {T}/attack gates are creature-conditional). Reporting it on a freshly
+            // played Mountain would mislead the agent into thinking it can't tap for mana.
+            summoningSick = onBattlefield
+                && container.get<SummoningSicknessComponent>() != null
+                && projected.isCreature(entityId),
             faceDown = container.get<FaceDownComponent>() != null,
             damageMarked = container.get<DamageComponent>()?.amount ?: 0,
             counters = container.get<CountersComponent>()?.counters

--- a/manual-scenarios/cards/t/turtle-blimp.json
+++ b/manual-scenarios/cards/t/turtle-blimp.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Turtle Blimp"],
+    "battlefield": [
+      {"name": "Coral Eel"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Horned Turtle"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -156,11 +156,12 @@ class CostHandler(
                     ?: return false
                 val attachedEntity = state.getEntity(attachedId) ?: return false
                 if (attachedEntity.has<TappedComponent>()) return false
-                // Check summoning sickness on the attached creature
-                val card = attachedEntity.get<CardComponent>()
-                if (card != null && card.typeLine.isCreature) {
+                // Check summoning sickness on the attached creature. Read creature-ness and
+                // haste from projected state so a Vehicle / animated permanent currently
+                // being a creature is gated correctly.
+                if (state.projectedState.isCreature(attachedId)) {
                     val hasSummoningSickness = attachedEntity.has<SummoningSicknessComponent>()
-                    val hasHaste = card.baseKeywords.contains(com.wingedsheep.sdk.core.Keyword.HASTE)
+                    val hasHaste = state.projectedState.hasKeyword(attachedId, com.wingedsheep.sdk.core.Keyword.HASTE)
                     if (hasSummoningSickness && !hasHaste) return false
                 }
                 true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -221,16 +221,16 @@ class ActivateAbilityHandler(
         }
 
         // Check summoning sickness for TapAttachedCreature cost (before general cost check
-        // to give a specific error message)
+        // to give a specific error message). Read creature-ness and haste from projected
+        // state so a Vehicle / animated land currently being a creature is gated correctly.
         if (effectiveCost is AbilityCost.TapAttachedCreature ||
             (effectiveCost is AbilityCost.Composite && effectiveCost.costs.any { it is AbilityCost.TapAttachedCreature })) {
             val attachedId = container.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()?.targetId
             if (attachedId != null) {
                 val attachedContainer = state.getEntity(attachedId)
-                val attachedCard = attachedContainer?.get<CardComponent>()
-                if (attachedCard != null && attachedCard.typeLine.isCreature) {
+                if (attachedContainer != null && state.projectedState.isCreature(attachedId)) {
                     val hasSummoningSickness = attachedContainer.has<SummoningSicknessComponent>()
-                    val hasHaste = attachedCard.baseKeywords.contains(Keyword.HASTE)
+                    val hasHaste = state.projectedState.hasKeyword(attachedId, Keyword.HASTE)
                     if (hasSummoningSickness && !hasHaste) {
                         return "Enchanted creature has summoning sickness"
                     }
@@ -288,12 +288,16 @@ class ActivateAbilityHandler(
             }
         }
 
-        // Check summoning sickness for tap abilities
+        // Check summoning sickness for tap abilities. CR 302.6 restricts a *creature's* {T}/{Q}
+        // activated ability — read creature-ness and haste from projected state so a Vehicle
+        // or animated permanent that became a creature this turn is gated correctly. The
+        // `!typeLine.isLand` carve-out is preserved (basic-land mana abilities are not
+        // restricted by summoning sickness).
         if (effectiveCost is AbilityCost.Tap ||
             (effectiveCost is AbilityCost.Composite && effectiveCost.costs.any { it is AbilityCost.Tap })) {
-            if (!cardComponent.typeLine.isLand && cardComponent.typeLine.isCreature) {
+            if (!cardComponent.typeLine.isLand && state.projectedState.isCreature(action.sourceId)) {
                 val hasSummoningSickness = container.has<SummoningSicknessComponent>()
-                val hasHaste = cardComponent.baseKeywords.contains(Keyword.HASTE)
+                val hasHaste = state.projectedState.hasKeyword(action.sourceId, Keyword.HASTE)
                 if (hasSummoningSickness && !hasHaste) {
                     return "This creature has summoning sickness"
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -612,10 +612,11 @@ object ZoneTransitionService {
                 )
             }
 
-            // Creatures enter with summoning sickness
-            if (cardComponent.typeLine.isCreature) {
-                updated = updated.with(SummoningSicknessComponent)
-            }
+            // All permanents enter summoning sick (CR 302.6 / 508.1a — the control-continuity
+            // check is about the permanent, not whether it was a creature the whole turn).
+            // Downstream checks gate on isCreature/{T}-cost so this is a no-op for lands and
+            // non-creature artifacts until they become creatures (Crew, animate-land, etc.).
+            updated = updated.with(SummoningSicknessComponent)
 
             // Tapped entry
             if (options.tapped || options.tappedAndAttacking) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -379,9 +379,12 @@ class CostEnumerationUtils(
         val container = state.getEntity(entityId) ?: return false
         if (container.has<TappedComponent>()) return false
         val cardComponent = container.get<CardComponent>() ?: return false
-        if (!cardComponent.typeLine.isLand && cardComponent.typeLine.isCreature) {
+        // Read creature-ness / haste from projected state so a Vehicle or animated permanent
+        // that is currently a creature is gated. Lands keep the carve-out (basic-land mana
+        // abilities are not restricted by summoning sickness).
+        if (!cardComponent.typeLine.isLand && state.projectedState.isCreature(entityId)) {
             val hasSummoningSickness = container.has<SummoningSicknessComponent>()
-            val hasHaste = cardComponent.baseKeywords.contains(Keyword.HASTE)
+            val hasHaste = state.projectedState.hasKeyword(entityId, Keyword.HASTE)
             if (hasSummoningSickness && !hasHaste) return false
         }
         return true
@@ -396,10 +399,11 @@ class CostEnumerationUtils(
             ?: return false
         val attachedEntity = state.getEntity(attachedId) ?: return false
         if (attachedEntity.has<TappedComponent>()) return false
-        val attachedCard = attachedEntity.get<CardComponent>()
-        if (attachedCard != null && attachedCard.typeLine.isCreature) {
+        // Read creature-ness / haste from projected state so a Vehicle or animated permanent
+        // currently being a creature is gated.
+        if (state.projectedState.isCreature(attachedId)) {
             val hasSummoningSickness = attachedEntity.has<SummoningSicknessComponent>()
-            val hasHaste = attachedCard.baseKeywords.contains(Keyword.HASTE)
+            val hasHaste = state.projectedState.hasKeyword(attachedId, Keyword.HASTE)
             if (hasSummoningSickness && !hasHaste) return false
         }
         return true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -976,10 +976,12 @@ class StackResolver(
                     .without<RevealedToComponent>()
             }
 
-            // Creatures enter with summoning sickness (including face-down creatures)
-            if (cardComponent?.typeLine?.isCreature == true || spellComponent.castFaceDown) {
-                updated = updated.with(SummoningSicknessComponent)
-            }
+            // All permanents enter summoning sick (CR 302.6 / 508.1a — the control-continuity
+            // check is about the permanent, not whether it was a creature the whole turn). Vehicles
+            // and animated lands that become creatures mid-turn must inherit the marker too.
+            // Downstream checks gate on isCreature/{T}-cost so this is harmless for lands and
+            // non-creature artifacts until they become creatures (Crew, animate-land, etc.).
+            updated = updated.with(SummoningSicknessComponent)
 
             // Track that this permanent entered the battlefield this turn
             updated = updated.with(EnteredThisTurnComponent)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -688,10 +688,14 @@ class ClientStateTransformer(
         // Get state components
         val isTapped = container.has<TappedComponent>()
         val isPhasedOut = container.has<PhasedOutComponent>()
-        // Summoning sickness doesn't affect creatures with haste
+        // Summoning sickness doesn't affect creatures with haste. The engine attaches the
+        // marker to every entering permanent (so Vehicles / animated lands inherit it when
+        // they become creatures), so gate on projected creature-ness here too — otherwise a
+        // freshly played Mountain or Equipment would report summoning sickness to the client.
         val hasSummoningSicknessComponent = container.has<SummoningSicknessComponent>()
         val hasHaste = keywords.contains(com.wingedsheep.sdk.core.Keyword.HASTE)
-        val hasSummoningSickness = hasSummoningSicknessComponent && !hasHaste
+        val hasSummoningSickness = hasSummoningSicknessComponent && !hasHaste &&
+            projectedState.isCreature(entityId)
 
         // Get morph data for face-down creatures
         val morphData = container.get<MorphDataComponent>()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VehicleEntersThisTurnAttackTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VehicleEntersThisTurnAttackTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.por.cards.CoralEel
+import com.wingedsheep.mtg.sets.definitions.tmt.cards.TurtleBlimp
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * CR 302.6 / 508.1a — a creature can't attack unless it has been under its controller's control
+ * continuously since their most recent turn began. The rule applies to the *permanent*, not just
+ * to things that were creatures the entire time, so a Vehicle that just entered this turn and was
+ * then crewed must still be summoning-sick for the purposes of attacking.
+ *
+ * Regression: `ZoneTransitionService` previously gated the `SummoningSicknessComponent` on
+ * `cardComponent.typeLine.isCreature`, so non-creature permanents (Vehicles, animated lands, etc.)
+ * that became creatures mid-turn could attack the turn they entered.
+ */
+class VehicleEntersThisTurnAttackTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(TurtleBlimp, CoralEel))
+        return driver
+    }
+
+    test("Turtle Blimp cast this turn cannot attack after being crewed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+
+        // Coral Eel (2/1) is a fine crew partner — power 2 satisfies Crew 2. Summoning sickness
+        // on the Eel is irrelevant: the Vehicle's Crew ability taps it as a cost, but that's not
+        // the creature activating a {T} ability of its own (CR 302.6 / 602.5a only restrict the
+        // creature's own {T}/{Q} costs).
+        driver.putCreatureOnBattlefield(you, "Coral Eel")
+
+        // Cast Turtle Blimp from hand so it enters via the real ZoneTransitionService path.
+        val blimpInHand = driver.putCardInHand(you, "Turtle Blimp")
+        driver.giveMana(you, Color.RED, 5)
+        driver.castSpell(you, blimpInHand).isSuccess shouldBe true
+        driver.bothPass()  // resolve the spell — Blimp enters, ETB queues the token
+        driver.bothPass()  // resolve the ETB trigger — 2/2 Mutant token enters
+
+        val blimpOnBattlefield = driver.findPermanent(you, "Turtle Blimp")
+            ?: error("Turtle Blimp not on battlefield after casting")
+        val eel = driver.findPermanent(you, "Coral Eel")
+            ?: error("Coral Eel not on battlefield")
+
+        // Crew it — Coral Eel's 2 power covers Crew 2. The Vehicle becomes a 3/4 artifact
+        // creature until end of turn.
+        driver.submitSuccess(CrewVehicle(you, blimpOnBattlefield, listOf(eel)))
+        driver.bothPass()  // resolve the Crew activation
+
+        // Advance to the declare-attackers step.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        // Attack must be refused: Turtle Blimp hasn't been under its controller's control
+        // continuously since the turn began (CR 302.6 / 508.1a).
+        driver.submitExpectFailure(
+            DeclareAttackers(you, mapOf(blimpOnBattlefield to opponent))
+        )
+    }
+})


### PR DESCRIPTION
## Summary

A Vehicle cast and crewed on the same turn was attacking the turn it entered
— a violation of CR 302.6 / 508.1a, which key off control-continuity of the
*permanent*, not whether it was a creature the whole turn. The same gap
affected animated lands and any "becomes a creature this turn" path.

## Fix

- `ZoneTransitionService` and `StackResolver` now attach `SummoningSicknessComponent`
  to every entering permanent, not just those whose printed type line is
  Creature. Downstream gates already short-circuit for lands and non-creature
  artifacts, so the marker is a no-op until the permanent becomes a creature.

- Downstream `{T}`-cost gates in `ActivateAbilityHandler`, `CostHandler`, and
  `CostEnumerationUtils` were reading `cardComponent.typeLine.isCreature`
  (base type) and `baseKeywords.contains(HASTE)` — both wrong for Vehicles
  post-crew and for creatures granted haste by a continuous effect. Switched
  to `state.projectedState.isCreature(...)` / `hasKeyword(..., HASTE)`,
  matching the CLAUDE.md invariant and the existing `ManaSolver` reads.

- `ObservationBuilder.summoningSick` now gates on `projected.isCreature(...)`
  so the gym observation no longer mislabels freshly-played Mountains and
  Equipment as sickness-bound.

## Tests

- New `VehicleEntersThisTurnAttackTest`: casts Turtle Blimp from hand, crews
  with Coral Eel, asserts attack is refused on the entry turn.
- Full `:rules-engine`, `:mtg-sdk`, `:gym`, and `:game-server` suites green.