### PR TITLE
Add TDM Sultai/black cards (batch B)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1817,6 +1817,13 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
 ### Cast / cost
 
 - `WasCast` — source was cast (not put onto the stack).
+- `TriggeringEntityWasCast` — the *triggering* entity (not the ability's source) was cast — i.e. it
+  carries a cast-origin marker (`CastFromHandComponent` / `CastFromGraveyardComponent`). The
+  cast-subject sibling of `WasCast`, for "whenever a creature you control enters, **if you cast it**,
+  …" intervening-if triggers where the source is a separate permanent and the cast subject is the
+  entering creature. Tokens, reanimated permanents, and "put onto the battlefield" permanents lack
+  the markers and are correctly excluded. Used by **The Sibsig Ceremony** (a plain `WasCast` there
+  would test the enchantment, not the entering creature). Resolution-only.
 - `WasCastFromHand` — cast specifically from hand.
 - `WasCastFromZone(zone)` — cast from a specific zone. For resolving spells it reads the spell's
   cast-origin; for a permanent already on the battlefield it falls back to the cast-origin marker

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -835,6 +835,15 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TriggeringEntityWasHistoric
 
     /**
+     * If you cast the triggering entity (the entering permanent), as opposed to it being put
+     * onto the battlefield by another effect. Sibling of [WasCast] for triggers whose source is
+     * a separate permanent (e.g. "whenever a creature you control enters, if you cast it" on
+     * The Sibsig Ceremony).
+     */
+    val TriggeringEntityWasCast: ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TriggeringEntityWasCast
+
+    /**
      * If the triggering entity entered or was cast from a graveyard.
      * Used by Twilight Diviner: "if they entered or were cast from a graveyard".
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -96,6 +96,21 @@ data object TriggeringEntityWasHistoric : Condition {
 }
 
 /**
+ * Condition: "if you cast it" referring to the *triggering* entity (not the ability's source).
+ * True when the entering permanent that triggered the ability was cast — i.e. it carries a
+ * cast-origin marker (cast from hand or graveyard) — and false when it was put onto the
+ * battlefield by another effect (token, reanimation, "put onto the battlefield"). This is the
+ * sibling of [com.wingedsheep.sdk.scripting.conditions.WasCast] for "whenever a creature you
+ * control enters, if you cast it" triggers, where the source is a separate permanent and the
+ * cast subject is the entering creature (e.g. The Sibsig Ceremony).
+ */
+@SerialName("TriggeringEntityWasCast")
+@Serializable
+data object TriggeringEntityWasCast : Condition {
+    override val description: String = "if you cast it"
+}
+
+/**
  * Condition: "if it entered or was cast from a graveyard".
  * True when the triggering entity has either EnteredFromGraveyardComponent (reanimated
  * directly from graveyard → battlefield) or CastFromGraveyardComponent (spell was cast

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/Perennation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/Perennation.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Perennation
+ * {3}{W}{B}{G}
+ * Sorcery
+ *
+ * Return target permanent card from your graveyard to the battlefield with a hexproof counter
+ * and an indestructible counter on it.
+ *
+ * Reanimation that staples on two keyword counters as the permanent enters. Modeled with the
+ * same shape as Season of the Burrow's reanimate-with-counters mode: target a permanent card in
+ * your graveyard, [Effects.PutOntoBattlefield] it (so it enters as the original object, keeping
+ * the entityId), then add a HEXPROOF counter and an INDESTRUCTIBLE counter to that same object.
+ * Both are keyword counters mapped in [StateProjector.KEYWORD_COUNTER_MAP], so the permanent
+ * gains hexproof and indestructible via projected state for as long as the counters remain.
+ */
+val Perennation = card("Perennation") {
+    manaCost = "{3}{W}{B}{G}"
+    colorIdentity = "WBG"
+    typeLine = "Sorcery"
+    oracleText = "Return target permanent card from your graveyard to the battlefield with a " +
+        "hexproof counter and an indestructible counter on it."
+
+    spell {
+        val returnTarget = target(
+            "target permanent card from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Permanent.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.PutOntoBattlefield(returnTarget)
+            .then(Effects.AddCounters(Counters.HEXPROOF, 1, EffectTarget.ContextTarget(0)))
+            .then(Effects.AddCounters(Counters.INDESTRUCTIBLE, 1, EffectTarget.ContextTarget(0)))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "212"
+        artist = "Eli Minaya"
+        flavorText = "The Abzan believe in perennation—death is not only an end, but a return " +
+            "to the beginning."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ffe7071e-a214-44e8-a571-129f0db44f76.jpg?1743204835"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RakshasasBargain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RakshasasBargain.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rakshasa's Bargain
+ * {2/B}{2/G}{2/U}
+ * Instant
+ *
+ * Look at the top four cards of your library. Put two of them into your hand and the rest
+ * into your graveyard.
+ *
+ * The classic Sultai "dig" — modeled with [EffectPatterns.lookAtTopAndKeep] (count = 4,
+ * keepCount = 2). The keeper cards go to hand and the remainder to the graveyard. Each of the
+ * three hybrid mana symbols can be paid with two generic or one of the respective color.
+ */
+val RakshasasBargain = card("Rakshasa's Bargain") {
+    manaCost = "{2/B}{2/G}{2/U}"
+    colorIdentity = "BGU"
+    typeLine = "Instant"
+    oracleText = "Look at the top four cards of your library. Put two of them into your hand " +
+        "and the rest into your graveyard."
+
+    spell {
+        effect = EffectPatterns.lookAtTopAndKeep(
+            count = 4,
+            keepCount = 2
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Yigit Koroglu"
+        flavorText = "\"You know you shouldn't and the Sultai forbid you. But you can't resist " +
+            "the temptation, can you?\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c409f4f-3b2c-4c33-b850-55b2a46f51ca.jpg?1743204844"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RevivalOfTheAncestors.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RevivalOfTheAncestors.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Revival of the Ancestors
+ * {1}{W}{B}{G}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Create three 1/1 white Spirit creature tokens.
+ * II — Distribute three +1/+1 counters among one, two, or three target creatures you control.
+ * III — Creatures you control gain trample and lifelink until end of turn.
+ *
+ * Chapter I creates three Spirit tokens. Chapter II declares one-to-three "you control" creature
+ * targets and uses [Effects.DistributeCountersAmongTargets] (total = 3) so the player allocates
+ * the +1/+1 counters across the chosen creatures at resolution. Chapter III grants trample and
+ * lifelink to every creature you control until end of turn via two
+ * [EffectPatterns.grantKeywordToAll] over [GroupFilter.AllCreaturesYouControl].
+ */
+val RevivalOfTheAncestors = card("Revival of the Ancestors") {
+    manaCost = "{1}{W}{B}{G}"
+    colorIdentity = "WBG"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Create three 1/1 white Spirit creature tokens.\n" +
+        "II — Distribute three +1/+1 counters among one, two, or three target creatures you control.\n" +
+        "III — Creatures you control gain trample and lifelink until end of turn."
+
+    sagaChapter(1) {
+        effect = Effects.CreateToken(
+            count = 3,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            imageUri = "https://cards.scryfall.io/normal/front/f/2/f22410b3-5c0b-4282-9b0b-5ba61229b6e7.jpg?1743176224"
+        )
+    }
+
+    sagaChapter(2) {
+        target(
+            "one, two, or three target creatures you control",
+            TargetCreature(
+                count = 3,
+                minCount = 1,
+                filter = TargetFilter(GameObjectFilter.Creature.youControl())
+            )
+        )
+        effect = Effects.DistributeCountersAmongTargets(totalCounters = 3)
+    }
+
+    sagaChapter(3) {
+        effect = EffectPatterns.grantKeywordToAll(Keyword.TRAMPLE, GroupFilter.AllCreaturesYouControl)
+            .then(EffectPatterns.grantKeywordToAll(Keyword.LIFELINK, GroupFilter.AllCreaturesYouControl))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "218"
+        artist = "Clint Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd742ff5-f0ea-4f4b-911e-4c09e2154dba.jpg?1744578010"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ScavengerRegent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ScavengerRegent.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Scavenger Regent // Exude Toxin
+ * {3}{B} // {X}{B}{B}
+ * Creature — Dragon // Sorcery — Omen
+ * 4/4
+ *
+ * Scavenger Regent:
+ *   Flying
+ *   Ward—Discard a card.
+ *
+ * Exude Toxin — {X}{B}{B}, Sorcery — Omen:
+ *   Each non-Dragon creature gets -X/-X until end of turn.
+ *   (Then shuffle this card into its owner's library.)
+ *
+ * Ward—Discard a card is modeled with [KeywordAbility.wardDiscard]. Exude Toxin is an Omen face
+ * (declared via the `omen { }` DSL, so on resolution the card shuffles into its owner's library
+ * per the Omen reminder text). The board-wide -X/-X is
+ * [EffectPatterns.modifyStatsForAll] over every creature without the Dragon subtype, with the
+ * amount read from the X paid for the spell ([DynamicAmount.XValue] negated).
+ */
+val ScavengerRegent = card("Scavenger Regent") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\nWard—Discard a card."
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.wardDiscard())
+
+    // Exude Toxin — Omen. Each non-Dragon creature gets -X/-X until end of turn.
+    omen("Exude Toxin") {
+        manaCost = "{X}{B}{B}"
+        typeLine = "Sorcery — Omen"
+        oracleText = "Each non-Dragon creature gets -X/-X until end of turn. " +
+            "(Then shuffle this card into its owner's library.)"
+        spell {
+            effect = EffectPatterns.modifyStatsForAll(
+                power = DynamicAmount.Multiply(DynamicAmount.XValue, -1),
+                toughness = DynamicAmount.Multiply(DynamicAmount.XValue, -1),
+                filter = GroupFilter(GameObjectFilter.Creature.notSubtype(Subtype.DRAGON))
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "90"
+        artist = "John Tedrick"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg?1752538974"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TheSibsigCeremony.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TheSibsigCeremony.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Sibsig Ceremony
+ * {B}{B}{B}
+ * Legendary Enchantment
+ *
+ * Creature spells you cast cost {2} less to cast.
+ * Whenever a creature you control enters, if you cast it, destroy that creature, then create a
+ * 2/2 black Zombie Druid creature token.
+ *
+ * The cost reduction is a [ModifySpellCost] static targeting creature spells you cast. The ETB
+ * trigger uses an ANY binding over creatures you control (the enchantment itself isn't a
+ * creature, so it never self-triggers). The "if you cast it" intervening-if refers to the
+ * entering creature, so it is gated with [Conditions.TriggeringEntityWasCast] — the cast-subject
+ * version of "if you cast it" (a plain `WasCast` would test the enchantment, not the creature).
+ * On resolution the entering creature is destroyed ([EffectTarget.TriggeringEntity]) and a 2/2
+ * black Zombie Druid token is created.
+ */
+val TheSibsigCeremony = card("The Sibsig Ceremony") {
+    manaCost = "{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Enchantment"
+    oracleText = "Creature spells you cast cost {2} less to cast.\n" +
+        "Whenever a creature you control enters, if you cast it, destroy that creature, then " +
+        "create a 2/2 black Zombie Druid creature token."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature),
+            modification = CostModification.ReduceGeneric(2)
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        triggerCondition = Conditions.TriggeringEntityWasCast
+        effect = Effects.Destroy(EffectTarget.TriggeringEntity)
+            .then(
+                Effects.CreateToken(
+                    power = 2,
+                    toughness = 2,
+                    colors = setOf(Color.BLACK),
+                    creatureTypes = setOf("Zombie", "Druid"),
+                    imageUri = "https://cards.scryfall.io/normal/front/f/1/f10d5813-7818-43e8-b08d-4ed8c54d0366.jpg?1748452772"
+                )
+            )
+        description = "Whenever a creature you control enters, if you cast it, destroy that " +
+            "creature, then create a 2/2 black Zombie Druid creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "91"
+        artist = "Eli Minaya"
+        flavorText = "\"Once flesh, now gold and jade. Once dead, now alive again. Once " +
+            "respected, now honored beyond imagination.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a9f2a62-1c61-4d2e-86d9-18cd84c31748.jpg?1743204325"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -74,6 +74,7 @@ import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityEnteredOrWasCastFromGraveyard
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadMinusOneMinusOneCounter
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityWasHistoric
+import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityWasCast
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityWasNotPutByThisSource
 import com.wingedsheep.sdk.scripting.conditions.TriggeringSpellHasSingleTarget
 import com.wingedsheep.sdk.scripting.conditions.TriggeringSpellMatchesFilter
@@ -269,6 +270,7 @@ class ConditionEvaluator(
             }
             is SacrificedPermanentHadSubtype -> ifResolution { evaluateSacrificedPermanentHadSubtype(condition, it) }
             is TriggeringEntityWasHistoric -> ifResolution { evaluateTriggeringEntityWasHistoric(state, it) }
+            is TriggeringEntityWasCast -> ifResolution { evaluateTriggeringEntityWasCast(state, it) }
             is TriggeringEntityEnteredOrWasCastFromGraveyard ->
                 ifResolution { evaluateTriggeringEntityEnteredOrWasCastFromGraveyard(state, it) }
             is TriggeringEntityHadMinusOneMinusOneCounter ->
@@ -699,6 +701,19 @@ class ConditionEvaluator(
         val entityId = context.triggeringEntityId ?: return false
         val card = state.getEntity(entityId)?.get<CardComponent>() ?: return false
         return card.typeLine.isHistoric
+    }
+
+    /**
+     * "if you cast it" referring to the triggering (entering) permanent. Mirrors
+     * [evaluateWasCast] but reads the cast-origin markers off the triggering entity rather than
+     * the ability's source, so it works for "whenever a creature you control enters, if you cast
+     * it" triggers where the source is a separate permanent. Tokens, reanimated, and
+     * "put onto the battlefield" permanents lack these markers and are correctly excluded.
+     */
+    private fun evaluateTriggeringEntityWasCast(state: GameState, context: EffectContext): Boolean {
+        val entityId = context.triggeringEntityId ?: return false
+        val entity = state.getEntity(entityId) ?: return false
+        return entity.has<CastFromHandComponent>() || entity.has<CastFromGraveyardComponent>()
     }
 
     private fun evaluateTriggeringEntityEnteredOrWasCastFromGraveyard(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PerennationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PerennationScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Perennation (TDM #212) — {3}{W}{B}{G} Sorcery.
+ *
+ * "Return target permanent card from your graveyard to the battlefield with a hexproof counter
+ *  and an indestructible counter on it."
+ *
+ * Confirms the reanimation puts the targeted creature card back onto the battlefield with one
+ * hexproof and one indestructible counter, and that those keyword counters grant the keywords
+ * through projected state.
+ */
+class PerennationScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Perennation reanimation with keyword counters") {
+
+            test("returns a creature card from graveyard with hexproof + indestructible counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Perennation")
+                    .withCardInGraveyard(1, "Hill Giant") // 3/3 permanent card
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellTargetingGraveyardCard(1, "Perennation", 1, "Hill Giant")
+                withClue("Casting Perennation should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Hill Giant is returned to the battlefield") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val counters = game.state.getEntity(giant)?.get<CountersComponent>()?.counters
+                withClue("It has a hexproof counter") {
+                    counters?.get(CounterType.HEXPROOF) shouldBe 1
+                }
+                withClue("It has an indestructible counter") {
+                    counters?.get(CounterType.INDESTRUCTIBLE) shouldBe 1
+                }
+
+                val projected = stateProjector.project(game.state)
+                withClue("The hexproof counter grants hexproof via projection") {
+                    projected.hasKeyword(giant, Keyword.HEXPROOF) shouldBe true
+                }
+                withClue("The indestructible counter grants indestructible via projection") {
+                    projected.hasKeyword(giant, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RakshasasBargainScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RakshasasBargainScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Rakshasa's Bargain (TDM #214) — {2/B}{2/G}{2/U} Instant.
+ *
+ * "Look at the top four cards of your library. Put two of them into your hand and the rest
+ *  into your graveyard."
+ *
+ * Confirms the EffectPatterns.lookAtTopAndKeep(count = 4, keepCount = 2) pipeline: the player is
+ * presented with the four top cards, keeps two (→ hand), and the other two go to the graveyard.
+ */
+class RakshasasBargainScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rakshasa's Bargain dig") {
+
+            test("look at top four, keep two to hand, rest to graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rakshasa's Bargain")
+                    // Six payable hybrid pips → six lands cover {2/B}{2/G}{2/U} via generic.
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val graveyardBefore = game.graveyardSize(1)
+
+                game.castSpell(1, "Rakshasa's Bargain").error shouldBe null
+                game.resolveStack()
+
+                // The spell pauses for a select-two-of-four decision.
+                withClue("Rakshasa's Bargain pauses for a keep-2 selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val decision = game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("Looks at the top four cards") {
+                    decision.options.size shouldBe 4
+                }
+                decision.minSelections shouldBe 2
+                decision.maxSelections shouldBe 2
+
+                game.selectCards(decision.options.take(2)).error shouldBe null
+
+                // Hand: -1 (the spell, now in graveyard) + 2 (kept cards).
+                withClue("Two cards kept go to hand (net +1 after the spell leaves hand)") {
+                    game.handSize(1) shouldBe handBefore - 1 + 2
+                }
+                // Graveyard: +2 (the rest) + 1 (the spell itself).
+                withClue("Remaining two cards plus the spell go to the graveyard") {
+                    game.graveyardSize(1) shouldBe graveyardBefore + 2 + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RevivalOfTheAncestorsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RevivalOfTheAncestorsScenarioTest.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Revival of the Ancestors (TDM #218) — {1}{W}{B}{G} Enchantment — Saga.
+ *
+ * "I — Create three 1/1 white Spirit creature tokens.
+ *  II — Distribute three +1/+1 counters among one, two, or three target creatures you control.
+ *  III — Creatures you control gain trample and lifelink until end of turn."
+ *
+ * Confirms chapter I: casting the Saga puts it onto the battlefield, the entering lore counter
+ * triggers chapter I, and three 1/1 white Spirit tokens are created.
+ *
+ * Chapters II/III advance via the lore-counter turn-based action on later turns, which the
+ * turn-driver-free ScenarioTestBase cannot reach cleanly (see the Thunder of Unity note in
+ * TdmGroup3ScenarioTest); they are exercised by the chapter-by-chapter saga driver suite instead.
+ */
+class RevivalOfTheAncestorsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Revival of the Ancestors chapter I") {
+
+            test("casting the Saga creates three 1/1 white Spirit tokens") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Revival of the Ancestors")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1) // {1}{W}{B}{G}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("Casting Revival of the Ancestors should succeed") {
+                    game.castSpell(1, "Revival of the Ancestors").error shouldBe null
+                }
+                game.resolveStack() // Saga enters (lore 1 → chapter I), then chapter I resolves
+
+                withClue("The Saga is on the battlefield") {
+                    game.isOnBattlefield("Revival of the Ancestors") shouldBe true
+                }
+                withClue("Chapter I creates three 1/1 white Spirit tokens") {
+                    game.findAllPermanents("Spirit Token").size shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScavengerRegentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScavengerRegentScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Scavenger Regent // Exude Toxin (TDM #90).
+ *
+ * Scavenger Regent — {3}{B} Dragon, 4/4, Flying, Ward—Discard a card.
+ * Exude Toxin — {X}{B}{B} Sorcery — Omen.
+ *   "Each non-Dragon creature gets -X/-X until end of turn.
+ *    (Then shuffle this card into its owner's library.)"
+ *
+ * Confirms the Omen face wipes non-Dragon creatures with -X/-X (Dragons untouched), then shuffles
+ * itself into the library rather than resolving to the battlefield.
+ */
+class ScavengerRegentScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Exude Toxin Omen face") {
+
+            test("each non-Dragon creature gets -X/-X; Dragons are unaffected; the Omen shuffles back") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Scavenger Regent")
+                    .withLandsOnBattlefield(1, "Swamp", 4) // {X=2}{B}{B}
+                    // A non-Dragon: Hill Giant 3/3 — survives -2/-2 at 1/1.
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    // A non-Dragon controlled by the opponent — "each" hits all creatures.
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2 → dies to -2/-2
+                    // A Dragon: a second Scavenger Regent creature face — unaffected.
+                    .withCardOnBattlefield(2, "Scavenger Regent") // 4/4 Dragon
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Scavenger Regent"
+                }
+                val giant = game.findPermanent("Hill Giant")!!
+                val dragon = game.findPermanent("Scavenger Regent")!!
+                val libraryBefore = game.librarySize(1)
+
+                // Cast the Omen face (faceIndex = 0) with X = 2.
+                val cast = game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = cardId, xValue = 2, faceIndex = 0)
+                )
+                withClue("Casting Exude Toxin should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The non-Dragon Grizzly Bears (2/2) is destroyed by -2/-2") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("The non-Dragon Hill Giant survives at 1/1 after -2/-2") {
+                    projector.getProjectedPower(game.state, giant) shouldBe 1
+                    projector.getProjectedToughness(game.state, giant) shouldBe 1
+                }
+                withClue("The Dragon is unaffected (stays 4/4)") {
+                    projector.getProjectedPower(game.state, dragon) shouldBe 4
+                    projector.getProjectedToughness(game.state, dragon) shouldBe 4
+                }
+                // Library: the Omen card shuffles back in (+1).
+                withClue("Exude Toxin shuffles itself into the library, not the battlefield") {
+                    game.librarySize(1) shouldBe libraryBefore + 1
+                    game.findCardsInLibrary(1, "Scavenger Regent").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSibsigCeremonyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSibsigCeremonyScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for The Sibsig Ceremony (TDM #91) — {B}{B}{B} Legendary Enchantment.
+ *
+ * "Creature spells you cast cost {2} less to cast.
+ *  Whenever a creature you control enters, if you cast it, destroy that creature, then create a
+ *  2/2 black Zombie Druid creature token."
+ *
+ * Confirms (1) the creature-spell cost reduction, (2) the "if you cast it" trigger destroying the
+ * cast creature and making a Zombie Druid token, and (3) that a creature put onto the battlefield
+ * by another effect (a token) does NOT trigger the destroy (the cast-subject intervening-if).
+ */
+class TheSibsigCeremonyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Sibsig Ceremony") {
+
+            test("a cast creature is destroyed and replaced with a 2/2 Zombie Druid token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Sibsig Ceremony")
+                    .withCardInHand(1, "Hill Giant") // {3}{R} → {2} less = {1}{R}
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // {3}{R} reduced by {2} → {1}{R}, payable with the two Mountains.
+                withClue("Hill Giant casts for {2} less (two lands cover {1}{R})") {
+                    game.castSpell(1, "Hill Giant").error shouldBe null
+                }
+                game.resolveStack() // Hill Giant enters → "if you cast it" trigger → resolves
+
+                withClue("The cast creature is destroyed by the trigger") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                }
+                withClue("A 2/2 black Zombie Druid token is created") {
+                    game.findAllPermanents("Zombie Druid Token").size shouldBe 1
+                }
+            }
+
+            test("a creature put onto the battlefield (not cast) does NOT trigger the destroy") {
+                // Reanimate Grizzly Bears with Perennation — it is *put onto* the battlefield, not
+                // cast, so The Sibsig Ceremony's "if you cast it" intervening-if is false.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Sibsig Ceremony")
+                    .withCardInHand(1, "Perennation") // {3}{W}{B}{G} reanimation
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellTargetingGraveyardCard(1, "Perennation", 1, "Grizzly Bears")
+                withClue("Casting Perennation should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Grizzly Bears was put onto the battlefield, not cast → no destroy, no token.
+                withClue("The reanimated (not-cast) creature survives") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("No Zombie Druid token is created for a non-cast enter") {
+                    game.findAllPermanents("Zombie Druid Token").size shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements 5 Tarkir: Dragonstorm (TDM) cards (continuing a stalled batch):

| Card | Cost / Type | Implementation |
|------|-------------|----------------|
| **Rakshasa's Bargain** | {2/B}{2/G}{2/U} Instant | `lookAtTopAndKeep(count=4, keepCount=2)` — keep 2 to hand, rest to graveyard |
| **The Sibsig Ceremony** | {B}{B}{B} Legendary Enchantment | `ModifySpellCost` (creature spells −{2}) + "if you cast it" enters-trigger destroying the creature and making a 2/2 Zombie Druid |
| **Revival of the Ancestors** | {1}{W}{B}{G} Enchantment — Saga | I: 3 Spirit tokens · II: distribute three +1/+1 counters · III: trample + lifelink |
| **Scavenger Regent // Exude Toxin** | {3}{B} Dragon // {X}{B}{B} Omen | Flying, Ward—Discard; Omen face gives each non-Dragon −X/−X |
| **Perennation** | {3}{W}{B}{G} Sorcery | Reanimate a permanent card with hexproof + indestructible counters |

## SDK change

Adds `Conditions.TriggeringEntityWasCast` — the cast-subject sibling of `WasCast` for
"whenever a creature you control enters, **if you cast it**" intervening-ifs (The Sibsig Ceremony).
It reads cast-origin markers (`CastFromHandComponent` / `CastFromGraveyardComponent`) off the
*triggering* entity rather than the ability's source, so tokens / reanimated / "put onto the
battlefield" creatures are correctly excluded. Documented in `docs/card-sdk-language-reference.md`.

## Fix to prior work

Scavenger Regent's Exude Toxin was using `adventure { }` (exile-and-recast). Changed to the
correct `omen { }` DSL so the card shuffles into its owner's library on resolution per Omen rules.

## Notes

- The 5 cards auto-register via the TDM package ClassGraph scan in `TarkirDragonstormSet.kt` — no
  manual set-file list to edit for this set.
- Revival's scenario test covers **chapter I**; chapters II/III require turn-based lore-counter
  advancement that `ScenarioTestBase` can't reach cleanly (same limitation noted for Thunder of
  Unity in `TdmGroup3ScenarioTest`).

## Tests

All 5 cards' scenario tests pass (6 tests total):

```
PerennationScenarioTest ... PASSED
RakshasasBargainScenarioTest ... PASSED
RevivalOfTheAncestorsScenarioTest ... PASSED
ScavengerRegentScenarioTest ... PASSED
TheSibsigCeremonyScenarioTest (2 tests) ... PASSED
```

Nothing skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)