### PR TITLE
Add TDM Jeskai cards (batch A)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1756,6 +1756,12 @@ keywordAbilities(KeywordAbility.Protection(Color.BLUE), KeywordAbility.Annihilat
   and projection). Desugars to `Compare(AggregateBattlefield(You, filter, DISTINCT_COUNTER_TYPES),
   GTE, count)`. Used by Hundred-Battle Veteran ("three or more different kinds of counters among
   creatures you control").
+- `TriggeringEntityHadCounters` — intervening-if for dies/leaves triggers: true when the triggering
+  entity had ≥1 counter of *any* kind on it the moment it left the battlefield (reads the last-known
+  total counter count, CR 603.10 / 603.6c). Resolution-only. Pair with `Triggers.YourCreatureDies` +
+  `Effects.MoveAllLastKnownCounters` for "whenever this or another creature you control dies, if it
+  had counters on it, move its counters" (Host of the Hereafter). Companion to the existing
+  `TriggeringEntityHadMinusOneMinusOneCounter` (which checks only -1/-1 counters, e.g. Retched Wretch).
 - `TargetControlsCreature(target)` — target player has a creature.
 - `TargetControlsLand(target)` — target player has a land.
 - `TargetMatchesFilter(filter, targetIndex = 0)` — the context target matches a `GameObjectFilter`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -849,6 +849,15 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadMinusOneMinusOneCounter
 
     /**
+     * If the triggering entity had at least one counter of any kind on it when it left
+     * the battlefield. Used as an intervening-if condition on dies/leaves triggers, e.g.
+     * Host of the Hereafter: "Whenever this creature or another creature you control dies,
+     * if it had counters on it, ...".
+     */
+    val TriggeringEntityHadCounters: ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadCounters
+
+    /**
      * If the triggering entity was NOT put onto the battlefield by this source's ability.
      * Used to break ETB-trigger loops on cards like Kodama of the East Tree:
      * "if it wasn't put onto the battlefield with this ability". Pair with

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -133,6 +133,19 @@ data object TriggeringEntityHadMinusOneMinusOneCounter : Condition {
 }
 
 /**
+ * Condition: "if it had counters on it" (intervening-if for dies/leaves triggers).
+ * Reads the last-known total counter count (across every counter kind) captured on the
+ * dying/leaving entity at the moment it left the battlefield (Rule 603.10 / 603.6c). True
+ * when that entity had at least one counter of any kind. Used by cards like Host of the
+ * Hereafter whose dies trigger only fires when the creature died with counters on it.
+ */
+@SerialName("TriggeringEntityHadCounters")
+@Serializable
+data object TriggeringEntityHadCounters : Condition {
+    override val description: String = "if it had counters on it"
+}
+
+/**
  * Condition: "with a single target" — true iff the triggering spell or ability
  * has exactly one target chosen. Reads the triggering entity's TargetsComponent.
  * Used by cards like Spinerock Tyrant whose trigger fires only when you cast an

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HostOfTheHereafter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/HostOfTheHereafter.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Host of the Hereafter — Tarkir: Dragonstorm #193
+ * {2}{B}{G} · Creature — Zombie Warlock · 2/2
+ *
+ * This creature enters with two +1/+1 counters on it.
+ * Whenever this creature or another creature you control dies, if it had counters on it,
+ * put its counters on up to one target creature you control.
+ *
+ * "This creature or another creature you control dies" is `Triggers.YourCreatureDies`
+ * (ANY binding, creatures-you-control filter — which includes Host itself). The intervening
+ * "if it had counters on it" (CR 603.4) is `Conditions.TriggeringEntityHadCounters`, reading
+ * the dying creature's last-known total counter count. `Effects.MoveAllLastKnownCounters`
+ * moves *every* counter kind from the dying creature (not just +1/+1) onto the chosen target,
+ * which is optional ("up to one").
+ */
+val HostOfTheHereafter = card("Host of the Hereafter") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Zombie Warlock"
+    power = 2
+    toughness = 2
+    oracleText = "This creature enters with two +1/+1 counters on it.\n" +
+        "Whenever this creature or another creature you control dies, if it had counters on it, " +
+        "put its counters on up to one target creature you control."
+
+    replacementEffect(EntersWithCounters(count = 2, selfOnly = true))
+
+    triggeredAbility {
+        trigger = Triggers.YourCreatureDies
+        triggerCondition = Conditions.TriggeringEntityHadCounters
+        target = TargetCreature(
+            optional = true,
+            filter = TargetFilter(GameObjectFilter.Creature.youControl())
+        )
+        effect = Effects.MoveAllLastKnownCounters(EffectTarget.ContextTarget(0))
+        description = "Whenever this creature or another creature you control dies, if it had " +
+            "counters on it, put its counters on up to one target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "193"
+        artist = "Annie Stegg"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f182957-8133-45a7-80a3-1944bead4d43.jpg?1743204755"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiRevelation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiRevelation.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetSpellOrPermanent
+
+/**
+ * Jeskai Revelation — Tarkir: Dragonstorm #196
+ * {4}{U}{R}{W} · Instant
+ *
+ * Return target spell or permanent to its owner's hand. Jeskai Revelation deals 4 damage
+ * to any target. Create two 1/1 white Monk creature tokens with prowess. Draw two cards.
+ * You gain 4 life.
+ *
+ * Two targets are chosen as the spell is cast: the bounce target (spell or permanent) and
+ * the damage target (any target). The remaining clauses are non-targeted and always happen.
+ */
+val JeskaiRevelation = card("Jeskai Revelation") {
+    manaCost = "{4}{U}{R}{W}"
+    colorIdentity = "URW"
+    typeLine = "Instant"
+    oracleText = "Return target spell or permanent to its owner's hand. Jeskai Revelation deals 4 " +
+        "damage to any target. Create two 1/1 white Monk creature tokens with prowess. Draw two " +
+        "cards. You gain 4 life."
+
+    spell {
+        val bounceTarget = target("target spell or permanent", TargetSpellOrPermanent())
+        val damageTarget = target("any target", Targets.Any)
+        effect = Effects.Composite(
+            Effects.ReturnToHand(bounceTarget),
+            Effects.DealDamage(4, damageTarget),
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Monk"),
+                keywords = setOf(Keyword.PROWESS),
+                count = 2,
+                imageUri = "https://cards.scryfall.io/normal/front/6/3/633d2d10-def7-426f-8496-ed6b45684299.jpg?1742421122"
+            ),
+            Effects.DrawCards(2),
+            Effects.GainLife(4),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "196"
+        artist = "Igor Grechanyi"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3cac0ad3-5107-4ed6-a688-d44bbd65e407.jpg?1743204770"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RallyTheMonastery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RallyTheMonastery.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Rally the Monastery — Tarkir: Dragonstorm #19
+ * {3}{W} · Instant
+ *
+ * This spell costs {2} less to cast if you've cast another spell this turn.
+ * Choose one —
+ * • Create two 1/1 white Monk creature tokens with prowess.
+ * • Up to two target creatures you control each get +2/+2 until end of turn.
+ * • Destroy target creature with power 4 or greater.
+ *
+ * The cost reduction is evaluated at cast time, before this spell is counted, so
+ * `YouCastSpellsThisTurn(atLeast = 1)` means "you've cast another spell this turn"
+ * (same pattern as Focus the Mind).
+ */
+val RallyTheMonastery = card("Rally the Monastery") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} less to cast if you've cast another spell this turn.\n" +
+        "Choose one —\n" +
+        "• Create two 1/1 white Monk creature tokens with prowess.\n" +
+        "• Up to two target creatures you control each get +2/+2 until end of turn.\n" +
+        "• Destroy target creature with power 4 or greater."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.YouCastSpellsThisTurn(atLeast = 1)),
+        )
+    }
+
+    spell {
+        effect = ModalEffect.chooseOne(
+            // Create two 1/1 white Monk creature tokens with prowess.
+            Mode.noTarget(
+                effect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.WHITE),
+                    creatureTypes = setOf("Monk"),
+                    keywords = setOf(Keyword.PROWESS),
+                    count = 2,
+                    imageUri = "https://cards.scryfall.io/normal/front/6/3/633d2d10-def7-426f-8496-ed6b45684299.jpg?1742421122"
+                ),
+                description = "Create two 1/1 white Monk creature tokens with prowess"
+            ),
+            // Up to two target creatures you control each get +2/+2 until end of turn.
+            Mode(
+                effect = ForEachTargetEffect(
+                    listOf(Effects.ModifyStats(2, 2, EffectTarget.ContextTarget(0)))
+                ),
+                targetRequirements = listOf(
+                    TargetCreature(
+                        count = 2,
+                        optional = true,
+                        filter = TargetFilter(GameObjectFilter.Creature.youControl())
+                    )
+                ),
+                description = "Up to two target creatures you control each get +2/+2 until end of turn"
+            ),
+            // Destroy target creature with power 4 or greater.
+            Mode.withTarget(
+                effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                target = TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.powerAtLeast(4))),
+                description = "Destroy target creature with power 4 or greater"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "David Astruga"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b56e0037-8143-4c13-83e1-0c3f44e685ea.jpg?1743204029"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SmileAtDeath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SmileAtDeath.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Smile at Death — Tarkir: Dragonstorm #24
+ * {3}{W}{W} · Enchantment
+ *
+ * At the beginning of your upkeep, return up to two target creature cards with power 2 or
+ * less from your graveyard to the battlefield. Put a +1/+1 counter on each of those creatures.
+ *
+ * Each chosen graveyard card is returned to the battlefield and then gets a +1/+1 counter,
+ * iterated per-target via [ForEachTargetEffect]. The target is optional ("up to two"); the
+ * returned card keeps its entity id across the zone move, so `ContextTarget(0)` still resolves
+ * to it for the counter (same pattern as Coiling Rebirth).
+ */
+val SmileAtDeath = card("Smile at Death") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, return up to two target creature cards with " +
+        "power 2 or less from your graveyard to the battlefield. Put a +1/+1 counter on each of " +
+        "those creatures."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        target = TargetObject(
+            count = 2,
+            optional = true,
+            filter = TargetFilter.CreatureInYourGraveyard.powerAtMost(2)
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(
+                MoveToZoneEffect(
+                    EffectTarget.ContextTarget(0),
+                    Zone.BATTLEFIELD,
+                    fromZone = Zone.GRAVEYARD
+                ).then(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)))
+            )
+        )
+        description = "At the beginning of your upkeep, return up to two target creature cards with " +
+            "power 2 or less from your graveyard to the battlefield. Put a +1/+1 counter on each of those creatures."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "24"
+        artist = "Olivier Bernard"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae2da18f-0d7d-446c-b463-8bf170ed95da.jpg?1743204050"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StillnessInMotion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/StillnessInMotion.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.LibraryPatterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Stillness in Motion — Tarkir: Dragonstorm #59
+ * {1}{U} · Enchantment
+ *
+ * At the beginning of your upkeep, mill three cards. Then if your library has no cards in
+ * it, exile this enchantment and put five cards from your graveyard on top of your library
+ * in any order.
+ *
+ * Mill three resolves first; the intervening payoff is gated on the post-mill library being
+ * empty (`Compare(Count(LIBRARY) == 0)`). When empty: exile this enchantment, then choose
+ * five cards from your graveyard (or all of them, if fewer) and put them on top of your
+ * library in a chosen order via the Gather → Select → Move pipeline.
+ */
+val StillnessInMotion = card("Stillness in Motion") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, mill three cards. Then if your library has no " +
+        "cards in it, exile this enchantment and put five cards from your graveyard on top of your " +
+        "library in any order."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = LibraryPatterns.mill(3).then(
+            ConditionalEffect(
+                condition = Compare(
+                    DynamicAmount.Count(Player.You, Zone.LIBRARY),
+                    ComparisonOperator.EQ,
+                    DynamicAmount.Fixed(0)
+                ),
+                effect = CompositeEffect(
+                    listOf(
+                        Effects.Exile(EffectTarget.Self),
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(Zone.GRAVEYARD, Player.You),
+                            storeAs = "graveyardCards"
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "graveyardCards",
+                            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(5)),
+                            storeSelected = "toTop"
+                        ),
+                        MoveCollectionEffect(
+                            from = "toTop",
+                            destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Top),
+                            order = CardOrder.ControllerChooses
+                        )
+                    )
+                )
+            )
+        )
+        description = "At the beginning of your upkeep, mill three cards. Then if your library has " +
+            "no cards in it, exile this enchantment and put five cards from your graveyard on top of " +
+            "your library in any order."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "59"
+        artist = "Kai Carpenter"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6289251-17e4-4987-96b9-2fb1a8f90e2a.jpg?1743697642"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -72,6 +72,7 @@ import com.wingedsheep.sdk.scripting.conditions.TargetSharesMostCommonColor
 import com.wingedsheep.sdk.scripting.conditions.ColorIsMostCommon
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityEnteredOrWasCastFromGraveyard
+import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadCounters
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadMinusOneMinusOneCounter
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityWasHistoric
 import com.wingedsheep.sdk.scripting.conditions.TriggeringEntityWasNotPutByThisSource
@@ -273,6 +274,8 @@ class ConditionEvaluator(
                 ifResolution { evaluateTriggeringEntityEnteredOrWasCastFromGraveyard(state, it) }
             is TriggeringEntityHadMinusOneMinusOneCounter ->
                 ifResolution { (it.triggerMinusOneMinusOneCounterCount ?: 0) > 0 }
+            is TriggeringEntityHadCounters ->
+                ifResolution { (it.triggerTotalCounterCount ?: 0) > 0 }
             is TriggeringEntityWasNotPutByThisSource ->
                 ifResolution { evaluateTriggeringEntityWasNotPutByThisSource(state, it) }
             is TriggeringSpellHasSingleTarget -> ifResolution { evaluateTriggeringSpellHasSingleTarget(state, it) }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HostOfTheHereafterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HostOfTheHereafterScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Host of the Hereafter (TDM #193).
+ *
+ * "{2}{B}{G} Creature — Zombie Warlock 2/2.
+ *  This creature enters with two +1/+1 counters on it.
+ *  Whenever this creature or another creature you control dies, if it had counters on it,
+ *  put its counters on up to one target creature you control."
+ *
+ * Exercises the new `Conditions.TriggeringEntityHadCounters` intervening-if and
+ * `Effects.MoveAllLastKnownCounters` on a "this or another creature you control dies" trigger.
+ */
+class HostOfTheHereafterScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Counterless Bear",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        fun plusOne(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Int =
+            game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+        context("Host of the Hereafter") {
+
+            test("Host enters with two +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Host of the Hereafter")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Host of the Hereafter").error shouldBe null
+                game.resolveStack()
+
+                val host = game.findPermanent("Host of the Hereafter")!!
+                withClue("Host enters with two +1/+1 counters") {
+                    plusOne(game, host) shouldBe 2
+                }
+            }
+
+            test("when this creature dies with counters, they move to up to one target creature you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Host of the Hereafter")
+                    .withCardOnBattlefield(1, "Counterless Bear", summoningSickness = false)
+                    .withCardsInHand(1, "Lightning Bolt", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast Host so the enters-with-two-counters replacement applies.
+                game.castSpell(1, "Host of the Hereafter").error shouldBe null
+                game.resolveStack()
+
+                val host = game.findPermanent("Host of the Hereafter")!!
+                val bear = game.findPermanent("Counterless Bear")!!
+                withClue("Host has two counters before dying") { plusOne(game, host) shouldBe 2 }
+
+                // Host is a 4/4 (2/2 base + two +1/+1). Two bolts (6 damage) kill it.
+                game.castSpell(1, "Lightning Bolt", host)
+                game.resolveStack()
+                game.castSpell(1, "Lightning Bolt", host)
+                game.resolveStack()
+
+                withClue("Host is in the graveyard") { game.findPermanent("Host of the Hereafter") shouldBe null }
+
+                // The dies trigger had counters → put them on the only valid target (the Bear).
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(bear))
+                    game.resolveStack()
+                }
+
+                withClue("Host's two +1/+1 counters moved onto the Bear") {
+                    plusOne(game, bear) shouldBe 2
+                }
+            }
+
+            test("a creature that died with no counters does not trigger the ability") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Host of the Hereafter", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Counterless Bear", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Counterless Bear")!!
+
+                // The Bear (a creature you control) has no counters; killing it must not
+                // produce a counter-move trigger (intervening "if it had counters" is false).
+                game.castSpell(1, "Lightning Bolt", bear)
+                game.resolveStack()
+
+                withClue("Bear is dead") { game.findPermanent("Counterless Bear") shouldBe null }
+                withClue("No pending target decision — the intervening 'if it had counters' is false") {
+                    game.hasPendingDecision() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RallyTheMonasteryTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RallyTheMonasteryTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.RallyTheMonastery
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Rally the Monastery.
+ *
+ * Rally the Monastery: {3}{W} Instant
+ * "This spell costs {2} less to cast if you've cast another spell this turn.
+ *  Choose one —
+ *   • Create two 1/1 white Monk creature tokens with prowess.
+ *   • Up to two target creatures you control each get +2/+2 until end of turn.
+ *   • Destroy target creature with power 4 or greater."
+ *
+ * Rules exercised:
+ *  - Cast-time cost reduction gated by an intervening "if" (you've cast another spell this turn).
+ *  - Modal "choose one" with three modes (token creation / up-to-two buff / conditional removal).
+ */
+class RallyTheMonasteryTest : FunSpec({
+
+    val BigCreature = CardDefinition.creature(
+        name = "Big Creature",
+        manaCost = ManaCost.parse("{3}{G}"),
+        subtypes = emptySet(),
+        power = 4,
+        toughness = 4,
+        oracleText = ""
+    )
+
+    val SmallCreature = CardDefinition.creature(
+        name = "Small Creature",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = emptySet(),
+        power = 1,
+        toughness = 1,
+        oracleText = ""
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RallyTheMonastery, BigCreature, SmallCreature))
+        return driver
+    }
+
+    test("mode 0 — creates two 1/1 white Monk tokens with prowess") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.giveMana(player1, Color.WHITE, 1)
+        driver.giveColorlessMana(player1, 3)
+        val rally = driver.putCardInHand(player1, "Rally the Monastery")
+
+        val before = driver.getCreatures(player1).size
+        val result = driver.submit(CastSpell(player1, rally, chosenModes = listOf(0)))
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        val monks = driver.getCreatures(player1).filter { driver.getCardName(it) == "Monk Token" }
+        monks.size shouldBe 2
+        driver.getCreatures(player1).size shouldBe before + 2
+    }
+
+    test("mode 2 — destroys target creature with power 4 or greater") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player2, "Big Creature")
+        val target = driver.getCreatures(player2).first()
+
+        driver.giveMana(player1, Color.WHITE, 1)
+        driver.giveColorlessMana(player1, 3)
+        val rally = driver.putCardInHand(player1, "Rally the Monastery")
+
+        val result = driver.submit(CastSpell(
+            player1, rally,
+            targets = listOf(ChosenTarget.Permanent(target)),
+            chosenModes = listOf(2),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(target)))
+        ))
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(player2, "Big Creature") shouldBe null
+    }
+
+    test("costs {2} less when you've cast another spell this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Lightning Bolt" to 20), startingLife = 20)
+        val player1 = driver.activePlayer!!
+        val player2 = driver.getOpponent(player1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // First spell of the turn.
+        val bolt = driver.putCardInHand(player1, "Lightning Bolt")
+        driver.giveMana(player1, Color.RED, 1)
+        driver.castSpell(player1, bolt, listOf(player2))
+        driver.bothPass()
+
+        // Now Rally should cost {1}{W} instead of {3}{W}: give exactly that.
+        driver.giveMana(player1, Color.WHITE, 1)
+        driver.giveColorlessMana(player1, 1)
+        val rally = driver.putCardInHand(player1, "Rally the Monastery")
+        val result = driver.submit(CastSpell(player1, rally, chosenModes = listOf(0)))
+        result.isSuccess shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmileAtDeathScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmileAtDeathScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Smile at Death (TDM #24).
+ *
+ * "{3}{W}{W} Enchantment.
+ *  At the beginning of your upkeep, return up to two target creature cards with power 2 or
+ *  less from your graveyard to the battlefield. Put a +1/+1 counter on each of those creatures."
+ */
+class SmileAtDeathScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Weak One",
+                manaCost = ManaCost.parse("{W}"),
+                subtypes = setOf(Subtype("Soldier")),
+                power = 1,
+                toughness = 1
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Big One",
+                manaCost = ManaCost.parse("{4}{G}"),
+                subtypes = setOf(Subtype("Beast")),
+                power = 5,
+                toughness = 5
+            )
+        )
+
+        fun plusOne(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Int =
+            game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+        context("Smile at Death upkeep") {
+
+            test("returns two power-2-or-less creature cards and puts a +1/+1 counter on each") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Smile at Death")
+                    .withCardInGraveyard(1, "Weak One")
+                    .withCardInGraveyard(1, "Grizzly Bears") // 2/2 — power 2, eligible
+                    .withCardInGraveyard(1, "Big One")        // power 5, ineligible
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Plains") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Plains") }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                fun gyCard(name: String) = game.state.getGraveyard(game.player1Id)
+                    .first { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(gyCard("Weak One"), gyCard("Grizzly Bears")))
+                    game.resolveStack()
+                }
+
+                val weakBf = game.findPermanent("Weak One")!!
+                val bearsBf = game.findPermanent("Grizzly Bears")!!
+                withClue("Weak One was returned to the battlefield") { weakBf shouldBe weakBf }
+                withClue("Each returned creature got a +1/+1 counter") {
+                    plusOne(game, weakBf) shouldBe 1
+                    plusOne(game, bearsBf) shouldBe 1
+                }
+                withClue("The power-5 creature was not a legal target and stayed in the graveyard") {
+                    game.findPermanent("Big One") shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StillnessInMotionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StillnessInMotionScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Stillness in Motion (TDM #59).
+ *
+ * "{1}{U} Enchantment.
+ *  At the beginning of your upkeep, mill three cards. Then if your library has no cards in it,
+ *  exile this enchantment and put five cards from your graveyard on top of your library in any order."
+ */
+class StillnessInMotionScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Stillness in Motion upkeep") {
+
+            test("mills three, and when the library empties exiles itself and refills the library from the graveyard") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stillness in Motion")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Exactly two cards in the controller's library so milling 3 empties it.
+                repeat(2) { builder = builder.withCardInLibrary(1, "Island") }
+                // Graveyard fuel: more than five cards so we put exactly five back.
+                repeat(7) { builder = builder.withCardInGraveyard(1, "Plains") }
+                // Opponent needs library so they don't deck during step advances.
+                repeat(10) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                // Choose five graveyard cards to put back, then order them on top.
+                (game.state.pendingDecision as? SelectCardsDecision)?.let { sel ->
+                    game.selectCards(sel.options.take(5))
+                    game.resolveStack()
+                }
+                (game.state.pendingDecision as? ReorderLibraryDecision)?.let { reorder ->
+                    game.submitDecision(OrderedResponse(reorder.id, reorder.cards))
+                    game.resolveStack()
+                }
+
+                val libSize = game.state.getLibrary(game.player1Id).size
+                withClue("Library was empty after milling 3 from a 2-card library, then refilled with five graveyard cards") {
+                    libSize shouldBe 5
+                }
+                withClue("Stillness in Motion exiled itself") {
+                    game.findPermanent("Stillness in Motion") shouldBe null
+                    game.state.getZone(game.player1Id, Zone.EXILE).any {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Stillness in Motion"
+                    } shouldBe true
+                }
+            }
+
+            test("when the library does not empty, only the mill happens") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Stillness in Motion")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Plenty of library so mill 3 leaves cards behind.
+                repeat(10) { builder = builder.withCardInLibrary(1, "Island") }
+                repeat(5) { builder = builder.withCardInGraveyard(1, "Plains") }
+                repeat(10) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val startLib = game.state.getLibrary(game.player1Id).size
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.resolveStack()
+
+                withClue("Library shrank by exactly the three milled cards (upkeep precedes the draw step)") {
+                    game.state.getLibrary(game.player1Id).size shouldBe startLib - 3
+                }
+                withClue("Enchantment stayed on the battlefield — library was not empty") {
+                    (game.findPermanent("Stillness in Motion") != null) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements five Tarkir: Dragonstorm (TDM) cards. Four use existing SDK primitives only; one introduces a small, reusable condition.

| Card | Cost / Type | Notes |
|------|-------------|-------|
| **Rally the Monastery** | {3}{W} Instant | Cost reduction "if you've cast another spell this turn" (`ModifySpellCost` + `CostGating.OnlyIf`) + modal choose-one: two prowess Monk tokens / up to two creatures +2/+2 / destroy creature with power 4+. |
| **Jeskai Revelation** | {4}{U}{R}{W} Mythic Instant | `TargetSpellOrPermanent` bounce + 4 damage to any target + two prowess Monk tokens + draw two + gain 4. Sequential composite, two targets chosen at cast. |
| **Host of the Hereafter** | {2}{B}{G} 2/2 | Enters with two +1/+1 counters; "this or another creature you control dies, if it had counters, move them to up to one target creature you control" via `Triggers.YourCreatureDies` + `Effects.MoveAllLastKnownCounters`. |
| **Smile at Death** | {3}{W}{W} Mythic Enchantment | Upkeep: reanimate up to two target power-2-or-less creature cards from graveyard, +1/+1 counter on each (`ForEachTargetEffect` over move-from-graveyard + add counter). |
| **Stillness in Motion** | {1}{U} Rare Enchantment | Upkeep: mill 3; if library empties, exile itself and put five graveyard cards on top in any order (`ConditionalEffect` gated on `Count(LIBRARY) == 0` + Gather→Select→Move pipeline with `CardOrder.ControllerChooses`). |

## New SDK building block

- **`Conditions.TriggeringEntityHadCounters`** — intervening-if (CR 603.4) reading the dying/leaving entity's last-known *total* counter count (any kind). Companion to the existing `-1/-1`-only condition; replaces an inline `Compare(LAST_KNOWN_TOTAL_COUNTER_COUNT >= 1)` with a readable named condition. Wired through the SDK condition object, `Conditions` facade, and `ConditionEvaluator`, and documented in `docs/card-sdk-language-reference.md`.

## Tests

New rules-engine scenario tests, all passing:
- `RallyTheMonasteryTest` (3) — token mode, destroy-power-4+ mode, cost reduction
- `HostOfTheHereafterScenarioTest` (3) — enters with counters, counters move on death to target, no-counter death does not trigger
- `SmileAtDeathScenarioTest` (1) — reanimates eligible cards + counters, power-5 card excluded
- `StillnessInMotionScenarioTest` (2) — empties-and-refills path, mill-only (library not empty) path

Also verified `SetLoaderTest` + `CardDiscoveryTest` pass (all five cards register/serialize).

## Skipped

None — all five cards implemented faithfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)