### PR TITLE
Add Lightstall Inquisitor to Edge of Eternities

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -324,8 +324,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `ReturnLinkedExileUnderOwnersControl()` — return under each card's owner.
 - `ReturnLinkedExileToHand()` — return all from linked exile to hand.
 - `ReturnOneFromLinkedExile()` — return one chosen card.
-- `GrantMayPlayFromExile(from, restriction?)` — owner may play matching cards from exile.
+- `GrantMayPlayFromExile(from, expiry?, withAnyManaType?, condition?, landEntersTapped?)` — controller may play matching cards from exile. `landEntersTapped=true` forces a played land tapped regardless of its own ETB script (Lightstall Inquisitor); PlayLandHandler reads the flag off the active `MayPlayPermission` at play time and stamps `TappedComponent` before the card's intrinsic `EntersTapped` branch runs.
 - `GrantPlayWithoutPayingCost(from)` — same, without paying mana costs.
+- `GrantPlayWithCostIncrease(from, amount)` — stamp `PlayWithCostIncreaseComponent(controllerId, amount)` on every card in the collection, so the next cast pays `{amount}` extra generic. Pair with `GrantMayPlayFromExile` for "each spell cast this way costs {N} more" clauses (Lightstall Inquisitor); for target-based "exile this permanent, owner may play it, opponents tax" effects use `Effects.ExileAndGrantOwnerPlayPermission` instead.
 - `GrantFreeCastTargetFromExile(target)` — cast specific exiled card for free.
 
 ### Stats & keywords

--- a/manual-scenarios/cards/l/lightstall-inquisitor.json
+++ b/manual-scenarios/cards/l/lightstall-inquisitor.json
@@ -1,0 +1,31 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Lightstall Inquisitor"],
+    "battlefield": [
+      {"name": "Plains", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Mountain", "Grizzly Bears"],
+    "battlefield": [
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -633,20 +633,34 @@ object Effects {
     /**
      * Grant "may play from exile" permission to all cards in a named collection.
      * Does NOT waive mana cost — pair with [GrantPlayWithoutPayingCost] for free play.
+     *
+     * Set [landEntersTapped] for "each land played this way enters tapped" clauses
+     * (Lightstall Inquisitor). Pair with [GrantPlayWithCostIncrease] to also tax
+     * spells cast via the permission.
      */
     fun GrantMayPlayFromExile(
         from: String,
         expiry: com.wingedsheep.sdk.scripting.effects.MayPlayExpiry =
             com.wingedsheep.sdk.scripting.effects.MayPlayExpiry.EndOfTurn,
         withAnyManaType: Boolean = false,
-        condition: com.wingedsheep.sdk.scripting.conditions.Condition? = null
-    ): Effect = GrantMayPlayFromExileEffect(from, expiry, withAnyManaType, condition)
+        condition: com.wingedsheep.sdk.scripting.conditions.Condition? = null,
+        landEntersTapped: Boolean = false
+    ): Effect = GrantMayPlayFromExileEffect(from, expiry, withAnyManaType, condition, landEntersTapped)
 
     /**
      * Grant "play without paying mana cost" permission to all cards in a named collection.
      * Card must still be in a playable zone (hand, or exile with GrantMayPlayFromExile).
      */
     fun GrantPlayWithoutPayingCost(from: String): Effect = GrantPlayWithoutPayingCostEffect(from)
+
+    /**
+     * Tax spells cast from a named collection — each card in [from] gets a
+     * generic-mana surcharge so the controller pays [amount] more to cast it.
+     * Pair with [GrantMayPlayFromExile] for "each spell cast this way costs {N}
+     * more to cast" clauses (Lightstall Inquisitor).
+     */
+    fun GrantPlayWithCostIncrease(from: String, amount: Int): Effect =
+        com.wingedsheep.sdk.scripting.effects.GrantPlayWithCostIncreaseEffect(from, amount)
 
     /**
      * Grant a single target entity in exile permission to be cast without paying its mana cost.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -966,7 +966,14 @@ data class GrantMayPlayFromExileEffect(
      * if you control a Kavu" — the permission persists with the card in exile, but is
      * only honored while the condition holds. Re-evaluated on every legal-action query.
      */
-    val condition: Condition? = null
+    val condition: Condition? = null,
+    /**
+     * When true, a land card played via this permission enters the battlefield tapped.
+     * Used by Lightstall Inquisitor-style "each land played this way enters tapped"
+     * clauses, where the tapped-on-entry rule is imposed by the granting effect rather
+     * than the played card's own script.
+     */
+    val landEntersTapped: Boolean = false
 ) : Effect {
     override val description: String = buildString {
         append("${expiry.description.replaceFirstChar { it.uppercase() }}, you may play the $from cards from exile")
@@ -975,6 +982,7 @@ data class GrantMayPlayFromExileEffect(
             append(condition.description)
         }
         if (withAnyManaType) append(", and mana of any type can be spent to cast them")
+        if (landEntersTapped) append(". Each land played this way enters tapped")
     }
 }
 
@@ -1070,6 +1078,30 @@ data class GrantPlayWithAdditionalCostEffect(
 ) : Effect {
     override val description: String =
         "Until end of turn, casting the $from cards requires: ${additionalCost.description}"
+}
+
+/**
+ * Add a generic-mana tax to every card in a named collection so that when the
+ * effect controller later casts one of them, the spell costs [amount] more to
+ * cast. Stamps PlayWithCostIncreaseComponent on each card in the collection,
+ * which CastSpellHandler reads at cast time.
+ *
+ * Pair with [GrantMayPlayFromExileEffect] to grant a permission *and* tax the
+ * cast — used by Lightstall Inquisitor ("Each spell cast this way costs {1}
+ * more to cast"), where each opponent exiles a card from their own hand and
+ * may play it with this tax.
+ *
+ * @property from Name of the collection containing the card(s)
+ * @property amount Generic mana added to each card's cost when the controller casts it
+ */
+@SerialName("GrantPlayWithCostIncrease")
+@Serializable
+data class GrantPlayWithCostIncreaseEffect(
+    val from: String,
+    val amount: Int
+) : Effect {
+    override val description: String =
+        "Each spell cast from $from costs {$amount} more to cast"
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LightstallInquisitor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/LightstallInquisitor.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lightstall Inquisitor
+ * {W}
+ * Creature — Angel Wizard
+ * 2/1
+ * Vigilance
+ * When this creature enters, each opponent exiles a card from their hand and may play
+ * that card for as long as it remains exiled. Each spell cast this way costs {1} more
+ * to cast. Each land played this way enters tapped.
+ *
+ * Implementation: ForEachPlayer(EachOpponent) iterates with controllerId rebound to the
+ * iterated opponent. Inside, the opponent's hand is gathered, that opponent (as
+ * Chooser.Controller within the iteration) selects one card, the card moves to their
+ * exile, then GrantMayPlayFromExile + GrantPlayWithCostIncrease apply the permanent
+ * cast-from-exile permission and the {1} surcharge. landEntersTapped=true on the
+ * permission propagates the tapped-on-entry clause to PlayLandHandler.
+ */
+val LightstallInquisitor = card("Lightstall Inquisitor") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "Vigilance\n" +
+        "When this creature enters, each opponent exiles a card from their hand and may " +
+        "play that card for as long as it remains exiled. Each spell cast this way costs " +
+        "{1} more to cast. Each land played this way enters tapped."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ForEachPlayerEffect(
+            players = Player.EachOpponent,
+            effects = listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.You),
+                    storeAs = "exileCandidates"
+                ),
+                SelectFromCollectionEffect(
+                    from = "exileCandidates",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "chosenCard",
+                    prompt = "Choose a card to exile"
+                ),
+                MoveCollectionEffect(
+                    from = "chosenCard",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                ),
+                Effects.GrantMayPlayFromExile(
+                    from = "chosenCard",
+                    expiry = MayPlayExpiry.Permanent,
+                    landEntersTapped = true
+                ),
+                Effects.GrantPlayWithCostIncrease(from = "chosenCard", amount = 1)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "Arif Wijaya"
+        flavorText = "Born of dead stars, the Astelli may fight for light, but they know the void as their womb."
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/635245e9-c27f-4a51-a6f1-bae62e696542.jpg?1752946647"
+        ruling("2025-07-25", "Playing the exiled card follows all normal timing restrictions.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -226,10 +226,12 @@ class PlayLandHandler(
                 // Permission already forced tapped — skip the shock-land "pay life" prompt
                 // and any conditional script logic; the land is already on the battlefield tapped.
                 //
-                // Strict CR 616.1a says both replacements (Lightstall's "enters tapped" rider
+                // Strict CR 616.1 says both replacements (Lightstall's "enters tapped" rider
                 // and the shock land's "you may pay 2 life; otherwise enters tapped") apply to
-                // the entry event and the controller picks which to resolve first. Either order
-                // ends with the land tapped, so the shock-land life-payment choice is always
+                // the entry event and the affected permanent's controller picks which to resolve
+                // first. Neither is a self-replacement effect (CR 614.15), so the choice falls to
+                // the catch-all step CR 616.1e. Either order ends with the land tapped, so the
+                // shock-land life-payment choice is always
                 // meaningless under a permission-forced-tapped grant. We elide the prompt
                 // rather than asking the player to make a no-op decision.
                 if (permissionForcesTapped) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -12,7 +12,9 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.permissions.activeMayPlayFor
 import com.wingedsheep.engine.state.permissions.hasMayPlayFor
+import com.wingedsheep.engine.state.permissions.removeMayPlayPermissionsForCard
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.sdk.core.Zone
@@ -141,6 +143,23 @@ class PlayLandHandler(
         newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
             .place(newState, action.playerId, action.cardId)
 
+        // A may-play permission with landEntersTapped=true forces the played land
+        // tapped regardless of the card's own ETB script — Lightstall Inquisitor's
+        // "each land played this way enters tapped" clause.
+        val permissionForcesTapped = fromZone == Zone.EXILE && permissionForcesLandTapped(
+            state, action.playerId, action.cardId
+        )
+        if (permissionForcesTapped) {
+            newState = newState.updateEntity(action.cardId) { c -> c.with(TappedComponent) }
+        }
+        // Clean up may-play permissions now that the card has left exile. Lands don't go
+        // through the stack, so StackResolver's removeMayPlayPermissionsForCard never runs
+        // for them; without this, a permanent permission would silently re-authorize the
+        // card if it later returned to exile.
+        if (fromZone == Zone.EXILE) {
+            newState = newState.removeMayPlayPermissionsForCard(action.cardId)
+        }
+
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
 
         // OnEnterRunEffect — generic "as ~ enters, run [effect]" replacement.
@@ -204,7 +223,11 @@ class PlayLandHandler(
         if (cardDef != null) {
             val entersTapped = cardDef.script.replacementEffects.filterIsInstance<EntersTapped>().firstOrNull()
             if (entersTapped != null) {
-                if (entersTapped.payLifeCost != null) {
+                // Permission already forced tapped — skip the shock-land "pay life" prompt
+                // and any conditional script logic; the land is already on the battlefield tapped.
+                if (permissionForcesTapped) {
+                    // Already handled: TappedComponent applied, control falls through to triggers/finish.
+                } else if (entersTapped.payLifeCost != null) {
                     // Shock land: ask the player if they want to pay life
                     // Use up a land drop first
                     newState = newState.updateEntity(action.playerId) { c ->
@@ -488,6 +511,19 @@ class PlayLandHandler(
         if (!inAnyExile) return false
         return state.hasMayPlayFor(cardId, playerId, conditionEvaluator)
     }
+
+    /**
+     * True when some active may-play permission authorizing [playerId] to play [cardId]
+     * also forces the played land tapped (Lightstall Inquisitor's "each land played this
+     * way enters tapped" clause). Read from [state] *before* the card left exile, since
+     * `removeMayPlayPermissionsForCard` runs as the card moves to the battlefield.
+     */
+    private fun permissionForcesLandTapped(
+        state: GameState,
+        playerId: EntityId,
+        cardId: EntityId
+    ): Boolean = state.activeMayPlayFor(cardId, playerId, conditionEvaluator)
+        .any { it.landEntersTapped }
 
     private fun hasPlayFromTopOfLibrary(state: GameState, playerId: EntityId): Boolean {
         for (entityId in state.getBattlefield(playerId)) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -225,6 +225,13 @@ class PlayLandHandler(
             if (entersTapped != null) {
                 // Permission already forced tapped — skip the shock-land "pay life" prompt
                 // and any conditional script logic; the land is already on the battlefield tapped.
+                //
+                // Strict CR 616.1a says both replacements (Lightstall's "enters tapped" rider
+                // and the shock land's "you may pay 2 life; otherwise enters tapped") apply to
+                // the entry event and the controller picks which to resolve first. Either order
+                // ends with the land tapped, so the shock-land life-payment choice is always
+                // meaningless under a permission-forced-tapped grant. We elide the prompt
+                // rather than asking the player to make a no-op decision.
                 if (permissionForcesTapped) {
                     // Already handled: TappedComponent applied, control falls through to triggers/finish.
                 } else if (entersTapped.payLifeCost != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
@@ -4,12 +4,14 @@ import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.PlayWithCostIncreaseComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
 import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithCostIncreaseEffect
 import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
 import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
 import kotlin.reflect.KClass
@@ -47,6 +49,7 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
                     sourceId = context.sourceId,
                     condition = effect.condition,
                     withAnyManaType = effect.withAnyManaType,
+                    landEntersTapped = effect.landEntersTapped,
                     permanent = isPermanent,
                     expiresAfterTurn = expiresAfterTurn,
                     timestamp = state.timestamp,
@@ -126,6 +129,43 @@ class GrantPlayWithoutPayingCostExecutor : EffectExecutor<GrantPlayWithoutPaying
         for (cardId in collection) {
             newState = newState.updateEntity(cardId) { container ->
                 container.with(PlayWithoutPayingCostComponent(controllerId = controllerId))
+            }
+        }
+
+        return EffectResult.success(newState)
+    }
+}
+
+/**
+ * Executor for GrantPlayWithCostIncreaseEffect.
+ *
+ * Stamps PlayWithCostIncreaseComponent on every card in the named collection so that
+ * when [context.controllerId] later casts the card, [GrantPlayWithCostIncreaseEffect.amount]
+ * generic mana is added to the spell's cost. Mirrors [GrantPlayWithoutPayingCostExecutor]
+ * but pushes a cost upwards rather than waiving it.
+ */
+class GrantPlayWithCostIncreaseExecutor : EffectExecutor<GrantPlayWithCostIncreaseEffect> {
+
+    override val effectType: KClass<GrantPlayWithCostIncreaseEffect> = GrantPlayWithCostIncreaseEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: GrantPlayWithCostIncreaseEffect,
+        context: EffectContext
+    ): EffectResult {
+        if (effect.amount <= 0) return EffectResult.success(state)
+        val controllerId = context.controllerId
+        val collection = context.pipeline.storedCollections[effect.from] ?: emptyList()
+
+        var newState = state
+        for (cardId in collection) {
+            newState = newState.updateEntity(cardId) { container ->
+                container.with(
+                    PlayWithCostIncreaseComponent(
+                        controllerId = controllerId,
+                        amount = effect.amount
+                    )
+                )
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -33,6 +33,7 @@ class LibraryExecutors(
         ShuffleLibraryExecutor(),
         GrantMayPlayFromExileExecutor(),
         GrantPlayWithoutPayingCostExecutor(),
+        GrantPlayWithCostIncreaseExecutor(),
         GrantPlayWithAdditionalCostExecutor(),
         GrantFreeCastTargetFromExileExecutor(),
         GatherUntilMatchExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/permissions/MayPlayPermission.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/permissions/MayPlayPermission.kt
@@ -28,6 +28,10 @@ import kotlinx.serialization.Serializable
  * @param condition Optional gate re-evaluated on every query. When present, the permission is
  *   only honored while the condition holds.
  * @param withAnyManaType If true, mana of any type can be spent to cast (Taster of Wares).
+ * @param landEntersTapped If true, a land card played via this permission enters the battlefield
+ *   tapped. Used by Lightstall Inquisitor-style exile-from-hand effects whose "lands played
+ *   this way enter tapped" clause must be enforced on top of the played card's intrinsic ETB
+ *   state, independent of the card's own script.
  * @param permanent If true, the permission is not auto-removed at end of turn cleanup. Permanent
  *   permissions are removed explicitly (e.g., when their card resolves). Non-permanent grants
  *   expire via [expiresAfterTurn].
@@ -44,6 +48,7 @@ data class MayPlayPermission(
     val sourceId: EntityId? = null,
     val condition: Condition? = null,
     val withAnyManaType: Boolean = false,
+    val landEntersTapped: Boolean = false,
     val permanent: Boolean = false,
     val expiresAfterTurn: Int? = null,
     val timestamp: Long

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightstallInquisitorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightstallInquisitorScenarioTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.PlayWithCostIncreaseComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Lightstall Inquisitor (EOE #24).
+ *
+ * "{W} Creature — Angel Wizard 2/1. Vigilance.
+ *  When this creature enters, each opponent exiles a card from their hand and may play
+ *  that card for as long as it remains exiled. Each spell cast this way costs {1} more
+ *  to cast. Each land played this way enters tapped."
+ *
+ * Verifies that the ETB pipeline:
+ *  - moves an opponent-chosen card from that opponent's hand to their own exile,
+ *  - grants a permanent may-play permission to the opponent (not to the caster),
+ *  - flags the exiled card with PlayWithCostIncreaseComponent for the {1} surcharge,
+ *  - and forces lands played via the permission to enter tapped.
+ */
+class LightstallInquisitorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lightstall Inquisitor ETB") {
+
+            test("casting Lightstall Inquisitor exiles opponent-chosen card and stamps permission, cost-increase, and land-tap markers") {
+                var builder = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Lightstall Inquisitor")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    // Two cards in opponent's hand → the SelectFromCollection step actually
+                    // prompts the opponent rather than auto-picking a single legal target.
+                    .withCardInHand(2, "Mountain")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Library fuel so neither player decks on step advances.
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val mountainId = game.findCardsInHand(2, "Mountain").single()
+
+                val cast = game.castSpell(1, "Lightstall Inquisitor")
+                cast.error shouldBe null
+                game.resolveStack()
+
+                // The ETB trigger pauses on the opponent's "choose a card from your hand"
+                // decision; player 2 selects the Mountain.
+                withClue("ETB trigger should pause for the opponent's exile selection") {
+                    game.hasPendingDecision() shouldBe true
+                    game.getPendingDecision()!!.playerId shouldBe game.player2Id
+                }
+                game.selectCards(listOf(mountainId))
+                game.resolveStack()
+
+                withClue("The Mountain should be in player 2's exile") {
+                    game.state.getExile(game.player2Id).contains(mountainId) shouldBe true
+                }
+                withClue("The Mountain should no longer be in player 2's hand") {
+                    game.state.getHand(game.player2Id).contains(mountainId) shouldBe false
+                }
+
+                val mayPlay = game.state.mayPlayPermissions.firstOrNull { mountainId in it.cardIds }
+                withClue("A may-play permission for the exiled card must exist") {
+                    mayPlay.shouldNotBeNull()
+                }
+                withClue("The may-play permission must belong to the opponent (the card's owner)") {
+                    mayPlay!!.controllerId shouldBe game.player2Id
+                }
+                withClue("The permission must persist for as long as the card remains exiled") {
+                    mayPlay!!.permanent shouldBe true
+                }
+                withClue("The permission must force any played land tapped") {
+                    mayPlay!!.landEntersTapped shouldBe true
+                }
+
+                val costIncrease = game.state.getEntity(mountainId)?.get<PlayWithCostIncreaseComponent>()
+                withClue("Exiled card must carry the {1} cast surcharge for the opponent") {
+                    costIncrease.shouldNotBeNull()
+                }
+                withClue("Cost increase must apply to the opponent (the player who may cast it)") {
+                    costIncrease!!.controllerId shouldBe game.player2Id
+                }
+                costIncrease!!.amount shouldBe 1
+            }
+
+            test("a land played from this exile enters the battlefield tapped") {
+                var builder = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Lightstall Inquisitor")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardInHand(2, "Mountain")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val mountainId = game.findCardsInHand(2, "Mountain").single()
+
+                game.castSpell(1, "Lightstall Inquisitor")
+                game.resolveStack()
+                game.selectCards(listOf(mountainId))
+                game.resolveStack()
+
+                // Hand the active turn over to player 2 so they can play their land.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val playResult = game.execute(PlayLand(game.player2Id, mountainId))
+                playResult.error shouldBe null
+
+                withClue("Mountain should have entered player 2's battlefield") {
+                    game.state.getBattlefield(game.player2Id).contains(mountainId) shouldBe true
+                }
+                val mountainContainer = game.state.getEntity(mountainId)
+                withClue("Land played via Lightstall Inquisitor's permission must enter tapped") {
+                    (mountainContainer?.get<TappedComponent>() != null) shouldBe true
+                }
+                withClue("Card name preserved through the zone change") {
+                    game.state.getEntity(mountainId)?.get<CardComponent>()?.name shouldBe "Mountain"
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightstallInquisitorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightstallInquisitorScenarioTest.kt
@@ -131,6 +131,84 @@ class LightstallInquisitorScenarioTest : ScenarioTestBase() {
                     game.state.getEntity(mountainId)?.get<CardComponent>()?.name shouldBe "Mountain"
                 }
             }
+
+            test("opponent cannot cast the exiled spell when they only have base-cost mana — the +{1} surcharge is enforced at cast time") {
+                // Grizzly Bears costs {1}{G}; the Lightstall surcharge raises it to {2}{G}.
+                // Two Forests is exactly enough for the base cost but one short of the surcharged cost,
+                // so a successful CastSpell here would prove the {1} clause is NOT being applied.
+                var builder = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Lightstall Inquisitor")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardInHand(2, "Grizzly Bears")
+                    // Decoy card so SelectFromCollection actually prompts the opponent
+                    // instead of auto-picking the single legal target.
+                    .withCardInHand(2, "Plains")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val grizzlyId = game.findCardsInHand(2, "Grizzly Bears").single()
+
+                game.castSpell(1, "Lightstall Inquisitor")
+                game.resolveStack()
+                game.selectCards(listOf(grizzlyId))
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val castResult = game.castSpellFromExile(2, "Grizzly Bears")
+                withClue("Casting at base cost {1}{G} with only 2 Forests must fail because the surcharge raises the effective cost to {2}{G}") {
+                    castResult.error shouldBe "Not enough mana to cast this spell"
+                }
+                withClue("The card stays in exile when the cast attempt fails") {
+                    game.state.getExile(game.player2Id).contains(grizzlyId) shouldBe true
+                }
+            }
+
+            test("opponent can cast the exiled spell when they have enough mana for the surcharged cost") {
+                // Surcharged cost is {2}{G}; three Forests cover it exactly. Resolving onto the
+                // battlefield proves the cost computation accepted the surcharge.
+                var builder = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Lightstall Inquisitor")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardInHand(2, "Grizzly Bears")
+                    // Decoy card so SelectFromCollection actually prompts the opponent.
+                    .withCardInHand(2, "Plains")
+                    .withLandsOnBattlefield(2, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val grizzlyId = game.findCardsInHand(2, "Grizzly Bears").single()
+
+                game.castSpell(1, "Lightstall Inquisitor")
+                game.resolveStack()
+                game.selectCards(listOf(grizzlyId))
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val castResult = game.castSpellFromExile(2, "Grizzly Bears")
+                withClue("Three Forests cover the surcharged {2}{G} cost — cast must succeed") {
+                    castResult.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears must resolve onto opponent's battlefield") {
+                    game.state.getBattlefield(game.player2Id).contains(grizzlyId) shouldBe true
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Implements Lightstall Inquisitor (EOE #24, {W} 2/1 Angel Wizard with vigilance):

▎ When this creature enters, each opponent exiles a card from their hand and may play that card for as long as it remains exiled. Each spell cast this way costs {1} more to cast. Each land played this way
▎ enters tapped.

SDK additions (collection-based, reusable):
- Effects.GrantPlayWithCostIncrease(from, amount) — stamps PlayWithCostIncreaseComponent on every card in a named pipeline collection, so CastSpellHandler's existing surcharge path taxes the cast at {amount}
more generic. Companion to the per-target ExileAndGrantOwnerPlayPermission (Soul Partition).
- Effects.GrantMayPlayFromExile(..., landEntersTapped) — new flag on the may-play permission. PlayLandHandler reads it off the active permission and stamps TappedComponent before the played land's own ETB
script runs. Per CR 616.1a both replacements end with the land tapped, so the shock-land "pay 2 life" prompt is intentionally elided under this grant.
- PlayLandHandler also now cleans up may-play permissions when a land plays from exile (lands skip the stack, so StackResolver's cleanup never ran for them — a pre-existing latent issue that benefits other
exile-grant cards too).

ETB pipeline: ForEachPlayer(EachOpponent) { GatherCards(hand) → SelectFromCollection → MoveCollection(exile) → GrantMayPlayFromExile(permanent, landEntersTapped) → GrantPlayWithCostIncrease(1) }. Each opponent
makes their own selection from their own hand.

Tests: Four scenario tests — markers stamped, land plays tapped, opponent's cast fails for "Not enough mana" when only base cost is available (proving the surcharge fires), and resolves onto the battlefield
when the surcharged cost is met.

Doc reference updated in the same change.