### PR TITLE
Add 6 Tarkir: Dragonstorm cards (batch 1)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1543,12 +1543,18 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   Yawgmoth's Agenda (`MayCastFromGraveyard(Nonland)`); `lifeCost = 1, duringYourTurnOnly = true` for
   Festival of Embers. Pair with `MayPlayLandsFromGraveyard` for "play lands and cast spells from
   your graveyard". Lands are *played*, not cast, so they need the lands permission separately.
-- `MayCastWithoutPayingManaCost(controllerOnly = false, firstSpellOfTurnOnly = false)` — a
+- `MayCastWithoutPayingManaCost(controllerOnly = false, firstSpellOfTurnOnly = false, spellFilter = Any)` — a
   battlefield permission to cast a spell without paying its mana cost (CR 118.9). Composable
   gates: `controllerOnly = true` restricts the benefit to the source's controller ("you" wording);
   `firstSpellOfTurnOnly = true` requires the caster to be the active player and to have cast
-  zero spells this turn. Weftwalking is `MayCastWithoutPayingManaCost(firstSpellOfTurnOnly = true)`;
-  a future "you may cast the first spell you cast each turn …" composes via both gates true.
+  zero spells this turn; `spellFilter` restricts *which* spells may be cast for free (card
+  predicates, matched in any zone — default `GameObjectFilter.Any` = every spell). Weftwalking is
+  `MayCastWithoutPayingManaCost(firstSpellOfTurnOnly = true)`; Dracogenesis is
+  `MayCastWithoutPayingManaCost(controllerOnly = true, spellFilter = GameObjectFilter.Any.withSubtype("Dragon"))`
+  ("You may cast Dragon spells without paying their mana costs"); a future "you may cast the first
+  spell you cast each turn …" composes via both gates true. The filter is enforced per-spell in
+  `CostCalculator.hasFreeCastPermission(state, casterId, spellCardDef)` (the enumerator threads the
+  card being cast through `EnumerationContext.freeCastPermissionFor(cardId)`).
   Cast-legality is checked by `CostCalculator.hasFreeCastPermission`. Surfaced as a dedicated
   `CastWithoutPayingManaCost` `LegalAction` variant routed through
   `CastSpell.useWithoutPayingManaCost = true` — emitted **alongside** Jodah-style

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -282,7 +282,7 @@ data object CantCastSpellsSharingColorWithLastCast : StaticAbility {
  *  - [spellFilter] — only spells whose card matches this filter may be cast for free
  *    (card predicates work in any zone). Default [GameObjectFilter.Any] = every spell.
  *    Dracogenesis is `MayCastWithoutPayingManaCost(controllerOnly = true,
- *    spellFilter = GameObjectFilter.withSubtype("Dragon"))`.
+ *    spellFilter = GameObjectFilter.Any.withSubtype("Dragon"))`.
  *
  * Composes for Weftwalking ({4}{U}{U}, EOE: "The first spell each player casts during each of
  * their turns may be cast without paying its mana cost.") via

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -279,6 +279,10 @@ data object CantCastSpellsSharingColorWithLastCast : StaticAbility {
  *    wording). Default false = any player benefits ("each player casts" wording).
  *  - [firstSpellOfTurnOnly] — if true, the caster must be the active player and must have cast
  *    no spells yet this turn. Default false = no first-spell gate.
+ *  - [spellFilter] — only spells whose card matches this filter may be cast for free
+ *    (card predicates work in any zone). Default [GameObjectFilter.Any] = every spell.
+ *    Dracogenesis is `MayCastWithoutPayingManaCost(controllerOnly = true,
+ *    spellFilter = GameObjectFilter.withSubtype("Dragon"))`.
  *
  * Composes for Weftwalking ({4}{U}{U}, EOE: "The first spell each player casts during each of
  * their turns may be cast without paying its mana cost.") via
@@ -296,16 +300,23 @@ data object CantCastSpellsSharingColorWithLastCast : StaticAbility {
 @Serializable
 data class MayCastWithoutPayingManaCost(
     val controllerOnly: Boolean = false,
-    val firstSpellOfTurnOnly: Boolean = false
+    val firstSpellOfTurnOnly: Boolean = false,
+    val spellFilter: GameObjectFilter = GameObjectFilter.Any
 ) : StaticAbility {
     override val description: String = buildString {
+        val noun = if (spellFilter == GameObjectFilter.Any) "spells" else "${spellFilter.description} spells"
         if (firstSpellOfTurnOnly) {
             if (controllerOnly) append("The first spell you cast each turn may be cast without paying its mana cost")
             else append("The first spell each player casts during each of their turns may be cast without paying its mana cost")
         } else {
-            if (controllerOnly) append("You may cast spells without paying their mana costs")
-            else append("Each player may cast spells without paying their mana costs")
+            if (controllerOnly) append("You may cast $noun without paying their mana costs")
+            else append("Each player may cast $noun without paying their mana costs")
         }
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = spellFilter.applyTextReplacement(replacer)
+        return if (newFilter !== spellFilter) copy(spellFilter = newFilter) else this
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BetorKinToAll.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BetorKinToAll.kt
@@ -60,6 +60,10 @@ val BetorKinToAll = card("Betor, Kin to All") {
                 )
             )
             // "Then if ... 40 or greater, each opponent loses half their life, rounded up."
+            // The loss amount is computed once from Player.Opponent's life, then applied to every
+            // EachOpponent target — exact in 1v1. In multiplayer each opponent would lose half of a
+            // single opponent's life rather than their own (a LoseLifeExecutor architecture limit,
+            // not this card's); revisit if/when multiplayer is supported.
             .then(
                 ConditionalEffect(
                     condition = totalToughnessAtLeast(40),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BetorKinToAll.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/BetorKinToAll.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.Condition
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.CardNumericProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Betor, Kin to All — Tarkir: Dragonstorm #172
+ * {2}{W}{B}{G} · Legendary Creature — Spirit Dragon · 5/7
+ *
+ * Flying
+ * At the beginning of your end step, if creatures you control have total toughness 10 or
+ * greater, draw a card. Then if creatures you control have total toughness 20 or greater,
+ * untap each creature you control. Then if creatures you control have total toughness 40
+ * or greater, each opponent loses half their life, rounded up.
+ */
+val BetorKinToAll = card("Betor, Kin to All") {
+    manaCost = "{2}{W}{B}{G}"
+    colorIdentity = "WBG"
+    typeLine = "Legendary Creature — Spirit Dragon"
+    power = 5
+    toughness = 7
+    oracleText = "Flying\n" +
+        "At the beginning of your end step, if creatures you control have total toughness 10 or " +
+        "greater, draw a card. Then if creatures you control have total toughness 20 or greater, " +
+        "untap each creature you control. Then if creatures you control have total toughness 40 " +
+        "or greater, each opponent loses half their life, rounded up."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        // Intervening "if" (CR 603.4): the 10-toughness gate is checked both as the trigger
+        // would go on the stack and again on resolution.
+        triggerCondition = totalToughnessAtLeast(10)
+        effect = Effects.DrawCards(1)
+            // "Then if ... 20 or greater, untap each creature you control."
+            .then(
+                ConditionalEffect(
+                    condition = totalToughnessAtLeast(20),
+                    effect = ForEachInGroupEffect(
+                        filter = GroupFilter.AllCreaturesYouControl,
+                        effect = TapUntapEffect(EffectTarget.Self, tap = false)
+                    )
+                )
+            )
+            // "Then if ... 40 or greater, each opponent loses half their life, rounded up."
+            .then(
+                ConditionalEffect(
+                    condition = totalToughnessAtLeast(40),
+                    effect = Effects.LoseHalfLife(
+                        roundUp = true,
+                        target = EffectTarget.PlayerRef(Player.EachOpponent),
+                        lifePlayer = Player.Opponent
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "172"
+        artist = "Alexander Ostrowski"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b475b071-5545-483e-a397-89451f258602.jpg?1743204665"
+    }
+}
+
+/** "Creatures you control have total toughness [threshold] or greater." */
+private fun totalToughnessAtLeast(threshold: Int): Condition = Compare(
+    DynamicAmount.AggregateBattlefield(
+        player = Player.You,
+        filter = GameObjectFilter.Creature,
+        aggregation = Aggregation.SUM,
+        property = CardNumericProperty.TOUGHNESS
+    ),
+    ComparisonOperator.GTE,
+    DynamicAmount.Fixed(threshold)
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CoriSteelCutter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CoriSteelCutter.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cori-Steel Cutter — Tarkir: Dragonstorm #103
+ * {1}{R} · Artifact — Equipment
+ *
+ * Equipped creature gets +1/+1 and has trample and haste.
+ * Flurry — Whenever you cast your second spell each turn, create a 1/1 white Monk creature
+ * token with prowess. You may attach this Equipment to it.
+ * Equip {1}{R}
+ */
+val CoriSteelCutter = card("Cori-Steel Cutter") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1 and has trample and haste.\n" +
+        "Flurry — Whenever you cast your second spell each turn, create a 1/1 white Monk creature " +
+        "token with prowess. You may attach this Equipment to it. (Whenever you cast a noncreature " +
+        "spell, the token gets +1/+1 until end of turn.)\n" +
+        "Equip {1}{R}"
+
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, Filters.EquippedCreature)
+    }
+
+    // Flurry — create the Monk, then optionally attach this Equipment to it.
+    flurry {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Monk"),
+            keywords = setOf(Keyword.PROWESS),
+            imageUri = "https://cards.scryfall.io/normal/front/6/3/633d2d10-def7-426f-8496-ed6b45684299.jpg?1742421122"
+        ).then(
+            MayEffect(
+                effect = Effects.AttachEquipment(EffectTarget.PipelineTarget(CREATED_TOKENS, 0)),
+                descriptionOverride = "You may attach this Equipment to it"
+            )
+        )
+    }
+
+    equipAbility("{1}{R}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "103"
+        artist = "Xabi Gaztelua"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/490eb213-9ae2-4b45-abec-6f1dfc83792a.jpg?1779102209"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/Dracogenesis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/Dracogenesis.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MayCastWithoutPayingManaCost
+
+/**
+ * Dracogenesis — Tarkir: Dragonstorm #105
+ * {6}{R}{R} · Enchantment
+ *
+ * You may cast Dragon spells without paying their mana costs.
+ */
+val Dracogenesis = card("Dracogenesis") {
+    manaCost = "{6}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "You may cast Dragon spells without paying their mana costs."
+
+    staticAbility {
+        ability = MayCastWithoutPayingManaCost(
+            controllerOnly = true,
+            spellFilter = GameObjectFilter.Any.withSubtype("Dragon")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "105"
+        artist = "Kai Carpenter"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d5674f9-22b2-45f9-902d-4fd245485c60.jpg?1743204385"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ElspethStormSlayer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ElspethStormSlayer.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.DoubleTokenCreation
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Elspeth, Storm Slayer — Tarkir: Dragonstorm #11
+ * {3}{W}{W} · Legendary Planeswalker — Elspeth · Loyalty 5
+ *
+ * If one or more tokens would be created under your control, twice that many of those tokens
+ * are created instead.
+ * +1: Create a 1/1 white Soldier creature token.
+ * 0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until your
+ *    next turn.
+ * −3: Destroy target creature an opponent controls with mana value 3 or greater.
+ */
+val ElspethStormSlayer = card("Elspeth, Storm Slayer") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Planeswalker — Elspeth"
+    startingLoyalty = 5
+    oracleText = "If one or more tokens would be created under your control, twice that many of " +
+        "those tokens are created instead.\n" +
+        "+1: Create a 1/1 white Soldier creature token.\n" +
+        "0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until " +
+        "your next turn.\n" +
+        "−3: Destroy target creature an opponent controls with mana value 3 or greater."
+
+    // If one or more tokens would be created under your control, twice that many instead.
+    replacementEffect(DoubleTokenCreation())
+
+    // +1: Create a 1/1 white Soldier creature token.
+    loyaltyAbility(+1) {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Soldier"),
+            imageUri = "https://cards.scryfall.io/normal/front/6/4/6455d903-6996-448f-9148-9068febecb00.jpg?1742506671"
+        )
+    }
+
+    // 0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until
+    // your next turn.
+    loyaltyAbility(0) {
+        effect = ForEachInGroupEffect(
+            filter = GroupFilter.AllCreaturesYouControl,
+            effect = AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        ).then(
+            ForEachInGroupEffect(
+                filter = GroupFilter.AllCreaturesYouControl,
+                effect = GrantKeywordEffect(Keyword.FLYING, EffectTarget.Self, Duration.UntilYourNextTurn)
+            )
+        )
+    }
+
+    // −3: Destroy target creature an opponent controls with mana value 3 or greater.
+    loyaltyAbility(-3) {
+        val victim = target(
+            "creature an opponent controls with mana value 3 or greater",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.opponentControls().manaValueAtLeast(3)))
+        )
+        effect = Effects.Destroy(victim)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "11"
+        artist = "Ekaterina Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73a065e3-b530-4e62-ab3c-4f6f908184ec.jpg?1743203994"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/EshkiDragonclaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/EshkiDragonclaw.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Eshki Dragonclaw — Tarkir: Dragonstorm #182
+ * {1}{G}{U}{R} · Legendary Creature — Human Warrior · 4/4
+ *
+ * Vigilance, trample, ward {1}
+ * At the beginning of combat on your turn, if you've cast both a creature spell and a
+ * noncreature spell this turn, draw a card and put two +1/+1 counters on Eshki Dragonclaw.
+ */
+val EshkiDragonclaw = card("Eshki Dragonclaw") {
+    manaCost = "{1}{G}{U}{R}"
+    colorIdentity = "GUR"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance, trample, ward {1}\n" +
+        "At the beginning of combat on your turn, if you've cast both a creature spell and a " +
+        "noncreature spell this turn, draw a card and put two +1/+1 counters on Eshki Dragonclaw."
+
+    keywords(Keyword.VIGILANCE, Keyword.TRAMPLE)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{1}")))
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.All(
+            Conditions.YouCastSpellsThisTurn(atLeast = 1, filter = GameObjectFilter.Creature),
+            Conditions.YouCastSpellsThisTurn(atLeast = 1, filter = GameObjectFilter.Noncreature)
+        )
+        effect = Effects.DrawCards(1).then(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "182"
+        artist = "Tran Nguyen"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d369c44-78ee-4f3c-bf2b-cddba7fe26d4.jpg?1743204706"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FelotharDawnOfTheAbzan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/FelotharDawnOfTheAbzan.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Felothar, Dawn of the Abzan — Tarkir: Dragonstorm #184
+ * {W}{B}{G} · Legendary Creature — Human Warrior · 3/3
+ *
+ * Trample
+ * Whenever Felothar enters or attacks, you may sacrifice a nonland permanent. When you do,
+ * put a +1/+1 counter on each creature you control.
+ */
+val FelotharDawnOfTheAbzan = card("Felothar, Dawn of the Abzan") {
+    manaCost = "{W}{B}{G}"
+    colorIdentity = "WBG"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Trample\n" +
+        "Whenever Felothar enters or attacks, you may sacrifice a nonland permanent. When you do, " +
+        "put a +1/+1 counter on each creature you control."
+
+    keywords(Keyword.TRAMPLE)
+
+    // Whenever Felothar enters ...
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = felotharSacrificeEffect()
+    }
+
+    // ... or attacks
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = felotharSacrificeEffect()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "184"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83e11f20-6524-4fba-9603-0b97e2d69aac.jpg?1743697572"
+    }
+}
+
+/**
+ * "You may sacrifice a nonland permanent. When you do, put a +1/+1 counter on each
+ * creature you control." Modeled as a reflexive trigger: the reflexive counter effect
+ * happens only if the controller actually sacrifices.
+ */
+private fun felotharSacrificeEffect(): Effect = ReflexiveTriggerEffect(
+    action = Effects.Sacrifice(
+        filter = GameObjectFilter.NonlandPermanent,
+        count = 1,
+        target = EffectTarget.Controller
+    ),
+    optional = true,
+    reflexiveEffect = ForEachInGroupEffect(
+        filter = GroupFilter.AllCreaturesYouControl,
+        effect = AddCountersEffect(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            count = 1,
+            target = EffectTarget.Self
+        )
+    )
+)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -323,7 +323,7 @@ class CastSpellHandler(
             if (action.useAlternativeCost) {
                 return "Cannot combine 'without paying its mana cost' with another alternative cost"
             }
-            if (!costCalculator.hasFreeCastPermission(state, action.playerId)) {
+            if (!costCalculator.hasFreeCastPermission(state, action.playerId, cardDef)) {
                 return "'Without paying its mana cost' is not available (gate closed or no source on the battlefield)"
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -121,6 +121,20 @@ class EnumerationContext(
         costCalculator.hasFreeCastPermission(state, playerId)
     }
 
+    /**
+     * Whether a battlefield [MayCastWithoutPayingManaCost] source grants this player permission to
+     * cast the specific card [cardId] for free. Unlike [freeCastPermissionAvailable] (a generic
+     * "any free-cast source exists?" probe), this honors a source's spell filter — e.g.
+     * Dracogenesis only frees Dragon spells.
+     */
+    fun freeCastPermissionFor(cardId: EntityId): Boolean {
+        val cardDef = state.getEntity(cardId)
+            ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+            ?.let { cardRegistry.getCard(it.cardDefinitionId) }
+            ?: return freeCastPermissionAvailable
+        return costCalculator.hasFreeCastPermission(state, playerId, cardDef)
+    }
+
     // Alternative casting costs from battlefield permanents (e.g., Jodah's WUBRG).
     val alternativeCastingCosts: List<ManaCost> by lazy {
         costCalculator.findAlternativeCastingCosts(state, playerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -393,7 +393,7 @@ class CastSpellEnumerator : ActionEnumerator {
             // A `MayCastWithoutPayingManaCost` battlefield permission (e.g. Weftwalking) makes the
             // spell affordable for {0} when its gates are open. Emitted by its own branch below;
             // don't continue out before reaching it.
-            val canAffordFreeCast = context.freeCastPermissionAvailable
+            val canAffordFreeCast = context.freeCastPermissionFor(cardId)
             if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordBlightPath && !canAffordBeholdPath && !canAffordFreeCast) {
                 // The primary face can't be paid for by any path. Normally we skip it entirely.
                 // But if this is an Adventure/Omen/modal-DFC card whose *secondary* face is
@@ -570,7 +570,7 @@ class CastSpellEnumerator : ActionEnumerator {
             // evoke, impending) when both are legal (CR 118.9a — only one alternative cost may
             // apply to a cast, and which one is the player's choice). Routes through
             // [CastSpell.useWithoutPayingManaCost].
-            val freeCastResult = if (context.freeCastPermissionAvailable) {
+            val freeCastResult = if (context.freeCastPermissionFor(cardId)) {
                 SelfAltCostResult(
                     manaCostString = "{0}",
                     autoTapPreview = if (context.skipAutoTapPreview) null else emptyList(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1085,7 +1085,11 @@ class CostCalculator(
      * still grant the caster their free cast when the source's wording doesn't require
      * controller-only.
      */
-    fun hasFreeCastPermission(state: GameState, casterId: EntityId): Boolean {
+    fun hasFreeCastPermission(
+        state: GameState,
+        casterId: EntityId,
+        spellCardDef: CardDefinition? = null
+    ): Boolean {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val card = container.get<CardComponent>() ?: continue
@@ -1101,6 +1105,13 @@ class CostCalculator(
                     if (state.activePlayerId != casterId) continue
                     if ((state.playerSpellsCastThisTurn[casterId] ?: 0) > 0) continue
                 }
+                // The permission may be scoped to a spell type (e.g. Dracogenesis — Dragons only).
+                // When the caller knows the spell being cast, enforce the filter; with no spell in
+                // hand (a generic "does any free-cast source exist?" probe) a filtered source still
+                // counts, since some castable spell may match.
+                if (spellCardDef != null && ability.spellFilter != GameObjectFilter.Any &&
+                    !matchesCardDefinition(spellCardDef, ability.spellFilter, entityId, state, state.projectedState)
+                ) continue
                 return true
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BetorKinToAllTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BetorKinToAllTest.kt
@@ -3,12 +3,24 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+
+/** A 0/20 vanilla wall: a couple of these let the battlefield clear Betor's 20- and 40-toughness gates. */
+private val ToughnessWall = CardDefinition.creature(
+    name = "Toughness Wall",
+    manaCost = ManaCost.parse("{4}{G}{G}"),
+    subtypes = setOf(Subtype("Wall")),
+    power = 0,
+    toughness = 20
+)
 
 /**
  * Tests for Betor, Kin to All ({2}{W}{B}{G}, 5/7, Flying):
@@ -23,7 +35,7 @@ class BetorKinToAllTest : FunSpec({
 
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all)
+        driver.registerCards(TestCards.all + ToughnessWall)
         driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
         return driver
@@ -64,5 +76,46 @@ class BetorKinToAllTest : FunSpec({
         driver.bothPass()
 
         driver.state.getZone(ZoneKey(me, Zone.HAND)).size shouldBe handBefore
+    }
+
+    test("total toughness 20+: each creature you control untaps; the 40 gate stays closed") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Betor (7) + Toughness Wall (20) = 27 — clears the draw (10) and untap (20) gates, not 40.
+        val betor = driver.putCreatureOnBattlefield(me, "Betor, Kin to All")
+        val wall = driver.putCreatureOnBattlefield(me, "Toughness Wall")
+        driver.tapPermanent(betor)
+        driver.tapPermanent(wall)
+
+        val oppLifeBefore = driver.getLifeTotal(opp)
+
+        advanceToEndStep(driver, me)
+        driver.bothPass() // resolve the end-step trigger
+
+        driver.isTapped(betor) shouldBe false
+        driver.isTapped(wall) shouldBe false
+        // 40-toughness gate not cleared: each opponent's life is untouched.
+        driver.getLifeTotal(opp) shouldBe oppLifeBefore
+    }
+
+    test("total toughness 40+: each opponent loses half their life, rounded up") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Betor (7) + two Toughness Walls (20 each) = 47 — clears all three gates.
+        driver.putCreatureOnBattlefield(me, "Betor, Kin to All")
+        driver.putCreatureOnBattlefield(me, "Toughness Wall")
+        driver.putCreatureOnBattlefield(me, "Toughness Wall")
+
+        // 21 life makes the round-up observable: ceil(21 / 2) = 11 lost -> 10 remaining.
+        driver.setLifeTotal(opp, 21)
+
+        advanceToEndStep(driver, me)
+        driver.bothPass()
+
+        driver.getLifeTotal(opp) shouldBe 10
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BetorKinToAllTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BetorKinToAllTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Betor, Kin to All ({2}{W}{B}{G}, 5/7, Flying):
+ * "At the beginning of your end step, if creatures you control have total toughness 10 or
+ *  greater, draw a card. Then if ... 20 or greater, untap each creature you control. Then if
+ *  ... 40 or greater, each opponent loses half their life, rounded up."
+ *
+ * The toughness thresholds use `Compare(AggregateBattlefield(SUM, TOUGHNESS), GTE, n)` over
+ * projected toughness; the 10 gate is the trigger's intervening "if".
+ */
+class BetorKinToAllTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun advanceToEndStep(driver: GameTestDriver, targetPlayer: EntityId) {
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.activePlayer shouldBe targetPlayer
+        driver.currentStep shouldBe Step.END
+    }
+
+    test("total toughness 10+: the end-step trigger draws a card") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // Betor (toughness 7) + Hill Giant (toughness 3) = 10 total toughness — clears the draw gate.
+        driver.putCreatureOnBattlefield(me, "Betor, Kin to All")
+        driver.putCreatureOnBattlefield(me, "Hill Giant")
+
+        val handBefore = driver.state.getZone(ZoneKey(me, Zone.HAND)).size
+
+        advanceToEndStep(driver, me)
+        driver.bothPass() // resolve the end-step trigger
+
+        driver.state.getZone(ZoneKey(me, Zone.HAND)).size shouldBe handBefore + 1
+    }
+
+    test("total toughness below 10: the intervening if fails, no draw") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // Betor alone = 7 toughness, under the 10 threshold.
+        driver.putCreatureOnBattlefield(me, "Betor, Kin to All")
+
+        val handBefore = driver.state.getZone(ZoneKey(me, Zone.HAND)).size
+
+        advanceToEndStep(driver, me)
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(me, Zone.HAND)).size shouldBe handBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoriSteelCutterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoriSteelCutterScenarioTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Keyword
@@ -87,6 +88,43 @@ class CoriSteelCutterScenarioTest : ScenarioTestBase() {
                 }
                 withClue("Flurry created exactly one Monk token") {
                     monks.size shouldBe 1
+                }
+            }
+
+            test("Flurry: accepting the prompt attaches the Equipment to the new Monk token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cori-Steel Cutter")
+                    .withCardsInHand(1, "Lightning Bolt", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2)
+                game.resolveStack()
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2)
+                game.resolveStack()
+
+                // Accept "you may attach this Equipment to it".
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                val cutter = game.findPermanent("Cori-Steel Cutter")!!
+                val monk = game.state.getBattlefield().first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Monk Token"
+                }
+                withClue("The Equipment is attached to the freshly-created Monk token") {
+                    game.state.getEntity(cutter)?.get<AttachedToComponent>()?.targetId shouldBe monk
+                }
+                val projected = game.state.projectedState
+                withClue("The equipped Monk is a 2/2 with trample and haste") {
+                    projected.getPower(monk) shouldBe 2
+                    projected.getToughness(monk) shouldBe 2
+                    projected.hasKeyword(monk, Keyword.TRAMPLE) shouldBe true
+                    projected.hasKeyword(monk, Keyword.HASTE) shouldBe true
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoriSteelCutterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoriSteelCutterScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Cori-Steel Cutter (TDM #103, {1}{R} Artifact — Equipment).
+ *
+ *   Equipped creature gets +1/+1 and has trample and haste.
+ *   Flurry — Whenever you cast your second spell each turn, create a 1/1 white Monk creature
+ *   token with prowess. You may attach this Equipment to it.
+ *   Equip {1}{R}
+ *
+ * Flurry is wired via the `flurry { }` builder ([com.wingedsheep.sdk.dsl.Triggers.NthSpellCast]
+ * with `n = 2`), and the optional attach is a [com.wingedsheep.sdk.scripting.effects.MayEffect]
+ * targeting the freshly-created token via the `CREATED_TOKENS` pipeline collection.
+ */
+class CoriSteelCutterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cori-Steel Cutter") {
+
+            test("equipped creature gets +1/+1 and gains trample and haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")  // 2/2 vanilla
+                    .withCardOnBattlefield(1, "Cori-Steel Cutter")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cutter = game.findPermanent("Cori-Steel Cutter")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val equip = cardRegistry.getCard("Cori-Steel Cutter")!!.script.activatedAbilities[0]
+                game.execute(
+                    com.wingedsheep.engine.core.ActivateAbility(
+                        game.player1Id, cutter, equip.id,
+                        targets = listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(bears))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("Grizzly Bears becomes a 3/3 (2/2 +1/+1)") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 3
+                }
+                withClue("...and gains trample and haste") {
+                    projected.hasKeyword(bears, Keyword.TRAMPLE) shouldBe true
+                    projected.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("Flurry: casting your second spell each turn creates a 1/1 white Monk token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cori-Steel Cutter")
+                    .withCardsInHand(1, "Lightning Bolt", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // First spell of the turn (targets the opponent).
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2)
+                game.resolveStack()
+
+                // Second spell triggers Flurry. Resolving the stack runs the trigger.
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2)
+                game.resolveStack()
+
+                // The optional "you may attach" prompt (no creatures to lose context) — decline if present.
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(false)
+                    game.resolveStack()
+                }
+
+                val monks = game.state.getBattlefield().filter { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Monk Token"
+                }
+                withClue("Flurry created exactly one Monk token") {
+                    monks.size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DracogenesisScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DracogenesisScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.MayCastWithoutPayingManaCost
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Dracogenesis (TDM #105) and the SDK primitive it introduces:
+ * a `spellFilter` on [MayCastWithoutPayingManaCost].
+ *
+ * Dracogenesis — {6}{R}{R} Enchantment.
+ *   "You may cast Dragon spells without paying their mana costs."
+ *
+ * The free-cast permission is now type-scoped: a Dragon spell may be cast for {0}, but a
+ * non-Dragon spell may not, even with Dracogenesis on the battlefield.
+ */
+class DracogenesisScenarioTest : ScenarioTestBase() {
+
+    private val calculator = CostCalculator(cardRegistry)
+
+    private fun com.wingedsheep.engine.state.GameState.cardInHand(playerId: EntityId, name: String): EntityId =
+        getHand(playerId).first { getEntity(it)?.get<CardComponent>()?.name == name }
+
+    init {
+        context("Dragon-scoped free cast") {
+
+            test("Dracogenesis grants free-cast permission for a Dragon spell but not a non-Dragon spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dracogenesis")
+                    .withCardInHand(1, "Dirgur Island Dragon")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .build()
+                val me = game.player1Id
+                val dragon = game.state.cardInHand(me, "Dirgur Island Dragon")
+                val bears = game.state.cardInHand(me, "Grizzly Bears")
+
+                calculator.hasFreeCastPermission(
+                    game.state, me, cardRegistry.requireCard("Dirgur Island Dragon")
+                ) shouldBe true
+                calculator.hasFreeCastPermission(
+                    game.state, me, cardRegistry.requireCard("Grizzly Bears")
+                ) shouldBe false
+
+                // Free-casting the non-Dragon is rejected outright (empty stack, our main phase —
+                // the only obstacle is the Dragon-scoped free-cast filter).
+                game.execute(
+                    CastSpell(me, bears, useWithoutPayingManaCost = true)
+                ).error shouldBe "'Without paying its mana cost' is not available (gate closed or no source on the battlefield)"
+
+                // The Dragon, by contrast, casts for free and lands on the stack.
+                game.execute(
+                    CastSpell(me, dragon, useWithoutPayingManaCost = true)
+                ).error shouldBe null
+                game.state.stack.contains(dragon) shouldBe true
+            }
+
+            test("without Dracogenesis, even a Dragon spell has no free-cast permission") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dirgur Island Dragon")
+                    .build()
+                val me = game.player1Id
+
+                calculator.hasFreeCastPermission(
+                    game.state, me, cardRegistry.requireCard("Dirgur Island Dragon")
+                ) shouldBe false
+            }
+
+            test("the static ability is the controller-only, Dragon-filtered variant") {
+                val def = cardRegistry.requireCard("Dracogenesis")
+                val ability = def.script.staticAbilities
+                    .filterIsInstance<MayCastWithoutPayingManaCost>()
+                    .single()
+                ability.controllerOnly shouldBe true
+                ability.spellFilter shouldBe
+                    com.wingedsheep.sdk.scripting.GameObjectFilter.Any.withSubtype("Dragon")
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElspethStormSlayerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElspethStormSlayerScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Elspeth, Storm Slayer (TDM #11, {3}{W}{W}, Loyalty 5).
+ *
+ *   If one or more tokens would be created under your control, twice that many of those tokens
+ *   are created instead.  ([com.wingedsheep.sdk.scripting.DoubleTokenCreation])
+ *   +1: Create a 1/1 white Soldier creature token.
+ *   0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until your
+ *      next turn.
+ *   −3: Destroy target creature an opponent controls with mana value 3 or greater.
+ */
+class ElspethStormSlayerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Elspeth, Storm Slayer") {
+
+            test("+1 creates two Soldier tokens (token-doubling replacement applies to her own ability)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elspeth, Storm Slayer")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elspeth = game.findPermanent("Elspeth, Storm Slayer")!!
+                game.state = game.state.updateEntity(elspeth) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 5))
+                }
+                val plus1 = cardRegistry.getCard("Elspeth, Storm Slayer")!!.script.activatedAbilities[0]
+                game.execute(ActivateAbility(game.player1Id, elspeth, plus1.id)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Token doubling turns the single Soldier into two") {
+                    game.findPermanents("Soldier Token").size shouldBe 2
+                }
+            }
+
+            test("0 puts a +1/+1 counter on each creature you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elspeth, Storm Slayer")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elspeth = game.findPermanent("Elspeth, Storm Slayer")!!
+                game.state = game.state.updateEntity(elspeth) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 5))
+                }
+                val zero = cardRegistry.getCard("Elspeth, Storm Slayer")!!.script.activatedAbilities[1]
+                game.execute(ActivateAbility(game.player1Id, elspeth, zero.id)).error shouldBe null
+                game.resolveStack()
+
+                fun counters(name: String, controller: Int): Int {
+                    val id = game.findPermanents(name).first { pid ->
+                        game.state.projectedState.getController(pid) ==
+                            (if (controller == 1) game.player1Id else game.player2Id)
+                    }
+                    return game.state.getEntity(id)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                }
+
+                withClue("Your creatures each gain a +1/+1 counter") {
+                    counters("Grizzly Bears", 1) shouldBe 1
+                    counters("Hill Giant", 1) shouldBe 1
+                }
+                withClue("The opponent's creature is untouched") {
+                    counters("Grizzly Bears", 2) shouldBe 0
+                }
+            }
+
+            test("−3 destroys an opponent's creature with mana value 3 or greater") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elspeth, Storm Slayer")
+                    .withCardOnBattlefield(2, "Hill Giant") // {3}{R}, MV 4
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elspeth = game.findPermanent("Elspeth, Storm Slayer")!!
+                game.state = game.state.updateEntity(elspeth) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 5))
+                }
+                val giant = game.findPermanent("Hill Giant")!!
+                val minus3 = cardRegistry.getCard("Elspeth, Storm Slayer")!!.script.activatedAbilities[2]
+                game.execute(
+                    ActivateAbility(
+                        game.player1Id, elspeth, minus3.id,
+                        targets = listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(giant))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Hill Giant (MV 4) is destroyed") {
+                    game.findPermanent("Hill Giant") shouldBe null
+                    game.state.getGraveyard(game.player2Id).any {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Hill Giant"
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EshkiDragonclawTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EshkiDragonclawTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Eshki Dragonclaw ({1}{G}{U}{R}, 4/4, Vigilance/Trample/Ward {1}):
+ * "At the beginning of combat on your turn, if you've cast both a creature spell and a
+ *  noncreature spell this turn, draw a card and put two +1/+1 counters on Eshki Dragonclaw."
+ *
+ * The intervening "if" is two `Conditions.YouCastSpellsThisTurn` (one per spell-kind filter)
+ * combined with `Conditions.All`.
+ */
+class EshkiDragonclawTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("having cast both a creature and noncreature spell, combat trigger draws and adds two counters") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val eshki = driver.putCreatureOnBattlefield(me, "Eshki Dragonclaw")
+
+        // Cast a creature spell ...
+        driver.giveMana(me, Color.GREEN, 2)
+        val bears = driver.putCardInHand(me, "Grizzly Bears")
+        driver.castSpell(me, bears).isSuccess shouldBe true
+        driver.bothPass()
+
+        // ... and a noncreature spell.
+        driver.giveMana(me, Color.RED, 1)
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.castSpell(me, bolt, listOf(opp)).isSuccess shouldBe true
+        driver.bothPass()
+
+        val handBefore = driver.state.getZone(ZoneKey(me, Zone.HAND)).size
+
+        // Advance to beginning of combat — the trigger fires and resolves.
+        driver.passPriorityUntil(Step.BEGIN_COMBAT, maxPasses = 200)
+        driver.bothPass()
+
+        plusCounters(driver, eshki) shouldBe 2
+        driver.state.getZone(ZoneKey(me, Zone.HAND)).size shouldBe handBefore + 1
+    }
+
+    test("casting only a creature spell does not satisfy the intervening if (no draw, no counters)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val eshki = driver.putCreatureOnBattlefield(me, "Eshki Dragonclaw")
+
+        driver.giveMana(me, Color.GREEN, 2)
+        val bears = driver.putCardInHand(me, "Grizzly Bears")
+        driver.castSpell(me, bears).isSuccess shouldBe true
+        driver.bothPass()
+
+        val handBefore = driver.state.getZone(ZoneKey(me, Zone.HAND)).size
+
+        driver.passPriorityUntil(Step.BEGIN_COMBAT, maxPasses = 200)
+        driver.bothPass()
+
+        plusCounters(driver, eshki) shouldBe 0
+        driver.state.getZone(ZoneKey(me, Zone.HAND)).size shouldBe handBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FelotharDawnOfTheAbzanTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FelotharDawnOfTheAbzanTest.kt
@@ -84,4 +84,30 @@ class FelotharDawnOfTheAbzanTest : FunSpec({
         plusCounters(driver, felotharCard) shouldBe 0
         plusCounters(driver, bears) shouldBe 0
     }
+
+    test("attacks trigger: sacrificing a nonland permanent puts a +1/+1 counter on each creature you control") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Felothar already in play (so its "attacks" trigger — the second triggeredAbility block —
+        // is what fires), plus a second creature to verify "each creature you control" and a
+        // sacrifice victim.
+        val felothar = driver.putCreatureOnBattlefield(me, "Felothar, Dawn of the Abzan")
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val fodder = driver.putCreatureOnBattlefield(me, "Hill Giant")
+        driver.removeSummoningSickness(felothar)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(felothar), opp)
+        driver.bothPass() // resolve the attacks trigger off the stack
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+        driver.submitCardSelection(me, listOf(fodder))
+
+        plusCounters(driver, felothar) shouldBe 1
+        plusCounters(driver, bears) shouldBe 1
+        driver.state.getGraveyard(me).contains(fodder) shouldBe true
+    }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FelotharDawnOfTheAbzanTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FelotharDawnOfTheAbzanTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Felothar, Dawn of the Abzan ({W}{B}{G}, 3/3, Trample):
+ * "Whenever Felothar enters or attacks, you may sacrifice a nonland permanent. When you do,
+ *  put a +1/+1 counter on each creature you control."
+ *
+ * Composed from a [com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect] (optional
+ * sacrifice) whose reflexive effect is a `ForEachInGroupEffect(AllCreaturesYouControl, +1/+1)`.
+ */
+class FelotharDawnOfTheAbzanTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("enters trigger: sacrificing a nonland permanent puts a +1/+1 counter on each creature you control") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // A second creature so we can verify "each creature you control" gets a counter,
+        // and an extra nonland permanent to feed the sacrifice (so it's a genuine choice).
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val fodder = driver.putCreatureOnBattlefield(me, "Hill Giant")
+
+        // Cast Felothar so its "enters" trigger fires.
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveMana(me, Color.GREEN, 1)
+        val felotharCard = driver.putCardInHand(me, "Felothar, Dawn of the Abzan")
+        driver.castSpell(me, felotharCard).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature spell
+        driver.bothPass() // resolve the enters trigger off the stack
+
+        // "You may sacrifice a nonland permanent."
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+
+        // Choose the Hill Giant as the sacrifice.
+        driver.submitCardSelection(me, listOf(fodder))
+
+        // Each creature you control still in play gets a +1/+1 counter (Felothar + the Bears).
+        plusCounters(driver, felotharCard) shouldBe 1
+        plusCounters(driver, bears) shouldBe 1
+        driver.state.getGraveyard(me).contains(fodder) shouldBe true
+    }
+
+    test("declining the optional sacrifice places no counters") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(me, "Hill Giant")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveMana(me, Color.GREEN, 1)
+        val felotharCard = driver.putCardInHand(me, "Felothar, Dawn of the Abzan")
+        driver.castSpell(me, felotharCard).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, false)
+
+        plusCounters(driver, felotharCard) shouldBe 0
+        plusCounters(driver, bears) shouldBe 0
+    }
+})


### PR DESCRIPTION
Implements 6 missing Tarkir: Dragonstorm (TDM) cards, each with a rules-engine scenario test.

## Cards

- **Eshki Dragonclaw** ({1}{G}{U}{R}, 4/4) — Vigilance, trample, ward {1}; begin-combat trigger gated on having cast both a creature spell and a noncreature spell this turn → draw + two +1/+1 counters. (`Conditions.All(YouCastSpellsThisTurn(Creature), YouCastSpellsThisTurn(Noncreature))`)
- **Felothar, Dawn of the Abzan** ({W}{B}{G}, 3/3, Trample) — enters/attacks: reflexive "you may sacrifice a nonland permanent; when you do, +1/+1 counter on each creature you control" (`ReflexiveTriggerEffect` + `ForEachInGroupEffect`).
- **Betor, Kin to All** ({2}{W}{B}{G}, 5/7, Flying) — end-step total-toughness thresholds: 10 → draw, 20 → untap each creature you control, 40 → each opponent loses half life. Uses `Compare(AggregateBattlefield(SUM, TOUGHNESS), GTE, n)` over projected toughness; the 10 gate is the trigger's intervening "if".
- **Dracogenesis** ({6}{R}{R}) — "You may cast Dragon spells without paying their mana costs."
- **Cori-Steel Cutter** ({1}{R}, Equipment) — equipped creature gets +1/+1 and trample/haste; Flurry creates a 1/1 white Monk with prowess and may attach the Equipment to it; Equip {1}{R}.
- **Elspeth, Storm Slayer** ({3}{W}{W}, Loyalty 5) — token-doubling static (`DoubleTokenCreation`) + `+1` make a Soldier, `0` +1/+1 counter on each of your creatures and they gain flying until your next turn, `-3` destroy an opponent's creature with mana value 3+.

## SDK change

Added a `spellFilter` parameter to `MayCastWithoutPayingManaCost` so the free-cast permission can be scoped to a spell type (Dracogenesis = Dragons only). Enforced per-spell in `CostCalculator.hasFreeCastPermission(state, caster, spellCardDef)`, threaded through `EnumerationContext.freeCastPermissionFor(cardId)`, the two `CastSpellEnumerator` call sites, and `CastSpellHandler.validate`. Default `GameObjectFilter.Any` preserves existing behavior (Weftwalking et al.). Documented in `docs/card-sdk-language-reference.md`.

## Skipped

- **Call the Spirit Dragons** — the upkeep ability (for each of the five fixed colors, put a +1/+1 counter on a Dragon you control of that color; win if five distinct Dragons received counters this way) requires an add-feature-scale interactive mechanic (fixed-five-color iteration with a per-color battlefield target selection + distinct-recipient win tracking) with no existing composition path. Its companion static ("Dragons you control have indestructible") is trivial, but the win-condition half is not, so the card is left unimplemented rather than shipped with a shortcut.

## Tests

New scenario tests (all passing): `EshkiDragonclawTest`, `FelotharDawnOfTheAbzanTest`, `BetorKinToAllTest`, `DracogenesisScenarioTest`, `CoriSteelCutterScenarioTest`, `ElspethStormSlayerScenarioTest`. Full `:rules-engine:test` suite and `:mtg-sdk:test` pass; `:game-server` compiles. `WeftwalkingScenarioTest` confirms the free-cast change is backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)