### PR TITLE
Add 6 TDM cards (lands, Narset, Rediscover the Way, Sarkhan Dragon Ascendant)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -306,6 +306,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   express "if you don't, X" riders — e.g. SOI shadow lands wrap this in
   `OnEnterRunEffect(...)` with `otherwise = Effects.Tap(EffectTarget.Self)` for the
   "this land enters tapped" branch.
+- `Effects.Behold(filter, ifBeheld?)` — resolution-time **behold** (`BeholdEffect`): "you may
+  behold a `filter`. If you do, `ifBeheld`." The behold itself is optional — the controller may
+  choose a matching permanent they control **or** reveal a matching card from hand (revealing emits
+  `CardsRevealedEvent`; battlefield permanents are merely chosen). If they decline, or control no
+  matching permanent and hold no matching card, `ifBeheld` does not run. Distinct from the cast-time
+  `AdditionalCost.Behold` / `AdditionalCost.BeholdOrPay` (which behold as a casting cost). Sarkhan,
+  Dragon Ascendant ETB: `Effects.Behold(GameObjectFilter.Any.withSubtype(Subtype.DRAGON),
+  ifBeheld = Effects.CreateTreasure())`.
 
 ### Library reveal & free cast
 
@@ -1286,6 +1294,14 @@ Triggers.youCastSpell(
     control on your next attack). With `fireOnce = false` (default) it fires on every matching event
     until expiry (double-strike combat damage). One-shot consumption happens when the trigger goes
     on the stack (`TriggerProcessor`), so a second matching event the same turn won't re-fire it.
+  - `targetRequirement = <TargetRequirement>` — a target chosen **each time** the delayed trigger
+    fires, exposed to `effect` as `EffectTarget.ContextTarget`. Use for delayed triggers whose payoff
+    targets: Rediscover the Way chapter III installs
+    `CreateDelayedTriggerEffect(trigger = Triggers.YouCastNoncreature, fireOnce = false,
+    expiry = EndOfTurn, targetRequirement = Targets.CreatureYouControl,
+    effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE))` — "whenever you cast a noncreature spell
+    this turn, target creature you control gains double strike". Works on both event-based and
+    step-based delayed triggers; null (default) for non-targeting delayed triggers.
 
 ---
 
@@ -2179,6 +2195,10 @@ restriction matches the spell context.
   creature- or mana-value-gated.
 - `ManaRestriction.SubtypeSpellsOrAbilitiesOnly(subtype, creatureOnly?)` — Cavern of Souls /
   Unclaimed Territory: only spells of a baked subtype, optionally creature-only.
+- `ManaRestriction.SubtypeSpellsOnly(subtypes)` — multi-subtype spend restriction: only spells
+  whose type line carries **any** of the given subtypes (OR-joined). Spell-only (no ability
+  variant). Maelstrom of the Spirit Dragon: `SubtypeSpellsOnly(setOf("Dragon", "Omen"))`
+  ("a Dragon spell or an Omen spell").
 - `ManaRestriction.CastFromExileOnly` — only spells cast from exile.
 - `ManaRestriction.CardTypeSpellsOrAbilitiesOnly(cardType, allowSpells?, allowAbilities?)` —
   Steelswarm Operator shape.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1314,6 +1314,16 @@ object Effects {
         CreatePredefinedTokenEffect("Treasure", count, tapped = tapped)
 
     /**
+     * "You may behold a [filter]. If you do, [ifBeheld]." — the resolution-time behold
+     * (choose a matching permanent you control or reveal a matching card from hand). See
+     * [com.wingedsheep.sdk.scripting.effects.BeholdEffect]. Used by Sarkhan, Dragon Ascendant.
+     */
+    fun Behold(
+        filter: com.wingedsheep.sdk.scripting.GameObjectFilter,
+        ifBeheld: Effect? = null
+    ): Effect = com.wingedsheep.sdk.scripting.effects.BeholdEffect(filter, ifBeheld)
+
+    /**
      * Create Food artifact tokens.
      * "{2}, {T}, Sacrifice this artifact: You gain 3 life."
      *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -381,6 +381,44 @@ sealed interface SuccessCriterion {
 }
 
 /**
+ * "Behold a [filter]" as a resolution-time effect (CR: a player beholds a permanent by either
+ * choosing a matching permanent they control or revealing a matching card from their hand).
+ * Unlike the cast-time [AdditionalCost.Behold] / [AdditionalCost.BeholdOrPay], this is the
+ * *effect-side* behold used inside abilities such as Sarkhan, Dragon Ascendant's ETB
+ * ("you may behold a Dragon. If you do, create a Treasure token.").
+ *
+ * The behold is optional: the player may decline (or be unable to behold if they control no
+ * matching permanent and hold no matching card), in which case [ifBeheld] does not run. When a
+ * choice is made, a matching hand card is revealed (battlefield permanents are merely chosen,
+ * not revealed) and [ifBeheld] runs. No information about the beheld object is otherwise stored —
+ * per the "behold reveals are identity, not parameters" principle, this effect only models the
+ * Dragon-storm behold-then-payoff shape.
+ *
+ * @property filter Which permanents/cards qualify to be beheld
+ * @property ifBeheld Effect that runs only if the player successfully beholds
+ */
+@SerialName("Behold")
+@Serializable
+data class BeholdEffect(
+    val filter: GameObjectFilter = GameObjectFilter.Any,
+    val ifBeheld: Effect? = null
+) : Effect {
+    override val description: String = buildString {
+        val filterDesc = filter.description
+        val article = if (filterDesc.firstOrNull()?.lowercase() in listOf("a", "e", "i", "o", "u")) "an" else "a"
+        append("You may behold $article $filterDesc")
+        if (ifBeheld != null) append(". If you do, ${ifBeheld.description.replaceFirstChar { it.lowercase() }}")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect {
+        val newFilter = filter.applyTextReplacement(replacer)
+        val newIfBeheld = ifBeheld?.applyTextReplacement(replacer)
+        return if (newFilter !== filter || newIfBeheld !== ifBeheld)
+            copy(filter = newFilter, ifBeheld = newIfBeheld) else this
+    }
+}
+
+/**
  * Effect with an optional cost - "You may [cost]. If you do, [ifPaid]."
  *
  * This is the fundamental building block for optional effects like:
@@ -589,7 +627,15 @@ data class CreateDelayedTriggerEffect(
      * [DelayedTriggerTiming]. Orthogonal to [fireOnlyOnControllersTurn], which gates
      * whose turn the trigger fires on.
      */
-    val timing: DelayedTriggerTiming = DelayedTriggerTiming.CURRENT_TURN_OR_LATER
+    val timing: DelayedTriggerTiming = DelayedTriggerTiming.CURRENT_TURN_OR_LATER,
+    /**
+     * Target requirement chosen *each time* the delayed trigger fires. Used for delayed
+     * triggers whose effect targets, e.g. "Whenever you cast a noncreature spell this turn,
+     * **target** creature you control gains double strike" (Rediscover the Way). The chosen
+     * target is exposed to [effect] as [com.wingedsheep.sdk.scripting.targets.EffectTarget.ContextTarget].
+     * Null for non-targeting delayed triggers (the common case).
+     */
+    val targetRequirement: TargetRequirement? = null
 ) : Effect {
     override val description: String = when {
         trigger != null -> "create a delayed trigger that fires on ${trigger.event::class.simpleName}"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
@@ -112,6 +112,28 @@ sealed interface ManaRestriction {
     }
 
     /**
+     * "Spend this mana only to cast a spell that has any of the given subtypes."
+     *
+     * Generalizes [SubtypeSpellsOrAbilitiesOnly] to a *set* of subtypes joined by OR, for
+     * cards whose mana is usable on more than one named subtype — e.g. Maelstrom of the
+     * Spirit Dragon ("a Dragon spell or an Omen spell"). The [subtypes] are baked into the
+     * restriction at the moment the mana is produced, so the restriction stays
+     * self-contained and serializable. Unlike [SubtypeSpellsOrAbilitiesOnly] this matches
+     * spells only (not activated abilities of sources of the subtype) — every printed
+     * multi-subtype variant so far is spell-only.
+     */
+    @SerialName("SubtypeSpellsOnly")
+    @Serializable
+    data class SubtypeSpellsOnly(
+        val subtypes: Set<String>
+    ) : ManaRestriction {
+        override val description: String = buildString {
+            append("Spend this mana only to cast ")
+            append(subtypes.joinToString(" or ") { "a $it spell" })
+        }
+    }
+
+    /**
      * "Spend this mana only to cast [cardType] spells [or activate abilities of [cardType] sources]."
      *
      * Parameterized over card type so the same restriction shape covers Steelswarm Operator

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GreatArashinCity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/GreatArashinCity.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Great Arashin City — Tarkir: Dragonstorm #257
+ * Land · Rare
+ *
+ * This land enters tapped unless you control a Forest or a Plains.
+ * {T}: Add {B}.
+ * {1}{B}, {T}, Exile a creature card from your graveyard: Create a 1/1 white Spirit creature token.
+ *
+ * Conditional enters-tapped is the check-land replacement [EntersTapped] gated on controlling a
+ * Forest or a Plains (same shape as Kishla Village). {T}: Add {B} is a mana ability. The Spirit
+ * ability is a non-mana activated ability whose cost composes {1}{B}, a tap, and exiling a
+ * creature card from the graveyard ([AbilityCost.ExileFromGraveyard]); it has no timing
+ * restriction, so it can be activated at instant speed.
+ */
+val GreatArashinCity = card("Great Arashin City") {
+    typeLine = "Land"
+    colorIdentity = "B"
+    oracleText = "This land enters tapped unless you control a Forest or a Plains.\n" +
+        "{T}: Add {B}.\n" +
+        "{1}{B}, {T}, Exile a creature card from your graveyard: Create a 1/1 white Spirit creature token."
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Conditions.Any(
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Forest")),
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Plains"))
+        )
+    ))
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Composite(
+            listOf(
+                AbilityCost.Mana(ManaCost.parse("{1}{B}")),
+                AbilityCost.Tap,
+                AbilityCost.ExileFromGraveyard(count = 1, filter = GameObjectFilter.Creature)
+            )
+        )
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            imageUri = "https://cards.scryfall.io/normal/front/f/2/f22410b3-5c0b-4282-9b0b-5ba61229b6e7.jpg?1743176224"
+        )
+        description = "Create a 1/1 white Spirit creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "257"
+        artist = "Josu Solano"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ecba23b6-9f3a-431e-bc22-f1fb04d27b68.jpg?1743205015"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MaelstromOfTheSpiritDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MaelstromOfTheSpiritDragon.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
+import com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Maelstrom of the Spirit Dragon — Tarkir: Dragonstorm #260
+ * Land · Rare
+ *
+ * {T}: Add {C}.
+ * {T}: Add one mana of any color. Spend this mana only to cast a Dragon spell or an Omen spell.
+ * {4}, {T}, Sacrifice this land: Search your library for a Dragon card, reveal it, put it into
+ *   your hand, then shuffle.
+ *
+ * Two mana abilities and one non-mana sacrifice tutor. The any-color ability tags its mana with
+ * [ManaRestriction.SubtypeSpellsOnly] for the subtypes "Dragon" and "Omen" — the new multi-subtype
+ * spend restriction (a spell qualifies if its type line carries either subtype; the Omen face of a
+ * modal DFC has the "Omen" subtype on the stack). The tutor is the atomic
+ * [EffectPatterns.searchLibrary] pipeline (find a Dragon card, reveal it, to hand, then shuffle).
+ */
+val MaelstromOfTheSpiritDragon = card("Maelstrom of the Spirit Dragon") {
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{T}: Add one mana of any color. Spend this mana only to cast a Dragon spell or an Omen spell.\n" +
+        "{4}, {T}, Sacrifice this land: Search your library for a Dragon card, reveal it, put it into " +
+        "your hand, then shuffle."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddColorlessManaEffect(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaOfChoiceEffect(
+            colorSet = ManaColorSet.AnyColor,
+            restriction = ManaRestriction.SubtypeSpellsOnly(setOf("Dragon", "Omen"))
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Composite(
+            listOf(
+                AbilityCost.Mana(ManaCost.parse("{4}")),
+                AbilityCost.Tap,
+                AbilityCost.SacrificeSelf
+            )
+        )
+        effect = EffectPatterns.searchLibrary(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.DRAGON),
+            count = 1,
+            reveal = true,
+            shuffleAfter = true
+        )
+        description = "Search your library for a Dragon card, reveal it, put it into your hand, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "260"
+        artist = "Carlos Palma Cruchaga"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4e90bfb-d9a5-48a9-9ff9-b0f50a813eee.jpg?1743205026"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MistriseVillage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MistriseVillage.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Mistrise Village — Tarkir: Dragonstorm #261
+ * Land · Rare
+ *
+ * This land enters tapped unless you control a Mountain or a Forest.
+ * {T}: Add {U}.
+ * {U}, {T}: The next spell you cast this turn can't be countered.
+ *
+ * Conditional enters-tapped is the check-land replacement [EntersTapped] gated on controlling a
+ * Mountain or a Forest (same shape as Kishla Village). {T}: Add {U} is a mana ability. The
+ * uncounterable ability ({U} + tap) installs a one-shot rider via
+ * [Effects.MakeNextSpellUncounterable] that protects only the next spell its controller casts
+ * this turn (no spell filter — any spell).
+ */
+val MistriseVillage = card("Mistrise Village") {
+    typeLine = "Land"
+    colorIdentity = "U"
+    oracleText = "This land enters tapped unless you control a Mountain or a Forest.\n" +
+        "{T}: Add {U}.\n" +
+        "{U}, {T}: The next spell you cast this turn can't be countered."
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Conditions.Any(
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Mountain")),
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Forest"))
+        )
+    ))
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Composite(
+            listOf(
+                AbilityCost.Mana(ManaCost.parse("{U}")),
+                AbilityCost.Tap
+            )
+        )
+        effect = Effects.MakeNextSpellUncounterable()
+        description = "The next spell you cast this turn can't be countered."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "261"
+        artist = "Constantin Marin"
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d44bccbf-6fab-46e4-8ddb-6577e27ec6e8.jpg?1743205033"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NarsetJeskaiWaymaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NarsetJeskaiWaymaster.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.dsl.EffectPatterns
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Narset, Jeskai Waymaster — Tarkir: Dragonstorm #209
+ * {U}{R}{W} · Legendary Creature — Human Monk · 3/4 · Rare
+ *
+ * At the beginning of your end step, you may discard your hand. If you do, draw cards equal to
+ * the number of spells you've cast this turn.
+ *
+ * "You may discard your hand. If you do, draw …" is the standard
+ * [MayEffect] + [IfYouDoEffect] pair (same shape as Vaultguard Trooper): the optional yes/no
+ * wraps [EffectPatterns.discardHand]; on "yes" the hand is discarded (even if empty) and the draw
+ * fires. The draw amount is [DynamicAmount.SpellsCastThisTurn] for the controller (reads the
+ * per-player `spellsCastThisTurnByPlayer` history), counting every spell cast this turn — Narset's
+ * own spell included if it was cast this turn.
+ */
+val NarsetJeskaiWaymaster = card("Narset, Jeskai Waymaster") {
+    manaCost = "{U}{R}{W}"
+    colorIdentity = "URW"
+    typeLine = "Legendary Creature — Human Monk"
+    power = 3
+    toughness = 4
+    oracleText = "At the beginning of your end step, you may discard your hand. If you do, draw " +
+        "cards equal to the number of spells you've cast this turn."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = MayEffect(
+            IfYouDoEffect(
+                action = EffectPatterns.discardHand(EffectTarget.Controller),
+                ifYouDo = Effects.DrawCards(DynamicAmount.SpellsCastThisTurn(Player.You))
+            )
+        )
+        description = "You may discard your hand. If you do, draw cards equal to the number of spells you've cast this turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "209"
+        artist = "Randy Vargas"
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b77cbc1-dbc8-44d9-aa29-15cbb19afecd.jpg?1743204826"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RediscoverTheWay.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/RediscoverTheWay.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.LibraryPatterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rediscover the Way — Tarkir: Dragonstorm #215
+ * {U}{R}{W} · Enchantment — Saga · Rare
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I, II — Look at the top three cards of your library. Put one of them into your hand and the
+ *         rest on the bottom of your library in any order.
+ * III — Whenever you cast a noncreature spell this turn, target creature you control gains
+ *       double strike until end of turn.
+ *
+ * Chapters I and II are the standard "look at top three, keep one to hand, bottom the rest in any
+ * order" dig — [LibraryPatterns.lookAtTopAndKeep] with the remainder going to the bottom of the
+ * library, ordered by the controller ([CardOrder.ControllerChooses]).
+ *
+ * Chapter III installs a turn-bounded, event-based delayed triggered ability:
+ * [CreateDelayedTriggerEffect] on [Triggers.YouCastNoncreature] with `fireOnce = false` (it fires
+ * for *every* noncreature spell cast this turn, not just the first) and `expiry = EndOfTurn`. Its
+ * [CreateDelayedTriggerEffect.targetRequirement] is "target creature you control", chosen each
+ * time the trigger fires; the chosen creature is granted double strike until end of turn via
+ * [Effects.GrantKeyword] reading `ContextTarget(0)`.
+ */
+val RediscoverTheWay = card("Rediscover the Way") {
+    manaCost = "{U}{R}{W}"
+    colorIdentity = "URW"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I, II — Look at the top three cards of your library. Put one of them into your hand and the rest " +
+        "on the bottom of your library in any order.\n" +
+        "III — Whenever you cast a noncreature spell this turn, target creature you control gains double " +
+        "strike until end of turn."
+
+    sagaChapter(1) {
+        effect = rediscoverDig()
+    }
+    sagaChapter(2) {
+        effect = rediscoverDig()
+    }
+    sagaChapter(3) {
+        effect = CreateDelayedTriggerEffect(
+            trigger = Triggers.YouCastNoncreature,
+            fireOnce = false,
+            expiry = DelayedTriggerExpiry.EndOfTurn,
+            targetRequirement = Targets.CreatureYouControl,
+            effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "215"
+        artist = "Clint Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/79d6decf-afd5-4e96-b87e-fd7ab7e3c068.jpg?1743204851"
+    }
+}
+
+/**
+ * "Look at the top three cards of your library. Put one of them into your hand and the rest on the
+ * bottom of your library in any order." A fresh instance backs each of chapters I and II.
+ */
+private fun rediscoverDig() = LibraryPatterns.lookAtTopAndKeep(
+    count = DynamicAmount.Fixed(3),
+    keepCount = DynamicAmount.Fixed(1),
+    keepDestination = CardDestination.ToZone(Zone.HAND),
+    restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+    restOrder = CardOrder.ControllerChooses,
+    selectedLabel = "Put into hand",
+    remainderLabel = "Put on bottom"
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SarkhanDragonAscendant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/SarkhanDragonAscendant.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.AddCreatureTypeEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sarkhan, Dragon Ascendant — Tarkir: Dragonstorm #118
+ * {1}{R} · Legendary Creature — Human Druid · 2/2 · Rare
+ *
+ * When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token.
+ * (To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)
+ * Whenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. Until end of turn,
+ * Sarkhan becomes a Dragon in addition to its other types and gains flying.
+ *
+ * The ETB uses the resolution-time [Effects.Behold] effect ("you may behold a Dragon; if you do,
+ * create a Treasure"). The second ability triggers on any Dragon you control entering
+ * ([Triggers.entersBattlefield] filtered to `Dragon` creatures you control, binding ANY): it adds
+ * a +1/+1 counter to Sarkhan, then until end of turn makes him a Dragon in addition to his other
+ * types ([AddCreatureTypeEffect] with [Duration.EndOfTurn]) and grants flying.
+ */
+val SarkhanDragonAscendant = card("Sarkhan, Dragon Ascendant") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Druid"
+    power = 2
+    toughness = 2
+    oracleText = "When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token. " +
+        "(To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)\n" +
+        "Whenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. Until end of turn, " +
+        "Sarkhan becomes a Dragon in addition to its other types and gains flying."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Behold(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.DRAGON),
+            ifBeheld = Effects.CreateTreasure()
+        )
+        description = "When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl().withSubtype(Subtype.DRAGON),
+            binding = TriggerBinding.ANY
+        )
+        effect = CompositeEffect(listOf(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            AddCreatureTypeEffect("Dragon", EffectTarget.Self, Duration.EndOfTurn),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self, Duration.EndOfTurn)
+        ))
+        description = "Whenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. " +
+            "Until end of turn, Sarkhan becomes a Dragon in addition to its other types and gains flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "118"
+        artist = "Billy Christian"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2200646-7b7c-489d-bbae-16b03e1d7fb2.jpg?1760616486"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -212,6 +212,27 @@ data class MayRevealCardFromHandContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the player chooses to behold (or declines) for
+ * [com.wingedsheep.sdk.scripting.effects.BeholdEffect].
+ *
+ * @property beholderId The player who was asked to behold
+ * @property sourceName Name of the source for prompts/events
+ * @property handOptionIds The subset of the decision options that live in the beholder's hand
+ *                          (revealed when chosen); battlefield options are merely chosen.
+ * @property ifBeheld Effect to run when the player successfully beholds
+ * @property effectContext Effect context propagated to [ifBeheld]
+ */
+@Serializable
+data class BeholdContinuation(
+    override val decisionId: String,
+    val beholderId: EntityId,
+    val sourceName: String?,
+    val handOptionIds: Set<EntityId>,
+    val ifBeheld: Effect?,
+    val effectContext: EffectContext,
+) : ContinuationFrame
+
+/**
  * Resume placing a triggered ability on the stack after the player answers a "may" question.
  *
  * When a triggered ability has both a MayEffect wrapper and targets (like Invigorating Boon's

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -181,6 +181,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ExileMultiZoneContinuation::class)
         subclass(MayAbilityContinuation::class)
         subclass(MayRevealCardFromHandContinuation::class)
+        subclass(BeholdContinuation::class)
         subclass(IfYouDoContinuation::class)
         subclass(HandSizeDiscardContinuation::class)
         subclass(LegendRuleContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
@@ -51,5 +51,12 @@ data class DelayedTriggeredAbility(
      */
     val fireOnce: Boolean = false,
     /** If set, this trigger won't fire before this turn number. Used for "your next end step" effects. */
-    val notBeforeTurn: Int? = null
+    val notBeforeTurn: Int? = null,
+    /**
+     * Target requirement chosen each time this delayed trigger fires. Threaded into the
+     * synthesised [com.wingedsheep.sdk.scripting.TriggeredAbility] so the player picks a
+     * target per firing (e.g. Rediscover the Way chapter III). Null for non-targeting
+     * delayed triggers.
+     */
+    val targetRequirement: com.wingedsheep.sdk.scripting.targets.TargetRequirement? = null
 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -303,7 +303,8 @@ class TriggerDetector(
                 ability = TriggeredAbility.create(
                     trigger = EventPattern.StepEvent(Step.END, Player.Each),
                     binding = TriggerBinding.ANY,
-                    effect = delayed.effect
+                    effect = delayed.effect,
+                    targetRequirement = delayed.targetRequirement
                 ),
                 sourceId = delayed.sourceId,
                 sourceName = delayed.sourceName,
@@ -578,7 +579,8 @@ class TriggerDetector(
                         ability = TriggeredAbility.create(
                             trigger = spec.event,
                             binding = spec.binding,
-                            effect = delayed.effect
+                            effect = delayed.effect,
+                            targetRequirement = delayed.targetRequirement
                         ),
                         sourceId = delayed.sourceId,
                         sourceName = delayed.sourceName,
@@ -624,6 +626,11 @@ class TriggerDetector(
             // "when a [filtered] creature next attacks" (AttackEvent).
             is com.wingedsheep.sdk.scripting.EventPattern.YouAttackEvent,
             is com.wingedsheep.sdk.scripting.EventPattern.AttackEvent ->
+                matcher.matchesTrigger(specEvent, spec.binding, event, sourceId, controllerId, state)
+            // Spell-cast delayed triggers ("whenever you cast a [filtered] spell this turn, …",
+            // Rediscover the Way chapter III) are filter-scoped: delegate to the canonical
+            // spell-cast matcher so the spell filter and casting-player predicate are honored.
+            is com.wingedsheep.sdk.scripting.EventPattern.SpellCastEvent ->
                 matcher.matchesTrigger(specEvent, spec.binding, event, sourceId, controllerId, state)
             is com.wingedsheep.sdk.scripting.EventPattern.DealsDamageEvent -> {
                 if (event !is com.wingedsheep.engine.core.DamageDealtEvent) return false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -30,6 +30,7 @@ class EffectAndTriggerContinuationResumer(
         },
         resumer(MayAbilityContinuation::class, ::resumeMayAbility),
         resumer(MayRevealCardFromHandContinuation::class, ::resumeMayRevealCardFromHand),
+        resumer(BeholdContinuation::class, ::resumeBehold),
         resumer(MayTriggerContinuation::class, ::resumeMayTrigger),
         resumer(ReflexiveTriggerResolveContinuation::class, ::resumeReflexiveTriggerResolve)
     )
@@ -330,6 +331,45 @@ class EffectAndTriggerContinuationResumer(
                 state, continuation.revealerId, chosenCardId, continuation.sourceName,
             )
         return checkForMore(revealedState, listOf(revealEvent))
+    }
+
+    private fun resumeBehold(
+        state: GameState,
+        continuation: BeholdContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(state, "Expected card selection response for behold")
+        }
+
+        val chosenId = response.selectedCards.firstOrNull()
+        if (chosenId == null) {
+            // Player declined to behold — the "if you do" payoff doesn't run.
+            return checkForMore(state, emptyList())
+        }
+
+        // If the beheld object was a card in hand, reveal it publicly. Battlefield permanents
+        // are chosen, not revealed.
+        var currentState = state
+        val events = mutableListOf<GameEvent>()
+        if (chosenId in continuation.handOptionIds) {
+            val (revealedState, revealEvent) = com.wingedsheep.engine.handlers.effects.composite
+                .MayRevealCardFromHandEffectExecutor.emitReveal(
+                    currentState, continuation.beholderId, chosenId, continuation.sourceName,
+                )
+            currentState = revealedState
+            events += revealEvent
+        }
+
+        val ifBeheld = continuation.ifBeheld
+            ?: return checkForMore(currentState, events)
+
+        val result = services.effectExecutorRegistry
+            .execute(currentState, ifBeheld, continuation.effectContext)
+            .toExecutionResult()
+        if (result.isPaused) return result
+        return checkForMore(result.state, events + result.events.toList())
     }
 
     private fun resumeReflexiveTriggerResolve(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BeholdEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BeholdEffectExecutor.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.handlers.effects.composite
+
+import com.wingedsheep.engine.core.BeholdContinuation
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.BeholdEffect
+import java.util.UUID
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [BeholdEffect] — the resolution-time "you may behold a [filter]" choice.
+ *
+ * Flow:
+ *  1. Compute the beholder's eligible objects: matching permanents they control (projected
+ *     state) and matching cards in their hand (base state, matching the cast-time Behold
+ *     convention in [com.wingedsheep.engine.handlers.CostHandler]).
+ *  2. If none are eligible, the player can't behold — skip the prompt and don't run `ifBeheld`.
+ *  3. Otherwise present a [SelectCardsDecision] with `minSelections = 0, maxSelections = 1` over
+ *     the union. The player either beholds one object or submits an empty selection (declines).
+ *  4. On behold: if the chosen object is a hand card, emit the public reveal; either way, run
+ *     `effect.ifBeheld` (the payoff, e.g. create a Treasure token).
+ *  5. On decline: nothing happens.
+ *
+ * @param effectExecutor sub-effect runner provided by the registry, used to chain into
+ *   `ifBeheld` (which itself may pause).
+ */
+class BeholdEffectExecutor(
+    private val effectExecutor: (GameState, com.wingedsheep.sdk.scripting.effects.Effect, EffectContext) -> EffectResult,
+    private val predicateEvaluator: PredicateEvaluator = PredicateEvaluator(),
+) : EffectExecutor<BeholdEffect> {
+
+    override val effectType: KClass<BeholdEffect> = BeholdEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: BeholdEffect,
+        context: EffectContext,
+    ): EffectResult {
+        val beholder = context.controllerId
+        val predicateContext = PredicateContext(
+            controllerId = beholder,
+            sourceId = context.sourceId,
+            targetOpponentId = context.opponentId,
+        )
+
+        val projected = state.projectedState
+        val battlefieldMatches = projected.getBattlefieldControlledBy(beholder).filter { permId ->
+            predicateEvaluator.matches(state, projected, permId, effect.filter, predicateContext)
+        }
+        val handMatches = state.getHand(beholder).filter { cardId ->
+            predicateEvaluator.matches(state, state.projectedState, cardId, effect.filter, predicateContext)
+        }
+
+        val options = (battlefieldMatches + handMatches).distinct()
+        if (options.isEmpty()) {
+            // Can't behold — the "if you do" payoff doesn't run.
+            return EffectResult.success(state)
+        }
+
+        val sourceName = context.sourceId
+            ?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+
+        val decisionId = UUID.randomUUID().toString()
+        val decision = SelectCardsDecision(
+            id = decisionId,
+            playerId = beholder,
+            prompt = "You may behold a ${effect.filter.description}",
+            context = DecisionContext(
+                sourceId = context.sourceId,
+                sourceName = sourceName,
+                phase = DecisionPhase.RESOLUTION,
+            ),
+            options = options,
+            minSelections = 0,
+            maxSelections = 1,
+        )
+
+        val continuation = BeholdContinuation(
+            decisionId = decisionId,
+            beholderId = beholder,
+            sourceName = sourceName,
+            handOptionIds = handMatches.toSet(),
+            ifBeheld = effect.ifBeheld,
+            effectContext = context,
+        )
+
+        val paused = state
+            .pushContinuation(continuation)
+            .withPendingDecision(decision)
+        return EffectResult.paused(paused, decision)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
@@ -32,6 +32,7 @@ class CompositeExecutors(
     private val ifYouDoEffectExecutor by lazy { IfYouDoEffectExecutor(effectExecutor) }
     private val mayEffectExecutor by lazy { MayEffectExecutor(effectExecutor) }
     private val mayRevealCardFromHandEffectExecutor by lazy { MayRevealCardFromHandEffectExecutor(effectExecutor) }
+    private val beholdEffectExecutor by lazy { BeholdEffectExecutor(effectExecutor) }
     private val mayPayManaExecutor by lazy { MayPayManaExecutor(cardRegistry, effectExecutor) }
     private val mayPayXForEffectExecutor by lazy { MayPayXForEffectExecutor(cardRegistry, effectExecutor) }
     private val budgetModalEffectExecutor by lazy { BudgetModalEffectExecutor(effectExecutor) }
@@ -73,6 +74,7 @@ class CompositeExecutors(
         ifYouDoEffectExecutor,
         mayEffectExecutor,
         mayRevealCardFromHandEffectExecutor,
+        beholdEffectExecutor,
         mayPayManaExecutor,
         mayPayXForEffectExecutor,
         modalEffectExecutor,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -87,7 +87,8 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             watchedEntityId = watchedEntityId,
             expiry = if (effect.trigger != null) effect.expiry else null,
             fireOnce = effect.trigger != null && effect.fireOnce,
-            notBeforeTurn = notBeforeTurn
+            notBeforeTurn = notBeforeTurn,
+            targetRequirement = effect.targetRequirement
         )
 
         return EffectResult.success(state.addDelayedTrigger(delayedTrigger))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
@@ -52,6 +52,9 @@ fun ManaRestriction.isSatisfiedBy(context: SpellPaymentContext): Boolean = when 
         (!creatureOnly || (!context.isAbilityActivation && context.isCreature)) &&
             context.subtypes.any { it.equals(subtype, ignoreCase = true) }
     is ManaRestriction.CastFromExileOnly -> !context.isAbilityActivation && context.isFromExile
+    is ManaRestriction.SubtypeSpellsOnly ->
+        !context.isAbilityActivation &&
+            subtypes.any { sub -> context.subtypes.any { it.equals(sub, ignoreCase = true) } }
     is ManaRestriction.CardTypeSpellsOrAbilitiesOnly ->
         if (context.isAbilityActivation) allowAbilities && cardType in context.abilitySourceCardTypes
         else allowSpells && cardType in context.cardTypes

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaelstromOfTheSpiritDragonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaelstromOfTheSpiritDragonScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.MaelstromOfTheSpiritDragon
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Maelstrom of the Spirit Dragon (TDM #260) — Land.
+ *
+ *   {T}: Add {C}.
+ *   {T}: Add one mana of any color. Spend this mana only to cast a Dragon spell or an Omen spell.
+ *   {4}, {T}, Sacrifice this land: Search your library for a Dragon card, ...
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.effects.ManaRestriction.SubtypeSpellsOnly]:
+ * the any-color mana may pay for a Dragon creature spell, but not for a non-Dragon spell.
+ */
+class MaelstromOfTheSpiritDragonScenarioTest : FunSpec({
+
+    val testDragon = CardDefinition.creature(
+        name = "Test Dragon",
+        manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype.DRAGON),
+        power = 4,
+        toughness = 4
+    )
+    val testOgre = CardDefinition.creature(
+        name = "Test Ogre",
+        manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Ogre")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + MaelstromOfTheSpiritDragon + testDragon + testOgre)
+        return driver
+    }
+
+    val anyColorDragonOmenAbility = MaelstromOfTheSpiritDragon.activatedAbilities[1].id
+
+    test("any-color mana tagged for Dragon/Omen can pay for a Dragon spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val maelstrom = driver.putPermanentOnBattlefield(p1, "Maelstrom of the Spirit Dragon")
+        // The mana ability pauses for a color choice; pick red.
+        driver.submit(ActivateAbility(p1, maelstrom, anyColorDragonOmenAbility))
+        driver.state.pendingDecision?.let { decision ->
+            driver.submitDecision(
+                p1,
+                com.wingedsheep.engine.core.ColorChosenResponse(decision.id, com.wingedsheep.sdk.core.Color.RED)
+            )
+        }
+
+        val pool = driver.state.getEntity(p1)?.get<ManaPoolComponent>()
+        pool!!.restrictedMana.size shouldBe 1
+
+        val dragon = driver.putCardInHand(p1, "Test Dragon")
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = dragon, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("any-color mana tagged for Dragon/Omen cannot pay for a non-Dragon, non-Omen spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val maelstrom = driver.putPermanentOnBattlefield(p1, "Maelstrom of the Spirit Dragon")
+        driver.submit(ActivateAbility(p1, maelstrom, anyColorDragonOmenAbility))
+        driver.state.pendingDecision?.let { decision ->
+            driver.submitDecision(
+                p1,
+                com.wingedsheep.engine.core.ColorChosenResponse(decision.id, com.wingedsheep.sdk.core.Color.RED)
+            )
+        }
+
+        val ogre = driver.putCardInHand(p1, "Test Ogre")
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = ogre, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        // The restricted mana can't pay for an Ogre and there's no other mana available.
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NarsetJeskaiWaymasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NarsetJeskaiWaymasterScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.NarsetJeskaiWaymaster
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Narset, Jeskai Waymaster (TDM #209).
+ *
+ *   At the beginning of your end step, you may discard your hand. If you do, draw cards equal to
+ *   the number of spells you've cast this turn.
+ *
+ * Exercises the `MayEffect(IfYouDoEffect(discardHand, DrawCards(SpellsCastThisTurn)))` shape: the
+ * draw count equals the number of spells cast that turn.
+ */
+class NarsetJeskaiWaymasterScenarioTest : FunSpec({
+
+    val bolt = card("Test Bolt") {
+        manaCost = "{R}"
+        typeLine = "Instant"
+        spell {
+            effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(NarsetJeskaiWaymaster, bolt))
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    test("discarding hand draws cards equal to spells cast this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Narset, Jeskai Waymaster")
+
+        // Cast two spells this turn.
+        repeat(2) {
+            driver.giveMana(controller, Color.RED, 1)
+            val boltCard = driver.putCardInHand(controller, "Test Bolt")
+            driver.submit(CastSpell(playerId = controller, cardId = boltCard))
+            driver.resolveStack()
+        }
+
+        driver.passPriorityUntil(Step.END)
+
+        // Narset's end-step "may" triggers; answer yes. The whole hand is discarded, then we draw
+        // cards equal to the number of spells cast this turn (2), so the hand ends at exactly 2.
+        var guard = 0
+        while (driver.state.pendingDecision == null && guard < 20) { driver.bothPass(); guard++ }
+        driver.submitYesNo(controller, true)
+        driver.resolveStack()
+
+        driver.getHand(controller).size shouldBe 2
+    }
+
+    test("declining the end-step ability keeps the hand and draws nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Narset, Jeskai Waymaster")
+        repeat(2) { driver.putCardInHand(controller, "Mountain") }
+        val handBefore = driver.getHand(controller).size
+
+        driver.passPriorityUntil(Step.END)
+        var guard = 0
+        while (driver.state.pendingDecision == null && guard < 20) { driver.bothPass(); guard++ }
+        driver.submitYesNo(controller, false)
+        driver.resolveStack()
+
+        driver.getHand(controller).size shouldBe handBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RediscoverTheWayScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RediscoverTheWayScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.RediscoverTheWay
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Rediscover the Way (TDM #215) chapter III — the *targeting* event-based delayed
+ * trigger.
+ *
+ *   III — Whenever you cast a noncreature spell this turn, target creature you control gains
+ *         double strike until end of turn.
+ *
+ * Chapter III installs `CreateDelayedTriggerEffect(trigger = YouCastNoncreature, fireOnce = false,
+ * expiry = EndOfTurn, targetRequirement = Targets.CreatureYouControl, effect = GrantKeyword(DOUBLE_STRIKE))`.
+ * Each noncreature spell cast that turn must prompt for a target creature you control and grant it
+ * double strike until end of turn — exercising the new
+ * [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect.targetRequirement].
+ */
+class RediscoverTheWayScenarioTest : FunSpec({
+
+    val bear = card("Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+    val bolt = card("Test Bolt") {
+        manaCost = "{R}"
+        typeLine = "Instant"
+        spell { effect = com.wingedsheep.sdk.dsl.Effects.DealDamage(3, com.wingedsheep.sdk.scripting.targets.EffectTarget.PlayerRef(com.wingedsheep.sdk.scripting.references.Player.EachOpponent)) }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RediscoverTheWay, bear, bolt))
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    fun GameTestDriver.advanceToMain(targetRound: Int) {
+        var guard = 0
+        while (!(state.turnNumber == targetRound && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to round $targetRound")
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> {
+                    autoSubmitCombatDeclarationIfNeeded()
+                    passPriority(state.priorityPlayerId!!)
+                }
+            }
+            guard++
+        }
+    }
+
+    fun GameTestDriver.castSaga(controller: EntityId) {
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        giveMana(controller, Color.BLUE, 1)
+        giveMana(controller, Color.RED, 1)
+        giveMana(controller, Color.WHITE, 1)
+        // Library cards so the chapter I/II "look at top three" has something to look at.
+        repeat(4) { putCardOnTopOfLibrary(controller, "Mountain") }
+        val saga = putCardInHand(controller, "Rediscover the Way")
+        castSpell(controller, saga)
+        resolveStack() // saga enters (lore 1 → chapter I) and chapter I resolves
+    }
+
+    test("Chapter III grants double strike to a chosen creature when you cast a noncreature spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+
+        driver.castSaga(controller)
+        driver.advanceToMain(2) // chapter II
+        driver.resolveStack()
+        driver.advanceToMain(3) // chapter III installs the delayed trigger
+        driver.resolveStack()
+
+        // The delayed double-strike trigger should now be resident.
+        driver.state.delayedTriggers.size shouldBe 1
+
+        // Put a creature on the battlefield to receive double strike, then cast a noncreature spell.
+        val target = driver.putCreatureOnBattlefield(controller, "Test Bear")
+        driver.giveMana(controller, Color.RED, 1)
+        val boltCard = driver.putCardInHand(controller, "Test Bolt")
+        driver.submit(CastSpell(playerId = controller, cardId = boltCard))
+
+        // Resolve the cast trigger: it should prompt to target our creature, then resolve the bolt.
+        var guard = 0
+        while ((driver.state.stack.isNotEmpty() || driver.state.pendingDecision != null) && guard < 50) {
+            val decision = driver.state.pendingDecision
+            if (decision is com.wingedsheep.engine.core.ChooseTargetsDecision) {
+                driver.submitTargetSelection(controller, listOf(target))
+            } else if (decision != null) {
+                driver.autoResolveDecision()
+            } else {
+                driver.bothPass()
+            }
+            guard++
+        }
+
+        driver.state.projectedState.hasKeyword(target, Keyword.DOUBLE_STRIKE) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarkhanDragonAscendantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarkhanDragonAscendantScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sarkhan, Dragon Ascendant (TDM #118).
+ *
+ *  When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token.
+ *  Whenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. Until end of turn,
+ *  Sarkhan becomes a Dragon in addition to its other types and gains flying.
+ *
+ * Exercises the new resolution-time [com.wingedsheep.sdk.scripting.effects.BeholdEffect]
+ * (behold-from-hand reveal → Treasure) and the Dragon-enters counter/flying buff.
+ */
+class SarkhanDragonAscendantScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Dragon",
+                manaCost = ManaCost.parse("{R}"),
+                subtypes = setOf(Subtype.DRAGON),
+                power = 4,
+                toughness = 4
+            )
+        )
+
+        context("Sarkhan, Dragon Ascendant") {
+
+            test("ETB: beholding a Dragon in hand creates a Treasure token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sarkhan, Dragon Ascendant")
+                    .withCardInHand(1, "Test Dragon")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Sarkhan, Dragon Ascendant")
+                withClue("Casting Sarkhan should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // The ETB behold decision: pick the Dragon card in hand.
+                val dragonInHand = game.findCardsInHand(1, "Test Dragon").first()
+                withClue("A behold decision should be pending") { game.hasPendingDecision() shouldBe true }
+                game.selectCards(listOf(dragonInHand))
+                game.resolveStack()
+
+                withClue("A Treasure token should have been created") {
+                    game.findPermanents("Treasure").size shouldBe 1
+                }
+            }
+
+            test("ETB: declining the behold creates no Treasure") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sarkhan, Dragon Ascendant")
+                    .withCardInHand(1, "Test Dragon")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Sarkhan, Dragon Ascendant")
+                game.resolveStack()
+
+                withClue("A behold decision should be pending") { game.hasPendingDecision() shouldBe true }
+                game.skipSelection() // decline to behold
+                game.resolveStack()
+
+                withClue("No Treasure when the behold is declined") {
+                    game.findPermanents("Treasure").size shouldBe 0
+                }
+            }
+
+            test("a Dragon entering puts a +1/+1 counter on Sarkhan and gives him flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Sarkhan, Dragon Ascendant", summoningSickness = false)
+                    .withCardInHand(1, "Test Dragon")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sarkhan = game.findPermanent("Sarkhan, Dragon Ascendant")!!
+
+                val cast = game.castSpell(1, "Test Dragon")
+                withClue("Casting the Dragon should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val counters = game.state.getEntity(sarkhan)?.get<CountersComponent>()
+                    ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                withClue("Sarkhan gains a +1/+1 counter when a Dragon enters") { counters shouldBe 1 }
+
+                withClue("Sarkhan gains flying until end of turn") {
+                    game.state.projectedState.hasKeyword(sarkhan, Keyword.FLYING) shouldBe true
+                }
+                withClue("Sarkhan becomes a Dragon in addition to his other types") {
+                    game.state.projectedState.getSubtypes(sarkhan).any { it.equals("Dragon", ignoreCase = true) } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarkhanDragonAscendantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SarkhanDragonAscendantScenarioTest.kt
@@ -84,6 +84,33 @@ class SarkhanDragonAscendantScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("ETB: beholding a Dragon you control (battlefield) creates a Treasure without revealing") {
+                // No Dragon in hand — the only behold option is the Dragon already on the
+                // battlefield, exercising the "choose a permanent you control" branch (no reveal).
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sarkhan, Dragon Ascendant")
+                    .withCardOnBattlefield(1, "Test Dragon", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dragon = game.findPermanent("Test Dragon")!!
+
+                val cast = game.castSpell(1, "Sarkhan, Dragon Ascendant")
+                withClue("Casting Sarkhan should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("A behold decision should be pending") { game.hasPendingDecision() shouldBe true }
+                game.selectCards(listOf(dragon)) // behold the Dragon we control
+                game.resolveStack()
+
+                withClue("Beholding a controlled Dragon creates a Treasure token") {
+                    game.findPermanents("Treasure").size shouldBe 1
+                }
+            }
+
             test("a Dragon entering puts a +1/+1 counter on Sarkhan and gives him flying") {
                 val game = scenario()
                     .withPlayers("Player", "Opponent")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmCheckLandsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmCheckLandsScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.GreatArashinCity
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.MistriseVillage
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the two TDM check-lands Great Arashin City (#257) and Mistrise Village (#261), plus
+ * Great Arashin City's Spirit-token ability.
+ */
+class TdmCheckLandsScenarioTest : FunSpec({
+
+    val testBear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(com.wingedsheep.sdk.core.Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun GameTestDriver.countPermanents(name: String): Int =
+        state.getBattlefield().count { state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == name }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + GreatArashinCity + MistriseVillage + testBear)
+        return driver
+    }
+
+    test("Great Arashin City enters untapped when you control a Forest") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putLandOnBattlefield(p1, "Forest")
+        val city = driver.putCardInHand(p1, "Great Arashin City")
+        driver.playLand(p1, city).isSuccess shouldBe true
+
+        driver.state.getEntity(city)?.has<TappedComponent>() shouldBe false
+    }
+
+    test("Great Arashin City enters tapped with no Forest or Plains") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val city = driver.putCardInHand(p1, "Great Arashin City")
+        driver.playLand(p1, city).isSuccess shouldBe true
+
+        driver.state.getEntity(city)?.has<TappedComponent>() shouldBe true
+    }
+
+    test("Great Arashin City: exiling a creature from graveyard creates a 1/1 Spirit") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val city = driver.putPermanentOnBattlefield(p1, "Great Arashin City")
+        driver.putCardInGraveyard(p1, "Test Bear")
+        driver.giveMana(p1, Color.BLACK, 2)
+
+        val spiritAbility = GreatArashinCity.activatedAbilities[1].id
+        driver.submit(ActivateAbility(p1, city, spiritAbility)).isSuccess shouldBe true
+        var guard = 0
+        while (driver.state.pendingDecision != null && guard < 10) { driver.autoResolveDecision(); guard++ }
+        var stackGuard = 0
+        while (driver.state.stack.isNotEmpty() && stackGuard < 20) { driver.bothPass(); stackGuard++ }
+
+        driver.countPermanents("Spirit Token") shouldBe 1
+    }
+
+    test("Mistrise Village enters untapped when you control a Mountain") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putLandOnBattlefield(p1, "Mountain")
+        val village = driver.putCardInHand(p1, "Mistrise Village")
+        driver.playLand(p1, village).isSuccess shouldBe true
+
+        driver.state.getEntity(village)?.has<TappedComponent>() shouldBe false
+    }
+
+    test("Mistrise Village taps for blue") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val village = driver.putPermanentOnBattlefield(p1, "Mistrise Village")
+        val manaAbility = MistriseVillage.activatedAbilities[0].id
+        driver.submit(ActivateAbility(p1, village, manaAbility)).isSuccess shouldBe true
+
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.blue shouldBe 1
+    }
+})


### PR DESCRIPTION
Implements six Tarkir: Dragonstorm (TDM) cards, plus three small, reusable SDK/engine features they need. All scenario tests pass and the full rules-engine + mtg-sdk + mtg-sets suites are green.

## Cards
- **Great Arashin City** (#257) — check-land; `{T}: Add {B}`; `{1}{B}, {T}, Exile a creature card from your graveyard: Create a 1/1 white Spirit`.
- **Mistrise Village** (#261) — check-land; `{T}: Add {U}`; `{U}, {T}: the next spell you cast this turn can't be countered` (existing `MakeNextSpellUncounterable` rider).
- **Maelstrom of the Spirit Dragon** (#260) — `{T}: Add {C}`; `{T}: any-color mana spendable only on a Dragon or Omen spell`; `{4}, {T}, Sacrifice: tutor a Dragon to hand`.
- **Narset, Jeskai Waymaster** (#209) — end step: may discard your hand, draw cards equal to spells cast this turn.
- **Rediscover the Way** (#215) — Saga; chapters I/II dig top three keep one; chapter III installs a per-cast targeting delayed trigger granting double strike to a chosen creature each noncreature spell you cast that turn.
- **Sarkhan, Dragon Ascendant** (#118) — ETB behold a Dragon → create a Treasure; whenever a Dragon you control enters, +1/+1 counter on Sarkhan and he becomes a Dragon with flying until end of turn.

## SDK / engine features (general-purpose, documented in `card-sdk-language-reference.md`)
- `ManaRestriction.SubtypeSpellsOnly(subtypes)` — mana spendable only on spells carrying any of N subtypes (Dragon **or** Omen).
- `CreateDelayedTriggerEffect.targetRequirement` — a target chosen each time a delayed trigger fires, threaded through `DelayedTriggeredAbility` → `TriggeredAbility.create`. Also wired `SpellCastEvent` into the filter-scoped delayed-trigger detector so "whenever you cast a [filtered] spell this turn, …" delayed triggers fire.
- `Effects.Behold(filter, ifBeheld)` — resolution-time behold effect (choose a controlled matching permanent or reveal a matching card from hand; then run the payoff), with executor + continuation, distinct from the existing cast-time `AdditionalCost.Behold`.

## Tests
New scenario tests cover restricted mana, the targeting delayed trigger, the behold→Treasure flow and Dragon-enters buff, Narset's discard/draw, and both check-lands. Full `:rules-engine:test`, `:mtg-sdk:test`, `:mtg-sets:test` pass.

## Not included
**Mardu Siegebreaker** is intentionally deferred — it needs a larger feature set than this batch (token copy of a *linked-exile* card + per-opponent attacking tokens with the correct defender + delayed sacrifice), which is multi-feature engine work better done on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)