### PR TITLE
LTR: cast-as-flash permission + ETB/LTB doubler, +3 cards

### DIFF
--- a/backlog/sdk-reusability-consolidation.md
+++ b/backlog/sdk-reusability-consolidation.md
@@ -323,7 +323,7 @@ ZoneChange/SpellCast/Attack/DealsDamage variants:
 - **`PlayFromTopOfLibrary`** / **`CastSpellTypesFromTopOfLibrary`** /
   **`LookAtTopOfLibrary`** / **`PlayLandsAndCastFilteredFromTopOfLibrary`** →
   `LibraryTopAccess(view, play)`. 4 → 1.
-- **`AdditionalETBTriggers`** vs **`AdditionalSourceTriggers`** →
+- **`AdditionalETBOrLTBTriggers`** vs **`AdditionalSourceTriggers`** →
   `AdditionalTriggers(triggerScope, sourceFilter)`.
 
 ### Targeting (`scripting/targets/`)

--- a/backlog/sets/lord-of-the-rings/TODO.md
+++ b/backlog/sets/lord-of-the-rings/TODO.md
@@ -107,12 +107,25 @@ steal no longer silently restores the designation when control reverts at end of
   needs a "Whenever you scry" trigger + "reveal top; if land, put onto battlefield tapped".
 
 ### Gap 4 — "cast [filter] spells as though they had flash" permission
-**Engine change:** a static/one-shot permission granting flash-timing to a filtered set of
-spells.
-- **Borne Upon a Wind** — "You may cast spells this turn as though they had flash."
-- **Gandalf, Friend of the Shire** — "You may cast sorcery spells as though they had flash."
-- **Gandalf the White** — "You may cast legendary spells and artifact spells as though they
-  had flash." (also needs the extra-trigger replacement below).
+**Status:** LANDED as `Effects.GrantFlashToSpells(target, spellFilter, duration)` plus
+`FlashGrantsThisTurnComponent` (PR `ltr-gap4-cast-as-flash`). The Effect is the turn-scoped,
+player-scoped sibling of the existing permanent-static `GrantFlashToSpellType`; both are
+consulted by `CastPermissionUtils.hasGrantedFlash` and `CastZoneResolver.hasGrantedFlash`.
+- **Borne Upon a Wind** — ✅ implemented.
+- **Gandalf, Friend of the Shire** — ✅ implemented.
+- **Gandalf the White** — partial: Flash keyword + the flash-spells static (filter
+  `Artifact ∨ Legendary`, controllerOnly) are live; the third clause (extra-trigger
+  replacement for ETB/LTB triggers from legendary/artifact permanents) is a separate gap
+  and tracked below.
+
+### Gap 4b — "triggers an additional time" replacement for legendary/artifact ETB/LTB
+**Engine change:** a trigger-counting replacement that fires a triggered ability twice when
+its trigger source is a legendary permanent or an artifact entering or leaving the
+battlefield (a narrow trigger-replication primitive — possibly composes from a future
+generalised "the next time this trigger would fire, it fires N times instead").
+- **Gandalf the White** — third clause: "If a legendary permanent or an artifact entering
+  or leaving the battlefield causes a triggered ability of a permanent you control to
+  trigger, that ability triggers an additional time."
 
 ### Gap 5 — Goad
 **Engine change:** Goad effect + goaded combat-forcing state (CR 701.41).

--- a/backlog/sets/lord-of-the-rings/TODO.md
+++ b/backlog/sets/lord-of-the-rings/TODO.md
@@ -113,19 +113,18 @@ player-scoped sibling of the existing permanent-static `GrantFlashToSpellType`; 
 consulted by `CastPermissionUtils.hasGrantedFlash` and `CastZoneResolver.hasGrantedFlash`.
 - **Borne Upon a Wind** — ✅ implemented.
 - **Gandalf, Friend of the Shire** — ✅ implemented.
-- **Gandalf the White** — partial: Flash keyword + the flash-spells static (filter
-  `Artifact ∨ Legendary`, controllerOnly) are live; the third clause (extra-trigger
-  replacement for ETB/LTB triggers from legendary/artifact permanents) is a separate gap
-  and tracked below.
+- **Gandalf the White** — ✅ implemented (Flash + flash-spells static + third clause via
+  the reshaped `AdditionalETBOrLTBTriggers`, see Gap 4b below).
 
 ### Gap 4b — "triggers an additional time" replacement for legendary/artifact ETB/LTB
-**Engine change:** a trigger-counting replacement that fires a triggered ability twice when
-its trigger source is a legendary permanent or an artifact entering or leaving the
-battlefield (a narrow trigger-replication primitive — possibly composes from a future
-generalised "the next time this trigger would fire, it fires N times instead").
-- **Gandalf the White** — third clause: "If a legendary permanent or an artifact entering
-  or leaving the battlefield causes a triggered ability of a permanent you control to
-  trigger, that ability triggers an additional time."
+**Status:** LANDED. The existing `AdditionalETBTriggers` primitive (Panharmonicon family) was
+reshaped into `AdditionalETBOrLTBTriggers` with a `BattlefieldDirection` set, generalising it
+to either ETB-only (default — Panharmonicon, Naban, Starfield Vocalist, Traveling Chocobo),
+LTB-only, or both. Gandalf the White's third clause uses `directions = {ENTERING, LEAVING}`
+with `mustBeYouControl = false`; the engine path was renamed to
+`TriggerDetector.duplicateETBOrLTBTriggers` and now consults `lastKnownController` for the
+leaving case (CR 603.10a last-known-information). Implements CR 603.2d.
+- **Gandalf the White** — ✅ implemented.
 
 ### Gap 5 — Goad
 **Engine change:** Goad effect + goaded combat-forcing state (CR 701.41).

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 196 / 291
+**Implemented:** 197 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -43,7 +43,7 @@ starter-deck/special cards and basic lands.
 - [x] Fog on the Barrow-Downs
 - [ ] Forge Anew
 - [ ] Frodo, Sauron's Bane
-- [ ] Gandalf the White
+- [x] Gandalf the White
 - [x] Hobbit's Sting
 - [x] Landroval, Horizon Witness
 - [x] Lost to Legend

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 195 / 291
+**Implemented:** 196 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -77,7 +77,7 @@ starter-deck/special cards and basic lands.
 - [x] Deceive the Messenger
 - [ ] Dreadful as the Storm
 - [ ] Elrond, Lord of Rivendell
-- [ ] Gandalf, Friend of the Shire
+- [x] Gandalf, Friend of the Shire
 - [ ] Glorious Gale
 - [ ] Goldberry, River-Daughter
 - [x] Grey Havens Navigator

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 194 / 291
+**Implemented:** 195 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.
@@ -71,7 +71,7 @@ starter-deck/special cards and basic lands.
 - [ ] Bewitching Leechcraft
 - [x] Bill Ferny, Bree Swindler
 - [x] Birthday Escape
-- [ ] Borne Upon a Wind
+- [x] Borne Upon a Wind
 - [x] Captain of Umbar
 - [x] Council's Deliberation
 - [x] Deceive the Messenger

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1455,15 +1455,20 @@ staticAbility {
   enforced as a whole-declaration check in `AttackPhaseManager`/`BlockPhaseManager` rather than a
   per-creature rule. While any permanent with the ability is on the battlefield, declaring more
   than the smallest cap is rejected. (`BlockerCountLimit` counts distinct blocking creatures.)
-- `AdditionalETBTriggers(enteringFilter, enteringMustBeYouControl = true)` — Panharmonicon / Naban
-  "for a subtype": when a permanent matching `enteringFilter` enters, triggered abilities of
-  permanents you control that fired from that ETB trigger an additional time. `TriggerDetector.duplicateETBTriggers`.
+- `AdditionalETBOrLTBTriggers(filter, mustBeYouControl = true, directions = setOf(ENTERING))` —
+  the Panharmonicon family (CR 603.2d "triggers additional times"). When a permanent matching
+  `filter` crosses the battlefield boundary in one of `directions`, triggered abilities of
+  permanents controlled by this ability's controller that fired from that event trigger an
+  additional time per copy. Default `{ENTERING}` covers Panharmonicon / Naban / Traveling Chocobo;
+  `mustBeYouControl = false` drops the "X you control" restriction on the cause (Starfield
+  Vocalist); adding `BattlefieldDirection.LEAVING` covers Gandalf the White's "entering or leaving
+  the battlefield" wording. `TriggerDetector.duplicateETBOrLTBTriggers`; additive across copies.
 - `AdditionalSourceTriggers(sourceFilter, excludeSelf = true)` — Twinflame Travelers: all triggered
   abilities of permanents matching `sourceFilter` you control trigger an additional time (not just ETB).
   `TriggerDetector.duplicateSourceTriggers`.
 - `AdditionalAttackTriggers(attackerFilter = GameObjectFilter.Any)` — Windcrag Siege (Mardu): the
-  attack-cause analogue of `AdditionalETBTriggers`. If a creature matching `attackerFilter` being
-  declared as an attacker causes an attack-related triggered ability ("whenever a creature
+  attack-cause analogue of `AdditionalETBOrLTBTriggers`. If a creature matching `attackerFilter`
+  being declared as an attacker causes an attack-related triggered ability ("whenever a creature
   attacks" / "whenever you attack") of a permanent you control to trigger, that ability triggers an
   additional time. `TriggerDetector.duplicateAttackTriggers`; additive across copies.
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -461,6 +461,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CreateGlobalTriggeredAbility(ability, duration = Duration.Permanent, descriptionOverride? = null)` — engine-wide triggered ability with no source permanent. `duration` is a plain parameter, so the one method covers every lifetime: `Duration.EndOfTurn` (False Cure, Death Frenzy), `Duration.UntilYourNextTurn` (Season of the Bold), `Duration.EndOfCombat`, `Duration.Permanent` (Dimensional Breach, planeswalker emblems), etc. `descriptionOverride` sets emblem display text.
 - `GrantSpellKeywordEffect` — grant a keyword to a spell on the stack.
 - `GrantSpellsCantBeCountered(target, filter, duration)` — target's matching spells become uncounterable (Domri shape).
+- `GrantFlashToSpells(target, spellFilter, duration)` — target may cast matching spells as though they had flash (CR 702.8a) for `duration` (default `EndOfTurn`). Resolution-time one-shot that records the grant on the player and survives the source spell leaving the stack. Used by **Borne Upon a Wind** ("You may cast spells this turn as though they had flash."); narrower filters like `GameObjectFilter.Sorcery` cover "you may cast sorcery spells as though they had flash" variants. Sibling of the permanent-static [`GrantFlashToSpellType`](#9-static-abilities) — use the static for "as long as this is on the battlefield" wording (the two Gandalfs); use this Effect for a turn-scoped or duration-bounded grant.
 
 ### Control & combat
 

--- a/manual-scenarios/cards/g/gandalf-the-white-all-clauses.json
+++ b/manual-scenarios/cards/g/gandalf-the-white-all-clauses.json
@@ -1,0 +1,50 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Faramir, Field Commander",
+      "Andúril, Flame of the West",
+      "Fell"
+    ],
+    "battlefield": [
+      {"name": "Gandalf the White"},
+      {"name": "Samwise Gamgee"},
+      {"name": "Gimli, Mournful Avenger"},
+      {"name": "Shire Scarecrow"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "ENDING",
+  "step": "END",
+  "activePlayer": 2,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": ["END"],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/g/gandalf-the-white-flash-permissions.json
+++ b/manual-scenarios/cards/g/gandalf-the-white-flash-permissions.json
@@ -1,6 +1,7 @@
 {
   "player1Name": "Alice",
   "player2Name": "AI",
+  "aiPlayer": 2,
   "player1": {
     "lifeTotal": 20,
     "hand": [
@@ -39,6 +40,6 @@
   "priorityPlayer": 1,
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
-  "player1OpponentStopAtSteps": ["END"],
+  "player1OpponentStopAtSteps": [],
   "player2OpponentStopAtSteps": []
 }

--- a/manual-scenarios/cards/g/gandalf-the-white-flash-permissions.json
+++ b/manual-scenarios/cards/g/gandalf-the-white-flash-permissions.json
@@ -1,0 +1,44 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "AI",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Faramir, Field Commander",
+      "Andúril, Flame of the West",
+      "Inherited Envelope"
+    ],
+    "battlefield": [
+      {"name": "Gandalf the White"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest", "Forest"]
+  },
+  "phase": "ENDING",
+  "step": "END",
+  "activePlayer": 2,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": ["END"],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -77,6 +77,7 @@ import com.wingedsheep.sdk.scripting.effects.GainControlByMostEffect
 import com.wingedsheep.sdk.scripting.effects.PlayerRankMetric
 import com.wingedsheep.sdk.scripting.effects.GiftGivenEffect
 import com.wingedsheep.sdk.scripting.effects.GrantSpellKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.GrantFlashToSpellsEffect
 import com.wingedsheep.sdk.scripting.effects.GrantSpellsCantBeCounteredEffect
 import com.wingedsheep.sdk.scripting.effects.GainControlEffect
 import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
@@ -2653,4 +2654,17 @@ object Effects {
         spellFilter: com.wingedsheep.sdk.scripting.GameObjectFilter = com.wingedsheep.sdk.scripting.GameObjectFilter.Creature,
         duration: com.wingedsheep.sdk.scripting.Duration = com.wingedsheep.sdk.scripting.Duration.EndOfTurn
     ): Effect = GrantSpellsCantBeCounteredEffect(target, spellFilter, duration)
+
+    /**
+     * [target] may cast spells matching [spellFilter] as though they had flash for [duration].
+     * Used for Borne Upon a Wind ("You may cast spells this turn as though they had flash.").
+     * Sibling of the permanent-static [com.wingedsheep.sdk.scripting.GrantFlashToSpellType], which
+     * lives on a battlefield permanent. Both are read by the cast-legality check; this Effect
+     * survives the source spell leaving the stack and the static survives its source's static lifetime.
+     */
+    fun GrantFlashToSpells(
+        target: com.wingedsheep.sdk.scripting.targets.EffectTarget = com.wingedsheep.sdk.scripting.targets.EffectTarget.Controller,
+        spellFilter: com.wingedsheep.sdk.scripting.GameObjectFilter = com.wingedsheep.sdk.scripting.GameObjectFilter.Any,
+        duration: com.wingedsheep.sdk.scripting.Duration = com.wingedsheep.sdk.scripting.Duration.EndOfTurn
+    ): Effect = GrantFlashToSpellsEffect(target, spellFilter, duration)
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -508,30 +508,61 @@ data object ExtraLoyaltyActivation : StaticAbility {
 }
 
 /**
- * When a permanent matching [enteringFilter] enters the battlefield, triggered abilities of
- * permanents you control that trigger from that entering trigger an additional time.
- *
- * This models Naban, Dean of Iteration and similar "Panharmonicon for a subtype" effects, as
- * well as Starfield Vocalist where the entering permanent can be any controller.
- *
- * [enteringFilter] restricts which entering permanents cause the doubling (e.g., Wizards, Birds,
- * or [GameObjectFilter.Any] for any permanent).
- *
- * [enteringMustBeYouControl] controls whether the entering permanent must be controlled by the
- * doubler's controller. Defaults to true to match the typical "X you control entering" wording
- * (Naban, Traveling Chocobo, Panharmonicon). Set to false for cards like Starfield Vocalist whose
- * oracle text omits the "under your control" restriction on the entering permanent — the trigger
- * still has to belong to a permanent you control, but the entering permanent does not.
- *
- * Multiple copies are additive: two copies yield three total triggers, etc.
+ * Whether [AdditionalETBOrLTBTriggers] watches the entering side, the leaving side, or both
+ * of a permanent's battlefield transit.
  */
-@SerialName("AdditionalETBTriggers")
 @Serializable
-data class AdditionalETBTriggers(
-    val enteringFilter: GameObjectFilter,
-    val enteringMustBeYouControl: Boolean = true,
+enum class BattlefieldDirection {
+    /** Permanent entered the battlefield (`ZoneChangeEvent.toZone == Zone.BATTLEFIELD`). */
+    @SerialName("Entering")
+    ENTERING,
+
+    /** Permanent left the battlefield (`ZoneChangeEvent.fromZone == Zone.BATTLEFIELD`). */
+    @SerialName("Leaving")
+    LEAVING
+}
+
+/**
+ * When a permanent matching [filter] crosses the battlefield boundary in one of [directions],
+ * triggered abilities of permanents controlled by this ability's controller that fired from
+ * that event trigger an additional time per copy. CR 603.2d ("An ability may state that a
+ * triggered ability triggers additional times").
+ *
+ * Models the Panharmonicon family (entering only) and, with `LEAVING` added, Gandalf-the-White-
+ * style "entering or leaving the battlefield" doublers. Concrete shapes:
+ *  - Panharmonicon — `filter = GameObjectFilter.Any` (creature/artifact only in oracle text;
+ *    use a composed filter), default `mustBeYouControl = true`, default `directions = {ENTERING}`.
+ *  - Naban, Dean of Iteration — `filter = Creature.withSubtype("Wizard")`, default flags.
+ *  - Traveling Chocobo — `filter = Land or Creature.withSubtype("Bird")`, default flags.
+ *  - Starfield Vocalist — `filter = GameObjectFilter.Any`, `mustBeYouControl = false`.
+ *  - Gandalf the White — `filter = Artifact or Any.legendary()`, `mustBeYouControl = false`,
+ *    `directions = setOf(ENTERING, LEAVING)`.
+ *
+ * @property filter Which permanent's entering/leaving counts as the "cause" event.
+ * @property mustBeYouControl When true (default), the cause permanent must be controlled by
+ *   this ability's controller — matches the typical "X you control entering" wording. Set to
+ *   false when the oracle text omits the "under your control" restriction on the cause
+ *   permanent (Starfield Vocalist, Gandalf the White). The triggered ability's source permanent
+ *   is always required to be controlled by this ability's controller regardless of this flag —
+ *   that part is the "of a permanent you control" half of the oracle text and isn't optional.
+ * @property directions Which transit directions are watched. Defaults to `{ENTERING}` (the
+ *   Panharmonicon shape). Add `LEAVING` to cover "entering or leaving the battlefield" wording
+ *   (Gandalf the White) or stand-alone "leaves the battlefield" doublers.
+ *
+ * Multiple copies are additive: N copies add N extra firings of each affected trigger.
+ */
+@SerialName("AdditionalETBOrLTBTriggers")
+@Serializable
+data class AdditionalETBOrLTBTriggers(
+    val filter: GameObjectFilter,
+    val mustBeYouControl: Boolean = true,
+    val directions: Set<BattlefieldDirection> = setOf(BattlefieldDirection.ENTERING),
     override val description: String = "Triggered abilities trigger an additional time"
 ) : StaticAbility {
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
 }
 
 /**
@@ -569,7 +600,7 @@ data class AdditionalSourceTriggers(
  * If a creature matching [attackerFilter] attacking causes a triggered ability of a permanent
  * you control to trigger, that ability triggers an additional time.
  *
- * This is the "attack-cause" analogue of [AdditionalETBTriggers]: instead of doubling triggers
+ * This is the "attack-cause" analogue of [AdditionalETBOrLTBTriggers]: instead of doubling triggers
  * caused by a permanent entering the battlefield, it doubles triggers caused by a creature being
  * declared as an attacker (the attackers-declared event). Models Windcrag Siege's Mardu mode:
  * "If a creature attacking causes a triggered ability of a permanent you control to trigger, that

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -385,6 +385,50 @@ data class GrantSpellKeywordEffect(
 }
 
 /**
+ * [target] may cast spells matching [spellFilter] as though they had flash, for [duration].
+ *
+ * Player-scoped, duration-bounded counterpart to the permanent-static
+ * [com.wingedsheep.sdk.scripting.GrantFlashToSpellType]: the static lives on a battlefield
+ * permanent and applies as long as the source is on the battlefield, while this Effect is a
+ * resolution-time one-shot that records a turn-scoped grant on the target player and survives
+ * the source (sorcery/instant) leaving the stack.
+ *
+ * Used for Borne Upon a Wind: "You may cast spells this turn as though they had flash."
+ * Composes for narrower-filter variants like "you may cast sorcery spells as though they had
+ * flash until end of turn" by passing `GameObjectFilter.Sorcery`.
+ *
+ * Per CR 702.8a flash means "you may play this card any time you could cast an instant." The
+ * permission is read at cast-legality time (CR 601.3) by `CastPermissionUtils.hasGrantedFlash`,
+ * so it composes with every casting path that already honors flash.
+ *
+ * @property target Whose spells gain flash (default: controller).
+ * @property spellFilter Which spells gain flash (defaults to every spell).
+ * @property duration How long the grant lasts (default: end of turn). The "as long as ~ is on
+ *   the battlefield" variant is covered by [com.wingedsheep.sdk.scripting.GrantFlashToSpellType]
+ *   instead, so this effect's typical durations are `EndOfTurn`, `UntilYourNextTurn`, etc.
+ */
+@SerialName("GrantFlashToSpells")
+@Serializable
+data class GrantFlashToSpellsEffect(
+    val target: EffectTarget = EffectTarget.Controller,
+    val spellFilter: GameObjectFilter = GameObjectFilter.Any,
+    val duration: Duration = Duration.EndOfTurn
+) : Effect {
+    override val description: String = buildString {
+        append(target.description.replaceFirstChar { it.uppercase() })
+        append(" may cast ")
+        append(if (spellFilter == GameObjectFilter.Any) "spells" else "${spellFilter.description} spells")
+        if (duration != Duration.Permanent) append(" ${duration.description}")
+        append(" as though they had flash")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect {
+        val newFilter = spellFilter.applyTextReplacement(replacer)
+        return if (newFilter !== spellFilter) copy(spellFilter = newFilter) else this
+    }
+}
+
+/**
  * Spells matching [spellFilter] that [target] casts can't be countered until [duration].
  *
  * Player-scoped counterpart to the permanent-static [com.wingedsheep.sdk.scripting.GrantCantBeCountered]:

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/NabanDeanOfIteration.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/NabanDeanOfIteration.kt
@@ -2,7 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.dom.cards
 
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.AdditionalETBTriggers
+import com.wingedsheep.sdk.scripting.AdditionalETBOrLTBTriggers
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 
 /**
@@ -22,8 +22,8 @@ val NabanDeanOfIteration = card("Naban, Dean of Iteration") {
     oracleText = "If a Wizard entering the battlefield under your control causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time."
 
     staticAbility {
-        ability = AdditionalETBTriggers(
-            enteringFilter = GameObjectFilter.Creature.withSubtype("Wizard"),
+        ability = AdditionalETBOrLTBTriggers(
+            filter = GameObjectFilter.Creature.withSubtype("Wizard"),
             description = "If a Wizard entering the battlefield under your control causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time"
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/StarfieldVocalist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/StarfieldVocalist.kt
@@ -2,7 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.eoe.cards
 
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.AdditionalETBTriggers
+import com.wingedsheep.sdk.scripting.AdditionalETBOrLTBTriggers
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 
 /**
@@ -26,9 +26,9 @@ val StarfieldVocalist = card("Starfield Vocalist") {
         "Warp {1}{U} (You may cast this card from your hand for its warp cost. Exile this creature at the beginning of the next end step, then you may cast it from exile on a later turn.)"
 
     staticAbility {
-        ability = AdditionalETBTriggers(
-            enteringFilter = GameObjectFilter.Any,
-            enteringMustBeYouControl = false,
+        ability = AdditionalETBOrLTBTriggers(
+            filter = GameObjectFilter.Any,
+            mustBeYouControl = false,
             description = "If a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time"
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TravelingChocobo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TravelingChocobo.kt
@@ -2,7 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.fin.cards
 
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.AdditionalETBTriggers
+import com.wingedsheep.sdk.scripting.AdditionalETBOrLTBTriggers
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
@@ -36,8 +36,8 @@ val TravelingChocobo = card("Traveling Chocobo") {
     }
 
     staticAbility {
-        ability = AdditionalETBTriggers(
-            enteringFilter = GameObjectFilter.Land or GameObjectFilter.Creature.withSubtype("Bird"),
+        ability = AdditionalETBOrLTBTriggers(
+            filter = GameObjectFilter.Land or GameObjectFilter.Creature.withSubtype("Bird"),
             description = "If a land or Bird you control entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time"
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BorneUponAWind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/BorneUponAWind.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Borne Upon a Wind
+ * {1}{U}
+ * Instant
+ *
+ * You may cast spells this turn as though they had flash.
+ * Draw a card.
+ *
+ * Granting flash to every spell the controller casts for the rest of the turn (CR 702.8a)
+ * is modelled via [com.wingedsheep.sdk.scripting.effects.GrantFlashToSpellsEffect], which
+ * stamps a turn-scoped `FlashGrantsThisTurnComponent` on the controller. The component is
+ * cleared by `CleanupPhaseManager.cleanupEndOfTurn` (CR 514.2).
+ */
+val BorneUponAWind = card("Borne Upon a Wind") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "You may cast spells this turn as though they had flash.\nDraw a card."
+
+    spell {
+        effect = Effects.GrantFlashToSpells(
+            spellFilter = GameObjectFilter.Any,
+            duration = Duration.EndOfTurn
+        ).then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "44"
+        artist = "Alexander Mokhov"
+        flavorText = "\"I looked on Aragorn and thought how great and terrible a Lord he might " +
+            "have become, had he taken the Ring for himself. Not for naught does Mordor fear him.\"" +
+            "\n—Legolas"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9379675-1a32-4e2b-8aaf-5f908c595f31.jpg?1686968037"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfFriendOfTheShire.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfFriendOfTheShire.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
+
+/**
+ * Gandalf, Friend of the Shire
+ * {3}{U}
+ * Legendary Creature — Avatar Wizard
+ * 2/4
+ *
+ * Flash
+ * You may cast sorcery spells as though they had flash.
+ * Whenever the Ring tempts you, if you chose a creature other than Gandalf as your
+ * Ring-bearer, draw a card.
+ *
+ * The "sorcery-speed → flash" permission is the permanent-static
+ * [GrantFlashToSpellType] (CR 702.8a) filtered to sorcery spells and scoped to the
+ * controller. The Ring-tempts trigger composes via the existing
+ * [Conditions.YouChoseOtherCreatureAsRingBearer] (Gap 3 in LTR's TODO).
+ */
+val GandalfFriendOfTheShire = card("Gandalf, Friend of the Shire") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 2
+    toughness = 4
+    oracleText = "Flash\n" +
+        "You may cast sorcery spells as though they had flash.\n" +
+        "Whenever the Ring tempts you, if you chose a creature other than Gandalf as your " +
+        "Ring-bearer, draw a card."
+
+    keywords(Keyword.FLASH)
+
+    staticAbility {
+        ability = GrantFlashToSpellType(
+            filter = GameObjectFilter.Sorcery,
+            controllerOnly = true
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.RingTemptsYou
+        triggerCondition = Conditions.YouChoseOtherCreatureAsRingBearer
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "Dmitry Burmak"
+        flavorText = "\"After a hundred years, Hobbits can still surprise you at a pinch.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc9cfcc7-be64-4871-8d52-851e43fe3305.jpg?1696231214"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfTheWhite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfTheWhite.kt
@@ -23,9 +23,10 @@ import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
  * The Flash keyword (CR 702.8) and the flash-permission static
  * ([GrantFlashToSpellType] with filter `Artifact ∨ Legendary`, controller-only) are
  * implemented. The third clause — "if X causes a triggered ability of a permanent you
- * control to trigger, that ability triggers an additional time" — is a *trigger
- * replacement* (CR 614.5-style "triggers an additional time") and shares no clean reusable
- * primitive with anything else in LTR yet. It is tracked in `TODO.md` as a follow-up gap.
+ * control to trigger, that ability triggers an additional time" — is a trigger-count
+ * modifier (CR 603.2d: "An ability may state that a triggered ability triggers additional
+ * times") and shares no clean reusable primitive with anything else in LTR yet. It is
+ * tracked in `TODO.md` as a follow-up gap.
  * The card stays unchecked in `cards.md` until that gap lands so the backlog correctly
  * reflects which clauses are live.
  */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfTheWhite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfTheWhite.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.ltr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
+
+/**
+ * Gandalf the White
+ * {3}{W}{W}
+ * Legendary Creature — Avatar Wizard
+ * 4/5
+ *
+ * Flash
+ * You may cast legendary spells and artifact spells as though they had flash.
+ * If a legendary permanent or an artifact entering or leaving the battlefield causes a
+ * triggered ability of a permanent you control to trigger, that ability triggers an
+ * additional time.
+ *
+ * **PARTIAL — third clause deferred.**
+ *
+ * The Flash keyword (CR 702.8) and the flash-permission static
+ * ([GrantFlashToSpellType] with filter `Artifact ∨ Legendary`, controller-only) are
+ * implemented. The third clause — "if X causes a triggered ability of a permanent you
+ * control to trigger, that ability triggers an additional time" — is a *trigger
+ * replacement* (CR 614.5-style "triggers an additional time") and shares no clean reusable
+ * primitive with anything else in LTR yet. It is tracked in `TODO.md` as a follow-up gap.
+ * The card stays unchecked in `cards.md` until that gap lands so the backlog correctly
+ * reflects which clauses are live.
+ */
+val GandalfTheWhite = card("Gandalf the White") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 4
+    toughness = 5
+    oracleText = "Flash\n" +
+        "You may cast legendary spells and artifact spells as though they had flash.\n" +
+        "If a legendary permanent or an artifact entering or leaving the battlefield causes " +
+        "a triggered ability of a permanent you control to trigger, that ability triggers an " +
+        "additional time."
+
+    keywords(Keyword.FLASH)
+
+    staticAbility {
+        ability = GrantFlashToSpellType(
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Any.legendary(),
+            controllerOnly = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "19"
+        artist = "Magali Villeneuve"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e384c20b-d0c1-4781-9d11-e89e5a6bf3fc.jpg?1686967821"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfTheWhite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/GandalfTheWhite.kt
@@ -3,6 +3,8 @@ package com.wingedsheep.mtg.sets.definitions.ltr.cards
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalETBOrLTBTriggers
+import com.wingedsheep.sdk.scripting.BattlefieldDirection
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
 
@@ -18,17 +20,16 @@ import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
  * triggered ability of a permanent you control to trigger, that ability triggers an
  * additional time.
  *
- * **PARTIAL — third clause deferred.**
- *
- * The Flash keyword (CR 702.8) and the flash-permission static
- * ([GrantFlashToSpellType] with filter `Artifact ∨ Legendary`, controller-only) are
- * implemented. The third clause — "if X causes a triggered ability of a permanent you
- * control to trigger, that ability triggers an additional time" — is a trigger-count
- * modifier (CR 603.2d: "An ability may state that a triggered ability triggers additional
- * times") and shares no clean reusable primitive with anything else in LTR yet. It is
- * tracked in `TODO.md` as a follow-up gap.
- * The card stays unchecked in `cards.md` until that gap lands so the backlog correctly
- * reflects which clauses are live.
+ * All three clauses compose from existing primitives:
+ *  - Flash keyword (CR 702.8) — `keywords(Keyword.FLASH)`.
+ *  - Flash permission static (CR 702.8a) — [GrantFlashToSpellType] with filter
+ *    `Artifact ∨ Legendary`, controller-only.
+ *  - Trigger-count modifier (CR 603.2d "An ability may state that a triggered ability
+ *    triggers additional times") — [AdditionalETBOrLTBTriggers] with the same
+ *    `Artifact ∨ Legendary` filter, `mustBeYouControl = false` (the cause permanent
+ *    can be either player's — the oracle text only requires the *trigger* to belong
+ *    to a permanent Gandalf's controller controls), and both `ENTERING` and `LEAVING`
+ *    directions watched.
  */
 val GandalfTheWhite = card("Gandalf the White") {
     manaCost = "{3}{W}{W}"
@@ -48,6 +49,15 @@ val GandalfTheWhite = card("Gandalf the White") {
         ability = GrantFlashToSpellType(
             filter = GameObjectFilter.Artifact or GameObjectFilter.Any.legendary(),
             controllerOnly = true
+        )
+    }
+
+    staticAbility {
+        ability = AdditionalETBOrLTBTriggers(
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Any.legendary(),
+            mustBeYouControl = false,
+            directions = setOf(BattlefieldDirection.ENTERING, BattlefieldDirection.LEAVING),
+            description = "If a legendary permanent or an artifact entering or leaving the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time"
         )
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -30,6 +30,7 @@ import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbiliti
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
 import com.wingedsheep.engine.state.components.player.DamageBonusComponent
 import com.wingedsheep.engine.state.components.player.DamageReceivedThisTurnComponent
+import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnComponent
 import com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent
@@ -361,6 +362,10 @@ class CleanupPhaseManager(
                 val spellsUncounterable = result.get<SpellsCantBeCounteredComponent>()
                 if (spellsUncounterable?.removeOn == PlayerEffectRemoval.EndOfTurn) {
                     result = result.without<SpellsCantBeCounteredComponent>()
+                }
+                val flashGrants = result.get<FlashGrantsThisTurnComponent>()
+                if (flashGrants?.removeOn == PlayerEffectRemoval.EndOfTurn) {
+                    result = result.without<FlashGrantsThisTurnComponent>()
                 }
                 val graveyardForage = result.get<MayCastCreaturesFromGraveyardWithForageComponent>()
                 if (graveyardForage?.removeOn == PlayerEffectRemoval.EndOfTurn) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -427,6 +427,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PermanentTypesEnteredBattlefieldThisTurnComponent::class)
         subclass(LandsEnteredUnderControlThisTurnComponent::class)
         subclass(SpellsCantBeCounteredComponent::class)
+        subclass(FlashGrantsThisTurnComponent::class)
         subclass(PutCounterOnCreatureThisTurnComponent::class)
         subclass(SkipNextTurnComponent::class)
         subclass(PlayerTurnHijackedComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -246,10 +246,11 @@ class TriggerDetector(
         // Detect Saga chapter triggers from lore counter additions
         detectSagaChapterTriggers(state, events, triggers)
 
-        // Duplicate triggers for "additional time" static abilities (e.g., Naban, Panharmonicon).
-        // When a creature matching the filter ETBs, triggered abilities on the controller's
+        // Duplicate triggers for "additional time" static abilities (e.g., Naban, Panharmonicon,
+        // Gandalf the White). When a permanent matching the filter enters or leaves the
+        // battlefield (per the static's directions), triggered abilities on the controller's
         // permanents that fired from that event trigger an additional time per copy.
-        duplicateETBTriggers(state, events, triggers)
+        duplicateETBOrLTBTriggers(state, events, triggers)
 
         // Duplicate triggers caused by a creature being declared as an attacker (Windcrag Siege's
         // Mardu mode). The attack-cause analogue of duplicateETBTriggers.
@@ -1835,15 +1836,18 @@ class TriggerDetector(
     }
 
     /**
-     * Duplicate ETB triggers for "additional time" static abilities (Naban, Panharmonicon).
+     * Duplicate ETB and LTB triggers for [AdditionalETBOrLTBTriggers] static abilities
+     * (Naban, Panharmonicon, Starfield Vocalist, Gandalf the White).
      *
-     * For each ZoneChangeEvent(to=BATTLEFIELD) in the events, checks if any permanent on
-     * the battlefield has AdditionalETBTriggers whose enteringFilter matches the entering entity.
-     * If so, duplicates all triggers that fired from that ETB event for the controller's permanents.
+     * For each ZoneChangeEvent whose `toZone == BATTLEFIELD` (entering) or whose `fromZone
+     * == BATTLEFIELD` (leaving), checks every battlefield permanent whose static matches the
+     * filter and the direction. For each match, duplicates triggers belonging to the
+     * static's controller whose triggering entity is the cause and whose trigger pattern
+     * matches the direction.
      *
      * Multiple copies are additive: N copies add N extra copies of each trigger.
      */
-    private fun duplicateETBTriggers(
+    private fun duplicateETBOrLTBTriggers(
         state: GameState,
         events: List<EngineGameEvent>,
         triggers: MutableList<PendingTrigger>
@@ -1851,18 +1855,23 @@ class TriggerDetector(
         val registry = cardRegistry
         val projected = state.projectedState
 
-        // Find ETB events (zone changes to battlefield)
-        val etbEvents = events.filterIsInstance<ZoneChangeEvent>().filter { it.toZone == Zone.BATTLEFIELD }
-        if (etbEvents.isEmpty()) return
+        // Battlefield-boundary-crossing events: pure entering, or pure leaving. A same-batch
+        // zone change that goes battlefield → battlefield is not a thing the engine emits, so
+        // we don't have to disambiguate.
+        val zoneEvents = events.filterIsInstance<ZoneChangeEvent>().filter {
+            it.toZone == Zone.BATTLEFIELD ||
+                (it.fromZone == Zone.BATTLEFIELD && it.toZone != Zone.BATTLEFIELD)
+        }
+        if (zoneEvents.isEmpty()) return
 
-        // Collect all AdditionalETBTriggers static abilities from battlefield permanents
-        data class ETBDoubler(
+        data class Doubler(
             val controllerId: EntityId,
             val filter: GameObjectFilter,
             val sourceId: EntityId,
-            val enteringMustBeYouControl: Boolean,
+            val mustBeYouControl: Boolean,
+            val directions: Set<BattlefieldDirection>,
         )
-        val doublers = mutableListOf<ETBDoubler>()
+        val doublers = mutableListOf<Doubler>()
 
         for (permanentId in state.getBattlefield()) {
             val container = state.getEntity(permanentId) ?: continue
@@ -1873,13 +1882,14 @@ class TriggerDetector(
 
             val classLevel = container.get<ClassLevelComponent>()?.currentLevel
             for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
-                if (ability is AdditionalETBTriggers) {
+                if (ability is AdditionalETBOrLTBTriggers) {
                     doublers.add(
-                        ETBDoubler(
+                        Doubler(
                             controllerId = controllerId,
-                            filter = ability.enteringFilter,
+                            filter = ability.filter,
                             sourceId = permanentId,
-                            enteringMustBeYouControl = ability.enteringMustBeYouControl,
+                            mustBeYouControl = ability.mustBeYouControl,
+                            directions = ability.directions,
                         )
                     )
                 }
@@ -1888,38 +1898,48 @@ class TriggerDetector(
 
         if (doublers.isEmpty()) return
 
-        // For each ETB event, check if the entering creature matches any doubler
         val duplicates = mutableListOf<PendingTrigger>()
 
-        for (etbEvent in etbEvents) {
-            val enteringEntityId = etbEvent.entityId
+        for (event in zoneEvents) {
+            val direction = if (event.toZone == Zone.BATTLEFIELD) BattlefieldDirection.ENTERING
+                else BattlefieldDirection.LEAVING
+            val causeEntityId = event.entityId
 
             for (doubler in doublers) {
-                if (doubler.enteringMustBeYouControl) {
-                    // The entering permanent must be controlled by the doubler's controller
-                    // (matches "X you control entering" wording — Naban, Traveling Chocobo, etc.)
-                    val enteringController = projected.getController(enteringEntityId) ?: etbEvent.ownerId
-                    if (enteringController != doubler.controllerId) continue
+                if (direction !in doubler.directions) continue
+
+                if (doubler.mustBeYouControl) {
+                    // Entering → consult projected controller (entity is on the battlefield now).
+                    // Leaving → projected state has no entry; use the last-known controller
+                    // snapshotted on the ZoneChangeEvent, falling back to owner.
+                    val causeController = when (direction) {
+                        BattlefieldDirection.ENTERING ->
+                            projected.getController(causeEntityId) ?: event.ownerId
+                        BattlefieldDirection.LEAVING ->
+                            event.lastKnownController ?: event.ownerId
+                    }
+                    if (causeController != doubler.controllerId) continue
                 }
 
-                // Check if the entering creature matches the filter
                 if (doubler.filter != GameObjectFilter.Any) {
                     if (!predicateEvaluator.matches(
-                            state, projected, enteringEntityId, doubler.filter,
+                            state, projected, causeEntityId, doubler.filter,
                             PredicateContext(controllerId = doubler.controllerId, sourceId = doubler.sourceId)
                         )) continue
                 }
 
-                // Find all existing triggers that fired from this ETB event
-                // and belong to permanents controlled by the doubler's controller
                 for (trigger in triggers) {
-                    if (trigger.triggerContext.triggeringEntityId != enteringEntityId) continue
+                    if (trigger.triggerContext.triggeringEntityId != causeEntityId) continue
                     if (trigger.controllerId != doubler.controllerId) continue
 
-                    // Only duplicate triggers that are ETB-related (ZoneChangeEvent triggers)
                     val triggerEvent = trigger.ability.trigger
                     if (triggerEvent !is EventPattern.ZoneChangeEvent) continue
-                    if (triggerEvent.to != Zone.BATTLEFIELD) continue
+                    when (direction) {
+                        BattlefieldDirection.ENTERING ->
+                            if (triggerEvent.to != Zone.BATTLEFIELD) continue
+                        BattlefieldDirection.LEAVING ->
+                            if (triggerEvent.from != Zone.BATTLEFIELD) continue
+                    }
 
                     duplicates.add(trigger)
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -32,7 +32,9 @@ import com.wingedsheep.engine.state.components.identity.RoomFaceId
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -1922,9 +1924,9 @@ class TriggerDetector(
                 }
 
                 if (doubler.filter != GameObjectFilter.Any) {
-                    if (!predicateEvaluator.matches(
-                            state, projected, causeEntityId, doubler.filter,
-                            PredicateContext(controllerId = doubler.controllerId, sourceId = doubler.sourceId)
+                    if (!causeMatchesDoublerFilter(
+                            state, projected, event, direction,
+                            doubler.filter, doubler.controllerId, doubler.sourceId
                         )) continue
                 }
 
@@ -1947,6 +1949,61 @@ class TriggerDetector(
         }
 
         triggers.addAll(duplicates)
+    }
+
+    /**
+     * Does the entity that crossed the battlefield boundary in [event] match the doubler's [filter]?
+     *
+     * Entering: the cause is live on the battlefield, so projected state is authoritative — match
+     * directly.
+     *
+     * Leaving: the cause is no longer on the battlefield. Its base entity (now in the graveyard)
+     * carries only its printed type line — the projected types it had on the battlefield are gone —
+     * and a token cause may even have been swept by 704.5d. Per CR 603.10a leaves-the-battlefield
+     * checks look back in time, so we evaluate the filter against the entity's last-known type line
+     * (snapshotted on the [ZoneChangeEvent]), mirroring `TriggerMatcher.matchesZoneChangeTrigger`.
+     * We overlay that type line onto the cause entity (synthesizing a minimal one if it was swept)
+     * and reuse the full filter engine, so `or`/color/subtype predicates all resolve correctly.
+     * Without this, a creature that was an artifact/legendary only via a continuous effect (e.g.
+     * a creature turned into an artifact, then destroyed) would silently fail Gandalf the White's
+     * `Artifact ∨ Legendary` filter and the trigger it caused wouldn't be doubled.
+     */
+    private fun causeMatchesDoublerFilter(
+        state: GameState,
+        projected: ProjectedState,
+        event: ZoneChangeEvent,
+        direction: BattlefieldDirection,
+        filter: GameObjectFilter,
+        controllerId: EntityId,
+        sourceId: EntityId
+    ): Boolean {
+        val context = PredicateContext(controllerId = controllerId, sourceId = sourceId)
+
+        if (direction == BattlefieldDirection.ENTERING) {
+            return predicateEvaluator.matches(state, projected, event.entityId, filter, context)
+        }
+
+        val lastKnownTypeLine = event.lastKnownTypeLine
+        val existing = state.getEntity(event.entityId)
+        val existingCard = existing?.get<CardComponent>()
+        val overlayCard = when {
+            existingCard != null ->
+                existingCard.copy(typeLine = lastKnownTypeLine ?: existingCard.typeLine)
+            lastKnownTypeLine != null -> CardComponent(
+                cardDefinitionId = event.lastKnownCardDefinitionId ?: event.entityName,
+                name = event.entityName,
+                manaCost = ManaCost.ZERO,
+                typeLine = lastKnownTypeLine
+            )
+            else -> return false
+        }
+        // Off-battlefield, so the original `projected` has no entry for this id and matches() falls
+        // back to the overlaid card's type line. No projection recompute needed.
+        val overlayState = state.withEntity(
+            event.entityId,
+            (existing ?: ComponentContainer.EMPTY).withComponent(overlayCard)
+        )
+        return predicateEvaluator.matches(overlayState, projected, event.entityId, filter, context)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.engine.state.components.identity.CommanderComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.state.permissions.hasMayPlayFor
+import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnComponent
 import com.wingedsheep.engine.state.components.player.MayCastCreaturesFromGraveyardWithForageComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -328,8 +329,20 @@ class CastZoneResolver(
             }
         }
 
-        // Check GrantFlashToSpellType static abilities on battlefield permanents
         val context = PredicateContext(controllerId = spellOwner)
+
+        // Turn-scoped grants on the spell owner (Borne Upon a Wind etc., via
+        // GrantFlashToSpellsEffect → FlashGrantsThisTurnComponent).
+        val turnGrants = state.getEntity(spellOwner)?.get<FlashGrantsThisTurnComponent>()
+        if (turnGrants != null) {
+            for (filter in turnGrants.filters) {
+                if (predicateEvaluator.matches(state, state.projectedState, spellCardId, filter, context)) {
+                    return true
+                }
+            }
+        }
+
+        // Check GrantFlashToSpellType static abilities on battlefield permanents
         for (playerId in state.turnOrder) {
             for (entityId in state.getBattlefield(playerId)) {
                 val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/GrantFlashToSpellsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/GrantFlashToSpellsExecutor.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PlayerEffectRemoval
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.GrantFlashToSpellsEffect
+import kotlin.reflect.KClass
+
+/**
+ * Records a turn-scoped flash permission on the target player.
+ *
+ * Adds an entry to the target's [FlashGrantsThisTurnComponent]; if the component is already
+ * present (e.g. a second Borne Upon a Wind resolves the same turn), the new filter is appended
+ * — multiple grants stack additively and all expire together at the duration's end.
+ *
+ * Sibling of [GrantSpellsCantBeCounteredExecutor].
+ */
+class GrantFlashToSpellsExecutor : EffectExecutor<GrantFlashToSpellsEffect> {
+
+    override val effectType: KClass<GrantFlashToSpellsEffect> = GrantFlashToSpellsEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: GrantFlashToSpellsEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolvePlayerTarget(effect.target)
+            ?: return EffectResult.error(state, "No valid target for grant-flash-to-spells effect")
+
+        if (!state.turnOrder.contains(targetId)) {
+            return EffectResult.error(state, "Target is not a player")
+        }
+
+        val removeOn = when (effect.duration) {
+            is Duration.Permanent -> PlayerEffectRemoval.Permanent
+            else -> PlayerEffectRemoval.EndOfTurn
+        }
+
+        val newState = state.updateEntity(targetId) { container ->
+            val existing = container.get<FlashGrantsThisTurnComponent>()
+            val mergedFilters = (existing?.filters ?: emptyList()) + effect.spellFilter
+            container.with(FlashGrantsThisTurnComponent(filters = mergedFilters, removeOn = removeOn))
+        }
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/GrantFlashToSpellsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/GrantFlashToSpellsExecutor.kt
@@ -35,7 +35,7 @@ class GrantFlashToSpellsExecutor : EffectExecutor<GrantFlashToSpellsEffect> {
             return EffectResult.error(state, "Target is not a player")
         }
 
-        val removeOn = when (effect.duration) {
+        val incomingRemoveOn = when (effect.duration) {
             is Duration.Permanent -> PlayerEffectRemoval.Permanent
             else -> PlayerEffectRemoval.EndOfTurn
         }
@@ -43,7 +43,15 @@ class GrantFlashToSpellsExecutor : EffectExecutor<GrantFlashToSpellsEffect> {
         val newState = state.updateEntity(targetId) { container ->
             val existing = container.get<FlashGrantsThisTurnComponent>()
             val mergedFilters = (existing?.filters ?: emptyList()) + effect.spellFilter
-            container.with(FlashGrantsThisTurnComponent(filters = mergedFilters, removeOn = removeOn))
+            // If either the existing or incoming grant is Permanent, keep Permanent — never
+            // demote a Permanent grant to EndOfTurn just because a later EndOfTurn grant landed.
+            // PlayerEffectRemoval is binary, so a single component duration can't track per-filter
+            // lifetimes; biasing toward Permanent at most over-extends EndOfTurn entries (harmless)
+            // rather than dropping a Permanent grant at cleanup (incorrect).
+            val mergedRemoveOn = if (existing?.removeOn == PlayerEffectRemoval.Permanent ||
+                incomingRemoveOn == PlayerEffectRemoval.Permanent
+            ) PlayerEffectRemoval.Permanent else PlayerEffectRemoval.EndOfTurn
+            container.with(FlashGrantsThisTurnComponent(filters = mergedFilters, removeOn = mergedRemoveOn))
         }
 
         return EffectResult.success(newState)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -49,6 +49,7 @@ class PlayerExecutors(
         GainCitysBlessingExecutor(),
         GiftGivenExecutor(),
         GrantCastCreaturesFromGraveyardWithForageExecutor(),
+        GrantFlashToSpellsExecutor(),
         GrantSpellKeywordExecutor(),
         GrantSpellsCantBeCounteredExecutor(),
         GrantDamageBonusExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
+import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivationRestriction
@@ -349,6 +350,18 @@ class CastPermissionUtils(
         }
 
         val context = PredicateContext(controllerId = spellOwner)
+
+        // Turn-scoped grants on the spell owner (Borne Upon a Wind etc., via
+        // GrantFlashToSpellsEffect → FlashGrantsThisTurnComponent).
+        val turnGrants = state.getEntity(spellOwner)?.get<FlashGrantsThisTurnComponent>()
+        if (turnGrants != null) {
+            for (filter in turnGrants.filters) {
+                if (predicateEvaluator.matches(state, state.projectedState, spellCardId, filter, context)) {
+                    return true
+                }
+            }
+        }
+
         for (playerId in state.turnOrder) {
             for (entityId in state.getBattlefield(playerId)) {
                 val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -413,6 +413,29 @@ data class SpellsCantBeCounteredComponent(
 ) : Component
 
 /**
+ * Spells matching any of [filters] that the player owning this component casts may be cast as
+ * though they had flash (CR 702.8a), for the duration described by [removeOn].
+ *
+ * Player-scoped, duration-bounded counterpart to the permanent-static
+ * [com.wingedsheep.sdk.scripting.GrantFlashToSpellType]. Both are consulted by
+ * [com.wingedsheep.engine.legalactions.utils.CastPermissionUtils.hasGrantedFlash]; this
+ * component lets the grant survive its source (a sorcery/instant such as Borne Upon a Wind)
+ * leaving the stack, since the static-on-permanent variant would die with its source.
+ *
+ * Multiple grants stack additively — each [com.wingedsheep.sdk.scripting.effects.GrantFlashToSpellsEffect]
+ * resolution appends to [filters]; a spell gains flash if it matches any entry. The whole
+ * component is removed in one shot when the duration elapses.
+ *
+ * @property filters Filters matched against the card being cast (read in any zone).
+ * @property removeOn When this component is removed.
+ */
+@Serializable
+data class FlashGrantsThisTurnComponent(
+    val filters: List<GameObjectFilter> = emptyList(),
+    val removeOn: PlayerEffectRemoval = PlayerEffectRemoval.EndOfTurn
+) : Component
+
+/**
  * Component indicating that a player cannot cast spells for the rest of this turn.
  * Applied by effects like Xantid Swarm ("defending player can't cast spells this turn").
  *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1734,17 +1734,20 @@ class ClientStateTransformer(
             )
         }
 
-        // Check for FlashGrantsThisTurnComponent (e.g., Borne Upon a Wind)
+        // Check for FlashGrantsThisTurnComponent (e.g., Borne Upon a Wind).
+        // GameObjectFilter.Any describes itself as "card" — render it as a bare "spells"
+        // so the Borne-Upon-a-Wind case reads naturally, and join multiple filter branches
+        // with "or" to keep stacked grants grammatical.
         container.get<FlashGrantsThisTurnComponent>()?.let { component ->
-            val filterDescription = component.filters
-                .joinToString(", ") { it.description }
-                .ifBlank { "Spells" }
+            val rendered = component.filters
+                .map { if (it == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) "" else it.description.lowercase() }
+                .filter { it.isNotEmpty() }
+            val spellPhrase = if (rendered.isEmpty()) "spells" else "${rendered.joinToString(" or ")} spells"
             effects.add(
                 ClientPlayerEffect(
                     effectId = "flash_grants_this_turn",
                     name = "Flash",
-                    description = "You may cast ${filterDescription.lowercase()} spells this turn " +
-                        "as though they had flash",
+                    description = "You may cast $spellPhrase this turn as though they had flash",
                     icon = "lightning"
                 )
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1734,6 +1734,22 @@ class ClientStateTransformer(
             )
         }
 
+        // Check for FlashGrantsThisTurnComponent (e.g., Borne Upon a Wind)
+        container.get<FlashGrantsThisTurnComponent>()?.let { component ->
+            val filterDescription = component.filters
+                .joinToString(", ") { it.description }
+                .ifBlank { "Spells" }
+            effects.add(
+                ClientPlayerEffect(
+                    effectId = "flash_grants_this_turn",
+                    name = "Flash",
+                    description = "You may cast ${filterDescription.lowercase()} spells this turn " +
+                        "as though they had flash",
+                    icon = "lightning"
+                )
+            )
+        }
+
         // Check for PlayerHexproofComponent (e.g., Dawn's Truce)
         if (container.has<PlayerHexproofComponent>()) {
             effects.add(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BorneUponAWindTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BorneUponAWindTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.BorneUponAWind
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Borne Upon a Wind ({1}{U} Instant): "You may cast spells this turn as though they had
+ * flash. Draw a card."
+ *
+ * The flash-permission primitive (GrantFlashToSpellsEffect / FlashGrantsThisTurnComponent)
+ * has its own unit coverage in [GrantFlashToSpellsEffectTest]. This test pins the printed
+ * card text end-to-end:
+ *  * resolving Borne Upon a Wind grants flash AND draws exactly one card
+ *  * the controller can cast a sorcery during the end step of the same turn (CR 702.8a, 601.3)
+ *  * the grant clears at the cleanup step (CR 514.2), so the next turn the same sorcery
+ *    can no longer be cast at instant speed
+ */
+class BorneUponAWindTest : FunSpec({
+
+    val testSorcery = CardDefinition.sorcery(
+        name = "Test Sorcery",
+        manaCost = ManaCost.parse("{1}{R}"),
+        oracleText = "Draw a card.",
+        script = CardScript.spell(effect = DrawCardsEffect(1))
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BorneUponAWind, testSorcery))
+        return driver
+    }
+
+    test("resolving Borne Upon a Wind grants flash and draws exactly one card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val handBefore = driver.getHandSize(p1)
+        val spell = driver.putCardInHand(p1, "Borne Upon a Wind")
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = p1, cardId = spell, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+
+        // The "Draw a card" half resolved: putCardInHand bumped the hand by 1, but the cast
+        // moved it back out, leaving the net change = +1 from the draw.
+        driver.getHandSize(p1) shouldBe handBefore + 1
+
+        val grants = driver.state.getEntity(p1)?.get<FlashGrantsThisTurnComponent>()
+        grants.shouldNotBeNull()
+        grants.filters.size shouldBe 1
+    }
+
+    test("the controller may cast a sorcery during the end step the same turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val borne = driver.putCardInHand(p1, "Borne Upon a Wind")
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = p1, cardId = borne, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+
+        val sorcery = driver.putCardInHand(p1, "Test Sorcery")
+        driver.giveMana(p1, Color.RED, 2)
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("the flash grant does not survive into the next turn (CR 514.2)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val borne = driver.putCardInHand(p1, "Borne Upon a Wind")
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = p1, cardId = borne, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+        driver.state.getEntity(p1)?.get<FlashGrantsThisTurnComponent>().shouldNotBeNull()
+
+        // Advance past p1's CLEANUP into p2's upkeep.
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.state.getEntity(p1)?.get<FlashGrantsThisTurnComponent>().shouldBeNull()
+
+        val sorcery = driver.putCardInHand(p1, "Test Sorcery")
+        driver.giveMana(p1, Color.RED, 2)
+        driver.passPriorityUntil(Step.END)
+        driver.passPriority(p2) // priority on p1 during p2's end step
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfFriendOfTheShireTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfFriendOfTheShireTest.kt
@@ -1,0 +1,171 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.GandalfFriendOfTheShire
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gandalf, Friend of the Shire (LTR — {3}{U}, Legendary Creature — Avatar Wizard, 2/4):
+ *   Flash
+ *   You may cast sorcery spells as though they had flash.
+ *   Whenever the Ring tempts you, if you chose a creature other than Gandalf as your
+ *   Ring-bearer, draw a card.
+ *
+ * Each clause is exercised in isolation:
+ *  1. Flash keyword (printed) — covered by `QuickSliverTest`; Gandalf's own line
+ *     `keywords(Keyword.FLASH)` is a single-keyword wiring and not re-tested here.
+ *  2. Sorcery-flash static — controller can cast a sorcery during the end step; an opponent
+ *     who controls a creature spell (not a sorcery) cannot benefit.
+ *  3. Ring-tempts-you draw — fires only when the chosen Ring-bearer is a creature *other*
+ *     than Gandalf (CR 701.54a via [Conditions.YouChoseOtherCreatureAsRingBearer]).
+ */
+class GandalfFriendOfTheShireTest : FunSpec({
+
+    val testSorcery = CardDefinition.sorcery(
+        name = "Test Sorcery",
+        manaCost = ManaCost.parse("{1}{R}"),
+        oracleText = "Draw a card.",
+        script = CardScript.spell(effect = DrawCardsEffect(1))
+    )
+
+    val testCreature = CardDefinition.creature(
+        name = "Test Beast",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 2,
+        toughness = 2
+    )
+
+    val ringTempter = card("Ring Tempter") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "The Ring tempts you."
+        spell { effect = Effects.TheRingTemptsYou() }
+    }
+
+    val ringBear = CardDefinition.creature("Ring Bear", ManaCost.parse("{2}"), emptySet(), 2, 2)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(GandalfFriendOfTheShire, testSorcery, testCreature, ringTempter, ringBear)
+        )
+        return driver
+    }
+
+    fun GameTestDriver.tempt(player: EntityId, bearerId: EntityId?) {
+        val cardId = putCardInHand(player, "Ring Tempter")
+        castSpell(player, cardId)
+        bothPass()
+        val decision = pendingDecision
+        if (decision is SelectCardsDecision && bearerId != null) {
+            submitDecision(player, CardsSelectedResponse(decision.id, listOf(bearerId)))
+        }
+    }
+
+    // 2 — static flash-for-sorceries clause.
+
+    test("controller may cast a sorcery during the end step with Gandalf on the battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf, Friend of the Shire")
+        val sorcery = driver.putCardInHand(p1, "Test Sorcery")
+        driver.giveMana(p1, Color.RED, 2)
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("the static does not grant flash to a non-sorcery spell (e.g. a creature)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Forest" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf, Friend of the Shire")
+        val beast = driver.putCardInHand(p1, "Test Beast")
+        driver.giveMana(p1, Color.GREEN, 2)
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = beast, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("the static is controller-only: an opponent's sorcery does not gain flash") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf, Friend of the Shire")
+        val sorcery = driver.putCardInHand(p2, "Test Sorcery")
+        driver.giveMana(p2, Color.RED, 2)
+        driver.passPriorityUntil(Step.END)
+        driver.passPriority(p1)
+
+        val result = driver.submit(
+            CastSpell(playerId = p2, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+
+    // 3 — Ring-tempts-you draw clause.
+
+    test("draws a card when the Ring tempts you and you pick a creature other than Gandalf") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(active, "Gandalf, Friend of the Shire")
+        val bear = driver.putCreatureOnBattlefield(active, "Ring Bear")
+        val handBefore = driver.getHandSize(active)
+
+        driver.tempt(active, bear)
+        driver.bothPass() // resolve Gandalf's Ring-tempts trigger
+
+        driver.getHandSize(active) shouldBe handBefore + 1
+    }
+
+    test("does NOT draw when you choose Gandalf as your Ring-bearer") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gandalf = driver.putPermanentOnBattlefield(active, "Gandalf, Friend of the Shire")
+        driver.putCreatureOnBattlefield(active, "Ring Bear")
+        val handBefore = driver.getHandSize(active)
+
+        driver.tempt(active, gandalf)
+        driver.bothPass()
+
+        driver.getHandSize(active) shouldBe handBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheWhiteTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheWhiteTest.kt
@@ -11,22 +11,33 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Supertype
 import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalETBOrLTBTriggers
+import com.wingedsheep.sdk.scripting.BattlefieldDirection
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 /**
- * Gandalf the White ({3}{W}{W} Legendary Creature — Avatar Wizard 4/5) — partial:
- *   Flash                                                                       (printed keyword)
- *   You may cast legendary spells and artifact spells as though they had flash. (Gap 4)
- *   …extra-trigger replacement…                                                 (deferred; separate gap)
+ * Gandalf the White ({3}{W}{W} Legendary Creature — Avatar Wizard 4/5):
+ *   Flash
+ *   You may cast legendary spells and artifact spells as though they had flash.
+ *   If a legendary permanent or an artifact entering or leaving the battlefield causes a
+ *   triggered ability of a permanent you control to trigger, that ability triggers an
+ *   additional time.
  *
- * Pins the two implemented clauses:
- *  * a legendary creature spell becomes castable at instant speed
- *  * an artifact spell becomes castable at instant speed
- *  * a vanilla non-legendary non-artifact creature spell does NOT become castable
- *  * the static is controller-only — an opponent does not benefit
+ * Each clause is covered:
+ *  * Flash + flash-permission static — legendary/artifact spells castable at instant speed,
+ *    controller-only; vanilla spells unaffected.
+ *  * Trigger-count modifier (CR 603.2d) — ETB and LTB triggers of a permanent the controller
+ *    controls fire an additional time when caused by a legendary or artifact entering or
+ *    leaving. mustBeYouControl = false on the cause: opponent's legendary/artifact still
+ *    triggers the doubling. The "of a permanent you control" half remains controller-only.
  */
 class GandalfTheWhiteTest : FunSpec({
 
@@ -54,6 +65,65 @@ class GandalfTheWhiteTest : FunSpec({
         toughness = 2
     )
 
+    // Artifact creature so the same entity can both die on the battlefield (Doom Blade target)
+    // AND satisfy Gandalf's `Artifact ∨ Legendary` filter on the cause event.
+    val testArtifactCreature = CardDefinition.artifactCreature(
+        name = "Test Construct",
+        manaCost = ManaCost.parse("{2}"),
+        subtypes = setOf(Subtype("Construct")),
+        power = 1,
+        toughness = 1
+    )
+
+    // "Soul Warden"-ish witness — watches every other creature entering and draws a card.
+    // Drawing is observable via hand size; doubling shows up as +2 instead of +1 per ETB.
+    val etbWatcher = card("ETB Witness") {
+        manaCost = "{1}{W}"
+        typeLine = "Creature — Human Cleric"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever another creature enters the battlefield, draw a card."
+        triggeredAbility {
+            trigger = Triggers.entersBattlefield(
+                filter = GameObjectFilter.Creature,
+                binding = TriggerBinding.OTHER
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    // A non-legendary sibling of Gandalf's third clause — same primitive, broad filter, both
+    // directions. Used to assert that two ETB-or-LTB doublers stack additively without
+    // dragging the legend rule into the test.
+    val testDoubler = card("Test Extra-Trigger") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = "If a permanent entering or leaving the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time."
+        staticAbility {
+            ability = AdditionalETBOrLTBTriggers(
+                filter = GameObjectFilter.Any,
+                mustBeYouControl = false,
+                directions = setOf(BattlefieldDirection.ENTERING, BattlefieldDirection.LEAVING)
+            )
+        }
+    }
+
+    // Same shape for LTB. We avoid a graveyard restriction so sacrifice/destroy/return all work.
+    val ltbWatcher = card("LTB Witness") {
+        manaCost = "{1}{B}"
+        typeLine = "Creature — Human Cleric"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever another creature leaves the battlefield, draw a card."
+        triggeredAbility {
+            trigger = Triggers.leavesBattlefield(
+                filter = GameObjectFilter.Creature,
+                binding = TriggerBinding.OTHER
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
         driver.registerCards(
@@ -61,7 +131,11 @@ class GandalfTheWhiteTest : FunSpec({
                 GandalfTheWhite,
                 testLegendaryBeast,
                 testArtifact,
-                testPlainCreature
+                testPlainCreature,
+                testArtifactCreature,
+                etbWatcher,
+                ltbWatcher,
+                testDoubler
             )
         )
         return driver
@@ -135,5 +209,169 @@ class GandalfTheWhiteTest : FunSpec({
             CastSpell(playerId = p2, cardId = legendary, paymentStrategy = PaymentStrategy.FromPool)
         )
         result.isSuccess shouldBe false
+    }
+
+    // ------------------------------------------------------------------
+    // Third clause — "triggers an additional time" (CR 603.2d) via
+    // AdditionalETBOrLTBTriggers with directions = {ENTERING, LEAVING}.
+    // ------------------------------------------------------------------
+
+    test("ETB: a legendary creature entering doubles your ETB-watcher trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        driver.putCreatureOnBattlefield(p1, "ETB Witness")
+        val legendary = driver.putCardInHand(p1, "Test Legendary Beast")
+        driver.giveMana(p1, Color.GREEN, 2)
+
+        val handBefore = driver.getHandSize(p1)
+        driver.castSpell(p1, legendary).isSuccess shouldBe true
+        driver.bothPass()  // resolve the legendary
+        driver.bothPass()  // first ETB Witness draw
+        driver.bothPass()  // duplicated ETB Witness draw
+
+        // Cast (-1) + 2 draws from the doubled trigger = net +1.
+        (driver.getHandSize(p1) - handBefore) shouldBe 1
+    }
+
+    test("ETB: a non-legendary non-artifact creature does NOT double the trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        driver.putCreatureOnBattlefield(p1, "ETB Witness")
+        val bear = driver.putCardInHand(p1, "Test Bear")
+        driver.giveMana(p1, Color.GREEN, 2)
+
+        val handBefore = driver.getHandSize(p1)
+        driver.castSpell(p1, bear).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()  // single ETB Witness draw
+
+        // Cast (-1) + 1 draw (no doubling) = net 0.
+        (driver.getHandSize(p1) - handBefore) shouldBe 0
+    }
+
+    test("ETB: mustBeYouControl=false — opponent's legendary still doubles your ETB trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        driver.putCreatureOnBattlefield(p1, "ETB Witness")
+        val legendary = driver.putCardInHand(p2, "Test Legendary Beast")
+
+        // Advance to p2's main phase so they can cast the (non-flash) legendary creature at
+        // sorcery speed. Gandalf's flash-permission static is controller-only, so p2 can't
+        // borrow flash to cast it on p1's turn.
+        driver.passPriorityUntil(Step.UPKEEP)        // p2's upkeep
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN) // p2's precombat main
+        driver.giveMana(p2, Color.GREEN, 2)
+
+        val handBefore = driver.getHandSize(p1)
+        driver.castSpell(p2, legendary).isSuccess shouldBe true
+        driver.bothPass()  // resolve legendary
+        driver.bothPass()  // first ETB Witness draw (p1)
+        driver.bothPass()  // duplicated ETB Witness draw (p1)
+
+        // p1 doesn't cast — hand only grows from the doubled draws on p1's ETB Witness.
+        (driver.getHandSize(p1) - handBefore) shouldBe 2
+    }
+
+    test("ETB: 'of a permanent YOU control' — opponent's ETB Witness is not doubled by your Gandalf") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        driver.putCreatureOnBattlefield(p2, "ETB Witness")
+        val legendary = driver.putCardInHand(p1, "Test Legendary Beast")
+        driver.giveMana(p1, Color.GREEN, 2)
+
+        val p2HandBefore = driver.getHandSize(p2)
+        driver.castSpell(p1, legendary).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass() // single (un-doubled) opponent draw
+
+        // Opponent's ETB Witness fires once; Gandalf does NOT duplicate it because the
+        // trigger's controller is p2, not p1 (Gandalf's controller).
+        (driver.getHandSize(p2) - p2HandBefore) shouldBe 1
+    }
+
+    test("LTB: an artifact creature dying doubles your LTB-watcher trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        driver.putCreatureOnBattlefield(p1, "LTB Witness")
+        val construct = driver.putCreatureOnBattlefield(p1, "Test Construct")
+        val doomBlade = driver.putCardInHand(p1, "Doom Blade")
+        driver.giveMana(p1, Color.BLACK, 2)
+
+        val handBefore = driver.getHandSize(p1)
+        driver.castSpell(p1, doomBlade, listOf(construct)).isSuccess shouldBe true
+        driver.bothPass()  // resolve Doom Blade — Test Construct dies
+        driver.bothPass()  // first LTB Witness draw
+        driver.bothPass()  // duplicated LTB Witness draw
+
+        // p1 cast (-1 from hand) + 2 draws = net +1.
+        (driver.getHandSize(p1) - handBefore) shouldBe 1
+    }
+
+    test("LTB: a non-legendary non-artifact creature dying does NOT double the trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        driver.putCreatureOnBattlefield(p1, "LTB Witness")
+        val bear = driver.putCreatureOnBattlefield(p1, "Test Bear")
+        val doomBlade = driver.putCardInHand(p1, "Doom Blade")
+        driver.giveMana(p1, Color.BLACK, 2)
+
+        val handBefore = driver.getHandSize(p1)
+        driver.castSpell(p1, doomBlade, listOf(bear)).isSuccess shouldBe true
+        driver.bothPass()  // resolve Doom Blade
+        driver.bothPass()  // single LTB Witness draw
+
+        // p1 cast (-1 from hand) + 1 draw = net 0.
+        (driver.getHandSize(p1) - handBefore) shouldBe 0
+    }
+
+    test("two ETB-or-LTB doublers stack additively: an artifact ETB triggers the watcher three times") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Gandalf + a non-legendary sibling using the same primitive. Avoids the legend rule
+        // SBA that two Gandalfs would invoke once a spell resolves.
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        driver.putPermanentOnBattlefield(p1, "Test Extra-Trigger")
+        driver.putCreatureOnBattlefield(p1, "ETB Witness")
+        val construct = driver.putCardInHand(p1, "Test Construct")
+        driver.giveColorlessMana(p1, 2)
+
+        val handBefore = driver.getHandSize(p1)
+        driver.castSpell(p1, construct).isSuccess shouldBe true
+        driver.bothPass()  // resolve Test Construct ETB
+        driver.bothPass()  // original ETB Witness draw
+        driver.bothPass()  // duplicated by Gandalf
+        driver.bothPass()  // duplicated by Test Extra-Trigger
+
+        // p1 cast (-1 from hand) + 3 draws = net +2.
+        (driver.getHandSize(p1) - handBefore) shouldBe 2
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheWhiteTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheWhiteTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.GandalfTheWhite
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Supertype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gandalf the White ({3}{W}{W} Legendary Creature — Avatar Wizard 4/5) — partial:
+ *   Flash                                                                       (printed keyword)
+ *   You may cast legendary spells and artifact spells as though they had flash. (Gap 4)
+ *   …extra-trigger replacement…                                                 (deferred; separate gap)
+ *
+ * Pins the two implemented clauses:
+ *  * a legendary creature spell becomes castable at instant speed
+ *  * an artifact spell becomes castable at instant speed
+ *  * a vanilla non-legendary non-artifact creature spell does NOT become castable
+ *  * the static is controller-only — an opponent does not benefit
+ */
+class GandalfTheWhiteTest : FunSpec({
+
+    val testLegendaryBeast = CardDefinition.creature(
+        name = "Test Legendary Beast",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 2,
+        toughness = 2,
+        supertypes = setOf(Supertype.LEGENDARY)
+    )
+
+    val testArtifact = CardDefinition(
+        name = "Test Trinket",
+        manaCost = ManaCost.parse("{2}"),
+        typeLine = TypeLine.artifact(),
+        oracleText = ""
+    )
+
+    val testPlainCreature = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                GandalfTheWhite,
+                testLegendaryBeast,
+                testArtifact,
+                testPlainCreature
+            )
+        )
+        return driver
+    }
+
+    test("controller may cast a legendary creature at instant speed with Gandalf the White") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        val legendary = driver.putCardInHand(p1, "Test Legendary Beast")
+        driver.giveMana(p1, Color.GREEN, 2)
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = legendary, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("controller may cast an artifact at instant speed with Gandalf the White") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        val trinket = driver.putCardInHand(p1, "Test Trinket")
+        driver.giveColorlessMana(p1, 2)
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = trinket, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("a vanilla non-legendary non-artifact creature still can't be cast at instant speed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        val bear = driver.putCardInHand(p1, "Test Bear")
+        driver.giveMana(p1, Color.GREEN, 2)
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = bear, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("the static is controller-only: an opponent's legendary creature doesn't gain flash") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        val legendary = driver.putCardInHand(p2, "Test Legendary Beast")
+        driver.giveMana(p2, Color.GREEN, 2)
+        driver.passPriorityUntil(Step.END)
+        driver.passPriority(p1)
+
+        val result = driver.submit(
+            CastSpell(playerId = p2, cardId = legendary, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheWhiteTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheWhiteTest.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Supertype
 import com.wingedsheep.sdk.core.TypeLine
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.CardDefinition
@@ -108,6 +109,39 @@ class GandalfTheWhiteTest : FunSpec({
         }
     }
 
+    // A sorcery that makes a legendary 2/2 creature token. Used to prove the LTB doubler reads
+    // the cause's last-known type info (CR 603.10a): a token is swept by 704.5d as it dies, so
+    // matching its `Legendary`-ness against live state would fail — the doubler must consult the
+    // ZoneChangeEvent's last-known type line instead.
+    val summonLegendToken = card("Summon Legend") {
+        manaCost = "{1}{G}"
+        typeLine = "Sorcery"
+        oracleText = "Create a legendary 2/2 green Spirit creature token."
+        spell {
+            effect = Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Spirit"),
+                legendary = true
+            )
+        }
+    }
+
+    // Turns a plain creature into an artifact for as long as it's on the battlefield (Layer 4).
+    // Once it dies, its graveyard card line is the printed (non-artifact) one again — only the
+    // ZoneChangeEvent's last-known type line still records the artifact-ness. This is the case
+    // that distinguishes live-state matching from last-known matching in the LTB doubler.
+    val artifactify = card("Artifactify") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        oracleText = "Target creature becomes an artifact in addition to its other types."
+        spell {
+            val creature = target("target creature", Targets.Creature)
+            effect = Effects.AddCardType("ARTIFACT", creature)
+        }
+    }
+
     // Same shape for LTB. We avoid a graveyard restriction so sacrifice/destroy/return all work.
     val ltbWatcher = card("LTB Witness") {
         manaCost = "{1}{B}"
@@ -135,7 +169,9 @@ class GandalfTheWhiteTest : FunSpec({
                 testArtifactCreature,
                 etbWatcher,
                 ltbWatcher,
-                testDoubler
+                testDoubler,
+                summonLegendToken,
+                artifactify
             )
         )
         return driver
@@ -326,6 +362,70 @@ class GandalfTheWhiteTest : FunSpec({
         driver.bothPass()  // duplicated LTB Witness draw
 
         // p1 cast (-1 from hand) + 2 draws = net +1.
+        (driver.getHandSize(p1) - handBefore) shouldBe 1
+    }
+
+    test("LTB: a legendary creature TOKEN dying doubles your trigger via last-known type info (CR 603.10a)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        driver.putCreatureOnBattlefield(p1, "LTB Witness")
+
+        // Make the legendary token by resolving a real spell, so it enters legitimately.
+        val summon = driver.putCardInHand(p1, "Summon Legend")
+        driver.giveMana(p1, Color.GREEN, 2)
+        driver.castSpell(p1, summon).isSuccess shouldBe true
+        driver.bothPass()  // resolve Summon Legend → legendary 2/2 Spirit token
+
+        // The only creature that's neither Gandalf nor the witness is the token.
+        val token = driver.getCreatures(p1).first { id ->
+            driver.getCardName(id) !in setOf("Gandalf the White", "LTB Witness")
+        }
+
+        val doomBlade = driver.putCardInHand(p1, "Doom Blade")
+        driver.giveMana(p1, Color.BLACK, 2)
+
+        val handBefore = driver.getHandSize(p1)
+        driver.castSpell(p1, doomBlade, listOf(token)).isSuccess shouldBe true
+        driver.bothPass()  // resolve Doom Blade — the legendary token dies and is swept (704.5d)
+        driver.bothPass()  // first LTB Witness draw
+        driver.bothPass()  // duplicated LTB Witness draw (Gandalf, matching the token's last-known Legendary)
+
+        // Doom Blade cast (-1) + 2 draws from the doubled trigger = net +1.
+        (driver.getHandSize(p1) - handBefore) shouldBe 1
+    }
+
+    test("LTB: a creature made an artifact by a continuous effect, then dying, doubles via last-known type (CR 603.10a)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Plains" to 20))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Gandalf the White")
+        driver.putCreatureOnBattlefield(p1, "LTB Witness")
+        // Plain (non-artifact, non-legendary) creature — its PRINTED type never matches Gandalf.
+        val bear = driver.putCreatureOnBattlefield(p1, "Test Bear")
+
+        // Make the bear an artifact for as long as it's on the battlefield.
+        val artifactify = driver.putCardInHand(p1, "Artifactify")
+        driver.giveColorlessMana(p1, 1)
+        driver.castSpell(p1, artifactify, listOf(bear)).isSuccess shouldBe true
+        driver.bothPass()  // resolve Artifactify — bear is now an artifact creature on the battlefield
+
+        val doomBlade = driver.putCardInHand(p1, "Doom Blade")
+        driver.giveMana(p1, Color.BLACK, 2)
+
+        val handBefore = driver.getHandSize(p1)
+        driver.castSpell(p1, doomBlade, listOf(bear)).isSuccess shouldBe true
+        driver.bothPass()  // resolve Doom Blade — the (now-artifact) bear dies; in the graveyard it
+                           // is a plain creature again, so only last-known info records the artifact type
+        driver.bothPass()  // first LTB Witness draw
+        driver.bothPass()  // duplicated LTB Witness draw (Gandalf matches the bear's last-known Artifact type)
+
+        // Doom Blade cast (-1) + 2 draws from the doubled trigger = net +1.
         (driver.getHandSize(p1) - handBefore) shouldBe 1
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrantFlashToSpellsEffectTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrantFlashToSpellsEffectTest.kt
@@ -1,0 +1,293 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PlayerEffectRemoval
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantFlashToSpellsEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Covers the Gap 4 primitive: [GrantFlashToSpellsEffect] / `FlashGrantsThisTurnComponent`.
+ *
+ * Two layers of coverage:
+ *  1. **Direct cast-permission check** — seed `FlashGrantsThisTurnComponent` on a player and
+ *     confirm a sorcery-speed spell becomes castable during the end step, that opponents do not
+ *     benefit, and that the filter is honored.
+ *  2. **End-to-end resolution** — cast an inline analogue of Borne Upon a Wind ({1}{U} instant:
+ *     "You may cast spells this turn as though they had flash. Draw a card."), resolve it, then
+ *     confirm a sorcery becomes castable later in the turn and that cleanup at end of turn
+ *     removes the grant (CR 514.2).
+ *
+ * CR references verified against MagicCompRules_20260417.txt:
+ *  - 702.8a — flash means "you may play this card any time you could cast an instant"
+ *  - 601.3 — a player can begin to cast a spell only if a rule or effect allows it
+ *  - 514.2 — at the end-of-turn cleanup step, "until end of turn" effects end
+ */
+class GrantFlashToSpellsEffectTest : FunSpec({
+
+    val testSorcery = CardDefinition.sorcery(
+        name = "Test Sorcery",
+        manaCost = ManaCost.parse("{1}{R}"),
+        oracleText = "Draw a card.",
+        script = CardScript.spell(effect = DrawCardsEffect(1))
+    )
+
+    val testCreature = CardDefinition.creature(
+        name = "Test Beast",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 2,
+        toughness = 2
+    )
+
+    // Inline analogue of Borne Upon a Wind, restricted to the gap-4 portion + a draw, so
+    // end-to-end resolution can be exercised before the card itself lands in its own commit.
+    val flashGranter = CardDefinition.instant(
+        name = "Test Flash Granter",
+        manaCost = ManaCost.parse("{1}{U}"),
+        oracleText = "You may cast spells this turn as though they had flash. Draw a card.",
+        script = CardScript.spell(
+            effect = CompositeEffect(
+                listOf(
+                    GrantFlashToSpellsEffect(
+                        spellFilter = GameObjectFilter.Any,
+                        duration = Duration.EndOfTurn
+                    ),
+                    DrawCardsEffect(1)
+                )
+            )
+        )
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(testSorcery, testCreature, flashGranter)
+        )
+        return driver
+    }
+
+    // ------------------------------------------------------------------
+    // 1. Direct cast-permission tests — seed the component, verify lookup.
+    // ------------------------------------------------------------------
+
+    test("baseline: without the grant a sorcery can't be cast during the end step") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sorcery = driver.putCardInHand(p1, "Test Sorcery")
+        driver.giveMana(p1, Color.RED, 2)
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("FlashGrantsThisTurnComponent makes a sorcery legal at end step (CR 702.8a, 601.3)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sorcery = driver.putCardInHand(p1, "Test Sorcery")
+        driver.giveMana(p1, Color.RED, 2)
+
+        // Seed the player-scoped flash permission directly (any spell, EOT duration).
+        driver.replaceState(
+            driver.state.updateEntity(p1) { container ->
+                container.with(
+                    FlashGrantsThisTurnComponent(
+                        filters = listOf(GameObjectFilter.Any),
+                        removeOn = PlayerEffectRemoval.EndOfTurn
+                    )
+                )
+            }
+        )
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("the grant is owner-scoped: an opponent's matching spell does not gain flash") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sorcery = driver.putCardInHand(p2, "Test Sorcery")
+        driver.giveMana(p2, Color.RED, 2)
+
+        // Grant on p1 — p2's sorcery must NOT inherit flash.
+        driver.replaceState(
+            driver.state.updateEntity(p1) { container ->
+                container.with(
+                    FlashGrantsThisTurnComponent(
+                        filters = listOf(GameObjectFilter.Any),
+                        removeOn = PlayerEffectRemoval.EndOfTurn
+                    )
+                )
+            }
+        )
+        driver.passPriorityUntil(Step.END)
+        driver.passPriority(p1) // give p2 priority
+
+        val result = driver.submit(
+            CastSpell(playerId = p2, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("filter is respected: a Sorcery-only grant does not flash a creature spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val beast = driver.putCardInHand(p1, "Test Beast")
+        driver.giveMana(p1, Color.GREEN, 2)
+
+        driver.replaceState(
+            driver.state.updateEntity(p1) { container ->
+                container.with(
+                    FlashGrantsThisTurnComponent(
+                        filters = listOf(GameObjectFilter.Sorcery),
+                        removeOn = PlayerEffectRemoval.EndOfTurn
+                    )
+                )
+            }
+        )
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = beast, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("filter is respected: a Sorcery-only grant does flash a sorcery spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sorcery = driver.putCardInHand(p1, "Test Sorcery")
+        driver.giveMana(p1, Color.RED, 2)
+
+        driver.replaceState(
+            driver.state.updateEntity(p1) { container ->
+                container.with(
+                    FlashGrantsThisTurnComponent(
+                        filters = listOf(GameObjectFilter.Sorcery),
+                        removeOn = PlayerEffectRemoval.EndOfTurn
+                    )
+                )
+            }
+        )
+        driver.passPriorityUntil(Step.END)
+
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    // ------------------------------------------------------------------
+    // 2. End-to-end: resolve an analogue Borne-Upon-a-Wind effect.
+    // ------------------------------------------------------------------
+
+    test("resolving GrantFlashToSpellsEffect records the grant on the controller") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val granter = driver.putCardInHand(p1, "Test Flash Granter")
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = p1, cardId = granter, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+
+        val grants = driver.state.getEntity(p1)?.get<FlashGrantsThisTurnComponent>()
+        grants.shouldNotBeNull()
+        grants.filters shouldBe listOf(GameObjectFilter.Any)
+        grants.removeOn shouldBe PlayerEffectRemoval.EndOfTurn
+    }
+
+    test("the grant clears at the end-of-turn cleanup step (CR 514.2)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Seed the grant directly; we only want to assert cleanup, not the resolution path.
+        driver.replaceState(
+            driver.state.updateEntity(p1) { container ->
+                container.with(
+                    FlashGrantsThisTurnComponent(
+                        filters = listOf(GameObjectFilter.Any),
+                        removeOn = PlayerEffectRemoval.EndOfTurn
+                    )
+                )
+            }
+        )
+        driver.state.getEntity(p1)?.get<FlashGrantsThisTurnComponent>().shouldNotBeNull()
+
+        // Advance into the opponent's upkeep — p1's CLEANUP has already run on the way through.
+        // (UNTAP is auto-advanced past without exposing a priority window, so targeting UPKEEP.)
+        driver.passPriorityUntil(Step.UPKEEP)
+
+        driver.state.getEntity(p1)?.get<FlashGrantsThisTurnComponent>().shouldBeNull()
+    }
+
+    test("multiple grants stack additively in one component (filters list grows)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+
+        driver.replaceState(
+            driver.state.updateEntity(p1) { container ->
+                container.with(
+                    FlashGrantsThisTurnComponent(filters = listOf(GameObjectFilter.Sorcery))
+                )
+            }
+        )
+        val before = driver.state.getEntity(p1)?.get<FlashGrantsThisTurnComponent>()!!.filters.size
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val granter = driver.putCardInHand(p1, "Test Flash Granter")
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = p1, cardId = granter, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+
+        val after = driver.state.getEntity(p1)?.get<FlashGrantsThisTurnComponent>()!!.filters.size
+        (after - before) shouldBe 1
+    }
+})


### PR DESCRIPTION
## Summary
Closes Gap 4 and Gap 4b in LTR's TODO and implements the three cards that
needed them.

**Gap 4 — "cast [filter] spells as though they had flash"**
- New `Effects.GrantFlashToSpells(target, spellFilter, duration)` →
  `FlashGrantsThisTurnComponent` on the target player. Turn-scoped,
  player-scoped sibling of the existing permanent-static
  `GrantFlashToSpellType`; both are consulted by
  `CastPermissionUtils.hasGrantedFlash` / `CastZoneResolver.hasGrantedFlash`
  (CR 601.3b, 702.8a). Cleared at cleanup (CR 514.2).

**Gap 4b — "triggers an additional time" for ETB *or* LTB**
- Existing `AdditionalETBTriggers` (Panharmonicon family) reshaped into
  `AdditionalETBOrLTBTriggers` with a `Set<BattlefieldDirection>`. Default
  `{ENTERING}` keeps Panharmonicon / Naban / Starfield Vocalist / Traveling
  Chocobo behaviour byte-identical; add `LEAVING` for Gandalf-the-White-
  style "entering or leaving the battlefield" doublers. LTB path reads
  `ZoneChangeEvent.lastKnownController` (CR 603.10a). CR 603.2d.

**Cards (LTR)**
- Borne Upon a Wind — Effect-only.
- Gandalf, Friend of the Shire — Flash + sorcery-flash static + existing
  Ring-tempts-you condition.
- Gandalf the White — Flash + legendary/artifact flash static + reshaped
  ETB-or-LTB doubler with `mustBeYouControl = false`.

Implemented count: 194 → 197 / 291.

## Test plan
- [x] `:rules-engine:test` — full suite green, incl. 22 new tests across
  `BorneUponAWindTest`, `GandalfFriendOfTheShireTest`,
  `GandalfTheWhiteTest`, `GrantFlashToSpellsEffectTest`.
- [x] `just check-card-printing` clean for all three cards (canonical in
  earliest real LTR printing).