### PR TITLE
Fix Gloom Ripper: count noncreature Changeling Elves toward X

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/GloomRipper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/GloomRipper.kt
@@ -48,8 +48,10 @@ val GloomRipper = card("Gloom Ripper") {
             )
         )
 
+        // "Elves you control" counts every Elf permanent, not just Elf creatures — a noncreature
+        // Changeling permanent (e.g. Firdoch Core) is an Elf, so filter on Permanent, not Creature.
         val elfCount = DynamicAmount.Add(
-            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.withSubtype(Subtype.ELF)).count(),
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Permanent.withSubtype(Subtype.ELF)).count(),
             DynamicAmounts.zone(Player.You, Zone.GRAVEYARD, GameObjectFilter.Any.withSubtype(Subtype.ELF)).count()
         )
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GloomRipperTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GloomRipperTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Gloom Ripper:
+ * {3}{B}{B} Creature — Elf Assassin 4/4
+ * When this creature enters, target creature you control gets +X/+0 until end of turn
+ * and up to one target creature an opponent controls gets -0/-X until end of turn, where X is
+ * the number of Elves you control plus the number of Elf cards in your graveyard.
+ *
+ * Regression: "Elves you control" must count every Elf permanent, not only Elf creatures. A
+ * noncreature Changeling permanent (Firdoch Core — Kindred Artifact — Shapeshifter) is an Elf
+ * and must count toward X.
+ */
+class GloomRipperTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("noncreature Changeling artifact counts toward Gloom Ripper's X") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A noncreature Changeling permanent — Firdoch Core is every creature type, so it is an Elf.
+        driver.putPermanentOnBattlefield(activePlayer, "Firdoch Core")
+
+        // The +X/+0 target: a vanilla 2/2 that is NOT an Elf, so it doesn't inflate the count.
+        val bears = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+
+        // Cast Gloom Ripper so its enters trigger fires.
+        val ripperCard = driver.putCardInHand(activePlayer, "Gloom Ripper")
+        driver.giveMana(activePlayer, Color.BLACK, 5)
+        driver.castSpell(activePlayer, ripperCard)
+        driver.bothPass() // Resolve Gloom Ripper; enters trigger goes on the stack.
+
+        // Choose the Grizzly Bears for the mandatory "creature you control" target.
+        // The opponent controls no creatures, so the "up to one" enemy target is empty.
+        driver.submitMultiTargetSelection(activePlayer, mapOf(0 to listOf(bears)))
+
+        driver.bothPass() // Resolve the enters trigger.
+
+        // X = Elves you control (Gloom Ripper itself + Firdoch Core via Changeling) = 2.
+        // Grizzly Bears is a 2/2, so +X/+0 makes it 4/2. Before the fix, Firdoch Core was
+        // ignored (it isn't a creature) and X would have been 1, yielding 3/2.
+        val projected = projector.project(driver.state)
+        projected.getPower(bears) shouldBe 4
+        projected.getToughness(bears) shouldBe 2
+    }
+})


### PR DESCRIPTION
## Problem

Gloom Ripper's enters trigger gives +X/+0 / -0/-X where **X = the number of Elves you control plus the number of Elf cards in your graveyard**. The battlefield half of that count used `GameObjectFilter.Creature.withSubtype(ELF)`, which requires the permanent to be a *creature*.

"Elves you control" counts every **Elf permanent**, not just Elf creatures. A noncreature Changeling permanent — e.g. **Firdoch Core** (`Kindred Artifact — Shapeshifter` with Changeling) — is every creature type, so it is an Elf and must count toward X even while it isn't a creature. It was silently dropped from the count.

## Fix

Switch the battlefield filter from `Creature` to `Permanent` so noncreature Elf permanents are included. The aggregate already evaluates the filter against projected state, so Changeling's granted subtypes are honored. The graveyard half already used the broad `Any` filter and was unaffected.

## Test

`GloomRipperTest` puts a Firdoch Core (noncreature Changeling artifact) and a vanilla Grizzly Bears on the battlefield, then casts Gloom Ripper. X = 2 (Gloom Ripper itself + Firdoch Core via Changeling), so the Bears becomes 4/2. Verified the test fails on the old `Creature` filter (X = 1 → 3/2) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)