### PR TITLE
Fix Fertile Ground any-color bonus not counting toward spell affordability

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2214,6 +2214,12 @@ sibling effect that reads `DynamicAmount.EntityProperty(EntityReference.AmassedA
 - `ChosenNumber` — number a player chose via a Choose action.
 - `VariableReference(name)` — named variable stored earlier by `StoreResult`/`StoreCount`.
 - `ColorsAmongPermanents(player)` — count of distinct colors among player's permanents.
+- `DistinctEntitiesInCollections(collections)` — number of *distinct* entities across the named
+  pipeline collections (union, de-duplicated by entity id). Facade: `DynamicAmounts.distinctEntitiesIn(vararg)`.
+  For "you affected N *different* objects" payoffs spread over several resolution-time selections —
+  e.g. Call the Spirit Dragons puts a +1/+1 counter on a chosen Dragon of each color (one `SelectTarget`
+  per color, each stored under its own key) and wins if five *different* Dragons received counters, so a
+  multicolored Dragon chosen for two colors counts once.
 
 ### `ManaColorSet`<a id="manacolorset"></a>
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -169,6 +169,14 @@ object DynamicAmounts {
             DynamicAmount.Fixed(1)
         )
 
+    /**
+     * Number of distinct entities across the named pipeline collections (union, de-duplicated
+     * by entity id). For "you affected N *different* objects" payoffs spread over several
+     * resolution-time selections — see [DynamicAmount.DistinctEntitiesInCollections].
+     */
+    fun distinctEntitiesIn(vararg collections: String): DynamicAmount =
+        DynamicAmount.DistinctEntitiesInCollections(collections.toList())
+
     // =========================================================================
     // Graveyard counting
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -316,6 +316,22 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         override val description: String = "the mana value of the $collectionName card"
     }
 
+    /**
+     * Number of *distinct* entities across several named pipeline collections.
+     *
+     * Each listed collection is unioned and de-duplicated by entity id, then the size of the
+     * union is returned. Use this for "did you affect N *different* objects" payoffs where the
+     * same object may have been selected in more than one pipeline step — e.g. Call the Spirit
+     * Dragons puts a +1/+1 counter on a Dragon you control of each color (one selection per
+     * color) and wins if five *different* Dragons received counters, even though a multicolored
+     * Dragon could have been chosen for two colors.
+     */
+    @SerialName("DistinctEntitiesInCollections")
+    @Serializable
+    data class DistinctEntitiesInCollections(val collections: List<String>) : DynamicAmount {
+        override val description: String = "the number of distinct selected permanents"
+    }
+
     // =========================================================================
     // Math Operations - Composable arithmetic on DynamicAmounts
     // =========================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CallTheSpiritDragons.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/CallTheSpiritDragons.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.tdm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Call the Spirit Dragons
+ * {W}{U}{B}{R}{G}
+ * Enchantment
+ *
+ * Dragons you control have indestructible.
+ * At the beginning of your upkeep, for each color, put a +1/+1 counter on a Dragon you control
+ * of that color. If you put +1/+1 counters on five Dragons this way, you win the game.
+ *
+ * Implementation notes:
+ * - "for each color" means each of the five colors (WUBRG), so the upkeep ability is one
+ *   resolution-time choice per color rather than a `ForEachColorOf` over the source's colors.
+ * - Putting a counter "on a Dragon you control of that color" is a *choice* (no "target"), so it
+ *   uses [Effects.SelectTarget] (resolution-time pick), not a declared trigger target. A
+ *   multicolored Dragon is a legal choice for every color it is, and may be chosen more than once.
+ * - The win condition fires only when five *different* Dragons each received a counter. Each
+ *   color's pick is stored under its own pipeline key and the win check counts the *distinct*
+ *   entities across all five keys via [DynamicAmounts.distinctEntitiesIn], so picking the same
+ *   multicolored Dragon for two colors correctly counts as one Dragon toward the win.
+ */
+val CallTheSpiritDragons = card("Call the Spirit Dragons") {
+    manaCost = "{W}{U}{B}{R}{G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Enchantment"
+    oracleText = "Dragons you control have indestructible.\n" +
+        "At the beginning of your upkeep, for each color, put a +1/+1 counter on a Dragon you control " +
+        "of that color. If you put +1/+1 counters on five Dragons this way, you win the game."
+
+    // Dragons you control have indestructible.
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.INDESTRUCTIBLE,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl().withSubtype(Subtype.DRAGON))
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+
+        // One choice per color (WUBRG). Each stores its picked Dragon under a distinct key.
+        val perColor = listOf(
+            Color.WHITE to "spiritDragonW",
+            Color.BLUE to "spiritDragonU",
+            Color.BLACK to "spiritDragonB",
+            Color.RED to "spiritDragonR",
+            Color.GREEN to "spiritDragonG"
+        )
+        val counterSteps = perColor.flatMap { (color, key) ->
+            val dragonOfColor = TargetCreature(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.youControl().withSubtype(Subtype.DRAGON).withColor(color)
+                )
+            )
+            listOf(
+                Effects.SelectTarget(dragonOfColor, key),
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.PipelineTarget(key))
+            )
+        }
+
+        // If five different Dragons received a +1/+1 counter this way, you win the game.
+        val winIfFiveDistinct = ConditionalEffect(
+            condition = Compare(
+                DynamicAmounts.distinctEntitiesIn(*perColor.map { it.second }.toTypedArray()),
+                ComparisonOperator.GTE,
+                DynamicAmount.Fixed(5)
+            ),
+            effect = Effects.WinGame(message = "Five spirit Dragons answered the call.")
+        )
+
+        effect = Effects.Composite(counterSteps + winIfFiveDistinct)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "174"
+        artist = "Liiga Smilshkalne"
+        flavorText = "The essence of Tarkir was shaped into draconic embodiments of the re-formed clans."
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1ad91db-5f16-4392-baf1-f8400ec11e0a.jpg?1743204672"
+        ruling("2025-04-04", "If you control a Dragon that is more than one color, you may put more than one +1/+1 counter on it with the last ability of Call the Spirit Dragons.")
+        ruling("2025-04-04", "The last ability will only cause you to win the game if you put a +1/+1 counter on each of five different Dragons with it.")
+        ruling("2025-04-04", "Because damage remains marked on a creature until the damage is removed as the turn ends, nonlethal damage dealt to a Dragon you control may become lethal if Call the Spirit Dragons leaves the battlefield during that turn.")
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -113,6 +113,13 @@ class DynamicAmountEvaluator(
                 state.getEntity(cardId)?.get<CardComponent>()?.manaValue ?: 0
             }
 
+            is DynamicAmount.DistinctEntitiesInCollections -> {
+                amount.collections
+                    .flatMap { context.pipeline.storedCollections[it].orEmpty() }
+                    .distinct()
+                    .size
+            }
+
             // Math operations — propagate [projectedState] so a mid-projection caller's
             // intermediate snapshot survives nested aggregates.
             is DynamicAmount.Add ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -392,6 +392,45 @@ class ManaSolver(
             return true
         }
 
+        // Helper for a colored pip that no *printed* source can produce, but an as-yet-untapped
+        // source carries an aura tap-bonus that can (Fertile Ground's "one mana of any color", or a
+        // fixed-color bonus matching the pip). Tapping such a source yields its printed mana PLUS the
+        // bonus; both flow into the bonus pool so the printed mana stays available for later passes
+        // (or floats), and one bonus is spent on this pip. Returns false when no bonus source fits.
+        //
+        // Without this, the colored pass — which runs before any source is tapped — sees an empty
+        // bonus pool and bails on a pip like {R} when the player's only red comes from a Fertile
+        // Ground forest, even though tapping that forest would produce it.
+        fun payColoredPipFromAuraBonus(color: Color): Boolean {
+            val source = remainingSources.firstOrNull { src ->
+                src.bonusManaPerTap > 0 && (src.bonusManaIsAnyColor || src.bonusManaColor == color)
+            } ?: return false
+            usedSources.add(source)
+            remainingSources.remove(source)
+            for (c in source.producesColors) {
+                availableSourcesByColor[c] = (availableSourcesByColor[c] ?: 1) - 1
+            }
+            // Printed mana → recorded as produced (mana-spent tally) and routed into the bonus pool
+            // so the generic pass can consume it (or it floats back to the player's pool).
+            val primaryColor = source.availableColorsFor(spellContext).firstOrNull()
+            if (primaryColor != null) {
+                manaProduced[source.entityId] = ManaProduction(color = primaryColor, amount = source.manaAmount)
+                bonusManaPool.add(BonusManaEntry(primaryColor, source.manaAmount, source.restriction))
+            } else {
+                manaProduced[source.entityId] = ManaProduction(colorless = source.manaAmount)
+            }
+            // Aura bonus → bonus pool (any-color or fixed), then spend one toward this pip.
+            bonusManaPool.add(
+                BonusManaEntry(
+                    color = source.bonusManaColor ?: Color.WHITE,
+                    amount = source.bonusManaPerTap,
+                    restriction = null,
+                    anyColor = source.bonusManaIsAnyColor,
+                )
+            )
+            return spendBonusMana(color)
+        }
+
         // 1. Pay colored costs first (most constrained)
         for (symbol in cost.symbols) {
             when (symbol) {
@@ -400,7 +439,12 @@ class ManaSolver(
                     if (spendBonusMana(symbol.color)) continue
 
                     val source = findBestSourceForColor(remainingSources, symbol.color, handRequirements, availableSourcesByColor, spellContext)
-                        ?: return null // Can't pay this colored cost
+                    if (source == null) {
+                        // No printed source makes this color. Fall back to an aura tap-bonus
+                        // (e.g. only a Fertile Ground forest can supply the {R}).
+                        if (payColoredPipFromAuraBonus(symbol.color)) continue
+                        return null // Can't pay this colored cost
+                    }
 
                     manaProduced[source.entityId] = ManaProduction(color = symbol.color, amount = source.manaAmount)
                     useSource(source, symbol.color)
@@ -418,7 +462,12 @@ class ManaSolver(
                     val source2 = findBestSourceForColor(remainingSources, symbol.color2, handRequirements, availableSourcesByColor, spellContext)
 
                     val source = when {
-                        source1 == null && source2 == null -> return null
+                        source1 == null && source2 == null -> {
+                            // Neither color has a printed source; try an aura tap-bonus for either.
+                            if (payColoredPipFromAuraBonus(symbol.color1)) continue
+                            if (payColoredPipFromAuraBonus(symbol.color2)) continue
+                            return null
+                        }
                         source1 == null -> source2!!
                         source2 == null -> source1
                         else -> {
@@ -441,7 +490,10 @@ class ManaSolver(
 
                     // For now, always pay with mana (not life)
                     val source = findBestSourceForColor(remainingSources, symbol.color, handRequirements, availableSourcesByColor, spellContext)
-                        ?: return null
+                    if (source == null) {
+                        if (payColoredPipFromAuraBonus(symbol.color)) continue
+                        return null
+                    }
 
                     manaProduced[source.entityId] = ManaProduction(color = symbol.color, amount = source.manaAmount)
                     useSource(source, symbol.color)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CallTheSpiritDragonsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CallTheSpiritDragonsScenarioTest.kt
@@ -1,0 +1,169 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.CallTheSpiritDragons
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Call the Spirit Dragons:
+ * {W}{U}{B}{R}{G} Enchantment
+ *
+ * Dragons you control have indestructible.
+ * At the beginning of your upkeep, for each color, put a +1/+1 counter on a Dragon you control
+ * of that color. If you put +1/+1 counters on five Dragons this way, you win the game.
+ */
+class CallTheSpiritDragonsScenarioTest : FunSpec({
+
+    fun dragon(name: String, cost: String) = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse(cost),
+        subtypes = setOf(Subtype.DRAGON),
+        power = 4,
+        toughness = 4
+    )
+
+    val WhiteDragon = dragon("Test White Dragon", "{4}{W}")
+    val BlueDragon = dragon("Test Blue Dragon", "{4}{U}")
+    val BlackDragon = dragon("Test Black Dragon", "{4}{B}")
+    val RedDragon = dragon("Test Red Dragon", "{4}{R}")
+    val GreenDragon = dragon("Test Green Dragon", "{4}{G}")
+    val FiveColorDragon = dragon("Test Wedge Dragon", "{W}{U}{B}{R}{G}")
+    val PlainBear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                CallTheSpiritDragons, WhiteDragon, BlueDragon, BlackDragon,
+                RedDragon, GreenDragon, FiveColorDragon, PlainBear
+            )
+        )
+        return driver
+    }
+
+    fun advanceToControllerUpkeep(driver: GameTestDriver, controller: EntityId) {
+        driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        if (driver.activePlayer != controller) {
+            driver.passPriorityUntil(Step.DRAW, maxPasses = 200)
+            driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        }
+        driver.currentStep shouldBe Step.UPKEEP
+        driver.activePlayer shouldBe controller
+    }
+
+    fun counters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("Dragons you control have indestructible; other creatures and opponents' Dragons do not") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Call the Spirit Dragons")
+        val myDragon = driver.putCreatureOnBattlefield(controller, "Test Red Dragon")
+        val myBear = driver.putCreatureOnBattlefield(controller, "Test Bear")
+        val theirDragon = driver.putCreatureOnBattlefield(opponent, "Test Blue Dragon")
+
+        val projected = StateProjector().project(driver.state)
+        projected.hasKeyword(myDragon, Keyword.INDESTRUCTIBLE) shouldBe true
+        projected.hasKeyword(myBear, Keyword.INDESTRUCTIBLE) shouldBe false
+        projected.hasKeyword(theirDragon, Keyword.INDESTRUCTIBLE) shouldBe false
+    }
+
+    test("five different-colored Dragons each get a counter and you win the game") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+
+        val controller = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Call the Spirit Dragons")
+        val w = driver.putCreatureOnBattlefield(controller, "Test White Dragon")
+        val u = driver.putCreatureOnBattlefield(controller, "Test Blue Dragon")
+        val b = driver.putCreatureOnBattlefield(controller, "Test Black Dragon")
+        val r = driver.putCreatureOnBattlefield(controller, "Test Red Dragon")
+        val g = driver.putCreatureOnBattlefield(controller, "Test Green Dragon")
+
+        advanceToControllerUpkeep(driver, controller)
+        driver.stackSize shouldBe 1
+        // Each color has exactly one legal Dragon, so every pick auto-resolves (no decision).
+        driver.bothPass()
+
+        // One +1/+1 counter on each of the five Dragons.
+        counters(driver, w) shouldBe 1
+        counters(driver, u) shouldBe 1
+        counters(driver, b) shouldBe 1
+        counters(driver, r) shouldBe 1
+        counters(driver, g) shouldBe 1
+
+        // Five different Dragons received counters → controller wins.
+        driver.assertGameOver(expectedWinner = controller)
+    }
+
+    test("a single five-color Dragon gets five counters but does NOT win the game") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+
+        val controller = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Call the Spirit Dragons")
+        val wedge = driver.putCreatureOnBattlefield(controller, "Test Wedge Dragon")
+
+        advanceToControllerUpkeep(driver, controller)
+        driver.stackSize shouldBe 1
+        // The five-color Dragon is the only legal pick for every color, so all picks auto-resolve.
+        driver.bothPass()
+
+        // It received one counter per color = five counters, but it is only one Dragon.
+        counters(driver, wedge) shouldBe 5
+        driver.state.gameOver shouldBe false
+    }
+
+    test("only four colors covered: counters placed, but you do not win") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+
+        val controller = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Call the Spirit Dragons")
+        val w = driver.putCreatureOnBattlefield(controller, "Test White Dragon")
+        val u = driver.putCreatureOnBattlefield(controller, "Test Blue Dragon")
+        val b = driver.putCreatureOnBattlefield(controller, "Test Black Dragon")
+        val r = driver.putCreatureOnBattlefield(controller, "Test Red Dragon")
+        // No green Dragon.
+
+        advanceToControllerUpkeep(driver, controller)
+        driver.stackSize shouldBe 1
+        driver.bothPass()
+
+        counters(driver, w) shouldBe 1
+        counters(driver, u) shouldBe 1
+        counters(driver, b) shouldBe 1
+        counters(driver, r) shouldBe 1
+        // Only four Dragons received counters → no win.
+        driver.state.gameOver shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FertileGroundAnyColorAffordabilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FertileGroundAnyColorAffordabilityTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.LegalActionEnricher
+import com.wingedsheep.mtg.sets.definitions.inv.cards.ChaoticStrike
+import com.wingedsheep.mtg.sets.definitions.inv.cards.FertileGround
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression: Fertile Ground's "add an additional one mana of any color" lets the enchanted land
+ * pay a colored pip no other source can produce. The auto-tap solver paid colored pips before
+ * tapping any source, so the any-color bonus — which only lands in the bonus pool once its source
+ * is tapped — was invisible to the colored pass. A player whose only red came from a Fertile Ground
+ * forest was told they could not afford `{1}{R}`, so the engine never paused to offer the trick.
+ *
+ * Reported via: attacking with a 2/1 (Goblin Guide) into a 1/1 (Savannah Lions) block, holding
+ * Chaotic Strike ({1}{R}) with only forests in play — one enchanted with Fertile Ground. The engine
+ * skipped the declare-blockers priority window because it judged Chaotic Strike unaffordable.
+ */
+class FertileGroundAnyColorAffordabilityTest : FunSpec({
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FertileGround, ChaoticStrike))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    /** Put a non-creature aura on the battlefield already attached to [target]. */
+    fun GameTestDriver.attachAura(playerId: EntityId, cardDef: CardDefinition, target: EntityId): EntityId {
+        val auraId = EntityId.generate()
+        val cardComponent = CardComponent(
+            cardDefinitionId = cardDef.name,
+            name = cardDef.name,
+            manaCost = cardDef.manaCost,
+            typeLine = cardDef.typeLine,
+            oracleText = cardDef.oracleText,
+            baseStats = cardDef.creatureStats,
+            baseKeywords = cardDef.keywords,
+            baseFlags = cardDef.flags,
+            colors = cardDef.colors,
+            ownerId = playerId,
+            spellEffect = cardDef.spellEffect
+        )
+        val container = ComponentContainer.of(
+            cardComponent,
+            OwnerComponent(playerId),
+            ControllerComponent(playerId),
+            AttachedToComponent(target)
+        )
+        var newState = state.withEntity(auraId, container)
+        newState = newState.addToZone(ZoneKey(playerId, Zone.BATTLEFIELD), auraId)
+        val existing = newState.getEntity(target)?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(target) { it.with(AttachmentsComponent(existing + auraId)) }
+        replaceState(newState)
+        return auraId
+    }
+
+    test("two plain forests cannot pay {1}{R} (no red source)") {
+        val (driver, you) = newGame()
+        repeat(2) { driver.putLandOnBattlefield(you, "Forest") }
+
+        ManaSolver(driver.cardRegistry)
+            .canPay(driver.state, you, ManaCost.parse("{1}{R}")) shouldBe false
+    }
+
+    test("a Fertile Ground forest supplies the {R}, making {1}{R} payable") {
+        val (driver, you) = newGame()
+        driver.putLandOnBattlefield(you, "Forest")
+        val enchantedForest = driver.putLandOnBattlefield(you, "Forest")
+        driver.attachAura(you, FertileGround, enchantedForest)
+
+        ManaSolver(driver.cardRegistry)
+            .canPay(driver.state, you, ManaCost.parse("{1}{R}")) shouldBe true
+    }
+
+    test("a single Fertile Ground forest pays {1}{R} on its own (printed {G} + any-color bonus)") {
+        val (driver, you) = newGame()
+        val enchantedForest = driver.putLandOnBattlefield(you, "Forest")
+        driver.attachAura(you, FertileGround, enchantedForest)
+
+        val solver = ManaSolver(driver.cardRegistry)
+        // {G} pays the generic {1}; the any-color bonus pays the {R}.
+        solver.canPay(driver.state, you, ManaCost.parse("{1}{R}")) shouldBe true
+        // And the bonus alone covers a lone colored pip.
+        solver.canPay(driver.state, you, ManaCost.parse("{R}")) shouldBe true
+    }
+
+    test("Chaotic Strike is an affordable legal action in the declare-blockers window via Fertile Ground") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FertileGround, ChaoticStrike))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val attacker = driver.activePlayer!!
+        val defender = if (attacker == driver.player1) driver.player2 else driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val goblin = driver.putCreatureOnBattlefield(attacker, "Goblin Guide")     // 2/1
+        val lions = driver.putCreatureOnBattlefield(defender, "Savannah Lions")    // 1/1
+        driver.removeSummoningSickness(goblin)
+
+        // Attacker holds Chaotic Strike and only forests — one enchanted with Fertile Ground.
+        driver.putCardInHand(attacker, "Chaotic Strike")
+        driver.putLandOnBattlefield(attacker, "Forest")
+        val enchantedForest = driver.putLandOnBattlefield(attacker, "Forest")
+        driver.attachAura(attacker, FertileGround, enchantedForest)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(goblin), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(defender, mapOf(lions to listOf(goblin)))
+        driver.submit(PassPriority(defender))
+
+        // Active player now holds the pre-damage priority window (where Chaotic Strike is legal).
+        driver.state.priorityPlayerId shouldBe attacker
+        driver.currentStep shouldBe Step.DECLARE_BLOCKERS
+
+        val services = EngineServices(driver.cardRegistry)
+        val enumerator = LegalActionEnumerator(
+            driver.cardRegistry, services.manaSolver, services.costCalculator,
+            services.predicateEvaluator, services.conditionEvaluator, services.turnManager
+        )
+        val enricher = LegalActionEnricher(services.manaSolver, driver.cardRegistry)
+        val legalActions = enricher.enrich(enumerator.enumerate(driver.state, attacker), driver.state, attacker)
+
+        val chaoticStrike = legalActions.filter {
+            it.actionType == "CastSpell" && it.description.contains("Chaotic Strike", ignoreCase = true)
+        }
+        chaoticStrike.shouldNotBeEmpty()
+        chaoticStrike.first().isAffordable shouldBe true
+    }
+})


### PR DESCRIPTION
## Problem

A player attacking with a 2/1 into a 1/1 block, holding **Chaotic Strike** (`{1}{R}`) with only forests in play — one enchanted with **Fertile Ground** — was never offered the spell. The engine skipped the declare-blockers priority window because it judged Chaotic Strike unaffordable, even though the Fertile Ground forest can produce the `{R}`.

## Root cause

`ManaSolver.solve()` pays colored pips **first**, before tapping any source. An aura tap-bonus like Fertile Ground's *"add an additional one mana of any color"* only enters the bonus pool **once its source is tapped** (in `useSource`). So when the colored pass reached the `{R}` pip:

1. The bonus pool was still empty → `spendBonusMana(RED)` failed.
2. No *printed* source produces red (forests make green) → `findBestSourceForColor` returned null.
3. `solve()` returned `null` → `canPay()` returned false → the spell was treated as unaffordable and the engine never paused.

This was order-dependent and affected any colored pip whose only payment was an any-color (or matching fixed-color) aura bonus on a not-yet-tapped source.

## Fix

Add `payColoredPipFromAuraBonus(color)` to the solver. When no printed source can pay a colored pip, it taps an untapped source whose aura bonus can. Both the source's printed mana **and** its aura bonus flow into the bonus pool, so the printed mana stays available for the generic pass (or floats back to the player's pool), and one bonus is spent on the pip. Wired into the colored, hybrid, and Phyrexian pip passes (the monocolored-hybrid pass already falls back to its generic side).

The fix is a last-resort fallback — it only runs when the normal printed-source lookup fails, so existing payments are unchanged.

## Tests

New `FertileGroundAnyColorAffordabilityTest`:
- two plain forests **cannot** pay `{1}{R}` (no red source);
- a Fertile Ground forest makes `{1}{R}` payable;
- a single Fertile Ground forest pays `{1}{R}` on its own (printed `{G}` + any-color bonus) and a lone `{R}`;
- end-to-end: Chaotic Strike is an **affordable legal action** in the declare-blockers window (reproduces the reported scenario via `LegalActionEnumerator` + `LegalActionEnricher`).

Full `:rules-engine:test` suite passes, including the existing Fertile Ground / Hidden Grotto / monocolored-hybrid / Maelstrom mana tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)