### PR TITLE
Add Tannuk, Steadfast Second to Edge of Eternities with hand-warp gra…

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 255 / 261
+**Implemented:** 257 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -125,7 +125,7 @@
 - [x] Larval Scoutlander
 - [x] Lashwhip Predator
 - [x] Lightless Evangel
-- [ ] Lightstall Inquisitor
+- [x] Lightstall Inquisitor
 - [x] Lithobraking
 - [x] Loading Zone
 - [x] Lost in Space
@@ -226,7 +226,7 @@
 - [x] Syr Vondam, the Lucent
 - [x] Systems Override
 - [x] Tannuk, Memorial Ensign
-- [ ] Tannuk, Steadfast Second
+- [x] Tannuk, Steadfast Second
 - [x] Tapestry Warden
 - [x] Temporal Intervention
 - [ ] Terminal Velocity

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1619,7 +1619,10 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   by CR 702.185a and the granters' "in your hand" wording — the grant doesn't extend warp to other
   zones. Routed through `WarpGrants.effectiveWarp` alongside printed warp; the granter's controller
   is the only beneficiary. (Tannuk, Steadfast Second = `GrantWarpToCardsInHand(filter = artifact OR
-  red creature, cost = {2}{R})`.)
+  red creature, cost = {2}{R})`.) When the granted warp lands on a card that *also* has another
+  alternative cost (e.g. a red evoke creature), both casts are offered and disambiguated by
+  `CastSpell.alternativeCostType` (see `engine-server-interface.md`) — picking "Evoke" charges the
+  evoke cost, not warp, even though warp would win a naive priority order.
 - `MayCastWithoutPayingManaCost(controllerOnly = false, firstSpellOfTurnOnly = false, spellFilter = Any)` — a
   battlefield permission to cast a spell without paying its mana cost (CR 118.9). Composable
   gates: `controllerOnly = true` restricts the benefit to the source's controller ("you" wording);

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1612,6 +1612,14 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   Yawgmoth's Agenda (`MayCastFromGraveyard(Nonland)`); `lifeCost = 1, duringYourTurnOnly = true` for
   Festival of Embers. Pair with `MayPlayLandsFromGraveyard` for "play lands and cast spells from
   your graveyard". Lands are *played*, not cast, so they need the lands permission separately.
+- `GrantWarpToCardsInHand(filter, cost)` — cards in the controller's hand matching `filter` gain
+  warp (CR 702.185) with mana cost `cost`. Behaves identically to a printed warp keyword: surfaces a
+  "Cast (Warp)" legal action, marks `wasWarped` on resolution, and the post-resolution permanent is
+  exiled at the next end step and can be cast again from exile for its regular mana cost. Hand-only
+  by CR 702.185a and the granters' "in your hand" wording — the grant doesn't extend warp to other
+  zones. Routed through `WarpGrants.effectiveWarp` alongside printed warp; the granter's controller
+  is the only beneficiary. (Tannuk, Steadfast Second = `GrantWarpToCardsInHand(filter = artifact OR
+  red creature, cost = {2}{R})`.)
 - `MayCastWithoutPayingManaCost(controllerOnly = false, firstSpellOfTurnOnly = false, spellFilter = Any)` — a
   battlefield permission to cast a spell without paying its mana cost (CR 118.9). Composable
   gates: `controllerOnly = true` restricts the benefit to the source's controller ("you" wording);

--- a/docs/engine-server-interface.md
+++ b/docs/engine-server-interface.md
@@ -137,6 +137,7 @@ Used to play a card from Hand, Graveyard, Exile, or Command Zone.
 | `xValue`          | `Int?`                  | The declared value for `{X}` costs (e.g., Fireball).                                                                            |
 | **`chosenCosts`** | **`Map<Int, Int>`**     | **Modular Optional Costs.** Maps the index of the optional cost definition to times paid. (e.g., Kicker, Buyback, Multikicker). |
 | `payment`         | `ManaPaymentStrategy?`  | (Optional) Explicit instructions on how to pay (e.g., "Use Treasure token").                                                    |
+| `alternativeCost` | `AlternativeCostType?`  | **Which** alternative cost is being used (warp, evoke, impending, flashback, harmonize, self-alt, granted) when more than one is legal for the same card+zone — e.g. a battlefield-granted warp on a card that also has evoke. The engine stamps this on every alternative-cost legal action; the client echoes it back unchanged. `null` falls back to a fixed priority order (legacy/AI callers). Mirrors the separate "without paying its mana cost" flag — CR 118.9a allows only one alternative cost per cast. |
 
 #### B. `ActivateAbility`
 

--- a/manual-scenarios/cards/t/tannuk-steadfast-second.json
+++ b/manual-scenarios/cards/t/tannuk-steadfast-second.json
@@ -1,0 +1,51 @@
+{
+  "_description": "Tannuk, Steadfast Second — exercises both clauses. (1) Haste anthem: Frontline War-Rager on Alice's side enters with summoning sickness, but Tannuk grants 'other creatures you control have haste', so it can attack on its first turn. (2) Warp grant on hand cards: Alice's hand has Chrome Companion (artifact card — gains warp {2}{R}), Frontline War-Rager (red creature card — gains warp {2}{R}), and Blooming Stinger (green creature, not artifact — does NOT gain warp). With 5 Mountains untapped, the action menu should offer 'Cast (Warp)' on Chrome Companion and the hand-Frontline at cost {2}{R} each, but not on Blooming Stinger. Casting via warp marks the resolved permanent as warped, scheduling the next end-step exile. After the exile, the card sits in exile with WarpExiledComponent and is re-castable for its regular mana cost on a later turn.",
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Chrome Companion",
+      "Frontline War-Rager",
+      "Blooming Stinger"
+    ],
+    "battlefield": [
+      {"name": "Tannuk, Steadfast Second", "summoningSickness": false},
+      {"name": "Frontline War-Rager", "summoningSickness": true},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Mountain",
+      "Mountain"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Glory Seeker"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Plains",
+      "Plains",
+      "Plains"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.sdk.scripting
 
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.conditions.IsNotYourTurn
 import com.wingedsheep.sdk.scripting.conditions.IsYourTurn
@@ -183,6 +184,40 @@ data class GrantKeywordToOwnSpells(
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = spellFilter.applyTextReplacement(replacer)
         return if (newFilter !== spellFilter) copy(spellFilter = newFilter) else this
+    }
+}
+
+/**
+ * Grants warp (CR 702.185) to cards in the granter's controller's hand that match [filter].
+ * Models oracle text like "Artifact cards and red creature cards in your hand have warp {2}{R}."
+ *
+ * Read by the cast-from-hand enumerator and the cast handler the same way printed
+ * [KeywordAbility.Warp] is read: the granted warp surfaces an alternative "Cast (Warp)" legal
+ * action whose cost is [cost], the spell is marked `wasWarped` on resolution, and the
+ * post-resolution permanent is exiled at the beginning of the next end step (CR 702.185b),
+ * after which it can be cast again from exile for its regular mana cost (CR 702.185a — the
+ * warp alternative cost is hand-only). The grant is controller-only — only the source
+ * permanent's controller benefits.
+ *
+ * Hand-only by design: CR 702.185a restricts warp to the hand, and the granter's oracle text
+ * scopes the grant to cards "in your hand". This static doesn't extend warp to other zones —
+ * warp-exiled cards are recast from exile via the standard `MayPlayPermission` (regular mana
+ * cost), independent of whether the original cast used printed or granted warp.
+ *
+ * @property filter Which cards in the controller's hand gain warp (e.g., artifact or red creature)
+ * @property cost The warp mana cost the granted ability uses
+ */
+@SerialName("GrantWarpToCardsInHand")
+@Serializable
+data class GrantWarpToCardsInHand(
+    val filter: GameObjectFilter,
+    val cost: ManaCost
+) : StaticAbility {
+    override val description: String =
+        "${filter.description.replaceFirstChar { it.uppercase() }} in your hand have warp $cost"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TannukSteadfastSecond.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TannukSteadfastSecond.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GrantWarpToCardsInHand
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tannuk, Steadfast Second
+ * {2}{R}{R}
+ * Legendary Creature — Kavu Pilot
+ * 3/5
+ * Other creatures you control have haste.
+ * Artifact cards and red creature cards in your hand have warp {2}{R}.
+ */
+val TannukSteadfastSecond = card("Tannuk, Steadfast Second") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Kavu Pilot"
+    power = 3
+    toughness = 5
+    oracleText = "Other creatures you control have haste.\n" +
+        "Artifact cards and red creature cards in your hand have warp {2}{R}. " +
+        "(You may cast a card from your hand for its warp cost. Exile that permanent at the " +
+        "beginning of the next end step, then you may cast it from exile on a later turn.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()).other(),
+        )
+    }
+
+    staticAbility {
+        ability = GrantWarpToCardsInHand(
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature.withColor(Color.RED),
+            cost = ManaCost.parse("{2}{R}"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "162"
+        artist = "Raymond Swanland"
+        flavorText = "\"We're a few bones short of a skeleton crew, Sami, but we've got plenty of spine.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44607ed3-9523-40ac-9f61-0edd011cf762.jpg?1752947211"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
@@ -96,8 +96,49 @@ data class CastSpell(
      * flashback, harmonize, warp, evoke, impending, `selfAlternativeCost`) when both are legal.
      * The enumerator emits a separate `CastWithoutPayingManaCost` action per granted permission.
      */
-    val useWithoutPayingManaCost: Boolean = false
+    val useWithoutPayingManaCost: Boolean = false,
+    /**
+     * When [useAlternativeCost] is true, identifies *which* alternative cost the player chose.
+     *
+     * A card can have more than one alternative cost available simultaneously for the same
+     * card+zone — most commonly when a battlefield static grants warp to a card that already
+     * has evoke/impending/a self-alternative cost (e.g. Tannuk, Steadfast Second granting warp
+     * to a red evoke creature in hand). Because every alternative-cost legal action sets
+     * `useAlternativeCost = true`, that flag alone can't say which one was clicked, so the
+     * handler would otherwise fall back to a fixed priority order and silently charge the wrong
+     * cost. This discriminator records the choice explicitly (CR 601.2b/601.2f — the player
+     * announces the alternative cost as part of casting).
+     *
+     * `null` means "unspecified" — the handler falls back to its legacy priority chain. The
+     * legal-action enumerators always stamp it; only hand-constructed actions (some tests,
+     * synthesized free casts) leave it null. Mirrors how [useWithoutPayingManaCost] was split
+     * out as its own flag for the same reason (CR 118.9a — only one alternative cost per cast).
+     */
+    val alternativeCostType: AlternativeCostType? = null
 ) : GameAction
+
+/**
+ * Which alternative casting cost a [CastSpell] with `useAlternativeCost = true` is using. Lets the
+ * handler honor the player's explicit choice instead of guessing by priority when several
+ * alternative costs are legal for the same card at once (CR 118.9a — only one may apply).
+ */
+@Serializable
+enum class AlternativeCostType {
+    /** Flashback ([com.wingedsheep.sdk.scripting.KeywordAbility.Flashback]) — graveyard. */
+    FLASHBACK,
+    /** Harmonize ([com.wingedsheep.sdk.scripting.KeywordAbility.Harmonize], printed or granted) — graveyard. */
+    HARMONIZE,
+    /** Warp ([com.wingedsheep.sdk.scripting.KeywordAbility.Warp], printed or granted) — hand (graveyard if opted in). */
+    WARP,
+    /** Evoke ([com.wingedsheep.sdk.scripting.KeywordAbility.Evoke]) — hand. */
+    EVOKE,
+    /** Impending ([com.wingedsheep.sdk.scripting.KeywordAbility.Impending]) — hand. */
+    IMPENDING,
+    /** A card's own `selfAlternativeCost` (e.g. Zahid's "tap an untapped artifact") — hand. */
+    SELF_ALTERNATIVE,
+    /** A battlefield-granted alternative cost (e.g. Jodah's {W}{U}{B}{R}{G}) — `GrantAlternativeCastingCost`. */
+    GRANTED
+}
 
 /**
  * Defines how a player intends to pay the mana cost of a spell or ability.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.handlers.actions.spell
 
+import com.wingedsheep.engine.core.AlternativeCostType
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.CastWithCreatureTypeContinuation
 import com.wingedsheep.engine.core.ChooseOptionDecision
@@ -104,6 +105,16 @@ import kotlin.reflect.KClass
  * This handler owns the top-level validate/execute flow, cast restrictions,
  * additional cost processing, and trigger detection.
  */
+/**
+ * True if this cast's [CastSpell.alternativeCostType] permits the given alternative cost [type] —
+ * either because the player explicitly chose it, or because no choice was recorded (`null`, the
+ * legacy path) and the handler should fall back to its priority chain. Used to gate each branch of
+ * the alternative-cost resolution so an explicit choice (e.g. evoke) isn't overridden by a
+ * higher-priority cost that also happens to be available (e.g. a granted warp).
+ */
+private fun CastSpell.altAllows(type: AlternativeCostType): Boolean =
+    alternativeCostType == null || alternativeCostType == type
+
 class CastSpellHandler(
     private val cardRegistry: CardRegistry,
     private val turnManager: TurnManager,
@@ -272,7 +283,7 @@ class CastSpellHandler(
         }
 
         // Validate self-alternative cost's additional costs when using alternative cost
-        if (action.useAlternativeCost && cardDef != null) {
+        if (action.useAlternativeCost && cardDef != null && action.altAllows(AlternativeCostType.SELF_ALTERNATIVE)) {
             val selfAltCost = cardDef.script.selfAlternativeCost
             if (selfAltCost != null && selfAltCost.additionalCosts.isNotEmpty()) {
                 val selfAltCostError = validateAdditionalCosts(state, selfAltCost.additionalCosts, action)
@@ -281,7 +292,7 @@ class CastSpellHandler(
         }
 
         // Validate flashback's bundled additional cost (e.g., "Flashback—{1}{R}, Behold three Elementals")
-        if (action.useAlternativeCost && cardDef != null && hasFlashback) {
+        if (action.useAlternativeCost && cardDef != null && hasFlashback && action.altAllows(AlternativeCostType.FLASHBACK)) {
             val flashbackAdditional = cardDef.keywordAbilities
                 .filterIsInstance<KeywordAbility.Flashback>()
                 .firstOrNull()
@@ -296,6 +307,7 @@ class CastSpellHandler(
         // Granted warps ([com.wingedsheep.sdk.scripting.GrantWarpToCardsInHand]) currently carry no
         // additional cost, but [WarpGrants] is the source of truth either way.
         if (action.useAlternativeCost && cardDef != null &&
+            action.altAllows(AlternativeCostType.WARP) &&
             zoneResolver.hasWarpPermission(state, action.playerId, action.cardId)
         ) {
             val warpAdditional = WarpGrants.effectiveWarp(
@@ -346,9 +358,13 @@ class CastSpellHandler(
             val flashbackAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Flashback>().firstOrNull()
             // Harmonize may be printed on the card or granted at runtime (Songcrafter Mage).
             val harmonizeAbility = HarmonizeGrants.effectiveHarmonize(state, action.cardId, cardDef)
-            if (flashbackAbility != null && zoneResolver.hasFlashbackPermission(state, action.playerId, action.cardId)) {
+            // Each branch is gated by [CastSpell.altAllows] so an explicit player choice (e.g.
+            // evoke) isn't overridden by a higher-priority cost that also happens to be legal
+            // (e.g. a granted warp). With no choice recorded, every gate is open and this falls
+            // back to the original priority order.
+            if (action.altAllows(AlternativeCostType.FLASHBACK) && flashbackAbility != null && zoneResolver.hasFlashbackPermission(state, action.playerId, action.cardId)) {
                 costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, flashbackAbility.cost, action.playerId)
-            } else if (harmonizeAbility != null && zoneResolver.hasHarmonizePermission(state, action.playerId, action.cardId)) {
+            } else if (action.altAllows(AlternativeCostType.HARMONIZE) && harmonizeAbility != null && zoneResolver.hasHarmonizePermission(state, action.playerId, action.cardId)) {
                 // Harmonize cost (printed or granted). The per-creature power reduction is
                 // applied afterward via alternativePayment.
                 costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, harmonizeAbility.cost, action.playerId)
@@ -359,22 +375,22 @@ class CastSpellHandler(
                 val warpAbility = WarpGrants.effectiveWarp(
                     state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
                 )
-                if (warpAbility != null && zoneResolver.hasWarpPermission(state, action.playerId, action.cardId)) {
+                if (action.altAllows(AlternativeCostType.WARP) && warpAbility != null && zoneResolver.hasWarpPermission(state, action.playerId, action.cardId)) {
                     costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, warpAbility.cost, action.playerId)
                 } else {
                     // Check evoke cost
                     val evokeAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Evoke>().firstOrNull()
-                    if (evokeAbility != null) {
+                    if (action.altAllows(AlternativeCostType.EVOKE) && evokeAbility != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, evokeAbility.cost, action.playerId)
                     } else {
                         // Check impending cost
                         val impendingAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Impending>().firstOrNull()
-                        if (impendingAbility != null) {
+                        if (action.altAllows(AlternativeCostType.IMPENDING) && impendingAbility != null) {
                             costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, impendingAbility.cost, action.playerId)
                         } else {
                             // Check self-alternative cost (e.g., Zahid's {3}{U} + tap artifact)
                             val selfAltCost = cardDef.script.selfAlternativeCost
-                            if (selfAltCost != null) {
+                            if (action.altAllows(AlternativeCostType.SELF_ALTERNATIVE) && selfAltCost != null) {
                                 val altMana = selfAltCost.manaCost
                                 costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altMana, action.playerId)
                             } else {
@@ -1340,9 +1356,11 @@ class CastSpellHandler(
             val flashbackAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Flashback>().firstOrNull()
             // Harmonize may be printed on the card or granted at runtime (Songcrafter Mage).
             val harmonizeAbility = HarmonizeGrants.effectiveHarmonize(currentState, action.cardId, cardDef)
-            if (flashbackAbility != null && zoneResolver.hasFlashbackPermission(currentState, action.playerId, action.cardId)) {
+            // Branches gated by [CastSpell.altAllows] — mirrors validate(); honors the player's
+            // explicit alternative-cost choice instead of a fixed priority order.
+            if (action.altAllows(AlternativeCostType.FLASHBACK) && flashbackAbility != null && zoneResolver.hasFlashbackPermission(currentState, action.playerId, action.cardId)) {
                 costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, flashbackAbility.cost, action.playerId)
-            } else if (harmonizeAbility != null && zoneResolver.hasHarmonizePermission(currentState, action.playerId, action.cardId)) {
+            } else if (action.altAllows(AlternativeCostType.HARMONIZE) && harmonizeAbility != null && zoneResolver.hasHarmonizePermission(currentState, action.playerId, action.cardId)) {
                 costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, harmonizeAbility.cost, action.playerId)
             } else {
                 // Check warp cost (hand only — CR 702.185a). Re-casts from exile pay the regular
@@ -1351,21 +1369,21 @@ class CastSpellHandler(
                 val warpAbility = WarpGrants.effectiveWarp(
                     currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
                 )
-                if (warpAbility != null && zoneResolver.hasWarpPermission(currentState, action.playerId, action.cardId)) {
+                if (action.altAllows(AlternativeCostType.WARP) && warpAbility != null && zoneResolver.hasWarpPermission(currentState, action.playerId, action.cardId)) {
                     costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, warpAbility.cost, action.playerId)
                 } else {
                     // Check evoke cost
                     val evokeAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Evoke>().firstOrNull()
-                    if (evokeAbility != null) {
+                    if (action.altAllows(AlternativeCostType.EVOKE) && evokeAbility != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, evokeAbility.cost, action.playerId)
                     } else {
                         // Check impending cost
                         val impendingAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Impending>().firstOrNull()
-                        if (impendingAbility != null) {
+                        if (action.altAllows(AlternativeCostType.IMPENDING) && impendingAbility != null) {
                             costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, impendingAbility.cost, action.playerId)
                         } else {
                             val selfAltCost = cardDef.script.selfAlternativeCost
-                            if (selfAltCost != null) {
+                            if (action.altAllows(AlternativeCostType.SELF_ALTERNATIVE) && selfAltCost != null) {
                                 val altMana = selfAltCost.manaCost
                                 costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, altMana, action.playerId)
                             } else {
@@ -1487,10 +1505,14 @@ class CastSpellHandler(
                 if (kickerAdditionalCost != null) add(kickerAdditionalCost)
             }
             if (action.useAlternativeCost && cardDef != null) {
+                // Each bundled additional cost is gated by the chosen alternative-cost type so a
+                // collision (e.g. granted warp on a card also being evoked) doesn't drag in the
+                // unchosen cost's bundled additional cost.
                 val selfAltCost = cardDef.script.selfAlternativeCost
-                if (selfAltCost != null) addAll(selfAltCost.additionalCosts)
+                if (selfAltCost != null && action.altAllows(AlternativeCostType.SELF_ALTERNATIVE)) addAll(selfAltCost.additionalCosts)
                 // Flashback's bundled additional cost (e.g., Behold three Elementals)
-                if (zoneResolver.hasFlashbackPermission(currentState, action.playerId, action.cardId)) {
+                if (action.altAllows(AlternativeCostType.FLASHBACK) &&
+                    zoneResolver.hasFlashbackPermission(currentState, action.playerId, action.cardId)) {
                     val flashbackAdditional = cardDef.keywordAbilities
                         .filterIsInstance<KeywordAbility.Flashback>()
                         .firstOrNull()
@@ -1501,7 +1523,8 @@ class CastSpellHandler(
                 // [WarpGrants] so granted warps ([GrantWarpToCardsInHand]) participate too —
                 // currently they carry no additional cost, but routing through the same helper
                 // keeps the seam.
-                if (zoneResolver.hasWarpPermission(currentState, action.playerId, action.cardId)) {
+                if (action.altAllows(AlternativeCostType.WARP) &&
+                    zoneResolver.hasWarpPermission(currentState, action.playerId, action.cardId)) {
                     val warpAdditional = WarpGrants.effectiveWarp(
                         currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
                     )?.additionalCost
@@ -2070,21 +2093,24 @@ class CastSpellHandler(
             if (pauseResult != null) return pauseResult
         }
 
-        // Determine if this spell is being cast using warp. Mirrors the cost-resolution
-        // heuristic above (printed warp OR a battlefield grant gives this card warp); set when
-        // the alternative path could plausibly be warp so the post-resolution exile trigger
-        // fires for granted warps too.
+        // Determine if this spell is being cast using warp. Gated by the chosen alternative-cost
+        // type so that when warp collides with another alternative cost (e.g. a granted warp on a
+        // card being evoked) only the chosen one drives its post-resolution behavior. With no
+        // choice recorded, falls back to the legacy "card has warp" heuristic.
         val wasWarped = action.useAlternativeCost && cardDef != null &&
+            action.altAllows(AlternativeCostType.WARP) &&
             WarpGrants.effectiveWarp(
                 currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
             ) != null
 
         // Determine if this spell is being cast using evoke
         val wasEvoked = action.useAlternativeCost && cardDef != null &&
+            action.altAllows(AlternativeCostType.EVOKE) &&
             cardDef.keywordAbilities.any { it is KeywordAbility.Evoke }
 
         // Determine if this spell is being cast using impending
         val wasImpending = action.useAlternativeCost && cardDef != null &&
+            action.altAllows(AlternativeCostType.IMPENDING) &&
             cardDef.keywordAbilities.any { it is KeywordAbility.Impending }
 
         // Extract per-color mana spent from payment events (for mana-spent-gated triggers)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.core.CardsRevealedEvent
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
+import com.wingedsheep.engine.mechanics.WarpGrants
 import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.core.PermanentsSacrificedEvent
@@ -291,14 +292,15 @@ class CastSpellHandler(
             }
         }
 
-        // Validate warp's bundled additional cost (e.g., "Warp—{B}, Pay 2 life." on Timeline Culler)
+        // Validate warp's bundled additional cost (e.g., "Warp—{B}, Pay 2 life." on Timeline Culler).
+        // Granted warps ([com.wingedsheep.sdk.scripting.GrantWarpToCardsInHand]) currently carry no
+        // additional cost, but [WarpGrants] is the source of truth either way.
         if (action.useAlternativeCost && cardDef != null &&
             zoneResolver.hasWarpPermission(state, action.playerId, action.cardId)
         ) {
-            val warpAdditional = cardDef.keywordAbilities
-                .filterIsInstance<KeywordAbility.Warp>()
-                .firstOrNull()
-                ?.additionalCost
+            val warpAdditional = WarpGrants.effectiveWarp(
+                state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
+            )?.additionalCost
             if (warpAdditional != null) {
                 val warpCostError = validateAdditionalCosts(state, listOf(warpAdditional), action)
                 if (warpCostError != null) return warpCostError
@@ -351,8 +353,12 @@ class CastSpellHandler(
                 // applied afterward via alternativePayment.
                 costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, harmonizeAbility.cost, action.playerId)
             } else {
-                // Check warp cost (hand only — CR 702.185a). Re-casts from exile pay the regular mana cost.
-                val warpAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Warp>().firstOrNull()
+                // Check warp cost (hand only — CR 702.185a). Re-casts from exile pay the regular
+                // mana cost. Printed warp wins; a battlefield grant ([GrantWarpToCardsInHand])
+                // supplies the cost when the card has no printed warp.
+                val warpAbility = WarpGrants.effectiveWarp(
+                    state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
+                )
                 if (warpAbility != null && zoneResolver.hasWarpPermission(state, action.playerId, action.cardId)) {
                     costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, warpAbility.cost, action.playerId)
                 } else {
@@ -1339,8 +1345,12 @@ class CastSpellHandler(
             } else if (harmonizeAbility != null && zoneResolver.hasHarmonizePermission(currentState, action.playerId, action.cardId)) {
                 costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, harmonizeAbility.cost, action.playerId)
             } else {
-                // Check warp cost (hand only — CR 702.185a). Re-casts from exile pay the regular mana cost.
-                val warpAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Warp>().firstOrNull()
+                // Check warp cost (hand only — CR 702.185a). Re-casts from exile pay the regular
+                // mana cost. Printed warp wins; a battlefield grant ([GrantWarpToCardsInHand])
+                // supplies the cost when the card has no printed warp.
+                val warpAbility = WarpGrants.effectiveWarp(
+                    currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
+                )
                 if (warpAbility != null && zoneResolver.hasWarpPermission(currentState, action.playerId, action.cardId)) {
                     costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, warpAbility.cost, action.playerId)
                 } else {
@@ -1487,12 +1497,14 @@ class CastSpellHandler(
                         ?.additionalCost
                     if (flashbackAdditional != null) add(flashbackAdditional)
                 }
-                // Warp's bundled additional cost (e.g., "Pay 2 life" on Timeline Culler)
+                // Warp's bundled additional cost (e.g., "Pay 2 life" on Timeline Culler). Use
+                // [WarpGrants] so granted warps ([GrantWarpToCardsInHand]) participate too —
+                // currently they carry no additional cost, but routing through the same helper
+                // keeps the seam.
                 if (zoneResolver.hasWarpPermission(currentState, action.playerId, action.cardId)) {
-                    val warpAdditional = cardDef.keywordAbilities
-                        .filterIsInstance<KeywordAbility.Warp>()
-                        .firstOrNull()
-                        ?.additionalCost
+                    val warpAdditional = WarpGrants.effectiveWarp(
+                        currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
+                    )?.additionalCost
                     if (warpAdditional != null) add(warpAdditional)
                 }
             }
@@ -2058,9 +2070,14 @@ class CastSpellHandler(
             if (pauseResult != null) return pauseResult
         }
 
-        // Determine if this spell is being cast using warp
+        // Determine if this spell is being cast using warp. Mirrors the cost-resolution
+        // heuristic above (printed warp OR a battlefield grant gives this card warp); set when
+        // the alternative path could plausibly be warp so the post-resolution exile trigger
+        // fires for granted warps too.
         val wasWarped = action.useAlternativeCost && cardDef != null &&
-            cardDef.keywordAbilities.any { it is KeywordAbility.Warp }
+            WarpGrants.effectiveWarp(
+                currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
+            ) != null
 
         // Determine if this spell is being cast using evoke
         val wasEvoked = action.useAlternativeCost && cardDef != null &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.handlers.actions.spell
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
+import com.wingedsheep.engine.mechanics.WarpGrants
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
@@ -250,7 +251,9 @@ class CastZoneResolver(
      * Check if a card has an active Warp keyword ability that can be used from
      * its current zone. By default warp is hand-only (CR 702.185a); a Warp whose
      * `fromGraveyard` flag is set (e.g., Timeline Culler) also lets the card be
-     * cast for its warp cost from the caster's graveyard.
+     * cast for its warp cost from the caster's graveyard. A battlefield static
+     * ability ([com.wingedsheep.sdk.scripting.GrantWarpToCardsInHand]) can also
+     * grant warp to a card currently in the controller's hand.
      */
     fun hasWarpPermission(
         state: GameState,
@@ -260,11 +263,11 @@ class CastZoneResolver(
         val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: return false
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return false
         val warp = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Warp>().firstOrNull()
-            ?: return false
-
-        if (cardId in state.getZone(ZoneKey(playerId, Zone.HAND))) return true
-        if (warp.fromGraveyard && cardId in state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))) return true
-        return false
+        if (warp != null) {
+            if (cardId in state.getZone(ZoneKey(playerId, Zone.HAND))) return true
+            if (warp.fromGraveyard && cardId in state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))) return true
+        }
+        return WarpGrants.hasGrantedWarpInHand(state, cardId, playerId, cardRegistry, predicateEvaluator)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.legalactions.enumerators
 
+import com.wingedsheep.engine.core.AlternativeCostType
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.PlayLand
 import com.wingedsheep.engine.state.GameState
@@ -1054,7 +1055,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     LegalAction(
                         actionType = "CastWithFlashback",
                         description = "Cast ${cardComponent.name} (Flashback)",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.FLASHBACK),
                         affordable = false,
                         manaCostString = flashback.cost.toString(),
                         sourceZone = "GRAVEYARD"
@@ -1101,7 +1102,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     LegalAction(
                         actionType = "CastWithFlashback",
                         description = "Cast ${cardComponent.name} (Flashback)",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.FLASHBACK),
                         affordable = false,
                         manaCostString = costString,
                         additionalCostInfo = flashbackBeholdInfo,
@@ -1131,7 +1132,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         LegalAction(
                             actionType = "CastWithFlashback",
                             description = "Cast ${cardComponent.name} (Flashback)",
-                            action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                            action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.FLASHBACK),
                             validTargets = firstInfo.validTargets,
                             requiresTargets = true,
                             targetCount = firstReq.count,
@@ -1150,7 +1151,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     LegalAction(
                         actionType = "CastWithFlashback",
                         description = "Cast ${cardComponent.name} (Flashback)",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.FLASHBACK),
                         manaCostString = costString,
                         additionalCostInfo = flashbackBeholdInfo,
                         autoTapPreview = autoTapPreview,
@@ -1191,7 +1192,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     LegalAction(
                         actionType = "CastWithHarmonize",
                         description = "Cast ${cardComponent.name} (Harmonize)",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.HARMONIZE),
                         affordable = false,
                         manaCostString = harmonize.cost.toString(),
                         hasHarmonize = true,
@@ -1228,7 +1229,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     LegalAction(
                         actionType = "CastWithHarmonize",
                         description = "Cast ${cardComponent.name} (Harmonize)",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.HARMONIZE),
                         affordable = false,
                         manaCostString = costString,
                         hasHarmonize = true,
@@ -1254,7 +1255,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         LegalAction(
                             actionType = "CastWithHarmonize",
                             description = "Cast ${cardComponent.name} (Harmonize)",
-                            action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                            action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.HARMONIZE),
                             validTargets = firstInfo.validTargets,
                             requiresTargets = true,
                             targetCount = firstReq.count,
@@ -1275,7 +1276,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     LegalAction(
                         actionType = "CastWithHarmonize",
                         description = "Cast ${cardComponent.name} (Harmonize)",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.HARMONIZE),
                         manaCostString = costString,
                         hasXCost = hasXCost,
                         maxAffordableX = maxAffordableX,
@@ -1343,7 +1344,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     LegalAction(
                         actionType = "CastWithWarp",
                         description = "Cast ${cardComponent.name} (Warp)",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.WARP),
                         affordable = false,
                         manaCostString = warpAbility.cost.toString(),
                         sourceZone = sourceZoneLabel
@@ -1367,7 +1368,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     LegalAction(
                         actionType = "CastWithWarp",
                         description = "Cast ${cardComponent.name} (Warp)",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.WARP),
                         affordable = false,
                         manaCostString = costString,
                         sourceZone = sourceZoneLabel
@@ -1409,7 +1410,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         LegalAction(
                             actionType = "CastWithWarp",
                             description = "Cast ${cardComponent.name} (Warp)",
-                            action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                            action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.WARP),
                             validTargets = firstInfo.validTargets,
                             requiresTargets = true,
                             targetCount = firstReq.count,
@@ -1429,7 +1430,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     LegalAction(
                         actionType = "CastWithWarp",
                         description = "Cast ${cardComponent.name} (Warp)",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.WARP),
                         manaCostString = costString,
                         autoTapPreview = autoTapPreview,
                         hasXCost = hasXCost,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -32,6 +32,7 @@ import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
 import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
+import com.wingedsheep.engine.mechanics.WarpGrants
 import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 
@@ -1318,9 +1319,16 @@ class CastFromZoneEnumerator : ActionEnumerator {
 
             val cardDef = context.cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
 
-            val warpAbility = cardDef.keywordAbilities
-                .filterIsInstance<KeywordAbility.Warp>()
-                .firstOrNull() ?: continue
+            // Printed warp wins; otherwise consult battlefield grants
+            // ([com.wingedsheep.sdk.scripting.GrantWarpToCardsInHand]). Granted warp is
+            // hand-only, so it never satisfies a graveyard pass.
+            val printedWarp = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Warp>().firstOrNull()
+            val warpAbility: KeywordAbility.Warp = printedWarp
+                ?: if (zone == Zone.HAND) {
+                    WarpGrants.effectiveWarp(
+                        state, cardId, cardDef, playerId, context.cardRegistry, context.predicateEvaluator
+                    ) ?: continue
+                } else continue
 
             // Graveyard casts are only legal for warp abilities that explicitly opt in
             // (CR 702.185a — default warp is hand-only).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.legalactions.enumerators
 
+import com.wingedsheep.engine.core.AlternativeCostType
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.AdditionalCostData
@@ -826,7 +827,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
                                 description = "Cast ${cardComponent.name} (${altCostInfo.first})",
-                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true),
+                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true, alternativeCostType = AlternativeCostType.GRANTED),
                                 manaCostString = altCostInfo.first,
                                 requiresDamageDistribution = requiresDamageDistribution,
                                 totalDamageToDistribute = totalDamageToDistribute,
@@ -838,7 +839,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
                                 description = "Cast ${cardComponent.name} (${selfAltCostResult.manaCostString})",
-                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true),
+                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true, alternativeCostType = AlternativeCostType.SELF_ALTERNATIVE),
                                 manaCostString = selfAltCostResult.manaCostString,
                                 additionalCostInfo = selfAltCostResult.additionalCostInfo,
                                 requiresDamageDistribution = requiresDamageDistribution,
@@ -851,7 +852,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
                                 description = "Evoke ${cardComponent.name} (${evokeCostResult.manaCostString})",
-                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true),
+                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true, alternativeCostType = AlternativeCostType.EVOKE),
                                 manaCostString = evokeCostResult.manaCostString,
                                 autoTapPreview = evokeCostResult.autoTapPreview
                             ))
@@ -860,7 +861,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
                                 description = "Impending ${cardComponent.name} (${impendingCostResult.manaCostString})",
-                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true),
+                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget), useAlternativeCost = true, alternativeCostType = AlternativeCostType.IMPENDING),
                                 manaCostString = impendingCostResult.manaCostString,
                                 autoTapPreview = impendingCostResult.autoTapPreview
                             ))
@@ -936,7 +937,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
                                 description = "Cast ${cardComponent.name} (${altCostInfo.first})",
-                                action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                                action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.GRANTED),
                                 validTargets = firstReqInfo.validTargets,
                                 requiresTargets = true,
                                 targetCount = firstReq.count,
@@ -956,7 +957,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
                                 description = "Cast ${cardComponent.name} (${selfAltCostResult.manaCostString})",
-                                action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                                action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.SELF_ALTERNATIVE),
                                 validTargets = firstReqInfo.validTargets,
                                 requiresTargets = true,
                                 targetCount = firstReq.count,
@@ -977,7 +978,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
                                 description = "Evoke ${cardComponent.name} (${evokeCostResult.manaCostString})",
-                                action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                                action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.EVOKE),
                                 validTargets = firstReqInfo.validTargets,
                                 requiresTargets = true,
                                 targetCount = firstReq.count,
@@ -994,7 +995,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             result.add(LegalAction(
                                 actionType = "CastWithAlternativeCost",
                                 description = "Impending ${cardComponent.name} (${impendingCostResult.manaCostString})",
-                                action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                                action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.IMPENDING),
                                 validTargets = firstReqInfo.validTargets,
                                 requiresTargets = true,
                                 targetCount = firstReq.count,
@@ -1094,7 +1095,7 @@ class CastSpellEnumerator : ActionEnumerator {
                     result.add(LegalAction(
                         actionType = "CastWithAlternativeCost",
                         description = "Cast ${cardComponent.name} (${altCostInfo.first})",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.GRANTED),
                         manaCostString = altCostInfo.first,
                         autoTapPreview = altCostInfo.second
                     ))
@@ -1103,7 +1104,7 @@ class CastSpellEnumerator : ActionEnumerator {
                     result.add(LegalAction(
                         actionType = "CastWithAlternativeCost",
                         description = "Cast ${cardComponent.name} (${selfAltCostResult.manaCostString})",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.SELF_ALTERNATIVE),
                         manaCostString = selfAltCostResult.manaCostString,
                         additionalCostInfo = selfAltCostResult.additionalCostInfo,
                         autoTapPreview = selfAltCostResult.autoTapPreview
@@ -1113,7 +1114,7 @@ class CastSpellEnumerator : ActionEnumerator {
                     result.add(LegalAction(
                         actionType = "CastWithAlternativeCost",
                         description = "Evoke ${cardComponent.name} (${evokeCostResult.manaCostString})",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.EVOKE),
                         manaCostString = evokeCostResult.manaCostString,
                         autoTapPreview = evokeCostResult.autoTapPreview
                     ))
@@ -1122,7 +1123,7 @@ class CastSpellEnumerator : ActionEnumerator {
                     result.add(LegalAction(
                         actionType = "CastWithAlternativeCost",
                         description = "Impending ${cardComponent.name} (${impendingCostResult.manaCostString})",
-                        action = CastSpell(playerId, cardId, useAlternativeCost = true),
+                        action = CastSpell(playerId, cardId, useAlternativeCost = true, alternativeCostType = AlternativeCostType.IMPENDING),
                         manaCostString = impendingCostResult.manaCostString,
                         autoTapPreview = impendingCostResult.autoTapPreview
                     ))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/WarpGrants.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/WarpGrants.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GrantWarpToCardsInHand
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Single source of truth for "does this card have warp, and at what cost?" — used by every warp
+ * read site (the cast-from-zone enumerator, the cast handler's cost/additional-cost lookups,
+ * permission resolution, and the `wasWarped` resolution flag).
+ *
+ * Warp (CR 702.185) can be either printed on the card ([KeywordAbility.Warp] in the card's
+ * keyword abilities) or granted at runtime to a card in the controller's hand by a battlefield
+ * static ability ([GrantWarpToCardsInHand], e.g. "Artifact cards and red creature cards in your
+ * hand have warp {2}{R}"). Routing every call site through here keeps the two sources consistent
+ * so a granted warp behaves identically to a printed one — same alternative-cast legality, same
+ * delayed exile trigger, same recast-from-exile path.
+ *
+ * Granted warp is hand-only by CR 702.185a and the granters' oracle text. Once the warped
+ * permanent has been exiled at end of turn, the card stops matching the granter's filter
+ * (it's no longer in hand); the recast-from-exile step uses the regular mana cost via the
+ * [com.wingedsheep.engine.state.permissions.MayPlayPermission] added by
+ * [com.wingedsheep.engine.handlers.effects.zones.WarpExileExecutor], so a granted-warp card
+ * with no printed warp is still recastable from exile.
+ */
+object WarpGrants {
+
+    /**
+     * The effective warp ability for [cardId], or null if it has none. A printed warp on
+     * [cardDef] wins; otherwise the first matching [GrantWarpToCardsInHand] on the
+     * battlefield (controlled by [playerId]) is returned as a synthetic
+     * [KeywordAbility.Warp] carrying the grant's cost.
+     */
+    fun effectiveWarp(
+        state: GameState,
+        cardId: EntityId,
+        cardDef: CardDefinition?,
+        playerId: EntityId,
+        cardRegistry: CardRegistry,
+        predicateEvaluator: PredicateEvaluator
+    ): KeywordAbility.Warp? {
+        cardDef?.keywordAbilities
+            ?.firstOrNull { it is KeywordAbility.Warp }
+            ?.let { return it as KeywordAbility.Warp }
+
+        // Granted warp applies only to cards currently in the controller's hand.
+        if (cardId !in state.getZone(ZoneKey(playerId, Zone.HAND))) return null
+        return findGrantedWarp(state, cardId, playerId, cardRegistry, predicateEvaluator)
+    }
+
+    /**
+     * Returns true if [cardId] is in [playerId]'s hand and a battlefield static ability
+     * controlled by [playerId] grants warp to it. Hand-only by design (CR 702.185a).
+     */
+    fun hasGrantedWarpInHand(
+        state: GameState,
+        cardId: EntityId,
+        playerId: EntityId,
+        cardRegistry: CardRegistry,
+        predicateEvaluator: PredicateEvaluator
+    ): Boolean {
+        if (cardId !in state.getZone(ZoneKey(playerId, Zone.HAND))) return false
+        return findGrantedWarp(state, cardId, playerId, cardRegistry, predicateEvaluator) != null
+    }
+
+    private fun findGrantedWarp(
+        state: GameState,
+        cardId: EntityId,
+        playerId: EntityId,
+        cardRegistry: CardRegistry,
+        predicateEvaluator: PredicateEvaluator
+    ): KeywordAbility.Warp? {
+        val context = PredicateContext(controllerId = playerId)
+        // Controlled view — not the ownership-keyed zone map — so the grant follows whoever
+        // currently controls the source permanent (Mind Control, Act of Treason, etc.) rather
+        // than its owner. CR 109.4: "you" in an ability refers to the object's controller.
+        for (entityId in state.controlledBattlefield(playerId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val def = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            for (ability in def.script.staticAbilities) {
+                if (ability !is GrantWarpToCardsInHand) continue
+                if (predicateEvaluator.matches(state, state.projectedState, cardId, ability.filter, context)) {
+                    return KeywordAbility.Warp(ability.cost)
+                }
+            }
+        }
+        return null
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlternativeCostChoiceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlternativeCostChoiceScenarioTest.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AlternativeCostType
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.battlefield.WarpedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression tests for the explicit alternative-cost discriminator
+ * ([CastSpell.alternativeCostType]).
+ *
+ * A card can legally have two alternative costs available at once for the same card+zone — most
+ * commonly a battlefield static (Tannuk, Steadfast Second) granting warp to a card in hand that
+ * already has evoke. Both legal actions set `useAlternativeCost = true`, so without an explicit
+ * discriminator the handler falls back to a fixed priority order (warp > evoke) and silently
+ * charges the wrong cost. These tests pin the player's choice down end to end:
+ *  - the enumerated "Evoke" and "Cast (Warp)" actions now carry distinct discriminators, and
+ *  - executing each charges and behaves as that cost, not the higher-priority one.
+ */
+class AlternativeCostChoiceScenarioTest : ScenarioTestBase() {
+
+    init {
+        // A red creature (so Tannuk's "red creature cards in your hand" grant applies) with a
+        // cheap evoke. Defined inline because no real-set evoke creature is registered in the
+        // ScenarioTestBase card pool.
+        val redEvoker = card("Red Evoker") {
+            manaCost = "{4}{R}"
+            colorIdentity = "R"
+            typeLine = "Creature — Elemental"
+            power = 2
+            toughness = 2
+            oracleText = "Evoke {R}"
+            evoke = "{R}"
+        }
+        cardRegistry.register(redEvoker)
+
+        context("warp grant colliding with evoke") {
+
+            test("the enumerated Evoke and Cast (Warp) actions carry distinct discriminators") {
+                val game = warpPlusEvokeBoard()
+
+                val evokerActions = game.getLegalActions(1).filter { info ->
+                    (info.action as? CastSpell)?.let { cast ->
+                        game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Red Evoker"
+                    } == true
+                }
+                val evokeAction = evokerActions.firstOrNull { it.description.startsWith("Evoke") }
+                val warpAction = evokerActions.firstOrNull { it.actionType == "CastWithWarp" }
+
+                withClue("both alternative-cost actions are offered") {
+                    evokeAction shouldNotBe null
+                    warpAction shouldNotBe null
+                }
+                withClue("evoke action is tagged EVOKE") {
+                    (evokeAction!!.action as CastSpell).alternativeCostType shouldBe AlternativeCostType.EVOKE
+                }
+                withClue("warp action is tagged WARP") {
+                    (warpAction!!.action as CastSpell).alternativeCostType shouldBe AlternativeCostType.WARP
+                }
+                withClue("the two actions are now distinguishable (the bug was that they were identical)") {
+                    (evokeAction!!.action) shouldNotBe (warpAction!!.action)
+                }
+            }
+
+            test("executing the Evoke action charges the evoke cost ({R}), not warp ({2}{R})") {
+                val game = warpPlusEvokeBoard()
+                val evokeAction = game.getLegalActions(1).first { info ->
+                    info.description.startsWith("Evoke") &&
+                        (info.action as? CastSpell)?.let { cast ->
+                            game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Red Evoker"
+                        } == true
+                }.action as CastSpell
+
+                game.execute(evokeAction).error shouldBe null
+
+                val tapped = game.state.getBattlefield(game.player1Id).count { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Mountain" &&
+                        game.state.getEntity(id)?.has<TappedComponent>() == true
+                }
+                withClue("evoke {R} taps exactly one Mountain (warp {2}{R} would tap three)") {
+                    tapped shouldBe 1
+                }
+                withClue("the spell was not treated as warped") {
+                    game.state.spellWarpedThisTurn shouldBe false
+                }
+            }
+
+            test("executing the Cast (Warp) action charges the warp cost ({2}{R}) and marks it warped") {
+                val game = warpPlusEvokeBoard()
+                val warpAction = game.getLegalActions(1).first { info ->
+                    info.actionType == "CastWithWarp" &&
+                        (info.action as? CastSpell)?.let { cast ->
+                            game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Red Evoker"
+                        } == true
+                }.action as CastSpell
+
+                game.execute(warpAction).error shouldBe null
+                game.resolveStack()
+
+                val tapped = game.state.getBattlefield(game.player1Id).count { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Mountain" &&
+                        game.state.getEntity(id)?.has<TappedComponent>() == true
+                }
+                withClue("warp {2}{R} taps three Mountains") {
+                    tapped shouldBe 3
+                }
+                withClue("the resolved permanent is marked warped and spellWarpedThisTurn is set") {
+                    game.state.spellWarpedThisTurn.shouldBeTrue()
+                    val evoker = game.findPermanent("Red Evoker")
+                    evoker shouldNotBe null
+                    game.state.getEntity(evoker!!)?.has<WarpedComponent>() shouldBe true
+                }
+            }
+        }
+
+        // Legacy fallback: an action with no discriminator (older/AI/hand-built callers) still
+        // resolves through the priority chain. With only evoke available (no Tannuk), the
+        // null-discriminator alt cast is unambiguously evoke.
+        test("a null-discriminator alternative cast still resolves (legacy priority fallback)") {
+            var builder = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Red Evoker")
+                .withLandsOnBattlefield(1, "Mountain", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            repeat(5) { builder = builder.withCardInLibrary(2, "Mountain") }
+            val game = builder.build()
+
+            // castSpellWithAlternativeCost builds CastSpell(useAlternativeCost = true) with no type.
+            game.castSpellWithAlternativeCost(1, "Red Evoker").error shouldBe null
+            val tapped = game.state.getBattlefield(game.player1Id).count { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Mountain" &&
+                    game.state.getEntity(id)?.has<TappedComponent>() == true
+            }
+            withClue("legacy path falls back to evoke {R} (the only alt cost available)") {
+                tapped shouldBe 1
+            }
+        }
+    }
+
+    private fun warpPlusEvokeBoard(): TestGame {
+        var builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Tannuk, Steadfast Second", summoningSickness = false)
+            .withCardInHand(1, "Red Evoker")
+            .withLandsOnBattlefield(1, "Mountain", 3) // enough for warp {2}{R}
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        repeat(5) { builder = builder.withCardInLibrary(2, "Mountain") }
+        return builder.build()
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TannukSteadfastSecondScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TannukSteadfastSecondScenarioTest.kt
@@ -1,0 +1,234 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.WarpedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.WarpExiledComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Tannuk, Steadfast Second (EOE #162) — {2}{R}{R} Legendary Kavu Pilot 3/5.
+ *
+ * "Other creatures you control have haste."
+ * "Artifact cards and red creature cards in your hand have warp {2}{R}."
+ *
+ * Covers the haste anthem (granted to other creatures, not Tannuk itself) and the new
+ * `GrantWarpToCardsInHand` SDK static — that matching cards in the controller's hand pick up
+ * warp legally castable at the granted cost, non-matching cards do not, the granted-warp cast
+ * resolves with the same warp end-step exile trigger as a printed warp, and removing Tannuk
+ * from the battlefield cancels the grant.
+ */
+class TannukSteadfastSecondScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Tannuk haste anthem") {
+
+            test("other creatures you control have haste; Tannuk itself does not") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tannuk, Steadfast Second", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Goblin Guide", summoningSickness = true)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tannuk = game.findPermanent("Tannuk, Steadfast Second")!!
+                val goblin = game.findPermanent("Goblin Guide")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = game.state.projectedState
+
+                withClue("Tannuk's anthem grants haste to other creatures the controller owns") {
+                    projected.hasKeyword(goblin, Keyword.HASTE) shouldBe true
+                    projected.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+                withClue("'Other creatures' excludes Tannuk itself") {
+                    projected.hasKeyword(tannuk, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("opponent creatures do not gain haste from Tannuk") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tannuk, Steadfast Second", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Goblin Guide", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val opponentGoblin = game.state.getBattlefield(game.player2Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Goblin Guide"
+                }
+                game.state.projectedState.hasKeyword(opponentGoblin, Keyword.HASTE) shouldBe false
+            }
+        }
+
+        context("Tannuk warp grant") {
+
+            test("a red creature card in hand has warp {2}{R} as a legal cast") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tannuk, Steadfast Second", summoningSickness = false)
+                    .withCardInHand(1, "Goblin Guide")
+                    .withLandsOnBattlefield(1, "Mountain", 3) // enough for {2}{R} warp
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(2, "Mountain") }
+                val game = builder.build()
+
+                val warpAction = game.getLegalActions(1).firstOrNull { info ->
+                    info.actionType == "CastWithWarp" &&
+                        (info.action as? CastSpell)?.let { cast ->
+                            game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Goblin Guide"
+                        } == true
+                }
+                withClue("Goblin Guide picks up warp from Tannuk and surfaces a CastWithWarp action") {
+                    warpAction shouldNotBe null
+                }
+            }
+
+            test("an artifact card in hand has warp {2}{R} as a legal cast") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tannuk, Steadfast Second", summoningSickness = false)
+                    .withCardInHand(1, "Frogmite")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(2, "Mountain") }
+                val game = builder.build()
+
+                val warpAction = game.getLegalActions(1).firstOrNull { info ->
+                    info.actionType == "CastWithWarp" &&
+                        (info.action as? CastSpell)?.let { cast ->
+                            game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Frogmite"
+                        } == true
+                }
+                withClue("Frogmite (artifact card) picks up warp from Tannuk") {
+                    warpAction shouldNotBe null
+                }
+            }
+
+            test("a non-matching card (green creature, no artifact type) does NOT gain warp") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tannuk, Steadfast Second", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(2, "Mountain") }
+                val game = builder.build()
+
+                val warpAction = game.getLegalActions(1).firstOrNull { info ->
+                    info.actionType == "CastWithWarp" &&
+                        (info.action as? CastSpell)?.let { cast ->
+                            game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Grizzly Bears"
+                        } == true
+                }
+                withClue("Grizzly Bears is neither artifact nor red — Tannuk's grant must not apply") {
+                    warpAction shouldBe null
+                }
+            }
+
+            test("casting via the granted warp cost resolves into a warped permanent that is exiled at end of turn") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tannuk, Steadfast Second", summoningSickness = false)
+                    .withCardInHand(1, "Goblin Guide")
+                    .withLandsOnBattlefield(1, "Mountain", 3) // warp cost is {2}{R}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Mountain") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Mountain") }
+                val game = builder.build()
+
+                val castResult = game.castSpellWithAlternativeCost(1, "Goblin Guide")
+                castResult.error shouldBe null
+                game.resolveStack()
+
+                val goblin = game.findPermanent("Goblin Guide")
+                withClue("Granted-warp cast resolves into a real permanent") {
+                    goblin shouldNotBe null
+                }
+                withClue("Warp-cast permanents carry WarpedComponent for the end-step exile trigger") {
+                    game.state.getEntity(goblin!!)?.has<WarpedComponent>() shouldBe true
+                }
+                withClue("spellWarpedThisTurn flips true so void payoffs see the warp") {
+                    game.state.spellWarpedThisTurn shouldBe true
+                }
+
+                // Advance to end step; the delayed warp trigger fires and exiles the permanent.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Warped permanent is exiled at the next end step (CR 702.185b)") {
+                    game.findPermanent("Goblin Guide") shouldBe null
+                }
+                val exiled = game.state.getExile(game.player1Id).firstOrNull { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Goblin Guide"
+                }
+                withClue("Exiled warped card carries WarpExiledComponent for the recast-from-exile permission") {
+                    exiled shouldNotBe null
+                    game.state.getEntity(exiled!!)?.has<WarpExiledComponent>() shouldBe true
+                }
+                withClue(
+                    "A granted-warp card with no printed warp (Goblin Guide) still gets a " +
+                        "MayPlayPermission for the recast-from-exile path — CR 702.185a says the " +
+                        "recast pays the regular mana cost, so the printed warp's absence on the " +
+                        "card definition does not block re-casting."
+                ) {
+                    game.state.mayPlayPermissions.any { permission ->
+                        permission.controllerId == game.player1Id && exiled in permission.cardIds
+                    } shouldBe true
+                }
+            }
+
+            test("when Tannuk leaves the battlefield, the warp grant on cards in hand ends") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tannuk, Steadfast Second", summoningSickness = false)
+                    .withCardInHand(1, "Goblin Guide")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(2, "Mountain") }
+                val game = builder.build()
+
+                // Sanity: Goblin Guide gets the granted warp action while Tannuk is on the field.
+                val before = game.getLegalActions(1).firstOrNull { info ->
+                    info.actionType == "CastWithWarp" &&
+                        (info.action as? CastSpell)?.let { cast ->
+                            game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Goblin Guide"
+                        } == true
+                }
+                before shouldNotBe null
+
+                // Send Tannuk to the graveyard out-of-band — the grant must drop with it.
+                val tannukId = game.findPermanent("Tannuk, Steadfast Second")!!
+                val transition = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+                    state = game.state,
+                    entityId = tannukId,
+                    destinationZone = com.wingedsheep.sdk.core.Zone.GRAVEYARD
+                )
+                game.state = transition.state
+
+                val after = game.getLegalActions(1).firstOrNull { info ->
+                    info.actionType == "CastWithWarp" &&
+                        (info.action as? CastSpell)?.let { cast ->
+                            game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Goblin Guide"
+                        } == true
+                }
+                withClue("Granted warp must be off as soon as Tannuk leaves the battlefield") {
+                    after shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…nt support

Tannuk's haste anthem composes existing `GrantKeyword(HASTE, Creature.youControl().other())`, but its second clause — "Artifact cards and red creature cards in your hand have warp {2}{R}" — needed a new SDK seam: a battlefield static that grants warp to matching cards in the controller's hand. Added `GrantWarpToCardsInHand(filter, cost)` plus a `WarpGrants` engine helper (mirroring `HarmonizeGrants`) that funnels every printed-or-granted warp lookup through one chokepoint, so the cast-from-zone enumerator, `CastSpellHandler` (validate + execute, cost + bundled additional cost, and the `wasWarped` resolution flag), and `CastZoneResolver.hasWarpPermission` all treat a granted warp identically to a printed one — same alternative-cast legal action, same end-step exile trigger, same `WarpExiledComponent` recast-from-exile path.

The granter scan iterates `state.controlledBattlefield(playerId)` rather than the ownership-keyed `getBattlefield(playerId)`, so the grant follows whoever currently controls the source permanent (CR 109.4) — a stolen Tannuk grants warp to its new controller, not its owner. Recasts from exile go through the standard `MayPlayPermission` added by `WarpExileExecutor` (regular mana cost per CR 702.185a), so a granted-warp card with no printed warp on its definition is still recastable from exile; the scenario test asserts the permission is wired up after the end-step exile.