### PR TITLE
Add Jandor's Ring to Arabian Nights with last-drawn discard cost

### DIFF
--- a/backlog/sets/arabian-nights/TODO.md
+++ b/backlog/sets/arabian-nights/TODO.md
@@ -15,9 +15,9 @@ Set scaffolding is done:
 
 Verify status anytime with: `scripts/card-status --set ARN` (and `--list --set ARN`).
 
-## Progress (as of 2026-06-02)
+## Progress (as of 2026-06-05)
 
-**Implemented: 56 / 78** (`scripts/card-status --set ARN`). Full per-card status lives in
+**Implemented: 59 / 78** (`scripts/card-status --set ARN`). Full per-card status lives in
 `cards.md` — that file's `Implemented:` count is the source of truth; keep it in sync as boxes
 are checked. The triage buckets below are pruned to **remaining work only**; a card is removed
 from its bucket once it lands on a branch.
@@ -30,6 +30,9 @@ from its bucket once it lands on a branch.
   this way" clause needs `SacrificeContinuation` to thread `updatedSacrificedPermanents`
   back through the resumer (the auto-sac path now captures snapshots, but the multi-land
   decision path does not).
+- `arn-jandors-ring` — `AbilityCost.DiscardLastDrawnThisTurn` + per-player
+  `GameState.lastCardDrawnThisTurnByPlayer` tracker (updated at every `CardsDrawnEvent`
+  emit site during a turn, cleared in `TurnManager.startNewTurn`) + Jandor's Ring.
 
 ## Data sources — do NOT hit the network
 
@@ -111,7 +114,6 @@ Remaining:
 - **Untap-cost lock**: Magnetic Mountain (blue creatures don't untap unless {4} each).
 - **Cumulative counters dealing damage**: Cyclone.
 - **Card-from-outside-the-game**: Ring of Ma'rûf (wish-style).
-- **Last-drawn-card tracking**: Jandor's Ring.
 - **Ante**: Jeweled Bird — needs the ante mechanic (often unsupported / house-ruled).
 - **Subgame**: Shahrazad — a full Magic subgame; the largest single feature here.
 - **Jihad** — multi-condition enchantment that references a chosen color/player. Implement

--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 57 / 78
+**Implemented:** 59 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -78,7 +78,7 @@
 - [x] Dancing Scimitar
 - [x] Ebony Horse
 - [x] Flying Carpet
-- [ ] Jandor's Ring
+- [x] Jandor's Ring
 - [x] Jandor's Saddlebags
 - [ ] Jeweled Bird
 - [x] Pyramids

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -162,6 +162,14 @@ excluded.
   "Discard two cards at random").
 - `Costs.DiscardHand` — discard your entire hand.
 - `Costs.DiscardSelf` — discard this card (cycling-style).
+- `Costs.DiscardLastDrawnThisTurn` — discard the specific card you drew most recently this turn
+  (Jandor's Ring: "{2}, {T}, Discard the last card you drew this turn: Draw a card."). The engine
+  tracks the per-player most-recently-drawn entity on `GameState.lastCardDrawnThisTurnByPlayer`
+  (updated at every `CardsDrawnEvent` emit site during a turn; the last id of a multi-card draw
+  wins; cleared at every turn boundary) and discards it automatically — no player selection. The
+  cost is unpayable when the controller has not drawn a card this turn or the tracked card has
+  since left their hand (matches the Scryfall ruling: "If you do not have the card still in your
+  hand, you can't pay the cost").
 - `Costs.ExileSelf` — exile this permanent (or graveyard card, for graveyard-activated abilities).
 - `Costs.ExileFromGraveyard(count, filter)` — exile N matching cards from your graveyard.
 - `Costs.ExileXFromGraveyard(filter)` — exile X cards from your graveyard (X = the ability's

--- a/manual-scenarios/cards/j/jandors-ring.json
+++ b/manual-scenarios/cards/j/jandors-ring.json
@@ -1,0 +1,38 @@
+{
+  "_description": "Jandor's Ring — {2}, {T}, Discard the last card you drew this turn: Draw a card. Scenario starts in Alice's UPKEEP so the natural turn flow draws her a card during the upcoming DRAW step, which populates GameState.lastCardDrawnThisTurnByPlayer with the drawn entity. After passing into PRECOMBAT_MAIN, the new 'DiscardLastDrawnThisTurn' cost is payable and the action menu should offer Jandor's Ring's tap ability. Activating it should: (1) tap Jandor's Ring and consume {2} from the two Plains; (2) move the Mountain just drawn from the library into the graveyard as the discard cost (NOT the Forest, which was in Alice's hand before the turn began); (3) draw the next library card (Island) into her hand. After that, the tracker now points at Island, so a second activation would discard Island instead — provided Alice has more mana.",
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Forest", "Opt", "Cruel Truths"],
+    "battlefield": [
+      {"name": "Jandor's Ring"},
+      {"name": "Swamp"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Island", "Swamp", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest", "Forest", "Forest"]
+  },
+  "phase": "BEGINNING",
+  "step": "UPKEEP",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -128,6 +128,14 @@ object Costs {
     val DiscardSelf: AbilityCost = AbilityCost.DiscardSelf
 
     /**
+     * Discard the specific card you drew most recently this turn (Jandor's Ring).
+     * Unpayable when you haven't drawn a card this turn, or the tracked card has
+     * since left your hand. The engine resolves the card automatically — no player
+     * selection is required at payment time.
+     */
+    val DiscardLastDrawnThisTurn: AbilityCost = AbilityCost.DiscardLastDrawnThisTurn
+
+    /**
      * Sacrifice this permanent (for abilities that sacrifice themselves as cost).
      */
     val SacrificeSelf: AbilityCost = AbilityCost.SacrificeSelf

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -267,6 +267,26 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
         override val description: String = "Discard this card"
     }
 
+    /**
+     * Discard the specific card the controller drew most recently this turn (CR 121
+     * "draws"). The engine tracks the per-player most-recently-drawn card on
+     * `GameState.lastCardDrawnThisTurnByPlayer`, updated whenever a `CardsDrawnEvent`
+     * fires during a turn and cleared at every turn boundary. Used by Jandor's Ring
+     * ("{2}, {T}, Discard the last card you drew this turn: Draw a card.") and any
+     * future card that scopes a discard cost to the same notion.
+     *
+     * The cost is unpayable when (a) the controller has not drawn a card this turn,
+     * or (b) the tracked card has since left their hand. Per Scryfall ruling on
+     * Jandor's Ring: "If you draw more than one card due to a spell or ability, you
+     * must discard the last one of those drawn." — the tracker takes the *last* id
+     * in a multi-card `CardsDrawnEvent`, then is overwritten by any later draw event.
+     */
+    @SerialName("CostDiscardLastDrawnThisTurn")
+    @Serializable
+    data object DiscardLastDrawnThisTurn : AbilityCost {
+        override val description: String = "Discard the last card you drew this turn"
+    }
+
     /** Sacrifice self (the permanent with this ability) */
     @SerialName("CostSacrificeSelf")
     @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/JandorsRing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/JandorsRing.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jandor's Ring
+ * {6}
+ * Artifact
+ * {2}, {T}, Discard the last card you drew this turn: Draw a card.
+ */
+val JandorsRing = card("Jandor's Ring") {
+    manaCost = "{6}"
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}, Discard the last card you drew this turn: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.DiscardLastDrawnThisTurn)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "64"
+        artist = "Dan Frazier"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71504078-a16f-4dc4-9626-0ecc42b1e93b.jpg?1562916016"
+
+        ruling(
+            "2004-10-04",
+            "If you do not have the card still in your hand, you can't pay the cost."
+        )
+        ruling(
+            "2004-10-04",
+            "If you draw more than one card due to a spell or ability, you must discard the last one of those drawn."
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -102,7 +102,8 @@ class TurnManager(
             pendingUncounterableSpells = emptyList(),
             spellWarpedThisTurn = false,
             nonlandPermanentLeftBattlefieldThisTurn = false,
-            lastCastSpellColors = null
+            lastCastSpellColors = null,
+            lastCardDrawnThisTurnByPlayer = emptyMap()
         )
 
         // Reset cards-drawn-this-turn count for ALL players (not just active player)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -126,6 +126,13 @@ class CostHandler(
                 val handZone = ZoneKey(controllerId, Zone.HAND)
                 state.getZone(handZone).contains(sourceId)
             }
+            is AbilityCost.DiscardLastDrawnThisTurn -> {
+                // Per the Jandor's Ring rulings: "If you do not have the card still in your hand,
+                // you can't pay the cost." Track is populated by every CardsDrawnEvent emit site
+                // during a turn and cleared at the turn boundary.
+                val tracked = state.lastCardDrawnThisTurnByPlayer[controllerId] ?: return false
+                state.getZone(ZoneKey(controllerId, Zone.HAND)).contains(tracked)
+            }
             is AbilityCost.SacrificeSelf -> {
                 // Source must be on the battlefield
                 val battlefieldZone = ZoneKey(controllerId, Zone.BATTLEFIELD)
@@ -416,6 +423,19 @@ class CostHandler(
 
                 val result = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
                     .discardCard(state, ownerId, sourceId)
+                CostPaymentResult.success(result.state, manaPool, result.events)
+            }
+            is AbilityCost.DiscardLastDrawnThisTurn -> {
+                // The engine picks the card from the per-player tracker — no player choice. canPay
+                // already verifies the tracked entity is still in the controller's hand; recheck
+                // here defensively in case payment is re-entered after state change.
+                val tracked = state.lastCardDrawnThisTurnByPlayer[controllerId]
+                    ?: return CostPaymentResult.failure("You haven't drawn a card this turn")
+                if (!state.getZone(ZoneKey(controllerId, Zone.HAND)).contains(tracked)) {
+                    return CostPaymentResult.failure("The card you drew last this turn is no longer in your hand")
+                }
+                val result = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+                    .discardCard(state, controllerId, tracked)
                 CostPaymentResult.success(result.state, manaPool, result.events)
             }
             is AbilityCost.SacrificeSelf -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawLoop.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawLoop.kt
@@ -122,12 +122,16 @@ object DrawLoop {
         perCardEvents: List<GameEvent>
     ): EffectResult {
         val events = mutableListOf<GameEvent>()
+        var newState = state
         if (drawnCards.isNotEmpty()) {
-            val cardNames = drawnCards.map { state.getEntity(it)?.get<CardComponent>()?.name ?: "Card" }
+            val cardNames = drawnCards.map { newState.getEntity(it)?.get<CardComponent>()?.name ?: "Card" }
             events.add(CardsDrawnEvent(playerId, drawnCards.size, drawnCards, cardNames))
+            newState = newState.copy(
+                lastCardDrawnThisTurnByPlayer = newState.lastCardDrawnThisTurnByPlayer + (playerId to drawnCards.last())
+            )
         }
         events.addAll(perCardEvents)
-        return EffectResult.success(state, events)
+        return EffectResult.success(newState, events)
     }
 
     /**
@@ -144,14 +148,18 @@ object DrawLoop {
         pauseResult: EffectResult
     ): EffectResult {
         val allEvents = mutableListOf<GameEvent>()
+        var pausedState = pauseResult.state
         if (drawnCards.isNotEmpty()) {
             val cardNames = drawnCards.map { state.getEntity(it)?.get<CardComponent>()?.name ?: "Card" }
             allEvents.add(CardsDrawnEvent(playerId, drawnCards.size, drawnCards.toList(), cardNames))
+            pausedState = pausedState.copy(
+                lastCardDrawnThisTurnByPlayer = pausedState.lastCardDrawnThisTurnByPlayer + (playerId to drawnCards.last())
+            )
         }
         allEvents.addAll(perCardEvents)
         allEvents.addAll(pauseResult.events)
         return EffectResult.paused(
-            pauseResult.state,
+            pausedState,
             pauseResult.pendingDecision!!,
             allEvents
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawRevealDiscardUnlessExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawRevealDiscardUnlessExecutor.kt
@@ -69,6 +69,9 @@ class DrawRevealDiscardUnlessExecutor(
             // dispatch, so "if you would draw a card, instead ..." effects are not applied here.
             val drawnCard = currentState.getEntity(drawnCardId)?.get<CardComponent>()
             allEvents.add(CardsDrawnEvent(playerId, 1, listOf(drawnCardId), listOf(drawnCard?.name ?: "Card")))
+            currentState = currentState.copy(
+                lastCardDrawnThisTurnByPlayer = currentState.lastCardDrawnThisTurnByPlayer + (playerId to drawnCardId)
+            )
             allEvents.addAll(drawResult.events)
 
             // "reveal it" — show the drawn card to the opponent whether it's kept or discarded.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -256,6 +256,14 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             discardTargets = targets
                         }
                     }
+                    is AbilityCost.DiscardLastDrawnThisTurn -> {
+                        // No player choice — engine picks the tracked entity at payment. Gate the
+                        // ability if the controller hasn't drawn a card this turn or the tracked
+                        // card has since left their hand (Jandor's Ring's "if you do not have the
+                        // card still in your hand, you can't pay the cost" ruling).
+                        val tracked = state.lastCardDrawnThisTurnByPlayer[playerId] ?: continue
+                        if (tracked !in state.getZone(ZoneKey(playerId, Zone.HAND))) continue
+                    }
                     is AbilityCost.RemoveCounterFromSelf -> {
                         val counters = container.get<CountersComponent>()
                         val counterType = resolveCounterType(effectiveCost.counterType)
@@ -408,6 +416,13 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     if (!subCost.atRandom) {
                                         discardCost = subCost
                                         discardTargets = targets
+                                    }
+                                }
+                                is AbilityCost.DiscardLastDrawnThisTurn -> {
+                                    val tracked = state.lastCardDrawnThisTurnByPlayer[playerId]
+                                    if (tracked == null || tracked !in state.getZone(ZoneKey(playerId, Zone.HAND))) {
+                                        costCanBePaid = false
+                                        break
                                     }
                                 }
                                 is AbilityCost.ExileXFromGraveyard -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -122,6 +122,15 @@ data class GameState(
     val lastCastSpellColors: Set<Color>? = null,
 
     /**
+     * Per-player entity id of the card most recently drawn this turn (CR 121 draws), or
+     * absent if that player has not drawn a card this turn. Updated at every
+     * [com.wingedsheep.engine.core.CardsDrawnEvent] emit site during a turn (the *last*
+     * id in a multi-card batch wins, per Scryfall ruling) and cleared at every turn
+     * boundary. Read by the `DiscardLastDrawnThisTurn` ability cost (Jandor's Ring).
+     */
+    val lastCardDrawnThisTurnByPlayer: Map<EntityId, EntityId> = emptyMap(),
+
+    /**
      * Game-mode configuration the engine reads for format-dependent behaviour (commander damage
      * threshold, command-zone redirect, etc.). Defaults to [Format.Standard] so existing
      * persisted states / tests need no migration.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JandorsRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JandorsRingScenarioTest.kt
@@ -105,16 +105,15 @@ class JandorsRingScenarioTest : ScenarioTestBase() {
                 game.state.lastCardDrawnThisTurnByPlayer.containsKey(game.player1Id) shouldBe false
 
                 val ring = game.findPermanent("Jandor's Ring")!!
-                val payableRingActivations = game.getLegalActions(1).filter { info ->
-                    info.isAffordable &&
-                        (info.action as? ActivateAbility)?.sourceId == ring &&
-                        (info.action as? ActivateAbility)?.abilityId == ringAbilityId
+                val ringActivations = game.getLegalActions(1).filter { info ->
+                    (info.action as? ActivateAbility)?.sourceId == ring &&
+                        info.action.abilityId == ringAbilityId
                 }
                 // The enumerator still emits the ability as a greyed-out unaffordable entry so
-                // the UI can show "you can't activate this yet" — the assertion is that nothing
-                // affordable is offered, not that the ability is omitted entirely.
-                withClue("With no card drawn this turn, no payable activation must be enumerated") {
-                    payableRingActivations shouldBe emptyList()
+                // the UI can show "you can't activate this yet" — the ability is not omitted
+                // entirely, it is offered as a single unaffordable action.
+                withClue("With no card drawn this turn, the ring is offered only as a greyed-out unaffordable action") {
+                    ringActivations.map { it.isAffordable } shouldBe listOf(false)
                 }
             }
 
@@ -134,16 +133,16 @@ class JandorsRingScenarioTest : ScenarioTestBase() {
                 )
 
                 val ring = game.findPermanent("Jandor's Ring")!!
-                val payableRingActivations = game.getLegalActions(1).filter { info ->
-                    info.isAffordable &&
-                        (info.action as? ActivateAbility)?.sourceId == ring &&
-                        (info.action as? ActivateAbility)?.abilityId == ringAbilityId
+                val ringActivations = game.getLegalActions(1).filter { info ->
+                    (info.action as? ActivateAbility)?.sourceId == ring &&
+                        info.action.abilityId == ringAbilityId
                 }
                 withClue(
                     "Per Scryfall ruling: 'If you do not have the card still in your hand, " +
-                        "you can't pay the cost.' — the activation must drop out of payable actions."
+                        "you can't pay the cost.' — the ring stays enumerated but only as a " +
+                        "greyed-out unaffordable action."
                 ) {
-                    payableRingActivations shouldBe emptyList()
+                    ringActivations.map { it.isAffordable } shouldBe listOf(false)
                 }
             }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JandorsRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JandorsRingScenarioTest.kt
@@ -1,0 +1,279 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Jandor's Ring (ARN #64) — {6} Artifact.
+ *
+ * "{2}, {T}, Discard the last card you drew this turn: Draw a card."
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.AbilityCost.DiscardLastDrawnThisTurn]
+ * SDK cost and the per-player `GameState.lastCardDrawnThisTurnByPlayer` tracker the cost
+ * reads from. Covers the happy path (draw → activate → discard tracked card, draw fresh
+ * card), both unpayable cases from the Scryfall rulings ("haven't drawn this turn" and
+ * "the drawn card is no longer in your hand"), the multi-card-draw rule ("if you draw
+ * more than one card, you must discard the last one of those drawn"), and the turn
+ * boundary (tracker resets at start of next turn).
+ */
+class JandorsRingScenarioTest : ScenarioTestBase() {
+
+    private val ringAbilityId =
+        cardRegistry.getCard("Jandor's Ring")!!.activatedAbilities.first().id
+
+    // Inline draw-2 sorcery used to drive a single CardsDrawnEvent of size 2, so we can
+    // assert the tracker records the *last* of the batch (Scryfall's multi-card rule).
+    private val drawTwoTest = card("Draw Two Test") {
+        manaCost = "{2}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.DrawCards(2) }
+    }
+
+    init {
+        cardRegistry.register(drawTwoTest)
+
+        context("Jandor's Ring") {
+
+            test("happy path: discards the tracked drawn card and draws a fresh one") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Jandor's Ring", summoningSickness = false)
+                    .withCardInHand(1, "Mountain")           // pretend this was just drawn
+                    .withCardInHand(1, "Forest")             // pretend this was drawn earlier
+                    .withLandsOnBattlefield(1, "Plains", 2)  // pay {2}
+                    .withCardInLibrary(1, "Island")          // top of library (drawn next)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tracked = game.findCardsInHand(1, "Mountain").single()
+                game.state = game.state.copy(
+                    lastCardDrawnThisTurnByPlayer = mapOf(game.player1Id to tracked)
+                )
+                val ring = game.findPermanent("Jandor's Ring")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = ring,
+                        abilityId = ringAbilityId,
+                    )
+                )
+                withClue("Activating Jandor's Ring should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Tracked card (Mountain) moves from hand to graveyard as the discard cost") {
+                    game.isInHand(1, "Mountain") shouldBe false
+                    game.isInGraveyard(1, "Mountain") shouldBe true
+                }
+                withClue("Earlier-drawn cards in hand are not discarded") {
+                    game.isInHand(1, "Forest") shouldBe true
+                }
+                withClue("The replacement draw pulls the top of the library (Island)") {
+                    game.isInHand(1, "Island") shouldBe true
+                }
+                withClue(
+                    "After the draw resolved, the tracker now points at the freshly drawn " +
+                        "Island — a subsequent activation would target it."
+                ) {
+                    val island = game.findCardsInHand(1, "Island").single()
+                    game.state.lastCardDrawnThisTurnByPlayer[game.player1Id] shouldBe island
+                }
+            }
+
+            test("ability is not legal when controller has not drawn a card this turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Jandor's Ring", summoningSickness = false)
+                    .withCardInHand(1, "Mountain")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // No entry in lastCardDrawnThisTurnByPlayer for the controller.
+                game.state.lastCardDrawnThisTurnByPlayer.containsKey(game.player1Id) shouldBe false
+
+                val ring = game.findPermanent("Jandor's Ring")!!
+                val payableRingActivations = game.getLegalActions(1).filter { info ->
+                    info.isAffordable &&
+                        (info.action as? ActivateAbility)?.sourceId == ring &&
+                        (info.action as? ActivateAbility)?.abilityId == ringAbilityId
+                }
+                // The enumerator still emits the ability as a greyed-out unaffordable entry so
+                // the UI can show "you can't activate this yet" — the assertion is that nothing
+                // affordable is offered, not that the ability is omitted entirely.
+                withClue("With no card drawn this turn, no payable activation must be enumerated") {
+                    payableRingActivations shouldBe emptyList()
+                }
+            }
+
+            test("ability is not legal when the tracked card has left the hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Jandor's Ring", summoningSickness = false)
+                    .withCardInGraveyard(1, "Mountain") // tracked card is in graveyard, not hand
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stale = game.findCardsInGraveyard(1, "Mountain").single()
+                game.state = game.state.copy(
+                    lastCardDrawnThisTurnByPlayer = mapOf(game.player1Id to stale)
+                )
+
+                val ring = game.findPermanent("Jandor's Ring")!!
+                val payableRingActivations = game.getLegalActions(1).filter { info ->
+                    info.isAffordable &&
+                        (info.action as? ActivateAbility)?.sourceId == ring &&
+                        (info.action as? ActivateAbility)?.abilityId == ringAbilityId
+                }
+                withClue(
+                    "Per Scryfall ruling: 'If you do not have the card still in your hand, " +
+                        "you can't pay the cost.' — the activation must drop out of payable actions."
+                ) {
+                    payableRingActivations shouldBe emptyList()
+                }
+            }
+
+            test("draw step populates the tracker with the drawn entity id") {
+                // The simpler half of the rulings: the draw step's CardsDrawnEvent updates the
+                // tracker, which is what an activated DiscardLastDrawnThisTurn cost reads. Using
+                // turn 2 because the first player skips their turn-1 draw (CR 103.8a).
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Jandor's Ring", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .withTurnNumber(2)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                // Stack the library so we know exactly which entity will be drawn.
+                builder = builder.withCardInLibrary(1, "Island")
+                repeat(3) { builder = builder.withCardInLibrary(1, "Mountain") }
+                val game = builder.build()
+
+                game.state.lastCardDrawnThisTurnByPlayer[game.player1Id] shouldBe null
+
+                // Advance through the draw step. After the draw step the player has drawn one
+                // card from the top of the library; passUntilPhase stops at the precombat main
+                // priority window with the draw having happened.
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val drawnEntity = game.findCardsInHand(1, "Island").firstOrNull()
+                    ?: game.findCardsInHand(1, "Mountain").firstOrNull()
+                withClue("The draw step actually moved a card into the player's hand") {
+                    drawnEntity shouldNotBe null
+                }
+                withClue("The tracker is populated by the draw step's CardsDrawnEvent") {
+                    game.state.lastCardDrawnThisTurnByPlayer[game.player1Id] shouldBe drawnEntity
+                }
+            }
+
+            test("multi-card draw points the tracker at the LAST card drawn, and the ring discards that one") {
+                // Per the Jandor's Ring Scryfall ruling: "If you draw more than one card due to
+                // a spell or ability, you must discard the last one of those drawn." Cast a
+                // draw-2 sorcery with a stacked library, then assert the tracker holds the
+                // *second*-drawn id (not the first), and that activating the ring discards that
+                // second card — leaving the first-drawn one untouched in hand.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Jandor's Ring", summoningSickness = false)
+                    .withCardInHand(1, "Draw Two Test")
+                    .withLandsOnBattlefield(1, "Plains", 4) // {2} for the spell + {2} for the ring
+                    .withCardInLibrary(1, "Mountain") // drawn first by the draw-2 spell
+                    .withCardInLibrary(1, "Forest")   // drawn second — should become the tracked card
+                    .withCardInLibrary(1, "Island")   // drawn by the ring's replacement draw
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Draw Two Test")
+                game.resolveStack()
+
+                val forest = game.findCardsInHand(1, "Forest").single()
+                withClue(
+                    "Tracker holds the LAST of the draw-2 batch (Forest, drawn 2nd), not the " +
+                        "first (Mountain). Per Scryfall: 'you must discard the last one of those drawn.'"
+                ) {
+                    game.state.lastCardDrawnThisTurnByPlayer[game.player1Id] shouldBe forest
+                }
+
+                val ring = game.findPermanent("Jandor's Ring")!!
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = ring,
+                        abilityId = ringAbilityId,
+                    )
+                )
+                withClue("Activating Jandor's Ring should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Forest (the LAST of the draw-2) is discarded as the cost") {
+                    game.isInGraveyard(1, "Forest") shouldBe true
+                    game.isInHand(1, "Forest") shouldBe false
+                }
+                withClue("Mountain (drawn first, but NOT 'last') stays in hand") {
+                    game.isInHand(1, "Mountain") shouldBe true
+                }
+                withClue("The ring's replacement draw pulls Island from the top of the library") {
+                    game.isInHand(1, "Island") shouldBe true
+                }
+            }
+
+            test("turn boundary clears the tracker so the ability is not legal at the start of next turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Jandor's Ring", summoningSickness = false)
+                    .withCardInHand(1, "Mountain")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(2, "Forest") // opponent needs to be able to draw on their turn
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tracked = game.findCardsInHand(1, "Mountain").single()
+                game.state = game.state.copy(
+                    lastCardDrawnThisTurnByPlayer = mapOf(game.player1Id to tracked)
+                )
+
+                // We're already in PRECOMBAT_MAIN, so step out of it first (passUntilPhase exits
+                // immediately if the target is the current state). Walk through end step, then
+                // continue to opponent's main — TurnManager fires at the turn boundary in between
+                // and must clear the per-player tracker map.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                withClue(
+                    "The active player flipped to the opponent — confirms we actually crossed " +
+                        "a turn boundary, not just a step boundary on the same turn."
+                ) {
+                    game.state.activePlayerId shouldBe game.player2Id
+                }
+                withClue(
+                    "Player 1's stale entry from the prior turn must be cleared. The opponent " +
+                        "will have its own entry from its draw step on this new turn."
+                ) {
+                    game.state.lastCardDrawnThisTurnByPlayer[game.player1Id] shouldBe null
+                }
+                withClue("Mountain is still in player 1's hand — it was never discarded") {
+                    val handZone = com.wingedsheep.engine.state.ZoneKey(game.player1Id, Zone.HAND)
+                    (tracked in game.state.getZone(handZone)) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the Arabian Nights artifact "{6} — {2}, {T}, Discard the last card you drew this turn: Draw a card." Composing with existing primitives wasn't sufficient: the discard cost picks a specific entity (the *one* card you drew most recently this turn), which the existing `AbilityCost.Discard(filter, count)` can't express — its filter-and-count shape would force a player selection rather than auto-resolving on the tracked entity. New SDK seam:

- `AbilityCost.DiscardLastDrawnThisTurn` — payable when the per-player tracker points at a card still in the controller's hand; unpayable otherwise (matches the Scryfall ruling "If you do not have the card still in your hand, you can't pay the cost"). Engine picks the entity automatically — no `discardChoices` round-trip — so the activation doesn't need a pre-payment selection UI flow.

- `GameState.lastCardDrawnThisTurnByPlayer: Map<EntityId, EntityId>` — updated at every `CardsDrawnEvent` emit site during a turn (the *last* id in a multi-card batch wins, per the second Jandor's Ring ruling "If you draw more than one card due to a spell or ability, you must discard the last one of those drawn") and cleared in `TurnManager.startNewTurn`. `DrawLoop` (both success and pause paths) and `DrawRevealDiscardUnlessExecutor` write the field next to where they emit the event; mulligan and opening-hand draws deliberately do not touch it.

`CostHandler` (canPay + pay) and `ActivatedAbilityEnumerator` (both the top-level cost branch and the composite sub-cost branch — Jandor's Ring wraps the new cost in `Composite(Mana, Tap, DiscardLastDrawnThisTurn)`) consult `WarpGrants`-style: the gate marks the ability unaffordable when the tracker is empty or the entity has left the hand, so the UI still surfaces the action as a greyed-out entry rather than dropping it. DSL reference (§Costs) updated in the same change per the project rule.

Scenario tests cover all four behaviours the rulings hinge on: happy path (cost discards the tracked card and the replacement draw retargets the tracker at the freshly drawn card), both unpayable branches (no draw this turn; tracked card has left the hand), the draw step populating the tracker via its `CardsDrawnEvent`, the multi-card-draw rule (`Effects.DrawCards(2)` spell → tracker holds the second-drawn id → ring discards that one, not the first), and the turn-boundary reset clearing the per-player entry.