### PR TITLE
Deckbuilder: roomy, filterable printing picker

### DIFF
--- a/.claude/skills/add-card/SKILL.md
+++ b/.claude/skills/add-card/SKILL.md
@@ -255,6 +255,18 @@ just test    # Cards with new effects
 
 Fix only failures caused by your changes. If a pre-existing test fails, report it and stop.
 
+**Expected: a card-snapshot diff.** A new card makes `CardDefinitionSnapshotTest` (in `mtg-sets`)
+fail, because the set's committed golden no longer matches. This is normal — re-bless it and include
+the new golden in the commit:
+
+```bash
+./gradlew :mtg-sets:test --tests "*CardDefinitionSnapshotTest" -DupdateSnapshots=true
+```
+
+Then scan the diff in `git diff mtg-sets/src/test/resources/snapshots/cards/<SET>.json`: it should
+show **only** your card's tree added (and nothing changed on other cards). If an *unrelated* card
+also moved, that's a real signal you changed shared SDK behavior — investigate before committing.
+
 ## Step 9: Walkthrough New Engine Mechanics
 
 **Only if Step 4 introduced new effects, keywords, triggers, conditions, static abilities, or replacement effects.**

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -975,15 +975,11 @@ export function DeckbuilderPage() {
     }
   }, [pinnedPrintings, pinnedPrintingArt])
 
-  // Currently-open printing picker. `anchor` is the chip's bounding box so the popover
-  // can position itself relative to the row that opened it. Stored at the page level so
-  // (a) the popover escapes the deck-list scroll container and (b) only one picker is
-  // ever open at a time without each row needing to know about the others.
-  const [pickerOpenFor, setPickerOpenFor] = useState<{ name: string; anchor: DOMRect } | null>(null)
-  const handleOpenPicker = useCallback(
-    (name: string, anchor: DOMRect) => setPickerOpenFor({ name, anchor }),
-    [],
-  )
+  // Currently-open printing picker. The picker renders as a centered modal, so it only
+  // needs the card name. Stored at the page level so only one picker is ever open at a
+  // time without each row needing to know about the others.
+  const [pickerOpenFor, setPickerOpenFor] = useState<{ name: string } | null>(null)
+  const handleOpenPicker = useCallback((name: string) => setPickerOpenFor({ name }), [])
   const handleClosePicker = useCallback(() => setPickerOpenFor(null), [])
 
   // Deck-mode left-rail card preview. Hover state is lifted out of DeckCentricView so the
@@ -1310,7 +1306,6 @@ export function DeckbuilderPage() {
         <PrintingPicker
           cardName={pickerOpenFor.name}
           pinned={pinnedPrintings[pickerOpenFor.name]}
-          anchor={pickerOpenFor.anchor}
           onPick={(ref) => {
             setPinnedPrinting(pickerOpenFor.name, ref)
             handleClosePicker()
@@ -3716,7 +3711,7 @@ function DeckListPanel({
   onSuggestBasics: () => void
   pinnedPrintings: Record<string, PrintingRef>
   pinnedPrintingArt: Record<string, { imageUri: string | null; backFaceImageUri: string | null }>
-  onOpenPicker: (name: string, anchor: DOMRect) => void
+  onOpenPicker: (name: string) => void
 }) {
   const grouped = useMemo(
     () => groupForDeckList(deckCards, catalog, commander),
@@ -3870,7 +3865,7 @@ const DeckRow = memo(function DeckRow({
   onEnter: (entry: { name: string; card: CardSummary | undefined }) => void
   onLeave: () => void
   pinnedPrinting: PrintingRef | undefined
-  onOpenPicker: (name: string, anchor: DOMRect) => void
+  onOpenPicker: (name: string) => void
 }) {
   const illegal =
     activeFormat !== null &&
@@ -4020,7 +4015,7 @@ const DeckRow = memo(function DeckRow({
           }`}
           onClick={(e) => {
             e.stopPropagation()
-            onOpenPicker(entry.name, e.currentTarget.getBoundingClientRect())
+            onOpenPicker(entry.name)
           }}
           title={
             pinnedPrinting
@@ -4236,7 +4231,7 @@ function DeckCentricView({
   onHoverEnter: (entry: { name: string; card: CardSummary | undefined }) => void
   onHoverLeave: () => void
   pinnedPrintings: Record<string, PrintingRef>
-  onOpenPicker: (name: string, anchor: DOMRect) => void
+  onOpenPicker: (name: string) => void
 }) {
   const grouped = useMemo(
     () => groupByCardType(deckCards, catalog, commander),

--- a/web-client/src/components/deckbuilder/PrintingPicker.module.css
+++ b/web-client/src/components/deckbuilder/PrintingPicker.module.css
@@ -1,12 +1,24 @@
-.popover {
+.overlay {
   position: fixed;
+  inset: 0;
   z-index: 60;
   display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.dialog {
+  display: flex;
   flex-direction: column;
+  width: min(92vw, 1100px);
+  max-height: 85vh;
   background: var(--bg-elevated, #1d2028);
   border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 8px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+  border-radius: 10px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
   color: var(--text-primary, #e6e8ed);
   overflow: hidden;
 }
@@ -14,25 +26,62 @@
 .header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--space-2, 8px);
-  padding: 8px 10px;
+  padding: 10px 14px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(0, 0, 0, 0.25);
 }
 
 .title {
   font-weight: 600;
-  font-size: 0.85rem;
+  font-size: 1rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 0 1 auto;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0 4px;
+}
+
+.setSelect {
+  flex: 0 1 240px;
+  min-width: 0;
+  padding: 5px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(0, 0, 0, 0.3);
+  color: var(--text-primary, #e6e8ed);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.search {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 5px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(0, 0, 0, 0.3);
+  color: var(--text-primary, #e6e8ed);
+  font-size: 0.8rem;
+}
+
+.search::placeholder {
+  color: var(--text-muted, #8b94a4);
 }
 
 .clearButton {
-  font-size: 0.72rem;
-  padding: 3px 8px;
-  border-radius: 4px;
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  padding: 5px 10px;
+  border-radius: 6px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: transparent;
   color: var(--text-primary);
@@ -48,10 +97,74 @@
   background: rgba(255, 255, 255, 0.08);
 }
 
+.closeButton {
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: transparent;
+  color: var(--text-muted, #8b94a4);
+  cursor: pointer;
+}
+
+.closeButton:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+}
+
 .body {
-  padding: 8px;
+  padding: 12px 14px 16px;
   overflow-y: auto;
   flex: 1 1 auto;
+}
+
+.group {
+  margin-bottom: 18px;
+}
+
+.group:last-child {
+  margin-bottom: 0;
+}
+
+.groupHeader {
+  position: sticky;
+  top: -12px;
+  z-index: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 8px;
+  padding: 6px 2px;
+  background: var(--bg-elevated, #1d2028);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.groupName {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.groupCode {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #8b94a4);
+}
+
+.groupCount {
+  margin-left: auto;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--text-muted, #8b94a4);
+  font-variant-numeric: tabular-nums;
 }
 
 .grid {
@@ -59,8 +172,8 @@
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 10px;
 }
 
 .tile {
@@ -131,15 +244,15 @@
 }
 
 .muted {
-  padding: 16px;
+  padding: 24px;
   text-align: center;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   color: var(--text-muted, #8b94a4);
 }
 
 .error {
-  padding: 16px;
+  padding: 24px;
   text-align: center;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   color: var(--danger, #ff6b6b);
 }

--- a/web-client/src/components/deckbuilder/PrintingPicker.tsx
+++ b/web-client/src/components/deckbuilder/PrintingPicker.tsx
@@ -1,16 +1,22 @@
 /**
- * Printing picker popover for the deckbuilder.
+ * Printing picker for the deckbuilder.
  *
- * Opens from a row chip on each deck entry. Fetches `/api/cards/{name}/printings`
- * once per open and shows every known printing as an art thumbnail. Selecting a
- * thumbnail calls back with the picked [PrintingRef]; the picker doesn't own the
- * pinned-state — the deckbuilder does, since pins persist alongside the deck list.
+ * Opens as a centered modal from a row chip on each deck entry. Fetches
+ * `/api/cards/{name}/printings` once per open and shows every known printing as an
+ * art thumbnail. Selecting a thumbnail calls back with the picked [PrintingRef]; the
+ * picker doesn't own the pinned-state — the deckbuilder does, since pins persist
+ * alongside the deck list.
  *
- * Selecting "Default" clears any pin (the engine resolves the card's canonical
- * printing as before). The currently-pinned thumbnail is highlighted so the user
- * can confirm without re-reading the set code.
+ * Because some cards (basic lands especially) have hundreds of printings, the modal
+ * gives the grid room to breathe: printings are grouped under per-set headers and can
+ * be narrowed by a set filter and a free-text search (set / collector number / artist).
+ * Art tiles load lazily so an "All sets" view of a basic land stays cheap.
+ *
+ * Selecting "Use default" clears any pin (the engine resolves the card's canonical
+ * printing as before). The currently-pinned thumbnail is highlighted so the user can
+ * confirm without re-reading the set code.
  */
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { PrintingRef } from '@/types'
 import styles from './PrintingPicker.module.css'
 
@@ -30,18 +36,22 @@ export interface PrintingDTO {
   readonly borderColor: string | null
 }
 
+/** All printings sharing one set, ready to render under a single header. */
+interface SetGroup {
+  readonly setCode: string
+  readonly setName: string | null
+  readonly printings: PrintingDTO[]
+}
+
 export function PrintingPicker({
   cardName,
   pinned,
-  anchor,
   onPick,
   onClear,
   onClose,
 }: {
   cardName: string
   pinned: PrintingRef | undefined
-  /** Bounding rect of the chip the picker is anchored to. The popover positions itself relative to it. */
-  anchor: DOMRect
   /**
    * Selection callback. Receives the full [PrintingDTO] so the deckbuilder can populate
    * its art-by-name cache without a second round-trip — the picker already has every
@@ -53,14 +63,18 @@ export function PrintingPicker({
 }) {
   const [printings, setPrintings] = useState<PrintingDTO[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [setFilter, setSetFilter] = useState<string>('') // '' = all sets
+  const [search, setSearch] = useState('')
   const dialogRef = useRef<HTMLDivElement | null>(null)
 
   // Fetch on open. Re-runs only when the card name changes — the picker is
-  // unmounted/remounted between rows so there's no stale-card race.
+  // unmounted/remounted between rows so there's no stale-card race. Filters reset with it.
   useEffect(() => {
     let cancelled = false
     setPrintings(null)
     setError(null)
+    setSetFilter('')
+    setSearch('')
     fetch(`/api/cards/${encodeURIComponent(cardName)}/printings`)
       .then((r) => {
         if (r.status === 404) return [] as PrintingDTO[]
@@ -78,83 +92,155 @@ export function PrintingPicker({
     }
   }, [cardName])
 
-  // Dismiss on outside click and Escape.
+  // Dismiss on Escape. (Outside-click is handled by the backdrop's onMouseDown.)
   useEffect(() => {
-    const onDoc = (e: MouseEvent) => {
-      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) onClose()
-    }
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
-    document.addEventListener('mousedown', onDoc)
     window.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onDoc)
-      window.removeEventListener('keydown', onKey)
-    }
+    return () => window.removeEventListener('keydown', onKey)
   }, [onClose])
 
-  // Anchor below-left of the chip, but flip above when there isn't room. The popover
-  // is fixed-positioned so it escapes any overflow:hidden on parent rows.
-  const popoverHeight = 360
-  const popoverWidth = 360
-  const fitsBelow = anchor.bottom + 8 + popoverHeight <= window.innerHeight
-  const top = fitsBelow ? anchor.bottom + 8 : Math.max(8, anchor.top - 8 - popoverHeight)
-  const left = Math.min(
-    Math.max(8, anchor.left),
-    window.innerWidth - popoverWidth - 8,
-  )
+  // Distinct sets present on this card. Printings already arrive sorted newest-first from
+  // the server, so first-seen order is the right set order too. Drives the set-filter
+  // dropdown — we only offer sets this card actually has, not the whole catalogue.
+  const setOptions = useMemo(() => {
+    const seen = new Map<string, string | null>()
+    for (const p of printings ?? []) {
+      if (!seen.has(p.setCode)) seen.set(p.setCode, p.setName)
+    }
+    return Array.from(seen, ([code, name]) => ({ code, name }))
+  }, [printings])
+
+  // Apply set filter + free-text search, then group what remains under set headers,
+  // preserving the server's newest-first order within and across sets.
+  const groups = useMemo<SetGroup[]>(() => {
+    if (!printings) return []
+    const needle = search.trim().toLowerCase()
+    const byCode = new Map<string, SetGroup>()
+    for (const p of printings) {
+      if (setFilter && p.setCode !== setFilter) continue
+      if (
+        needle &&
+        !p.setCode.toLowerCase().includes(needle) &&
+        !(p.setName?.toLowerCase().includes(needle) ?? false) &&
+        !p.collectorNumber.toLowerCase().includes(needle) &&
+        !(p.artist?.toLowerCase().includes(needle) ?? false)
+      ) {
+        continue
+      }
+      const group = byCode.get(p.setCode)
+      if (group) group.printings.push(p)
+      else byCode.set(p.setCode, { setCode: p.setCode, setName: p.setName, printings: [p] })
+    }
+    return Array.from(byCode.values())
+  }, [printings, setFilter, search])
+
+  const totalShown = useMemo(() => groups.reduce((n, g) => n + g.printings.length, 0), [groups])
 
   const isCurrent = (p: PrintingDTO): boolean =>
     pinned !== undefined && pinned.setCode === p.setCode && pinned.collectorNumber === p.collectorNumber
 
+  const hasPrintings = printings !== null && printings.length > 0
+
   return (
     <div
-      ref={dialogRef}
-      className={styles.popover}
-      role="dialog"
-      aria-label={`Pick a printing for ${cardName}`}
-      style={{ top, left, width: popoverWidth, maxHeight: popoverHeight }}
+      className={styles.overlay}
+      onMouseDown={(e) => {
+        if (!dialogRef.current?.contains(e.target as Node)) onClose()
+      }}
     >
-      <header className={styles.header}>
-        <span className={styles.title}>{cardName}</span>
-        <button type="button" className={styles.clearButton} onClick={onClear} disabled={pinned === undefined}>
-          Use default
-        </button>
-      </header>
-      <div className={styles.body}>
-        {printings === null && error === null && <div className={styles.muted}>Loading printings…</div>}
-        {error !== null && <div className={styles.error}>Couldn't load printings: {error}</div>}
-        {printings !== null && printings.length === 0 && (
-          <div className={styles.muted}>No printings registered for this card yet.</div>
-        )}
-        {printings !== null && printings.length > 0 && (
-          <ul className={styles.grid}>
-            {printings.map((p) => (
-              <li
-                key={`${p.setCode}-${p.collectorNumber}`}
-                className={`${styles.tile} ${isCurrent(p) ? styles.tileActive : ''}`}
+      <div
+        ref={dialogRef}
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Pick a printing for ${cardName}`}
+      >
+        <header className={styles.header}>
+          <span className={styles.title}>{cardName}</span>
+          {hasPrintings && (
+            <div className={styles.controls}>
+              <select
+                className={styles.setSelect}
+                value={setFilter}
+                onChange={(e) => setSetFilter(e.target.value)}
+                aria-label="Filter by set"
               >
-                <button
-                  type="button"
-                  className={styles.tileButton}
-                  onClick={() => onPick(p)}
-                  title={`${p.setName ?? p.setCode} #${p.collectorNumber}${p.artist ? ` — ${p.artist}` : ''}`}
-                >
-                  {p.imageUri ? (
-                    <img src={p.imageUri} alt="" className={styles.tileImage} loading="lazy" />
-                  ) : (
-                    <div className={styles.tileImagePlaceholder}>{p.setCode}</div>
-                  )}
-                  <span className={styles.tileMeta}>
-                    <span className={styles.tileSetCode}>{p.setCode}</span>
-                    <span className={styles.tileCollector}>#{p.collectorNumber}</span>
-                  </span>
-                </button>
-              </li>
+                <option value="">All sets ({printings.length})</option>
+                {setOptions.map((s) => (
+                  <option key={s.code} value={s.code}>
+                    {s.name ? `${s.name} (${s.code})` : s.code}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="search"
+                className={styles.search}
+                placeholder="Search set, number, artist…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                aria-label="Search printings"
+              />
+            </div>
+          )}
+          <button
+            type="button"
+            className={styles.clearButton}
+            onClick={onClear}
+            disabled={pinned === undefined}
+          >
+            Use default
+          </button>
+          <button type="button" className={styles.closeButton} onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+        </header>
+        <div className={styles.body}>
+          {printings === null && error === null && <div className={styles.muted}>Loading printings…</div>}
+          {error !== null && <div className={styles.error}>Couldn't load printings: {error}</div>}
+          {printings !== null && printings.length === 0 && (
+            <div className={styles.muted}>No printings registered for this card yet.</div>
+          )}
+          {hasPrintings && totalShown === 0 && (
+            <div className={styles.muted}>No printings match this filter.</div>
+          )}
+          {hasPrintings &&
+            groups.map((g) => (
+              <section key={g.setCode} className={styles.group}>
+                <h3 className={styles.groupHeader}>
+                  <span className={styles.groupName}>{g.setName ?? g.setCode}</span>
+                  <span className={styles.groupCode}>{g.setCode}</span>
+                  <span className={styles.groupCount}>{g.printings.length}</span>
+                </h3>
+                <ul className={styles.grid}>
+                  {g.printings.map((p) => (
+                    <li
+                      key={`${p.setCode}-${p.collectorNumber}`}
+                      className={`${styles.tile} ${isCurrent(p) ? styles.tileActive : ''}`}
+                    >
+                      <button
+                        type="button"
+                        className={styles.tileButton}
+                        onClick={() => onPick(p)}
+                        title={`${p.setName ?? p.setCode} #${p.collectorNumber}${p.artist ? ` — ${p.artist}` : ''}`}
+                      >
+                        {p.imageUri ? (
+                          <img src={p.imageUri} alt="" className={styles.tileImage} loading="lazy" />
+                        ) : (
+                          <div className={styles.tileImagePlaceholder}>{p.setCode}</div>
+                        )}
+                        <span className={styles.tileMeta}>
+                          <span className={styles.tileSetCode}>{p.setCode}</span>
+                          <span className={styles.tileCollector}>#{p.collectorNumber}</span>
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </section>
             ))}
-          </ul>
-        )}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## What

Reworks the deckbuilder's printing selector. The old picker was a 360×360 popover anchored to the deck-row chip, with a flat 2-column grid and no filtering — fine for a card with a handful of printings, but an inconvenient way to find the right art for cards with many printings. Basic lands have *hundreds*.

The new picker is a **centered modal** that:

- shows many printings at once in a responsive auto-fill grid (≈6–8 columns on a wide screen),
- **groups printings under per-set headers**, newest set first,
- adds a **set-filter dropdown** (only the sets this card actually has, derived from the fetched printings — no extra request) and a **free-text search** over set name/code, collector number, and artist.

## Screenshots

**Grouped, all sets (Forest — 35 printings):**

![Printing picker grouped by set](https://raw.githubusercontent.com/wingedsheep/argentum-engine/improve-printing-picker-screenshots/picker-grouped.png)

**Search filter narrowing to one set:**

![Printing picker filtered](https://raw.githubusercontent.com/wingedsheep/argentum-engine/improve-printing-picker-screenshots/picker-filter.png)

> The screenshots live on the throwaway branch `improve-printing-picker-screenshots`, not in this PR's diff.

## Scope

Frontend only. The `/api/cards/{name}/printings` response already carried everything needed (set name/code, collector number, artist), so there are **no backend, type, or store changes**. Pins are still stored as `PrintingRef` keyed by card name exactly as before; `onPick`/`onClear`/`onClose` are unchanged.

Because the picker now centers itself, the chip's bounding-rect anchor that `DeckbuilderPage` threaded through `onOpenPicker` is removed (dead after the layout change).

## Notes / follow-ups

- No virtualization in this pass. Lazy-loaded `<img>` + the set filter keep an "All sets" view of a basic land cheap; if profiling shows the all-sets view of a basic still stutters, the follow-up is to window the grid or cap per-set with a "show all" expander.
- The set filter is a plain styled `<select>`. The file already has a richer `SetCombobox` (type-to-search) used for the catalog set filter — easy to swap in later if we want search-in-dropdown here too.

## Verification

- `npm run typecheck` and `npm run build` pass.
- Manually driven against the running stack (screenshots above): grouping, set filter, search, and the existing pin/"Use default" behavior all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)