### PR TITLE
Introduce GatedEffect frame; migrate OptionalCostEffect onto it

### DIFF
--- a/backlog/gated-effect-migration-handoff.md
+++ b/backlog/gated-effect-migration-handoff.md
@@ -1,0 +1,273 @@
+# Handoff: migrate the rest of the gated-effect cluster onto `GatedEffect`
+
+You are continuing **phase-rs Lesson 1** (`backlog/phase-rs-lessons.md`). The frame already
+exists; your job is to migrate the *remaining* optional/gated wrapper effects onto it, one wrapper
+per PR, deleting each wrapper's bespoke executor as you go. This document is self-contained — read
+it fully before touching code. It assumes **no prior context**.
+
+> **Prerequisite.** The frame landed in **PR #484** (branch `gated-effect-frame`): `GatedEffect` +
+> `Gate` + one executor/continuation/resumer, with `OptionalCostEffect` already migrated as the
+> worked example. Start from that branch or from `main` *after* #484 merges. If `GatedEffect`
+> doesn't exist in `mtg-sdk`, you're on the wrong base — stop and rebase.
+
+> **Process rules (non-negotiable).**
+> - Use the **`add-feature` skill** for each migration — these are load-bearing SDK/engine changes.
+> - Verify any **CR rule number** before citing it (download the rules `.txt` and `grep`; don't
+>   trust memory). See root `CLAUDE.md`.
+> - **One wrapper per PR.** The snapshot re-bless and blast radius differ wildly per wrapper; mixing
+>   them makes review impossible.
+> - Don't revert/stash other agents' in-flight work. If a refactor collides, pause and report.
+
+---
+
+## 1. What the frame is
+
+`GatedEffect` replaces the "one wrapper type + one executor + one continuation touchpoint per
+optional concern" pattern with a single composable frame:
+
+```kotlin
+GatedEffect(
+    gate: Gate,                 // what must succeed first
+    then: Effect,               // runs iff the gate succeeds
+    otherwise: Effect? = null,  // runs iff the gate fails ("if you don't" / "otherwise")
+    decisionMaker: EffectTarget? = null,  // who resolves the gate (default: controller)
+    descriptionOverride: String? = null,
+    hint: String? = null,
+)
+
+sealed interface Gate {
+    data class MayDecide(prompt: String? = null, hint: String? = null) : Gate   // pure yes/no
+    data class MayPay(cost: Effect) : Gate                                       // may pay a cost
+}
+```
+
+**The point** (sdk-language-design "composition over enumeration"): one executor + one continuation
+resumer own the *canonical resolution order*, so target-locking-vs-gate-timing is correct **by
+construction** for every gate instead of being re-encoded (and re-bugged) per wrapper:
+
+1. Targets on `then`/`otherwise` are locked when the ability goes on the stack (trigger time,
+   **CR 603.3d**) — independent of the gate.
+2. The gate is resolved at resolution time (**CR 117.3a**) by `decisionMaker`.
+3. Success → `then`; failure → `otherwise`.
+
+### Where the frame lives (branch `gated-effect-frame`)
+
+| Concern | File |
+|---|---|
+| `GatedEffect`, `Gate`, `OptionalCostEffect` facade | `mtg-sdk/.../scripting/effects/GatedEffects.kt` |
+| Executor (MayPay affordability + yes/no; MayDecide yes/no) | `rules-engine/.../handlers/effects/composite/GatedEffectExecutor.kt` |
+| Continuation `GatedEffectContinuation` | `rules-engine/.../core/CoreContinuations.kt` |
+| Continuation serial registration | `rules-engine/.../core/Serialization.kt` (`subclass(GatedEffectContinuation::class)`) |
+| Resumer `resumeGatedEffect` + registration | `rules-engine/.../handlers/continuations/EffectAndTriggerContinuationResumer.kt` |
+| Executor registration | `rules-engine/.../handlers/effects/composite/CompositeExecutors.kt` |
+| Target-index walk | `mtg-sdk/.../serialization/CardValidator.kt` (`is GatedEffect`) |
+| Reference tests | `rules-engine/.../scenarios/GatedEffectScenarioTest.kt` |
+| Doc | `docs/card-sdk-language-reference.md` (search "GatedEffect") |
+
+---
+
+## 2. The reference migration (study this first)
+
+`OptionalCostEffect` → `Gate.MayPay` is already done. It is your template. Read the diff of PR #484
+(`git show` the commit `Introduce GatedEffect frame…`). The moves were:
+
+1. **Convert the wrapper data class into a facade *function* of the same name + signature**, in the
+   same package, returning a `GatedEffect`. This is the key trick: card source like
+   `OptionalCostEffect(cost = …, ifPaid = …)` keeps compiling unchanged (it now calls a function),
+   but the *compiled/serialized* form becomes `Gated`. No card edits.
+   ```kotlin
+   fun OptionalCostEffect(cost: Effect, ifPaid: Effect, ifNotPaid: Effect? = null,
+                          descriptionOverride: String? = null): GatedEffect =
+       GatedEffect(gate = Gate.MayPay(cost), then = ifPaid, otherwise = ifNotPaid,
+                   descriptionOverride = descriptionOverride)
+   ```
+2. **Fix the few type-level references** the lowering broke: `is OptionalCostEffect` / `as
+   OptionalCostEffect` / `shouldBeInstanceOf<OptionalCostEffect>` / facade return types. (For
+   OptionalCost that was `CardValidator` + `CardDslTest` + the `mayPay`/`mayPayOrElse` patterns.)
+3. **Delete the bespoke executor** (`OptionalCostEffectExecutor.kt`) and its registration in
+   `CompositeExecutors.kt`; the `GatedEffectExecutor` now handles the gate.
+4. **Re-bless the snapshot goldens** and confirm the diff is a *pure rename* (type + field-key
+   change + re-indent), nothing structural.
+5. **Update `docs/card-sdk-language-reference.md`** in the same PR.
+6. Add scenario tests proving parity (and, where a gate is new, the canonical order).
+
+The wrapper's *human description* should be reproduced by `GatedEffect`/`Gate` so prompts and any
+description-derived UI stay identical (note: `description` is a computed `val`, not serialized, so
+it never appears in snapshots — only the structural type/field changes do).
+
+---
+
+## 3. Two migration shapes
+
+**Shape A — wrapper maps to an *existing* gate** (`MayPay` or `MayDecide`): pure facade lowering as
+above. No engine change beyond deleting the old executor.
+
+**Shape B — wrapper needs a *new* gate**: first **add the `Gate` variant** + a branch in
+`GatedEffectExecutor` + a branch in `resumeGatedEffect` + the `CardValidator` walk, *then* lower the
+wrapper onto it. `DoAction` (for IfYouDo) and `WhenCondition` (for ConditionalEffect) are Shape B.
+
+When you add a `Gate` variant, also extend the `when (gate)` in `CardValidator.collectIndicesRecursive`
+(it's exhaustive) and in `GatedEffect.description`.
+
+---
+
+## 4. The remaining wrappers
+
+Counts are `grep` hits in `*/src/main` as of this writing — they signal blast radius (= how many
+snapshot goldens re-bless). Recommended order is easiest/lowest-risk first; it deviates from the
+lesson's order on purpose (do the cheap, mechanical ones before the two monsters).
+
+| # | Wrapper | → Gate | Shape | src files | Notes |
+|---|---|---|---|---|---|
+| 1 | `MayPayManaEffect` | `MayPay(PayManaCostEffect(cost))` | A | ~36 | Watch the **trigger-time** "may pay" variant (see §5). |
+| 2 | `BlightEffect` | `MayPay(<blight pipeline>)` | A | ~2 | Tiny. Cost = the blight cost effect; `then` = inner. |
+| 3 | `TapCreatureForEffectEffect` | `MayPay(<tap-a-creature>)` | A | ~2 | Tiny. |
+| 4 | `ConditionalEffect` | `WhenCondition(condition)` **(new)** | B | ~168 | Synchronous gate (no pause). Big re-bless. See §5. |
+| 5 | `MayEffect` | `MayDecide` | A* | ~129 | Biggest behavior surface + cast sites. See §5 — needs MayDecide extended first. Huge re-bless. |
+| 6 | `IfYouDoEffect` | `DoAction(action, criterion)` **(new)** | B | ~16 | Hardest mechanically: action-drain + `SuccessCriterion`. See §5. |
+| 7 | `PayOrSufferEffect` | `MayPay(cost)` with `then=null, otherwise=suffer` | A/B | ~28 | Uses `PayCost` (not `Effect`) + its own continuations. Decide if it folds cleanly. |
+| 8 | `MayPayXForEffect` | new "may pay X" gate | B | ~4 | Number chooser, not yes/no. Only if the algebra extends cleanly. |
+| 9 | `AnyPlayerMayPayEffect` | `AnyPlayerMayPay(cost)` **(new)** | B | ~6 | **APNAP multi-player** — the single-`decisionMaker` frame doesn't model this. Lesson says keep separate unless it folds cleanly. Likely *leave as-is*. |
+
+\* `MayEffect` is "Shape A" only after you extend `MayDecide`/`GatedEffectExecutor` to cover its
+extra behavior (see §5).
+
+### Do **NOT** fold (per the lesson — these are identity/timing, not gate parameters)
+
+- `BeholdEffect` — reveal/identity semantics. May *contain* a `GatedEffect` as its payoff.
+- `ReflexiveTriggerEffect` — target chosen *after* the action (distinct timing axis).
+- `Duration` — stays a clean field on the effects that need it.
+- unless-cost (`CounterEffect` + `CounterCondition`) — already unified; leave it.
+
+---
+
+## 5. Per-wrapper gotchas
+
+### `ConditionalEffect` → `Gate.WhenCondition` (do this one early)
+- Synchronous: evaluate the `Condition` and run `then`/`otherwise` with **no pause**. Mirror
+  `ConditionalEffectExecutor`'s use of the condition evaluator. The condition must evaluate
+  identically at resolution and projection (use `ConditionEvaluationContext`; never a separate
+  `*ProjectionCondition`).
+- `ConditionalEffect` fields are `effect`/`elseEffect` → `then`/`otherwise`. There are ~2 type
+  checks to fix.
+- Don't confuse it with `ConditionalOnCollectionExecutor` (a different effect — leave it).
+- 168 files re-bless: expect a large but mechanical snapshot diff. Confirm it's pure rename.
+
+### `MayPayManaEffect` → `Gate.MayPay(PayManaCostEffect(cost))`
+- The resolution-time form lowers cleanly: `Gate.MayPay` already runs `CompositeEffect(cost, then,
+  stopOnError)` and `PayManaCostExecutor` handles mana-source selection — so paying mana already
+  works through the frame.
+- **Caution:** there is a separate *trigger-time* "you may pay" path (`MayPayManaTriggerContinuation`
+  in `ManaContinuations.kt`, driven by `TriggerProcessor` and `ManaPaymentContinuationResumer`) used
+  when the "may pay" is offered as a trigger goes on the stack rather than at resolution. Audit those
+  sites (`grep -rn "as MayPayManaEffect"`) and decide whether the trigger path also routes through
+  the frame or stays. Don't delete `MayPayManaExecutor` until every path is covered.
+
+### `MayEffect` → `Gate.MayDecide` (biggest; extend the gate first)
+`MayEffect` carries behavior the current minimal `MayDecide` doesn't yet model. **Before** lowering,
+extend `GatedEffectExecutor`'s `MayDecide` branch (and `MayDecide`/`GatedEffect` as needed) to cover:
+- `sourceRequiredZone` — skip silently if the source left the required zone.
+- `inlineOnTrigger` — must flow into `DecisionContext(inlineOnTrigger = …)`.
+- `ChooseActionEffect` feasibility — `MayEffectExecutor` skips the prompt when the inner
+  `ChooseActionEffect` has no feasible choices; port that.
+- `decisionMaker` (already supported) and `hint`.
+
+Then handle the **6 type-level cast sites** (`grep -rn "is MayEffect\|as MayEffect"` over
+`*/src/main`). The important coupling is the **may-trigger** machinery: `MayTriggerContinuation` /
+`resumeMayTrigger` (in `EffectAndTriggerContinuationResumer.kt`) and `TriggerProcessor` do
+`trigger.ability.effect as MayEffect` to unwrap a "may" *trigger* (yes/no asked as the trigger goes
+on the stack, then targets). That is a distinct flow from the resolution-time `MayEffect`. You must
+either (a) keep that trigger-time unwrap working against `GatedEffect`/`Gate.MayDecide`, or (b)
+migrate it deliberately. Do not leave a half-cast that compiles but silently mis-resolves "may"
+triggers. ~129 files re-bless — the largest snapshot diff in the whole effort.
+
+### `IfYouDoEffect` → `Gate.DoAction(action, criterion)` (hardest mechanically)
+This gate is **not decision-driven** — it runs an `action` (which may itself pause), then evaluates
+`SuccessCriterion` against a pre-action snapshot to decide `then` vs `otherwise`. The existing
+machinery to absorb:
+- `IfYouDoEffectExecutor` (pre-pushes a continuation *before* the action runs),
+- `IfYouDoContinuation` + `IfYouDoSnapshot`,
+- the **auto-resumer** in `CoreAutoResumerModule` that fires when the action's own continuations
+  drain (there is no yes/no decision to resume on).
+
+`GatedEffectContinuation` today only handles the yes/no (decision-driven) resume. For `DoAction`
+you'll need the action-drain/auto-resume path too — either extend the frame's continuation to carry
+the snapshot + criterion and teach `CoreAutoResumerModule` about it, or keep a dedicated
+continuation for the action-drain case while still routing through one `GatedEffectExecutor`. Keep
+the `SuccessCriterion` evaluation logic (`Auto`/`CollectionNonEmpty`/`Always`) intact. Add scenario
+tests for: action did work → `then`; action did nothing (declined / empty hand / no legal
+sacrifice) → `otherwise`; action paused mid-way then completed.
+
+### `PayOrSufferEffect` / `AnyPlayerMayPayEffect` / `MayPayXForEffect`
+- `PayOrSuffer` is "[suffer] unless you pay [cost]" — i.e. `MayPay(cost)` with `then = null,
+  otherwise = suffer`. But it stores a `PayCost` (not an `Effect`) and has its own continuations
+  (`PayOrSufferContinuation`, `PayOrSufferChoiceContinuation`). Only fold it if it lowers cleanly;
+  otherwise leave it and note why.
+- `MayPayX` needs a number chooser (0..max), not a yes/no — a genuinely different gate. Defer unless
+  the algebra extends naturally.
+- `AnyPlayerMayPay` is APNAP, multi-player; the single-`decisionMaker` frame can't express the
+  ordering. The lesson says keep it separate. **Recommend leaving it** unless you can model
+  multi-player order cleanly — document the decision either way.
+
+---
+
+## 6. The mechanical recipe (per wrapper)
+
+1. **Branch + skill.** New branch off the latest base; invoke `add-feature`.
+2. **(Shape B only)** Add the `Gate` variant; add its branch in `GatedEffectExecutor.execute`, in
+   `resumeGatedEffect` (or the auto-resumer for action-drain gates), in
+   `CardValidator.collectIndicesRecursive`, and in `GatedEffect.description`. Compile.
+3. **Lower the wrapper:** replace the `data class` with a same-name/same-signature facade `fun`
+   returning `GatedEffect`, in the same package. Keep KDoc.
+4. **Fix type-level references** (`is`/`as`/`shouldBeInstanceOf`/facade return types). Use
+   `grep -rn "\bWrapperName\b" --include=*.kt`.
+5. **Delete the bespoke executor** + its `CompositeExecutors.kt` registration (and any now-dead
+   continuation/resumer — but only once *every* path is migrated; audit casts first).
+6. **Build incrementally:** `./gradlew :mtg-sdk:compileKotlin :rules-engine:compileKotlin
+   :mtg-sets:compileKotlin`.
+7. **Tests:** add/adjust engine scenario tests proving parity (and canonical order for new gates).
+   Update any SDK unit test that constructed the wrapper as a type.
+8. **Re-bless snapshots** and eyeball the diff is a pure rename:
+   ```
+   ./gradlew :mtg-sets:test --tests "*CardDefinitionSnapshotTest" -DupdateSnapshots=true
+   git diff mtg-sets/src/test/resources/snapshots/cards/   # confirm type/field rename only
+   ```
+9. **Docs:** update `docs/card-sdk-language-reference.md` in the same PR.
+10. **Full sweep, then PR:**
+    ```
+    ./gradlew :mtg-sdk:test :mtg-sets:test :rules-engine:test :game-server:test
+    ```
+
+---
+
+## 7. Load-bearing rules (will bite you)
+
+- **`Effect` and `Gate` are sealed interfaces** → new `Gate` variants auto-register for kotlinx
+  serialization with just `@Serializable` + `@SerialName("Gate.X")`. **`ContinuationFrame` is NOT** —
+  any new continuation must be added to the `polymorphic(ContinuationFrame::class)` block in
+  `rules-engine/.../core/Serialization.kt`, or you'll get a runtime serialization error.
+- **Continuations must carry targets.** Any frame that later executes an effect referencing
+  `EffectTarget.ContextTarget(n)` must propagate the `EffectContext` (with `targets`/`namedTargets`),
+  or the effect resolves with an empty context and silently fizzles. `GatedEffectContinuation`
+  already carries `effectContext` — keep it.
+- **Pure data, no logic in SDK.** `Gate`/`GatedEffect` are serializable data bags; all behavior lives
+  in the executor/resumer.
+- **Immutability**; **events not silent mutations**; **projected state for battlefield reads** — all
+  still apply (root `CLAUDE.md`).
+- **Snapshot churn is expected and is the safety net.** A pure-rename diff across N sets is the
+  *correct* outcome of a clean lowering; a structural change in the diff means you changed behavior —
+  investigate before re-blessing.
+- **Update the DSL reference in the same change** (`mtg-sdk` standing rule).
+
+---
+
+## 8. Definition of done (per wrapper PR)
+
+- [ ] Wrapper is a facade `fun` lowering to `GatedEffect`; no card source edits.
+- [ ] Bespoke executor (+ dead continuation/resumer, if fully superseded) deleted; registration removed.
+- [ ] All `is`/`as`/`shouldBeInstanceOf` sites updated; no `as Wrapper` cast left mis-resolving.
+- [ ] Scenario tests prove behavioral parity (+ canonical order for new gates) and pass.
+- [ ] Snapshot goldens re-blessed; diff verified as a pure rename.
+- [ ] `docs/card-sdk-language-reference.md` updated.
+- [ ] `:mtg-sdk :mtg-sets :rules-engine :game-server` test suites green.
+- [ ] CR numbers in comments/commit verified against the official rules text.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -569,7 +569,22 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   Crab). Do **not** pass a magic `count = 20` to mean "any number" — use `unlimited`/`dynamicMaxCount`.
 - `PhaseOutEffect(target = Self)` — phase the target permanent out (Rule 702.26); facade `Effects.PhaseOut(target)`. While phased out it's treated as though it doesn't exist (excluded from `getBattlefield`, so from projection, triggers, combat, targeting, and SBAs) and phases back in before its controller's next untap step. Indirect phasing (attached Auras/Equipment) is handled automatically. Used as the `suffer` branch of a pay-or-phase trigger (Vaporous Djinn: "phases out unless you pay {U}{U}" = `PayOrSufferEffect(PayCost.Mana(...), Effects.PhaseOut())`).
 - `MarkExileOnDeathEffect(target)` — replace next "to graveyard" with "to exile".
-- `OptionalCostEffect(cost, effect)` — pay cost to trigger an effect.
+- `GatedEffect(gate, then, otherwise?, decisionMaker?)` — **the unified resolution frame for the
+  optional / gated-effect cluster** (phase-rs Lesson 1). A `Gate` decides whether `then` runs; if it
+  fails, `otherwise` runs. One executor + one continuation/resumer own the canonical unwind order, so
+  targets on `then`/`otherwise` lock at trigger time (CR 603.3d) and the gate is resolved at
+  resolution time (CR 117.3a) by `decisionMaker` (defaults to the controller) — the may-vs-target
+  timing is correct by construction rather than re-encoded per wrapper. Gates:
+  - `Gate.MayDecide(prompt?, hint?)` — pure yes/no ("You may [then].").
+  - `Gate.MayPay(cost)` — "You may [cost]. If you do, [then]." `cost` is a cost **effect**
+    (`PayManaCostEffect`, `PayLifeEffect`, `SacrificeEffect`, or a `CompositeEffect` of them). An
+    unaffordable cost (mana/life recognized; other shapes assumed payable) skips the prompt straight
+    to `otherwise`. On "yes", the cost is paid then `then` runs (`stopOnError`: an unpayable cost
+    aborts the payoff). New gate kinds (`DoAction` for IfYouDo, `WhenCondition` for ConditionalEffect,
+    APNAP `AnyPlayerMayPay`) fold in as those wrappers migrate.
+- `OptionalCostEffect(cost, ifPaid, ifNotPaid?)` — "You may [cost]. If you do, [ifPaid]." Facade
+  preserved for existing cards; it now **lowers to `GatedEffect` with a `Gate.MayPay`** gate (compiled
+  form is `Gated`, not a distinct `OptionalCost` type).
 - `Effects.AnyPlayerMayPay(cost, consequence)` / `Effects.UnlessAnyPlayerPays(cost, effect)` —
   back the single `AnyPlayerMayPayEffect(cost, consequence?, consequenceIfNonePaid?)`, which asks
   each player in APNAP order whether to pay `cost`. The first to pay runs `consequence` and stops

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/EffectPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/EffectPatterns.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
 import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.SearchDestination
@@ -44,10 +45,10 @@ object EffectPatterns {
     // Optional Cost Patterns (MiscPatterns)
     // =========================================================================
 
-    fun mayPay(cost: Effect, effect: Effect): OptionalCostEffect =
+    fun mayPay(cost: Effect, effect: Effect): GatedEffect =
         MiscPatterns.mayPay(cost, effect)
 
-    fun mayPayOrElse(cost: Effect, ifPaid: Effect, ifNotPaid: Effect): OptionalCostEffect =
+    fun mayPayOrElse(cost: Effect, ifPaid: Effect, ifNotPaid: Effect): GatedEffect =
         MiscPatterns.mayPayOrElse(cost, ifPaid, ifNotPaid)
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MiscPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MiscPatterns.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
 import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
@@ -37,10 +38,10 @@ import com.wingedsheep.sdk.scripting.values.EffectVariable
  */
 object MiscPatterns {
 
-    fun mayPay(cost: Effect, effect: Effect): OptionalCostEffect =
+    fun mayPay(cost: Effect, effect: Effect): GatedEffect =
         OptionalCostEffect(cost, effect)
 
-    fun mayPayOrElse(cost: Effect, ifPaid: Effect, ifNotPaid: Effect): OptionalCostEffect =
+    fun mayPayOrElse(cost: Effect, ifPaid: Effect, ifNotPaid: Effect): GatedEffect =
         OptionalCostEffect(cost, ifPaid, ifNotPaid)
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -419,43 +419,6 @@ data class BeholdEffect(
 }
 
 /**
- * Effect with an optional cost - "You may [cost]. If you do, [ifPaid]."
- *
- * This is the fundamental building block for optional effects like:
- * - "You may pay {2}. If you do, draw a card."
- * - "You may sacrifice a creature. If you do, deal 3 damage to any target."
- * - "You may discard a card. If you do, draw two cards."
- *
- * @property cost The optional cost the player may pay (e.g., PayLifeEffect, SacrificeEffect)
- * @property ifPaid The effect that happens if the player pays the cost
- * @property ifNotPaid Optional effect if the player doesn't pay (usually null)
- */
-@SerialName("OptionalCost")
-@Serializable
-data class OptionalCostEffect(
-    val cost: Effect,
-    val ifPaid: Effect,
-    val ifNotPaid: Effect? = null,
-    val descriptionOverride: String? = null
-) : Effect {
-    override val description: String = descriptionOverride ?: buildString {
-        append("You may ${cost.description.replaceFirstChar { it.lowercase() }}. ")
-        append("If you do, ${ifPaid.description.replaceFirstChar { it.lowercase() }}")
-        if (ifNotPaid != null) {
-            append(". Otherwise, ${ifNotPaid.description.replaceFirstChar { it.lowercase() }}")
-        }
-    }
-
-    override fun applyTextReplacement(replacer: TextReplacer): Effect {
-        val newCost = cost.applyTextReplacement(replacer)
-        val newIfPaid = ifPaid.applyTextReplacement(replacer)
-        val newIfNotPaid = ifNotPaid?.applyTextReplacement(replacer)
-        return if (newCost !== cost || newIfPaid !== ifPaid || newIfNotPaid !== ifNotPaid)
-            copy(cost = newCost, ifPaid = newIfPaid, ifNotPaid = newIfNotPaid) else this
-    }
-}
-
-/**
  * Reflexive trigger - "When you do, [effect]."
  *
  * Used for abilities that trigger from the resolution of another effect.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/GatedEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/GatedEffects.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.sdk.scripting.effects
+
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.text.TextReplacer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// =============================================================================
+// Gated effects — one resolution frame for the optional / gated-effect cluster
+// =============================================================================
+
+/**
+ * One resolution frame for the optional / gated-effect cluster.
+ *
+ * A [GatedEffect] pairs a [Gate] — the thing that must succeed first — with a [then]
+ * effect that runs iff the gate succeeds and an optional [otherwise] that runs iff it
+ * fails. A single executor and a single continuation resumer own the canonical unwind
+ * order for *every* gate kind, so the "decide / pay vs. lock-targets" timing that used to
+ * be re-encoded (and re-bugged) per wrapper is correct by construction:
+ *
+ *  1. Targets for [then] / [otherwise] are locked when the ability is put on the stack
+ *     (trigger time, CR 603.3d) — independent of the gate, before the gate is resolved.
+ *  2. The gate is resolved at resolution time (CR 117.3a) via [decisionMaker].
+ *  3. On success → [then]; on failure → [otherwise].
+ *
+ * This is the "composition over enumeration" replacement for the wrapper-per-concern
+ * cluster (MayEffect / IfYouDoEffect / OptionalCostEffect / …). It currently models the
+ * decision-driven gates ([Gate.MayDecide], [Gate.MayPay]); the action-outcome gate
+ * (IfYouDo) and the any-player-pays gate are folded in as their wrappers migrate.
+ *
+ * @property gate What must succeed before [then] runs.
+ * @property then Effect that runs iff the gate succeeds.
+ * @property otherwise Effect that runs iff the gate fails ("if you don't" / "otherwise").
+ * @property decisionMaker Who resolves the gate. Defaults to the ability's controller.
+ *   Only the prompt is delegated; [then] still resolves under the original controller.
+ * @property descriptionOverride Hand-written text to use instead of the gate-derived one.
+ * @property hint Optional reminder text shown under the yes/no prompt.
+ */
+@SerialName("Gated")
+@Serializable
+data class GatedEffect(
+    val gate: Gate,
+    val then: Effect,
+    val otherwise: Effect? = null,
+    val decisionMaker: EffectTarget? = null,
+    val descriptionOverride: String? = null,
+    val hint: String? = null
+) : Effect {
+    override val description: String = descriptionOverride ?: when (val g = gate) {
+        is Gate.MayDecide -> g.prompt ?: buildString {
+            append("You may ${then.description.replaceFirstChar { it.lowercase() }}")
+            if (otherwise != null) {
+                append(". Otherwise, ${otherwise.description.replaceFirstChar { it.lowercase() }}")
+            }
+        }
+        is Gate.MayPay -> buildString {
+            append("You may ${g.cost.description.replaceFirstChar { it.lowercase() }}. ")
+            append("If you do, ${then.description.replaceFirstChar { it.lowercase() }}")
+            if (otherwise != null) {
+                append(". Otherwise, ${otherwise.description.replaceFirstChar { it.lowercase() }}")
+            }
+        }
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect {
+        val newGate = gate.applyTextReplacement(replacer)
+        val newThen = then.applyTextReplacement(replacer)
+        val newOtherwise = otherwise?.applyTextReplacement(replacer)
+        return if (newGate !== gate || newThen !== then || newOtherwise !== otherwise)
+            copy(gate = newGate, then = newThen, otherwise = newOtherwise) else this
+    }
+}
+
+/**
+ * The condition a [GatedEffect] must clear before its [GatedEffect.then] runs.
+ *
+ * Each variant captures one *gate kind* from the former wrapper cluster; they all share
+ * the single [GatedEffect] frame, its executor, and its resumer. New gate kinds are added
+ * here as the remaining wrappers migrate in (IfYouDoEffect → a `DoAction` gate that scores
+ * an action against a `SuccessCriterion`; ConditionalEffect → a `WhenCondition` gate;
+ * AnyPlayerMayPayEffect → an APNAP `AnyPlayerMayPay` gate).
+ */
+@Serializable
+sealed interface Gate {
+    /** Rewrite any effects this gate carries (text-replacement for variabilized cards). */
+    fun applyTextReplacement(replacer: TextReplacer): Gate
+
+    /**
+     * Pure yes/no — "You may [then]." The decision-maker chooses whether
+     * [GatedEffect.then] happens at all. Replaces the simple MayEffect shape.
+     *
+     * @property prompt Optional override for the yes/no prompt text.
+     * @property hint Optional reminder text shown under the prompt.
+     */
+    @SerialName("Gate.MayDecide")
+    @Serializable
+    data class MayDecide(
+        val prompt: String? = null,
+        val hint: String? = null
+    ) : Gate {
+        override fun applyTextReplacement(replacer: TextReplacer): Gate = this
+    }
+
+    /**
+     * Optionally pay a cost — "You may [cost]. If you do, [then]." The gate succeeds iff
+     * the [cost] effect is paid in full. Affordability is checked before prompting, so an
+     * unpayable cost skips straight to [GatedEffect.otherwise] rather than offering an
+     * impossible "yes". Replaces OptionalCostEffect.
+     *
+     * @property cost The cost effect the decision-maker may pay — e.g. `PayManaCostEffect`,
+     *   `PayLifeEffect`, `SacrificeEffect`, or a `CompositeEffect` composing them.
+     */
+    @SerialName("Gate.MayPay")
+    @Serializable
+    data class MayPay(
+        val cost: Effect
+    ) : Gate {
+        override fun applyTextReplacement(replacer: TextReplacer): Gate {
+            val newCost = cost.applyTextReplacement(replacer)
+            return if (newCost !== cost) copy(cost = newCost) else this
+        }
+    }
+}
+
+/**
+ * "You may [cost]. If you do, [ifPaid]. Otherwise, [ifNotPaid]."
+ *
+ * Backwards-compatible facade preserved for the cards (and the `mayPay` / `mayPayOrElse`
+ * patterns) that authored against the former `OptionalCostEffect` data class. It now lowers
+ * to a [GatedEffect] with a [Gate.MayPay] gate — one frame, one executor, one resumer — so
+ * there is no bespoke optional-cost executor or continuation. Card source is unchanged; only
+ * the compiled/serialized representation moved to `Gated`.
+ */
+@Suppress("FunctionName")
+fun OptionalCostEffect(
+    cost: Effect,
+    ifPaid: Effect,
+    ifNotPaid: Effect? = null,
+    descriptionOverride: String? = null
+): GatedEffect = GatedEffect(
+    gate = Gate.MayPay(cost),
+    then = ifPaid,
+    otherwise = ifNotPaid,
+    descriptionOverride = descriptionOverride
+)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
@@ -32,7 +32,8 @@ import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
-import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
 import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
@@ -179,10 +180,13 @@ object CardValidator {
                 collectIndicesRecursive(effect.effect, indices)
                 effect.elseEffect?.let { collectIndicesRecursive(it, indices) }
             }
-            is OptionalCostEffect -> {
-                collectIndicesRecursive(effect.cost, indices)
-                collectIndicesRecursive(effect.ifPaid, indices)
-                effect.ifNotPaid?.let { collectIndicesRecursive(it, indices) }
+            is GatedEffect -> {
+                when (val gate = effect.gate) {
+                    is Gate.MayPay -> collectIndicesRecursive(gate.cost, indices)
+                    is Gate.MayDecide -> {}
+                }
+                collectIndicesRecursive(effect.then, indices)
+                effect.otherwise?.let { collectIndicesRecursive(it, indices) }
             }
             is ReflexiveTriggerEffect -> {
                 collectIndicesRecursive(effect.action, indices)

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/CardDslTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/CardDslTest.kt
@@ -17,6 +17,8 @@ import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
 import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
 import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
 import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
@@ -912,9 +914,10 @@ class CardDslTest : DescribeSpec({
                 DrawCardsEffect(2)
             )
 
-            effect.shouldBeInstanceOf<OptionalCostEffect>()
-            effect.cost shouldBe PayLifeEffect(3)
-            effect.ifPaid shouldBe DrawCardsEffect(2, EffectTarget.Controller)
+            val gated = effect.shouldBeInstanceOf<GatedEffect>()
+            val gate = gated.gate.shouldBeInstanceOf<Gate.MayPay>()
+            gate.cost shouldBe PayLifeEffect(3)
+            gated.then shouldBe DrawCardsEffect(2, EffectTarget.Controller)
         }
 
         it("should create reflexive trigger shorthand") {

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -15767,14 +15767,17 @@
                         },
                         "binding": "ANY",
                         "effect": {
-                            "type": "OptionalCost",
-                            "cost": {
-                                "type": "Sacrifice",
-                                "filter": "nonland permanent",
-                                "count": 3,
-                                "excludeSource": true
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.MayPay",
+                                "cost": {
+                                    "type": "Sacrifice",
+                                    "filter": "nonland permanent",
+                                    "count": 3,
+                                    "excludeSource": true
+                                }
                             },
-                            "ifPaid": {
+                            "then": {
                                 "type": "Composite",
                                 "effects": [
                                     {
@@ -22547,21 +22550,24 @@
                             "storeAs": "eligible"
                         },
                         {
-                            "type": "OptionalCost",
-                            "cost": {
-                                "type": "Composite",
-                                "effects": [
-                                    {
-                                        "type": "PayManaCost",
-                                        "cost": "{W}{B}"
-                                    },
-                                    {
-                                        "type": "PayLife",
-                                        "amount": 2
-                                    }
-                                ]
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.MayPay",
+                                "cost": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "PayManaCost",
+                                            "cost": "{W}{B}"
+                                        },
+                                        {
+                                            "type": "PayLife",
+                                            "amount": 2
+                                        }
+                                    ]
+                                }
                             },
-                            "ifPaid": {
+                            "then": {
                                 "type": "Composite",
                                 "effects": [
                                     {
@@ -22612,21 +22618,24 @@
                             "storeAs": "eligible"
                         },
                         {
-                            "type": "OptionalCost",
-                            "cost": {
-                                "type": "Composite",
-                                "effects": [
-                                    {
-                                        "type": "PayManaCost",
-                                        "cost": "{W}{B}"
-                                    },
-                                    {
-                                        "type": "PayLife",
-                                        "amount": 2
-                                    }
-                                ]
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.MayPay",
+                                "cost": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "PayManaCost",
+                                            "cost": "{W}{B}"
+                                        },
+                                        {
+                                            "type": "PayLife",
+                                            "amount": 2
+                                        }
+                                    ]
+                                }
                             },
-                            "ifPaid": {
+                            "then": {
                                 "type": "Composite",
                                 "effects": [
                                     {

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -9544,45 +9544,48 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "OptionalCost",
-                    "cost": {
-                        "type": "Composite",
-                        "effects": [
-                            {
-                                "type": "GatherCards",
-                                "source": {
-                                    "type": "ControlledPermanents",
-                                    "filter": "creature"
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "ControlledPermanents",
+                                        "filter": "creature"
+                                    },
+                                    "storeAs": "blightTargets"
                                 },
-                                "storeAs": "blightTargets"
-                            },
-                            {
-                                "type": "SelectFromCollection",
-                                "from": "blightTargets",
-                                "selection": {
-                                    "type": "ChooseExactly",
-                                    "count": {
-                                        "type": "Fixed",
-                                        "amount": 1
-                                    }
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "blightTargets",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "blighted",
+                                    "prompt": "Blight 2 — choose a creature you control",
+                                    "useTargetingUI": true
                                 },
-                                "storeSelected": "blighted",
-                                "prompt": "Blight 2 — choose a creature you control",
-                                "useTargetingUI": true
-                            },
-                            {
-                                "type": "AddCountersToCollection",
-                                "collectionName": "blighted",
-                                "counterType": "-1/-1",
-                                "count": 2
-                            }
-                        ]
+                                {
+                                    "type": "AddCountersToCollection",
+                                    "collectionName": "blighted",
+                                    "counterType": "-1/-1",
+                                    "count": 2
+                                }
+                            ]
+                        }
                     },
-                    "ifPaid": {
+                    "then": {
                         "type": "Composite",
                         "effects": []
                     },
-                    "ifNotPaid": {
+                    "otherwise": {
                         "type": "LoseLife",
                         "amount": {
                             "type": "Fixed",
@@ -15377,40 +15380,43 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "OptionalCost",
-                    "cost": {
-                        "type": "Composite",
-                        "effects": [
-                            {
-                                "type": "GatherCards",
-                                "source": {
-                                    "type": "ControlledPermanents",
-                                    "filter": "creature"
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "ControlledPermanents",
+                                        "filter": "creature"
+                                    },
+                                    "storeAs": "blightTargets"
                                 },
-                                "storeAs": "blightTargets"
-                            },
-                            {
-                                "type": "SelectFromCollection",
-                                "from": "blightTargets",
-                                "selection": {
-                                    "type": "ChooseExactly",
-                                    "count": {
-                                        "type": "Fixed",
-                                        "amount": 1
-                                    }
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "blightTargets",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "blighted",
+                                    "prompt": "Blight 1 — choose a creature you control",
+                                    "useTargetingUI": true
                                 },
-                                "storeSelected": "blighted",
-                                "prompt": "Blight 1 — choose a creature you control",
-                                "useTargetingUI": true
-                            },
-                            {
-                                "type": "AddCountersToCollection",
-                                "collectionName": "blighted",
-                                "counterType": "-1/-1"
-                            }
-                        ]
+                                {
+                                    "type": "AddCountersToCollection",
+                                    "collectionName": "blighted",
+                                    "counterType": "-1/-1"
+                                }
+                            ]
+                        }
                     },
-                    "ifPaid": {
+                    "then": {
                         "type": "CreatePredefinedToken",
                         "tokenType": "Treasure"
                     },
@@ -19773,12 +19779,15 @@
                 "trigger": "SpellCastEvent",
                 "binding": "ANY",
                 "effect": {
-                    "type": "OptionalCost",
-                    "cost": {
-                        "type": "PayLife",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayLife",
+                            "amount": 1
+                        }
                     },
-                    "ifPaid": {
+                    "then": {
                         "type": "DrawCards",
                         "count": {
                             "type": "Fixed",

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -9315,12 +9315,15 @@
     "oracleText": "You may sacrifice a Food. If you do, target creature gets +4/+4 until end of turn. Otherwise, that creature gets +2/+2 until end of turn.",
     "script": {
         "spellEffect": {
-            "type": "OptionalCost",
-            "cost": {
-                "type": "Sacrifice",
-                "filter": "Food"
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.MayPay",
+                "cost": {
+                    "type": "Sacrifice",
+                    "filter": "Food"
+                }
             },
-            "ifPaid": {
+            "then": {
                 "type": "ModifyStats",
                 "powerModifier": {
                     "type": "Fixed",
@@ -9335,7 +9338,7 @@
                     "name": "target creature"
                 }
             },
-            "ifNotPaid": {
+            "otherwise": {
                 "type": "ModifyStats",
                 "powerModifier": {
                     "type": "Fixed",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -1100,68 +1100,71 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "OptionalCost",
-                    "cost": {
-                        "type": "Composite",
-                        "effects": [
-                            {
-                                "type": "GatherCards",
-                                "source": {
-                                    "type": "ControlledPermanents",
-                                    "filter": {
-                                        "cardPredicates": [
-                                            {
-                                                "type": "Or",
-                                                "predicates": [
-                                                    "IsCreature",
-                                                    {
-                                                        "type": "And",
-                                                        "predicates": [
-                                                            "IsArtifact",
-                                                            {
-                                                                "type": "HasSubtype",
-                                                                "subtype": "Treasure"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            }
-                                        ],
-                                        "statePredicates": [
-                                            "IsUntapped"
-                                        ]
-                                    }
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "ControlledPermanents",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                {
+                                                    "type": "Or",
+                                                    "predicates": [
+                                                        "IsCreature",
+                                                        {
+                                                            "type": "And",
+                                                            "predicates": [
+                                                                "IsArtifact",
+                                                                {
+                                                                    "type": "HasSubtype",
+                                                                    "subtype": "Treasure"
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "statePredicates": [
+                                                "IsUntapped"
+                                            ]
+                                        }
+                                    },
+                                    "storeAs": "rentTargets"
                                 },
-                                "storeAs": "rentTargets"
-                            },
-                            {
-                                "type": "SelectFromCollection",
-                                "from": "rentTargets",
-                                "selection": {
-                                    "type": "ChooseExactly",
-                                    "count": {
-                                        "type": "Fixed",
-                                        "amount": 2
-                                    }
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "rentTargets",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "toTap",
+                                    "prompt": "Tap two untapped creatures and/or Treasures you control",
+                                    "useTargetingUI": true
                                 },
-                                "storeSelected": "toTap",
-                                "prompt": "Tap two untapped creatures and/or Treasures you control",
-                                "useTargetingUI": true
-                            },
-                            {
-                                "type": "TapUntapCollection",
-                                "collectionName": "toTap"
-                            }
-                        ]
+                                {
+                                    "type": "TapUntapCollection",
+                                    "collectionName": "toTap"
+                                }
+                            ]
+                        }
                     },
-                    "ifPaid": {
+                    "then": {
                         "type": "DrawCards",
                         "count": {
                             "type": "Fixed",
                             "amount": 1
                         }
                     },
-                    "ifNotPaid": "SacrificeSelf",
+                    "otherwise": "SacrificeSelf",
                     "descriptionOverride": "Tap two untapped creatures and/or Treasures you control. If you do, draw a card. Otherwise, sacrifice Rent Is Due."
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -3463,12 +3463,15 @@
                 "id": "ability_1",
                 "trigger": "AttackEvent",
                 "effect": {
-                    "type": "OptionalCost",
-                    "cost": {
-                        "type": "PayManaCost",
-                        "cost": "{1}{W}"
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}{W}"
+                        }
                     },
-                    "ifPaid": {
+                    "then": {
                         "type": "Modal",
                         "modes": [
                             {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.Gate
 import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -188,6 +189,32 @@ data class MayAbilityContinuation(
     val sourceName: String?,
     val effectIfYes: Effect?,
     val effectIfNo: Effect?,
+    val effectContext: EffectContext
+) : ContinuationFrame
+
+/**
+ * Resume a [com.wingedsheep.sdk.scripting.effects.GatedEffect] after its gate has been
+ * resolved by a yes/no decision.
+ *
+ * The unified frame for the decision-driven gate kinds ([Gate.MayDecide], [Gate.MayPay]):
+ * the executor pauses with a [YesNoDecision], and this continuation carries everything the
+ * resumer needs to dispatch the right branch in the canonical order — run [then] on success
+ * (for [Gate.MayPay], paying [Gate.MayPay.cost] first), or [otherwise] on a decline.
+ *
+ * [effectContext] carries the locked `targets` so a targeted [then] (e.g. "you may pay {2};
+ * if you do, destroy target creature") resolves against the trigger-time target rather than
+ * re-choosing one — see the engine load-bearing rule on propagating targets.
+ *
+ * @property gate The gate that was offered (determines how a "yes" is consumed).
+ * @property then Effect to run iff the gate succeeds.
+ * @property otherwise Effect to run iff the gate fails / is declined.
+ */
+@Serializable
+data class GatedEffectContinuation(
+    override val decisionId: String,
+    val gate: Gate,
+    val then: Effect,
+    val otherwise: Effect?,
     val effectContext: EffectContext
 ) : ContinuationFrame
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -180,6 +180,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ReturnToHandContinuation::class)
         subclass(ExileMultiZoneContinuation::class)
         subclass(MayAbilityContinuation::class)
+        subclass(GatedEffectContinuation::class)
         subclass(MayRevealCardFromHandContinuation::class)
         subclass(BeholdContinuation::class)
         subclass(IfYouDoContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -4,7 +4,10 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.Gate
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import java.util.UUID
 
@@ -29,6 +32,7 @@ class EffectAndTriggerContinuationResumer(
             ExecutionResult.success(state)
         },
         resumer(MayAbilityContinuation::class, ::resumeMayAbility),
+        resumer(GatedEffectContinuation::class, ::resumeGatedEffect),
         resumer(MayRevealCardFromHandContinuation::class, ::resumeMayRevealCardFromHand),
         resumer(BeholdContinuation::class, ::resumeBehold),
         resumer(MayTriggerContinuation::class, ::resumeMayTrigger),
@@ -306,6 +310,49 @@ class EffectAndTriggerContinuationResumer(
         }
 
         val result = services.effectExecutorRegistry.execute(state, effectToExecute, context).toExecutionResult()
+
+        if (result.isPaused) {
+            return result
+        }
+
+        return checkForMore(result.state, result.events.toList())
+    }
+
+    /**
+     * Resume a [GatedEffect] after its gate's yes/no decision. The canonical unwind:
+     * on "yes", run [GatedEffectContinuation.then] — for [Gate.MayPay], pay the cost first
+     * (a `stopOnError` composite so an unpayable cost aborts the payoff, mirroring the former
+     * OptionalCost behavior); on "no", run [GatedEffectContinuation.otherwise]. The locked
+     * targets travel in the continuation's [EffectContext], so a targeted `then` resolves
+     * against its trigger-time target.
+     */
+    private fun resumeGatedEffect(
+        state: GameState,
+        continuation: GatedEffectContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is YesNoResponse) {
+            return ExecutionResult.error(state, "Expected yes/no response for gated effect")
+        }
+
+        val effectToExecute: Effect? = if (response.choice) {
+            when (val gate = continuation.gate) {
+                is Gate.MayDecide -> continuation.then
+                is Gate.MayPay ->
+                    CompositeEffect(listOf(gate.cost, continuation.then), stopOnError = true)
+            }
+        } else {
+            continuation.otherwise
+        }
+
+        if (effectToExecute == null) {
+            return checkForMore(state, emptyList())
+        }
+
+        val result = services.effectExecutorRegistry
+            .execute(state, effectToExecute, continuation.effectContext)
+            .toExecutionResult()
 
         if (result.isPaused) {
             return result

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeEffectExecutor.kt
@@ -58,8 +58,8 @@ class CompositeEffectExecutor(
             if (!result.isSuccess && !result.isPaused) {
                 if (effect.stopOnError) {
                     // Cost-then-payoff composite: if the cost fails, abort remaining effects.
-                    // Used by OptionalCostEffect where paying the cost is mandatory for the
-                    // payoff — if you can't pay {W}{B}, you don't get the reanimation.
+                    // Used by the GatedEffect Gate.MayPay resumer, where paying the cost is
+                    // mandatory for the payoff — if you can't pay {W}{B}, you don't reanimate.
                     val cleanState = if (remainingEffects.isNotEmpty()) {
                         val (_, stateWithoutCont) = result.state.popContinuation()
                         stateWithoutCont

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
@@ -37,7 +37,7 @@ class CompositeExecutors(
     private val mayPayXForEffectExecutor by lazy { MayPayXForEffectExecutor(cardRegistry, effectExecutor) }
     private val budgetModalEffectExecutor by lazy { BudgetModalEffectExecutor(effectExecutor) }
     private val modalEffectExecutor by lazy { ModalEffectExecutor(effectExecutor) }
-    private val optionalCostEffectExecutor by lazy { OptionalCostEffectExecutor(cardRegistry, effectExecutor) }
+    private val gatedEffectExecutor by lazy { GatedEffectExecutor(cardRegistry, effectExecutor) }
     private val payManaCostExecutor by lazy { PayManaCostExecutor(cardRegistry) }
     private val reflexiveTriggerEffectExecutor by lazy { ReflexiveTriggerEffectExecutor(effectExecutor, targetFinder, decisionHandler) }
     private val flipCoinExecutor by lazy { FlipCoinExecutor(effectExecutor) }
@@ -78,7 +78,7 @@ class CompositeExecutors(
         mayPayManaExecutor,
         mayPayXForEffectExecutor,
         modalEffectExecutor,
-        optionalCostEffectExecutor,
+        gatedEffectExecutor,
         payManaCostExecutor,
         reflexiveTriggerEffectExecutor,
         flipCoinExecutor,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -3,57 +3,72 @@ package com.wingedsheep.engine.handlers.effects.composite
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.registry.CardRegistry
-import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
-import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
 import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
 import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
- * Executor for OptionalCostEffect.
- * Handles "You may [cost]. If you do, [ifPaid]. Otherwise, [ifNotPaid]." effects.
+ * One executor for the [GatedEffect] frame — the unified replacement for the bespoke
+ * may / optional-cost executors. It owns the canonical resolution order for every
+ * decision-driven [Gate]:
  *
- * Presents a yes/no choice. If yes, executes [cost] then [ifPaid].
- * If no, executes [ifNotPaid] (if present).
+ *  1. Resolve the decision-maker (defaults to the ability's controller).
+ *  2. [Gate.MayPay] only: skip the prompt entirely when the cost is unaffordable, falling
+ *     through to [GatedEffect.otherwise] — asking yes/no for an unpayable cost is a UX trap
+ *     that can also silently drop pieces of a composite cost.
+ *  3. Pause with a [YesNoDecision]. The [GatedEffectContinuation] carries the *already-locked*
+ *     targets in its [EffectContext], so a targeted [GatedEffect.then] resolves against the
+ *     trigger-time target (CR 603.3d) instead of re-choosing one at resolution.
  *
- * Used for Gift mechanics and similar optional cost patterns.
+ * The "yes" branch is consumed by `EffectAndTriggerContinuationResumer.resumeGatedEffect`;
+ * the gate kind decides *how* — run [GatedEffect.then] directly ([Gate.MayDecide]) or pay the
+ * cost first ([Gate.MayPay]).
  */
-class OptionalCostEffectExecutor(
+class GatedEffectExecutor(
     private val cardRegistry: CardRegistry,
     private val effectExecutor: (GameState, Effect, EffectContext) -> EffectResult
-) : EffectExecutor<OptionalCostEffect> {
+) : EffectExecutor<GatedEffect> {
 
-    override val effectType: KClass<OptionalCostEffect> = OptionalCostEffect::class
+    override val effectType: KClass<GatedEffect> = GatedEffect::class
 
     private val manaSolver = ManaSolver(cardRegistry)
 
     override fun execute(
         state: GameState,
-        effect: OptionalCostEffect,
+        effect: GatedEffect,
         context: EffectContext
     ): EffectResult {
-        val playerId = context.controllerId
+        val playerId = effect.decisionMaker
+            ?.let { TargetResolutionUtils.resolvePlayerTarget(it, context, state) }
+            ?: context.controllerId
 
-        // If the player can't actually pay the cost, skip the prompt entirely
-        // and fall through to ifNotPaid (or no-op). Asking yes/no for an
-        // unpayable cost is a UX trap that can also silently skip pieces of
-        // a composite cost (e.g. paying life when mana can't be paid).
-        if (!canAfford(state, playerId, effect.cost)) {
-            return effect.ifNotPaid
+        // Gate.MayPay: don't offer an impossible "yes" — fall straight through to `otherwise`.
+        val gate = effect.gate
+        if (gate is Gate.MayPay && !canAfford(state, playerId, gate.cost)) {
+            return effect.otherwise
                 ?.let { effectExecutor(state, it, context) }
                 ?: EffectResult.success(state)
         }
 
         val sourceName = context.sourceId?.let { sourceId ->
             state.getEntity(sourceId)?.get<CardComponent>()?.name
+        }
+
+        val hint = when (gate) {
+            is Gate.MayDecide -> gate.hint ?: effect.hint
+            is Gate.MayPay -> effect.hint
         }
 
         val decisionId = UUID.randomUUID().toString()
@@ -68,18 +83,15 @@ class OptionalCostEffectExecutor(
                 triggeringEntityId = context.triggeringEntityId
             ),
             yesText = "Yes",
-            noText = "No"
+            noText = "No",
+            hint = hint
         )
 
-        // If yes: execute cost then ifPaid (stopOnError ensures cost failure aborts the payoff)
-        val effectIfYes = CompositeEffect(listOf(effect.cost, effect.ifPaid), stopOnError = true)
-
-        val continuation = MayAbilityContinuation(
+        val continuation = GatedEffectContinuation(
             decisionId = decisionId,
-            playerId = playerId,
-            sourceName = sourceName,
-            effectIfYes = effectIfYes,
-            effectIfNo = effect.ifNotPaid,
+            gate = gate,
+            then = effect.then,
+            otherwise = effect.otherwise,
             effectContext = context
         )
 
@@ -101,13 +113,11 @@ class OptionalCostEffectExecutor(
     }
 
     /**
-     * Checks whether [playerId] can pay the given cost effect right now.
-     *
-     * Recognizes the payment primitives that appear inside an [OptionalCostEffect]'s
-     * cost slot: [PayManaCostEffect], [PayLifeEffect], and a [CompositeEffect]
-     * composing them. Unknown effect shapes are assumed payable — failing open
-     * preserves existing behavior for exotic cost pipelines and still lets the
-     * executor abort later via `stopOnError`.
+     * Whether [playerId] can pay [cost] right now. Mirrors the former
+     * `OptionalCostEffectExecutor`: recognizes the payment primitives that appear in a
+     * [Gate.MayPay] cost slot ([PayManaCostEffect], [PayLifeEffect], and a [CompositeEffect]
+     * composing them). Unknown shapes fail open (assumed payable) so exotic cost pipelines
+     * still prompt and abort later via the resumer's `stopOnError` composite.
      */
     private fun canAfford(state: GameState, playerId: EntityId, cost: Effect): Boolean =
         when (cost) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GatedEffectScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GatedEffectScenarioTest.kt
@@ -1,0 +1,293 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for the unified [GatedEffect] resolution frame (phase-rs Lesson 1).
+ *
+ * Exercised through inline test cards whose ETB triggers carry gated effects:
+ *  - [Gate.MayPay] (the lowering target for `OptionalCostEffect`) — pay / decline / can't-afford.
+ *  - The may-vs-target canonical order: a targeted `then` locks its target at trigger time
+ *    (CR 603.3d), *before* the may-pay decision is offered at resolution (CR 117.3a). This is
+ *    the timing the old wrapper nesting (`MayEffect(IfYouDoEffect(...))`) had to get right by
+ *    hand; the single frame makes it correct by construction.
+ *  - [Gate.MayDecide] — the pure yes/no gate new cards can opt into.
+ */
+class GatedEffectScenarioTest : ScenarioTestBase() {
+
+    init {
+        // "When this enters, you may pay 2 life. If you do, draw a card." → Gate.MayPay
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Gated Drawer",
+                manaCost = ManaCost.parse("{0}"),
+                subtypes = setOf(Subtype("Wizard")),
+                power = 1,
+                toughness = 1,
+                script = CardScript(
+                    triggeredAbilities = listOf(
+                        TriggeredAbility(
+                            id = AbilityId.generate(),
+                            trigger = Triggers.EntersBattlefield.event,
+                            binding = Triggers.EntersBattlefield.binding,
+                            effect = OptionalCostEffect(
+                                cost = PayLifeEffect(2),
+                                ifPaid = DrawCardsEffect(1)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        // "When this enters, you may pay 2 life. If you do, destroy target creature." → Gate.MayPay
+        // with a TARGETED payoff: the target is locked when the trigger goes on the stack.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Gated Slayer",
+                manaCost = ManaCost.parse("{0}"),
+                subtypes = setOf(Subtype("Assassin")),
+                power = 1,
+                toughness = 1,
+                script = CardScript(
+                    triggeredAbilities = listOf(
+                        TriggeredAbility(
+                            id = AbilityId.generate(),
+                            trigger = Triggers.EntersBattlefield.event,
+                            binding = Triggers.EntersBattlefield.binding,
+                            effect = OptionalCostEffect(
+                                cost = PayLifeEffect(2),
+                                ifPaid = Effects.Destroy(EffectTarget.ContextTarget(0))
+                            ),
+                            targetRequirement = Targets.Creature
+                        )
+                    )
+                )
+            )
+        )
+
+        // "When this enters, you may draw a card." → Gate.MayDecide (pure yes/no, no cost).
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Gated Seer",
+                manaCost = ManaCost.parse("{0}"),
+                subtypes = setOf(Subtype("Wizard")),
+                power = 1,
+                toughness = 1,
+                script = CardScript(
+                    triggeredAbilities = listOf(
+                        TriggeredAbility(
+                            id = AbilityId.generate(),
+                            trigger = Triggers.EntersBattlefield.event,
+                            binding = Triggers.EntersBattlefield.binding,
+                            effect = GatedEffect(
+                                gate = Gate.MayDecide(),
+                                then = DrawCardsEffect(1)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Target Dummy",
+                manaCost = ManaCost.parse("{1}"),
+                subtypes = setOf(Subtype("Golem")),
+                power = 0,
+                toughness = 3
+            )
+        )
+
+        context("Gate.MayPay (OptionalCostEffect lowering)") {
+
+            test("paying the cost runs the payoff") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gated Drawer")
+                    .withCardInLibrary(1, "Target Dummy")
+                    .withCardInLibrary(1, "Target Dummy")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Gated Drawer").error shouldBe null
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                val handBefore = game.handSize(1)
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("paid 2 life") { game.getLifeTotal(1) shouldBe 18 }
+                withClue("drew a card") { game.handSize(1) shouldBe handBefore + 1 }
+            }
+
+            test("declining the cost runs neither cost nor payoff") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gated Drawer")
+                    .withCardInLibrary(1, "Target Dummy")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Gated Drawer").error shouldBe null
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                val handBefore = game.handSize(1)
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("no life paid") { game.getLifeTotal(1) shouldBe 20 }
+                withClue("no card drawn") { game.handSize(1) shouldBe handBefore }
+            }
+
+            test("an unaffordable cost skips the prompt entirely") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gated Drawer")
+                    .withCardInLibrary(1, "Target Dummy")
+                    .withLifeTotal(1, 1) // can't pay 2 life
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castSpell(1, "Gated Drawer").error shouldBe null
+                game.resolveStack()
+
+                withClue("no yes/no prompt for an unpayable cost") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("life untouched") { game.getLifeTotal(1) shouldBe 1 }
+                withClue("no card drawn (it cast the creature, so hand is one smaller)") {
+                    game.handSize(1) shouldBe handBefore - 1
+                }
+            }
+        }
+
+        context("canonical order: targets lock before the gate decision") {
+
+            test("target is chosen at trigger time, then the may-pay decision resolves it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gated Slayer")
+                    .withCardOnBattlefield(2, "Target Dummy")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dummy = game.findPermanent("Target Dummy")!!
+
+                game.castSpell(1, "Gated Slayer").error shouldBe null
+                game.resolveStack()
+
+                // 1. Targets are locked FIRST — before any may-pay prompt.
+                withClue("targets are chosen at trigger time, before the gate") {
+                    game.getPendingDecision().shouldBeInstanceOf<ChooseTargetsDecision>()
+                }
+                game.selectTargets(listOf(dummy))
+                game.resolveStack()
+
+                // 2. Only now is the may-pay gate offered, at resolution.
+                withClue("the gate decision comes after the target is locked") {
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("paid 2 life") { game.getLifeTotal(1) shouldBe 18 }
+                withClue("the pre-locked target was destroyed") {
+                    game.isInGraveyard(2, "Target Dummy") shouldBe true
+                }
+            }
+
+            test("declining the gate leaves the locked target unharmed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gated Slayer")
+                    .withCardOnBattlefield(2, "Target Dummy")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dummy = game.findPermanent("Target Dummy")!!
+
+                game.castSpell(1, "Gated Slayer").error shouldBe null
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<ChooseTargetsDecision>()
+                game.selectTargets(listOf(dummy))
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("no life paid") { game.getLifeTotal(1) shouldBe 20 }
+                withClue("the target survives") {
+                    game.isInGraveyard(2, "Target Dummy") shouldBe false
+                    game.isOnBattlefield("Target Dummy") shouldBe true
+                }
+            }
+        }
+
+        context("Gate.MayDecide (pure yes/no)") {
+
+            test("yes runs the effect, no skips it") {
+                fun run(choice: Boolean): Pair<Int, Int> {
+                    val game = scenario()
+                        .withPlayers("Player1", "Player2")
+                        .withCardInHand(1, "Gated Seer")
+                        .withCardInLibrary(1, "Target Dummy")
+                        .withActivePlayer(1)
+                        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                        .build()
+
+                    game.castSpell(1, "Gated Seer").error shouldBe null
+                    game.resolveStack()
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                    val handBefore = game.handSize(1)
+                    game.answerYesNo(choice)
+                    game.resolveStack()
+                    return handBefore to game.handSize(1)
+                }
+
+                val (yesBefore, yesAfter) = run(true)
+                withClue("yes draws a card") { yesAfter shouldBe yesBefore + 1 }
+
+                val (noBefore, noAfter) = run(false)
+                withClue("no draws nothing") { noAfter shouldBe noBefore }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements **phase-rs Lesson 1** from `backlog/phase-rs-lessons.md` — *"Unify the optional/gated-effect cluster behind one resolution frame."* This is the lesson's **Phase 1 (introduce the frame)** plus the smallest concrete wrapper migration (**OptionalCostEffect**), per the chosen scope.

## Why
The optional/gated cluster modelled every "do something conditionally" concern as its own wrapper `Effect` + its own executor + its own pause/continuation touchpoint. Because the wrappers compose by *nesting*, the may-vs-target / cost-vs-target timing was load-bearing and re-encoded (and re-bugged) per card. This replaces that enumeration with one composable frame: a `Gate` decides whether `then` runs, and **one** executor + **one** continuation resumer own the canonical unwind order.

## What

**SDK**
- `GatedEffect(gate, then, otherwise?, decisionMaker?, …)` + sealed `Gate`:
  - `Gate.MayPay(cost)` — "You may [cost]. If you do, [then]." (the `OptionalCostEffect` shape)
  - `Gate.MayDecide(prompt?, hint?)` — pure yes/no, available for new cards to opt into
- `OptionalCostEffect(...)` is now a **facade function lowering to `GatedEffect(Gate.MayPay)`**. Card source and the `mayPay`/`mayPayOrElse` patterns are unchanged — only the compiled/serialized form moves from `OptionalCost` to `Gated`. `CardValidator` walks the new shape.

**Engine**
- One `GatedEffectExecutor` (affordability pre-check + yes/no for `MayPay`; pure yes/no for `MayDecide`) and one `resumeGatedEffect` replace `OptionalCostEffectExecutor`, which is **deleted**.
- `GatedEffectContinuation` carries the locked targets in its `EffectContext`, so a targeted `then` resolves against its **trigger-time** target (CR 603.3d) — the may-vs-target ordering is correct *by construction* rather than per wrapper.

## Canonical-order proof
`GatedEffectScenarioTest` proves a `MayPay` gate with a *targeted* payoff ("you may pay 2 life; if you do, destroy target creature") chooses its target at trigger time **before** the may-pay decision is offered at resolution — and that declining leaves the locked target unharmed. Plus pay/decline/can't-afford parity and the new `MayDecide` gate.

## Cross-layer trace
- **SDK** — `@Serializable`; `Effect` is sealed so `GatedEffect`/`Gate` auto-register. Round-trips through the schema-driven `CompactJsonTransformer` (snapshot net green).
- **Engine** — executor + continuation (registered in `Serialization.kt`) + resumer wired.
- **Projection / triggers** — none (resolution-time only).
- **Server DTO / client** — no new DTO: the gate emits the existing `YesNoDecision` + `DecisionRequestedEvent("YES_NO")`, which the client already renders. No frontend change.

## Tests
- `GatedEffectScenarioTest` (6 cases, all green).
- `CardDslTest` updated for the lowering.
- Snapshot goldens re-blessed for the 5 affected sets (**BLB/ECL/LTR/SPM/TDM**) — a pure `OptionalCost` → `Gated` rename (verified line-by-line).
- Full `:mtg-sdk :mtg-sets :rules-engine :game-server` test suites pass.

## Deferred (explicitly out of scope; next migrations)
`DoAction` (IfYouDoEffect), `WhenCondition` (ConditionalEffect), and APNAP `AnyPlayerMayPay` — each folds in as its wrapper migrates. `BeholdEffect`/`ReflexiveTriggerEffect`/`Duration` stay separate per the lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)