### PR TITLE
Add "creatures that crewed/saddled it this turn" tracker (OTJ gap #2)

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -11,11 +11,10 @@ basics).
 ## Bottom line
 
 OTJ is built around a small set of named mechanics, **most of which the engine already supports**:
-Plot, Spree, "commit a crime", the Outlaw creature-type group, Treasure, and Crew are all done.
-The **one headline keyword gap is Saddle / Mount** (17 cards) — there is zero engine support for
-it. Everything else is a handful of small recurring primitives plus ~12 genuinely one-off cards.
-Once Saddle lands, the overwhelming majority of the set is buildable today (standard creatures,
-removal, Deserts, Plot/Spree spells, crime payoffs, token-makers).
+Plot, Spree, "commit a crime", the Outlaw creature-type group, Treasure, Crew, **and now Saddle /
+Mount** are all done. With Saddle landed, the overwhelming majority of the set is buildable today
+(standard creatures, removal, Deserts, Plot/Spree spells, crime payoffs, token-makers). What's left
+is a handful of small recurring primitives plus ~12 genuinely one-off cards.
 
 ### Already supported — no new engine work
 
@@ -51,11 +50,16 @@ What follows are the **genuine gaps** — elements no current SDK primitive expr
 
 ## Tier 1 — Headline keyword (17 cards, highest leverage)
 
-### 1. Saddle N + Mount subtype — **the one big gap**
+### 1. Saddle N + Mount subtype — ✅ DONE
 
-Zero engine references to "saddle" anywhere in `mtg-sdk/src` or `rules-engine/src`. (The `Mount`
-subtype *string* already exists in `Subtype.kt`, so Mount-referencing filters like "you control a
-Mount" work — only the keyword action and saddled state are missing.)
+**Implemented:** `Keyword.SADDLE` + `KeywordAbility.saddle(n)` DSL, the `SaddleMount` special action
++ `SaddleMountHandler` (taps other untapped creatures totalling power ≥ N, sorcery-speed gated),
+`SaddledComponent` (cleared in `CleanupPhaseManager`), `StatePredicate.IsSaddled` /
+`Conditions.SourceIsSaddled` for "while saddled" gating, and `SaddleEnumerator` for the tap-for-power
+selection UI. Tests: `SaddleScenarioTest`. The `Mount` subtype string already existed in
+`Subtype.kt`.
+
+<details><summary>Original gap description</summary>
 
 Saddle is an activated special action: **"Tap any number of other untapped creatures you control
 with total power N or greater: This Mount becomes saddled until end of turn. Saddle only as a
@@ -77,21 +81,35 @@ saddled**, …" or "As long as it's saddled, …".
   Courser, Ornery Tumblewagg, Quilled Charger, Rambling Possum, Seraphic Steed, Stubborn
   Burrowfiend, The Gitrog Ravenous Ride, Trained Arynx.
 
+</details>
+
 ---
 
 ## Tier 2 — Small recurring primitives
 
-### 2. "Contributed this turn" set-tracker (saddled-it / crewed-it)
+### 2. "Contributed this turn" set-tracker (saddled-it / crewed-it) — ✅ DONE
 
 Several Mounts and one Vehicle pay off the **set of creatures that saddled / crewed this permanent
-this turn** — to put counters on them, bounce them, or count them. Crew and (the new) Saddle both
-perform the action but record nothing afterward. Needs one shared per-permanent, per-turn
-**"contributors this turn"** record (cleared each turn) with a `DynamicAmount.Count` / collection
-gather over it.
+this turn** — to put counters on them, bounce them, or count them.
 
-→ Giant Beaver, Ornery Tumblewagg, Rambling Possum (saddlers get counters / bounce),
+**Implemented:** a per-permanent `CrewSaddleContributorsComponent(creatureIds)` recorded by both
+`CrewVehicleHandler` and `SaddleMountHandler` (union across activations) and cleared at end of turn
+in `CleanupPhaseManager`. Two source-relative read surfaces, both keyed off the ability's source via
+`PredicateContext.sourceId`:
+  - membership — `StatePredicate.CrewedOrSaddledSourceThisTurn` /
+    `GameObjectFilter.crewedOrSaddledSourceThisTurn()`, for "target/choose/return a creature that
+    crewed/saddled it this turn" (the target system restricts to live creatures).
+  - count — `DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn` /
+    `DynamicAmounts.creaturesThatCrewedOrSaddledThisTurn()`. Retains contributors that have since
+    left, so it counts every creature that crewed it even if some are gone as the ability resolves
+    (Luxurious Locomotive ruling).
+
+Tests: `CrewSaddleContributorsScenarioTest`.
+
+→ Unblocks: Giant Beaver, Ornery Tumblewagg, Rambling Possum (saddlers get counters / bounce),
   The Gitrog Ravenous Ride & Calamity (consume the saddlers), **Luxurious Locomotive** (Treasure per
-  creature that crewed it this turn). Same shape — build once, share between Saddle and Crew.
+  creature that crewed it this turn — note: dynamic-count Treasure creation is still Int-only; that
+  card additionally needs a dynamic `CreateTreasure` or a `CreateTokenEffect`-based Treasure).
 
 ### 3. `DynamicAmount` over spells cast this turn (filtered, per-player, exclude-self) — ✅ DONE
 
@@ -206,12 +224,10 @@ this turn" can't be expressed. Add the tracker (engine accumulates on draw event
 
 ## Recommended build order
 
-1. **Saddle N + Mount** (Tier 1) — the single highest-leverage feature; unlocks 17 cards. Build the
-   keyword, the tap-creatures-totalling-power-N special action (reuse Convoke/Harmonize selection),
-   the `SaddledComponent`, and the "while saddled" condition.
-2. **Tier 2 shared primitives** — the contributors-this-turn tracker (#2, shared by Saddle and
-   Crew), the spells-cast `DynamicAmount` (#3), the `fromHand` cast-zone flag (#4), the cast-for-free
-   condition (#5), `CARDS_DRAWN` (#6). Small, each unlocks a few scattered cards.
+1. ✅ **Saddle N + Mount** (Tier 1) — done.
+2. **Tier 2 shared primitives** — ✅ contributors-this-turn tracker (#2), ✅ spells-cast
+   `DynamicAmount` (#3). Remaining: the `fromHand` cast-zone flag (#4), the cast-for-free condition
+   (#5), `CARDS_DRAWN` (#6). Small, each unlocks a few scattered cards. **Next up: #4 (`fromHand`).**
 3. **Tier-3 one-offs** as the relevant legendaries / rares come up — none block large numbers of
    cards; pick them off individually.
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -857,6 +857,10 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   / cost calculation report `false` (no X context).
 - `.tapped()` / `.untapped()` — tap state.
 - `.saddled()` — permanent is saddled (CR 702.171b); backed by `StatePredicate.IsSaddled`.
+- `.crewedOrSaddledSourceThisTurn()` — source-relative: creature crewed (CR 702.122) or saddled
+  (CR 702.171) the effect's source permanent this turn; backed by
+  `StatePredicate.CrewedOrSaddledSourceThisTurn` (see Object-state predicates). For
+  "target/choose/return a creature that crewed/saddled it this turn".
 - `.nontoken()` / `.token()` — token vs printed.
 - `.faceDown()` — face-down state.
 - `.card(filter)` — defer to a card-shape filter for off-battlefield checks.
@@ -910,6 +914,14 @@ work for abilities-on-stack (which carry no `CardComponent`).
   creature". Note: it's only evaluated where the context carries a source entity — currently the
   recipient filter of a `PreventDamage` replacement (see §15); it's inert in group/projection,
   untap, and trigger-gating contexts.
+- `CrewedOrSaddledSourceThisTurn` (filter builder `crewedOrSaddledSourceThisTurn()`) —
+  source-relative (CR 702.122 / 702.171): matches a creature that crewed or saddled the effect's
+  source permanent this turn (i.e. one tapped to pay that permanent's Crew/Saddle cost). Resolves
+  against `PredicateContext.sourceId` by reading the source's `CrewSaddleContributorsComponent`;
+  inert with no source context (group/projection, untap, trigger-gating). Used for Mount/Vehicle
+  payoffs that target/choose/sacrifice/return "a creature that crewed/saddled it this turn" (Giant
+  Beaver, Rambling Possum, The Gitrog, Calamity). For the *count* of those creatures use
+  `DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn` instead.
 - `IsFaceDown` — currently face-down.
 - `HasCounter(type)` — has at least one counter of `type`.
 - `AttachedToCardType(cardType)` — Aura/Equipment whose `AttachedToComponent` points to a
@@ -2156,6 +2168,14 @@ Numbers computed at resolution time.
   permanent (CR 702.167c). Reads the source's `CraftedFromExiledComponent`. Used for the
   `*`-power CDA on Mastercraft Raptor (Saheeli's Lattice back face). Evaluates to 0 when the
   source has no recorded materials.
+- `CreaturesThatCrewedOrSaddledThisTurn` (facade `DynamicAmounts.creaturesThatCrewedOrSaddledThisTurn()`)
+  — number of distinct creatures that crewed (CR 702.122) or saddled (CR 702.171) the source
+  permanent this turn. Source-relative: reads the source's `CrewSaddleContributorsComponent` and
+  returns its size. Retains contributors that have since left the battlefield, so the count
+  includes creatures no longer present as the ability resolves (Luxurious Locomotive ruling) — a
+  plain `Count` over `crewedOrSaddledSourceThisTurn()` can't express that. Evaluates to 0 with no
+  source / no component. For *which* creatures (targeting/gathering) use the
+  `CrewedOrSaddledSourceThisTurn` state predicate instead.
 
 ### Counters
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -363,4 +363,13 @@ object DynamicAmounts {
 
     fun triggeringToughness(): DynamicAmount =
         DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.Toughness)
+
+    /**
+     * Number of distinct creatures that crewed or saddled this permanent this turn (source-
+     * relative; includes contributors that have since left the battlefield). See
+     * [DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn]. Used by "for each creature that
+     * crewed it this turn" (Luxurious Locomotive).
+     */
+    fun creaturesThatCrewedOrSaddledThisTurn(): DynamicAmount =
+        DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -466,6 +466,14 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.IsSaddled
     )
 
+    /**
+     * Must have crewed (CR 702.122) or saddled (CR 702.171) the effect's source permanent this
+     * turn. Source-relative — see [StatePredicate.CrewedOrSaddledSourceThisTurn].
+     */
+    fun crewedOrSaddledSourceThisTurn() = copy(
+        statePredicates = statePredicates + StatePredicate.CrewedOrSaddledSourceThisTurn
+    )
+
     /** Must be face-down */
     fun faceDown() = copy(
         statePredicates = statePredicates + StatePredicate.IsFaceDown

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -244,6 +244,21 @@ sealed interface StatePredicate {
         override val description: String = "saddled"
     }
 
+    /**
+     * Creature that crewed (CR 702.122) or saddled (CR 702.171) the effect's source permanent this
+     * turn — i.e. one of the creatures tapped to pay that permanent's Crew/Saddle cost. Source-
+     * relative: resolves against the source entity supplied in the evaluation context (its
+     * `CrewSaddleContributorsComponent`), so it only matches creatures recorded on *that* Mount /
+     * Vehicle. Yields false with no source context. Used for Mount/Vehicle payoffs that target,
+     * choose, sacrifice, or return "a creature that crewed/saddled it this turn" (Giant Beaver,
+     * Rambling Possum, The Gitrog, Calamity).
+     */
+    @SerialName("CrewedOrSaddledSourceThisTurn")
+    @Serializable
+    data object CrewedOrSaddledSourceThisTurn : Entity {
+        override val description: String = "that crewed or saddled it this turn"
+    }
+
     // =============================================================================
     // Zone-Specific Markers (Entity)
     // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -839,4 +839,24 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         override val description: String = "the total power of the exiled cards used to craft it"
     }
 
+    /**
+     * Number of distinct creatures that crewed (CR 702.122) or saddled (CR 702.171) the source
+     * permanent this turn.
+     *
+     * Source-relative: reads the source's
+     * `com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent` and
+     * returns the size of the recorded set. The set retains contributors that have since left the
+     * battlefield, so this counts every creature that crewed/saddled it this turn even if some are
+     * no longer present as the ability resolves (per the Luxurious Locomotive ruling). A plain
+     * battlefield-filter count ([Count] over [CrewedOrSaddledSourceThisTurn]) cannot express that,
+     * which is why this reads the record directly. Evaluates to zero with no source / no component.
+     *
+     * Used by "for each creature that crewed it this turn" (Luxurious Locomotive).
+     */
+    @SerialName("CreaturesThatCrewedOrSaddledThisTurn")
+    @Serializable
+    data object CreaturesThatCrewedOrSaddledThisTurn : DynamicAmount {
+        override val description: String = "the number of creatures that crewed or saddled it this turn"
+    }
+
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -379,6 +379,7 @@ class BeginningPhaseManager(
         StatePredicate.IsEquipped,
         StatePredicate.IsModified,
         StatePredicate.IsSaddled,
+        StatePredicate.CrewedOrSaddledSourceThisTurn,
         StatePredicate.IsWarpExiled,
         StatePredicate.WasCastForWarp -> true
         is StatePredicate.AttachedToCardType -> true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent
 import com.wingedsheep.engine.state.components.battlefield.SaddledComponent
 import com.wingedsheep.engine.state.components.battlefield.AbilityResolutionCountThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.DamageComponent
@@ -464,6 +465,10 @@ class CleanupPhaseManager(
             if (container.has<SaddledComponent>()) {
                 needsUpdate = true
             }
+            // "Creatures that crewed/saddled it this turn" resets each turn
+            if (container.has<CrewSaddleContributorsComponent>()) {
+                needsUpdate = true
+            }
             if (needsUpdate) {
                 newState = newState.updateEntity(entityId) { c ->
                     c.without<AbilityActivatedThisTurnComponent>()
@@ -479,6 +484,7 @@ class CleanupPhaseManager(
                         .without<WasDealtDamageThisTurnComponent>()
                         .without<DamageDealtByPlayersThisTurnComponent>()
                         .without<SaddledComponent>()
+                        .without<CrewSaddleContributorsComponent>()
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -372,6 +372,7 @@ val engineSerializersModule = SerializersModule {
         subclass(WasKickedComponent::class)
         subclass(EvokedComponent::class)
         subclass(SaddledComponent::class)
+        subclass(CrewSaddleContributorsComponent::class)
         subclass(CastForImpendingComponent::class)
         subclass(SuspendedComponent::class)
         subclass(CastRecordComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1182,6 +1182,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsSaddled,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.CrewedOrSaddledSourceThisTurn,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsWarpExiled,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasCastForWarp,
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasCounter,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -372,6 +372,15 @@ class DynamicAmountEvaluator(
                 }
             }
 
+            is DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn -> {
+                val sourceId = context.sourceId
+                if (sourceId == null) 0 else {
+                    state.getEntity(sourceId)
+                        ?.get<com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent>()
+                        ?.creatureIds?.size ?: 0
+                }
+            }
+
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent
 import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.HasDealtCombatDamageToPlayerComponent
 import com.wingedsheep.engine.state.components.battlefield.HasDealtDamageComponent
@@ -682,6 +683,16 @@ class PredicateEvaluator {
                     sourceAttacking.bandId == null -> false
                     else -> container.get<AttackingComponent>()?.bandId == sourceAttacking.bandId
                 }
+            }
+
+            // Crewed/saddled the effect's source permanent this turn (CR 702.122 / 702.171).
+            // Source-relative: reads the source's CrewSaddleContributorsComponent and checks
+            // membership. Inert with no source context.
+            StatePredicate.CrewedOrSaddledSourceThisTurn -> {
+                val sourceId = context?.sourceId
+                val contributors = sourceId
+                    ?.let { state.getEntity(it)?.get<CrewSaddleContributorsComponent>() }
+                contributors != null && entityId in contributors.creatureIds
             }
 
             // Summoning sickness / ETB

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.mechanics.stack.StackResolver
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
@@ -135,6 +136,13 @@ class CrewVehicleHandler(
                 c.with(TappedComponent)
             }
             events.add(TappedEvent(creatureId, creatureName))
+        }
+
+        // Record the crew so Vehicle payoffs can read "creatures that crewed it this turn"
+        // (e.g. Luxurious Locomotive). Union across activations within the turn.
+        currentState = currentState.updateEntity(action.vehicleId) { c ->
+            val existing = c.get<CrewSaddleContributorsComponent>()?.creatureIds ?: emptySet()
+            c.with(CrewSaddleContributorsComponent(existing + action.crewCreatures))
         }
 
         // Create the crew ability effect: Vehicle becomes an artifact creature

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.mechanics.stack.StackResolver
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
@@ -131,6 +132,13 @@ class SaddleMountHandler(
                 c.with(TappedComponent)
             }
             events.add(TappedEvent(creatureId, creatureName))
+        }
+
+        // Record the saddlers so Mount payoffs can read "creatures that saddled it this turn".
+        // Union across activations: saddle may be activated again even while already saddled.
+        currentState = currentState.updateEntity(action.mountId) { c ->
+            val existing = c.get<CrewSaddleContributorsComponent>()?.creatureIds ?: emptySet()
+            c.with(CrewSaddleContributorsComponent(existing + action.saddleCreatures))
         }
 
         // Put the saddle ability on the stack: this permanent becomes saddled until end of turn.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -341,6 +341,10 @@ internal class AffectsFilterResolver {
         // (there's no per-recipient "source" here); it's only evaluated in damage-prevention
         // recipient filters via PredicateEvaluator. Never match in this context.
         StatePredicate.InSameBandAsSource -> false
+        // Likewise source-relative: "crewed/saddled the source this turn" needs the ability's
+        // source permanent, absent in group-static projection. Only meaningful in target/count
+        // contexts via PredicateEvaluator / DynamicAmountEvaluator. Never match here.
+        StatePredicate.CrewedOrSaddledSourceThisTurn -> false
         StatePredicate.EnteredThisTurn -> container.has<EnteredThisTurnComponent>()
         StatePredicate.WasDealtDamageThisTurn -> container.has<WasDealtDamageThisTurnComponent>()
         StatePredicate.HasDealtDamage -> container.has<HasDealtDamageComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -104,6 +104,30 @@ data object EvokedComponent : Component
 data object SaddledComponent : Component
 
 /**
+ * Records the distinct creatures that have crewed (CR 702.122) or saddled (CR 702.171) this
+ * permanent during the current turn — the creatures tapped to pay a Crew or Saddle cost on it.
+ * A permanent is only ever a Vehicle (crew) or a Mount (saddle), so one set covers both keywords.
+ *
+ * Two payoff shapes read this, both source-relative (keyed off the ability's source permanent):
+ *  - membership, via
+ *    [com.wingedsheep.sdk.scripting.predicates.StatePredicate.CrewedOrSaddledSourceThisTurn], for
+ *    "target/choose/return a creature that crewed/saddled it this turn" (Giant Beaver, Rambling
+ *    Possum, The Gitrog, Calamity) — the target system already restricts those to live creatures.
+ *  - count, via [com.wingedsheep.sdk.scripting.values.DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn],
+ *    for "for each creature that crewed it this turn" (Luxurious Locomotive). The recorded ids
+ *    persist even after a contributor leaves the battlefield, so the count includes creatures no
+ *    longer present as the ability resolves (per the Luxurious Locomotive ruling).
+ *
+ * Transient: the union across every crew/saddle activation this turn (saddle may be activated
+ * repeatedly), cleared in [CleanupPhaseManager.cleanupEndOfTurn] and naturally gone if this
+ * permanent itself leaves the battlefield (a fresh entity has no battlefield components).
+ */
+@Serializable
+data class CrewSaddleContributorsComponent(
+    val creatureIds: Set<EntityId>
+) : Component
+
+/**
  * Marks a permanent as having been cast for its impending cost (CR 702.176a).
  * The "isn't a creature" static and the end-step time-counter trigger both gate on
  * impending-cost-paid AND has-time-counter, so this marker survives for as long as

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrewSaddleContributorsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrewSaddleContributorsScenarioTest.kt
@@ -1,0 +1,229 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.core.SaddleMount
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * End-to-end scenario tests for the shared "creatures that crewed/saddled this permanent this
+ * turn" tracker (OTJ engine gap #2). Exercises the two read surfaces:
+ *
+ *  - membership, via [StatePredicate.CrewedOrSaddledSourceThisTurn] used as a target filter —
+ *    "put a +1/+1 counter on target creature that saddled it this turn" (Giant Beaver shape).
+ *  - count, via [DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn] — "draw a card for each
+ *    creature that crewed it this turn" (Luxurious Locomotive shape; faithful enough using a
+ *    dynamic DrawCards as the observable payoff).
+ *
+ * Both tracked off a per-permanent [CrewSaddleContributorsComponent] recorded by the Crew and
+ * Saddle handlers and cleared at end of turn.
+ */
+class CrewSaddleContributorsScenarioTest : FunSpec({
+
+    // Mount that pays off the saddlers: "Whenever it attacks while saddled, put a +1/+1 counter
+    // on target creature that saddled it this turn." 2/2 with Saddle 2.
+    val saddlePayoffMount = card("Saddler's Reward") {
+        manaCost = "{2}{G}"
+        typeLine = "Creature — Horse Mount"
+        power = 2
+        toughness = 2
+        oracleText = "Saddle 2\nWhenever Saddler's Reward attacks while saddled, put a +1/+1 " +
+            "counter on target creature that saddled it this turn."
+        keywordAbility(KeywordAbility.saddle(2))
+        triggeredAbility {
+            trigger = Triggers.Attacks
+            triggerCondition = Conditions.SourceIsSaddled
+            val saddler = target(
+                "target creature that saddled it this turn",
+                TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.crewedOrSaddledSourceThisTurn()))
+            )
+            effect = Effects.AddCounters("+1/+1", 1, saddler)
+        }
+    }
+
+    // Vehicle that pays off the crew: "Whenever it attacks, draw a card for each creature that
+    // crewed it this turn." 4/4 with Crew 1.
+    val crewPayoffVehicle = card("Prospector's Wagon") {
+        manaCost = "{3}"
+        typeLine = "Artifact — Vehicle"
+        power = 4
+        toughness = 4
+        oracleText = "Whenever Prospector's Wagon attacks, draw a card for each creature that " +
+            "crewed it this turn.\nCrew 1"
+        keywordAbility(KeywordAbility.crew(1))
+        triggeredAbility {
+            trigger = Triggers.Attacks
+            effect = Effects.DrawCards(DynamicAmounts.creaturesThatCrewedOrSaddledThisTurn())
+        }
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(saddlePayoffMount)
+        driver.registerCard(crewPayoffVehicle)
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.contributors(id: EntityId): Set<EntityId> =
+        state.getEntity(id)?.get<CrewSaddleContributorsComponent>()?.creatureIds ?: emptySet()
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // --- Recording -----------------------------------------------------------------------------
+
+    test("saddling records the saddlers on the Mount") {
+        val driver = newDriver()
+        val mount = driver.putCreatureOnBattlefield(driver.player1, "Saddler's Reward")
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") // power 2
+
+        driver.contributors(mount) shouldBe emptySet()
+
+        driver.submitSuccess(SaddleMount(driver.player1, mount, listOf(bear)))
+        driver.bothPass()
+
+        driver.contributors(mount) shouldBe setOf(bear)
+    }
+
+    test("crewing records the crew on the Vehicle (union across creatures)") {
+        val driver = newDriver()
+        val wagon = driver.putPermanentOnBattlefield(driver.player1, "Prospector's Wagon")
+        val bear1 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val bear2 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+
+        driver.submitSuccess(CrewVehicle(driver.player1, wagon, listOf(bear1, bear2)))
+        driver.bothPass()
+
+        driver.contributors(wagon) shouldBe setOf(bear1, bear2)
+    }
+
+    test("the record is source-relative: saddlers of one Mount don't count for another") {
+        val driver = newDriver()
+        val mountA = driver.putCreatureOnBattlefield(driver.player1, "Saddler's Reward")
+        val mountB = driver.putCreatureOnBattlefield(driver.player1, "Saddler's Reward")
+        val bearA = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val bearB = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+
+        driver.submitSuccess(SaddleMount(driver.player1, mountA, listOf(bearA)))
+        driver.bothPass()
+        driver.submitSuccess(SaddleMount(driver.player1, mountB, listOf(bearB)))
+        driver.bothPass()
+
+        driver.contributors(mountA) shouldBe setOf(bearA)
+        driver.contributors(mountB) shouldBe setOf(bearB)
+    }
+
+    // --- Membership predicate (target filter) --------------------------------------------------
+
+    test("only creatures that saddled it this turn are legal targets, and the counter lands") {
+        val driver = newDriver()
+        val mount = driver.putCreatureOnBattlefield(driver.player1, "Saddler's Reward")
+        val saddler = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val bystander = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.removeSummoningSickness(mount)
+
+        driver.submitSuccess(SaddleMount(driver.player1, mount, listOf(saddler)))
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(mount), driver.player2)
+
+        // The attack-while-saddled trigger asks for a target; only the saddler qualifies.
+        val decision = driver.state.pendingDecision as ChooseTargetsDecision
+        decision.legalTargets.getValue(0) shouldContain saddler
+        decision.legalTargets.getValue(0) shouldNotContain bystander
+
+        driver.submitTargetSelection(driver.player1, listOf(saddler))
+        driver.bothPass()
+
+        driver.plusOneCounters(saddler) shouldBe 1
+        driver.plusOneCounters(bystander) shouldBe 0
+    }
+
+    // --- Count DynamicAmount -------------------------------------------------------------------
+
+    test("the attack payoff counts each creature that crewed it this turn") {
+        val driver = newDriver()
+        val wagon = driver.putPermanentOnBattlefield(driver.player1, "Prospector's Wagon")
+        val bear1 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val bear2 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.removeSummoningSickness(wagon)
+
+        driver.submitSuccess(CrewVehicle(driver.player1, wagon, listOf(bear1, bear2)))
+        driver.bothPass()
+
+        val handBefore = driver.getHandSize(driver.player1)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(wagon), driver.player2)
+        driver.bothPass()
+
+        // Two creatures crewed it → drew two cards.
+        driver.getHandSize(driver.player1) shouldBe handBefore + 2
+    }
+
+    test("the count includes a crewer that has since left the battlefield (Luxurious Locomotive ruling)") {
+        val driver = newDriver()
+        val wagon = driver.putPermanentOnBattlefield(driver.player1, "Prospector's Wagon")
+        val bear1 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val bear2 = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.removeSummoningSickness(wagon)
+
+        driver.submitSuccess(CrewVehicle(driver.player1, wagon, listOf(bear1, bear2)))
+        driver.bothPass()
+
+        // One crewer leaves the battlefield before the attack trigger resolves; its id remains
+        // recorded, so it is still counted.
+        driver.moveToGraveyard(bear2)
+        driver.contributors(wagon) shouldContain bear2
+
+        val handBefore = driver.getHandSize(driver.player1)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(wagon), driver.player2)
+        driver.bothPass()
+
+        driver.getHandSize(driver.player1) shouldBe handBefore + 2
+    }
+
+    // --- Cleanup -------------------------------------------------------------------------------
+
+    test("the record is cleared at end of turn") {
+        val driver = newDriver()
+        val mount = driver.putCreatureOnBattlefield(driver.player1, "Saddler's Reward")
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+
+        driver.submitSuccess(SaddleMount(driver.player1, mount, listOf(bear)))
+        driver.bothPass()
+        driver.contributors(mount) shouldBe setOf(bear)
+
+        // Advance through this turn's cleanup into the next turn.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.contributors(mount) shouldBe emptySet()
+    }
+})

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -841,6 +841,19 @@ class GameTestDriver {
     }
 
     /**
+     * Move a permanent from the battlefield to its owner's graveyard (test helper). Strips its
+     * battlefield zone membership without running dies/leaves triggers — a blunt removal for
+     * setting up "the permanent is gone now" states. Returns silently if the entity has no owner.
+     */
+    fun moveToGraveyard(entityId: EntityId) {
+        val ownerId = _state.getEntity(entityId)
+            ?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()?.playerId
+            ?: return
+        _state = _state.removeFromZone(ZoneKey(ownerId, Zone.BATTLEFIELD), entityId)
+        _state = _state.addToZone(ZoneKey(ownerId, Zone.GRAVEYARD), entityId)
+    }
+
+    /**
      * Remove summoning sickness from a creature (test helper).
      * This allows the creature to attack/tap immediately.
      */


### PR DESCRIPTION
## What

OTJ engine gap #2: a shared, per-permanent record of the creatures that **crewed or saddled** a permanent this turn, with two source-relative read surfaces. Several OTJ Mounts and one Vehicle pay off this set — putting counters on the saddlers, bouncing them, or counting them — but Crew and Saddle previously recorded nothing after performing the action.

(Gap #1, Saddle/Mount, was already implemented; this PR also checks it and #2 off in the backlog.)

## How

- **`CrewSaddleContributorsComponent(creatureIds)`** on the Mount/Vehicle, written by `CrewVehicleHandler` and `SaddleMountHandler` (union across activations), cleared at end of turn in `CleanupPhaseManager`, and naturally gone if the permanent leaves. Registered for polymorphic serialization.
- **Membership** — `StatePredicate.CrewedOrSaddledSourceThisTurn` / `GameObjectFilter.crewedOrSaddledSourceThisTurn()`, keyed off `PredicateContext.sourceId`. For "target/choose/return a creature that crewed/saddled it this turn" (Giant Beaver, Rambling Possum, The Gitrog, Calamity). The target system already restricts these to live creatures.
- **Count** — `DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn` / `DynamicAmounts.creaturesThatCrewedOrSaddledThisTurn()`. Reads the component's size; the record retains contributors that have since left, so the count includes creatures no longer present as the ability resolves — per the **Luxurious Locomotive** ruling (a plain battlefield-filter count can't express that).

Both reads are inert without a source context (group/projection, untap, trigger-gating), mirroring the existing `InSameBandAsSource` source-relative predicate. Designed as one primitive shared by Crew and Saddle, parameterized over the source — not a per-card effect.

## Tests

`CrewSaddleContributorsScenarioTest` (7 tests) covers recording, source-relativity (saddlers of one Mount don't count for another), the target filter (legal targets exclude non-saddlers; the counter lands), the count, the "departed crewer still counts" ruling, and end-of-turn cleanup. Adds a reusable `GameTestDriver.moveToGraveyard` helper.

Full `:mtg-sdk:test` + `:rules-engine:test` (2919 tests) pass; `game-server`, `gym*`, `ai`, `mtg-sets` compile; card snapshot net unchanged.

## Docs

`docs/card-sdk-language-reference.md` updated for the new predicate, filter builder, and dynamic amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)