### PR TITLE
Remove dead gated-effect wrappers (BlightEffect, TapCreatureForEffectEffect)

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -3,7 +3,6 @@ package com.wingedsheep.sdk.scripting.effects
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.TriggerSpec
@@ -667,60 +666,6 @@ data class StoreCountEffect(
     override fun applyTextReplacement(replacer: TextReplacer): Effect {
         val newEffect = effect.applyTextReplacement(replacer)
         return if (newEffect !== effect) copy(effect = newEffect) else this
-    }
-}
-
-/**
- * Blight effect - "may blight N. If you do, [effect]"
- * Blight N means "put N -1/-1 counters on a creature you control".
- * This is an optional cost-gated effect used in triggered abilities.
- *
- * The player may choose a creature they control to blight. If they do,
- * the inner effect happens. If they don't (or can't), nothing happens.
- *
- * @property blightAmount Number of -1/-1 counters to place
- * @property innerEffect The effect that happens if the player blights
- * @property targetId The creature chosen to receive the counters (filled in during resolution)
- */
-@SerialName("Blight")
-@Serializable
-data class BlightEffect(
-    val blightAmount: Int,
-    val innerEffect: Effect,
-    val targetId: EntityId? = null
-) : Effect {
-    override val description: String = buildString {
-        append("You may blight $blightAmount. If you do, ")
-        append(innerEffect.description.replaceFirstChar { it.lowercase() })
-    }
-
-    override fun applyTextReplacement(replacer: TextReplacer): Effect {
-        val newInnerEffect = innerEffect.applyTextReplacement(replacer)
-        return if (newInnerEffect !== innerEffect) copy(innerEffect = newInnerEffect) else this
-    }
-}
-
-/**
- * "May tap another untapped creature you control. If you do, [effect]."
- * This is an optional cost-gated effect - the player may pay the cost to get the effect.
- *
- * @property innerEffect The effect that happens if the player pays the tap cost
- * @property targetId The creature chosen to tap (filled in during resolution)
- */
-@SerialName("TapCreatureForEffect")
-@Serializable
-data class TapCreatureForEffectEffect(
-    val innerEffect: Effect,
-    val targetId: EntityId? = null
-) : Effect {
-    override val description: String = buildString {
-        append("You may tap another untapped creature you control. If you do, ")
-        append(innerEffect.description.replaceFirstChar { it.lowercase() })
-    }
-
-    override fun applyTextReplacement(replacer: TextReplacer): Effect {
-        val newInnerEffect = innerEffect.applyTextReplacement(replacer)
-        return if (newInnerEffect !== innerEffect) copy(innerEffect = newInnerEffect) else this
     }
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
@@ -5,7 +5,6 @@ import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
 import com.wingedsheep.sdk.scripting.effects.AddMinusCountersEffect
 import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureTypeEffect
-import com.wingedsheep.sdk.scripting.effects.BlightEffect
 import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
 import com.wingedsheep.sdk.scripting.effects.ChangeCreatureTypeTextEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
@@ -42,7 +41,6 @@ import com.wingedsheep.sdk.scripting.effects.RemoveDamageShieldEffect
 import com.wingedsheep.sdk.scripting.effects.RemoveFromCombatEffect
 import com.wingedsheep.sdk.scripting.effects.StoreCountEffect
 import com.wingedsheep.sdk.scripting.effects.StoreResultEffect
-import com.wingedsheep.sdk.scripting.effects.TapCreatureForEffectEffect
 import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
 import com.wingedsheep.sdk.scripting.effects.TransformAllCreaturesEffect
 import com.wingedsheep.sdk.scripting.effects.TransformEffect
@@ -194,8 +192,6 @@ object CardValidator {
             }
             is StoreResultEffect -> collectIndicesRecursive(effect.effect, indices)
             is StoreCountEffect -> collectIndicesRecursive(effect.effect, indices)
-            is BlightEffect -> collectIndicesRecursive(effect.innerEffect, indices)
-            is TapCreatureForEffectEffect -> collectIndicesRecursive(effect.innerEffect, indices)
             is MayPayManaEffect -> collectIndicesRecursive(effect.effect, indices)
             is ModalEffect -> effect.modes.forEach { collectIndicesRecursive(it.effect, indices) }
             is PayOrSufferEffect -> collectIndicesRecursive(effect.suffer, indices)


### PR DESCRIPTION
## What

Part of **phase-rs Lesson 1** — migrating the gated-effect wrapper cluster onto the new `GatedEffect` frame (`backlog/gated-effect-migration-handoff.md`). This PR clears two of the listed "easy Shape-A" wrappers that turned out to be **dead code**.

## Why deletion instead of facade-lowering

The handoff prescribes lowering each wrapper to a same-name facade `fun` that returns a `GatedEffect`, preserving live card source while deleting the wrapper's bespoke executor. Investigating `BlightEffect` and `TapCreatureForEffectEffect`:

- **No card or DSL facade constructs either one** (`grep` across `mtg-sets`/`mtg-sdk` `src` finds only the declaration + the `CardValidator` walk).
- **Neither has an engine executor** — there is no `BlightEffectExecutor` / `TapCreatureForEffectExecutor` and no registration in `CompositeExecutors`. Resolving one would have fizzled.
- **Neither appears in any `CardDefinitionSnapshotTest` golden.**

So there is no live card source to preserve and no bespoke executor to remove. Lowering them would only add facade functions that nothing calls — dead weight that cuts against the repo's "no single-use patterns" rule. Deleting them serves the handoff's intent (shrink the wrapper cluster) directly.

> Note: the live **blight mechanic** is the unrelated `AdditionalCost.BlightVariable` cost path (Soul Immolation, Blossombind) — untouched here.

## Changes

- Delete the `BlightEffect` and `TapCreatureForEffectEffect` data classes from `CompositeEffects.kt` (+ now-orphaned `EntityId` import).
- Drop their two branches and imports from `CardValidator.collectIndicesRecursive`.

## Verification

- `:mtg-sdk`, `:rules-engine`, `:mtg-sets` compile.
- `:mtg-sdk:test` and `:mtg-sets:test` pass.
- **Zero snapshot churn** — confirms nothing serialized these types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)