### PR TITLE
Add cast-from-zone qualifier to the spell-cast tracker (OTJ gap #4)

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -127,7 +127,23 @@ stack entity id via a new `CastSpellRecord.sourceEntityId`. Both cards are now b
 Salvo via `Add(Fixed(2), …excludeSelf=true)`; Magebane via the `Noncreature` filter). Tests:
 `SpellsCastThisTurnAmountTest`.
 
-### 4. "Cast from your hand" cast-zone qualifier on the spell-cast tracker
+### 4. "Cast from your hand" cast-zone qualifier on the spell-cast tracker — ✅ DONE
+
+**Implemented:** `CastSpellRecord` now carries `castFromZone: Zone?`, stamped in `CastSpellHandler`
+from `StackResolver.findCastFromZone(...)` at cast time (the card is still in its origin zone there, so
+it agrees with the `SpellOnStackComponent.castFromZone` that `castSpell` sets). Both read surfaces gained
+a symmetric `fromZone` qualifier, matched **independently of the spell filter** so a face-down/morph
+cast from hand still counts (CR 708.2):
+  - condition — `PlayerCastSpellsThisTurn(..., fromZone)` / `Conditions.YouCastSpellsThisTurn(atLeast,
+    filter, fromZone)`. The Prairie Dog cycle's "you haven't cast a spell from your hand this turn" is
+    `Not(YouCastSpellsThisTurn(1, fromZone = Zone.HAND))`.
+  - count — `DynamicAmount.SpellsCastThisTurn(..., fromZone)` /
+    `DynamicAmounts.spellsCastThisTurn(..., fromZone)`.
+
+Flashback/forage (GRAVEYARD), plot/foretell (EXILE), and commander (COMMAND) casts are all distinguished
+from hand casts. Tests: `CastFromZoneThisTurnTest`.
+
+<details><summary>Original gap description</summary>
 
 `CastSpellRecord` (verified: `typeLine, manaValue, colors, isFaceDown, paidWithTreasureMana`) has
 **no source-zone field**, so "you haven't cast a spell **from your hand** this turn" can't be
@@ -137,6 +153,8 @@ distinguished from plotted / flashback / impulse casts. Add a `fromHand` (or `so
 → Inventive Wingsmith, Prairie Dog, Canyon Crab, Emergent Haunting, Jem Lightfoote, Wrangler of the
   Damned, Annie Flash the Veteran. (Stoic Sphinx says "haven't cast a spell this turn" with no zone
   qualifier — buildable today.)
+
+</details>
 
 ### 5. "Cast for free / no mana was spent" cast-state condition
 
@@ -226,8 +244,8 @@ this turn" can't be expressed. Add the tracker (engine accumulates on draw event
 
 1. ✅ **Saddle N + Mount** (Tier 1) — done.
 2. **Tier 2 shared primitives** — ✅ contributors-this-turn tracker (#2), ✅ spells-cast
-   `DynamicAmount` (#3). Remaining: the `fromHand` cast-zone flag (#4), the cast-for-free condition
-   (#5), `CARDS_DRAWN` (#6). Small, each unlocks a few scattered cards. **Next up: #4 (`fromHand`).**
+   `DynamicAmount` (#3), ✅ `fromHand` cast-zone flag (#4). Remaining: the cast-for-free condition
+   (#5), `CARDS_DRAWN` (#6). Small, each unlocks a few scattered cards. **Next up: #5 (cast-for-free).**
 3. **Tier-3 one-offs** as the relevant legendaries / rares come up — none block large numbers of
    cards; pick them off individually.
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2047,8 +2047,15 @@ default to "you" so card authors don't need to pass it explicitly.
 
 - `YouAttackedWithCreaturesThisTurn(filter, atLeast)` — Raid/Battalion shape. Backed by
   `PlayerAttackedWithCreaturesThisTurn(Player.You, filter, atLeast)`.
-- `YouCastSpellsThisTurn(atLeast, filter)` — Prowess/Magecraft shape. Backed by
-  `PlayerCastSpellsThisTurn(Player.You, filter, atLeast)`.
+- `YouCastSpellsThisTurn(atLeast, filter, fromZone?)` — Prowess/Magecraft shape. Backed by
+  `PlayerCastSpellsThisTurn(Player.You, filter, atLeast, fromZone)`. `fromZone` (default any) restricts
+  the count to spells cast from that zone, matched independently of `filter` (a face-down/morph spell
+  cast from hand still counts, CR 708.2). With `fromZone = Zone.HAND`, negating gives the Prairie Dog
+  cycle's "you haven't cast a spell from your hand this turn":
+  `Not(YouCastSpellsThisTurn(1, fromZone = Zone.HAND))` (Inventive Wingsmith, Prairie Dog, Canyon Crab,
+  Emergent Haunting, Wrangler of the Damned). The origin zone is captured on each `CastSpellRecord`
+  (`castFromZone`) at cast time, so flashback/forage (GRAVEYARD), plot/foretell (EXILE), and commander
+  (COMMAND) casts are all distinguished from hand casts.
 - `TriggeringSpellMatches(filter)` — intervening-if guard: the spell that triggered this ability
   matches `filter`. Reads the triggering entity's static card characteristics (so it stays correct
   after the spell leaves the stack). General "whenever you cast a spell, if it's a/an X ..." gate.
@@ -2166,13 +2173,15 @@ Numbers computed at resolution time.
 - `HandSize(player)` — cards in hand.
 - `TurnCount(player)` — turn number for that player.
 - `TurnTracking(player, TurnTracker)` — value of a per-turn counter (see below).
-- `SpellsCastThisTurn(player, filter?, excludeSelf?)` — count of spells `player` has cast this
-  turn, read from the per-player cast history (`GameState.spellsCastThisTurnByPlayer`). `filter`
+- `SpellsCastThisTurn(player, filter?, excludeSelf?, fromZone?)` — count of spells `player` has cast
+  this turn, read from the per-player cast history (`GameState.spellsCastThisTurnByPlayer`). `filter`
   matches a spell characteristic captured at cast time — type/color/mana value (face-down casts
   never match a non-empty filter); defaults to `GameObjectFilter.Any`. `excludeSelf` (default
   `false`) drops the resolving spell's *own* record, matched by its stack entity id, for "the
-  number of **other** spells you've cast this turn". The triggering spell is already recorded and
-  counts unless `excludeSelf`. DSL: `DynamicAmounts.spellsCastThisTurn(player, filter, excludeSelf)`.
+  number of **other** spells you've cast this turn". `fromZone` (default any) restricts to spells cast
+  from that zone (`CastSpellRecord.castFromZone`), matched independently of `filter`. The triggering
+  spell is already recorded and counts unless `excludeSelf`. DSL:
+  `DynamicAmounts.spellsCastThisTurn(player, filter, excludeSelf, fromZone)`.
   - Thunder Salvo ("2 plus the number of other spells you've cast this turn"):
     `Add(Fixed(2), SpellsCastThisTurn(Player.You, excludeSelf = true))`.
   - Magebane Lizard ("the number of noncreature spells they've cast this turn"):

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -631,12 +631,17 @@ object Conditions {
      * Counts every spell cast — countered, fizzled, or still on the stack all count.
      * Defaults to any spell, matching the typical "you've cast two or more spells
      * this turn" pattern (Brightspear Zealot, Illvoi Infiltrator).
+     *
+     * Pass [fromZone] to restrict to spells cast from that zone, independently of [filter].
+     * Negate with [not] for the Prairie Dog cycle's "you haven't cast a spell from your hand
+     * this turn": `not(YouCastSpellsThisTurn(1, fromZone = Zone.HAND))`.
      */
     fun YouCastSpellsThisTurn(
         atLeast: Int,
-        filter: com.wingedsheep.sdk.scripting.GameObjectFilter = com.wingedsheep.sdk.scripting.GameObjectFilter.Any
+        filter: com.wingedsheep.sdk.scripting.GameObjectFilter = com.wingedsheep.sdk.scripting.GameObjectFilter.Any,
+        fromZone: com.wingedsheep.sdk.core.Zone? = null
     ): ConditionInterface =
-        PlayerCastSpellsThisTurn(Player.You, filter, atLeast)
+        PlayerCastSpellsThisTurn(Player.You, filter, atLeast, fromZone)
 
     /**
      * If this is the first spell you've cast this turn that mana from a Treasure was

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -291,13 +291,17 @@ object DynamicAmounts {
      * // "noncreature spells they've cast this turn" (Magebane Lizard)
      * DynamicAmounts.spellsCastThisTurn(Player.TriggeringPlayer, GameObjectFilter.Noncreature)
      * ```
+     *
+     * Pass [fromZone] to count only spells cast from that zone (e.g. `Zone.HAND`), matched
+     * independently of [filter].
      */
     fun spellsCastThisTurn(
         player: Player = Player.You,
         filter: GameObjectFilter = GameObjectFilter.Any,
-        excludeSelf: Boolean = false
+        excludeSelf: Boolean = false,
+        fromZone: Zone? = null
     ): DynamicAmount =
-        DynamicAmount.SpellsCastThisTurn(player, filter, excludeSelf)
+        DynamicAmount.SpellsCastThisTurn(player, filter, excludeSelf, fromZone)
 
     /** The starting life total of a player (20 in standard, 40 in commander). */
     fun startingLifeTotal(player: Player = Player.You): DynamicAmount =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.sdk.scripting.conditions
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.text.TextReplacer
@@ -129,19 +130,28 @@ data class PlayerAttackedWithCreaturesThisTurn(
  * Used for cards like Brightspear Zealot ("as long as you've cast two or more
  * spells this turn") and Illvoi Infiltrator ("if you've cast two or more spells
  * this turn"). Pass `GameObjectFilter.Any` for the unfiltered "any spell" form.
+ *
+ * [fromZone] optionally restricts the count to spells cast from that zone. With
+ * `fromZone = Zone.HAND` this expresses "you('ve) cast a spell from your hand this turn"
+ * (negate it for the Prairie Dog cycle's "you haven't cast a spell from your hand this turn").
+ * The zone qualifier is matched independently of [filter], so a face-down (morph) spell cast
+ * from hand still counts even though its characteristics are unknown (CR 708.2).
  */
 @SerialName("PlayerCastSpellsThisTurn")
 @Serializable
 data class PlayerCastSpellsThisTurn(
     val player: Player = Player.You,
     val filter: GameObjectFilter = GameObjectFilter.Any,
-    val atLeast: Int
+    val atLeast: Int,
+    val fromZone: Zone? = null
 ) : Condition {
-    override val description: String =
-        if (filter == GameObjectFilter.Any)
-            "if ${player.description} cast $atLeast or more spells this turn"
-        else
-            "if ${player.description} cast $atLeast or more ${DynamicAmount.pluralize(filter.description)} spells this turn"
+    override val description: String = buildString {
+        append("if ${player.description} cast $atLeast or more ")
+        if (filter != GameObjectFilter.Any) append("${DynamicAmount.pluralize(filter.description)} ")
+        append("spells")
+        if (fromZone != null) append(" from ${fromZone.name.lowercase()}")
+        append(" this turn")
+    }
     override fun applyTextReplacement(replacer: TextReplacer): Condition {
         val newFilter = filter.applyTextReplacement(replacer)
         return if (newFilter !== filter) copy(filter = newFilter) else this

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -794,13 +794,15 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
      * @param player Whose cast history to count (summed when the ref resolves to several players)
      * @param filter Spell characteristics to match (default [GameObjectFilter.Any])
      * @param excludeSelf Exclude the resolving spell's own cast record (default false)
+     * @param fromZone Restrict to spells cast from this zone, independently of [filter] (default any zone)
      */
     @SerialName("SpellsCastThisTurn")
     @Serializable
     data class SpellsCastThisTurn(
         val player: Player = Player.You,
         val filter: GameObjectFilter = GameObjectFilter.Any,
-        val excludeSelf: Boolean = false
+        val excludeSelf: Boolean = false,
+        val fromZone: Zone? = null
     ) : DynamicAmount {
         override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount {
             val newFilter = filter.applyTextReplacement(replacer)
@@ -816,6 +818,7 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                 Player.You -> append("you've cast")
                 else -> append("${player.description} has cast")
             }
+            if (fromZone != null) append(" from ${fromZone.name.lowercase()}")
             append(" this turn")
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -545,14 +545,16 @@ class ConditionEvaluator(
         val playerId = resolvePlayer(state, condition.player, ctx) ?: return false
         val records = state.spellsCastThisTurnByPlayer[playerId] ?: return false
         if (records.size < condition.atLeast) return false
-        if (condition.filter == GameObjectFilter.Any) return true
         val evaluator = PredicateEvaluator()
         var matches = 0
         for (record in records) {
-            if (evaluator.matchesFilter(record, condition.filter)) {
-                matches++
-                if (matches >= condition.atLeast) return true
-            }
+            // The zone qualifier is checked independently of the filter: a face-down (morph) spell
+            // cast from hand still counts as "cast a spell from your hand" even though matchesFilter
+            // bails on face-down characteristics (CR 708.2).
+            if (condition.fromZone != null && record.castFromZone != condition.fromZone) continue
+            if (condition.filter != GameObjectFilter.Any && !evaluator.matchesFilter(record, condition.filter)) continue
+            matches++
+            if (matches >= condition.atLeast) return true
         }
         return false
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -352,6 +352,8 @@ class DynamicAmountEvaluator(
                     val records = state.spellsCastThisTurnByPlayer[playerId] ?: emptyList()
                     records.count { record ->
                         (selfId == null || record.sourceEntityId != selfId) &&
+                            // Zone qualifier is checked independently of the filter (see condition note).
+                            (amount.fromZone == null || record.castFromZone == amount.fromZone) &&
                             predicateEvaluator.matchesFilter(record, amount.filter)
                     }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -2139,6 +2139,12 @@ class CastSpellHandler(
                 // The cast card moves to the stack keeping its entity id, so this matches the
                 // resolving spell's EffectContext.sourceId (used by SpellsCastThisTurn excludeSelf).
                 sourceEntityId = action.cardId,
+                // Origin zone of the cast (HAND for a normal cast; GRAVEYARD/EXILE/COMMAND for
+                // flashback/forage, plot/foretell, commander, …). The card is still in its origin
+                // zone here — stackResolver.castSpell (below) moves it — so this resolves the same
+                // way castSpell stamps SpellOnStackComponent.castFromZone. Powers "you haven't cast
+                // a spell from your hand this turn" (Prairie Dog cycle).
+                castFromZone = stackResolver.findCastFromZone(currentState, action.cardId, action.playerId),
             )
             val existing = currentState.spellsCastThisTurnByPlayer[action.playerId] ?: emptyList()
             currentState = currentState.copy(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2194,9 +2194,12 @@ class StackResolver(
     // =========================================================================
 
     /**
-     * Determine which zone a card is being cast from.
+     * Determine which zone a card is being cast from. Called internally by [castSpell] (before the
+     * card is removed from its origin zone) and by `CastSpellHandler` to stamp `castFromZone` on the
+     * turn's [com.wingedsheep.engine.state.CastSpellRecord]; both invoke it while the card is still
+     * in its origin zone so they agree on the result.
      */
-    private fun findCastFromZone(
+    internal fun findCastFromZone(
         state: GameState,
         cardId: EntityId,
         playerId: EntityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -650,6 +650,13 @@ data class CommanderDamageEntry(
  * It lets a resolving spell exclude its own record from a count of spells cast this turn —
  * e.g. Thunder Salvo's "the number of *other* spells you've cast this turn". Null for synthetic
  * records constructed only for retroactive filter matching.
+ *
+ * [castFromZone] is the zone the spell was cast from (HAND for a normal cast, GRAVEYARD for
+ * flashback/forage, EXILE for a plotted/foretold/impulse cast, COMMAND for a commander, …). It
+ * lets "you haven't cast a spell *from your hand* this turn" (Inventive Wingsmith, Prairie Dog,
+ * Canyon Crab, Emergent Haunting, Wrangler of the Damned) distinguish hand casts from casts
+ * originating in any other zone. Null for synthetic records and for casts whose origin zone
+ * couldn't be determined.
  */
 @Serializable
 data class CastSpellRecord(
@@ -659,4 +666,5 @@ data class CastSpellRecord(
     val isFaceDown: Boolean,
     val paidWithTreasureMana: Boolean = false,
     val sourceEntityId: EntityId? = null,
+    val castFromZone: Zone? = null,
 )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastFromZoneThisTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastFromZoneThisTurnTest.kt
@@ -1,0 +1,234 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.CastSpellRecord
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.BonebindOrator
+import com.wingedsheep.mtg.sets.definitions.blb.cards.OsteomancerAdept
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.PlayerCastSpellsThisTurn
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cast-zone qualifier on the spell-cast tracker (OTJ engine gap #4).
+ *
+ * Each [CastSpellRecord] now captures the zone the spell was cast from (`castFromZone`), so a count
+ * or intervening-if can ask specifically about spells cast *from your hand* — the Prairie Dog cycle's
+ * "if you haven't cast a spell from your hand this turn" (Inventive Wingsmith, Prairie Dog, Canyon
+ * Crab, Emergent Haunting, Wrangler of the Damned). A hand cast must be distinguished from a
+ * flashback/forage (GRAVEYARD), plot/foretell (EXILE), or commander (COMMAND) cast.
+ *
+ * The first group drives the real cast pipeline to prove the engine stamps the origin zone correctly;
+ * the second pins the condition's zone-aware counting (incl. the face-down/morph edge); the third
+ * does the same for the symmetric [DynamicAmount.SpellsCastThisTurn] read surface.
+ */
+class CastFromZoneThisTurnTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(OsteomancerAdept, BonebindOrator, PredefinedTokens.Food))
+        return driver
+    }
+
+    fun lastRecord(driver: GameTestDriver, player: EntityId): CastSpellRecord =
+        driver.state.spellsCastThisTurnByPlayer[player]!!.last()
+
+    // =========================================================================
+    // Engine populates castFromZone from the real origin zone
+    // =========================================================================
+
+    test("a spell cast from hand records castFromZone = HAND") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, listOf(you)).isSuccess shouldBe true
+
+        lastRecord(driver, you).castFromZone shouldBe Zone.HAND
+    }
+
+    test("a spell cast from the graveyard (forage) records castFromZone = GRAVEYARD, not HAND") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20))
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val adept = driver.putCreatureOnBattlefield(you, "Osteomancer Adept")
+        driver.removeSummoningSickness(adept)
+        driver.putPermanentOnBattlefield(you, "Food") // forage cost
+        val orator = driver.putCardInGraveyard(you, "Bonebind Orator")
+
+        val abilityId = OsteomancerAdept.activatedAbilities.first().id
+        driver.submitSuccess(ActivateAbility(playerId = you, sourceId = adept, abilityId = abilityId))
+        driver.bothPass() // resolve the ability — grants forage-cast permission
+
+        driver.giveMana(you, Color.BLACK, 2)
+        driver.castSpell(you, orator).isSuccess shouldBe true
+
+        lastRecord(driver, you).castFromZone shouldBe Zone.GRAVEYARD
+    }
+
+    // =========================================================================
+    // Condition: PlayerCastSpellsThisTurn with fromZone (the Prairie Dog gate)
+    // =========================================================================
+
+    test("end-to-end: a hand cast satisfies fromZone=HAND; a graveyard cast does not") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20))
+        val you = driver.activePlayer!!
+        val opp = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val evaluator = ConditionEvaluator()
+        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+
+        // Cast a creature from the graveyard via forage — the only cast this turn.
+        val adept = driver.putCreatureOnBattlefield(you, "Osteomancer Adept")
+        driver.removeSummoningSickness(adept)
+        driver.putPermanentOnBattlefield(you, "Food")
+        val orator = driver.putCardInGraveyard(you, "Bonebind Orator")
+        val abilityId = OsteomancerAdept.activatedAbilities.first().id
+        driver.submitSuccess(ActivateAbility(playerId = you, sourceId = adept, abilityId = abilityId))
+        driver.bothPass()
+        driver.giveMana(you, Color.BLACK, 2)
+        driver.castSpell(you, orator).isSuccess shouldBe true
+
+        // You *have* cast a spell, but not from your hand.
+        evaluator.evaluate(driver.state, PlayerCastSpellsThisTurn(Player.You, atLeast = 1), ctx) shouldBe true
+        evaluator.evaluate(driver.state, PlayerCastSpellsThisTurn(Player.You, atLeast = 1, fromZone = Zone.HAND), ctx) shouldBe false
+        evaluator.evaluate(driver.state, PlayerCastSpellsThisTurn(Player.You, atLeast = 1, fromZone = Zone.GRAVEYARD), ctx) shouldBe true
+
+        // Now cast a spell from hand — the hand qualifier flips true.
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, listOf(opp)).isSuccess shouldBe true
+        evaluator.evaluate(driver.state, PlayerCastSpellsThisTurn(Player.You, atLeast = 1, fromZone = Zone.HAND), ctx) shouldBe true
+    }
+
+    test("condition: fromZone counts only matching-zone records, honoring atLeast and filter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.player1
+        val opp = driver.player2
+        val evaluator = ConditionEvaluator()
+        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+
+        val instant = TypeLine.parse("Instant")
+        val creature = TypeLine.parse("Creature")
+        val state = driver.state.copy(
+            spellsCastThisTurnByPlayer = mapOf(
+                you to listOf(
+                    CastSpellRecord(instant, 1, emptySet(), false, castFromZone = Zone.HAND),
+                    CastSpellRecord(creature, 2, emptySet(), false, castFromZone = Zone.HAND),
+                    CastSpellRecord(instant, 1, emptySet(), false, castFromZone = Zone.GRAVEYARD),
+                )
+            )
+        )
+
+        // 2 hand casts → atLeast 1 and 2 hold, 3 fails.
+        evaluator.evaluate(state, PlayerCastSpellsThisTurn(Player.You, atLeast = 1, fromZone = Zone.HAND), ctx) shouldBe true
+        evaluator.evaluate(state, PlayerCastSpellsThisTurn(Player.You, atLeast = 2, fromZone = Zone.HAND), ctx) shouldBe true
+        evaluator.evaluate(state, PlayerCastSpellsThisTurn(Player.You, atLeast = 3, fromZone = Zone.HAND), ctx) shouldBe false
+        // Only one GRAVEYARD cast.
+        evaluator.evaluate(state, PlayerCastSpellsThisTurn(Player.You, atLeast = 2, fromZone = Zone.GRAVEYARD), ctx) shouldBe false
+        // filter + zone combine: one instant cast from hand.
+        evaluator.evaluate(
+            state,
+            PlayerCastSpellsThisTurn(Player.You, GameObjectFilter.Instant, atLeast = 1, fromZone = Zone.HAND),
+            ctx
+        ) shouldBe true
+        evaluator.evaluate(
+            state,
+            PlayerCastSpellsThisTurn(Player.You, GameObjectFilter.Instant, atLeast = 2, fromZone = Zone.HAND),
+            ctx
+        ) shouldBe false
+        // No zone → all three count.
+        evaluator.evaluate(state, PlayerCastSpellsThisTurn(Player.You, atLeast = 3), ctx) shouldBe true
+    }
+
+    test("condition: a face-down (morph) spell cast from hand still counts toward fromZone=HAND") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.player1
+        val opp = driver.player2
+        val evaluator = ConditionEvaluator()
+        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+
+        // A face-down spell has no known characteristics (CR 708.2), but it was still cast from hand.
+        val state = driver.state.copy(
+            spellsCastThisTurnByPlayer = mapOf(
+                you to listOf(
+                    CastSpellRecord(TypeLine.parse("Creature"), 0, emptySet(), isFaceDown = true, castFromZone = Zone.HAND),
+                )
+            )
+        )
+        // Any-filter zone gate counts it...
+        evaluator.evaluate(state, PlayerCastSpellsThisTurn(Player.You, atLeast = 1, fromZone = Zone.HAND), ctx) shouldBe true
+        // ...but a typed filter still can't match a face-down spell's hidden characteristics.
+        evaluator.evaluate(
+            state,
+            PlayerCastSpellsThisTurn(Player.You, GameObjectFilter.Creature, atLeast = 1, fromZone = Zone.HAND),
+            ctx
+        ) shouldBe false
+    }
+
+    // =========================================================================
+    // DynamicAmount: SpellsCastThisTurn with fromZone (symmetric read surface)
+    // =========================================================================
+
+    test("dynamicAmount: fromZone counts only matching-zone records") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.player1
+        val opp = driver.player2
+        val evaluator = DynamicAmountEvaluator()
+        val ctx = EffectContext(sourceId = null, controllerId = you, opponentId = opp)
+
+        val instant = TypeLine.parse("Instant")
+        val state = driver.state.copy(
+            spellsCastThisTurnByPlayer = mapOf(
+                you to listOf(
+                    CastSpellRecord(instant, 1, emptySet(), false, castFromZone = Zone.HAND),
+                    CastSpellRecord(instant, 1, emptySet(), false, castFromZone = Zone.HAND),
+                    CastSpellRecord(instant, 1, emptySet(), false, castFromZone = Zone.GRAVEYARD),
+                    CastSpellRecord(instant, 1, emptySet(), false, castFromZone = null),
+                )
+            )
+        )
+
+        evaluator.evaluate(state, DynamicAmount.SpellsCastThisTurn(Player.You), ctx) shouldBe 4
+        evaluator.evaluate(state, DynamicAmount.SpellsCastThisTurn(Player.You, fromZone = Zone.HAND), ctx) shouldBe 2
+        evaluator.evaluate(state, DynamicAmount.SpellsCastThisTurn(Player.You, fromZone = Zone.GRAVEYARD), ctx) shouldBe 1
+        evaluator.evaluate(state, DynamicAmount.SpellsCastThisTurn(Player.You, fromZone = Zone.EXILE), ctx) shouldBe 0
+    }
+
+    // =========================================================================
+    // Descriptions
+    // =========================================================================
+
+    test("descriptions read with the zone qualifier") {
+        PlayerCastSpellsThisTurn(Player.You, atLeast = 1, fromZone = Zone.HAND).description shouldBe
+            "if you cast 1 or more spells from hand this turn"
+        DynamicAmount.SpellsCastThisTurn(Player.You, fromZone = Zone.HAND).description shouldBe
+            "the number of spells you've cast from hand this turn"
+    }
+})


### PR DESCRIPTION
## What

Implements **OTJ engine gap #4** — a *cast-zone* qualifier on the per-player spell-cast tracker, so the engine can answer "have you cast a spell **from your hand** this turn?" distinctly from a plotted / flashback / forage / commander cast.

Each `CastSpellRecord` now carries `castFromZone: Zone?`, stamped in `CastSpellHandler` from `StackResolver.findCastFromZone(...)` at cast time. The card is still in its origin zone at that point, so the value agrees with the `castFromZone` that `castSpell` writes onto `SpellOnStackComponent`.

Both read surfaces over the cast history gained a symmetric `fromZone` qualifier, matched **independently of the spell filter** so a face-down / morph spell cast from hand still counts (CR 708.2):

- **condition** — `PlayerCastSpellsThisTurn(..., fromZone)` / `Conditions.YouCastSpellsThisTurn(atLeast, filter, fromZone)`
- **count** — `DynamicAmount.SpellsCastThisTurn(..., fromZone)` / `DynamicAmounts.spellsCastThisTurn(..., fromZone)`

## Why

Unblocks the Prairie Dog cycle's "if you haven't cast a spell from your hand this turn", expressed as `Not(YouCastSpellsThisTurn(1, fromZone = Zone.HAND))`:
**Inventive Wingsmith, Prairie Dog, Canyon Crab, Emergent Haunting, Wrangler of the Damned.**

## Layer trace

- **SDK (data):** new nullable, defaulted, serializable fields on `CastSpellRecord`, `PlayerCastSpellsThisTurn`, `DynamicAmount.SpellsCastThisTurn`; facades updated. Existing `description` output is byte-identical when `fromZone == null` (no card-snapshot diff).
- **Engine:** `CastSpellHandler` populates the zone; `findCastFromZone` made `internal` and reused (single source of truth shared with `castSpell`).
- **Evaluators:** zone clause added to both the condition and dynamic-amount evaluators, independent of the filter.
- **No new GameEvent / client-visible state / legal action** → no server DTO or frontend changes. Purely internal turn-tracking; the cards that consume it are ordinary triggers using existing effects.
- **Docs:** `card-sdk-language-reference.md` updated for both surfaces.

## Tests

`CastFromZoneThisTurnTest` (all green), covering:
- `castFromZone` populated as **HAND** (normal cast) and **GRAVEYARD** (forage cast) through the real cast pipeline
- end-to-end discrimination: a graveyard cast satisfies `fromZone = GRAVEYARD` and the unqualified count but **not** `fromZone = HAND`; a subsequent hand cast flips it
- `atLeast` threshold + `filter` + zone combinations
- the face-down/morph edge (counts under `Any`, still can't match a typed filter)
- the symmetric `DynamicAmount` zone counting (incl. `null`-zone records)
- description strings

Existing condition consumers (`BrightspearZealotTest`, `AlaniaDivergentStormTest`, `EshkiDragonclawTest`, `SpellsCastThisTurnAmountTest`) and the card-definition snapshot suite remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)