### PR TITLE
mtgish coverage + auto-generation spike tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,43 @@ scripts/card-status --list --set BLB       # missing cards grouped under Extra:
 scripts/card-status --cards BLB            # full listing split into Draft: / Extra: sections
 ```
 
+## mtgish coverage + auto-gen tooling (spike, `spike/mtgish-coverage/`)
+
+A **predictive, non-authoritative** toolchain that maps the [mtgish](https://github.com/i5jb/mtgish)
+oracle-IR corpus onto our SDK capabilities, to triage the backlog and draft easy cards. It is a
+`scripts/`-style analyzer, **never a card loader** — ground truth stays a human-authored `cardDef`
+whose scenario test passes. The mtgish→Argentum bridge lives in `spike/mtgish-coverage/mapping.json`;
+full rationale + measured results in [`spike/mtgish-coverage/FINDINGS.md`](spike/mtgish-coverage/FINDINGS.md).
+First run auto-downloads the 29 MB mtgish IR (gitignored).
+
+```bash
+# COVERAGE — which missing cards need no engine work, and which feature unlocks the most.
+just coverage --set TMP                 # implemented / FREE-to-implement / blocked + feature leaderboard
+just coverage --set TMP --free          # also list the implementable-today cards
+just coverage --card "Shivan Dragon"    # one card: required capabilities + verdict
+just coverage --calibrate POR           # trust check: implemented cards must classify coverable (~99%)
+
+# FIDELITY — could we AUTO-AUTHOR a card? Diffs the bridge vs each card's compiled golden snapshot.
+just coverage-fidelity --set POR        # tiers cards AUTO / SCAFFOLD / MISS + mean recall
+just coverage-fidelity --all            # cross-set generalization table (AUTO ~75% on Portal, ~45% unseen)
+just coverage-fidelity --emit "Lava Axe"  # print the generated cardDef DSL for one card
+
+# AUTO-GEN — turn the bridge on a set's UNIMPLEMENTED cards.
+just coverage-gaps --set TMP            # AUTOGEN / SCAFFOLD / BLOCKED counts + blocked-capability leaderboard
+just coverage-generate --set TMP        # draft .kt for the AUTOGEN cards -> spike/mtgish-coverage/generated/<set>/
+```
+
+**When to use.** Spoiler-season/backlog triage (`coverage` leaderboard = which feature unlocks the
+most cards); deciding whether a missing card is pure authoring vs. needs `add-feature`
+(`coverage-gaps`); getting a blank-page head-start on simple cards (`coverage-generate`).
+
+**Hard rules.** Generated `.kt` are **DRAFTS in a staging dir** — they must compile, get a scenario
+test, and be human-reviewed before moving into a set's `cards/` package. Treat coverage/AUTOGEN as
+*advisory ranking*, never a gate: mtgish IR is approximate (it can emit a clean-looking but
+subtly-wrong target), and the bridge is Portal-tuned, so AUTO drops to ~45% on unseen sets until you
+extend `mapping.json` (which converges — one entry helps all sets). Keep using the `add-card` skill
+for real implementation.
+
 ## Module Layout
 
 | Module | Purpose | Deps |

--- a/justfile
+++ b/justfile
@@ -64,6 +64,40 @@ check:
 card-status *ARGS:
     scripts/card-status {{ARGS}}
 
+# Predict engine coverage via the mtgish bridge — which missing cards are free vs blocked.
+# Whole set:   just coverage --set TMP            (implemented / FREE / blocked + leaderboard)
+#              just coverage --set TMP --free     (also list the free-to-implement cards)
+#              just coverage --set TMP --blocked  (also list blocked cards + reasons)
+# One card:    just coverage --card "Shivan Dragon"
+# Trust check: just coverage --calibrate POR      (implemented cards must classify coverable)
+[group: 'build']
+coverage *ARGS:
+    python3 spike/mtgish-coverage/probe.py {{ARGS}}
+
+# Generation fidelity — could we AUTO-AUTHOR a card from mtgish? Diffs the bridge's output
+# against each card's compiled golden snapshot, tiering AUTO / SCAFFOLD / MISS.
+# Whole set:  just coverage-fidelity --set POR
+#             just coverage-fidelity --set POR --list SCAFFOLD
+# Cross-set:  just coverage-fidelity --all          (generalization table — bridge applied unchanged)
+# One card:   just coverage-fidelity --emit "Shivan Dragon"   (prints generated cardDef DSL)
+[group: 'build']
+coverage-fidelity *ARGS:
+    python3 spike/mtgish-coverage/fidelity.py {{ARGS}}
+
+# Auto-gen gap: of a set's UNIMPLEMENTED cards, how many could the bridge draft now?
+#   just coverage-gaps --set TMP                 # AUTOGEN / SCAFFOLD / BLOCKED + leaderboard
+#   just coverage-gaps --set TMP --list AUTOGEN  # list the draftable cards
+[group: 'build']
+coverage-gaps *ARGS:
+    python3 spike/mtgish-coverage/autogen.py --gaps {{ARGS}}
+
+# Generate draft .kt files for a set's AUTOGEN-predicted missing cards into a STAGING dir.
+# DRAFTS ONLY — they must compile + pass a scenario test + be reviewed before use.
+#   just coverage-generate --set TMP             # -> spike/mtgish-coverage/generated/tmp/
+[group: 'build']
+coverage-generate *ARGS:
+    python3 spike/mtgish-coverage/autogen.py --write {{ARGS}}
+
 # Verify backlog/sets/*/cards.md headers match actual [x] / [x]+[ ] counts
 [group: 'build']
 check-backlog:

--- a/spike/mtgish-coverage/.gitignore
+++ b/spike/mtgish-coverage/.gitignore
@@ -1,0 +1,4 @@
+data/
+registry.effects.txt
+__pycache__/
+generated/

--- a/spike/mtgish-coverage/FINDINGS.md
+++ b/spike/mtgish-coverage/FINDINGS.md
@@ -1,0 +1,281 @@
+# Spike: mtgish as the Lesson 5 coverage-probe extractor backend
+
+**Question.** phase-rs-lessons.md Lesson 5 wants an *oracle-text → required-capability
+extractor*. Its risky tier is the heuristic "clause templates" (hand-rolled regex). Could
+**mtgish**'s pre-parsed oracle IR replace that tier? The cost of doing so is a
+`mtgish-tag → Argentum-capability` **mapping** we'd have to author and maintain. This spike
+measures how big and how durable that mapping is, using the doc's own **calibration loop**:
+every *already-implemented* card must classify as *coverable-now*; any that doesn't is a hole
+in the mapping, not a real feature gap.
+
+## What was built
+
+- `probe.py` — three parts, all tooling, never loads a card:
+  1. **Capability registry**, scanned from Kotlin source so it can't rot: 312 Effect
+     `@SerialName`s + 74 `Keyword` enum entries.
+  2. **Extractor** — walks a card's mtgish IR (`data/mtgish.lines.json`, 32,464 cards) and
+     collects the capability-bearing tags (`_Action`, `_Rule`, `_Trigger`, `_Cost`,
+     `_LayerEffect`).
+  3. **Calibration** — for each implemented card, `required ∖ supported`; reports recall +
+     the unmapped-tag tail.
+- `mapping.json` — the hand-authored bridge (74 entries). This file *is* the maintenance cost
+  being measured. `effect`/`keyword` entries are **validated against the registry** (a wrong
+  guess surfaces as a MISSING gap — the mechanism catching its own error); `composed` =
+  Argentum builds it from primitives (destroy = `MoveToZone→graveyard`, search, discard…);
+  `ignore` = a structural mtgish envelope (`SpellActions`, `TriggerA`, the `May/Unless/If`
+  gate cluster) whose capability lives in nested nodes.
+
+## Results
+
+**Calibration (Portal, 184 implemented cards):**
+
+```
+RECALL: 182/184 = 98.9% coverable-now
+  - 0 tags mapped to a MISSING engine capability  ← every effect/keyword guess validated
+  - 2 blocked cards = the 2 tags left deliberately unmapped:
+      Exhaustion   (EachPermanentDoesntUntapDuringControllersNextUntap)
+      False Peace  (SkipAllCombatPhasesTheirNextTurn)
+```
+
+**Vocabulary is small and Zipfian.** Portal's entire 184-card corpus uses **77 distinct
+tags**; the top 30 cover 83% of occurrences. A whole classic set is mappable in ~75 lines.
+
+**Marginal cost per new set (the real tractability number).** Reusing the Portal mapping
+unchanged:
+
+| Set | distinct tags | already covered | **new entries to author** |
+|-----|---------------|-----------------|---------------------------|
+| POR | 77 | 75 | 2 |
+| LEA (Alpha) | 19 | 9 | 10 |
+| ARN (Arabian Nights) | 68 | 32 | **36** |
+
+ARN is the stress case (idiosyncratic early-MTG mechanics). Its 36 marginal tags decompose as
+9 `_Rule` (envelopes/keywords ≈ free), 6 `_Trigger`, 3 `_Cost`, 3 `_LayerEffect`, and only
+**15 genuinely new `_Action` effects** — every one mapping to a capability Argentum already has
+(`AddMana`, `GainControlOfPermanentUntil`, `CreateTokens`, `RegeneratePermanent`,
+`PutCountersOnPermanent`, `RemoveCreatureFromCombat`, coin-flip variants…). Zero needed a new
+engine feature — correct, since ARN is fully implemented. The vocabulary saturates: each set
+adds a tapering handful, converging on a global mapping.
+
+## Verdict
+
+**Viable, behind the calibration loop — and the loop works.** A few hundred mapping lines
+cover the classic-era corpus; the per-set marginal cost is a dozen-ish entries that shrink as
+the vocabulary saturates. The registry-validation half already caught nothing wrong here only
+because the guesses were right — but it *is* live: mis-map an effect to a non-existent
+SerialName and it reports as MISSING, exactly as designed.
+
+**Caveats the spike confirms (not blockers):**
+- The mapping is genuine, ongoing work — you trade *writing regex templates* for *writing
+  mapping entries + discovering Argentum's composition for each mtgish action* (e.g. realizing
+  "destroy" is `MoveToZone`, not a leaf). Comparable effort, but the mapping is **declarative
+  and greppable** where regex is not, and mtgish gives 32k cards of pre-parsed structure for free.
+- Triggers/costs are accepted as `supported` without validation here — Phase 1 should scan the
+  `Triggers.*` / `Costs.*` facades to close that, same pattern as the effect registry.
+- This is *prediction*, never a loader. Ground truth stays: authored DSL + passing scenario test.
+
+## The tool (`just coverage`)
+
+The probe now has three lenses, wired into the justfile beside `card-status`. It reuses
+`card-status`'s Scryfall cache to pull a set's full canonical list, so it classifies *missing*
+cards too — the actual backlog-triage deliverable.
+
+```bash
+just coverage --set TMP             # implemented / FREE-to-implement / blocked + leaderboard
+just coverage --set TMP --free      # also list the free-to-implement (missing+coverable) cards
+just coverage --set TMP --blocked   # also list blocked cards + the blocking tags
+just coverage --card "Shivan Dragon"  # one card: required capabilities + verdict
+just coverage --calibrate POR       # trust check: implemented cards must classify coverable
+```
+
+**Worked example — Tempest (`just coverage --set TMP`):** 16 implemented, **114 free to
+implement now** (no engine work), 205 blocked. The feature leaderboard ranks the blocking
+capabilities by how many cards each unlocks (`AddMana ×22`, `EnchantPermanent ×19`,
+`AtUpkeep trigger ×17`, …) — a sorted worklist: author the free pile today, map/triage the
+leaderboard top-down, and each entry you close reclassifies a batch as free.
+
+Two verdict classes in the leaderboard keep it honest:
+- `GAP` — tag maps to a capability **absent from the registry**: a genuine engine-feature gap.
+- `??` — tag has **no mapping entry**: triage (usually a mapping hole, occasionally a new
+  mechanic). With a Portal-seeded mapping most of Tempest's "blocked" is `??`, i.e. mapping
+  debt, not real engine gaps — exactly what you'd expect, and what the leaderboard tells you to
+  pay down.
+
+**Keyword auto-resolve.** Any unmapped tag whose PascalCase name converts to a real `Keyword`
+enum member (`FirstStrike→FIRST_STRIKE`, `Shadow→SHADOW`) is treated as covered — registry-
+validated, so it never over-claims (envelopes like `Activated` stay unmapped). This collapsed
+the single biggest category of mapping holes (Tempest free 88→114) with zero hand-mapping.
+
+## Not yet done (next steps if pursued)
+
+1. **`KeywordAbility` registry** — auto-resolve only sees the base `Keyword` enum; cost-bearing
+   keywords (`Buyback`, `Echo`, …) live in `KeywordAbility` and still show as `??`. Scan that
+   facade too (same pattern). Likewise `Triggers.*` / `Costs.*` to validate the `supported` kind.
+2. **mtgish name-matching** — classic sets join 100% by exact front-face name; modern sets with
+   DFCs / split / adventure / reprints will need fuzzier joining (mtgish keys on oracle name).
+3. **License** — mtgish is "MIT-ish, talk to a lawyer." Fine for an offline `scripts/` artifact
+   consuming its committed JSON; clear before any vendoring.
+
+## Generation fidelity — can we *auto-author*, not just *cover*? (`just coverage-fidelity`)
+
+Coverage asks "does every capability exist?" Generation asks the harder thing: "could a script
+emit the correct `cardDef { }`?" To measure it honestly without a Kotlin compiler, `fidelity.py`
+diffs the bridge's output against each card's **compiled golden snapshot**
+(`mtg-sets/src/test/resources/snapshots/cards/POR.json`) — both sides are Argentum `@SerialName`
+tags, so it's apples-to-apples. Each card is tiered:
+
+```
+just coverage-fidelity --set POR    →  184 cards (vs compiled golden)
+  AUTO      138   75.0%   recall=1, every target/filter recovered -> emit whole
+  SCAFFOLD   30   16.3%   right effects, but structure (pipeline/gate/unrecognized filter) needs wiring
+  MISS       16    8.7%   bridge omits a capability the card uses
+  mean capability recall: 93.0%
+```
+
+**AUTO is real — the emitter reproduces hand-authored DSL byte-for-byte.** `--emit "Hand of Death"`
+produces, line for line, the committed `HandOfDeath.kt`:
+
+```kotlin
+spell {
+    val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
+    effect = MoveToZoneEffect(t, Zone.GRAVEYARD, byDestruction = true)
+}
+```
+
+`Monstrous Growth` (`ModifyStatsEffect(powerModifier = 4, toughnessModifier = 4, target = t)`) and
+`Anaconda` (`keywords(Keyword.SWAMPWALK)`) likewise match exactly. The recovery layer reads mtgish's
+target/filter/amount operands the coverage map discards — `TargetPermanent{And(IsNonColor Black,
+IsCardtype Creature)}` → `TargetCreature(filter = ...notColor(Color.BLACK))`.
+
+**This run is post-improvement.** The first cut scored AUTO 57% / SCAFFOLD 21% / MISS 22%. Two
+changes, both driven by the diff, moved it to **75 / 16 / 9**:
+
+1. **Structure recovery from the mtgish side.** "Can *we* reconstruct the targets/filters?" replaces
+   "is the card complex?" mtgish fully encodes the common target vocabulary (`IsCardtype ×72`,
+   `And ×40`, player filters), so filtered-single-target cards (`destroy target nonblack creature`)
+   are AUTO, not SCAFFOLD. +18 points of AUTO.
+2. **Lowering-rule tags surfaced by calibration.** The MISS pile taught the bridge how Argentum
+   *lowers* verbs: single-card move → `MoveToZone`, mass → `MoveCollection`, tap-all → `TapUntap`
+   over a group, unless-gate → `PayOrSuffer`. Encoding those (general rules, not per-card fits)
+   cut MISS from 41 to 16. This is the calibration loop working as designed: implemented cards
+   reveal the correct lowering, you encode it once, it generalizes.
+
+**Where it still breaks — and the diff names it precisely:**
+
+- **MISS (9%)** — `MoveCollection ×7` (the genuinely ambiguous single-vs-many discard/look/mill
+  lowering) plus a one-each tail of real per-card capabilities (`SkipCombatPhases`, `PlayAdditionalLands`,
+  `MustBeBlocked`, `Taunt`…). These are honest residue, not low-hanging fruit.
+- **SCAFFOLD (16%)** — a ranked worklist: `SearchLibrary ×7`, `DestroyEachPermanent ×6`, the
+  `Unless/MayCost` gate cluster ×6, each-player iteration, multi-target counts. Each is a known
+  structure a converter *could* render with more work — the report ranks them so you'd extend the
+  emitter highest-value-first.
+- **mtgish is approximate — even AUTO needs review.** `Lava Axe` ("deal 5 to target player") emits
+  `AnyTarget()` because mtgish parsed it as the over-broad `TargetPlayerOrPermanent`. It still scores
+  AUTO and still compiles — but it's *subtly wrong*. Proof that AUTO is a *ceiling*, not a guarantee:
+  only a compile + scenario test catches this, which is why the gate stays human-reviewed.
+
+**Verdict on auto-authoring.** Even after improvement, ~**75%** of 100%-*coverage* cards are
+cleanly emittable, ~16% are review-drafts, ~9% the bridge gets wrong — and the AUTO slice skews
+toward cards that are *already cheap to hand-author*. So the product is still a **reviewed draft
+scaffolder**, never an unattended loader; the fidelity tier is the routing signal (AUTO → near-final
+draft, SCAFFOLD → head-start with structure flagged, MISS → `add-card` by hand), and a compile +
+scenario test remains the only real correctness gate.
+
+## Cross-set generalization — the decisive finding (`just coverage-fidelity --all`)
+
+The Portal numbers above were tuned *on Portal*. The honest question is whether the bridge
+generalizes. Applying the **same bridge, unchanged**, to other fully-implemented sets that have a
+golden snapshot:
+
+```
+  SET   matched   AUTO  SCAFFOLD   MISS  recall
+  POR       184  75.0%     16.3%   8.7%   93.0%   <- the set the mapping was built on
+  INV       312  48.1%      5.4%  46.5%   70.0%
+  ONS       327  38.2%     13.5%  48.3%   65.3%
+  KTK       242  46.7%      7.9%  45.5%   70.1%
+  DOM       242  46.7%      7.9%  45.5%   69.2%
+  LGN       145  53.1%      6.2%  40.7%   69.3%
+  SCG       143  46.2%     11.2%  42.7%   68.2%
+  ARN        58  44.8%     15.5%  39.7%   70.3%
+```
+
+**AUTO halves off the home set (75% → ~45%); the 75% was substantially a Portal artifact.** This is
+the single most important result in the spike — measured, not asserted.
+
+**But the gap is *tractable, converging debt*, not a wall.** The MISS pile on unseen sets is
+overwhelmingly **effect verbs Argentum already has but Portal never exercised** — `AddMana`,
+`CreateTokens`, `AddCounters`, `Regenerate`, `GainControl`, `ExilePermanent`, the `May`-gate family.
+Each is one mapping line, validated against the registry. Adding **26 such universal lines lifted
+recall ~10–14 points on every unseen set at once** (KTK 56→70%, INV 58→70%, ONS 55→65%) — the
+convergence property: the bridge is shared infrastructure, so one fix helps all sets, and the
+vocabulary saturates as you go. Reaching Portal's 93%/75% on a new set means paying down its share
+of the long tail (~160 rarer verbs remain across these six sets).
+
+**What this means for the verdict.** Auto-authoring is *even less* of a free lunch than the Portal
+slice implied:
+- A first-time set lands around **45% AUTO / 45% MISS** with today's bridge.
+- Closing the gap is real, ongoing mapping work — but it *accumulates* (every verb mapped is mapped
+  forever, for all sets) rather than resetting per set. The bridge is a **build-and-converge asset**,
+  not build-once and not throwaway.
+- It still only produces *review drafts*: even at Portal's 93% recall, `Lava Axe` emits a wrong
+  target from a clean parse. The scenario test stays the gate.
+
+So the recommendation is unchanged but now quantified: a **reviewed draft scaffolder** is worth it
+*if* you commit to growing the mapping across the corpus (the `--all` recall column is the KPI to
+watch); it is not a push-button "implement every coverable card" tool.
+
+## Auto-gen gap detector + draft generator (`autogen.py`)
+
+The end-to-end payoff: turn the bridge on a set's *unimplemented* cards and (1) predict which it
+could draft today, (2) emit those drafts.
+
+```
+just coverage-gaps --set TMP            # of 319 unimplemented Tempest cards:
+  AUTOGEN     36   bridge could draft a whole card now
+  SCAFFOLD   113   covered, but structure needs hand-wiring
+  BLOCKED    170   capability gap (needs mapping or engine work)
+  BLOCKED leaderboard: EnchantPermanent ×19 (auras), AtUpkeep-trigger ×17, ...
+
+just coverage-generate --set TMP        # writes 36 draft .kt -> generated/tmp/  (staging, gitignored)
+```
+
+A generated draft (`generated/tmp/LightningBlast.kt`), complete with package + exact imports:
+
+```kotlin
+// === GENERATED DRAFT — do NOT merge as-is. ===
+val LightningBlast = card("Lightning Blast") {
+    manaCost = "{3}{R}"
+    typeLine = "Instant"
+    spell {
+        val t = target("target", AnyTarget())
+        effect = DealDamageEffect(4, t)
+    }
+    metadata { rarity = Rarity.COMMON /* TODO verify rarity + add Scryfall fields */ }
+}
+```
+
+**Prediction without a snapshot is harder, and the tool is honest about it.** Missing cards have no
+golden tree, so AUTOGEN = `coverable` (probe) ∧ `structure recoverable` (fidelity) ∧ `emitter renders
+the whole card`. The completeness gate is strict: when target recovery can't faithfully render a
+filter (e.g. Disenchant's *artifact-or-enchantment* target), `target_dsl` returns `None` and the card
+drops to SCAFFOLD rather than emitting a confidently-wrong `TargetPermanent()`. That one fix moved 5
+Tempest cards out of AUTOGEN — silent-wrong avoided by construction.
+
+**Two deliberate safety choices**, consistent with the whole spike:
+- Drafts go to a **staging dir, never the live set.** They're predictions from approximate IR; the
+  gate stays compile + scenario test + human review, then drop into `cards/` (which auto-registers
+  via classpath scan). This is a scaffolder, not a card loader.
+- The generator emits **only what it can render whole** (36/319 for Tempest: 19 keyword creatures,
+  6 damage spells, 11 vanilla) — exactly the cheap-to-author slice. It is a blank-page eliminator
+  for the easy pile, freeing human time for the SCAFFOLD/BLOCKED cards where it actually goes.
+
+## Files
+
+- `probe.py` — registry scan + extractor + classifier + the three coverage lenses.
+- `fidelity.py` — generation-fidelity scorer (vs golden snapshot), `--all` cross-set, DSL emitter.
+- `autogen.py` — auto-gen gap detector (`--gaps`) + draft generator (`--write`) for missing cards.
+- `generated/<set>/` — staging output of draft `.kt` files (gitignored; review before use).
+- `mapping.json` — the hand-authored mtgish→Argentum bridge (the measured maintenance cost);
+  `composed` entries carry `tags` naming the concrete primitives they'd compile to (for fidelity).
+- `data/mtgish.lines.json` — 32k-card mtgish IR (gitignored; auto-downloaded on first run).
+- `registry.effects.txt` — generated dump of effect SerialNames (gitignored).

--- a/spike/mtgish-coverage/autogen.py
+++ b/spike/mtgish-coverage/autogen.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Auto-generation gap detector + draft generator, on top of the mtgish bridge.
+
+Two modes:
+  --gaps SET    Of a set's UNIMPLEMENTED cards, predict which the bridge could auto-author
+                today: AUTOGEN (covered + structure recoverable + emitter renders it whole),
+                SCAFFOLD (covered but needs hand-wiring), BLOCKED (capability gap), with a
+                leaderboard of what blocks the rest.
+  --write SET   Emit a draft `.kt` for every AUTOGEN-predicted missing card into a STAGING
+                dir (default spike/mtgish-coverage/generated/<set>/). Never the live set.
+
+WHY STAGING, NOT THE LIVE SET. These are *predictions* from approximate mtgish IR with no
+golden snapshot to check against — cross-set AUTO precision is ~45% and even clean emits can
+be subtly wrong (see FINDINGS: Lava Axe). The project's ground truth is a human-authored card
+whose scenario test passes. So this produces review-drafts that still must: (1) compile,
+(2) get a scenario test, (3) be eyeballed — then dropped into the set's `cards/` package
+(which auto-registers via classpath scan). It is deliberately NOT a card loader.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+SPIKE_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SPIKE_DIR))
+import probe      # noqa: E402
+import fidelity   # noqa: E402
+
+SYMBOL_IMPORTS = {
+    "card": "com.wingedsheep.sdk.dsl.card",
+    "Rarity": "com.wingedsheep.sdk.model.Rarity",
+    "Keyword": "com.wingedsheep.sdk.core.Keyword",
+    "Color": "com.wingedsheep.sdk.core.Color",
+    "Zone": "com.wingedsheep.sdk.core.Zone",
+    "DealDamageEffect": "com.wingedsheep.sdk.scripting.effects.DealDamageEffect",
+    "ModifyStatsEffect": "com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect",
+    "MoveToZoneEffect": "com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect",
+    "DrawCardsEffect": "com.wingedsheep.sdk.scripting.effects.DrawCardsEffect",
+    "GainLifeEffect": "com.wingedsheep.sdk.scripting.effects.GainLifeEffect",
+    "LoseLifeEffect": "com.wingedsheep.sdk.scripting.effects.LoseLifeEffect",
+    "TargetFilter": "com.wingedsheep.sdk.scripting.filters.unified.TargetFilter",
+    "TargetCreature": "com.wingedsheep.sdk.scripting.targets.TargetCreature",
+    "TargetPlayer": "com.wingedsheep.sdk.scripting.targets.TargetPlayer",
+    "TargetPermanent": "com.wingedsheep.sdk.scripting.targets.TargetPermanent",
+    "AnyTarget": "com.wingedsheep.sdk.scripting.targets.AnyTarget",
+}
+PERMANENT_TYPES = {"Creature", "Artifact", "Enchantment", "Land", "Planeswalker"}
+
+
+def card_tags(card):
+    t = Counter()
+    probe.extract_tags(card.get("Rules", []), t)
+    return t
+
+
+def is_permanent(card):
+    return any(t in PERMANENT_TYPES for t in card.get("Typeline", {}).get("Cardtypes", []))
+
+
+def spell_actions(card):
+    """(targets|None, actions) for a spell — handles Targeted and bare ActionList shapes."""
+    targets, actions = fidelity.find_targeted(card)
+    if actions:
+        return targets, actions
+    found = [None]
+
+    def walk(n):
+        if isinstance(n, dict):
+            if n.get("_Actions") == "ActionList" and isinstance(n.get("args"), list):
+                found[0] = n["args"]
+            for v in n.values():
+                walk(v)
+        elif isinstance(n, list):
+            for v in n:
+                walk(v)
+    walk(card.get("Rules", []))
+    return None, (found[0] or [])
+
+
+def render_kotlin(card, effects, keywords, mapping):
+    """Return (text, complete). complete=True only when the emitter renders the WHOLE card."""
+    used = {"card", "Rarity"}
+    reasons = fidelity.unrecoverable_reasons(card)
+    tags = card_tags(card)
+    action_tags = [v for (d, v) in tags if d == "_Action"]
+    has_trigger = any(d == "_Trigger" for (d, v) in tags)
+    has_activated = any(d == "_Rule" and v in ("Activated", "ActivatedWithModifiers")
+                        for (d, v) in tags)
+
+    kw = set()
+    fidelity.find_landwalk_keywords(card.get("Rules", []), keywords, kw)
+    for (disc, val) in tags:
+        if val == "Landwalk":
+            continue
+        entry = mapping.get(f"{disc}:{val}", mapping.get(val))
+        auto = probe.pascal_to_upper_snake(val) if isinstance(val, str) else ""
+        if (entry and entry.get("kind") == "keyword") or auto in keywords:
+            kw.add((entry or {}).get("tag", auto))
+    if kw:
+        used.add("Keyword")
+
+    spell_lines, complete = [], True
+    if is_permanent(card):
+        # complete only if it's a pure vanilla/keyword permanent (no abilities we can't render)
+        if action_tags or has_trigger or has_activated or reasons:
+            complete = False
+    else:  # spell
+        targets, actions = spell_actions(card)
+        if reasons or len(actions) != 1:
+            complete = False
+        else:
+            edsl = fidelity.effect_dsl(actions[0], "t")
+            if not edsl:
+                complete = False
+            elif targets:
+                tdsl = fidelity.target_dsl(targets[0])
+                if not tdsl or len(targets) != 1:
+                    complete = False
+                else:
+                    spell_lines = ["    spell {",
+                                   f'        val t = target("target", {tdsl})',
+                                   f"        effect = {edsl}", "    }"]
+                    _note_symbols(tdsl + " " + edsl, used)
+            else:  # non-targeted single effect
+                spell_lines = ["    spell {", f"        effect = {edsl}", "    }"]
+                _note_symbols(edsl, used)
+
+    ident = re.sub(r"[^A-Za-z0-9]", "", card["Name"])
+    pt = card.get("CardPT")
+    body = [f'val {ident} = card("{card["Name"]}") {{',
+            f'    manaCost = "{fidelity.render_mana(card.get("ManaCost"))}"',
+            f'    typeLine = "{fidelity.render_typeline(card.get("Typeline", {}))}"']
+    if pt:
+        body += [f'    power = {pt.get("Power")}', f'    toughness = {pt.get("Toughness")}']
+    if kw:
+        body.append(f'    keywords({", ".join("Keyword." + k for k in sorted(kw))})')
+    body += spell_lines
+    body.append("    metadata { rarity = Rarity.COMMON /* TODO verify rarity + add Scryfall fields */ }")
+    body.append("}")
+
+    imports = sorted({SYMBOL_IMPORTS[s] for s in used if s in SYMBOL_IMPORTS})
+    header = [
+        "// === GENERATED DRAFT — do NOT merge as-is. ===",
+        "// Source: mtgish IR via the coverage bridge (predictive, approximate).",
+        "// Before use: (1) compile, (2) write & pass a scenario test, (3) review the rules text.",
+        "// Then move into the set's cards/ package (auto-registers via classpath scan).",
+        "",
+        f"package com.wingedsheep.mtg.sets.definitions.SET.cards   // TODO set package",
+        "",
+    ] + [f"import {i}" for i in imports] + ["", ""]
+    return "\n".join(header + body) + "\n", complete
+
+
+def _note_symbols(text, used):
+    for sym in ("DealDamageEffect", "ModifyStatsEffect", "MoveToZoneEffect", "DrawCardsEffect",
+                "GainLifeEffect", "LoseLifeEffect", "TargetCreature", "TargetPlayer",
+                "TargetPermanent", "AnyTarget", "TargetFilter", "Color", "Zone"):
+        if sym in text:
+            used.add(sym)
+
+
+def classify(card, effects, keywords, mapping):
+    coverable, _reqs, _bl = probe.analyze(card, effects, keywords, mapping)
+    if not coverable:
+        return "BLOCKED"
+    _text, complete = render_kotlin(card, effects, keywords, mapping)
+    return "AUTOGEN" if complete else "SCAFFOLD"
+
+
+def missing_with_mtgish(set_code):
+    """(missing_card_names, {name: mtgish_card}) for a set's unimplemented cards."""
+    draft, extra = probe.canonical_names(set_code)
+    if draft is None:
+        sys.exit(f"no Scryfall data for {set_code.upper()} — run: just card-status --set {set_code.upper()}")
+    impl = probe.implemented_names(set_code)
+    missing = sorted((draft | extra) - impl)
+    idx = probe.load_mtgish_index(set(missing))
+    return missing, idx
+
+
+def mode_gaps(set_code, effects, keywords, mapping, list_cat):
+    missing, idx = missing_with_mtgish(set_code)
+    cats = {"AUTOGEN": [], "SCAFFOLD": [], "BLOCKED": [], "UNMATCHED": []}
+    block_tax = Counter()
+    for name in missing:
+        card = idx.get(name)
+        if card is None:
+            cats["UNMATCHED"].append(name)
+            continue
+        cat = classify(card, effects, keywords, mapping)
+        cats[cat].append(name)
+        if cat == "BLOCKED":
+            _ok, _r, blockers = probe.analyze(card, effects, keywords, mapping)
+            for _d, v, _verdict in blockers:
+                block_tax[v] += 1
+
+    n_missing = len(missing)
+    print(f"== {set_code.upper()} auto-generation gap — {n_missing} unimplemented cards ==\n")
+    print(f"  AUTOGEN   {len(cats['AUTOGEN']):>4}   bridge could draft a whole card now")
+    print(f"  SCAFFOLD  {len(cats['SCAFFOLD']):>4}   covered, but structure needs hand-wiring")
+    print(f"  BLOCKED   {len(cats['BLOCKED']):>4}   capability gap (needs mapping or engine work)")
+    if cats["UNMATCHED"]:
+        print(f"  (unmatched in mtgish: {len(cats['UNMATCHED'])} — name join / Un-set / too new)")
+    print(f"\n  -> `just coverage-generate --set {set_code.upper()}` drafts the {len(cats['AUTOGEN'])} "
+          f"AUTOGEN cards into a staging dir.")
+
+    if block_tax:
+        print("\nBLOCKED leaderboard — capability ranked by # cards it would unlock:")
+        for cap, c in block_tax.most_common(15):
+            print(f"  x{c:<4} {cap}")
+    if list_cat:
+        names = cats.get(list_cat.upper(), [])
+        print(f"\n{list_cat.upper()} ({len(names)}):")
+        for nm in names:
+            print(f"  - {nm}")
+    return 0
+
+
+def mode_write(set_code, effects, keywords, mapping, outdir):
+    missing, idx = missing_with_mtgish(set_code)
+    out = Path(outdir) if outdir else SPIKE_DIR / "generated" / set_code.lower()
+    out.mkdir(parents=True, exist_ok=True)
+    written = 0
+    for name in missing:
+        card = idx.get(name)
+        if card is None or not probe.analyze(card, effects, keywords, mapping)[0]:
+            continue
+        text, complete = render_kotlin(card, effects, keywords, mapping)
+        if not complete:
+            continue
+        text = text.replace(".definitions.SET.cards", f".definitions.{set_code.lower()}.cards")
+        fname = re.sub(r"[^A-Za-z0-9]", "", name) + ".kt"
+        (out / fname).write_text(text)
+        written += 1
+    print(f"wrote {written} draft card(s) to {out}")
+    print("These are DRAFTS — compile, add a scenario test, and review before moving into the set.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--set", metavar="CODE", required=True)
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--gaps", action="store_true", help="report the auto-gen gap (default)")
+    g.add_argument("--write", action="store_true", help="write draft .kt files for AUTOGEN cards")
+    ap.add_argument("--list", metavar="CAT", help="with --gaps: list AUTOGEN/SCAFFOLD/BLOCKED")
+    ap.add_argument("--out", metavar="DIR", help="with --write: output dir (default generated/<set>)")
+    args = ap.parse_args()
+    effects, keywords, mapping = (probe.load_effect_serialnames(), probe.load_keywords(),
+                                  probe.load_mapping())
+    if args.write:
+        return mode_write(args.set, effects, keywords, mapping, args.out)
+    return mode_gaps(args.set, effects, keywords, mapping, args.list)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spike/mtgish-coverage/fidelity.py
+++ b/spike/mtgish-coverage/fidelity.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""
+GENERATION-fidelity probe — answers "could we auto-AUTHOR this card from mtgish?",
+not merely "is it covered?" (that's probe.py).
+
+Ground truth = the committed golden snapshot of every card's COMPILED Argentum tree
+(mtg-sets/src/test/resources/snapshots/cards/<CODE>.json). No Kotlin parsing, no
+compilation: both sides end up as Argentum @SerialName tags, so the comparison is
+apples-to-apples in Argentum's own vocabulary.
+
+For each card we compare:
+  truth  = the semantic effect/keyword capabilities in the compiled golden tree
+  gen    = the Argentum capabilities the mtgish->mapping.json bridge would emit
+and tier the card:
+  AUTO     recall==1 AND no parameter-hiding structure  -> a generator could emit it whole
+  SCAFFOLD recall==1 BUT the tree has target filters / conditions / pipelines whose
+           parameters the (capability-level) mapping discards -> right effects, wrong/missing wiring
+  MISS     recall<1 -> the mapping doesn't even name a capability the human used
+
+This is a STATIC fidelity estimate. It proves capability+shape alignment, NOT behavioural
+correctness — only a compile + scenario test does that (and that's the real gate). Tiers are
+a ceiling on "auto-generable", not a guarantee.
+
+Usage:
+  python3 fidelity.py --set POR                 # tier the whole set + miss taxonomy
+  python3 fidelity.py --set POR --list SCAFFOLD  # list cards in a tier
+  python3 fidelity.py --emit "Shivan Dragon"     # show generated cardDef DSL for one card
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+SPIKE_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SPIKE_DIR))
+import probe  # noqa: E402  reuse registry scan + mtgish extractor/index
+
+SNAP_DIR = probe.REPO_ROOT / "mtg-sets/src/test/resources/snapshots/cards"
+
+# Pure structural plumbing — present in the compiled tree but not a game "action".
+# Excluded from the capability comparison on BOTH sides so we score what the card DOES.
+# (SCAFFOLD-vs-AUTO is decided from the mtgish side via unrecoverable_reasons(), not here.)
+PLUMBING = {
+    "Composite", "GatherCards", "SelectFromCollection", "ChooseUpTo", "ChooseExactly",
+    "ForEachInGroup", "ForEachPlayer", "ForEachTarget", "ToZone", "FromZone",
+    "TopOfLibrary", "Random",
+}
+
+
+# ---------------------------------------------------------------------------
+# Truth side — parse the golden snapshot into per-card compiled trees.
+# ---------------------------------------------------------------------------
+def parse_snapshot(code: str) -> dict[str, dict]:
+    path = SNAP_DIR / f"{code.upper()}.json"
+    if not path.exists():
+        sys.exit(f"no golden snapshot at {path} — this set has no committed snapshot to diff against")
+    text = path.read_text()
+    out: dict[str, dict] = {}
+    # blocks are "// Name\n{json}\n"
+    parts = re.split(r"^// (.+)$", text, flags=re.MULTILINE)
+    # parts = ['', name1, body1, name2, body2, ...]
+    for i in range(1, len(parts) - 1, 2):
+        name, body = parts[i].strip(), parts[i + 1].strip()
+        try:
+            out[probe.front(name)] = json.loads(body)
+        except json.JSONDecodeError:
+            pass
+    return out
+
+
+def walk_types(node, types: Counter, keywords: set):
+    if isinstance(node, dict):
+        t = node.get("type")
+        if isinstance(t, str):
+            types[t] += 1
+        kws = node.get("keywords")
+        if isinstance(kws, list):
+            keywords.update(k for k in kws if isinstance(k, str))
+        for v in node.values():
+            walk_types(v, types, keywords)
+    elif isinstance(node, list):
+        for v in node:
+            walk_types(v, types, keywords)
+
+
+def truth_caps(cardjson, effects):
+    types, keywords = Counter(), set()
+    walk_types(cardjson, types, keywords)
+    semantic = {t for t in types if t in effects and t not in PLUMBING}
+    return semantic, keywords
+
+
+# ---------------------------------------------------------------------------
+# Structure recovery — can a capability-level converter reconstruct this card's
+# targets/filters from mtgish, or are there params it must leave for a human?
+# This is computed from the MTGISH side ("can WE recover it?"), not the truth side
+# ("is the card complex?") — a filtered single target IS recoverable, so AUTO.
+# ---------------------------------------------------------------------------
+RECOGNIZED_TARGETS = {
+    "TargetPlayer", "TargetPermanent", "AnyTarget", "TargetPlayerOrPermanent",
+    "TargetGraveyardCard", "TargetSpell",
+}
+RECOGNIZED_FILTERS = {
+    "IsCardtype", "And", "Or", "IsColor", "IsNonColor", "IsLandType", "ControlledByAPlayer",
+    "SinglePermanent", "SinglePlayer", "AnyPlayer", "Opponent", "You", "InAPlayersGraveyard",
+    "IsAttacking", "IsTapped", "Ref_TargetPermanents", "Ref_TargetPermanent",
+}
+# mtgish constructs whose PARAMETERS a capability-level converter can't fully render -> SCAFFOLD.
+PROBLEMATIC = {
+    "If", "Conditional", "Unless", "MayCost", "PayOrSuffer",
+    "EachPlayerAction", "EachPlayerActions", "HavePlayerTakeAction",
+    "SearchLibrary", "LookAtTheTopNumberCardsOfLibrary", "LookAtTheTopNumberCardsOfPlayersLibrary",
+    "DestroyEachPermanent", "DestroyEachPermanentNoRegen", "TapEachPermanent", "UntapEachPermanent",
+    "PutEachPermanentIntoItsOwnersHand", "ShuffleGraveyardCardIntoLibrary",
+    "NumberTargetPermanents", "UptoNumberTargetPermanents", "OneOrTwoTargetPermanents",
+}
+
+
+def _filter_predicates(node, out):
+    if isinstance(node, dict):
+        for k in ("_Permanents", "_Players", "_CardsInGraveyard"):
+            if isinstance(node.get(k), str):
+                out.add(node[k])
+        for v in node.values():
+            _filter_predicates(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            _filter_predicates(v, out)
+
+
+def unrecoverable_reasons(card):
+    """Empty set => the whole card is structurally recoverable from mtgish (AUTO-eligible)."""
+    reasons = set()
+
+    def walk(n):
+        if isinstance(n, dict):
+            for disc in ("_Rule", "_Action", "_Trigger", "_Cost"):
+                if n.get(disc) in PROBLEMATIC:
+                    reasons.add(n[disc])
+            tgt = n.get("_Target")
+            if tgt is not None:
+                if tgt not in RECOGNIZED_TARGETS:
+                    reasons.add(f"target:{tgt}")
+                preds = set()
+                _filter_predicates(n.get("args"), preds)
+                for p in preds:
+                    if p not in RECOGNIZED_FILTERS:
+                        reasons.add(f"filter:{p}")
+            for v in n.values():
+                walk(v)
+        elif isinstance(n, list):
+            for v in n:
+                walk(v)
+
+    walk(card.get("Rules", []))
+    return reasons
+
+
+# ---------------------------------------------------------------------------
+# Generated side — what the mtgish->mapping bridge would emit, in Argentum tags.
+# ---------------------------------------------------------------------------
+def find_landwalk_keywords(node, keywords, out):
+    """mtgish encodes landwalk generically as Landwalk{IsLandType: <Subtype>};
+    recover the specific <SUBTYPE>WALK keyword the engine actually has."""
+    if isinstance(node, dict):
+        if node.get("_Rule") == "Landwalk":
+            sub = node.get("args", {})
+            name = sub.get("args") if isinstance(sub, dict) else None
+            if isinstance(name, str):
+                kw = name.upper() + "WALK"
+                if kw in keywords:
+                    out.add(kw)
+        for v in node.values():
+            find_landwalk_keywords(v, keywords, out)
+    elif isinstance(node, list):
+        for v in node:
+            find_landwalk_keywords(v, keywords, out)
+
+
+def gen_caps(mtgish_card, mapping, effects, keywords):
+    tags = Counter()
+    probe.extract_tags(mtgish_card.get("Rules", []), tags)
+    eff, kw = set(), set()
+    find_landwalk_keywords(mtgish_card.get("Rules", []), keywords, kw)
+    for (disc, val), _n in tags.items():
+        entry = mapping.get(f"{disc}:{val}", mapping.get(val))
+        if entry is None:
+            auto = probe.pascal_to_upper_snake(val) if isinstance(val, str) else ""
+            if auto in keywords:
+                kw.add(auto)
+            continue
+        kind = entry.get("kind")
+        if kind == "effect" and entry["tag"] in effects:
+            eff.add(entry["tag"])
+        elif kind == "keyword" and entry["tag"] in keywords:
+            kw.add(entry["tag"])
+        # `tags` = the concrete primitives a composed verb compiles to, OR a lowering rider
+        # on an envelope (e.g. Unless -> PayOrSuffer). Honored for ANY kind.
+        for t in entry.get("tags", []):
+            if t in effects and t not in PLUMBING:
+                eff.add(t)
+    return eff, kw
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+def score_card(truth, gen, recoverable):
+    t_eff, t_kw = truth
+    g_eff, g_kw = gen
+    t_all, g_all = t_eff | t_kw, g_eff | g_kw
+    missing = t_all - g_all
+    recall = 1.0 if not t_all else len(t_all & g_all) / len(t_all)
+    if missing:
+        tier = "MISS"
+    elif not recoverable:
+        tier = "SCAFFOLD"
+    else:
+        tier = "AUTO"
+    return tier, recall, missing
+
+
+def score_set(code, effects, keywords, mapping):
+    """Score every snapshot card of a set. Returns a stats dict (used by --set and --all)."""
+    truth = parse_snapshot(code)
+    mtgish = probe.load_mtgish_index(set(truth.keys()))
+    tiers = {"AUTO": [], "SCAFFOLD": [], "MISS": [], "UNMATCHED": []}
+    miss_tax, scaffold_reasons, recalls = Counter(), Counter(), []
+    for name in sorted(truth):
+        mt = mtgish.get(name)
+        if mt is None:
+            tiers["UNMATCHED"].append(name)
+            continue
+        t = truth_caps(truth[name], effects)
+        g = gen_caps(mt, mapping, effects, keywords)
+        reasons = unrecoverable_reasons(mt)
+        tier, recall, missing = score_card(t, g, not reasons)
+        tiers[tier].append(name)
+        recalls.append(recall)
+        for m in missing:
+            miss_tax[m] += 1
+        if tier == "SCAFFOLD":
+            for r in reasons:
+                scaffold_reasons[r] += 1
+    total = sum(len(v) for v in tiers.values())
+    matched = total - len(tiers["UNMATCHED"])
+    return {
+        "code": code.upper(), "total": total, "matched": matched, "tiers": tiers,
+        "avg_recall": (sum(recalls) / len(recalls) * 100 if recalls else 0),
+        "miss_tax": miss_tax, "scaffold_reasons": scaffold_reasons,
+    }
+
+
+# substantial snapshot sets, by implemented-card count (the only ones with a meaningful sample)
+ALL_SETS = ["POR", "INV", "ONS", "KTK", "DOM", "LGN", "SCG", "ARN"]
+
+
+def mode_all(effects, keywords, mapping):
+    print("== cross-set generation fidelity (one Portal-tuned bridge, applied unchanged) ==")
+    print("   the gap from POR is the per-corpus mapping debt; convergence = one fix helps all\n")
+    print(f"  {'SET':<5} {'matched':>7} {'AUTO':>6} {'SCAFFOLD':>9} {'MISS':>6} {'recall':>7}")
+    print("  " + "-" * 46)
+    for code in ALL_SETS:
+        try:
+            s = score_set(code, effects, keywords, mapping)
+        except SystemExit:
+            continue
+        m = s["matched"] or 1
+        print(f"  {s['code']:<5} {s['matched']:>7} "
+              f"{len(s['tiers']['AUTO']) / m * 100:>5.1f}% "
+              f"{len(s['tiers']['SCAFFOLD']) / m * 100:>8.1f}% "
+              f"{len(s['tiers']['MISS']) / m * 100:>5.1f}% "
+              f"{s['avg_recall']:>6.1f}%")
+    return 0
+
+
+def mode_set(code, effects, keywords, mapping, list_tier):
+    s = score_set(code, effects, keywords, mapping)
+    tiers, matched = s["tiers"], s["matched"]
+    miss_tax, scaffold_reasons, avg_recall = s["miss_tax"], s["scaffold_reasons"], s["avg_recall"]
+    print(f"== {code.upper()} generation fidelity — {matched} cards (vs compiled golden) ==\n")
+
+    def pct(k):
+        return f"{len(tiers[k]) / matched * 100:5.1f}%" if matched else "  —  "
+    print(f"  AUTO      {len(tiers['AUTO']):>4}  {pct('AUTO')}  generator could emit whole "
+          f"(recall=1, every target/filter recovered)")
+    print(f"  SCAFFOLD  {len(tiers['SCAFFOLD']):>4}  {pct('SCAFFOLD')}  right effects, but some "
+          f"structure (condition / pipeline / unrecognized filter) needs human wiring")
+    print(f"  MISS      {len(tiers['MISS']):>4}  {pct('MISS')}  bridge omits a capability "
+          f"the card uses")
+    print(f"\n  mean capability recall: {avg_recall:.1f}%  (effects+keywords matched per card)")
+    if tiers["UNMATCHED"]:
+        print(f"  (unmatched in mtgish: {len(tiers['UNMATCHED'])})")
+
+    if miss_tax:
+        print("\nMISS taxonomy — Argentum capabilities the bridge failed to emit "
+              "(mapping holes to close):")
+        for cap, c in miss_tax.most_common(20):
+            print(f"  x{c:<4} {cap}")
+    if scaffold_reasons:
+        print("\nSCAFFOLD reasons — mtgish structure not auto-recovered "
+              "(ranked; the worklist to push SCAFFOLD->AUTO):")
+        for r, c in scaffold_reasons.most_common(15):
+            print(f"  x{c:<4} {r}")
+
+    if list_tier:
+        names = tiers.get(list_tier.upper(), [])
+        print(f"\n{list_tier.upper()} ({len(names)}):")
+        for nm in names:
+            print(f"  - {nm}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Emitter — best-effort mtgish -> Argentum cardDef DSL for one card.
+# Faithful for shells (name/cost/type/PT/keywords); spell effects render the mapped
+# facade with TODO markers where mtgish params aren't recovered. Illustrative, not a compiler.
+# ---------------------------------------------------------------------------
+MANA = {"ManaCostW": "{W}", "ManaCostU": "{U}", "ManaCostB": "{B}", "ManaCostR": "{R}",
+        "ManaCostG": "{G}", "ManaCostC": "{C}", "ManaCostX": "{X}"}
+
+
+def render_mana(cost):
+    out = []
+    for s in cost or []:
+        sym = s.get("_ManaSymbol")
+        if sym == "ManaCostGeneric":
+            out.append("{%s}" % s.get("args", 0))
+        else:
+            out.append(MANA.get(sym, "{?}"))
+    return "".join(out)
+
+
+def render_typeline(tl):
+    sup = " ".join(tl.get("Supertypes", []))
+    types = " ".join(tl.get("Cardtypes", []))
+    subs = " ".join(tl.get("Subtypes", []))
+    left = (sup + " " + types).strip()
+    return f"{left} — {subs}" if subs else left
+
+
+# --- recovery of targets / filters / amounts from mtgish action args -> Argentum DSL ---
+def _find_integer(node):
+    if isinstance(node, dict):
+        if node.get("_GameNumber") == "Integer":
+            return node.get("args")
+        if node.get("_GameNumber") in ("XValue", "X"):
+            return "X"
+        for v in node.values():
+            r = _find_integer(v)
+            if r is not None:
+                return r
+    elif isinstance(node, list):
+        for v in node:
+            r = _find_integer(v)
+            if r is not None:
+                return r
+    return None
+
+
+def _find_adjust_pt(node):
+    if isinstance(node, dict):
+        if node.get("_LayerEffect") == "AdjustPT":
+            return node.get("args")
+        for v in node.values():
+            r = _find_adjust_pt(v)
+            if r:
+                return r
+    elif isinstance(node, list):
+        for v in node:
+            r = _find_adjust_pt(v)
+            if r:
+                return r
+    return None
+
+
+def creature_filter_dsl(filter_node):
+    """mtgish _Permanents filter -> TargetFilter.Creature[.notColor()/.color()] (best effort)."""
+    base = "TargetFilter.Creature"
+    suffix = ""
+    preds = json.dumps(filter_node)  # cheap scan; precise enough for the common predicates
+    m = re.search(r'"IsNonColor".*?"_Color":\s*"(\w+)"', preds)
+    if m:
+        suffix += f".notColor(Color.{m.group(1).upper()})"
+    m = re.search(r'"IsColor".*?"_Color":\s*"(\w+)"', preds)
+    if m:
+        suffix += f".color(Color.{m.group(1).upper()})"
+    return base + suffix
+
+
+def target_dsl(tnode):
+    """Faithful Argentum target, or None if the filter can't be rendered (-> SCAFFOLD, not a
+    silently-wrong AUTO). Honesty matters more than coverage here."""
+    ttype = tnode.get("_Target")
+    args = tnode.get("args")
+    if ttype == "TargetPlayer":
+        return "TargetPlayer()"
+    if ttype in ("AnyTarget", "TargetPlayerOrPermanent"):
+        return "AnyTarget()"
+    if ttype == "TargetPermanent":
+        blob = json.dumps(args)
+        types = set(re.findall(r'"IsCardtype",\s*"args":\s*"(\w+)"', blob))
+        if types == {"Creature"}:
+            return f"TargetCreature(filter = {creature_filter_dsl(args)})"
+        if not types and "IsCardtype" not in blob:
+            return "TargetPermanent()"          # genuinely unfiltered
+        return None                              # artifact/enchantment/land/multi-type — not renderable yet
+    # graveyard / spell / numbered targets need zone/count wiring we don't generate -> SCAFFOLD
+    return None
+
+
+def find_targeted(card):
+    """Return (targets, actions) from a SpellActions->Targeted shape, else (None, None)."""
+    found = [None]
+
+    def walk(n):
+        if isinstance(n, dict):
+            if n.get("_Actions") == "Targeted" and isinstance(n.get("args"), list):
+                found[0] = n["args"]
+            for v in n.values():
+                walk(v)
+        elif isinstance(n, list):
+            for v in n:
+                walk(v)
+    walk(card.get("Rules", []))
+    if not found[0] or len(found[0]) < 2:
+        return None, None
+    targets = found[0][0] if isinstance(found[0][0], list) else []
+    alist = found[0][1]
+    actions = alist.get("args", []) if isinstance(alist, dict) else []
+    return targets, actions
+
+
+def effect_dsl(action_node, tvar):
+    a = action_node.get("_Action")
+    args = action_node.get("args")
+    if a in ("SpellDealsDamage", "PermanentDealsDamage"):
+        return f"DealDamageEffect({_find_integer(args)}, {tvar})"
+    if a == "DestroyPermanent":
+        return f"MoveToZoneEffect({tvar}, Zone.GRAVEYARD, byDestruction = true)"
+    if a == "CreatePermanentLayerEffectUntil":
+        pt = _find_adjust_pt(args)
+        if pt:
+            return (f"ModifyStatsEffect(powerModifier = {pt[0]}, "
+                    f"toughnessModifier = {pt[1]}, target = {tvar})")
+    if a in ("DrawNumberCards", "DrawACard"):
+        return f"DrawCardsEffect({_find_integer(args) or 1})"
+    if a == "GainLife":
+        return f"GainLifeEffect({_find_integer(args)})"
+    if a == "LoseLife":
+        return f"LoseLifeEffect({_find_integer(args)})"
+    return None
+
+
+def emit(name, effects, keywords, mapping):
+    idx = probe.load_mtgish_index({name})
+    card = idx.get(probe.front(name)) or next(
+        (c for k, c in idx.items() if k.lower() == probe.front(name).lower()), None)
+    if not card:
+        print(f"'{name}': not found in mtgish IR")
+        return 1
+    kw_lines = set()
+    find_landwalk_keywords(card.get("Rules", []), keywords, kw_lines)
+    tags = Counter()
+    probe.extract_tags(card.get("Rules", []), tags)
+    for (disc, val), _n in tags.items():
+        if val == "Landwalk":
+            continue
+        entry = mapping.get(f"{disc}:{val}", mapping.get(val))
+        auto = probe.pascal_to_upper_snake(val) if isinstance(val, str) else ""
+        if (entry and entry.get("kind") == "keyword") or auto in keywords:
+            kw_lines.add((entry or {}).get("tag", auto))
+
+    reasons = unrecoverable_reasons(card)
+    pt = card.get("CardPT")
+    ident = re.sub(r"[^A-Za-z0-9]", "", name)
+    print(f'val {ident} = card("{card["Name"]}") {{')
+    print(f'    manaCost = "{render_mana(card.get("ManaCost"))}"')
+    print(f'    typeLine = "{render_typeline(card.get("Typeline", {}))}"')
+    if pt:
+        print(f'    power = {pt.get("Power")}')
+        print(f'    toughness = {pt.get("Toughness")}')
+    if kw_lines:
+        print(f'    keywords({", ".join("Keyword." + k for k in sorted(kw_lines))})')
+
+    # spell block — recover target + effect for the common single-target shape
+    targets, actions = find_targeted(card)
+    if targets is not None and actions:
+        tdsl = target_dsl(targets[0]) if targets else None
+        edsl = effect_dsl(actions[0], "t") if actions else None
+        if tdsl and edsl and len(actions) == 1:
+            print("    spell {")
+            print(f'        val t = target("target", {tdsl})')
+            print(f"        effect = {edsl}")
+            print("    }")
+        else:
+            print("    spell {  // PARTIAL — recovery incomplete:")
+            if not tdsl and targets:
+                print(f"        // target not recovered: {targets[0].get('_Target')}")
+            if not edsl:
+                print(f"        // effect not recovered: {actions[0].get('_Action')}")
+            if len(actions) > 1:
+                print(f"        // {len(actions)} chained actions — only first inspected")
+            print("    }")
+    elif reasons:
+        print(f"    // STRUCTURE needs human wiring: {', '.join(sorted(reasons))}")
+
+    print("    metadata { /* auto-filled from Scryfall: rarity, collectorNumber, artist, imageUri */ }")
+    print("}")
+    tier = "AUTO" if not reasons else "SCAFFOLD"
+    print(f"// fidelity tier: {tier}" + (f" — reasons: {sorted(reasons)}" if reasons else ""))
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--set", metavar="CODE", help="tier a whole set against its golden snapshot")
+    g.add_argument("--all", action="store_true", help="cross-set table over all substantial sets")
+    g.add_argument("--emit", metavar="NAME", nargs="+", help="emit generated DSL for one card")
+    ap.add_argument("--list", metavar="TIER", help="with --set: list cards in AUTO/SCAFFOLD/MISS")
+    args = ap.parse_args()
+    effects, keywords, mapping = (probe.load_effect_serialnames(), probe.load_keywords(),
+                                  probe.load_mapping())
+    if args.emit:
+        return emit(" ".join(args.emit), effects, keywords, mapping)
+    if args.all:
+        return mode_all(effects, keywords, mapping)
+    return mode_set(args.set, effects, keywords, mapping, args.list)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spike/mtgish-coverage/mapping.json
+++ b/spike/mtgish-coverage/mapping.json
@@ -1,0 +1,530 @@
+{
+  "__doc__": "Hand-authored bridge: mtgish IR tag -> Argentum capability. This file IS the maintenance cost the spike measures. kinds: 'effect'/'keyword' validate the tag against the source-scanned registry (a wrong guess shows up as a MISSING gap = the mechanism catching a mapping error); 'composed' = Argentum builds it from existing primitives (no leaf SerialName, e.g. destroy = MoveToZone->graveyard); 'ignore' = a structural mtgish envelope that carries no capability itself (the real capability is in its nested nodes); 'supported' = a trigger/cost the spike accepts without registry validation (a Triggers.*/Costs.* facade scan would harden this in Phase 1). Keys match the bare mtgish value; the probe also accepts 'disc:value'. Two tags are left intentionally UNMAPPED to exercise the residual-tail report.",
+  "Flying": {
+    "kind": "keyword",
+    "tag": "FLYING"
+  },
+  "Haste": {
+    "kind": "keyword",
+    "tag": "HASTE"
+  },
+  "Vigilance": {
+    "kind": "keyword",
+    "tag": "VIGILANCE"
+  },
+  "Reach": {
+    "kind": "keyword",
+    "tag": "REACH"
+  },
+  "Defender": {
+    "kind": "keyword",
+    "tag": "DEFENDER"
+  },
+  "Landwalk": {
+    "kind": "composed",
+    "note": "specific *WALK keywords (SWAMPWALK, FORESTWALK, ...)"
+  },
+  "SpellActions": {
+    "kind": "ignore",
+    "note": "envelope: 'this spell does X'"
+  },
+  "CastEffect": {
+    "kind": "ignore",
+    "note": "envelope: on-cast actions"
+  },
+  "PermanentRuleEffect": {
+    "kind": "ignore",
+    "note": "envelope: static ability"
+  },
+  "TriggerA": {
+    "kind": "ignore",
+    "note": "envelope: triggered ability (cond in _Trigger)"
+  },
+  "Activated": {
+    "kind": "ignore",
+    "note": "envelope: activated ability"
+  },
+  "ActivatedWithModifiers": {
+    "kind": "ignore",
+    "note": "envelope: activated ability"
+  },
+  "PayMana": {
+    "kind": "supported",
+    "note": "cost: pay mana (universal)"
+  },
+  "And": {
+    "kind": "ignore",
+    "note": "envelope: cost/action conjunction"
+  },
+  "MayAction": {
+    "kind": "ignore",
+    "note": "gate envelope: 'you may' (Lesson 1 cluster)"
+  },
+  "MayCost": {
+    "kind": "ignore",
+    "note": "gate envelope: 'you may pay' (Lesson 1 cluster)"
+  },
+  "Unless": {
+    "kind": "ignore",
+    "note": "gate envelope: 'unless ...' (Lesson 1 cluster)",
+    "tags": [
+      "PayOrSuffer"
+    ]
+  },
+  "If": {
+    "kind": "ignore",
+    "note": "conditional envelope"
+  },
+  "PlayerAction": {
+    "kind": "ignore",
+    "note": "envelope: 'target player does X'"
+  },
+  "EachPlayerAction": {
+    "kind": "ignore",
+    "note": "envelope: APNAP each-player"
+  },
+  "EachPlayerActions": {
+    "kind": "ignore",
+    "note": "envelope: APNAP each-player (plural)"
+  },
+  "HavePlayerTakeAction": {
+    "kind": "ignore",
+    "note": "envelope: delegated action"
+  },
+  "CreatePermanentLayerEffectUntil": {
+    "kind": "ignore",
+    "note": "envelope: continuous effect (capability is the _LayerEffect)"
+  },
+  "CreateEachPermanentLayerEffectUntil": {
+    "kind": "ignore",
+    "note": "envelope: continuous effect, each"
+  },
+  "CreateEachPermanentRuleEffectUntil": {
+    "kind": "ignore",
+    "note": "envelope: continuous rule, each"
+  },
+  "CreatePlayerEffectUntil": {
+    "kind": "ignore",
+    "note": "envelope: player-scoped continuous effect"
+  },
+  "SpellDealsDamage": {
+    "kind": "effect",
+    "tag": "DealDamage"
+  },
+  "PermanentDealsDamage": {
+    "kind": "effect",
+    "tag": "DealDamage"
+  },
+  "SpellDealsDistributedDamage": {
+    "kind": "effect",
+    "tag": "DividedDamage"
+  },
+  "DrawNumberCards": {
+    "kind": "effect",
+    "tag": "DrawCards"
+  },
+  "DrawACard": {
+    "kind": "effect",
+    "tag": "DrawCards"
+  },
+  "DrawUptoNumberCards": {
+    "kind": "effect",
+    "tag": "DrawUpTo"
+  },
+  "GainLife": {
+    "kind": "effect",
+    "tag": "GainLife"
+  },
+  "LoseLife": {
+    "kind": "effect",
+    "tag": "LoseLife"
+  },
+  "SacrificePermanent": {
+    "kind": "effect",
+    "tag": "Sacrifice"
+  },
+  "CounterSpell": {
+    "kind": "effect",
+    "tag": "Counter"
+  },
+  "TakeAnExtraTurn": {
+    "kind": "effect",
+    "tag": "TakeExtraTurn"
+  },
+  "LoseTheGame": {
+    "kind": "effect",
+    "tag": "LoseGame"
+  },
+  "Shuffle": {
+    "kind": "effect",
+    "tag": "ShuffleLibrary"
+  },
+  "RevealHand": {
+    "kind": "effect",
+    "tag": "RevealHand"
+  },
+  "LookAtPlayersHand": {
+    "kind": "effect",
+    "tag": "LookAtTargetHand"
+  },
+  "TapPermanent": {
+    "kind": "effect",
+    "tag": "TapUntap"
+  },
+  "UntapPermanent": {
+    "kind": "effect",
+    "tag": "TapUntap"
+  },
+  "TapEachPermanent": {
+    "kind": "composed",
+    "tag": "TapUntapCollection",
+    "tags": [
+      "TapUntap"
+    ]
+  },
+  "UntapEachPermanent": {
+    "kind": "composed",
+    "tag": "TapUntapCollection",
+    "tags": [
+      "TapUntap"
+    ]
+  },
+  "AdjustPT": {
+    "kind": "effect",
+    "tag": "ModifyStats"
+  },
+  "AddAbility": {
+    "kind": "effect",
+    "tag": "GrantKeyword"
+  },
+  "GainLifeForEach": {
+    "kind": "composed",
+    "note": "GainLife + DynamicAmount",
+    "tags": [
+      "GainLife"
+    ]
+  },
+  "DestroyPermanent": {
+    "kind": "composed",
+    "note": "MoveToZone -> graveyard",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "DestroyEachPermanent": {
+    "kind": "composed",
+    "note": "MoveCollection -> graveyard",
+    "tags": [
+      "MoveCollection",
+      "MoveToZone"
+    ]
+  },
+  "DestroyEachPermanentNoRegen": {
+    "kind": "composed",
+    "note": "MoveCollection -> graveyard, no-regen flag",
+    "tags": [
+      "MoveCollection",
+      "MoveToZone"
+    ]
+  },
+  "SearchLibrary": {
+    "kind": "composed",
+    "note": "Gather->Select->Move SearchLibrary pattern",
+    "tags": [
+      "MoveCollection",
+      "ShuffleLibrary"
+    ]
+  },
+  "DiscardACard": {
+    "kind": "composed",
+    "note": "MoveToZone hand->graveyard",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "DiscardNumberCards": {
+    "kind": "composed",
+    "note": "MoveToZone hand->graveyard, N",
+    "tags": [
+      "MoveCollection"
+    ]
+  },
+  "DiscardAnyNumberOfCards": {
+    "kind": "composed",
+    "note": "MoveToZone hand->graveyard, any",
+    "tags": [
+      "MoveCollection"
+    ]
+  },
+  "DiscardACardAtRandom": {
+    "kind": "composed",
+    "note": "MoveToZone hand->graveyard, random",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "PutGraveyardCardIntoHand": {
+    "kind": "composed",
+    "note": "MoveCollection graveyard->hand",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "PutGraveyardCardOntoBattlefield": {
+    "kind": "composed",
+    "note": "MoveCollection graveyard->battlefield (reanimate)",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "ShuffleGraveyardCardIntoLibrary": {
+    "kind": "composed",
+    "note": "MoveCollection + ShuffleLibrary",
+    "tags": [
+      "MoveToZone",
+      "ShuffleLibrary"
+    ]
+  },
+  "ReturnDeadGraveyardCardToTopOfLibrary": {
+    "kind": "composed",
+    "note": "MoveCollection -> library top",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "ShuffleHandIntoLibrary": {
+    "kind": "composed",
+    "note": "MoveCollection hand->library + ShuffleLibrary",
+    "tags": [
+      "MoveCollection",
+      "ShuffleLibrary"
+    ]
+  },
+  "PutPermanentIntoItsOwnersHand": {
+    "kind": "composed",
+    "note": "bounce: MoveToZone/ForceReturnOwnPermanent",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "PutEachPermanentIntoItsOwnersHand": {
+    "kind": "composed",
+    "note": "EachPlayerReturnsPermanentToHand",
+    "tags": [
+      "MoveCollection",
+      "MoveToZone"
+    ]
+  },
+  "PutPermanentOnTopOfOwnersLibrary": {
+    "kind": "composed",
+    "note": "PutOnLibraryPositionOfChoice",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "LookAtTheTopNumberCardsOfLibrary": {
+    "kind": "composed",
+    "note": "look/scry pipeline (Gather->reveal-to-self)"
+  },
+  "LookAtTheTopNumberCardsOfPlayersLibrary": {
+    "kind": "composed",
+    "note": "look pipeline on opponent library"
+  },
+  "CreateReplaceWouldDealDamageUntil": {
+    "kind": "composed",
+    "note": "PreventDamageShield / RedirectNextDamage",
+    "tags": [
+      "PreventDamageShield"
+    ]
+  },
+  "CreateTriggerUntil": {
+    "kind": "composed",
+    "note": "CreateGlobalTriggeredAbility (duration)",
+    "tags": [
+      "CreateGlobalTriggeredAbility"
+    ]
+  },
+  "CreateFutureTrigger": {
+    "kind": "composed",
+    "note": "CreateDelayedTrigger",
+    "tags": [
+      "CreateDelayedTrigger"
+    ]
+  },
+  "SacrificeAPermanent": {
+    "kind": "supported",
+    "note": "cost: sacrifice"
+  },
+  "SacrificeNumberPermanents": {
+    "kind": "supported",
+    "note": "cost: sacrifice N"
+  },
+  "DiscardACardOfType": {
+    "kind": "composed",
+    "note": "cost: discard filtered"
+  },
+  "WhenAPermanentEntersTheBattlefield": {
+    "kind": "supported",
+    "note": "trigger: ETB (Triggers.* scan validates in P1)"
+  },
+  "WhenACreatureOrPlaneswalkerDies": {
+    "kind": "supported",
+    "note": "trigger: dies"
+  },
+  "WhenACreatureAttacks": {
+    "kind": "supported",
+    "note": "trigger: attacks"
+  },
+  "WhenACreatureDealsCombatDamageToAPlayer": {
+    "kind": "supported",
+    "note": "trigger: combat damage to player"
+  },
+  "AddMana": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "AddMana"
+  },
+  "AddManaRepeated": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "AddMana"
+  },
+  "AddColorlessMana": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "AddColorlessMana"
+  },
+  "CreateTokens": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "CreateToken"
+  },
+  "PutACounterOfTypeOnPermanent": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "AddCounters"
+  },
+  "PutNumberCountersOfTypeOnPermanent": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "AddCounters"
+  },
+  "CreatePermanentLayerEffect": {
+    "kind": "ignore",
+    "note": "universal (cross-set calibration)"
+  },
+  "CreatePermanentRuleEffectUntil": {
+    "kind": "ignore",
+    "note": "universal (cross-set calibration)"
+  },
+  "RegeneratePermanent": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "Regenerate"
+  },
+  "GainControlOfPermanent": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "GainControl"
+  },
+  "GainControlOfPermanentUntil": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "GainControl"
+  },
+  "RemoveCreatureFromCombat": {
+    "kind": "effect",
+    "note": "universal (cross-set calibration)",
+    "tag": "RemoveFromCombat"
+  },
+  "DestroyPermanentNoRegen": {
+    "kind": "composed",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "ExilePermanent": {
+    "kind": "composed",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "ExileGraveyardCard": {
+    "kind": "composed",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "ExileEachPermanent": {
+    "kind": "composed",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "MoveCollection",
+      "MoveToZone"
+    ]
+  },
+  "ReturnGraveyardCardToHand": {
+    "kind": "composed",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "MoveToZone"
+    ]
+  },
+  "PutEachGraveyardCardIntoHand": {
+    "kind": "composed",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "MoveCollection"
+    ]
+  },
+  "MillNumberCards": {
+    "kind": "composed",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "MoveCollection"
+    ]
+  },
+  "MillCards": {
+    "kind": "composed",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "MoveCollection"
+    ]
+  },
+  "PlayerMayAction": {
+    "kind": "ignore",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "May"
+    ]
+  },
+  "PlayerMayCost": {
+    "kind": "ignore",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "May"
+    ]
+  },
+  "MayActions": {
+    "kind": "ignore",
+    "note": "universal (cross-set calibration)",
+    "tags": [
+      "May"
+    ]
+  },
+  "ChooseACreatureType": {
+    "kind": "ignore",
+    "note": "universal (cross-set calibration)"
+  },
+  "ChooseAColor": {
+    "kind": "ignore",
+    "note": "universal (cross-set calibration)"
+  },
+  "IfElse": {
+    "kind": "ignore",
+    "note": "universal (cross-set calibration)"
+  }
+}

--- a/spike/mtgish-coverage/probe.py
+++ b/spike/mtgish-coverage/probe.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+mtgish coverage probe — phase-rs-lessons.md Lesson 5 (oracle-text -> required-capability).
+
+Predicts, from mtgish's pre-parsed oracle IR, which cards the engine could already
+support with NO new engine work ("coverable-now") and which are blocked on a missing
+capability. TOOLING ONLY — it never loads a card; ground truth stays authored-DSL +
+passing scenario test. See FINDINGS.md.
+
+Three lenses:
+  --set CODE        full coverage of a set: implemented / free-to-implement / blocked,
+                    plus a feature leaderboard (which missing capability unlocks the most).
+  --card "NAME"     analyze one card: its required capabilities and the coverable verdict.
+  --calibrate CODE  trust check: every ALREADY-IMPLEMENTED card must classify coverable-now;
+                    anything that doesn't is a hole in mapping.json / the registry.
+
+The bridge it leans on is mapping.json (mtgish tag -> Argentum capability), the artifact
+whose size/durability the spike measures.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+from collections import Counter
+from pathlib import Path
+
+sys.dont_write_bytecode = True  # don't drop __pycache__ into scripts/ when importing card-status
+
+SPIKE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SPIKE_DIR.parent.parent
+SDK_EFFECTS = REPO_ROOT / "mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects"
+KEYWORD_KT = REPO_ROOT / "mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt"
+DEFINITIONS = REPO_ROOT / "mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions"
+MTGISH_LINES = SPIKE_DIR / "data/mtgish.lines.json"
+MTGISH_URL = "https://raw.githubusercontent.com/i5jb/mtgish/main/data/mtgish.lines.json"
+CARD_STATUS = REPO_ROOT / "scripts/card-status"
+
+
+# ---------------------------------------------------------------------------
+# Reuse card-status's Scryfall cache + set discovery (imported, not duplicated).
+# ---------------------------------------------------------------------------
+def _load_card_status():
+    # card-status has no .py extension, so name the source loader explicitly.
+    loader = importlib.machinery.SourceFileLoader("card_status", str(CARD_STATUS))
+    spec = importlib.util.spec_from_loader("card_status", loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["card_status"] = mod  # @dataclass resolves __module__ via sys.modules
+    loader.exec_module(mod)
+    return mod
+
+
+CS = _load_card_status()
+
+
+def ensure_data() -> None:
+    if MTGISH_LINES.exists():
+        return
+    MTGISH_LINES.parent.mkdir(parents=True, exist_ok=True)
+    print(f"downloading mtgish IR (~29MB) -> {MTGISH_LINES} ...", file=sys.stderr)
+    urllib.request.urlretrieve(MTGISH_URL, MTGISH_LINES)
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — Capability registry, scanned from Kotlin source (cannot rot).
+# ---------------------------------------------------------------------------
+def load_effect_serialnames() -> set[str]:
+    tags: set[str] = set()
+    for kt in SDK_EFFECTS.glob("*.kt"):
+        for m in re.finditer(r'@SerialName\("([^"]+)"\)', kt.read_text()):
+            tag = m.group(1)
+            if "." not in tag:  # drop nested-enum serialnames (SuccessCriterion.Auto)
+                tags.add(tag)
+    return tags
+
+
+def load_keywords() -> set[str]:
+    return set(re.findall(r"^\s+([A-Z][A-Z0-9_]+)\b", KEYWORD_KT.read_text(), re.MULTILINE))
+
+
+def load_mapping() -> dict:
+    return json.loads((SPIKE_DIR / "mapping.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — Extractor: walk a mtgish card IR, collect required-capability tags.
+# ---------------------------------------------------------------------------
+CAPABILITY_DISCRIMINATORS = {
+    "_Rule", "_Action", "_Trigger", "_Cost", "_LayerEffect",
+    "_ReplacementActionWouldEnter",
+}
+
+
+def extract_tags(node, out: Counter) -> None:
+    if isinstance(node, dict):
+        for disc in CAPABILITY_DISCRIMINATORS:
+            if disc in node:
+                out[(disc, node[disc])] += 1
+        for v in node.values():
+            extract_tags(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            extract_tags(v, out)
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — Classification of one card against the registry + mapping.
+# ---------------------------------------------------------------------------
+# verdicts: ok / composed / supported / ignore  -> covered
+#           MISSING (mapped to a capability not in the registry — a named engine gap)
+#           UNMAPPED (no mapping entry — triage: new mechanic OR a mapping hole)
+def pascal_to_upper_snake(s: str) -> str:
+    """FirstStrike -> FIRST_STRIKE, Shadow -> SHADOW (mtgish keyword tag -> Keyword enum)."""
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", s).upper()
+
+
+def analyze(card, effects, keywords, mapping):
+    tags = Counter()
+    extract_tags(card.get("Rules", []), tags)
+    reqs = []          # (disc, val, verdict, detail)
+    blockers = []      # (disc, val, verdict) that prevent coverage
+    for (disc, val), _n in tags.items():
+        entry = mapping.get(f"{disc}:{val}", mapping.get(val))
+        if entry is None:
+            # Principled fallback: if the tag IS a Keyword enum member, it's covered.
+            # Only claims coverage when the keyword genuinely exists (registry-validated),
+            # so envelopes like Activated/SpellActions stay correctly unmapped.
+            kw = pascal_to_upper_snake(val) if isinstance(val, str) else ""
+            if kw in keywords:
+                reqs.append((disc, val, "ok", f"{kw} (keyword auto)"))
+                continue
+            reqs.append((disc, val, "UNMAPPED", ""))
+            blockers.append((disc, val, "UNMAPPED"))
+            continue
+        kind = entry.get("kind")
+        if kind == "effect":
+            ok = entry["tag"] in effects
+            reqs.append((disc, val, "ok" if ok else "MISSING", entry["tag"]))
+            if not ok:
+                blockers.append((disc, val, "MISSING"))
+        elif kind == "keyword":
+            ok = entry["tag"] in keywords
+            reqs.append((disc, val, "ok" if ok else "MISSING", entry["tag"]))
+            if not ok:
+                blockers.append((disc, val, "MISSING"))
+        else:  # composed / supported / ignore
+            reqs.append((disc, val, kind, entry.get("note", "")))
+    return (not blockers), reqs, blockers
+
+
+# ---------------------------------------------------------------------------
+# Card-data wiring
+# ---------------------------------------------------------------------------
+def front(name: str) -> str:
+    return CS.front_face(name)
+
+
+def implemented_names(set_code: str) -> set[str]:
+    info = next((s for s in CS.discover_sets() if s.code == set_code.upper()), None)
+    if info is None:
+        return set()
+    return {front(n) for n in CS.scan_implementations(info.cards_dir)}
+
+
+def canonical_names(set_code: str, *, refresh: bool = False):
+    """(draft_names, extra_names) front-faced, from card-status's Scryfall cache."""
+    payload = CS.load_canonical(set_code.upper(), force_refresh=refresh)
+    if payload is None:
+        return None, None
+    draft = {front(n) for n in payload["draft_names"]}
+    extra = {front(n) for n in payload["extra_names"]} - draft
+    return draft, extra
+
+
+def load_mtgish_index(names: set[str]) -> dict[str, dict]:
+    """Map front-faced name -> mtgish card, for the requested names only."""
+    ensure_data()
+    want = {n.lower() for n in names}
+    found: dict[str, dict] = {}
+    with MTGISH_LINES.open() as fh:
+        for line in fh:
+            if '"Name":"' not in line:
+                continue
+            card = json.loads(line)
+            fn = front(card.get("Name", ""))
+            if fn.lower() in want:
+                found[fn] = card
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+def mode_card(name, effects, keywords, mapping) -> int:
+    idx = load_mtgish_index({name})
+    # case-insensitive resolve
+    card = idx.get(front(name)) or next(
+        (c for k, c in idx.items() if k.lower() == front(name).lower()), None)
+    if card is None:
+        print(f"'{name}': not found in mtgish IR (name mismatch, or an Un-set/excluded card)")
+        return 1
+    coverable, reqs, _ = analyze(card, effects, keywords, mapping)
+    print(f"Card: {card['Name']}")
+    print(f"Verdict: {'COVERABLE-NOW (no engine work)' if coverable else 'BLOCKED (needs engine work)'}\n")
+    print("Required capabilities (from mtgish IR):")
+    order = {"UNMAPPED": 0, "MISSING": 1, "ok": 2, "composed": 3, "supported": 4, "ignore": 5}
+    for disc, val, verdict, detail in sorted(reqs, key=lambda r: order.get(r[2], 9)):
+        mark = {"ok": "ok  ", "composed": "comp", "supported": "supp", "ignore": "--  ",
+                "MISSING": "GAP ", "UNMAPPED": "??  "}[verdict]
+        arrow = f" -> {detail}" if detail else ""
+        print(f"  [{mark}] {disc:<13} {val}{arrow}")
+    impl = implemented_names_for_card(card["Name"])
+    if impl:
+        print(f"\nAlready implemented in: {', '.join(sorted(impl))}")
+    return 0 if coverable else 2
+
+
+def implemented_names_for_card(name: str) -> set[str]:
+    """Which set folders already implement this card name."""
+    hits = set()
+    fn = front(name)
+    for s in CS.discover_sets():
+        if fn in {front(n) for n in CS.scan_implementations(s.cards_dir)}:
+            hits.add(s.code)
+    return hits
+
+
+def mode_set(code, effects, keywords, mapping, *, show, refresh) -> int:
+    draft, extra = canonical_names(code, refresh=refresh)
+    if draft is None:
+        print(f"no Scryfall data for set {code.upper()} (run: just card-status --set {code.upper()})")
+        return 1
+    canonical = draft | extra
+    impl = implemented_names(code)
+    idx = load_mtgish_index(canonical)
+
+    buckets = {"impl": [], "free": [], "blocked": [], "unmatched": []}
+    leaderboard = Counter()        # blocking tag -> # missing cards it blocks
+    leaderboard_kind = {}          # tag -> MISSING/UNMAPPED
+    blocked_detail = {}            # card -> blockers
+    for name in sorted(canonical):
+        if name in impl:
+            buckets["impl"].append(name)
+            continue
+        card = idx.get(name)
+        if card is None:
+            buckets["unmatched"].append(name)
+            continue
+        coverable, _reqs, blockers = analyze(card, effects, keywords, mapping)
+        if coverable:
+            buckets["free"].append(name)
+        else:
+            buckets["blocked"].append(name)
+            blocked_detail[name] = blockers
+            for disc, val, verdict in blockers:
+                leaderboard[(disc, val)] += 1
+                leaderboard_kind[(disc, val)] = verdict
+
+    total = len(canonical)
+    print(f"== {code.upper()} — {total} cards "
+          f"({len(draft)} draft / {len(extra)} extra) ==")
+    print(f"  implemented:            {len(buckets['impl'])}")
+    print(f"  FREE to implement now:  {len(buckets['free'])}   (missing, fully coverable)")
+    print(f"  blocked on engine work: {len(buckets['blocked'])}")
+    if buckets["unmatched"]:
+        print(f"  (unmatched in mtgish:   {len(buckets['unmatched'])} — name join / Un-set)")
+
+    if leaderboard:
+        print("\nFeature leaderboard — missing capability ranked by # blocked cards it unlocks:")
+        for (disc, val), n in leaderboard.most_common(20):
+            tag = "GAP " if leaderboard_kind[(disc, val)] == "MISSING" else "??  "
+            label = "engine capability absent" if tag == "GAP " else "unmapped — triage"
+            print(f"  [{tag}] x{n:<4} {disc} = {val}   ({label})")
+
+    if show in ("free", "all"):
+        print(f"\nFREE to implement now ({len(buckets['free'])}):")
+        for n in buckets["free"]:
+            print(f"  + {n}")
+    if show in ("blocked", "all"):
+        print(f"\nBLOCKED ({len(buckets['blocked'])}):")
+        for n in buckets["blocked"]:
+            why = ",".join(v for _, v, _ in blocked_detail[n])
+            print(f"  - {n}   [{why}]")
+    return 0
+
+
+def mode_calibrate(code, effects, keywords, mapping) -> int:
+    names = implemented_names(code)
+    idx = load_mtgish_index(names)
+    coverable_n = 0
+    holes = Counter()
+    blocked = []
+    for name, card in sorted(idx.items()):
+        ok, _reqs, blockers = analyze(card, effects, keywords, mapping)
+        if ok:
+            coverable_n += 1
+        else:
+            blocked.append((name, blockers))
+            for disc, val, _v in blockers:
+                holes[(disc, val)] += 1
+    total = len(idx)
+    recall = coverable_n / total * 100 if total else 0
+    print(f"CALIBRATION {code.upper()}: {coverable_n}/{total} implemented cards "
+          f"classify coverable-now = {recall:.1f}%  (target ~100%)")
+    if holes:
+        print("Holes (implemented cards the bridge can't yet cover -> fix mapping/registry):")
+        for (disc, val), n in holes.most_common():
+            print(f"  x{n:<4} {disc} = {val}")
+        for name, blockers in blocked:
+            print(f"    {name}: {','.join(v for _, v, _ in blockers)}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--set", metavar="CODE", help="analyze a whole set (implemented/free/blocked)")
+    g.add_argument("--card", metavar="NAME", nargs="+",
+                   help="analyze one card by name (quotes optional; tokens are rejoined)")
+    g.add_argument("--calibrate", metavar="CODE", help="trust check over implemented cards")
+    ap.add_argument("--free", action="store_const", const="free", dest="show",
+                    help="with --set: also list the free-to-implement cards")
+    ap.add_argument("--blocked", action="store_const", const="blocked", dest="show",
+                    help="with --set: also list the blocked cards + reasons")
+    ap.add_argument("--all", action="store_const", const="all", dest="show",
+                    help="with --set: list both free and blocked")
+    ap.add_argument("--refresh", action="store_true", help="force Scryfall re-fetch")
+    args = ap.parse_args()
+
+    effects, keywords, mapping = load_effect_serialnames(), load_keywords(), load_mapping()
+    if args.card:
+        return mode_card(" ".join(args.card), effects, keywords, mapping)
+    if args.calibrate:
+        return mode_calibrate(args.calibrate, effects, keywords, mapping)
+    return mode_set(args.set, effects, keywords, mapping,
+                    show=args.show, refresh=args.refresh)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

A **predictive, non-authoritative** toolchain (`spike/mtgish-coverage/`) that maps the [mtgish](https://github.com/i5jb/mtgish) oracle-IR corpus (~32k cards) onto our SDK capabilities, to triage the backlog and draft easy cards. It is a `scripts/`-style analyzer, **never a card loader** — ground truth stays a human-authored `cardDef` whose scenario test passes. Spun out of the ideas in `backlog/phase-rs-lessons.md` (Lesson 5).

## The tooling (wired into `justfile`)

**Coverage** — `just coverage --set X | --card "N" | --calibrate X`
Which missing cards need no engine work; a feature leaderboard (which capability unlocks the most cards). Calibrates ~99% on implemented Portal.

**Fidelity** — `just coverage-fidelity --set X | --all | --emit "N"`
Could we *auto-author* a card? Tiers each card **AUTO / SCAFFOLD / MISS** by diffing the bridge's output against the card's compiled golden snapshot (`CardDefinitionSnapshotTest` output) — apples-to-apples in Argentum's own `@SerialName` vocabulary, no Kotlin parsing. `--emit` reproduces hand-authored DSL (e.g. `Hand of Death` byte-for-byte).

**Auto-gen** — `just coverage-gaps --set X` / `just coverage-generate --set X`
Classify a set's *unimplemented* cards (AUTOGEN / SCAFFOLD / BLOCKED + blocked-capability leaderboard), then draft the AUTOGEN ones into a gitignored staging dir.

## Key measured findings (see `FINDINGS.md`)

- Coverage generalizes cheaply; the keyword auto-resolver + a small per-set mapping does most of the work.
- Generation AUTO is **~75% on Portal** (the set the bridge was tuned on) but **~45% on unseen sets** — the mapping is a **converging per-corpus investment** (one entry helps all sets), not build-once. Quantified via `--all`.
- mtgish IR is approximate (it can emit a clean-looking but *subtly wrong* target, e.g. `Lava Axe → AnyTarget`), so even AUTO is a ceiling — only a compile + scenario test proves behaviour.

## Guardrails (also in `CLAUDE.md`)

- Generated `.kt` are **DRAFTS in a staging dir** — must compile, get a scenario test, and be human-reviewed before entering a set's `cards/` package.
- Coverage/AUTOGEN is **advisory ranking, never a gate**. Real implementation still goes through the `add-card` skill.

## Scope / notes

- Pure tooling: no engine, SDK, server, or client changes. Touches only `CLAUDE.md`, `justfile`, and the new `spike/mtgish-coverage/` dir.
- First run auto-downloads a 29 MB mtgish IR file (gitignored); generated drafts and the registry dump are gitignored too.
- This is a **spike for evaluation** — merging makes the analysis tooling and findings available; it does not change any card or engine behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)