### PR TITLE
Add shared CostPaymentService (PayCost-payment unification, PR 1)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CostPaymentContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CostPaymentContinuations.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.effects.Effect
+import kotlinx.serialization.Serializable
+
+/**
+ * Resume after a player responds to a cost-payment prompt created by
+ * `com.wingedsheep.engine.mechanics.cost.CostPaymentService.pay`.
+ *
+ * A *single* frame serves all ten [PayCost] variants: the resumer dispatches on [cost]'s shape to
+ * interpret the response — yes/no for mana / life / random-discard, card-selection for
+ * discard / exile / reveal / sacrifice / return / tap, option-pick for [PayCost.Choice]. On a paid
+ * outcome it performs the payment and runs [onPaid]; on a declined or short selection it runs
+ * [onDeclined]. Either way it then calls `checkForMore`, so a caller-pushed frame beneath this one
+ * resumes for non-effect follow-ups.
+ *
+ * [PayCost.OwnManaCost] is resolved to a concrete [PayCost.Mana] (against the source's printed cost)
+ * before the frame is created, so it never appears here. A [PayCost.Choice] is stored already reduced
+ * to the *affordable* options, so the chosen option index maps positionally onto [PayCost.Choice.options]
+ * and an index past the end means "decline".
+ *
+ * @property payerId the player paying the cost.
+ * @property sourceId the spell/permanent the cost is attached to (needed for self-exclusion and
+ *   own-mana-cost resolution).
+ * @property sourceName name of the source for event/prompt text.
+ * @property cost the (already-resolved) cost being paid.
+ * @property onPaid effect to run after the cost is paid (null = nothing).
+ * @property onDeclined effect to run if the cost is declined or unpayable (null = nothing).
+ * @property targets / [namedTargets] / [storedCollections] context threaded into the follow-up so it
+ *   can resolve `ContextTarget`s and reference pipeline collections.
+ */
+@Serializable
+data class CostPaymentContinuation(
+    override val decisionId: String,
+    val payerId: EntityId,
+    val sourceId: EntityId,
+    val sourceName: String,
+    val cost: PayCost,
+    val onPaid: Effect? = null,
+    val onDeclined: Effect? = null,
+    val targets: List<ChosenTarget> = emptyList(),
+    val namedTargets: Map<String, ChosenTarget> = emptyMap(),
+    val storedCollections: Map<String, List<EntityId>> = emptyMap()
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -189,6 +189,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CommanderZoneChoiceContinuation::class)
         subclass(PayOrSufferContinuation::class)
         subclass(PayOrSufferChoiceContinuation::class)
+        subclass(CostPaymentContinuation::class)
         subclass(ChooseColorThenContinuation::class)
         subclass(ChooseNumberThenContinuation::class)
         subclass(ChooseManaColorContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
@@ -41,6 +41,7 @@ class ContinuationHandler(
         registerModule(DiscardAndDrawContinuationResumer(services))
         registerModule(StateBasedContinuationResumer(services))
         registerModule(SacrificeAndPayContinuationResumer(services))
+        registerModule(CostPaymentContinuationResumer(services))
         registerModule(ManaPaymentContinuationResumer(services))
         registerModule(LibraryAndZoneContinuationResumer(services))
         registerModule(ModalAndCloneContinuationResumer(services))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -1,0 +1,175 @@
+package com.wingedsheep.engine.handlers.continuations
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CostPaymentContinuation
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PipelineState
+import com.wingedsheep.engine.mechanics.cost.CostPaymentContext
+import com.wingedsheep.engine.mechanics.cost.CostPaymentService
+import com.wingedsheep.engine.mechanics.cost.PaymentResult
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.effects.Effect
+
+/**
+ * Resumer for [CostPaymentContinuation] — the single resume path for every [PayCost] variant paid
+ * through [CostPaymentService].
+ *
+ * It reads the player's response (yes/no, card selection, or option pick depending on the cost
+ * shape), decides paid vs. declined, delegates the actual mutation to
+ * [CostPaymentService.performPayment], then runs the continuation's `onPaid` / `onDeclined` follow-up
+ * and chains via `checkForMore` so any caller-pushed frame beneath resumes too.
+ */
+class CostPaymentContinuationResumer(
+    private val services: EngineServices
+) : ContinuationResumerModule {
+
+    private val paymentService = CostPaymentService(services)
+
+    override fun resumers(): List<ContinuationResumer<*>> = listOf(
+        resumer(CostPaymentContinuation::class, ::resume)
+    )
+
+    fun resume(
+        state: GameState,
+        continuation: CostPaymentContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult = when (val cost = continuation.cost) {
+        is PayCost.Choice -> resumeChoice(state, continuation, cost, response, checkForMore)
+        // Yes/no costs: mana, life, and random discard.
+        is PayCost.Mana, is PayCost.PayLife ->
+            resumeYesNo(state, continuation, cost, response, checkForMore)
+        is PayCost.Discard ->
+            if (cost.random) resumeYesNo(state, continuation, cost, response, checkForMore)
+            else resumeSelection(state, continuation, cost, response, checkForMore)
+        // Selection costs.
+        is PayCost.Exile, is PayCost.RevealCard, is PayCost.Sacrifice,
+        is PayCost.ReturnToHand, is PayCost.Tap ->
+            resumeSelection(state, continuation, cost, response, checkForMore)
+        // Resolved away before the frame is built; should never reach the resumer.
+        is PayCost.OwnManaCost ->
+            ExecutionResult.error(state, "OwnManaCost should have been resolved before payment")
+    }
+
+    private fun resumeYesNo(
+        state: GameState,
+        continuation: CostPaymentContinuation,
+        cost: PayCost,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is YesNoResponse) {
+            return ExecutionResult.error(state, "Expected yes/no response for cost payment")
+        }
+        if (!response.choice) return declined(state, continuation, checkForMore)
+
+        val execution = paymentService.performPayment(state, continuation.payerId, cost, continuation.sourceId, emptyList())
+        // A defensive payment failure (e.g. mana solve came up short) falls through to declined.
+        return if (execution.success) paid(execution.state, execution.events, continuation, checkForMore)
+        else declined(state, continuation, checkForMore)
+    }
+
+    private fun resumeSelection(
+        state: GameState,
+        continuation: CostPaymentContinuation,
+        cost: PayCost,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(state, "Expected card-selection response for cost payment")
+        }
+        if (response.selectedCards.size < paymentService.requiredCount(cost)) {
+            return declined(state, continuation, checkForMore)
+        }
+        val execution = paymentService.performPayment(state, continuation.payerId, cost, continuation.sourceId, response.selectedCards)
+        return if (execution.success) paid(execution.state, execution.events, continuation, checkForMore)
+        else declined(state, continuation, checkForMore)
+    }
+
+    private fun resumeChoice(
+        state: GameState,
+        continuation: CostPaymentContinuation,
+        cost: PayCost.Choice,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is OptionChosenResponse) {
+            return ExecutionResult.error(state, "Expected option-choice response for cost payment")
+        }
+        // The trailing option (index == options.size) is "Don't pay".
+        if (response.optionIndex >= cost.options.size) {
+            return declined(state, continuation, checkForMore)
+        }
+        // Re-enter the service with the chosen sub-cost, carrying the same follow-up. It pushes a
+        // fresh CostPaymentContinuation and pauses again — handling a sub-cost that itself needs input.
+        val chosen = cost.options[response.optionIndex]
+        val result = paymentService.pay(state, continuation.payerId, chosen, continuation.sourceId, contextOf(continuation))
+        return when (result) {
+            is PaymentResult.Pending -> ExecutionResult.paused(result.state, result.pendingDecision, result.events)
+            // canAfford was checked when building the option list, so a sub-cost should be payable;
+            // treat any unexpected non-pending result as a decline so the punisher branch still runs.
+            else -> declined(result.state, continuation, checkForMore)
+        }
+    }
+
+    private fun paid(
+        state: GameState,
+        priorEvents: List<GameEvent>,
+        continuation: CostPaymentContinuation,
+        checkForMore: CheckForMore
+    ): ExecutionResult = runFollowup(state, priorEvents, continuation.onPaid, continuation, checkForMore)
+
+    private fun declined(
+        state: GameState,
+        continuation: CostPaymentContinuation,
+        checkForMore: CheckForMore
+    ): ExecutionResult = runFollowup(state, emptyList(), continuation.onDeclined, continuation, checkForMore)
+
+    private fun runFollowup(
+        state: GameState,
+        priorEvents: List<GameEvent>,
+        followup: Effect?,
+        continuation: CostPaymentContinuation,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (followup == null) return checkForMore(state, priorEvents)
+        val result = services.effectExecutorRegistry
+            .execute(state, followup, effectContext(state, continuation))
+            .toExecutionResult()
+        val allEvents = priorEvents + result.events
+        return if (result.isPaused) {
+            ExecutionResult.paused(result.state, result.pendingDecision!!, allEvents)
+        } else {
+            checkForMore(result.state, allEvents)
+        }
+    }
+
+    private fun effectContext(state: GameState, continuation: CostPaymentContinuation): EffectContext =
+        EffectContext(
+            sourceId = continuation.sourceId,
+            controllerId = continuation.payerId,
+            opponentId = state.turnOrder.firstOrNull { it != continuation.payerId },
+            targets = continuation.targets,
+            pipeline = PipelineState(
+                namedTargets = continuation.namedTargets,
+                storedCollections = continuation.storedCollections
+            )
+        )
+
+    private fun contextOf(continuation: CostPaymentContinuation): CostPaymentContext =
+        CostPaymentContext(
+            onPaid = continuation.onPaid,
+            onDeclined = continuation.onDeclined,
+            targets = continuation.targets,
+            namedTargets = continuation.namedTargets,
+            storedCollections = continuation.storedCollections
+        )
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentContext.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.engine.mechanics.cost
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.Effect
+
+/**
+ * Per-call configuration for [CostPaymentService.pay]: what should happen once a payment resolves,
+ * plus the context an `onPaid` / `onDeclined` follow-up needs to resolve targets.
+ *
+ * The follow-ups are serializable [Effect]s so they ride the [com.wingedsheep.engine.core.CostPaymentContinuation]
+ * across a pause. That covers the effect-shaped consumers this service is built for — PayOrSuffer's
+ * "suffer" ([onDeclined]) and AnyPlayerMayPay's "consequence" ([onPaid]) — and the eventual
+ * gated-frame fold. Consumers whose follow-up is engine logic (morph's turn-face-up, chain-copy)
+ * instead push their own continuation frame *beneath* the payment continuation; the resumer's
+ * `checkForMore` call then resumes it once payment settles.
+ *
+ * @property onPaid effect to run once the cost is fully paid (null = nothing).
+ * @property onDeclined effect to run if the payer declines or cannot pay (null = nothing).
+ * @property targets targets carried into the follow-up so an `EffectTarget.ContextTarget(n)` still
+ *   resolves (see the engine rule on continuations propagating targets).
+ * @property namedTargets named targets from the originating pipeline.
+ * @property storedCollections pipeline collections carried into the follow-up so it can reference
+ *   cards gathered earlier in the same resolution.
+ */
+data class CostPaymentContext(
+    val onPaid: Effect? = null,
+    val onDeclined: Effect? = null,
+    val targets: List<ChosenTarget> = emptyList(),
+    val namedTargets: Map<String, ChosenTarget> = emptyMap(),
+    val storedCollections: Map<String, List<EntityId>> = emptyMap()
+)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -1,0 +1,508 @@
+package com.wingedsheep.engine.mechanics.cost
+
+import com.wingedsheep.engine.core.CardsDiscardedEvent
+import com.wingedsheep.engine.core.CardsRevealedEvent
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.CostPaymentContinuation
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.DecisionRequestedEvent
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.LifeChangeReason
+import com.wingedsheep.engine.core.LifeChangedEvent
+import com.wingedsheep.engine.core.ManaSpentEvent
+import com.wingedsheep.engine.core.PermanentsSacrificedEvent
+import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.mechanics.mana.ManaPool
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import java.util.UUID
+
+/**
+ * Single, shared engine service that owns paying every [PayCost] variant.
+ *
+ * Before this existed, five consumers (morph turn-face-up, PayOrSuffer, AnyPlayerMayPay, chain-copy,
+ * and the face-up legal-action enumerator) each carried their own `when (cost: PayCost)` switch, each
+ * covering a *different, incomplete* subset of the ten variants — so a cost that worked as a morph
+ * cost could silently fail as a punisher cost and vice-versa. This service consolidates the two
+ * questions every one of them asks:
+ *
+ * - [canAfford] — the affordability pre-check (CR 118.3). Pure and allocation-light enough to run in
+ *   legal-action enumeration; never mutates or prompts.
+ * - [pay] — performs the payment, pausing with the right decision (battlefield targeting for
+ *   sacrifice / return / tap, card-selection for discard / exile / reveal, yes/no for mana / life,
+ *   option-pick for [PayCost.Choice]) and resuming through a single
+ *   [com.wingedsheep.engine.core.CostPaymentContinuation].
+ *
+ * It is deliberately *not* a lowering of costs into effects (a cost is checked, atomic, and can't be
+ * responded to — categorically not an effect): [PayCost] stays the authoring vocabulary; this is just
+ * the one place that executes it.
+ *
+ * The payment-performing mutations ([performPayment]) live here too so the resumer is a thin caller.
+ */
+class CostPaymentService(private val services: EngineServices) {
+
+    private val predicateEvaluator = PredicateEvaluator()
+    private val decisionHandler = DecisionHandler()
+
+    // ---------------------------------------------------------------------------------------------
+    // Affordability (CR 118.3) — pure, no mutation, safe for the legal-action hot path.
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Whether [payerId] can pay [cost]. For battlefield selection costs the [sourceId] is excluded
+     * from the candidate pool (you can't sacrifice/return/tap the very permanent whose cost this is).
+     */
+    fun canAfford(state: GameState, payerId: EntityId, cost: PayCost, sourceId: EntityId): Boolean {
+        return when (val c = resolve(state, cost, sourceId)) {
+            is PayCost.Mana -> services.manaSolver.canPay(state, payerId, c.cost)
+            // Only unresolvable own-mana-costs reach here (missing source/card component) — unpayable.
+            is PayCost.OwnManaCost -> false
+            // CR 119.4 — a player may pay life only if their life total is at least the amount; paying
+            // life that would reduce them to 0 or less is legal (they then lose as a state-based action).
+            is PayCost.PayLife -> life(state, payerId) >= c.amount
+            is PayCost.Discard -> cardsInHand(state, payerId, c.filter).size >= c.count
+            is PayCost.Exile -> cardsInZone(state, payerId, c.filter, c.zone).size >= c.count
+            is PayCost.RevealCard -> cardsInHand(state, payerId, c.filter).size >= c.count
+            is PayCost.Sacrifice -> controlledMatching(state, payerId, c.filter, sourceId).size >= c.count
+            is PayCost.ReturnToHand -> controlledMatching(state, payerId, c.filter, sourceId).size >= c.count
+            is PayCost.Tap -> controlledUntapped(state, payerId, c.filter, sourceId).size >= c.count
+            is PayCost.Choice -> c.options.any { canAfford(state, payerId, it, sourceId) }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Pay — build the right prompt and push a single continuation.
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Attempt to pay [cost]. Returns [PaymentResult.Unaffordable] synchronously when the payer can't
+     * pay; otherwise returns [PaymentResult.Pending] with a [CostPaymentContinuation] pushed. The
+     * terminal paid/declined outcome (and the [ctx] follow-up) is realized when that continuation
+     * resumes.
+     */
+    fun pay(
+        state: GameState,
+        payerId: EntityId,
+        cost: PayCost,
+        sourceId: EntityId,
+        ctx: CostPaymentContext = CostPaymentContext()
+    ): PaymentResult {
+        val resolved = resolve(state, cost, sourceId)
+        if (!canAfford(state, payerId, resolved, sourceId)) {
+            return PaymentResult.Unaffordable(state)
+        }
+        val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "the source"
+
+        return when (resolved) {
+            is PayCost.Mana ->
+                yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Pay ${resolved.cost}?", "Pay ${resolved.cost}")
+            is PayCost.PayLife ->
+                yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Pay ${resolved.amount} life?", "Pay ${resolved.amount} life")
+            is PayCost.Discard ->
+                if (resolved.random) {
+                    val word = if (resolved.count == 1) "a card" else "${resolved.count} cards"
+                    yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Discard $word at random?", "Discard")
+                } else {
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInHand(state, payerId, resolved.filter), resolved.count, useTargetingUI = false)
+                }
+            is PayCost.Exile ->
+                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInZone(state, payerId, resolved.filter, resolved.zone), resolved.count, useTargetingUI = resolved.zone == Zone.BATTLEFIELD)
+            is PayCost.RevealCard ->
+                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInHand(state, payerId, resolved.filter), resolved.count, useTargetingUI = false)
+            is PayCost.Sacrifice ->
+                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, resolved.filter, sourceId), resolved.count, useTargetingUI = true)
+            is PayCost.ReturnToHand ->
+                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, resolved.filter, sourceId), resolved.count, useTargetingUI = true)
+            is PayCost.Tap ->
+                selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledUntapped(state, payerId, resolved.filter, sourceId), resolved.count, useTargetingUI = true)
+            is PayCost.Choice -> choicePrompt(state, payerId, resolved, sourceId, sourceName, ctx)
+            // resolve() only yields OwnManaCost when unresolvable, and canAfford already rejected it.
+            is PayCost.OwnManaCost -> PaymentResult.Unaffordable(state)
+        }
+    }
+
+    private fun yesNoPrompt(
+        state: GameState,
+        payerId: EntityId,
+        cost: PayCost,
+        sourceId: EntityId,
+        sourceName: String,
+        ctx: CostPaymentContext,
+        prompt: String,
+        yesText: String
+    ): PaymentResult {
+        val result = decisionHandler.createYesNoDecision(
+            state = state,
+            playerId = payerId,
+            sourceId = sourceId,
+            sourceName = sourceName,
+            prompt = prompt,
+            yesText = yesText,
+            noText = "Don't pay",
+            phase = DecisionPhase.RESOLUTION
+        )
+        val decision = result.pendingDecision!!
+        val stateWithContinuation = result.state.pushContinuation(continuation(decision.id, payerId, sourceId, sourceName, cost, ctx))
+        return PaymentResult.Pending(stateWithContinuation, decision, result.events)
+    }
+
+    private fun selectionPrompt(
+        state: GameState,
+        payerId: EntityId,
+        cost: PayCost,
+        sourceId: EntityId,
+        sourceName: String,
+        ctx: CostPaymentContext,
+        options: List<EntityId>,
+        count: Int,
+        useTargetingUI: Boolean
+    ): PaymentResult {
+        val result = decisionHandler.createCardSelectionDecision(
+            state = state,
+            playerId = payerId,
+            sourceId = sourceId,
+            sourceName = sourceName,
+            prompt = "${cost.description.replaceFirstChar { it.uppercase() }}?",
+            options = options,
+            minSelections = 0,
+            maxSelections = count,
+            ordered = false,
+            phase = DecisionPhase.RESOLUTION,
+            useTargetingUI = useTargetingUI
+        )
+        val decision = result.pendingDecision!!
+        val stateWithContinuation = result.state.pushContinuation(continuation(decision.id, payerId, sourceId, sourceName, cost, ctx))
+        return PaymentResult.Pending(stateWithContinuation, decision, result.events)
+    }
+
+    private fun choicePrompt(
+        state: GameState,
+        payerId: EntityId,
+        cost: PayCost.Choice,
+        sourceId: EntityId,
+        sourceName: String,
+        ctx: CostPaymentContext
+    ): PaymentResult {
+        // Offer only options the payer can actually pay; index 0..affordable.size-1 maps positionally,
+        // and the trailing "Don't pay" option means decline.
+        val affordable = cost.options.filter { canAfford(state, payerId, it, sourceId) }
+        val labels = affordable.map { it.description.replaceFirstChar { ch -> ch.uppercase() } } + "Don't pay"
+        val decisionId = UUID.randomUUID().toString()
+        val decision = ChooseOptionDecision(
+            id = decisionId,
+            playerId = payerId,
+            prompt = "Choose one:",
+            context = DecisionContext(sourceId = sourceId, sourceName = sourceName, phase = DecisionPhase.RESOLUTION),
+            options = labels
+        )
+        // Store the reduced (affordable-only) Choice so the resumer can map the option index directly.
+        val reduced = PayCost.Choice(affordable)
+        val stateWithContinuation = state.withPendingDecision(decision)
+            .pushContinuation(continuation(decisionId, payerId, sourceId, sourceName, reduced, ctx))
+        return PaymentResult.Pending(
+            stateWithContinuation,
+            decision,
+            listOf(DecisionRequestedEvent(decisionId, payerId, "CHOOSE_OPTION", decision.prompt))
+        )
+    }
+
+    private fun continuation(
+        decisionId: String,
+        payerId: EntityId,
+        sourceId: EntityId,
+        sourceName: String,
+        cost: PayCost,
+        ctx: CostPaymentContext
+    ): CostPaymentContinuation = CostPaymentContinuation(
+        decisionId = decisionId,
+        payerId = payerId,
+        sourceId = sourceId,
+        sourceName = sourceName,
+        cost = cost,
+        onPaid = ctx.onPaid,
+        onDeclined = ctx.onDeclined,
+        targets = ctx.targets,
+        namedTargets = ctx.namedTargets,
+        storedCollections = ctx.storedCollections
+    )
+
+    // ---------------------------------------------------------------------------------------------
+    // Perform payment — mutate state once the payer has committed. Called by the resumer.
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Apply the payment for [cost], where [selected] holds the entities the payer chose for a
+     * selection cost (empty for yes/no costs and random discard). Returns the new state, the emitted
+     * events, and whether the payment actually completed (mana solving can still fail defensively).
+     *
+     * [cost] must already be resolved ([PayCost.OwnManaCost] mapped to [PayCost.Mana]) and, for
+     * [PayCost.Choice], a single chosen sub-cost — the resumer never calls this with a Choice.
+     */
+    fun performPayment(
+        state: GameState,
+        payerId: EntityId,
+        cost: PayCost,
+        sourceId: EntityId,
+        selected: List<EntityId>
+    ): CostPaymentExecution = when (cost) {
+        is PayCost.Mana -> payMana(state, payerId, cost.cost, sourceId)
+        is PayCost.PayLife -> payLife(state, payerId, cost.amount)
+        is PayCost.Discard ->
+            if (cost.random) discardRandom(state, payerId, cost.filter, cost.count)
+            else discardSelected(state, payerId, selected)
+        is PayCost.Exile -> exileSelected(state, payerId, selected, cost.zone)
+        is PayCost.RevealCard -> revealSelected(state, payerId, selected)
+        is PayCost.Sacrifice -> sacrificeSelected(state, payerId, selected)
+        is PayCost.ReturnToHand -> returnSelected(state, selected)
+        is PayCost.Tap -> tapSelected(state, selected)
+        is PayCost.OwnManaCost -> CostPaymentExecution(state, emptyList(), success = false)
+        is PayCost.Choice -> CostPaymentExecution(state, emptyList(), success = false)
+    }
+
+    private fun payMana(state: GameState, payerId: EntityId, manaCost: ManaCost, sourceId: EntityId): CostPaymentExecution {
+        val playerEntity = state.getEntity(payerId) ?: return CostPaymentExecution(state, emptyList(), false)
+        val poolComponent = playerEntity.get<ManaPoolComponent>() ?: ManaPoolComponent()
+        val pool = ManaPool(
+            poolComponent.white, poolComponent.blue, poolComponent.black,
+            poolComponent.red, poolComponent.green, poolComponent.colorless
+        )
+
+        // Spend floating mana first, then tap sources for the remainder.
+        val partial = pool.payPartial(manaCost)
+        var combined = pool
+        var current = state
+        val events = mutableListOf<GameEvent>()
+
+        if (!partial.remainingCost.isEmpty()) {
+            val solution = services.manaSolver.solve(current, payerId, partial.remainingCost)
+                ?: return CostPaymentExecution(state, emptyList(), false)
+            val (afterTaps, tapEvents) = services.manaAbilitySideEffectExecutor
+                .tapSourcesWithSideEffects(current, solution, payerId)
+            current = afterTaps
+            events.addAll(tapEvents)
+            for ((_, production) in solution.manaProduced) {
+                combined = if (production.color != null) combined.add(production.color)
+                else combined.addColorless(production.colorless)
+            }
+        }
+
+        val newPool = combined.pay(manaCost) ?: return CostPaymentExecution(state, emptyList(), false)
+        current = current.updateEntity(payerId) {
+            it.with(ManaPoolComponent(newPool.white, newPool.blue, newPool.black, newPool.red, newPool.green, newPool.colorless))
+        }
+
+        val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "the source"
+        events.add(
+            ManaSpentEvent(
+                playerId = payerId,
+                reason = "Pay cost for $sourceName",
+                white = combined.white - newPool.white,
+                blue = combined.blue - newPool.blue,
+                black = combined.black - newPool.black,
+                red = combined.red - newPool.red,
+                green = combined.green - newPool.green,
+                colorless = combined.colorless - newPool.colorless
+            )
+        )
+        return CostPaymentExecution(current, events, success = true)
+    }
+
+    private fun payLife(state: GameState, payerId: EntityId, amount: Int): CostPaymentExecution {
+        val currentLife = life(state, payerId)
+        val newLife = currentLife - amount
+        var newState = state.updateEntity(payerId) { it.with(LifeTotalComponent(newLife)) }
+        newState = DamageUtils.markLifeLostThisTurn(newState, payerId)
+        val events = listOf(LifeChangedEvent(payerId, currentLife, newLife, LifeChangeReason.PAYMENT))
+        return CostPaymentExecution(newState, events, success = true)
+    }
+
+    private fun discardSelected(state: GameState, payerId: EntityId, selected: List<EntityId>): CostPaymentExecution {
+        val handZone = ZoneKey(payerId, Zone.HAND)
+        val graveyardZone = ZoneKey(payerId, Zone.GRAVEYARD)
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+        val names = mutableListOf<String>()
+        for (cardId in selected) {
+            val name = newState.getEntity(cardId)?.get<CardComponent>()?.name ?: "Unknown"
+            names.add(name)
+            newState = newState.removeFromZone(handZone, cardId).addToZone(graveyardZone, cardId)
+            events.add(ZoneChangeEvent(cardId, name, Zone.HAND, Zone.GRAVEYARD, payerId))
+        }
+        events.add(0, CardsDiscardedEvent(payerId, selected, names))
+        return CostPaymentExecution(newState, events, success = true)
+    }
+
+    private fun discardRandom(state: GameState, payerId: EntityId, filter: GameObjectFilter, count: Int): CostPaymentExecution {
+        val handZone = ZoneKey(payerId, Zone.HAND)
+        val graveyardZone = ZoneKey(payerId, Zone.GRAVEYARD)
+        val context = PredicateContext(controllerId = payerId)
+        val valid = state.getZone(handZone).filter {
+            predicateEvaluator.matches(state, state.projectedState, it, filter, context)
+        }
+        if (valid.isEmpty()) return CostPaymentExecution(state, emptyList(), success = false)
+
+        val (shuffled, stateAfterShuffle) = state.nextRandom { shuffle(valid) }
+        val toDiscard = shuffled.take(count)
+        var newState = stateAfterShuffle
+        val events = mutableListOf<GameEvent>()
+        val names = mutableListOf<String>()
+        for (cardId in toDiscard) {
+            val name = newState.getEntity(cardId)?.get<CardComponent>()?.name ?: "Unknown"
+            names.add(name)
+            newState = newState.removeFromZone(handZone, cardId).addToZone(graveyardZone, cardId)
+            events.add(ZoneChangeEvent(cardId, name, Zone.HAND, Zone.GRAVEYARD, payerId))
+        }
+        events.add(0, CardsDiscardedEvent(payerId, toDiscard, names))
+        return CostPaymentExecution(newState, events, success = true)
+    }
+
+    private fun exileSelected(state: GameState, payerId: EntityId, selected: List<EntityId>, zone: Zone): CostPaymentExecution {
+        val fromZone = ZoneKey(payerId, zone)
+        val exileZone = ZoneKey(payerId, Zone.EXILE)
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+        for (cardId in selected) {
+            val name = newState.getEntity(cardId)?.get<CardComponent>()?.name ?: "Unknown"
+            newState = newState.removeFromZone(fromZone, cardId).addToZone(exileZone, cardId)
+            events.add(ZoneChangeEvent(cardId, name, zone, Zone.EXILE, payerId))
+        }
+        return CostPaymentExecution(newState, events, success = true)
+    }
+
+    private fun revealSelected(state: GameState, payerId: EntityId, selected: List<EntityId>): CostPaymentExecution {
+        // The cards stay in hand; revealing is purely informational.
+        val names = selected.map { state.getEntity(it)?.get<CardComponent>()?.name ?: "Unknown" }
+        val events = listOf(CardsRevealedEvent(payerId, selected, names, source = "Cost payment"))
+        return CostPaymentExecution(state, events, success = true)
+    }
+
+    private fun sacrificeSelected(state: GameState, payerId: EntityId, selected: List<EntityId>): CostPaymentExecution {
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+        if (selected.isNotEmpty()) {
+            val names = selected.map { newState.getEntity(it)?.get<CardComponent>()?.name ?: "Unknown" }
+            events.add(PermanentsSacrificedEvent(payerId, selected, names))
+            newState = ZoneTransitionService.trackFoodSacrifice(newState, selected, payerId)
+        }
+        for (permanentId in selected) {
+            val transition = ZoneTransitionService.moveToZone(newState, permanentId, Zone.GRAVEYARD)
+            newState = transition.state
+            events.addAll(transition.events)
+        }
+        return CostPaymentExecution(newState, events, success = true)
+    }
+
+    private fun returnSelected(state: GameState, selected: List<EntityId>): CostPaymentExecution {
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+        for (permanentId in selected) {
+            val result = ZoneMovementUtils.movePermanentToZone(newState, permanentId, Zone.HAND)
+            if (result.error != null) return CostPaymentExecution(state, emptyList(), success = false)
+            newState = result.state
+            events.addAll(result.events)
+        }
+        return CostPaymentExecution(newState, events, success = true)
+    }
+
+    private fun tapSelected(state: GameState, selected: List<EntityId>): CostPaymentExecution {
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+        for (permanentId in selected) {
+            val entity = newState.getEntity(permanentId) ?: continue
+            if (entity.has<TappedComponent>()) continue
+            val name = entity.get<CardComponent>()?.name ?: "Unknown"
+            newState = newState.updateEntity(permanentId) { it.with(TappedComponent) }
+            events.add(TappedEvent(permanentId, name))
+        }
+        return CostPaymentExecution(newState, events, success = true)
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Shared helpers
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Lowers [PayCost.OwnManaCost] to a concrete [PayCost.Mana] against the source's printed cost so
+     * every other code path sees a uniform shape. A source with no mana cost (a land, a token) has an
+     * empty [ManaCost] — which is `{0}` and trivially payable. Returns the cost unchanged if the
+     * source/card component is missing (unresolvable → reported unaffordable).
+     */
+    private fun resolve(state: GameState, cost: PayCost, sourceId: EntityId): PayCost {
+        if (cost !is PayCost.OwnManaCost) return cost
+        val manaCost = state.getEntity(sourceId)?.get<CardComponent>()?.manaCost ?: return cost
+        return PayCost.Mana(manaCost)
+    }
+
+    private fun life(state: GameState, playerId: EntityId): Int =
+        state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+
+    private fun cardsInHand(state: GameState, playerId: EntityId, filter: GameObjectFilter): List<EntityId> {
+        val context = PredicateContext(controllerId = playerId)
+        return state.getZone(playerId, Zone.HAND).filter {
+            predicateEvaluator.matches(state, state.projectedState, it, filter, context)
+        }
+    }
+
+    private fun cardsInZone(state: GameState, playerId: EntityId, filter: GameObjectFilter, zone: Zone): List<EntityId> {
+        if (zone == Zone.BATTLEFIELD) {
+            return BattlefieldFilterUtils.findMatchingOnBattlefield(
+                state, filter.youControl(), PredicateContext(controllerId = playerId)
+            )
+        }
+        val context = PredicateContext(controllerId = playerId)
+        return state.getZone(playerId, zone).filter {
+            predicateEvaluator.matches(state, state.projectedState, it, filter, context)
+        }
+    }
+
+    private fun controlledMatching(state: GameState, playerId: EntityId, filter: GameObjectFilter, sourceId: EntityId): List<EntityId> =
+        BattlefieldFilterUtils.findMatchingOnBattlefield(
+            state, filter.youControl(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
+        )
+
+    private fun controlledUntapped(state: GameState, playerId: EntityId, filter: GameObjectFilter, sourceId: EntityId): List<EntityId> =
+        BattlefieldFilterUtils.findMatchingOnBattlefield(
+            state, filter.youControl().untapped(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
+        )
+
+    /** How many entities a selection cost requires; 0 for non-selection costs. */
+    fun requiredCount(cost: PayCost): Int = when (cost) {
+        is PayCost.Discard -> cost.count
+        is PayCost.Exile -> cost.count
+        is PayCost.RevealCard -> cost.count
+        is PayCost.Sacrifice -> cost.count
+        is PayCost.ReturnToHand -> cost.count
+        is PayCost.Tap -> cost.count
+        else -> 0
+    }
+}
+
+/**
+ * Result of [CostPaymentService.performPayment]: the post-payment state, the events it emitted, and
+ * whether the payment actually completed ([success] is false only on a defensive failure such as a
+ * mana solve that unexpectedly comes up short, in which case [state]/[events] are left untouched).
+ */
+data class CostPaymentExecution(
+    val state: GameState,
+    val events: List<GameEvent>,
+    val success: Boolean
+)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/PaymentResult.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/PaymentResult.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.mechanics.cost
+
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.state.GameState
+
+/**
+ * Outcome of an attempt to pay a [com.wingedsheep.sdk.scripting.costs.PayCost] through the shared
+ * [CostPaymentService].
+ *
+ * A *cost* (CR 118) is all-or-nothing and affordability-checkable before commitment, so its outcome
+ * is a small closed set rather than a free-form effect result:
+ *
+ * - [Unaffordable] — the payer cannot pay (CR 118.3: "a player can't pay a cost they can't pay").
+ *   Returned synchronously by [CostPaymentService.pay]; no decision is shown.
+ * - [Pending] — payment requires player input. A [com.wingedsheep.engine.core.CostPaymentContinuation]
+ *   has been pushed onto the continuation stack; the terminal outcome ([Paid] / [Declined]) is
+ *   realized when that continuation resumes.
+ * - [Paid] — the cost was fully paid; [state] already reflects the payment.
+ * - [Declined] — the payer could afford the cost but chose not to pay it.
+ *
+ * [CostPaymentService.pay] returns only [Unaffordable] or [Pending] — every affordable cost prompts
+ * before committing, so [Paid] / [Declined] are produced inside the continuation resumer (which runs
+ * the corresponding `onPaid` / `onDeclined` follow-up from the [CostPaymentContext]). They exist as
+ * first-class results so a future caller that drives payment without a follow-up effect can branch on
+ * them directly.
+ */
+sealed interface PaymentResult {
+    val state: GameState
+    val events: List<GameEvent>
+
+    /** The cost was fully paid; [state] reflects the payment. */
+    data class Paid(
+        override val state: GameState,
+        override val events: List<GameEvent> = emptyList()
+    ) : PaymentResult
+
+    /** The payer could afford the cost but chose not to pay it. */
+    data class Declined(
+        override val state: GameState,
+        override val events: List<GameEvent> = emptyList()
+    ) : PaymentResult
+
+    /** The payer cannot pay the cost; no prompt was shown (CR 118.3). */
+    data class Unaffordable(
+        override val state: GameState,
+        override val events: List<GameEvent> = emptyList()
+    ) : PaymentResult
+
+    /** Payment needs player input; a [com.wingedsheep.engine.core.CostPaymentContinuation] is pushed. */
+    data class Pending(
+        override val state: GameState,
+        val pendingDecision: PendingDecision,
+        override val events: List<GameEvent> = emptyList()
+    ) : PaymentResult
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
@@ -1,0 +1,451 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsRevealedEvent
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.mechanics.cost.CostPaymentContext
+import com.wingedsheep.engine.mechanics.cost.CostPaymentService
+import com.wingedsheep.engine.mechanics.cost.PaymentResult
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Phase 1 of the PayCost-payment unification (see backlog/paycost-payment-unification.md):
+ * the shared [CostPaymentService] that owns affordability + payment for all ten [PayCost] variants.
+ *
+ * The service is not yet wired into any consumer, so these tests drive it directly: build a board,
+ * call [CostPaymentService.canAfford] / [CostPaymentService.pay], then submit the decision through the
+ * real [com.wingedsheep.engine.core.ActionProcessor] so the [com.wingedsheep.engine.core.CostPaymentContinuation]
+ * resumes exactly as it will in production.
+ */
+class CostPaymentServiceTest : ScenarioTestBase() {
+
+    private fun bfCardByName(state: GameState, playerId: EntityId, name: String): EntityId =
+        state.getBattlefield(playerId).first { state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    init {
+
+        // -----------------------------------------------------------------------------------------
+        // Mana
+        // -----------------------------------------------------------------------------------------
+
+        test("Mana: canAfford follows available mana; paying taps a source") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide") // the cost's source ({R} creature)
+                .withLandsOnBattlefield(1, "Forest", 1)
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val forest = bfCardByName(game.state, game.player1Id, "Forest")
+
+            service.canAfford(game.state, game.player1Id, PayCost.Mana(ManaCost.parse("{G}")), source).shouldBeTrue()
+            service.canAfford(game.state, game.player1Id, PayCost.Mana(ManaCost.parse("{U}")), source).shouldBeFalse()
+
+            val pending = service.pay(game.state, game.player1Id, PayCost.Mana(ManaCost.parse("{G}")), source)
+            pending.shouldBeInstanceOf<PaymentResult.Pending>()
+            game.state = pending.state
+            game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
+
+            game.state.getEntity(forest)!!.has<TappedComponent>().shouldBeTrue()
+        }
+
+        test("Mana: declining leaves the source untapped and runs onDeclined") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .withLandsOnBattlefield(1, "Forest", 1)
+                .withCardInLibrary(1, "Forest")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val forest = bfCardByName(game.state, game.player1Id, "Forest")
+
+            val pending = service.pay(
+                game.state, game.player1Id, PayCost.Mana(ManaCost.parse("{G}")), source,
+                CostPaymentContext(onDeclined = Effects.DrawCards(1))
+            ) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(YesNoResponse(pending.pendingDecision.id, false))
+
+            game.state.getEntity(forest)!!.has<TappedComponent>().shouldBeFalse()
+            game.state.getHand(game.player1Id).size shouldBe 1 // drew from onDeclined
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // OwnManaCost
+        // -----------------------------------------------------------------------------------------
+
+        test("OwnManaCost: resolves to the source's printed cost and pays it") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide") // printed cost {R}
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val mountain = bfCardByName(game.state, game.player1Id, "Mountain")
+
+            service.canAfford(game.state, game.player1Id, PayCost.OwnManaCost, source).shouldBeTrue()
+
+            val pending = service.pay(game.state, game.player1Id, PayCost.OwnManaCost, source) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
+
+            game.state.getEntity(mountain)!!.has<TappedComponent>().shouldBeTrue()
+        }
+
+        test("OwnManaCost: unaffordable without the right mana") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+
+            service.canAfford(game.state, game.player1Id, PayCost.OwnManaCost, source).shouldBeFalse()
+            service.pay(game.state, game.player1Id, PayCost.OwnManaCost, source)
+                .shouldBeInstanceOf<PaymentResult.Unaffordable>()
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // PayLife (CR 119.4)
+        // -----------------------------------------------------------------------------------------
+
+        test("PayLife: canAfford uses CR 119.4 (life >= amount); paying deducts life") {
+            val game = scenario().withPlayers().withLifeTotal(1, 5)
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+
+            service.canAfford(game.state, game.player1Id, PayCost.PayLife(5), source).shouldBeTrue() // exactly enough
+            service.canAfford(game.state, game.player1Id, PayCost.PayLife(6), source).shouldBeFalse()
+
+            val pending = service.pay(game.state, game.player1Id, PayCost.PayLife(3), source) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
+
+            game.state.getEntity(game.player1Id)!!.get<LifeTotalComponent>()!!.life shouldBe 2
+        }
+
+        test("PayLife: declining keeps life unchanged") {
+            val game = scenario().withPlayers().withLifeTotal(1, 5)
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+
+            val pending = service.pay(game.state, game.player1Id, PayCost.PayLife(3), source) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(YesNoResponse(pending.pendingDecision.id, false))
+
+            game.state.getEntity(game.player1Id)!!.get<LifeTotalComponent>()!!.life shouldBe 5
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Discard
+        // -----------------------------------------------------------------------------------------
+
+        test("Discard: selecting the card moves it to the graveyard; declining keeps it in hand") {
+            val game = scenario().withPlayers()
+                .withCardInHand(1, "Forest")
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val card = game.state.getHand(game.player1Id).first()
+            val cost = PayCost.Discard(GameObjectFilter.Any, 1)
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
+
+            // Paid
+            val paid = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
+            game.state = paid.state
+            game.submitDecision(CardsSelectedResponse(paid.pendingDecision.id, listOf(card)))
+            game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain card
+            game.state.getHand(game.player1Id).shouldBe(emptyList())
+        }
+
+        test("Discard: declining keeps the card in hand") {
+            val game = scenario().withPlayers()
+                .withCardInHand(1, "Forest")
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val card = game.state.getHand(game.player1Id).first()
+
+            val pending = service.pay(game.state, game.player1Id, PayCost.Discard(GameObjectFilter.Any, 1), source) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, emptyList()))
+            game.state.getHand(game.player1Id) shouldContain card
+        }
+
+        test("Discard: unaffordable with an empty hand") {
+            val game = scenario().withPlayers().withCardOnBattlefield(1, "Goblin Guide").build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            service.canAfford(game.state, game.player1Id, PayCost.Discard(GameObjectFilter.Any, 1), source).shouldBeFalse()
+            service.pay(game.state, game.player1Id, PayCost.Discard(GameObjectFilter.Any, 1), source)
+                .shouldBeInstanceOf<PaymentResult.Unaffordable>()
+        }
+
+        test("Discard (random): paying discards a card at random") {
+            val game = scenario().withPlayers()
+                .withCardInHand(1, "Forest")
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val card = game.state.getHand(game.player1Id).first()
+
+            val pending = service.pay(game.state, game.player1Id, PayCost.Discard(GameObjectFilter.Any, 1, random = true), source) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
+            game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain card
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Exile
+        // -----------------------------------------------------------------------------------------
+
+        test("Exile: from graveyard moves the chosen card to exile") {
+            val game = scenario().withPlayers()
+                .withCardInGraveyard(1, "Forest")
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val card = game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)).first()
+            val cost = PayCost.Exile(GameObjectFilter.Any, Zone.GRAVEYARD, 1)
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
+            val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, listOf(card)))
+            game.state.getZone(ZoneKey(game.player1Id, Zone.EXILE)) shouldContain card
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // RevealCard
+        // -----------------------------------------------------------------------------------------
+
+        test("RevealCard: paying reveals the card but leaves it in hand") {
+            val game = scenario().withPlayers()
+                .withCardInHand(1, "Forest")
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val card = game.state.getHand(game.player1Id).first()
+            val cost = PayCost.RevealCard(GameObjectFilter.Any, 1)
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
+            val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
+            game.state = pending.state
+            val result = game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, listOf(card)))
+
+            game.state.getHand(game.player1Id) shouldContain card // stays in hand
+            result.events.any { it is CardsRevealedEvent }.shouldBeTrue()
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Sacrifice
+        // -----------------------------------------------------------------------------------------
+
+        test("Sacrifice: excludes the source; paying sacrifices the chosen permanent") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide") // source — must be excluded
+                .withCardOnBattlefield(1, "Savannah Lions") // the fodder
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
+            val cost = PayCost.Sacrifice(GameObjectFilter.Any, 1)
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
+            val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, listOf(fodder)))
+
+            game.state.getBattlefield(game.player1Id) shouldContain source // source untouched
+            game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain fodder
+        }
+
+        test("Sacrifice: unaffordable when only the source is on the battlefield") {
+            val game = scenario().withPlayers().withCardOnBattlefield(1, "Goblin Guide").build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            service.canAfford(game.state, game.player1Id, PayCost.Sacrifice(GameObjectFilter.Any, 1), source).shouldBeFalse()
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // ReturnToHand
+        // -----------------------------------------------------------------------------------------
+
+        test("ReturnToHand: paying returns the chosen permanent to hand") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .withCardOnBattlefield(1, "Savannah Lions")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
+            val cost = PayCost.ReturnToHand(GameObjectFilter.Any, 1)
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
+            val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, listOf(fodder)))
+
+            game.state.getHand(game.player1Id) shouldContain fodder
+            game.state.getBattlefield(game.player1Id).contains(fodder).shouldBeFalse()
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Tap
+        // -----------------------------------------------------------------------------------------
+
+        test("Tap: paying taps the chosen untapped permanent; tapped ones aren't eligible") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .withCardOnBattlefield(1, "Savannah Lions") // untapped fodder
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
+            val cost = PayCost.Tap(GameObjectFilter.Any, 1)
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
+            val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, listOf(fodder)))
+
+            game.state.getEntity(fodder)!!.has<TappedComponent>().shouldBeTrue()
+        }
+
+        test("Tap: unaffordable when the only other permanent is already tapped") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .withCardOnBattlefield(1, "Savannah Lions", tapped = true)
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            service.canAfford(game.state, game.player1Id, PayCost.Tap(GameObjectFilter.Any, 1), source).shouldBeFalse()
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Choice (recursion: an option that itself needs input)
+        // -----------------------------------------------------------------------------------------
+
+        test("Choice: picking a sub-cost recurses into it and pays it") {
+            val game = scenario().withPlayers().withLifeTotal(1, 10)
+                .withCardInHand(1, "Forest")
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val card = game.state.getHand(game.player1Id).first()
+            val cost = PayCost.Choice(listOf(PayCost.PayLife(3), PayCost.Discard(GameObjectFilter.Any, 1)))
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
+
+            // Pick option index 1 (discard) → recurse into the discard selection.
+            val choice = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
+            game.state = choice.state
+            game.submitDecision(OptionChosenResponse(choice.pendingDecision.id, 1))
+            // The recursion left a fresh card-selection decision pending.
+            game.state.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            game.submitDecision(CardsSelectedResponse(game.state.pendingDecision!!.id, listOf(card)))
+
+            game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain card
+            game.state.getEntity(game.player1Id)!!.get<LifeTotalComponent>()!!.life shouldBe 10 // life path untouched
+        }
+
+        test("Choice: the trailing 'Don't pay' option declines and runs onDeclined") {
+            val game = scenario().withPlayers().withLifeTotal(1, 10)
+                .withCardInHand(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val cost = PayCost.Choice(listOf(PayCost.PayLife(3), PayCost.Discard(GameObjectFilter.Any, 1)))
+
+            val pending = service.pay(
+                game.state, game.player1Id, cost, source,
+                CostPaymentContext(onDeclined = Effects.DrawCards(1))
+            ) as PaymentResult.Pending
+            game.state = pending.state
+            // Two affordable options + the trailing "Don't pay" at index 2.
+            game.submitDecision(OptionChosenResponse(pending.pendingDecision.id, 2))
+
+            game.state.getEntity(game.player1Id)!!.get<LifeTotalComponent>()!!.life shouldBe 10
+            game.state.getHand(game.player1Id).size shouldBe 2 // original Forest + drawn card
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Follow-up effects
+        // -----------------------------------------------------------------------------------------
+
+        test("onPaid runs after a successful payment") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .withCardOnBattlefield(1, "Savannah Lions")
+                .withCardInLibrary(1, "Forest")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
+
+            val pending = service.pay(
+                game.state, game.player1Id, PayCost.Sacrifice(GameObjectFilter.Any, 1), source,
+                CostPaymentContext(onPaid = Effects.DrawCards(1))
+            ) as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, listOf(fodder)))
+
+            game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain fodder
+            game.state.getHand(game.player1Id).size shouldBe 1 // onPaid drew a card
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Serialization — the continuation must round-trip (it rides GameState across a pause).
+        // -----------------------------------------------------------------------------------------
+
+        test("CostPaymentContinuation round-trips through the engine serializers module") {
+            val json = kotlinx.serialization.json.Json {
+                serializersModule = com.wingedsheep.engine.core.engineSerializersModule
+                encodeDefaults = true
+            }
+            val original: com.wingedsheep.engine.core.ContinuationFrame =
+                com.wingedsheep.engine.core.CostPaymentContinuation(
+                    decisionId = "d1",
+                    payerId = EntityId.of("player-1"),
+                    sourceId = EntityId.of("src"),
+                    sourceName = "Goblin Guide",
+                    cost = PayCost.Choice(listOf(PayCost.PayLife(3), PayCost.Discard(GameObjectFilter.Any, 1))),
+                    onPaid = Effects.DrawCards(1),
+                    onDeclined = Effects.GainLife(2)
+                )
+            val encoded = json.encodeToString(com.wingedsheep.engine.core.ContinuationFrame.serializer(), original)
+            val decoded = json.decodeFromString(com.wingedsheep.engine.core.ContinuationFrame.serializer(), encoded)
+            decoded shouldBe original
+        }
+    }
+}


### PR DESCRIPTION
## What

Phase 1 (PR 1) of the **PayCost-payment unification** scoping doc (`backlog/paycost-payment-unification.md`, Option C): a single engine **`CostPaymentService`** that owns affordability and payment for all **ten** `PayCost` variants, plus the one `CostPaymentContinuation` + resumer that drives them.

Today five consumers (morph turn-face-up, `PayOrSufferExecutor`, `AnyPlayerMayPayExecutor`, `ChainCopyExecutor`, and the face-up legal-action enumerator) each carry their own `when (cost: PayCost)` switch, each covering a *different, incomplete* subset of the variants — so a cost that works as a morph cost can silently fail as a punisher cost and vice-versa. This PR builds the one place that executes every variant. **No consumer is migrated yet** (that's PRs 2–4), so this is purely additive with no behavior change — the gate is the per-variant unit tests.

## API

- **`canAfford(state, payer, cost, source): Boolean`** — pure, allocation-light affordability pre-check (CR 118.3), safe for the legal-action hot path.
- **`pay(state, payer, cost, source, ctx): PaymentResult`** — returns `Unaffordable` synchronously, or `Pending` with a `CostPaymentContinuation` pushed; pauses with the *right* decision per variant (battlefield targeting for sacrifice/return/tap, card-selection for discard/exile/reveal, yes/no for mana/life, option-pick for `Choice`). Terminal `Paid`/`Declined` are realized on resume.
- **`PaymentResult`** = `Paid` / `Declined` / `Unaffordable` / `Pending`.
- **`CostPaymentContext`** = serializable `onPaid` / `onDeclined` follow-up effects + target/collection context threaded into them.

## Files

| File | Role |
|---|---|
| `rules-engine/.../mechanics/cost/CostPaymentService.kt` | `canAfford` + `pay` + per-variant payment mutations |
| `rules-engine/.../mechanics/cost/PaymentResult.kt` | result sealed type |
| `rules-engine/.../mechanics/cost/CostPaymentContext.kt` | follow-up + context |
| `rules-engine/.../core/CostPaymentContinuations.kt` | one continuation for all ten variants |
| `rules-engine/.../handlers/continuations/CostPaymentContinuationResumer.kt` | resume: interpret response → pay → onPaid/onDeclined → `checkForMore` |
| `ContinuationHandler.kt`, `Serialization.kt` | register resumer + polymorphic frame |
| `rules-engine/.../scenarios/CostPaymentServiceTest.kt` | 21 tests |

## Tests

`CostPaymentServiceTest` (21 tests, all green): `canAfford` true/false and `pay`→paid/declined for every variant; `OwnManaCost` resolution to the source's printed cost; `Choice` recursion (a chosen sub-cost that itself prompts); `onPaid`/`onDeclined` follow-ups firing; and a `CostPaymentContinuation` serialization round-trip. Full `:rules-engine:test` suite passes; `:game-server` compiles.

## Notes for the migration PRs (2–4)

- **`PayLife` affordability uses CR 119.4 (`life >= amount`)** — slightly more permissive than `PayOrSufferExecutor`'s old `life > amount`. The punisher migration should keep the yes/no prompt that lets the player decline a lethal payment.
- **Effect-shaped follow-ups** ride the continuation as `onPaid`/`onDeclined` (serves PayOrSuffer's *suffer*, AnyPlayerMayPay's *consequence*, and the eventual gated-frame fold). **Morph & chain-copy**, whose follow-up is engine logic, push their own frame *beneath* the payment continuation and resume via the resumer's `checkForMore`.
- **`pay()` is single-payer** — AnyPlayerMayPay's APNAP loop stays in that consumer, calling `canAfford`/`pay` per player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)