### PR TITLE
Migrate non-mana morph payment onto the shared CostPaymentService (PayCost unification PR 2)

### DIFF
--- a/backlog/paycost-payment-unification.md
+++ b/backlog/paycost-payment-unification.md
@@ -1,6 +1,7 @@
 # Scoping: unifying `PayCost` payment (the "`PayCost → Effect`" question)
 
-**Status:** design scoping, not yet scheduled. **Owner:** TBD. **Related:**
+**Status:** Option C in progress — PR 1 (`CostPaymentService` + continuation) and **PR 2 (migrate
+Morph)** landed. **Owner:** TBD. **Related:**
 [`gated-effect-migration-handoff-remaining.md`](gated-effect-migration-handoff-remaining.md)
 (this doc closes out the open question its §5 #4 left — "should `PayOrSufferEffect` fold onto the
 gated frame via a `PayCost → Effect` adapter?").
@@ -204,7 +205,15 @@ cost/effect category error.
    yet (service unused → no behavior change to verify against).
 2. **PR 2 — migrate Morph** (`TurnFaceUpHandler` + `TurnFaceUpEnumerator`) onto the service. Biggest
    single dedup; unlocks Choice/Tap/OwnManaCost morph costs. Existing morph scenario tests are the
-   safety net; add tests for the newly-enabled variants.
+   safety net; add tests for the newly-enabled variants. — **DONE.** Non-mana morph costs delegate to
+   `CostPaymentService.pay(onPaid = TurnFaceUpEffect(Self))`; completion rides on `onPaid`, so a
+   declined/unaffordable cost simply leaves the creature face down. `canAfford` was lifted to a
+   `CostPaymentService` companion (parameterized by `ManaSolver`) so the enumerator shares the one
+   affordability impl. **Mana morph payment deliberately stays in the handler** — the service's yes/no
+   mana path doesn't model morph's explicit mana-source selection / X / auto-tap preview, so migrating
+   it would be a UX + capability regression. The per-variant payment switch, the `validate()` target
+   checks, the `find*Targets` helpers, and the enumerator's per-variant affordability all collapsed;
+   also fixed a CR 119.4 bug (pay-life morph was offered below the required life).
 3. **PR 3 — migrate `PayOrSufferExecutor`** onto the service (gains ReturnToHand/RevealCard).
 4. **PR 4 — migrate `AnyPlayerMayPayExecutor` + `ChainCopyExecutor`** onto the service (each gains all
    variants).

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -212,6 +212,12 @@ unless you Y") and by `morphCost` (non-mana face-up cost). Distinct from `Abilit
 which model an ability's activation cost; `PayCost` models a single cost the engine prompts the
 player to pay against an alternative consequence.
 
+Non-mana `morphCost` payment is routed through the shared engine `CostPaymentService`, so **every
+`PayCost` variant below works as a morph cost** (including `Tap` / `Choice` / `OwnManaCost`): turning
+the creature face up pauses for the cost-specific decision and only flips once the cost is paid.
+(Mana morph costs keep their own up-front payment — explicit mana-source selection, X, auto-tap
+preview — in the turn-face-up handler.)
+
 - `PayCost.Mana(ManaCost)` — pay mana (auto-taps lands via the solver). "...unless you pay {U}{U}"
   (Vaporous Djinn).
 - `PayCost.OwnManaCost` — pay the mana cost of the permanent the cost applies to (its *own* mana
@@ -219,8 +225,8 @@ player to pay against an alternative consequence.
   Essence Leak ("...sacrifice this permanent unless you pay its mana cost"), where the affected
   permanent — not a fixed cost — owns the mana cost. The engine resolves it into a concrete
   `PayCost.Mana` against that permanent before prompting.
-- `PayCost.PayLife(amount)` — pay N life; offered only when the player has more than N life.
-  "...unless you pay 3 life."
+- `PayCost.PayLife(amount)` — pay N life; offered only when the player's life total is at least N
+  (CR 119.4). "...unless you pay 3 life."
 - `PayCost.Discard(filter = Any, count = 1, random = false)` — discard cards matching `filter`.
   Random variant prompts a yes/no and the engine picks the discards (Pillaging Horde).
 - `PayCost.Sacrifice(filter = Any, count = 1)` — sacrifice permanents you control matching

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -1,11 +1,7 @@
 package com.wingedsheep.engine.handlers.actions.morph
 
-import com.wingedsheep.engine.core.CardsDiscardedEvent
-import com.wingedsheep.engine.core.CardsRevealedEvent
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
-import com.wingedsheep.engine.core.LifeChangeReason
-import com.wingedsheep.engine.core.LifeChangedEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.core.TappedEvent
@@ -14,29 +10,28 @@ import com.wingedsheep.engine.core.TurnFaceUpEvent
 import com.wingedsheep.engine.event.TriggerDetector
 import com.wingedsheep.engine.event.TriggerProcessor
 import com.wingedsheep.engine.handlers.CostHandler
-import com.wingedsheep.engine.handlers.PredicateContext
-import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.handlers.actions.ActionHandler
-import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+import com.wingedsheep.engine.mechanics.cost.CostPaymentContext
+import com.wingedsheep.engine.mechanics.cost.CostPaymentService
+import com.wingedsheep.engine.mechanics.cost.PaymentResult
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.core.Color
-import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.effects.TurnFaceUpEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import kotlin.reflect.KClass
 
 /**
@@ -56,11 +51,10 @@ class TurnFaceUpHandler(
     private val triggerProcessor: TriggerProcessor,
     private val effectExecutorRegistry: com.wingedsheep.engine.handlers.effects.EffectExecutorRegistry,
     private val manaAbilitySideEffectExecutor: com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor,
+    private val costPaymentService: CostPaymentService,
     private val staticAbilityHandler: StaticAbilityHandler = StaticAbilityHandler(cardRegistry)
 ) : ActionHandler<TurnFaceUp> {
     override val actionType: KClass<TurnFaceUp> = TurnFaceUp::class
-
-    private val predicateEvaluator = PredicateEvaluator()
 
     override fun validate(state: GameState, action: TurnFaceUp): String? {
         if (state.priorityPlayerId != action.playerId) {
@@ -86,12 +80,15 @@ class TurnFaceUpHandler(
         val morphData = container.get<MorphDataComponent>()
             ?: return "This creature cannot be turned face up (no morph cost)"
 
-        // Validate cost payment based on morph cost type
-        // Apply morph cost increases from permanents like Exiled Doomsayer
+        // Validate cost payment based on morph cost type.
+        // Apply morph cost increases from permanents like Exiled Doomsayer.
         val morphCostIncrease = costCalculator.calculateMorphCostIncrease(state)
-        when (morphData.morphCost) {
+        when (val morphCost = morphData.morphCost) {
             is PayCost.Mana -> {
-                val manaCost = costCalculator.increaseGenericCost(morphData.morphCost.cost, morphCostIncrease)
+                // Mana morph payment stays in this handler: it carries the rich up-front UX
+                // (explicit mana-source selection, X, auto-tap preview) that the shared
+                // CostPaymentService's yes/no mana path deliberately doesn't model.
+                val manaCost = costCalculator.increaseGenericCost(morphCost.cost, morphCostIncrease)
                 val xValue = action.xValue ?: 0
                 when (action.paymentStrategy) {
                     is PaymentStrategy.AutoPay -> {
@@ -136,88 +133,15 @@ class TurnFaceUpHandler(
                     }
                 }
             }
-            is PayCost.PayLife -> {
-                val lifeTotal = state.getEntity(action.playerId)
-                    ?.get<LifeTotalComponent>()?.life ?: 0
-                if (lifeTotal < 1) {
-                    return "You don't have enough life to turn this creature face up"
-                }
-                // Note: paying life doesn't require a minimum — you can pay life
-                // even if it would reduce you to 0 or below (you lose as SBA)
-            }
-            is PayCost.ReturnToHand -> {
-                val validTargets = findReturnToHandTargets(state, action.playerId, morphData.morphCost, action.sourceId)
-                if (validTargets.size < morphData.morphCost.count) {
-                    return "Not enough permanents to return to pay morph cost"
-                }
-                if (action.costTargetIds.size != morphData.morphCost.count) {
-                    return "Must return exactly ${morphData.morphCost.count} permanent(s) to pay morph cost"
-                }
-                for (targetId in action.costTargetIds) {
-                    if (targetId !in validTargets) {
-                        return "Invalid target for return-to-hand morph cost: $targetId"
-                    }
+            // Every other morph cost (life, sacrifice, discard, reveal, exile, return, tap,
+            // own-mana-cost, choice) is paid through CostPaymentService at resolution. The only
+            // pre-check the action needs is affordability (CR 118.3) — the cost-specific selection
+            // happens afterward as a decision pause, so there are no costTargetIds to validate.
+            else -> {
+                if (!costPaymentService.canAfford(state, action.playerId, morphCost, action.sourceId)) {
+                    return "Cannot pay the morph cost to turn this creature face up"
                 }
             }
-            is PayCost.Sacrifice -> {
-                val validTargets = findSacrificeTargets(state, action.playerId, morphData.morphCost, action.sourceId)
-                if (validTargets.size < morphData.morphCost.count) {
-                    return "Not enough permanents to sacrifice to pay morph cost"
-                }
-                if (action.costTargetIds.size != morphData.morphCost.count) {
-                    return "Must sacrifice exactly ${morphData.morphCost.count} permanent(s) to pay morph cost"
-                }
-                for (targetId in action.costTargetIds) {
-                    if (targetId !in validTargets) {
-                        return "Invalid target for sacrifice morph cost: $targetId"
-                    }
-                }
-            }
-            is PayCost.Discard -> {
-                val validTargets = findDiscardTargets(state, action.playerId, morphData.morphCost)
-                if (validTargets.size < morphData.morphCost.count) {
-                    return "Not enough cards in hand matching the discard requirement"
-                }
-                if (action.costTargetIds.size != morphData.morphCost.count) {
-                    return "Must discard exactly ${morphData.morphCost.count} card(s) to pay morph cost"
-                }
-                for (targetId in action.costTargetIds) {
-                    if (targetId !in validTargets) {
-                        return "Invalid target for discard morph cost: $targetId"
-                    }
-                }
-            }
-            is PayCost.RevealCard -> {
-                val validTargets = findRevealTargets(state, action.playerId, morphData.morphCost)
-                if (validTargets.size < morphData.morphCost.count) {
-                    return "Not enough cards in hand matching the reveal requirement"
-                }
-                if (action.costTargetIds.size != morphData.morphCost.count) {
-                    return "Must reveal exactly ${morphData.morphCost.count} card(s) to pay morph cost"
-                }
-                for (targetId in action.costTargetIds) {
-                    if (targetId !in validTargets) {
-                        return "Invalid target for reveal morph cost: $targetId"
-                    }
-                }
-            }
-            is PayCost.Exile -> {
-                val validTargets = findExileTargets(state, action.playerId, morphData.morphCost)
-                if (validTargets.size < morphData.morphCost.count) {
-                    return "Not enough cards in ${morphData.morphCost.zone.name.lowercase()} matching the exile requirement"
-                }
-                if (action.costTargetIds.size != morphData.morphCost.count) {
-                    return "Must exile exactly ${morphData.morphCost.count} card(s) to pay morph cost"
-                }
-                for (targetId in action.costTargetIds) {
-                    if (targetId !in validTargets) {
-                        return "Invalid target for exile morph cost: $targetId"
-                    }
-                }
-            }
-            is PayCost.Choice -> return "Choice morph costs are not supported"
-            is PayCost.Tap -> return "Tap morph costs are not supported"
-            is PayCost.OwnManaCost -> return "Own-mana-cost morph costs are not supported"
         }
 
         return null
@@ -240,20 +164,9 @@ class TurnFaceUpHandler(
         // Pay the morph cost (including any morph cost increases)
         val morphCostIncrease = costCalculator.calculateMorphCostIncrease(currentState)
         val xValue = action.xValue ?: 0
-        when (morphData.morphCost) {
-            is PayCost.PayLife -> {
-                val lifeCost = morphData.morphCost.amount
-                val currentLife = currentState.getEntity(action.playerId)
-                    ?.get<LifeTotalComponent>()?.life ?: 0
-                val newLife = currentLife - lifeCost
-                currentState = currentState.updateEntity(action.playerId) { c ->
-                    c.with(LifeTotalComponent(newLife))
-                }
-                events.add(LifeChangedEvent(action.playerId, currentLife, newLife, LifeChangeReason.LIFE_LOSS))
-                currentState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(currentState, action.playerId)
-            }
+        when (val morphCost = morphData.morphCost) {
             is PayCost.Mana -> {
-                val manaCost = costCalculator.increaseGenericCost(morphData.morphCost.cost, morphCostIncrease)
+                val manaCost = costCalculator.increaseGenericCost(morphCost.cost, morphCostIncrease)
                 when (action.paymentStrategy) {
                     is PaymentStrategy.FromPool -> {
                         val poolComponent = currentState.getEntity(action.playerId)?.get<ManaPoolComponent>()
@@ -413,67 +326,37 @@ class TurnFaceUpHandler(
                     }
                 }
             }
-            is PayCost.ReturnToHand -> {
-                for (targetId in action.costTargetIds) {
-                    val result = ZoneMovementUtils.movePermanentToZone(currentState, targetId, Zone.HAND)
-                    if (result.error != null) {
-                        return ExecutionResult.error(currentState, result.error)
-                    }
-                    currentState = result.newState
-                    events.addAll(result.events)
+            // Every non-mana morph cost (life, sacrifice, discard, reveal, exile, return, tap,
+            // own-mana-cost, choice) is handed to the shared CostPaymentService. It pauses for the
+            // cost-specific decision — battlefield targeting for sacrifice/return/tap, card
+            // selection for discard/reveal/exile, yes/no for life — and on payment runs `onPaid`,
+            // which flips the creature face up (plus any megamorph faceUpEffect). The resulting
+            // TurnFaceUpEvent is picked up by SubmitDecisionHandler, which fires the "when turned
+            // face up" triggers and restores priority. A decline runs nothing, leaving the creature
+            // face down — equivalent to never having taken the action.
+            else -> {
+                val flip: com.wingedsheep.sdk.scripting.effects.Effect =
+                    morphData.faceUpEffect
+                        ?.let { Effects.Composite(TurnFaceUpEffect(EffectTarget.Self), it) }
+                        ?: TurnFaceUpEffect(EffectTarget.Self)
+                return when (
+                    val result = costPaymentService.pay(
+                        currentState,
+                        action.playerId,
+                        morphCost,
+                        action.sourceId,
+                        CostPaymentContext(onPaid = flip)
+                    )
+                ) {
+                    is PaymentResult.Pending ->
+                        ExecutionResult.paused(result.state, result.pendingDecision, events + result.events)
+                    is PaymentResult.Unaffordable ->
+                        ExecutionResult.error(currentState, "Cannot pay the morph cost to turn this creature face up")
+                    // Selection / yes-no payments never settle synchronously — they always pause first.
+                    else ->
+                        ExecutionResult.error(currentState, "Unexpected synchronous morph payment result")
                 }
             }
-            is PayCost.Sacrifice -> {
-                for (targetId in action.costTargetIds) {
-                    val result = ZoneMovementUtils.movePermanentToZone(currentState, targetId, Zone.GRAVEYARD)
-                    if (result.error != null) {
-                        return ExecutionResult.error(currentState, result.error)
-                    }
-                    currentState = result.newState
-                    events.addAll(result.events)
-                }
-            }
-            is PayCost.Discard -> {
-                val discardedIds = mutableListOf<EntityId>()
-                val discardedNames = mutableListOf<String>()
-                for (targetId in action.costTargetIds) {
-                    val targetCard = currentState.getEntity(targetId)?.get<CardComponent>()
-                    discardedNames.add(targetCard?.name ?: "Unknown")
-                    discardedIds.add(targetId)
-                    val result = ZoneMovementUtils.moveCardToZone(currentState, targetId, Zone.GRAVEYARD)
-                    if (result.error != null) {
-                        return ExecutionResult.error(currentState, result.error)
-                    }
-                    currentState = result.newState
-                    events.addAll(result.events)
-                }
-                events.add(0, CardsDiscardedEvent(action.playerId, discardedIds, discardedNames))
-            }
-            is PayCost.RevealCard -> {
-                // Reveal the card(s) — they stay in hand
-                val revealedIds = mutableListOf<EntityId>()
-                val revealedNames = mutableListOf<String>()
-                for (targetId in action.costTargetIds) {
-                    val targetCard = currentState.getEntity(targetId)?.get<CardComponent>()
-                    revealedNames.add(targetCard?.name ?: "Unknown")
-                    revealedIds.add(targetId)
-                }
-                events.add(CardsRevealedEvent(action.playerId, revealedIds, revealedNames, source = "Morph cost"))
-            }
-            is PayCost.Exile -> {
-                val sourceZone = morphData.morphCost.zone
-                for (targetId in action.costTargetIds) {
-                    val result = ZoneMovementUtils.moveCardToZone(currentState, targetId, Zone.EXILE)
-                    if (result.error != null) {
-                        return ExecutionResult.error(currentState, result.error)
-                    }
-                    currentState = result.newState
-                    events.addAll(result.events)
-                }
-            }
-            is PayCost.Choice -> return ExecutionResult.error(currentState, "Choice morph costs are not supported")
-            is PayCost.Tap -> return ExecutionResult.error(currentState, "Tap morph costs are not supported")
-            is PayCost.OwnManaCost -> return ExecutionResult.error(currentState, "Own-mana-cost morph costs are not supported")
         }
 
         // Turn the creature face up and add static ability components
@@ -533,108 +416,6 @@ class TurnFaceUpHandler(
         return ExecutionResult.success(currentState.withPriority(action.playerId), events)
     }
 
-    /**
-     * Find valid permanents on the battlefield that can be returned to hand to pay a morph cost.
-     * Uses projected state to account for type-changing effects (e.g., Artificial Evolution).
-     *
-     * @param excludeEntityId The face-down creature being turned up (cannot return itself)
-     */
-    fun findReturnToHandTargets(
-        state: GameState,
-        playerId: EntityId,
-        cost: PayCost.ReturnToHand,
-        excludeEntityId: EntityId
-    ): List<EntityId> {
-        val projected = state.projectedState
-        val predicateContext = PredicateContext(controllerId = playerId)
-
-        return projected.getBattlefieldControlledBy(playerId).filter { entityId ->
-            if (entityId == excludeEntityId) return@filter false
-            val container = state.getEntity(entityId) ?: return@filter false
-            container.get<CardComponent>() ?: return@filter false
-
-            predicateEvaluator.matches(state, projected, entityId, cost.filter, predicateContext)
-        }
-    }
-
-    /**
-     * Find valid permanents on the battlefield that can be sacrificed to pay a morph cost.
-     * Uses projected state to account for type-changing effects.
-     *
-     * @param excludeEntityId The face-down creature being turned up (cannot sacrifice itself)
-     */
-    fun findSacrificeTargets(
-        state: GameState,
-        playerId: EntityId,
-        cost: PayCost.Sacrifice,
-        excludeEntityId: EntityId
-    ): List<EntityId> {
-        val projected = state.projectedState
-        val predicateContext = PredicateContext(controllerId = playerId)
-
-        return projected.getBattlefieldControlledBy(playerId).filter { entityId ->
-            if (entityId == excludeEntityId) return@filter false
-            val container = state.getEntity(entityId) ?: return@filter false
-            container.get<CardComponent>() ?: return@filter false
-
-            predicateEvaluator.matches(state, projected, entityId, cost.filter, predicateContext)
-        }
-    }
-
-    /**
-     * Find valid cards in hand that can be discarded to pay a morph cost.
-     * Hand cards use base state (not projected) per convention for non-battlefield zones.
-     */
-    fun findDiscardTargets(
-        state: GameState,
-        playerId: EntityId,
-        cost: PayCost.Discard
-    ): List<EntityId> {
-        val handZone = ZoneKey(playerId, Zone.HAND)
-        val hand = state.getZone(handZone)
-        val predicateContext = PredicateContext(controllerId = playerId)
-
-        return hand.filter { cardId ->
-            predicateEvaluator.matches(state, state.projectedState, cardId, cost.filter, predicateContext)
-        }
-    }
-
-    /**
-     * Find valid cards in hand that can be revealed to pay a morph cost.
-     * Hand cards use base state (not projected) per convention for non-battlefield zones.
-     */
-    fun findRevealTargets(
-        state: GameState,
-        playerId: EntityId,
-        cost: PayCost.RevealCard
-    ): List<EntityId> {
-        val handZone = ZoneKey(playerId, Zone.HAND)
-        val hand = state.getZone(handZone)
-        val predicateContext = PredicateContext(controllerId = playerId)
-
-        return hand.filter { cardId ->
-            predicateEvaluator.matches(state, state.projectedState, cardId, cost.filter, predicateContext)
-        }
-    }
-
-    /**
-     * Find valid cards in a zone that can be exiled to pay a morph cost.
-     * Non-battlefield zones use base state per convention.
-     */
-    fun findExileTargets(
-        state: GameState,
-        playerId: EntityId,
-        cost: PayCost.Exile
-    ): List<EntityId> {
-        val zoneKey = ZoneKey(playerId, cost.zone)
-        val cards = state.getZone(zoneKey)
-        val predicateContext = PredicateContext(controllerId = playerId)
-
-        return cards.filter { cardId ->
-            predicateEvaluator.matches(state, state.projectedState, cardId, cost.filter, predicateContext)
-        }
-    }
-
     companion object {
         fun create(services: EngineServices): TurnFaceUpHandler {
             return TurnFaceUpHandler(
@@ -645,7 +426,8 @@ class TurnFaceUpHandler(
                 services.triggerDetector,
                 services.triggerProcessor,
                 services.effectExecutorRegistry,
-                services.manaAbilitySideEffectExecutor
+                services.manaAbilitySideEffectExecutor,
+                CostPaymentService(services)
             )
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
@@ -2,9 +2,9 @@ package com.wingedsheep.engine.legalactions.enumerators
 
 import com.wingedsheep.engine.core.TurnFaceUp
 import com.wingedsheep.engine.legalactions.ActionEnumerator
-import com.wingedsheep.engine.legalactions.AdditionalCostData
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.mechanics.cost.CostPaymentService
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
@@ -16,8 +16,10 @@ import com.wingedsheep.sdk.scripting.costs.PayCost
  * Turning a creature face up is a special action that doesn't use the stack
  * and can be done any time the player has priority (CR 702.37e).
  *
- * Handles morph costs: Mana (including X), PayLife, ReturnToHand, Sacrifice,
- * Discard, RevealCard, and Exile.
+ * Mana morph costs keep their rich enumeration here (X selection + auto-tap preview). Every other
+ * morph cost is gated by a single [CostPaymentService.canAfford] check; the cost-specific selection
+ * is then driven by [CostPaymentService] as a decision pause when the action is taken, rather than
+ * pre-selected via [AdditionalCostData][com.wingedsheep.engine.legalactions.AdditionalCostData].
  */
 class TurnFaceUpEnumerator : ActionEnumerator {
 
@@ -73,115 +75,22 @@ class TurnFaceUpEnumerator : ActionEnumerator {
                         )
                     }
                 }
-                is PayCost.PayLife -> {
-                    // Life-payment morph is always available (paying life that kills you is legal)
-                    result.add(
-                        LegalAction(
-                            actionType = "ActivateAbility",
-                            description = "Turn face-up (${cost.description})",
-                            action = TurnFaceUp(playerId, entityId)
-                        )
-                    )
-                }
-                is PayCost.ReturnToHand -> {
-                    val validTargets = context.costUtils.findReturnToHandTargets(state, playerId, cost.filter, entityId)
-                    if (validTargets.size >= cost.count) {
+                // Every non-mana morph cost is paid through CostPaymentService at resolution, so the
+                // legal action only needs an affordability gate here — the cost-specific selection
+                // happens afterward as a decision pause (handled by the standard decision flow), not
+                // via AdditionalCostData pre-selection. One canAfford check replaces the former
+                // per-variant target-finding branches and unlocks the variants the morph handler used
+                // to reject (Tap / Choice / OwnManaCost).
+                else -> {
+                    if (CostPaymentService.canAfford(state, playerId, cost, entityId, context.manaSolver)) {
                         result.add(
                             LegalAction(
                                 actionType = "ActivateAbility",
                                 description = "Turn face-up (${cost.description})",
-                                action = TurnFaceUp(playerId, entityId),
-                                additionalCostInfo = AdditionalCostData(
-                                    description = cost.description,
-                                    costType = "BouncePermanent",
-                                    validSacrificeTargets = validTargets,
-                                    sacrificeCount = cost.count
-                                )
+                                action = TurnFaceUp(playerId, entityId)
                             )
                         )
                     }
-                }
-                is PayCost.Sacrifice -> {
-                    val validTargets = context.costUtils.findMorphSacrificeTargets(state, playerId, cost.filter, entityId)
-                    if (validTargets.size >= cost.count) {
-                        result.add(
-                            LegalAction(
-                                actionType = "ActivateAbility",
-                                description = "Turn face-up (${cost.description})",
-                                action = TurnFaceUp(playerId, entityId),
-                                additionalCostInfo = AdditionalCostData(
-                                    description = cost.description,
-                                    costType = "SacrificePermanent",
-                                    validSacrificeTargets = validTargets,
-                                    sacrificeCount = cost.count
-                                )
-                            )
-                        )
-                    }
-                }
-                is PayCost.Discard -> {
-                    val validTargets = context.costUtils.findMorphDiscardTargets(state, playerId, cost.filter)
-                    if (validTargets.size >= cost.count) {
-                        result.add(
-                            LegalAction(
-                                actionType = "ActivateAbility",
-                                description = "Turn face-up (${cost.description})",
-                                action = TurnFaceUp(playerId, entityId),
-                                additionalCostInfo = AdditionalCostData(
-                                    description = cost.description,
-                                    costType = "DiscardCard",
-                                    validDiscardTargets = validTargets,
-                                    discardCount = cost.count
-                                )
-                            )
-                        )
-                    }
-                }
-                is PayCost.RevealCard -> {
-                    val validTargets = context.costUtils.findMorphRevealTargets(state, playerId, cost.filter)
-                    if (validTargets.size >= cost.count) {
-                        result.add(
-                            LegalAction(
-                                actionType = "ActivateAbility",
-                                description = "Turn face-up (${cost.description})",
-                                action = TurnFaceUp(playerId, entityId),
-                                additionalCostInfo = AdditionalCostData(
-                                    description = cost.description,
-                                    costType = "RevealCard",
-                                    validDiscardTargets = validTargets,
-                                    discardCount = cost.count
-                                )
-                            )
-                        )
-                    }
-                }
-                is PayCost.Exile -> {
-                    val validTargets = context.costUtils.findMorphExileTargets(state, playerId, cost.filter, cost.zone)
-                    if (validTargets.size >= cost.count) {
-                        result.add(
-                            LegalAction(
-                                actionType = "ActivateAbility",
-                                description = "Turn face-up (${cost.description})",
-                                action = TurnFaceUp(playerId, entityId),
-                                additionalCostInfo = AdditionalCostData(
-                                    description = cost.description,
-                                    costType = "ExileFromZone",
-                                    validExileTargets = validTargets,
-                                    exileMinCount = cost.count,
-                                    exileMaxCount = cost.count
-                                )
-                            )
-                        )
-                    }
-                }
-                is PayCost.Choice -> {
-                    // Choice morph costs not supported
-                }
-                is PayCost.Tap -> {
-                    // Tap morph costs not supported
-                }
-                is PayCost.OwnManaCost -> {
-                    // Own-mana-cost morph costs not supported
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.mechanics.mana.ManaPool
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
@@ -70,24 +71,13 @@ class CostPaymentService(private val services: EngineServices) {
     /**
      * Whether [payerId] can pay [cost]. For battlefield selection costs the [sourceId] is excluded
      * from the candidate pool (you can't sacrifice/return/tap the very permanent whose cost this is).
+     *
+     * Delegates to the [companion][Companion] form so legal-action enumerators
+     * (e.g. `TurnFaceUpEnumerator`) can call affordability directly with just a [ManaSolver] —
+     * one implementation, shared between the payment service and the hot enumeration path.
      */
-    fun canAfford(state: GameState, payerId: EntityId, cost: PayCost, sourceId: EntityId): Boolean {
-        return when (val c = resolve(state, cost, sourceId)) {
-            is PayCost.Mana -> services.manaSolver.canPay(state, payerId, c.cost)
-            // Only unresolvable own-mana-costs reach here (missing source/card component) — unpayable.
-            is PayCost.OwnManaCost -> false
-            // CR 119.4 — a player may pay life only if their life total is at least the amount; paying
-            // life that would reduce them to 0 or less is legal (they then lose as a state-based action).
-            is PayCost.PayLife -> life(state, payerId) >= c.amount
-            is PayCost.Discard -> cardsInHand(state, payerId, c.filter).size >= c.count
-            is PayCost.Exile -> cardsInZone(state, payerId, c.filter, c.zone).size >= c.count
-            is PayCost.RevealCard -> cardsInHand(state, payerId, c.filter).size >= c.count
-            is PayCost.Sacrifice -> controlledMatching(state, payerId, c.filter, sourceId).size >= c.count
-            is PayCost.ReturnToHand -> controlledMatching(state, payerId, c.filter, sourceId).size >= c.count
-            is PayCost.Tap -> controlledUntapped(state, payerId, c.filter, sourceId).size >= c.count
-            is PayCost.Choice -> c.options.any { canAfford(state, payerId, it, sourceId) }
-        }
-    }
+    fun canAfford(state: GameState, payerId: EntityId, cost: PayCost, sourceId: EntityId): Boolean =
+        canAfford(state, payerId, cost, sourceId, services.manaSolver)
 
     // ---------------------------------------------------------------------------------------------
     // Pay — build the right prompt and push a single continuation.
@@ -440,50 +430,6 @@ class CostPaymentService(private val services: EngineServices) {
     // Shared helpers
     // ---------------------------------------------------------------------------------------------
 
-    /**
-     * Lowers [PayCost.OwnManaCost] to a concrete [PayCost.Mana] against the source's printed cost so
-     * every other code path sees a uniform shape. A source with no mana cost (a land, a token) has an
-     * empty [ManaCost] — which is `{0}` and trivially payable. Returns the cost unchanged if the
-     * source/card component is missing (unresolvable → reported unaffordable).
-     */
-    private fun resolve(state: GameState, cost: PayCost, sourceId: EntityId): PayCost {
-        if (cost !is PayCost.OwnManaCost) return cost
-        val manaCost = state.getEntity(sourceId)?.get<CardComponent>()?.manaCost ?: return cost
-        return PayCost.Mana(manaCost)
-    }
-
-    private fun life(state: GameState, playerId: EntityId): Int =
-        state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
-
-    private fun cardsInHand(state: GameState, playerId: EntityId, filter: GameObjectFilter): List<EntityId> {
-        val context = PredicateContext(controllerId = playerId)
-        return state.getZone(playerId, Zone.HAND).filter {
-            predicateEvaluator.matches(state, state.projectedState, it, filter, context)
-        }
-    }
-
-    private fun cardsInZone(state: GameState, playerId: EntityId, filter: GameObjectFilter, zone: Zone): List<EntityId> {
-        if (zone == Zone.BATTLEFIELD) {
-            return BattlefieldFilterUtils.findMatchingOnBattlefield(
-                state, filter.youControl(), PredicateContext(controllerId = playerId)
-            )
-        }
-        val context = PredicateContext(controllerId = playerId)
-        return state.getZone(playerId, zone).filter {
-            predicateEvaluator.matches(state, state.projectedState, it, filter, context)
-        }
-    }
-
-    private fun controlledMatching(state: GameState, playerId: EntityId, filter: GameObjectFilter, sourceId: EntityId): List<EntityId> =
-        BattlefieldFilterUtils.findMatchingOnBattlefield(
-            state, filter.youControl(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
-        )
-
-    private fun controlledUntapped(state: GameState, playerId: EntityId, filter: GameObjectFilter, sourceId: EntityId): List<EntityId> =
-        BattlefieldFilterUtils.findMatchingOnBattlefield(
-            state, filter.youControl().untapped(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
-        )
-
     /** How many entities a selection cost requires; 0 for non-selection costs. */
     fun requiredCount(cost: PayCost): Int = when (cost) {
         is PayCost.Discard -> cost.count
@@ -493,6 +439,82 @@ class CostPaymentService(private val services: EngineServices) {
         is PayCost.ReturnToHand -> cost.count
         is PayCost.Tap -> cost.count
         else -> 0
+    }
+
+    /**
+     * Affordability + the pure cost-candidate reads live here so the one implementation is shared by
+     * both the payment service (instance [pay]/[canAfford]) and legal-action enumeration, which has a
+     * [ManaSolver] but not a full [EngineServices]. Everything here is pure and allocation-light
+     * enough for the enumeration hot path — it never mutates or prompts.
+     */
+    companion object {
+        private val predicateEvaluator = PredicateEvaluator()
+
+        /**
+         * Whether [payerId] can pay [cost]; see the instance [canAfford]. Takes a bare [ManaSolver]
+         * so legal-action enumerators can gate the action without constructing the full service.
+         */
+        fun canAfford(state: GameState, payerId: EntityId, cost: PayCost, sourceId: EntityId, manaSolver: ManaSolver): Boolean {
+            return when (val c = resolve(state, cost, sourceId)) {
+                is PayCost.Mana -> manaSolver.canPay(state, payerId, c.cost)
+                // Only unresolvable own-mana-costs reach here (missing source/card component) — unpayable.
+                is PayCost.OwnManaCost -> false
+                // CR 119.4 — a player may pay life only if their life total is at least the amount; paying
+                // life that would reduce them to 0 or less is legal (they then lose as a state-based action).
+                is PayCost.PayLife -> life(state, payerId) >= c.amount
+                is PayCost.Discard -> cardsInHand(state, payerId, c.filter).size >= c.count
+                is PayCost.Exile -> cardsInZone(state, payerId, c.filter, c.zone).size >= c.count
+                is PayCost.RevealCard -> cardsInHand(state, payerId, c.filter).size >= c.count
+                is PayCost.Sacrifice -> controlledMatching(state, payerId, c.filter, sourceId).size >= c.count
+                is PayCost.ReturnToHand -> controlledMatching(state, payerId, c.filter, sourceId).size >= c.count
+                is PayCost.Tap -> controlledUntapped(state, payerId, c.filter, sourceId).size >= c.count
+                is PayCost.Choice -> c.options.any { canAfford(state, payerId, it, sourceId, manaSolver) }
+            }
+        }
+
+        /**
+         * Lowers [PayCost.OwnManaCost] to a concrete [PayCost.Mana] against the source's printed cost so
+         * every other code path sees a uniform shape. A source with no mana cost (a land, a token) has an
+         * empty [ManaCost] — which is `{0}` and trivially payable. Returns the cost unchanged if the
+         * source/card component is missing (unresolvable → reported unaffordable).
+         */
+        fun resolve(state: GameState, cost: PayCost, sourceId: EntityId): PayCost {
+            if (cost !is PayCost.OwnManaCost) return cost
+            val manaCost = state.getEntity(sourceId)?.get<CardComponent>()?.manaCost ?: return cost
+            return PayCost.Mana(manaCost)
+        }
+
+        private fun life(state: GameState, playerId: EntityId): Int =
+            state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+
+        fun cardsInHand(state: GameState, playerId: EntityId, filter: GameObjectFilter): List<EntityId> {
+            val context = PredicateContext(controllerId = playerId)
+            return state.getZone(playerId, Zone.HAND).filter {
+                predicateEvaluator.matches(state, state.projectedState, it, filter, context)
+            }
+        }
+
+        fun cardsInZone(state: GameState, playerId: EntityId, filter: GameObjectFilter, zone: Zone): List<EntityId> {
+            if (zone == Zone.BATTLEFIELD) {
+                return BattlefieldFilterUtils.findMatchingOnBattlefield(
+                    state, filter.youControl(), PredicateContext(controllerId = playerId)
+                )
+            }
+            val context = PredicateContext(controllerId = playerId)
+            return state.getZone(playerId, zone).filter {
+                predicateEvaluator.matches(state, state.projectedState, it, filter, context)
+            }
+        }
+
+        fun controlledMatching(state: GameState, playerId: EntityId, filter: GameObjectFilter, sourceId: EntityId): List<EntityId> =
+            BattlefieldFilterUtils.findMatchingOnBattlefield(
+                state, filter.youControl(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
+            )
+
+        fun controlledUntapped(state: GameState, playerId: EntityId, filter: GameObjectFilter, sourceId: EntityId): List<EntityId> =
+            BattlefieldFilterUtils.findMatchingOnBattlefield(
+                state, filter.youControl().untapped(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
+            )
     }
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MorphCostPaymentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MorphCostPaymentTest.kt
@@ -1,0 +1,191 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.scg.cards.PutridRaptor
+import com.wingedsheep.mtg.sets.definitions.scg.cards.RavenGuildInitiate
+import com.wingedsheep.mtg.sets.definitions.scg.cards.SkirkVolcanist
+import com.wingedsheep.mtg.sets.definitions.scg.cards.ZombieCutthroat
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for the non-mana morph costs, which turn the creature face up through the shared
+ * [CostPaymentService][com.wingedsheep.engine.mechanics.cost.CostPaymentService] (phase 2 of the
+ * PayCost-payment unification — see `backlog/paycost-payment-unification.md`).
+ *
+ * Each non-mana morph cost now pauses for the cost-specific decision (yes/no for life, card
+ * selection for discard, battlefield targeting for sacrifice / return / tap) and only flips the
+ * creature face up once the cost is actually paid. Declining or being unable to pay leaves the
+ * creature face down. This also unlocks the [PayCost.Tap] / [PayCost.Choice] / [PayCost.OwnManaCost]
+ * morph costs the old hand-rolled switch rejected.
+ */
+class MorphCostPaymentTest : FunSpec({
+
+    // A creature with a (newly supported) Tap morph cost — "Morph—Tap an untapped land you control."
+    val tapMorphTester = card("Tap Morph Tester") {
+        manaCost = "{2}"
+        typeLine = "Creature — Wizard"
+        power = 2
+        toughness = 2
+        morphCost = PayCost.Tap(GameObjectFilter.Land, count = 1)
+    }
+
+    // A plain Bird for Raven Guild Initiate's "return a Bird" cost to target.
+    val testBird = card("Test Falcon") {
+        manaCost = "{1}{U}"
+        typeLine = "Creature — Bird"
+        power = 1
+        toughness = 1
+    }
+
+    val allCards = TestCards.all + listOf(
+        SkirkVolcanist, PutridRaptor, RavenGuildInitiate, ZombieCutthroat, tapMorphTester, testBird
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    fun GameTestDriver.putFaceDownCreature(playerId: EntityId, cardName: String): EntityId {
+        val creatureId = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = allCards.first { it.name == cardName }
+        val morphAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Morph>().firstOrNull()
+        replaceState(state.updateEntity(creatureId) { container ->
+            var c = container.with(FaceDownComponent)
+            if (morphAbility != null) {
+                c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+            }
+            c
+        })
+        removeSummoningSickness(creatureId)
+        return creatureId
+    }
+
+    fun GameTestDriver.beginTurn(): EntityId {
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return activePlayer!!
+    }
+
+    test("pay life turns the creature face up and loses the life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.beginTurn()
+
+        val cutthroat = driver.putFaceDownCreature(player, "Zombie Cutthroat")
+
+        // The pay-life morph cost now prompts before the flip.
+        driver.submit(TurnFaceUp(playerId = player, sourceId = cutthroat)).error shouldBe null
+        driver.state.getEntity(cutthroat)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+
+        driver.submitYesNo(player, true)
+
+        driver.state.getEntity(cutthroat)?.get<FaceDownComponent>() shouldBe null
+        driver.assertLifeTotal(player, 15)
+    }
+
+    test("declining the life payment leaves the creature face down") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.beginTurn()
+
+        val cutthroat = driver.putFaceDownCreature(player, "Zombie Cutthroat")
+
+        driver.submit(TurnFaceUp(playerId = player, sourceId = cutthroat))
+        driver.submitYesNo(player, false)
+
+        driver.state.getEntity(cutthroat)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        driver.assertLifeTotal(player, 20)
+    }
+
+    test("cannot turn face up when life is below the morph cost (CR 119.4)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.beginTurn()
+
+        val cutthroat = driver.putFaceDownCreature(player, "Zombie Cutthroat")
+        driver.setLifeTotal(player, 4) // less than the 5-life morph cost
+
+        driver.submit(TurnFaceUp(playerId = player, sourceId = cutthroat)).isSuccess shouldBe false
+        driver.state.getEntity(cutthroat)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+    }
+
+    test("discard a Zombie card to turn face up") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.beginTurn()
+
+        val raptor = driver.putFaceDownCreature(player, "Putrid Raptor")
+        val zombieInHand = driver.putCardInHand(player, "Putrid Raptor") // a Zombie card
+
+        driver.submit(TurnFaceUp(playerId = player, sourceId = raptor)).error shouldBe null
+        driver.submitCardSelection(player, listOf(zombieInHand))
+
+        driver.state.getEntity(raptor)?.get<FaceDownComponent>() shouldBe null
+        driver.getGraveyard(player).contains(zombieInHand) shouldBe true
+        driver.getHand(player).contains(zombieInHand) shouldBe false
+    }
+
+    test("return a Bird you control to turn face up") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val player = driver.beginTurn()
+
+        val initiate = driver.putFaceDownCreature(player, "Raven Guild Initiate")
+        val bird = driver.putCreatureOnBattlefield(player, "Test Falcon")
+
+        driver.submit(TurnFaceUp(playerId = player, sourceId = initiate)).error shouldBe null
+        driver.submitCardSelection(player, listOf(bird))
+
+        driver.state.getEntity(initiate)?.get<FaceDownComponent>() shouldBe null
+        driver.getHand(player).contains(bird) shouldBe true
+    }
+
+    test("sacrifice two Mountains to turn face up") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.beginTurn()
+
+        val volcanist = driver.putFaceDownCreature(player, "Skirk Volcanist")
+        val m1 = driver.putLandOnBattlefield(player, "Mountain")
+        val m2 = driver.putLandOnBattlefield(player, "Mountain")
+
+        driver.submit(TurnFaceUp(playerId = player, sourceId = volcanist)).error shouldBe null
+        // Battlefield targeting for the two Mountains; the flip happens before the
+        // "when turned face up" damage trigger goes on the stack.
+        driver.submitCardSelection(player, listOf(m1, m2))
+
+        driver.state.getEntity(volcanist)?.get<FaceDownComponent>() shouldBe null
+        driver.getGraveyard(player).contains(m1) shouldBe true
+        driver.getGraveyard(player).contains(m2) shouldBe true
+    }
+
+    test("tap a permanent to turn face up — newly unlocked Tap morph cost") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.beginTurn()
+
+        val tester = driver.putFaceDownCreature(player, "Tap Morph Tester")
+        val land = driver.putLandOnBattlefield(player, "Forest")
+
+        driver.submit(TurnFaceUp(playerId = player, sourceId = tester)).error shouldBe null
+        driver.submitCardSelection(player, listOf(land))
+
+        driver.state.getEntity(tester)?.get<FaceDownComponent>() shouldBe null
+        driver.state.getEntity(land)?.get<TappedComponent>() shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuthlessRipperTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuthlessRipperTest.kt
@@ -68,17 +68,15 @@ class RuthlessRipperTest : FunSpec({
         // Put a second Ruthless Ripper in hand (it's black, so it can be revealed)
         val blackCardInHand = driver.putCardInHand(activePlayer, "Ruthless Ripper")
 
-        // Turn face up, revealing the black card
-        val result = driver.submit(
-            TurnFaceUp(
-                playerId = activePlayer,
-                sourceId = ripper,
-                costTargetIds = listOf(blackCardInHand)
-            )
-        )
-        // The result may be paused for the triggered ability's target selection
-        // isPaused is expected here — the triggered ability fires and needs a target
+        // Turn face up. The reveal morph cost is now paid through CostPaymentService, so the
+        // action pauses for a card-selection decision (which black card to reveal) before the flip.
+        val result = driver.submit(TurnFaceUp(playerId = activePlayer, sourceId = ripper))
         (result.error == null) shouldBe true
+        // Still face-down until the cost is paid.
+        driver.state.getEntity(ripper)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+
+        // Pay the cost by revealing the black card.
+        driver.submitCardSelection(activePlayer, listOf(blackCardInHand))
 
         // The card should now be face up
         driver.state.getEntity(ripper)?.get<FaceDownComponent>() shouldBe null


### PR DESCRIPTION
Phase 2 of [`backlog/paycost-payment-unification.md`](backlog/paycost-payment-unification.md) (Option C). Routes **non-mana** morph turn-face-up payment through the shared `CostPaymentService` (built in PR #496) instead of `TurnFaceUpHandler`'s own incomplete per-variant `when (PayCost)` switch.

## What changed

- **`TurnFaceUpHandler`** — keeps the **mana** path in the handler (explicit mana-source selection, X, auto-tap preview — UX the service's yes/no mana path deliberately doesn't model) and delegates **every other variant** to `CostPaymentService.pay(..., onPaid = TurnFaceUpEffect(Self))`. Completion rides on `onPaid`, so a **declined or unaffordable** cost simply leaves the creature face down. The emitted `TurnFaceUpEvent` is picked up by `SubmitDecisionHandler`, which fires the "when turned face up" triggers and restores priority — same as the synchronous mana path.
- **`TurnFaceUpEnumerator`** — collapses its per-variant target-finding into one `CostPaymentService.canAfford` gate (mana keeps its rich X / auto-tap branch). Selection now happens via the standard decision pause, so the morph legal action no longer carries `AdditionalCostData` pre-selection.
- **`CostPaymentService`** — `canAfford` + the pure cost-candidate reads were lifted to a `companion` (parameterized by `ManaSolver`) so the enumerator shares the one affordability impl without coupling to `EngineServices`.

## Why this shape

- A literal full migration of **mana** morph payment to the service would regress real UX (explicit source choice, X morph, auto-tap preview baked into the legal action) and capability — so mana stays in the handler. Every other variant is a clean win.
- **Unlocks `Tap` / `Choice` / `OwnManaCost` morph costs**, which the old hand-rolled switch rejected with runtime "not supported" errors.
- Removes the duplicated payment switch, the `validate()` target checks, and the `find*Targets` helpers (net **−452 / +178** lines of behavior code excluding tests).

## Bug fix

Pay-life morph (Zombie Cutthroat) was offered when the player's life was *below* the cost. Affordability now correctly requires `life >= amount` (CR 119.4, verified against the Comprehensive Rules).

## UX

Non-mana morph costs now surface as standard server decisions handled by existing decision components: yes/no for life, card-selection for discard/reveal, on-battlefield targeting for sacrifice/return/tap (`useTargetingUI`). No client changes needed; the bare `TurnFaceUp` action submits and the engine drives the selection. All 5 morph e2e cards are mana morphs (unchanged path).

## Tests

- Updated `RuthlessRipperTest` — the reveal morph cost is now a decision pause; its "turned face up → target player loses 2 life" trigger still fires end to end.
- New `MorphCostPaymentTest` — pay-life (+ decline + insufficient-life/CR 119.4), discard a Zombie, return a Bird, sacrifice two Mountains, and the newly-unlocked **Tap** morph cost.
- Full `:rules-engine` and `:game-server` suites green; mana morph tests (Dermoplasm, Aerie Bowmasters, Rattleclaw Mystic, Sagu Mauler, Jeering Instigator, ExplicitManaPaymentColor) unchanged and passing.

Closes the PR-2 line item in the scoping doc. PRs 3–4 (PayOrSuffer, AnyPlayerMayPay + ChainCopy) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)