### PR TITLE
Fix dropped oracle text: emit oracleText from mtgish emitter

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/AlabasterDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/AlabasterDragon.kt
@@ -26,6 +26,7 @@ val AlabasterDragon = card("Alabaster Dragon") {
     manaCost = "{4}{W}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Dragon"
+    oracleText = "Flying\nWhen this creature dies, shuffle it into its owner's library."
     power = 4
     toughness = 4
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/AlluringScent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/AlluringScent.kt
@@ -21,6 +21,7 @@ val AlluringScent = card("Alluring Scent") {
     manaCost = "{1}{G}{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "All creatures able to block target creature this turn do so."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature))
         effect = MustBeBlockedEffect(t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Anaconda.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Anaconda.kt
@@ -20,6 +20,7 @@ val Anaconda = card("Anaconda") {
     manaCost = "{3}{G}"
     colorIdentity = "G"
     typeLine = "Creature — Snake"
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
     power = 3
     toughness = 3
     keywords(Keyword.SWAMPWALK)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/AngelicBlessing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/AngelicBlessing.kt
@@ -22,6 +22,7 @@ val AngelicBlessing = card("Angelic Blessing") {
     manaCost = "{2}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "Target creature gets +3/+3 and gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)"
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature))
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ArdentMilitia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ArdentMilitia.kt
@@ -20,6 +20,7 @@ val ArdentMilitia = card("Ardent Militia") {
     manaCost = "{4}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Human Soldier"
+    oracleText = "Vigilance"
     power = 2
     toughness = 5
     keywords(Keyword.VIGILANCE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ArmoredPegasus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ArmoredPegasus.kt
@@ -20,6 +20,7 @@ val ArmoredPegasus = card("Armored Pegasus") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Pegasus"
+    oracleText = "Flying"
     power = 1
     toughness = 2
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ArrogantVampire.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ArrogantVampire.kt
@@ -20,6 +20,7 @@ val ArrogantVampire = card("Arrogant Vampire") {
     manaCost = "{3}{B}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Vampire"
+    oracleText = "Flying"
     power = 4
     toughness = 3
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/AssassinsBlade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/AssassinsBlade.kt
@@ -26,6 +26,7 @@ val AssassinsBlade = card("Assassin's Blade") {
     manaCost = "{1}{B}"
     colorIdentity = "B"
     typeLine = "Instant"
+    oracleText = "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nDestroy target nonblack attacking creature."
     spell {
         castOnlyDuring(Step.DECLARE_ATTACKERS)
         castOnlyIf(YouWereAttackedThisStep)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BalanceOfPower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BalanceOfPower.kt
@@ -21,6 +21,7 @@ val BalanceOfPower = card("Balance of Power") {
     manaCost = "{3}{U}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "If target opponent has more cards in hand than you, draw cards equal to the difference."
     spell {
         target = TargetOpponent()
         effect = DrawCardsEffect(DynamicAmounts.handSizeDifferenceFromTargetOpponent())

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BalefulStare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BalefulStare.kt
@@ -28,6 +28,7 @@ val BalefulStare = card("Baleful Stare") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You draw a card for each Mountain and red card in it."
     spell {
         val t = target("target", TargetOpponent())
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BeeSting.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BeeSting.kt
@@ -20,6 +20,7 @@ val BeeSting = card("Bee Sting") {
     manaCost = "{3}{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "Bee Sting deals 2 damage to any target."
     spell {
         val t = target("target", AnyTarget())
         effect = DealDamageEffect(2, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Blaze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Blaze.kt
@@ -21,6 +21,7 @@ val Blaze = card("Blaze") {
     manaCost = "{X}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Blaze deals X damage to any target."
     spell {
         val t = target("target", AnyTarget())
         effect = DealDamageEffect(DynamicAmount.XValue, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BlessedReversal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BlessedReversal.kt
@@ -22,6 +22,7 @@ val BlessedReversal = card("Blessed Reversal") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Instant"
+    oracleText = "You gain 3 life for each creature attacking you."
     spell {
         effect = GainLifeEffect(
             DynamicAmount.Multiply(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BogRaiders.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BogRaiders.kt
@@ -20,6 +20,7 @@ val BogRaiders = card("Bog Raiders") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Zombie"
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
     power = 2
     toughness = 2
     keywords(Keyword.SWAMPWALK)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BoilingSeas.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BoilingSeas.kt
@@ -24,6 +24,7 @@ val BoilingSeas = card("Boiling Seas") {
     manaCost = "{3}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Destroy all Islands."
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.Land.withSubtype(Subtype.ISLAND)),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BreathOfLife.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BreathOfLife.kt
@@ -22,6 +22,7 @@ val BreathOfLife = card("Breath of Life") {
     manaCost = "{3}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to the battlefield."
     spell {
         val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
         effect = Effects.Move(t, Zone.BATTLEFIELD)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BullHippo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BullHippo.kt
@@ -20,6 +20,7 @@ val BullHippo = card("Bull Hippo") {
     manaCost = "{3}{G}"
     colorIdentity = "G"
     typeLine = "Creature — Hippo"
+    oracleText = "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)"
     power = 3
     toughness = 3
     keywords(Keyword.ISLANDWALK)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BurningCloak.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/BurningCloak.kt
@@ -22,6 +22,7 @@ val BurningCloak = card("Burning Cloak") {
     manaCost = "{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Target creature gets +2/+0 until end of turn. Burning Cloak deals 2 damage to that creature."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature))
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CapriciousSorcerer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CapriciousSorcerer.kt
@@ -24,6 +24,7 @@ val CapriciousSorcerer = card("Capricious Sorcerer") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Human Wizard Sorcerer"
+    oracleText = "{T}: This creature deals 1 damage to any target. Activate only during your turn, before attackers are declared."
     power = 1
     toughness = 1
     activatedAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ChargingBandits.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ChargingBandits.kt
@@ -22,6 +22,7 @@ val ChargingBandits = card("Charging Bandits") {
     manaCost = "{4}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Human Rogue"
+    oracleText = "Whenever this creature attacks, it gets +2/+0 until end of turn."
     power = 3
     toughness = 3
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ChargingPaladin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ChargingPaladin.kt
@@ -22,6 +22,7 @@ val ChargingPaladin = card("Charging Paladin") {
     manaCost = "{2}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Human Knight"
+    oracleText = "Whenever this creature attacks, it gets +0/+3 until end of turn."
     power = 2
     toughness = 2
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ChargingRhino.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ChargingRhino.kt
@@ -20,6 +20,7 @@ val ChargingRhino = card("Charging Rhino") {
     manaCost = "{3}{G}{G}"
     colorIdentity = "G"
     typeLine = "Creature — Rhino"
+    oracleText = "This creature can't be blocked by more than one creature."
     power = 4
     toughness = 4
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CloakOfFeathers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CloakOfFeathers.kt
@@ -24,6 +24,7 @@ val CloakOfFeathers = card("Cloak of Feathers") {
     manaCost = "{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Target creature gains flying until end of turn.\nDraw a card."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature))
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CloudDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CloudDragon.kt
@@ -23,6 +23,7 @@ val CloudDragon = card("Cloud Dragon") {
     manaCost = "{5}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Illusion Dragon"
+    oracleText = "Flying\nThis creature can block only creatures with flying."
     power = 5
     toughness = 4
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CloudPirates.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CloudPirates.kt
@@ -23,6 +23,7 @@ val CloudPirates = card("Cloud Pirates") {
     manaCost = "{U}"
     colorIdentity = "U"
     typeLine = "Creature — Human Pirate"
+    oracleText = "Flying\nThis creature can block only creatures with flying."
     power = 1
     toughness = 1
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CloudSpirit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CloudSpirit.kt
@@ -23,6 +23,7 @@ val CloudSpirit = card("Cloud Spirit") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Spirit"
+    oracleText = "Flying\nThis creature can block only creatures with flying."
     power = 3
     toughness = 1
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CommandOfUnsummoning.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CommandOfUnsummoning.kt
@@ -27,6 +27,7 @@ val CommandOfUnsummoning = card("Command of Unsummoning") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Instant"
+    oracleText = "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nReturn one or two target attacking creatures to their owner's hand."
     spell {
         castOnlyDuring(Step.DECLARE_ATTACKERS)
         castOnlyIf(YouWereAttackedThisStep)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CravenGiant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CravenGiant.kt
@@ -20,6 +20,7 @@ val CravenGiant = card("Craven Giant") {
     manaCost = "{2}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Giant"
+    oracleText = "This creature can't block."
     power = 4
     toughness = 1
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CravenKnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CravenKnight.kt
@@ -20,6 +20,7 @@ val CravenKnight = card("Craven Knight") {
     manaCost = "{1}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Human Knight"
+    oracleText = "This creature can't block."
     power = 2
     toughness = 2
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CruelBargain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CruelBargain.kt
@@ -24,6 +24,7 @@ val CruelBargain = card("Cruel Bargain") {
     manaCost = "{B}{B}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Draw four cards. You lose half your life, rounded up."
     spell {
         effect = Effects.Composite(
             DrawCardsEffect(4),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CruelFate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CruelFate.kt
@@ -31,6 +31,7 @@ val CruelFate = card("Cruel Fate") {
     manaCost = "{4}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Look at the top five cards of target opponent's library. Put one of those cards into that player's graveyard and the rest on top of their library in any order."
     spell {
         val t = target("target", TargetOpponent())
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CruelTutor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/CruelTutor.kt
@@ -24,6 +24,7 @@ val CruelTutor = card("Cruel Tutor") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Search your library for a card, then shuffle and put that card on top. You lose 2 life."
     spell {
         effect = Effects.Composite(
             Patterns.Library.searchLibrary(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DeepSeaSerpent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DeepSeaSerpent.kt
@@ -21,6 +21,7 @@ val DeepSeaSerpent = card("Deep-Sea Serpent") {
     manaCost = "{4}{U}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Serpent"
+    oracleText = "This creature can't attack unless defending player controls an Island."
     power = 5
     toughness = 5
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DeepWood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DeepWood.kt
@@ -22,6 +22,7 @@ val DeepWood = card("Deep Wood") {
     manaCost = "{1}{G}"
     colorIdentity = "G"
     typeLine = "Instant"
+    oracleText = "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nPrevent all damage that would be dealt to you this turn by attacking creatures."
     spell {
         castOnlyDuring(Step.DECLARE_ATTACKERS)
         castOnlyIf(YouWereAttackedThisStep)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DefiantStand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DefiantStand.kt
@@ -24,6 +24,7 @@ val DefiantStand = card("Defiant Stand") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Instant"
+    oracleText = "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nTarget creature gets +1/+3 until end of turn. Untap that creature."
     spell {
         castOnlyDuring(Step.DECLARE_ATTACKERS)
         castOnlyIf(YouWereAttackedThisStep)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DejaVu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DejaVu.kt
@@ -23,6 +23,7 @@ val DejaVu = card("Déjà Vu") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Return target sorcery card from your graveyard to your hand."
     spell {
         val t = target(
             "target",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DesertDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DesertDrake.kt
@@ -20,6 +20,7 @@ val DesertDrake = card("Desert Drake") {
     manaCost = "{3}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Drake"
+    oracleText = "Flying"
     power = 2
     toughness = 2
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Devastation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Devastation.kt
@@ -23,6 +23,7 @@ val Devastation = card("Devastation") {
     manaCost = "{5}{R}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Destroy all creatures and lands."
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.CreatureOrLand),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DjinnOfTheLamp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DjinnOfTheLamp.kt
@@ -20,6 +20,7 @@ val DjinnOfTheLamp = card("Djinn of the Lamp") {
     manaCost = "{5}{U}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Djinn"
+    oracleText = "Flying"
     power = 5
     toughness = 6
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DreadCharge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DreadCharge.kt
@@ -22,6 +22,7 @@ val DreadCharge = card("Dread Charge") {
     manaCost = "{3}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Black creatures you control can't be blocked this turn except by black creatures."
     spell {
         effect = GrantCantBeBlockedExceptByColorEffect(
             filter = GroupFilter(GameObjectFilter.Creature.withColor(Color.BLACK).youControl()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DreadReaper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DreadReaper.kt
@@ -24,6 +24,7 @@ val DreadReaper = card("Dread Reaper") {
     manaCost = "{3}{B}{B}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Horror"
+    oracleText = "Flying\nWhen this creature enters, you lose 5 life."
     power = 6
     toughness = 5
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/EbonDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/EbonDragon.kt
@@ -24,6 +24,7 @@ val EbonDragon = card("Ebon Dragon") {
     manaCost = "{5}{B}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Dragon"
+    oracleText = "Flying\nWhen this creature enters, you may have target opponent discard a card."
     power = 5
     toughness = 4
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/EliteCatWarrior.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/EliteCatWarrior.kt
@@ -20,6 +20,7 @@ val EliteCatWarrior = card("Elite Cat Warrior") {
     manaCost = "{2}{G}"
     colorIdentity = "G"
     typeLine = "Creature — Cat Warrior"
+    oracleText = "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)"
     power = 2
     toughness = 3
     keywords(Keyword.FORESTWALK)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/EndlessCockroaches.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/EndlessCockroaches.kt
@@ -23,6 +23,7 @@ val EndlessCockroaches = card("Endless Cockroaches") {
     manaCost = "{1}{B}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Insect"
+    oracleText = "When this creature dies, return it to its owner's hand."
     power = 1
     toughness = 1
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Exhaustion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Exhaustion.kt
@@ -20,6 +20,7 @@ val Exhaustion = card("Exhaustion") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Creatures and lands target opponent controls don't untap during their next untap step."
     spell {
         val t = target("target", TargetOpponent())
         effect = SkipUntapEffect(t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FalsePeace.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FalsePeace.kt
@@ -20,6 +20,7 @@ val FalsePeace = card("False Peace") {
     manaCost = "{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "Target player skips all combat phases of their next turn."
     spell {
         val t = target("target", TargetPlayer())
         effect = SkipCombatPhasesEffect(t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FinalStrike.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FinalStrike.kt
@@ -24,6 +24,7 @@ val FinalStrike = card("Final Strike") {
     manaCost = "{2}{B}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\nFinal Strike deals damage to target opponent or planeswalker equal to the sacrificed creature's power."
     additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Creature))
     spell {
         val t = target("target", TargetOpponentOrPlaneswalker())

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FireDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FireDragon.kt
@@ -29,6 +29,7 @@ val FireDragon = card("Fire Dragon") {
     manaCost = "{6}{R}{R}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Dragon"
+    oracleText = "Flying\nWhen this creature enters, it deals damage to target creature equal to the number of Mountains you control."
     power = 6
     toughness = 6
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FireImp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FireImp.kt
@@ -23,6 +23,7 @@ val FireImp = card("Fire Imp") {
     manaCost = "{2}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Imp"
+    oracleText = "When this creature enters, it deals 2 damage to target creature."
     power = 2
     toughness = 1
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FireSnake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FireSnake.kt
@@ -24,6 +24,7 @@ val FireSnake = card("Fire Snake") {
     manaCost = "{4}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Snake"
+    oracleText = "When this creature dies, destroy target land."
     power = 3
     toughness = 1
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FireTempest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FireTempest.kt
@@ -25,6 +25,7 @@ val FireTempest = card("Fire Tempest") {
     manaCost = "{5}{R}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Fire Tempest deals 6 damage to each creature and each player."
     spell {
         effect = Effects.Composite(
             Effects.ForEachInGroup(GroupFilter(GameObjectFilter.Creature), DealDamageEffect(6, EffectTarget.Self)),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FleetFootedMonk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/FleetFootedMonk.kt
@@ -21,6 +21,7 @@ val FleetFootedMonk = card("Fleet-Footed Monk") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Human Monk"
+    oracleText = "This creature can't be blocked by creatures with power 2 or greater."
     power = 1
     toughness = 1
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Flux.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Flux.kt
@@ -20,6 +20,7 @@ val Flux = card("Flux") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Each player discards any number of cards, then draws that many cards.\nDraw a card."
     spell {
         effect = Patterns.Hand.eachPlayerDiscardsDraws(controllerBonusDraw = 1)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ForkedLightning.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ForkedLightning.kt
@@ -20,6 +20,7 @@ val ForkedLightning = card("Forked Lightning") {
     manaCost = "{3}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Forked Lightning deals 4 damage divided as you choose among one, two, or three target creatures."
     spell {
         target = TargetCreature(count = 3, minCount = 1)
         effect = DividedDamageEffect(totalDamage = 4, minTargets = 1, maxTargets = 3)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Fruition.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Fruition.kt
@@ -23,6 +23,7 @@ val Fruition = card("Fruition") {
     manaCost = "{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "You gain 1 life for each Forest on the battlefield."
     spell {
         effect = GainLifeEffect(
             DynamicAmount.AggregateBattlefield(Player.Each, GameObjectFilter.Land.withSubtype(Subtype.FOREST))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/GiftOfEstates.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/GiftOfEstates.kt
@@ -23,6 +23,7 @@ val GiftOfEstates = card("Gift of Estates") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "If an opponent controls more lands than you, search your library for up to three Plains cards, reveal them, put them into your hand, then shuffle."
     spell {
         condition = Conditions.OpponentControlsMoreLands
         effect = Patterns.Library.searchLibrary(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Gravedigger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Gravedigger.kt
@@ -24,6 +24,7 @@ val Gravedigger = card("Gravedigger") {
     manaCost = "{3}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Zombie"
+    oracleText = "When this creature enters, you may return target creature card from your graveyard to your hand."
     power = 2
     toughness = 2
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/HandOfDeath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/HandOfDeath.kt
@@ -23,6 +23,7 @@ val HandOfDeath = card("Hand of Death") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Destroy target nonblack creature."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
         effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/HarshJustice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/HarshJustice.kt
@@ -22,6 +22,7 @@ val HarshJustice = card("Harsh Justice") {
     manaCost = "{2}{W}"
     colorIdentity = "W"
     typeLine = "Instant"
+    oracleText = "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nThis turn, whenever an attacking creature deals combat damage to you, it deals that much damage to its controller."
     spell {
         castOnlyDuring(Step.DECLARE_ATTACKERS)
         castOnlyIf(YouWereAttackedThisStep)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/HowlingFury.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/HowlingFury.kt
@@ -21,6 +21,7 @@ val HowlingFury = card("Howling Fury") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Target creature gets +4/+0 until end of turn."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature))
         effect = Effects.ModifyStats(4, 0, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/HulkingGoblin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/HulkingGoblin.kt
@@ -20,6 +20,7 @@ val HulkingGoblin = card("Hulking Goblin") {
     manaCost = "{1}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Goblin"
+    oracleText = "This creature can't block."
     power = 2
     toughness = 2
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/IngeniousThief.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/IngeniousThief.kt
@@ -24,6 +24,7 @@ val IngeniousThief = card("Ingenious Thief") {
     manaCost = "{1}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Human Rogue"
+    oracleText = "Flying\nWhen this creature enters, look at target player's hand."
     power = 1
     toughness = 1
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/JungleLion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/JungleLion.kt
@@ -20,6 +20,7 @@ val JungleLion = card("Jungle Lion") {
     manaCost = "{G}"
     colorIdentity = "G"
     typeLine = "Creature — Cat"
+    oracleText = "This creature can't block."
     power = 2
     toughness = 1
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/KeenEyedArchers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/KeenEyedArchers.kt
@@ -20,6 +20,7 @@ val KeenEyedArchers = card("Keen-Eyed Archers") {
     manaCost = "{2}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Elf Archer"
+    oracleText = "Reach (This creature can block creatures with flying.)"
     power = 2
     toughness = 2
     keywords(Keyword.REACH)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/KingsAssassin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/KingsAssassin.kt
@@ -26,6 +26,7 @@ val KingsAssassin = card("King's Assassin") {
     manaCost = "{1}{B}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Human Assassin"
+    oracleText = "{T}: Destroy target tapped creature. Activate only during your turn, before attackers are declared."
     power = 1
     toughness = 1
     activatedAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/LastChance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/LastChance.kt
@@ -19,6 +19,7 @@ val LastChance = card("Last Chance") {
     manaCost = "{R}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game."
     spell {
         effect = TakeExtraTurnEffect(loseAtEndStep = true)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/LavaAxe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/LavaAxe.kt
@@ -20,6 +20,7 @@ val LavaAxe = card("Lava Axe") {
     manaCost = "{4}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Lava Axe deals 5 damage to target player or planeswalker."
     spell {
         val t = target("target", TargetPlayerOrPlaneswalker())
         effect = DealDamageEffect(5, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/LavaFlow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/LavaFlow.kt
@@ -22,6 +22,7 @@ val LavaFlow = card("Lava Flow") {
     manaCost = "{3}{R}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Destroy target creature or land."
     spell {
         val t = target("target", TargetPermanent(filter = TargetFilter.CreatureOrLandPermanent))
         effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MercenaryKnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MercenaryKnight.kt
@@ -24,6 +24,7 @@ val MercenaryKnight = card("Mercenary Knight") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Human Mercenary Knight"
+    oracleText = "When this creature enters, sacrifice it unless you discard a creature card."
     power = 4
     toughness = 4
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MindKnives.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MindKnives.kt
@@ -20,6 +20,7 @@ val MindKnives = card("Mind Knives") {
     manaCost = "{1}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Target opponent discards a card at random."
     spell {
         val t = target("target", TargetOpponent())
         effect = Patterns.Hand.discardRandom(1, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MindRot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MindRot.kt
@@ -20,6 +20,7 @@ val MindRot = card("Mind Rot") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Target player discards two cards."
     spell {
         val t = target("target", TargetPlayer())
         effect = Patterns.Hand.discardCards(2, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Mobilize.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Mobilize.kt
@@ -22,6 +22,7 @@ val Mobilize = card("Mobilize") {
     manaCost = "{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "Untap all creatures you control."
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.Creature.youControl()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MonstrousGrowth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MonstrousGrowth.kt
@@ -21,6 +21,7 @@ val MonstrousGrowth = card("Monstrous Growth") {
     manaCost = "{1}{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "Target creature gets +4/+4 until end of turn."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature))
         effect = Effects.ModifyStats(4, 4, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MoonSprite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MoonSprite.kt
@@ -20,6 +20,7 @@ val MoonSprite = card("Moon Sprite") {
     manaCost = "{1}{G}"
     colorIdentity = "G"
     typeLine = "Creature — Faerie"
+    oracleText = "Flying"
     power = 1
     toughness = 1
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MysticDenial.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/MysticDenial.kt
@@ -21,6 +21,7 @@ val MysticDenial = card("Mystic Denial") {
     manaCost = "{1}{U}{U}"
     colorIdentity = "U"
     typeLine = "Instant"
+    oracleText = "Counter target creature or sorcery spell."
     spell {
         val t = target("target", TargetSpell(filter = TargetFilter.CreatureOrSorcerySpellOnStack))
         effect = CounterEffect()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NaturalSpring.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NaturalSpring.kt
@@ -20,6 +20,7 @@ val NaturalSpring = card("Natural Spring") {
     manaCost = "{3}{G}{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "Target player gains 8 life."
     spell {
         val t = target("target", TargetPlayer())
         effect = GainLifeEffect(8, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NaturesCloak.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NaturesCloak.kt
@@ -24,6 +24,7 @@ val NaturesCloak = card("Nature's Cloak") {
     manaCost = "{2}{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "Green creatures you control gain forestwalk until end of turn. (They can't be blocked as long as defending player controls a Forest.)"
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.Creature.withColor(Color.GREEN).youControl()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NaturesRuin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NaturesRuin.kt
@@ -24,6 +24,7 @@ val NaturesRuin = card("Nature's Ruin") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Destroy all green creatures."
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.Creature.withColor(Color.GREEN)),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NeedleStorm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NeedleStorm.kt
@@ -24,6 +24,7 @@ val NeedleStorm = card("Needle Storm") {
     manaCost = "{2}{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "Needle Storm deals 4 damage to each creature with flying."
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.Creature.withKeyword(Keyword.FLYING)),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NoxiousToad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/NoxiousToad.kt
@@ -21,6 +21,7 @@ val NoxiousToad = card("Noxious Toad") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Frog"
+    oracleText = "When this creature dies, each opponent discards a card."
     power = 1
     toughness = 1
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Omen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Omen.kt
@@ -24,6 +24,7 @@ val Omen = card("Omen") {
     manaCost = "{1}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Look at the top three cards of your library, then put them back in any order. You may shuffle.\nDraw a card."
     spell {
         effect = Effects.Composite(
             Patterns.Library.lookAtTopAndReorder(count = 3),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/OwlFamiliar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/OwlFamiliar.kt
@@ -25,6 +25,7 @@ val OwlFamiliar = card("Owl Familiar") {
     manaCost = "{1}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Bird"
+    oracleText = "Flying\nWhen this creature enters, draw a card, then discard a card."
     power = 1
     toughness = 1
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PathOfPeace.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PathOfPeace.kt
@@ -23,6 +23,7 @@ val PathOfPeace = card("Path of Peace") {
     manaCost = "{3}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "Destroy target creature. Its owner gains 4 life."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature))
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PersonalTutor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PersonalTutor.kt
@@ -21,6 +21,7 @@ val PersonalTutor = card("Personal Tutor") {
     manaCost = "{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Search your library for a sorcery card, reveal it, then shuffle and put that card on top."
     spell {
         effect = Patterns.Library.searchLibrary(
             filter = GameObjectFilter.Sorcery,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PhantomWarrior.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PhantomWarrior.kt
@@ -20,6 +20,7 @@ val PhantomWarrior = card("Phantom Warrior") {
     manaCost = "{1}{U}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Illusion Warrior"
+    oracleText = "This creature can't be blocked."
     power = 2
     toughness = 2
     flags(AbilityFlag.CANT_BE_BLOCKED)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PillagingHorde.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PillagingHorde.kt
@@ -23,6 +23,7 @@ val PillagingHorde = card("Pillaging Horde") {
     manaCost = "{2}{R}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Human Barbarian"
+    oracleText = "When this creature enters, sacrifice it unless you discard a card at random."
     power = 5
     toughness = 5
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PlantElemental.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PlantElemental.kt
@@ -25,6 +25,7 @@ val PlantElemental = card("Plant Elemental") {
     manaCost = "{1}{G}"
     colorIdentity = "G"
     typeLine = "Creature — Plant Elemental"
+    oracleText = "When this creature enters, sacrifice it unless you sacrifice a Forest."
     power = 3
     toughness = 4
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PrimevalForce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/PrimevalForce.kt
@@ -25,6 +25,7 @@ val PrimevalForce = card("Primeval Force") {
     manaCost = "{2}{G}{G}{G}"
     colorIdentity = "G"
     typeLine = "Creature — Elemental"
+    oracleText = "When this creature enters, sacrifice it unless you sacrifice three Forests."
     power = 8
     toughness = 8
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RagingCougar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RagingCougar.kt
@@ -20,6 +20,7 @@ val RagingCougar = card("Raging Cougar") {
     manaCost = "{2}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Cat"
+    oracleText = "Haste"
     power = 2
     toughness = 2
     keywords(Keyword.HASTE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RagingGoblin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RagingGoblin.kt
@@ -20,6 +20,7 @@ val RagingGoblin = card("Raging Goblin") {
     manaCost = "{R}"
     colorIdentity = "R"
     typeLine = "Creature — Goblin Berserker"
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)"
     power = 1
     toughness = 1
     keywords(Keyword.HASTE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RagingMinotaur.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RagingMinotaur.kt
@@ -20,6 +20,7 @@ val RagingMinotaur = card("Raging Minotaur") {
     manaCost = "{2}{R}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Minotaur Berserker"
+    oracleText = "Haste"
     power = 3
     toughness = 3
     keywords(Keyword.HASTE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RainOfSalt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RainOfSalt.kt
@@ -24,6 +24,7 @@ val RainOfSalt = card("Rain of Salt") {
     manaCost = "{4}{R}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Destroy two target lands."
     spell {
         val t = target("target", TargetPermanent(count = 2, filter = TargetFilter.Land))
         effect = ForEachTargetEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RainOfTears.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RainOfTears.kt
@@ -22,6 +22,7 @@ val RainOfTears = card("Rain of Tears") {
     manaCost = "{1}{B}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Destroy target land."
     spell {
         val t = target("target", TargetPermanent(filter = TargetFilter.Land))
         effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RenewingDawn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/RenewingDawn.kt
@@ -24,6 +24,7 @@ val RenewingDawn = card("Renewing Dawn") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "You gain 2 life for each Mountain target opponent controls."
     spell {
         val t = target("target", TargetOpponent())
         effect = GainLifeEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SacredKnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SacredKnight.kt
@@ -22,6 +22,7 @@ val SacredKnight = card("Sacred Knight") {
     manaCost = "{3}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Human Knight"
+    oracleText = "This creature can't be blocked by black and/or red creatures."
     power = 3
     toughness = 2
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SacredNectar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SacredNectar.kt
@@ -19,6 +19,7 @@ val SacredNectar = card("Sacred Nectar") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "You gain 4 life."
     spell {
         effect = GainLifeEffect(4)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ScorchingSpear.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ScorchingSpear.kt
@@ -20,6 +20,7 @@ val ScorchingSpear = card("Scorching Spear") {
     manaCost = "{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Scorching Spear deals 1 damage to any target."
     spell {
         val t = target("target", AnyTarget())
         effect = DealDamageEffect(1, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ScorchingWinds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ScorchingWinds.kt
@@ -26,6 +26,7 @@ val ScorchingWinds = card("Scorching Winds") {
     manaCost = "{R}"
     colorIdentity = "R"
     typeLine = "Instant"
+    oracleText = "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nScorching Winds deals 1 damage to each attacking creature."
     spell {
         castOnlyDuring(Step.DECLARE_ATTACKERS)
         castOnlyIf(YouWereAttackedThisStep)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SeasonedMarshal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SeasonedMarshal.kt
@@ -23,6 +23,7 @@ val SeasonedMarshal = card("Seasoned Marshal") {
     manaCost = "{2}{W}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Human Soldier"
+    oracleText = "Whenever this creature attacks, you may tap target creature."
     power = 2
     toughness = 2
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SerpentAssassin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SerpentAssassin.kt
@@ -25,6 +25,7 @@ val SerpentAssassin = card("Serpent Assassin") {
     manaCost = "{3}{B}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Snake Assassin"
+    oracleText = "When this creature enters, you may destroy target nonblack creature."
     power = 2
     toughness = 2
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SerpentWarrior.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SerpentWarrior.kt
@@ -22,6 +22,7 @@ val SerpentWarrior = card("Serpent Warrior") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Snake Warrior"
+    oracleText = "When this creature enters, you lose 3 life."
     power = 3
     toughness = 3
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SnappingDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SnappingDrake.kt
@@ -20,6 +20,7 @@ val SnappingDrake = card("Snapping Drake") {
     manaCost = "{3}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Drake"
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)"
     power = 3
     toughness = 2
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SorcerousSight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SorcerousSight.kt
@@ -23,6 +23,7 @@ val SorcerousSight = card("Sorcerous Sight") {
     manaCost = "{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Look at target opponent's hand.\nDraw a card."
     spell {
         val t = target("target", TargetOpponent())
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SoulShred.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SoulShred.kt
@@ -24,6 +24,7 @@ val SoulShred = card("Soul Shred") {
     manaCost = "{3}{B}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Soul Shred deals 3 damage to target nonblack creature. You gain 3 life."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SpiritualGuardian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SpiritualGuardian.kt
@@ -21,6 +21,7 @@ val SpiritualGuardian = card("Spiritual Guardian") {
     manaCost = "{3}{W}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Spirit"
+    oracleText = "When this creature enters, you gain 4 life."
     power = 3
     toughness = 4
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SpottedGriffin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SpottedGriffin.kt
@@ -20,6 +20,7 @@ val SpottedGriffin = card("Spotted Griffin") {
     manaCost = "{3}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Griffin"
+    oracleText = "Flying"
     power = 2
     toughness = 3
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Starlight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Starlight.kt
@@ -24,6 +24,7 @@ val Starlight = card("Starlight") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "You gain 3 life for each black creature target opponent controls."
     spell {
         val t = target("target", TargetOpponent())
         effect = GainLifeEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/StarlitAngel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/StarlitAngel.kt
@@ -20,6 +20,7 @@ val StarlitAngel = card("Starlit Angel") {
     manaCost = "{3}{W}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Angel"
+    oracleText = "Flying"
     power = 3
     toughness = 4
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Steadfastness.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Steadfastness.kt
@@ -22,6 +22,7 @@ val Steadfastness = card("Steadfastness") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "Creatures you control get +0/+3 until end of turn."
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.Creature.youControl()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SternMarshal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SternMarshal.kt
@@ -25,6 +25,7 @@ val SternMarshal = card("Stern Marshal") {
     manaCost = "{2}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Human Soldier"
+    oracleText = "{T}: Target creature gets +2/+2 until end of turn. Activate only during your turn, before attackers are declared."
     power = 2
     toughness = 2
     activatedAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SylvanTutor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SylvanTutor.kt
@@ -21,6 +21,7 @@ val SylvanTutor = card("Sylvan Tutor") {
     manaCost = "{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "Search your library for a creature card, reveal it, then shuffle and put that card on top."
     spell {
         effect = Patterns.Library.searchLibrary(
             filter = GameObjectFilter.Creature,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SymbolOfUnsummoning.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/SymbolOfUnsummoning.kt
@@ -24,6 +24,7 @@ val SymbolOfUnsummoning = card("Symbol of Unsummoning") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Return target creature to its owner's hand.\nDraw a card."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature))
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Taunt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Taunt.kt
@@ -20,6 +20,7 @@ val Taunt = card("Taunt") {
     manaCost = "{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "During target player's next turn, creatures that player controls attack you if able."
     spell {
         val t = target("target", TargetPlayer())
         effect = TauntEffect(t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TemporaryTruce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TemporaryTruce.kt
@@ -19,6 +19,7 @@ val TemporaryTruce = card("Temporary Truce") {
     manaCost = "{1}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "Each player may draw up to two cards. For each card less than two a player draws this way, that player gains 2 life."
     spell {
         effect = Patterns.Hand.eachPlayerMayDraw(maxCards = 2, lifePerCardNotDrawn = 2)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TheftOfDreams.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TheftOfDreams.kt
@@ -23,6 +23,7 @@ val TheftOfDreams = card("Theft of Dreams") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Draw a card for each tapped creature target opponent controls."
     spell {
         val t = target("target", TargetOpponent())
         effect = DrawCardsEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ThingFromTheDeep.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ThingFromTheDeep.kt
@@ -25,6 +25,7 @@ val ThingFromTheDeep = card("Thing from the Deep") {
     manaCost = "{6}{U}{U}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Leviathan"
+    oracleText = "Whenever this creature attacks, sacrifice it unless you sacrifice an Island."
     power = 9
     toughness = 9
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ThunderingWurm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ThunderingWurm.kt
@@ -24,6 +24,7 @@ val ThunderingWurm = card("Thundering Wurm") {
     manaCost = "{2}{G}"
     colorIdentity = "G"
     typeLine = "Creature — Wurm"
+    oracleText = "When this creature enters, sacrifice it unless you discard a land card."
     power = 4
     toughness = 4
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Thundermare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Thundermare.kt
@@ -26,6 +26,7 @@ val Thundermare = card("Thundermare") {
     manaCost = "{5}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Elemental Horse"
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhen this creature enters, tap all other creatures."
     power = 5
     toughness = 5
     keywords(Keyword.HASTE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TidalSurge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TidalSurge.kt
@@ -22,6 +22,7 @@ val TidalSurge = card("Tidal Surge") {
     manaCost = "{1}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Tap up to three target creatures without flying."
     spell {
         val t = target(
             "target",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TimeEbb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TimeEbb.kt
@@ -23,6 +23,7 @@ val TimeEbb = card("Time Ebb") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Put target creature on top of its owner's library."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature))
         effect = Effects.Move(t, Zone.LIBRARY, ZonePlacement.Top)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TouchOfBrilliance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TouchOfBrilliance.kt
@@ -19,6 +19,7 @@ val TouchOfBrilliance = card("Touch of Brilliance") {
     manaCost = "{3}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Draw two cards."
     spell {
         effect = DrawCardsEffect(2)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TreetopDefense.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/TreetopDefense.kt
@@ -26,6 +26,7 @@ val TreetopDefense = card("Treetop Defense") {
     manaCost = "{1}{G}"
     colorIdentity = "G"
     typeLine = "Instant"
+    oracleText = "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nCreatures you control gain reach until end of turn. (They can block creatures with flying.)"
     spell {
         castOnlyDuring(Step.DECLARE_ATTACKERS)
         castOnlyIf(YouWereAttackedThisStep)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/UndyingBeast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/UndyingBeast.kt
@@ -24,6 +24,7 @@ val UndyingBeast = card("Undying Beast") {
     manaCost = "{3}{B}"
     colorIdentity = "B"
     typeLine = "Creature — Beast"
+    oracleText = "When this creature dies, put it on top of its owner's library."
     power = 3
     toughness = 2
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ValorousCharge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/ValorousCharge.kt
@@ -23,6 +23,7 @@ val ValorousCharge = card("Valorous Charge") {
     manaCost = "{1}{W}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "White creatures get +2/+0 until end of turn."
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.Creature.withColor(Color.WHITE)),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VampiricFeast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VampiricFeast.kt
@@ -22,6 +22,7 @@ val VampiricFeast = card("Vampiric Feast") {
     manaCost = "{5}{B}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Vampiric Feast deals 4 damage to any target and you gain 4 life."
     spell {
         val t = target("target", AnyTarget())
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VampiricTouch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VampiricTouch.kt
@@ -22,6 +22,7 @@ val VampiricTouch = card("Vampiric Touch") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Vampiric Touch deals 2 damage to target opponent or planeswalker and you gain 2 life."
     spell {
         val t = target("target", TargetOpponentOrPlaneswalker())
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VenerableMonk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VenerableMonk.kt
@@ -21,6 +21,7 @@ val VenerableMonk = card("Venerable Monk") {
     manaCost = "{2}{W}"
     colorIdentity = "W"
     typeLine = "Creature — Human Monk Cleric"
+    oracleText = "When this creature enters, you gain 2 life."
     power = 2
     toughness = 2
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Vengeance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/Vengeance.kt
@@ -22,6 +22,7 @@ val Vengeance = card("Vengeance") {
     manaCost = "{3}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "Destroy target tapped creature."
     spell {
         val t = target("target", TargetCreature(filter = TargetFilter.Creature.tapped()))
         effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VirtuesRuin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VirtuesRuin.kt
@@ -24,6 +24,7 @@ val VirtuesRuin = card("Virtue's Ruin") {
     manaCost = "{2}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Destroy all white creatures."
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.Creature.withColor(Color.WHITE)),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VolcanicHammer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/VolcanicHammer.kt
@@ -20,6 +20,7 @@ val VolcanicHammer = card("Volcanic Hammer") {
     manaCost = "{1}{R}"
     colorIdentity = "R"
     typeLine = "Sorcery"
+    oracleText = "Volcanic Hammer deals 3 damage to any target."
     spell {
         val t = target("target", AnyTarget())
         effect = DealDamageEffect(3, t)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WallOfGranite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WallOfGranite.kt
@@ -20,6 +20,7 @@ val WallOfGranite = card("Wall of Granite") {
     manaCost = "{2}{R}"
     colorIdentity = "R"
     typeLine = "Creature — Wall"
+    oracleText = "Defender (This creature can't attack.)"
     power = 0
     toughness = 7
     keywords(Keyword.DEFENDER)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WarriorsCharge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WarriorsCharge.kt
@@ -22,6 +22,7 @@ val WarriorsCharge = card("Warrior's Charge") {
     manaCost = "{2}{W}"
     colorIdentity = "W"
     typeLine = "Sorcery"
+    oracleText = "Creatures you control get +1/+1 until end of turn."
     spell {
         effect = Effects.ForEachInGroup(
             GroupFilter(GameObjectFilter.Creature.youControl()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WickedPact.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WickedPact.kt
@@ -26,6 +26,7 @@ val WickedPact = card("Wicked Pact") {
     manaCost = "{1}{B}{B}"
     colorIdentity = "B"
     typeLine = "Sorcery"
+    oracleText = "Destroy two target nonblack creatures. You lose 5 life."
     spell {
         val t = target("target", TargetCreature(count = 2, filter = TargetFilter.Creature.notColor(Color.BLACK)))
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WillowDryad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WillowDryad.kt
@@ -20,6 +20,7 @@ val WillowDryad = card("Willow Dryad") {
     manaCost = "{G}"
     colorIdentity = "G"
     typeLine = "Creature — Dryad"
+    oracleText = "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)"
     power = 1
     toughness = 1
     keywords(Keyword.FORESTWALK)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WindDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WindDrake.kt
@@ -20,6 +20,7 @@ val WindDrake = card("Wind Drake") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Creature — Drake"
+    oracleText = "Flying"
     power = 2
     toughness = 2
     keywords(Keyword.FLYING)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WintersGrasp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WintersGrasp.kt
@@ -22,6 +22,7 @@ val WintersGrasp = card("Winter's Grasp") {
     manaCost = "{1}{G}{G}"
     colorIdentity = "G"
     typeLine = "Sorcery"
+    oracleText = "Destroy target land."
     spell {
         val t = target("target", TargetPermanent(filter = TargetFilter.Land))
         effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WitheringGaze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WitheringGaze.kt
@@ -28,6 +28,7 @@ val WitheringGaze = card("Withering Gaze") {
     manaCost = "{2}{U}"
     colorIdentity = "U"
     typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You draw a card for each Forest and green card in it."
     spell {
         val t = target("target", TargetOpponent())
         effect = Effects.Composite(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WoodElves.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/WoodElves.kt
@@ -24,6 +24,7 @@ val WoodElves = card("Wood Elves") {
     manaCost = "{2}{G}"
     colorIdentity = "G"
     typeLine = "Creature — Elf Scout"
+    oracleText = "When this creature enters, search your library for a Forest card, put that card onto the battlefield, then shuffle."
     power = 1
     toughness = 1
     triggeredAbility {

--- a/mtg-sets/src/test/resources/snapshots/cards/POR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/POR.json
@@ -3,6 +3,7 @@
     "name": "Alabaster Dragon",
     "manaCost": "{4}{W}{W}",
     "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhen this creature dies, shuffle it into its owner's library.",
     "creatureStats": {
         "power": 4,
         "toughness": 4
@@ -44,6 +45,7 @@
     "name": "Alluring Scent",
     "manaCost": "{1}{G}{G}",
     "typeLine": "Sorcery",
+    "oracleText": "All creatures able to block target creature this turn do so.",
     "script": {
         "spellEffect": {
             "type": "MustBeBlocked",
@@ -79,6 +81,7 @@
     "name": "Anaconda",
     "manaCost": "{3}{G}",
     "typeLine": "Creature — Snake",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
     "creatureStats": {
         "power": 3,
         "toughness": 3
@@ -103,6 +106,7 @@
     "name": "Angelic Blessing",
     "manaCost": "{2}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "Target creature gets +3/+3 and gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -158,6 +162,7 @@
     "name": "Ardent Militia",
     "manaCost": "{4}{W}",
     "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance",
     "creatureStats": {
         "power": 2,
         "toughness": 5
@@ -182,6 +187,7 @@
     "name": "Armored Pegasus",
     "manaCost": "{1}{W}",
     "typeLine": "Creature — Pegasus",
+    "oracleText": "Flying",
     "creatureStats": {
         "power": 1,
         "toughness": 2
@@ -205,6 +211,7 @@
     "name": "Arrogant Vampire",
     "manaCost": "{3}{B}{B}",
     "typeLine": "Creature — Vampire",
+    "oracleText": "Flying",
     "creatureStats": {
         "power": 4,
         "toughness": 3
@@ -229,6 +236,7 @@
     "name": "Assassin's Blade",
     "manaCost": "{1}{B}",
     "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nDestroy target nonblack attacking creature.",
     "script": {
         "spellEffect": {
             "type": "MoveToZone",
@@ -286,6 +294,7 @@
     "name": "Balance of Power",
     "manaCost": "{3}{U}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "If target opponent has more cards in hand than you, draw cards equal to the difference.",
     "script": {
         "spellEffect": {
             "type": "DrawCards",
@@ -326,6 +335,7 @@
     "name": "Baleful Stare",
     "manaCost": "{2}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Target opponent reveals their hand. You draw a card for each Mountain and red card in it.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -393,6 +403,7 @@
     "name": "Bee Sting",
     "manaCost": "{3}{G}",
     "typeLine": "Sorcery",
+    "oracleText": "Bee Sting deals 2 damage to any target.",
     "script": {
         "spellEffect": {
             "type": "DealDamage",
@@ -429,6 +440,7 @@
     "name": "Blaze",
     "manaCost": "{X}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Blaze deals X damage to any target.",
     "script": {
         "spellEffect": {
             "type": "DealDamage",
@@ -462,6 +474,7 @@
     "name": "Blessed Reversal",
     "manaCost": "{1}{W}",
     "typeLine": "Instant",
+    "oracleText": "You gain 3 life for each creature attacking you.",
     "script": {
         "spellEffect": {
             "type": "GainLife",
@@ -492,6 +505,7 @@
     "name": "Bog Raiders",
     "manaCost": "{2}{B}",
     "typeLine": "Creature — Zombie",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -515,6 +529,7 @@
     "name": "Boiling Seas",
     "manaCost": "{3}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy all Islands.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -566,6 +581,7 @@
     "name": "Breath of Life",
     "manaCost": "{3}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to the battlefield.",
     "script": {
         "spellEffect": {
             "type": "MoveToZone",
@@ -601,6 +617,7 @@
     "name": "Bull Hippo",
     "manaCost": "{3}{G}",
     "typeLine": "Creature — Hippo",
+    "oracleText": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)",
     "creatureStats": {
         "power": 3,
         "toughness": 3
@@ -625,6 +642,7 @@
     "name": "Burning Cloak",
     "manaCost": "{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Target creature gets +2/+0 until end of turn. Burning Cloak deals 2 damage to that creature.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -682,6 +700,7 @@
     "name": "Capricious Sorcerer",
     "manaCost": "{2}{U}",
     "typeLine": "Creature — Human Wizard Sorcerer",
+    "oracleText": "{T}: This creature deals 1 damage to any target. Activate only during your turn, before attackers are declared.",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -734,6 +753,7 @@
     "name": "Charging Bandits",
     "manaCost": "{4}{B}",
     "typeLine": "Creature — Human Rogue",
+    "oracleText": "Whenever this creature attacks, it gets +2/+0 until end of turn.",
     "creatureStats": {
         "power": 3,
         "toughness": 3
@@ -775,6 +795,7 @@
     "name": "Charging Paladin",
     "manaCost": "{2}{W}",
     "typeLine": "Creature — Human Knight",
+    "oracleText": "Whenever this creature attacks, it gets +0/+3 until end of turn.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -816,6 +837,7 @@
     "name": "Charging Rhino",
     "manaCost": "{3}{G}{G}",
     "typeLine": "Creature — Rhino",
+    "oracleText": "This creature can't be blocked by more than one creature.",
     "creatureStats": {
         "power": 4,
         "toughness": 4
@@ -845,6 +867,7 @@
     "name": "Cloak of Feathers",
     "manaCost": "{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Target creature gains flying until end of turn.\nDraw a card.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -892,6 +915,7 @@
     "name": "Cloud Dragon",
     "manaCost": "{5}{U}",
     "typeLine": "Creature — Illusion Dragon",
+    "oracleText": "Flying\nThis creature can block only creatures with flying.",
     "creatureStats": {
         "power": 5,
         "toughness": 4
@@ -931,6 +955,7 @@
     "name": "Cloud Pirates",
     "manaCost": "{U}",
     "typeLine": "Creature — Human Pirate",
+    "oracleText": "Flying\nThis creature can block only creatures with flying.",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -969,6 +994,7 @@
     "name": "Cloud Spirit",
     "manaCost": "{2}{U}",
     "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nThis creature can block only creatures with flying.",
     "creatureStats": {
         "power": 3,
         "toughness": 1
@@ -1008,6 +1034,7 @@
     "name": "Command of Unsummoning",
     "manaCost": "{2}{U}",
     "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nReturn one or two target attacking creatures to their owner's hand.",
     "script": {
         "spellEffect": {
             "type": "ForEachTarget",
@@ -1080,6 +1107,7 @@
     "name": "Craven Giant",
     "manaCost": "{2}{R}",
     "typeLine": "Creature — Giant",
+    "oracleText": "This creature can't block.",
     "creatureStats": {
         "power": 4,
         "toughness": 1
@@ -1105,6 +1133,7 @@
     "name": "Craven Knight",
     "manaCost": "{1}{B}",
     "typeLine": "Creature — Human Knight",
+    "oracleText": "This creature can't block.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -1130,6 +1159,7 @@
     "name": "Cruel Bargain",
     "manaCost": "{B}{B}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Draw four cards. You lose half your life, rounded up.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -1175,6 +1205,7 @@
     "name": "Cruel Fate",
     "manaCost": "{4}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Look at the top five cards of target opponent's library. Put one of those cards into that player's graveyard and the rest on top of their library in any order.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -1251,6 +1282,7 @@
     "name": "Cruel Tutor",
     "manaCost": "{2}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -1318,6 +1350,7 @@
     "name": "Deep Wood",
     "manaCost": "{1}{G}",
     "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nPrevent all damage that would be dealt to you this turn by attacking creatures.",
     "script": {
         "spellEffect": {
             "type": "PreventDamageShield",
@@ -1350,6 +1383,7 @@
     "name": "Deep-Sea Serpent",
     "manaCost": "{4}{U}{U}",
     "typeLine": "Creature — Serpent",
+    "oracleText": "This creature can't attack unless defending player controls an Island.",
     "creatureStats": {
         "power": 5,
         "toughness": 5
@@ -1384,6 +1418,7 @@
     "name": "Defiant Stand",
     "manaCost": "{1}{W}",
     "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nTarget creature gets +1/+3 until end of turn. Untap that creature.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -1449,6 +1484,7 @@
     "name": "Desert Drake",
     "manaCost": "{3}{R}",
     "typeLine": "Creature — Drake",
+    "oracleText": "Flying",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -1473,6 +1509,7 @@
     "name": "Devastation",
     "manaCost": "{5}{R}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy all creatures and lands.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -1524,6 +1561,7 @@
     "name": "Djinn of the Lamp",
     "manaCost": "{5}{U}{U}",
     "typeLine": "Creature — Djinn",
+    "oracleText": "Flying",
     "creatureStats": {
         "power": 5,
         "toughness": 6
@@ -1548,6 +1586,7 @@
     "name": "Dread Charge",
     "manaCost": "{3}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Black creatures you control can't be blocked this turn except by black creatures.",
     "script": {
         "spellEffect": {
             "type": "GrantCantBeBlockedExceptByColor",
@@ -1574,6 +1613,7 @@
     "name": "Dread Reaper",
     "manaCost": "{3}{B}{B}{B}",
     "typeLine": "Creature — Horror",
+    "oracleText": "Flying\nWhen this creature enters, you lose 5 life.",
     "creatureStats": {
         "power": 6,
         "toughness": 5
@@ -1616,6 +1656,7 @@
     "name": "Déjà Vu",
     "manaCost": "{2}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Return target sorcery card from your graveyard to your hand.",
     "script": {
         "spellEffect": {
             "type": "MoveToZone",
@@ -1652,6 +1693,7 @@
     "name": "Ebon Dragon",
     "manaCost": "{5}{B}{B}",
     "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhen this creature enters, you may have target opponent discard a card.",
     "creatureStats": {
         "power": 5,
         "toughness": 4
@@ -1735,6 +1777,7 @@
     "name": "Elite Cat Warrior",
     "manaCost": "{2}{G}",
     "typeLine": "Creature — Cat Warrior",
+    "oracleText": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)",
     "creatureStats": {
         "power": 2,
         "toughness": 3
@@ -1758,6 +1801,7 @@
     "name": "Endless Cockroaches",
     "manaCost": "{1}{B}{B}",
     "typeLine": "Creature — Insect",
+    "oracleText": "When this creature dies, return it to its owner's hand.",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -1795,6 +1839,7 @@
     "name": "Exhaustion",
     "manaCost": "{2}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Creatures and lands target opponent controls don't untap during their next untap step.",
     "script": {
         "spellEffect": {
             "type": "SkipUntap",
@@ -1826,6 +1871,7 @@
     "name": "False Peace",
     "manaCost": "{W}",
     "typeLine": "Sorcery",
+    "oracleText": "Target player skips all combat phases of their next turn.",
     "script": {
         "spellEffect": {
             "type": "SkipCombatPhases",
@@ -1857,6 +1903,7 @@
     "name": "Final Strike",
     "manaCost": "{2}{B}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature.\nFinal Strike deals damage to target opponent or planeswalker equal to the sacrificed creature's power.",
     "script": {
         "spellEffect": {
             "type": "DealDamage",
@@ -1899,6 +1946,7 @@
     "name": "Fire Dragon",
     "manaCost": "{6}{R}{R}{R}",
     "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhen this creature enters, it deals damage to target creature equal to the number of Mountains you control.",
     "creatureStats": {
         "power": 6,
         "toughness": 6
@@ -1952,6 +2000,7 @@
     "name": "Fire Imp",
     "manaCost": "{2}{R}",
     "typeLine": "Creature — Imp",
+    "oracleText": "When this creature enters, it deals 2 damage to target creature.",
     "creatureStats": {
         "power": 2,
         "toughness": 1
@@ -2001,6 +2050,7 @@
     "name": "Fire Snake",
     "manaCost": "{4}{R}",
     "typeLine": "Creature — Snake",
+    "oracleText": "When this creature dies, destroy target land.",
     "creatureStats": {
         "power": 3,
         "toughness": 1
@@ -2049,6 +2099,7 @@
     "name": "Fire Tempest",
     "manaCost": "{5}{R}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Fire Tempest deals 6 damage to each creature and each player.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -2100,6 +2151,7 @@
     "name": "Fleet-Footed Monk",
     "manaCost": "{1}{W}",
     "typeLine": "Creature — Human Monk",
+    "oracleText": "This creature can't be blocked by creatures with power 2 or greater.",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -2136,6 +2188,7 @@
     "name": "Flux",
     "manaCost": "{2}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Each player discards any number of cards, then draws that many cards.\nDraw a card.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -2228,6 +2281,7 @@
     "name": "Forked Lightning",
     "manaCost": "{3}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Forked Lightning deals 4 damage divided as you choose among one, two, or three target creatures.",
     "script": {
         "spellEffect": {
             "type": "DividedDamage",
@@ -2260,6 +2314,7 @@
     "name": "Fruition",
     "manaCost": "{G}",
     "typeLine": "Sorcery",
+    "oracleText": "You gain 1 life for each Forest on the battlefield.",
     "script": {
         "spellEffect": {
             "type": "GainLife",
@@ -2306,6 +2361,7 @@
     "name": "Gift of Estates",
     "manaCost": "{1}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "If an opponent controls more lands than you, search your library for up to three Plains cards, reveal them, put them into your hand, then shuffle.",
     "script": {
         "spellEffect": {
             "type": "Gated",
@@ -2420,6 +2476,7 @@
     "name": "Gravedigger",
     "manaCost": "{3}{B}",
     "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature enters, you may return target creature card from your graveyard to your hand.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -2468,6 +2525,7 @@
     "name": "Hand of Death",
     "manaCost": "{2}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy target nonblack creature.",
     "script": {
         "spellEffect": {
             "type": "MoveToZone",
@@ -2512,6 +2570,7 @@
     "name": "Harsh Justice",
     "manaCost": "{2}{W}",
     "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nThis turn, whenever an attacking creature deals combat damage to you, it deals that much damage to its controller.",
     "script": {
         "spellEffect": "ReflectCombatDamage",
         "castRestrictions": [
@@ -2581,6 +2640,7 @@
     "name": "Howling Fury",
     "manaCost": "{2}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Target creature gets +4/+0 until end of turn.",
     "script": {
         "spellEffect": {
             "type": "ModifyStats",
@@ -2623,6 +2683,7 @@
     "name": "Hulking Goblin",
     "manaCost": "{1}{R}",
     "typeLine": "Creature — Goblin",
+    "oracleText": "This creature can't block.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -2648,6 +2709,7 @@
     "name": "Ingenious Thief",
     "manaCost": "{1}{U}",
     "typeLine": "Creature — Human Rogue",
+    "oracleText": "Flying\nWhen this creature enters, look at target player's hand.",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -2693,6 +2755,7 @@
     "name": "Jungle Lion",
     "manaCost": "{G}",
     "typeLine": "Creature — Cat",
+    "oracleText": "This creature can't block.",
     "creatureStats": {
         "power": 2,
         "toughness": 1
@@ -2718,6 +2781,7 @@
     "name": "Keen-Eyed Archers",
     "manaCost": "{2}{W}",
     "typeLine": "Creature — Elf Archer",
+    "oracleText": "Reach (This creature can block creatures with flying.)",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -2741,6 +2805,7 @@
     "name": "King's Assassin",
     "manaCost": "{1}{B}{B}",
     "typeLine": "Creature — Human Assassin",
+    "oracleText": "{T}: Destroy target tapped creature. Activate only during your turn, before attackers are declared.",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -2815,6 +2880,7 @@
     "name": "Last Chance",
     "manaCost": "{R}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
     "script": {
         "spellEffect": {
             "type": "TakeExtraTurn",
@@ -2837,6 +2903,7 @@
     "name": "Lava Axe",
     "manaCost": "{4}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Lava Axe deals 5 damage to target player or planeswalker.",
     "script": {
         "spellEffect": {
             "type": "DealDamage",
@@ -2872,6 +2939,7 @@
     "name": "Lava Flow",
     "manaCost": "{3}{R}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature or land.",
     "script": {
         "spellEffect": {
             "type": "MoveToZone",
@@ -2929,6 +2997,7 @@
     "name": "Mercenary Knight",
     "manaCost": "{2}{B}",
     "typeLine": "Creature — Human Mercenary Knight",
+    "oracleText": "When this creature enters, sacrifice it unless you discard a creature card.",
     "creatureStats": {
         "power": 4,
         "toughness": 4
@@ -2968,6 +3037,7 @@
     "name": "Mind Knives",
     "manaCost": "{1}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Target opponent discards a card at random.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -3034,6 +3104,7 @@
     "name": "Mind Rot",
     "manaCost": "{2}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Target player discards two cards.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -3121,6 +3192,7 @@
     "name": "Mobilize",
     "manaCost": "{G}",
     "typeLine": "Sorcery",
+    "oracleText": "Untap all creatures you control.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -3150,6 +3222,7 @@
     "name": "Monstrous Growth",
     "manaCost": "{1}{G}",
     "typeLine": "Sorcery",
+    "oracleText": "Target creature gets +4/+4 until end of turn.",
     "script": {
         "spellEffect": {
             "type": "ModifyStats",
@@ -3192,6 +3265,7 @@
     "name": "Moon Sprite",
     "manaCost": "{1}{G}",
     "typeLine": "Creature — Faerie",
+    "oracleText": "Flying",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -3236,6 +3310,7 @@
     "name": "Mystic Denial",
     "manaCost": "{1}{U}{U}",
     "typeLine": "Instant",
+    "oracleText": "Counter target creature or sorcery spell.",
     "script": {
         "spellEffect": "Counter",
         "targetRequirements": [
@@ -3265,6 +3340,7 @@
     "name": "Natural Spring",
     "manaCost": "{3}{G}{G}",
     "typeLine": "Sorcery",
+    "oracleText": "Target player gains 8 life.",
     "script": {
         "spellEffect": {
             "type": "GainLife",
@@ -3301,6 +3377,7 @@
     "name": "Nature's Cloak",
     "manaCost": "{2}{G}",
     "typeLine": "Sorcery",
+    "oracleText": "Green creatures you control gain forestwalk until end of turn. (They can't be blocked as long as defending player controls a Forest.)",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -3330,6 +3407,7 @@
     "name": "Nature's Ruin",
     "manaCost": "{2}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy all green creatures.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -3361,6 +3439,7 @@
     "name": "Needle Storm",
     "manaCost": "{2}{G}",
     "typeLine": "Sorcery",
+    "oracleText": "Needle Storm deals 4 damage to each creature with flying.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -3393,6 +3472,7 @@
     "name": "Noxious Toad",
     "manaCost": "{2}{B}",
     "typeLine": "Creature — Frog",
+    "oracleText": "When this creature dies, each opponent discards a card.",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -3460,6 +3540,7 @@
     "name": "Omen",
     "manaCost": "{1}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Look at the top three cards of your library, then put them back in any order. You may shuffle.\nDraw a card.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -3520,6 +3601,7 @@
     "name": "Owl Familiar",
     "manaCost": "{1}{U}",
     "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhen this creature enters, draw a card, then discard a card.",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -3600,6 +3682,7 @@
     "name": "Path of Peace",
     "manaCost": "{3}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature. Its owner gains 4 life.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -3645,6 +3728,7 @@
     "name": "Personal Tutor",
     "manaCost": "{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Search your library for a sorcery card, reveal it, then shuffle and put that card on top.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -3700,6 +3784,7 @@
     "name": "Phantom Warrior",
     "manaCost": "{1}{U}{U}",
     "typeLine": "Creature — Illusion Warrior",
+    "oracleText": "This creature can't be blocked.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -3724,6 +3809,7 @@
     "name": "Pillaging Horde",
     "manaCost": "{2}{R}{R}",
     "typeLine": "Creature — Human Barbarian",
+    "oracleText": "When this creature enters, sacrifice it unless you discard a card at random.",
     "creatureStats": {
         "power": 5,
         "toughness": 5
@@ -3763,6 +3849,7 @@
     "name": "Plant Elemental",
     "manaCost": "{1}{G}",
     "typeLine": "Creature — Plant Elemental",
+    "oracleText": "When this creature enters, sacrifice it unless you sacrifice a Forest.",
     "creatureStats": {
         "power": 3,
         "toughness": 4
@@ -3802,6 +3889,7 @@
     "name": "Primeval Force",
     "manaCost": "{2}{G}{G}{G}",
     "typeLine": "Creature — Elemental",
+    "oracleText": "When this creature enters, sacrifice it unless you sacrifice three Forests.",
     "creatureStats": {
         "power": 8,
         "toughness": 8
@@ -3842,6 +3930,7 @@
     "name": "Raging Cougar",
     "manaCost": "{2}{R}",
     "typeLine": "Creature — Cat",
+    "oracleText": "Haste",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -3865,6 +3954,7 @@
     "name": "Raging Goblin",
     "manaCost": "{R}",
     "typeLine": "Creature — Goblin Berserker",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -3888,6 +3978,7 @@
     "name": "Raging Minotaur",
     "manaCost": "{2}{R}{R}",
     "typeLine": "Creature — Minotaur Berserker",
+    "oracleText": "Haste",
     "creatureStats": {
         "power": 3,
         "toughness": 3
@@ -3911,6 +4002,7 @@
     "name": "Rain of Salt",
     "manaCost": "{4}{R}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy two target lands.",
     "script": {
         "spellEffect": {
             "type": "ForEachTarget",
@@ -3954,6 +4046,7 @@
     "name": "Rain of Tears",
     "manaCost": "{1}{B}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy target land.",
     "script": {
         "spellEffect": {
             "type": "MoveToZone",
@@ -4031,6 +4124,7 @@
     "name": "Renewing Dawn",
     "manaCost": "{1}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "You gain 2 life for each Mountain target opponent controls.",
     "script": {
         "spellEffect": {
             "type": "GainLife",
@@ -4088,6 +4182,7 @@
     "name": "Sacred Knight",
     "manaCost": "{3}{W}",
     "typeLine": "Creature — Human Knight",
+    "oracleText": "This creature can't be blocked by black and/or red creatures.",
     "creatureStats": {
         "power": 3,
         "toughness": 2
@@ -4133,6 +4228,7 @@
     "name": "Sacred Nectar",
     "manaCost": "{1}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "You gain 4 life.",
     "script": {
         "spellEffect": {
             "type": "GainLife",
@@ -4158,6 +4254,7 @@
     "name": "Scorching Spear",
     "manaCost": "{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Scorching Spear deals 1 damage to any target.",
     "script": {
         "spellEffect": {
             "type": "DealDamage",
@@ -4193,6 +4290,7 @@
     "name": "Scorching Winds",
     "manaCost": "{R}",
     "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nScorching Winds deals 1 damage to each attacking creature.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -4235,6 +4333,7 @@
     "name": "Seasoned Marshal",
     "manaCost": "{2}{W}{W}",
     "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever this creature attacks, you may tap target creature.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -4278,6 +4377,7 @@
     "name": "Serpent Assassin",
     "manaCost": "{3}{B}{B}",
     "typeLine": "Creature — Snake Assassin",
+    "oracleText": "When this creature enters, you may destroy target nonblack creature.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -4334,6 +4434,7 @@
     "name": "Serpent Warrior",
     "manaCost": "{2}{B}",
     "typeLine": "Creature — Snake Warrior",
+    "oracleText": "When this creature enters, you lose 3 life.",
     "creatureStats": {
         "power": 3,
         "toughness": 3
@@ -4412,6 +4513,7 @@
     "name": "Snapping Drake",
     "manaCost": "{3}{U}",
     "typeLine": "Creature — Drake",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
     "creatureStats": {
         "power": 3,
         "toughness": 2
@@ -4435,6 +4537,7 @@
     "name": "Sorcerous Sight",
     "manaCost": "{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Look at target opponent's hand.\nDraw a card.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -4478,6 +4581,7 @@
     "name": "Soul Shred",
     "manaCost": "{3}{B}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Soul Shred deals 3 damage to target nonblack creature. You gain 3 life.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -4556,6 +4660,7 @@
     "name": "Spiritual Guardian",
     "manaCost": "{3}{W}{W}",
     "typeLine": "Creature — Spirit",
+    "oracleText": "When this creature enters, you gain 4 life.",
     "creatureStats": {
         "power": 3,
         "toughness": 4
@@ -4595,6 +4700,7 @@
     "name": "Spotted Griffin",
     "manaCost": "{3}{W}",
     "typeLine": "Creature — Griffin",
+    "oracleText": "Flying",
     "creatureStats": {
         "power": 2,
         "toughness": 3
@@ -4618,6 +4724,7 @@
     "name": "Starlight",
     "manaCost": "{1}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "You gain 3 life for each black creature target opponent controls.",
     "script": {
         "spellEffect": {
             "type": "GainLife",
@@ -4655,6 +4762,7 @@
     "name": "Starlit Angel",
     "manaCost": "{3}{W}{W}",
     "typeLine": "Creature — Angel",
+    "oracleText": "Flying",
     "creatureStats": {
         "power": 3,
         "toughness": 4
@@ -4679,6 +4787,7 @@
     "name": "Steadfastness",
     "manaCost": "{1}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "Creatures you control get +0/+3 until end of turn.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -4715,6 +4824,7 @@
     "name": "Stern Marshal",
     "manaCost": "{2}{W}",
     "typeLine": "Creature — Human Soldier",
+    "oracleText": "{T}: Target creature gets +2/+2 until end of turn. Activate only during your turn, before attackers are declared.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -4774,6 +4884,7 @@
     "name": "Sylvan Tutor",
     "manaCost": "{G}",
     "typeLine": "Sorcery",
+    "oracleText": "Search your library for a creature card, reveal it, then shuffle and put that card on top.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -4829,6 +4940,7 @@
     "name": "Symbol of Unsummoning",
     "manaCost": "{2}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Return target creature to its owner's hand.\nDraw a card.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -4876,6 +4988,7 @@
     "name": "Taunt",
     "manaCost": "{U}",
     "typeLine": "Sorcery",
+    "oracleText": "During target player's next turn, creatures that player controls attack you if able.",
     "script": {
         "spellEffect": {
             "type": "Taunt",
@@ -4907,6 +5020,7 @@
     "name": "Temporary Truce",
     "manaCost": "{1}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "Each player may draw up to two cards. For each card less than two a player draws this way, that player gains 2 life.",
     "script": {
         "spellEffect": {
             "type": "ForEachPlayer",
@@ -4947,6 +5061,7 @@
     "name": "Theft of Dreams",
     "manaCost": "{2}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Draw a card for each tapped creature target opponent controls.",
     "script": {
         "spellEffect": {
             "type": "DrawCards",
@@ -4980,6 +5095,7 @@
     "name": "Thing from the Deep",
     "manaCost": "{6}{U}{U}{U}",
     "typeLine": "Creature — Leviathan",
+    "oracleText": "Whenever this creature attacks, sacrifice it unless you sacrifice an Island.",
     "creatureStats": {
         "power": 9,
         "toughness": 9
@@ -5017,6 +5133,7 @@
     "name": "Thundering Wurm",
     "manaCost": "{2}{G}",
     "typeLine": "Creature — Wurm",
+    "oracleText": "When this creature enters, sacrifice it unless you discard a land card.",
     "creatureStats": {
         "power": 4,
         "toughness": 4
@@ -5056,6 +5173,7 @@
     "name": "Thundermare",
     "manaCost": "{5}{R}",
     "typeLine": "Creature — Elemental Horse",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhen this creature enters, tap all other creatures.",
     "creatureStats": {
         "power": 5,
         "toughness": 5
@@ -5101,6 +5219,7 @@
     "name": "Tidal Surge",
     "manaCost": "{1}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Tap up to three target creatures without flying.",
     "script": {
         "spellEffect": {
             "type": "ForEachTarget",
@@ -5150,6 +5269,7 @@
     "name": "Time Ebb",
     "manaCost": "{2}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Put target creature on top of its owner's library.",
     "script": {
         "spellEffect": {
             "type": "MoveToZone",
@@ -5186,6 +5306,7 @@
     "name": "Touch of Brilliance",
     "manaCost": "{3}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Draw two cards.",
     "script": {
         "spellEffect": {
             "type": "DrawCards",
@@ -5211,6 +5332,7 @@
     "name": "Treetop Defense",
     "manaCost": "{1}{G}",
     "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nCreatures you control gain reach until end of turn. (They can block creatures with flying.)",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -5250,6 +5372,7 @@
     "name": "Undying Beast",
     "manaCost": "{3}{B}",
     "typeLine": "Creature — Beast",
+    "oracleText": "When this creature dies, put it on top of its owner's library.",
     "creatureStats": {
         "power": 3,
         "toughness": 2
@@ -5287,6 +5410,7 @@
     "name": "Valorous Charge",
     "manaCost": "{1}{W}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "White creatures get +2/+0 until end of turn.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -5324,6 +5448,7 @@
     "name": "Vampiric Feast",
     "manaCost": "{5}{B}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Vampiric Feast deals 4 damage to any target and you gain 4 life.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -5372,6 +5497,7 @@
     "name": "Vampiric Touch",
     "manaCost": "{2}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Vampiric Touch deals 2 damage to target opponent or planeswalker and you gain 2 life.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -5419,6 +5545,7 @@
     "name": "Venerable Monk",
     "manaCost": "{2}{W}",
     "typeLine": "Creature — Human Monk Cleric",
+    "oracleText": "When this creature enters, you gain 2 life.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -5458,6 +5585,7 @@
     "name": "Vengeance",
     "manaCost": "{3}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy target tapped creature.",
     "script": {
         "spellEffect": {
             "type": "MoveToZone",
@@ -5495,6 +5623,7 @@
     "name": "Virtue's Ruin",
     "manaCost": "{2}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy all white creatures.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -5526,6 +5655,7 @@
     "name": "Volcanic Hammer",
     "manaCost": "{1}{R}",
     "typeLine": "Sorcery",
+    "oracleText": "Volcanic Hammer deals 3 damage to any target.",
     "script": {
         "spellEffect": {
             "type": "DealDamage",
@@ -5561,6 +5691,7 @@
     "name": "Wall of Granite",
     "manaCost": "{2}{R}",
     "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)",
     "creatureStats": {
         "power": 0,
         "toughness": 7
@@ -5585,6 +5716,7 @@
     "name": "Warrior's Charge",
     "manaCost": "{2}{W}",
     "typeLine": "Sorcery",
+    "oracleText": "Creatures you control get +1/+1 until end of turn.",
     "script": {
         "spellEffect": {
             "type": "ForEachInGroup",
@@ -5642,6 +5774,7 @@
     "name": "Wicked Pact",
     "manaCost": "{1}{B}{B}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy two target nonblack creatures. You lose 5 life.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -5705,6 +5838,7 @@
     "name": "Willow Dryad",
     "manaCost": "{G}",
     "typeLine": "Creature — Dryad",
+    "oracleText": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -5728,6 +5862,7 @@
     "name": "Wind Drake",
     "manaCost": "{2}{U}",
     "typeLine": "Creature — Drake",
+    "oracleText": "Flying",
     "creatureStats": {
         "power": 2,
         "toughness": 2
@@ -5751,6 +5886,7 @@
     "name": "Winter's Grasp",
     "manaCost": "{1}{G}{G}",
     "typeLine": "Sorcery",
+    "oracleText": "Destroy target land.",
     "script": {
         "spellEffect": {
             "type": "MoveToZone",
@@ -5788,6 +5924,7 @@
     "name": "Withering Gaze",
     "manaCost": "{2}{U}",
     "typeLine": "Sorcery",
+    "oracleText": "Target opponent reveals their hand. You draw a card for each Forest and green card in it.",
     "script": {
         "spellEffect": {
             "type": "Composite",
@@ -5855,6 +5992,7 @@
     "name": "Wood Elves",
     "manaCost": "{2}{G}",
     "typeLine": "Creature — Elf Scout",
+    "oracleText": "When this creature enters, search your library for a Forest card, put that card onto the battlefield, then shuffle.",
     "creatureStats": {
         "power": 1,
         "toughness": 1

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -41,6 +41,9 @@ object Emitter {
         body.add("    manaCost = \"${renderMana(card["ManaCost"])}\"")
         colorIdentityDsl(scryfall)?.let { body.add("    colorIdentity = \"$it\"") }
         body.add("    typeLine = \"${renderTypeline(card["Typeline"])}\"")
+        // Printed oracle text is display/training data (the gym observation surfaces it to agents); the
+        // engine still derives behaviour from the structured keywords/effects below, never from this string.
+        scryfall?.strField("oracle_text")?.takeIf { it.isNotEmpty() }?.let { body.add("    oracleText = \"${ktStr(it)}\"") }
         if (pt != null) { body.add("    power = ${pt["Power"].asInt()}"); body.add("    toughness = ${pt["Toughness"].asInt()}") }
         if (kw.isNotEmpty()) body.add("    keywords(${kw.sorted().joinToString(", ") { "Keyword.$it" }})")
         val cardLevelLines = ctx.cardLevelCastEffectLines(card) ?: return incomplete(ctx, body, scryfall, pkg)


### PR DESCRIPTION
## Problem

`TrainingObservationTest > oracle text is serialized for cards in visible zones` fails intermittently on `main` (TrainingObservationTest.kt:129).

Root cause: the mtgish whole-card emitter read each card's Scryfall oracle text **only for the KDoc header** and never emitted an `oracleText = "…"` field. The last Portal regen therefore silently dropped printed text for every generated card — e.g. Raging Goblin went from `oracleText = "Haste"` to empty.

The engine derives behaviour from the structured `keywords(...)` / effects, so **gameplay was unaffected**. But the gym `TrainingObservation` surfaces oracle text to agents, and the test asserts Raging Goblin's text contains `"Haste"`. The assertion only runs when Raging Goblin lands in the random opening hand, so the failure is intermittent.

## Fix

The emitter now writes the Scryfall oracle text as an `oracleText` field (display/training data only — behaviour still comes from the structured rules below it). Regenerated Portal via `coverage-refresh-set POR`.

The card-source diff is **purely one added `oracleText` line per card** (138 cards) — zero removed lines, zero other additions. The `POR.json` snapshot golden was re-blessed to match (138 `oracleText` insertions only).

## Verification

- `TrainingObservationTest` — green across 3 repeated runs (random opening hand)
- `CardDefinitionSnapshotTest` — green
- `verifyGeneratedCards` + fidelity gate — **PASS**, 158/158 Portal cards compile and gameplay-tree match golden
- full `:gym:test` and `:mtgish-tooling:test` suites — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)