### PR TITLE
Add player-target restrictions (TargetUnion PR 1)

### DIFF
--- a/backlog/target-union-with-arms.md
+++ b/backlog/target-union-with-arms.md
@@ -206,10 +206,15 @@ addition for the new `@Serializable` types.
 
 ## 7. Suggested PR breakdown
 
-1. **Player target restriction (prerequisite).** Add `Player.Candidate`; add `restriction: Condition?` to
-   `TargetPlayer`/`TargetOpponent`; thread through `findPlayerTargets`/`findOpponentTargets` +
-   `validatePlayerTarget`; add `Conditions.candidate*` facade. Driving card: a real "target player with N
-   or less life" / "target opponent who controls a creature" card + scenario test.
+1. **Player target restriction (prerequisite).** ✅ **Done.** Added `Player.Candidate` +
+   `EffectContext.candidatePlayerId`; `restriction: Condition?` on `TargetPlayer`/`TargetOpponent`;
+   one `PlayerTargetRestriction.isSatisfied(...)` helper routed through all three target sites
+   (`TargetFinder`, `TargetEnumerationUtils`, and both `TargetValidator` + the resolution-time
+   `StackResolver.validateTargets` for the CR 608.2b re-check); `Conditions.candidateLostLifeThisTurn()`
+   / `candidateLifeAtMost(n)` facade. No real "N or less life" card exists (Scryfall confirms), so the
+   prerequisite is proven by `PlayerTargetRestrictionScenarioTest` with inline cards mirroring Rix Maadi
+   Guildmage's "target player who lost life this turn" ability; real consumers (Rix Maadi Guildmage, the
+   Oath cycle) land when their sets are added.
 2. **`TargetUnion` + `TargetArm`.** Add the SDK types (`@Serializable`, `SerialName`, `TextReplaceable`);
    add enumeration union + validation in `TargetFinder` / `TargetEnumerationUtils` / `TargetValidator`.
    Driving card: a "deal damage to target creature or player" card (and/or the criteria-bearing variant) +

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -866,6 +866,36 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   `TargetObject(count = 2, optional = true, filter = TargetFilter.CardInGraveyard, sameOwner = true)`
   (Arashin Sunshield).
 
+### Player-target restrictions (`TargetPlayer.restriction` / `TargetOpponent.restriction`)
+
+A `TargetPlayer` / `TargetOpponent` can carry `restriction: Condition?` — a gate each candidate
+player must satisfy to be a legal target ("target player who lost life this turn", "target player
+with 10 or less life"). The restriction is evaluated against each player with
+`Player.Candidate` bound to that player, in all three target paths: legal-target enumeration,
+cast/activation validation, and the CR 608.2b re-check at resolution (a target whose restriction
+stopped holding — e.g. gained life above the threshold — is removed, fizzling a single-target spell).
+
+Author the restriction through the `Conditions.candidate*` facade (never hand-write `Player.Candidate`):
+
+- `Conditions.candidateLostLifeThisTurn()` — the targeted player lost life this turn (Rix Maadi Guildmage).
+- `Conditions.candidateLifeAtMost(n)` — the targeted player has `n` or less life.
+
+Because `Condition` descriptions don't read as English relative clauses, pass `descriptionOverride`
+whenever `restriction` is set:
+
+```kotlin
+target(
+    "target player who lost life this turn",
+    TargetPlayer(
+        restriction = Conditions.candidateLostLifeThisTurn(),
+        descriptionOverride = "target player who lost life this turn",
+    ),
+)
+```
+
+This is the player-arm prerequisite for the planned composable mixed `TargetUnion` (see
+`backlog/target-union-with-arms.md`).
+
 ---
 
 ## 7. Filters & predicates

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -723,6 +723,34 @@ object Conditions {
     val OpponentLostLifeThisTurn: ConditionInterface =
         trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.LIFE_LOST, player = Player.Opponent)
 
+    // =========================================================================
+    // Candidate-player target restrictions (CR 115)
+    // =========================================================================
+    // These read [Player.Candidate] — "the player being considered as a target" — so they only
+    // belong inside `TargetPlayer.restriction` / `TargetOpponent.restriction`. The engine binds
+    // each candidate player to `Player.Candidate` while enumerating and (per CR 608.2b)
+    // re-validating targets. Used in a normal resolution/projection condition slot, the candidate
+    // is unbound and the condition is false.
+
+    /**
+     * Candidate-target restriction: the player being targeted lost life this turn.
+     * Backs "target player who lost life this turn" (Rix Maadi Guildmage).
+     */
+    fun candidateLostLifeThisTurn(): ConditionInterface =
+        trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.LIFE_LOST, player = Player.Candidate)
+
+    /**
+     * Candidate-target restriction: the player being targeted has [n] or less life.
+     * Backs "target player with N or less life". The restriction is re-checked at resolution
+     * (CR 608.2b), so a player who gains above the threshold after being targeted is removed.
+     */
+    fun candidateLifeAtMost(n: Int): ConditionInterface =
+        Compare(
+            DynamicAmount.LifeTotal(Player.Candidate),
+            ComparisonOperator.LTE,
+            DynamicAmount.Fixed(n)
+        )
+
     /**
      * If N or more cards left your graveyard this turn.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
@@ -86,6 +86,21 @@ sealed interface Player {
         override val description: String = "that player"
     }
 
+    /**
+     * The player currently being considered as a target (CR 115). Bound by the engine's
+     * target enumerator/validator to each candidate player in turn while evaluating a
+     * [com.wingedsheep.sdk.scripting.targets.TargetPlayer.restriction] /
+     * [com.wingedsheep.sdk.scripting.targets.TargetOpponent.restriction]. It only resolves
+     * inside that restriction-evaluation context (where `EffectContext.candidatePlayerId`
+     * is set) — at effect-execution time there is no candidate, so it resolves to nothing.
+     * Reach it through the `Conditions.candidate*` facade rather than constructing it by hand.
+     */
+    @SerialName("Candidate")
+    @Serializable
+    data object Candidate : Player {
+        override val description: String = "that player"
+    }
+
     /** The player from the trigger context (e.g., player dealt combat damage) */
     @SerialName("TriggeringPlayer")
     @Serializable
@@ -127,6 +142,7 @@ sealed interface Player {
             EachOpponent -> "each opponent's"
             Any -> "a player's"
             is ContextPlayer -> "that player's"
+            Candidate -> "that player's"
             TriggeringPlayer -> "that player's"
             is ControllerOf -> "its controller's"
             is OwnerOf -> "its owner's"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.sdk.scripting.targets
 
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
 import com.wingedsheep.sdk.scripting.text.TextReplacer
@@ -52,6 +53,14 @@ sealed interface TargetRequirement : TextReplaceable<TargetRequirement> {
 
 /**
  * Target player (any player).
+ *
+ * [restriction], when non-null, is a [Condition] that each candidate player must satisfy to be a
+ * legal target ("target player who lost life this turn", "target player with 10 or less life").
+ * It is evaluated against each player with [Player.Candidate] bound to that player, both when
+ * enumerating legal targets and — per CR 608.2b — re-checked at resolution, so a target whose
+ * restriction stopped holding is removed. Author it through the `Conditions.candidate*` facade.
+ * Because condition descriptions don't read as English relative clauses, pass
+ * [descriptionOverride] (e.g. "target player who lost life this turn") whenever [restriction] is set.
  */
 @SerialName("TargetPlayer")
 @Serializable
@@ -60,6 +69,7 @@ data class TargetPlayer(
     override val optional: Boolean = false,
     override val unlimited: Boolean = false,
     override val id: String? = null,
+    val restriction: Condition? = null,
     private val descriptionOverride: String? = null
 ) : TargetRequirement {
     override val description: String = descriptionOverride
@@ -68,19 +78,35 @@ data class TargetPlayer(
             count == 1 -> "target player"
             else -> "target $count players"
         }
+
+    override fun applyTextReplacement(replacer: TextReplacer): TargetRequirement {
+        val newRestriction = restriction?.applyTextReplacement(replacer)
+        return if (newRestriction !== restriction) copy(restriction = newRestriction) else this
+    }
 }
 
 /**
  * Target opponent only.
+ *
+ * See [TargetPlayer.restriction] — [restriction] applies the same per-candidate gate, scoped to
+ * opponents of the controller.
  */
 @SerialName("TargetOpponent")
 @Serializable
 data class TargetOpponent(
     override val count: Int = 1,
     override val optional: Boolean = false,
-    override val id: String? = null
+    override val id: String? = null,
+    val restriction: Condition? = null,
+    private val descriptionOverride: String? = null
 ) : TargetRequirement {
-    override val description: String = if (count == 1) "target opponent" else "target $count opponents"
+    override val description: String = descriptionOverride
+        ?: if (count == 1) "target opponent" else "target $count opponents"
+
+    override fun applyTextReplacement(replacer: TextReplacer): TargetRequirement {
+        val newRestriction = restriction?.applyTextReplacement(replacer)
+        return if (newRestriction !== restriction) copy(restriction = newRestriction) else this
+    }
 }
 
 // =============================================================================

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/PlayerTargetRestrictionSerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/PlayerTargetRestrictionSerializationTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.sdk.serialization
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+import com.wingedsheep.sdk.scripting.targets.withId
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Round-trip + description tests for the player-target `restriction` slot (TargetUnion PR 1).
+ * The restriction and its [com.wingedsheep.sdk.scripting.references.Player.Candidate] reference
+ * ride inside `CardDefinition`, so they must serialize and survive a JSON round-trip.
+ */
+class PlayerTargetRestrictionSerializationTest : DescribeSpec({
+
+    val json = CardSerialization.json
+
+    describe("TargetPlayer / TargetOpponent restriction") {
+
+        it("round-trips a TargetPlayer carrying a Player.Candidate restriction") {
+            val original: TargetRequirement = TargetPlayer(
+                restriction = Conditions.candidateLifeAtMost(10),
+                descriptionOverride = "target player with 10 or less life"
+            )
+            val restored = json.decodeFromString(
+                TargetRequirement.serializer(),
+                json.encodeToString(TargetRequirement.serializer(), original)
+            )
+            restored shouldBe original
+            (restored as TargetPlayer).restriction shouldBe Conditions.candidateLifeAtMost(10)
+        }
+
+        it("round-trips a TargetOpponent carrying a LIFE_LOST tracker restriction") {
+            val original: TargetRequirement = TargetOpponent(
+                restriction = Conditions.candidateLostLifeThisTurn(),
+                descriptionOverride = "target opponent who lost life this turn"
+            )
+            val restored = json.decodeFromString(
+                TargetRequirement.serializer(),
+                json.encodeToString(TargetRequirement.serializer(), original)
+            )
+            restored shouldBe original
+        }
+
+        it("renders the descriptionOverride for a restricted target") {
+            TargetPlayer(
+                restriction = Conditions.candidateLostLifeThisTurn(),
+                descriptionOverride = "target player who lost life this turn"
+            ).description shouldBe "target player who lost life this turn"
+        }
+
+        it("preserves the restriction when an id is stamped via withId") {
+            val req = TargetPlayer(restriction = Conditions.candidateLifeAtMost(5))
+            val withId = req.withId("victim")
+            (withId as TargetPlayer).restriction shouldBe Conditions.candidateLifeAtMost(5)
+            withId.id shouldBe "victim"
+        }
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -381,6 +381,7 @@ class ConditionEvaluator(
             is Player.EachOpponent -> controllerId?.let { c -> state.turnOrder.filter { it != c } } ?: emptyList()
             is Player.Each -> state.turnOrder
             is Player.Any -> state.turnOrder
+            is Player.Candidate -> listOfNotNull((ctx as? Resolution)?.effectContext?.candidatePlayerId)
             else -> controllerId?.let { listOf(it) } ?: emptyList()
         }
 
@@ -506,6 +507,7 @@ class ConditionEvaluator(
                 state.turnOrder.firstOrNull { it != c }
             }
             is Player.TriggeringPlayer -> (ctx as? Resolution)?.effectContext?.triggeringPlayerId
+            is Player.Candidate -> (ctx as? Resolution)?.effectContext?.candidatePlayerId
             else -> null
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -667,6 +667,7 @@ class DynamicAmountEvaluator(
                 val activePlayer = state.activePlayerId ?: return state.turnOrder
                 listOf(activePlayer) + state.turnOrder.filter { it != activePlayer }
             }
+            is Player.Candidate -> listOfNotNull(context.candidatePlayerId)
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -25,6 +25,13 @@ data class EffectContext(
     val sourceId: EntityId?,
     val controllerId: EntityId,
     val opponentId: EntityId?,
+    /**
+     * The player currently under consideration as a target, bound while evaluating a
+     * `TargetPlayer.restriction` / `TargetOpponent.restriction` (CR 115). Resolves
+     * [com.wingedsheep.sdk.scripting.references.Player.Candidate]. Null in every normal
+     * effect-resolution context — there is no candidate once an effect is executing.
+     */
+    val candidatePlayerId: EntityId? = null,
     val targets: List<ChosenTarget> = emptyList(),
     /**
      * The X chosen for an X-cost spell/ability. Also reused by `ChooseNumberThenEffect` to

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.mechanics.targeting.PlayerTargetRestriction
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -64,8 +65,8 @@ class TargetFinder(
         triggeringEntityId: EntityId? = null
     ): List<EntityId> {
         return when (requirement) {
-            is TargetPlayer -> findPlayerTargets(state, requirement, controllerId)
-            is TargetOpponent -> findOpponentTargets(state, controllerId)
+            is TargetPlayer -> findPlayerTargets(state, requirement, controllerId, sourceId)
+            is TargetOpponent -> findOpponentTargets(state, requirement, controllerId, sourceId)
             is AnyTarget -> findAnyTargets(state, controllerId, sourceId, targetingSourceType)
             is TargetCreatureOrPlayer -> findCreatureOrPlayerTargets(state, controllerId, sourceId, targetingSourceType)
             is TargetOpponentOrPlaneswalker -> findOpponentOrPlaneswalkerTargets(state, controllerId, sourceId, targetingSourceType)
@@ -91,17 +92,25 @@ class TargetFinder(
     private fun findPlayerTargets(
         state: GameState,
         requirement: TargetPlayer,
-        controllerId: EntityId
+        controllerId: EntityId,
+        sourceId: EntityId?
     ): List<EntityId> {
         return state.turnOrder.filter { playerId ->
             state.hasEntity(playerId) && !playerHasShroud(state, playerId) &&
-                !playerHasHexproofAgainst(state, playerId, controllerId)
+                !playerHasHexproofAgainst(state, playerId, controllerId) &&
+                PlayerTargetRestriction.isSatisfied(state, requirement.restriction, playerId, controllerId, sourceId)
         }
     }
 
-    private fun findOpponentTargets(state: GameState, controllerId: EntityId): List<EntityId> {
+    private fun findOpponentTargets(
+        state: GameState,
+        requirement: TargetOpponent,
+        controllerId: EntityId,
+        sourceId: EntityId?
+    ): List<EntityId> {
         return state.turnOrder.filter { it != controllerId && state.hasEntity(it) && !playerHasShroud(state, it) &&
-            !playerHasHexproof(state, it) }
+            !playerHasHexproof(state, it) &&
+            PlayerTargetRestriction.isSatisfied(state, requirement.restriction, it, controllerId, sourceId) }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.legalactions.TargetInfo
 import com.wingedsheep.engine.mechanics.targeting.HexproofSuppression
+import com.wingedsheep.engine.mechanics.targeting.PlayerTargetRestriction
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
@@ -39,9 +40,11 @@ class TargetEnumerationUtils(
     ): List<EntityId> {
         return when (requirement) {
             is TargetPlayer -> state.turnOrder.filter { state.hasEntity(it) && !playerHasShroud(state, it) &&
-                !playerHasHexproofAgainst(state, it, playerId) }
+                !playerHasHexproofAgainst(state, it, playerId) &&
+                PlayerTargetRestriction.isSatisfied(state, requirement.restriction, it, playerId, sourceId) }
             is TargetOpponent -> state.turnOrder.filter { it != playerId && state.hasEntity(it) && !playerHasShroud(state, it) &&
-                !playerHasHexproof(state, it) }
+                !playerHasHexproof(state, it) &&
+                PlayerTargetRestriction.isSatisfied(state, requirement.restriction, it, playerId, sourceId) }
             is AnyTarget -> {
                 val creatures = findValidPermanentTargets(state, playerId, TargetFilter.Creature, sourceId)
                 val planeswalkers = findValidPermanentTargets(state, playerId, TargetFilter.Planeswalker, sourceId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -61,6 +61,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.TargetingSourceType
 import com.wingedsheep.engine.mechanics.targeting.HexproofSuppression
+import com.wingedsheep.engine.mechanics.targeting.PlayerTargetRestriction
 import com.wingedsheep.engine.state.components.battlefield.CantBeTargetedByOpponentAbilitiesComponent
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
@@ -2081,8 +2082,18 @@ class StackResolver(
         return targets.filterIndexed { index, target ->
             when (target) {
                 is ChosenTarget.Player -> {
-                    // Player is valid if they exist and haven't lost
-                    state.hasEntity(target.playerId)
+                    // Player is valid if they exist and haven't lost...
+                    if (!state.hasEntity(target.playerId)) return@filterIndexed false
+                    // ...and (CR 608.2b) the player-target restriction still holds. A player who
+                    // gained life above the threshold, or whose "lost life this turn" never
+                    // happened, is removed at resolution.
+                    val requirement = getRequirementForTargetIndex(index, targetRequirements)
+                    val restriction = when (requirement) {
+                        is TargetPlayer -> requirement.restriction
+                        is TargetOpponent -> requirement.restriction
+                        else -> null
+                    }
+                    PlayerTargetRestriction.isSatisfied(state, restriction, target.playerId, controllerId, sourceId)
                 }
 
                 is ChosenTarget.Permanent -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerTargetRestriction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerTargetRestriction.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.engine.mechanics.targeting
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.conditions.Condition
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Evaluates the optional [com.wingedsheep.sdk.scripting.targets.TargetPlayer.restriction] /
+ * [com.wingedsheep.sdk.scripting.targets.TargetOpponent.restriction] against a single candidate
+ * player (CR 115). The candidate is bound to [Player.Candidate] via
+ * [EffectContext.candidatePlayerId] so the restriction can read its life total, turn trackers,
+ * controlled permanents, etc. through the normal [Condition] vocabulary.
+ *
+ * This is the *single* place the restriction is interpreted; the three player-target sites
+ * (legal-target enumeration in `TargetFinder`, legal-action enumeration in
+ * `TargetEnumerationUtils`, and validation/CR-608.2b re-check in `TargetValidator`) all route
+ * through here so they can never diverge.
+ */
+object PlayerTargetRestriction {
+
+    private val conditionEvaluator = ConditionEvaluator()
+
+    /**
+     * True if [candidatePlayerId] satisfies [restriction] (or there is no restriction).
+     *
+     * @param controllerId the player choosing the target — used to resolve `Player.You`/`Opponent`
+     *   inside the restriction, so "an opponent who ..." reads relative to the chooser.
+     * @param sourceId the targeting source, for source-relative restriction reads.
+     */
+    fun isSatisfied(
+        state: GameState,
+        restriction: Condition?,
+        candidatePlayerId: EntityId,
+        controllerId: EntityId,
+        sourceId: EntityId? = null
+    ): Boolean {
+        if (restriction == null) return true
+        val context = EffectContext(
+            sourceId = sourceId,
+            controllerId = controllerId,
+            opponentId = state.getOpponent(controllerId),
+            candidatePlayerId = candidatePlayerId
+        )
+        return conditionEvaluator.evaluate(state, restriction, context)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -172,8 +172,8 @@ class TargetValidator {
         xValue: Int? = null
     ): String? {
         val error = when (requirement) {
-            is TargetPlayer -> validatePlayerTarget(state, target, casterId)
-            is TargetOpponent -> validateOpponentTarget(state, target, casterId)
+            is TargetPlayer -> validatePlayerTarget(state, target, requirement, casterId, sourceId)
+            is TargetOpponent -> validateOpponentTarget(state, target, requirement, casterId, sourceId)
             is AnyTarget -> validateAnyTarget(state, target, casterId)
             is TargetCreatureOrPlayer -> validateCreatureOrPlayerTarget(state, target, casterId)
             is TargetOpponentOrPlaneswalker -> validateOpponentOrPlaneswalkerTarget(state, target, casterId)
@@ -399,7 +399,13 @@ class TargetValidator {
         return null
     }
 
-    private fun validatePlayerTarget(state: GameState, target: ChosenTarget, casterId: EntityId): String? {
+    private fun validatePlayerTarget(
+        state: GameState,
+        target: ChosenTarget,
+        requirement: TargetPlayer,
+        casterId: EntityId,
+        sourceId: EntityId?
+    ): String? {
         if (target !is ChosenTarget.Player) {
             return "Target must be a player"
         }
@@ -412,10 +418,21 @@ class TargetValidator {
         if (playerHasHexproofAgainst(state, target.playerId, casterId)) {
             return "Target player has hexproof"
         }
+        // CR 608.2b: a target illegal at resolution is removed. Re-checking the restriction
+        // here covers both cast-time validation and the resolution-time re-validation.
+        if (!PlayerTargetRestriction.isSatisfied(state, requirement.restriction, target.playerId, casterId, sourceId)) {
+            return "Target player does not match: ${requirement.description}"
+        }
         return null
     }
 
-    private fun validateOpponentTarget(state: GameState, target: ChosenTarget, casterId: EntityId): String? {
+    private fun validateOpponentTarget(
+        state: GameState,
+        target: ChosenTarget,
+        requirement: TargetOpponent,
+        casterId: EntityId,
+        sourceId: EntityId?
+    ): String? {
         if (target !is ChosenTarget.Player) {
             return "Target must be a player"
         }
@@ -430,6 +447,9 @@ class TargetValidator {
         }
         if (playerHasHexproof(state, target.playerId)) {
             return "Target player has hexproof"
+        }
+        if (!PlayerTargetRestriction.isSatisfied(state, requirement.restriction, target.playerId, casterId, sourceId)) {
+            return "Target player does not match: ${requirement.description}"
         }
         return null
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlayerTargetRestrictionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlayerTargetRestrictionScenarioTest.kt
@@ -1,0 +1,277 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
+import com.wingedsheep.engine.state.components.player.LifeLostThisTurnComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for player-target restrictions — the `restriction: Condition?` slot on
+ * [TargetPlayer] / [com.wingedsheep.sdk.scripting.targets.TargetOpponent] (TargetUnion PR 1).
+ *
+ * The restriction is evaluated against each candidate player with
+ * [com.wingedsheep.sdk.scripting.references.Player.Candidate] bound to that player. These tests
+ * pin the three behaviours the engine must guarantee:
+ *
+ *  1. Legal-target *enumeration* excludes players who fail the restriction (and "target player"
+ *     spans every player — controller included — when they satisfy it).
+ *  2. *Cast/activation validation* rejects an illegal player target.
+ *  3. *Resolution re-check* (CR 608.2b): a target whose restriction stopped holding between
+ *     targeting and resolution is removed, fizzling a single-target spell.
+ *
+ * Driven by two inline cards: a drainer whose ability mirrors Rix Maadi Guildmage's real
+ * "target player who lost life this turn" ability, and a life-threshold sorcery ("target player
+ * with 10 or less life") whose restriction can flip false mid-stack to exercise the re-check.
+ */
+class PlayerTargetRestrictionScenarioTest : ScenarioTestBase() {
+
+    // {B}: Target player who lost life this turn loses 1 life.  (cf. Rix Maadi Guildmage)
+    private val lostLifeRestriction = Conditions.candidateLostLifeThisTurn()
+    private val drainer = card("Restriction Test Drainer") {
+        manaCost = "{1}{B}"
+        typeLine = "Creature — Human Cleric"
+        power = 1
+        toughness = 1
+        oracleText = "{B}: Target player who lost life this turn loses 1 life."
+        activatedAbility {
+            cost = com.wingedsheep.sdk.dsl.Costs.Mana("{B}")
+            val t = target(
+                "target player who lost life this turn",
+                TargetPlayer(
+                    restriction = lostLifeRestriction,
+                    descriptionOverride = "target player who lost life this turn"
+                )
+            )
+            effect = LoseLifeEffect(DynamicAmount.Fixed(1), t)
+        }
+    }
+
+    // Target player with 10 or less life loses 3 life.
+    private val lifeAtMostRestriction = Conditions.candidateLifeAtMost(10)
+    private val lance = card("Restriction Test Lance") {
+        manaCost = "{B}"
+        typeLine = "Sorcery"
+        oracleText = "Target player with 10 or less life loses 3 life."
+        spell {
+            val t = target(
+                "target player with 10 or less life",
+                TargetPlayer(
+                    restriction = lifeAtMostRestriction,
+                    descriptionOverride = "target player with 10 or less life"
+                )
+            )
+            effect = LoseLifeEffect(DynamicAmount.Fixed(3), t)
+        }
+    }
+
+    private val drainerAbilityId = drainer.activatedAbilities.first().id
+
+    // Enumerate legal player targets the same way the legal-action layer does — through
+    // TargetEnumerationUtils, the path that feeds the client's selectable-target list.
+    private val targetEnumerator = TargetEnumerationUtils(PredicateEvaluator())
+
+    init {
+        cardRegistry.register(drainer)
+        cardRegistry.register(lance)
+
+        context("\"target player who lost life this turn\" (LIFE_LOST tracker restriction)") {
+
+            test("enumeration: only the opponent who lost life this turn is a legal target; resolving drains them") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Restriction Test Drainer", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Opponent lost life this turn; controller did not.
+                game.state = game.state.updateEntity(game.player2Id) { it.with(LifeLostThisTurnComponent) }
+                val drainerId = game.findPermanent("Restriction Test Drainer")!!
+
+                val targets = targetEnumerator.findValidTargets(
+                    game.state, game.player1Id,
+                    TargetPlayer(restriction = lostLifeRestriction), drainerId
+                )
+                withClue("Restriction filters enumeration to the opponent who lost life") {
+                    targets shouldContain game.player2Id
+                    targets shouldNotContain game.player1Id
+                }
+
+                val before = game.getLifeTotal(2)
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = drainerId,
+                        abilityId = drainerAbilityId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                )
+                withClue("Activating against a player who lost life is legal: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("Resolution drains the targeted player for 1") {
+                    game.getLifeTotal(2) shouldBe before - 1
+                }
+            }
+
+            test("validation: activating against a player who did NOT lose life is rejected") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Restriction Test Drainer", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Nobody lost life this turn.
+                val drainerId = game.findPermanent("Restriction Test Drainer")!!
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = drainerId,
+                        abilityId = drainerAbilityId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                )
+                withClue("The restriction is unmet, so the activation is rejected") {
+                    activation.error shouldNotBe null
+                }
+            }
+
+            test("enumeration: the controller is a legal target when THEY lost life (target player spans all players)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Restriction Test Drainer", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Only the controller lost life this turn.
+                game.state = game.state.updateEntity(game.player1Id) { it.with(LifeLostThisTurnComponent) }
+                val drainerId = game.findPermanent("Restriction Test Drainer")!!
+
+                val targets = targetEnumerator.findValidTargets(
+                    game.state, game.player1Id,
+                    TargetPlayer(restriction = lostLifeRestriction), drainerId
+                )
+                withClue("\"target player\" includes the controller when they satisfy the restriction") {
+                    targets shouldContain game.player1Id
+                    targets shouldNotContain game.player2Id
+                }
+            }
+
+            test("enumeration: no player is a legal target when nobody lost life this turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Restriction Test Drainer", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val drainerId = game.findPermanent("Restriction Test Drainer")!!
+                withClue("With no life lost this turn, the restriction excludes every player") {
+                    targetEnumerator.findValidTargets(
+                        game.state, game.player1Id,
+                        TargetPlayer(restriction = lostLifeRestriction), drainerId
+                    ) shouldBe emptyList()
+                }
+            }
+        }
+
+        context("\"target player with 10 or less life\" (life-threshold restriction + CR 608.2b)") {
+
+            test("enumeration + cast: only a player at or below the threshold is a legal target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Restriction Test Lance")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val targets = targetEnumerator.findValidTargets(
+                    game.state, game.player1Id,
+                    TargetPlayer(restriction = lifeAtMostRestriction), sourceId = null
+                )
+                withClue("Opponent at 8 life (<=10) is legal; controller at 20 is not") {
+                    targets shouldContain game.player2Id
+                    targets shouldNotContain game.player1Id
+                }
+
+                game.castSpellTargetingPlayer(1, "Restriction Test Lance", targetPlayerNumber = 2)
+                game.resolveStack()
+                withClue("Resolving against the 8-life opponent drains 3") {
+                    game.getLifeTotal(2) shouldBe 5
+                }
+            }
+
+            test("validation: casting against a player above the threshold is rejected") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Restriction Test Lance")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellTargetingPlayer(1, "Restriction Test Lance", targetPlayerNumber = 2)
+                withClue("Both players are at 20 life, so no player satisfies the restriction") {
+                    cast.error shouldNotBe null
+                }
+            }
+
+            test("CR 608.2b: a target that rises above the threshold before resolution is removed and the spell fizzles") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Restriction Test Lance")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Legal at cast time (8 <= 10).
+                val cast = game.castSpellTargetingPlayer(1, "Restriction Test Lance", targetPlayerNumber = 2)
+                withClue("Targeting an 8-life player is legal at cast: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                // Before it resolves, the opponent's life rises above the threshold.
+                game.state = game.state.updateEntity(game.player2Id) { it.with(LifeTotalComponent(12)) }
+
+                game.resolveStack()
+                withClue(
+                    "The only target became illegal (12 > 10), so the spell is removed from the " +
+                        "stack without effect — the opponent loses no life."
+                ) {
+                    game.getLifeTotal(2) shouldBe 12
+                    game.isInGraveyard(1, "Restriction Test Lance") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a `restriction: Condition?` slot to `TargetPlayer` / `TargetOpponent`, gating each candidate player by a condition evaluated with a new `Player.Candidate` reference bound to that player. This is **PR 1 (the player-arm prerequisite)** of the composable mixed `TargetUnion` proposed in [`backlog/target-union-with-arms.md`](../blob/feature/player-target-restriction/backlog/target-union-with-arms.md) — itself item #6 of the SDK reusability consolidation backlog. It also independently unlocks the not-previously-expressible "target player with N or less life" / "target player who lost life this turn" shape.

## How

**SDK (`mtg-sdk`)**
- `Player.Candidate` — "the player being considered as a target" (CR 115).
- `restriction` + `descriptionOverride` on `TargetPlayer`/`TargetOpponent`; text-replacement recurses into the restriction.
- `Conditions.candidateLostLifeThisTurn()` / `candidateLifeAtMost(n)` facade (authors never hand-write `Player.Candidate`).

**Engine (`rules-engine`)**
- `EffectContext.candidatePlayerId` resolves `Player.Candidate` in `DynamicAmountEvaluator` + `ConditionEvaluator`.
- A single `PlayerTargetRestriction.isSatisfied(...)` helper is routed through **every** player-target site so they can't diverge:
  - enumeration — `TargetFinder`, `TargetEnumerationUtils`
  - cast/activation validation — `TargetValidator`
  - resolution-time **CR 608.2b** re-check — `StackResolver.validateTargets` (a target whose restriction stopped holding is removed; a single-target spell fizzles to its owner's graveyard).

Server-side only: no new `GameEvent`, no client contract change — only `.description` text crosses the boundary, unchanged in shape.

## Tests
- `PlayerTargetRestrictionScenarioTest` (rules-engine) — enumeration (incl. "target player" spanning the controller, and empty when nobody qualifies), cast/activation rejection, and the 608.2b fizzle, driven by inline cards mirroring **Rix Maadi Guildmage**'s "target player who lost life this turn" ability and a life-threshold spell.
- `PlayerTargetRestrictionSerializationTest` (mtg-sdk) — round-trip + description + `withId` preservation.
- Full `:rules-engine`, `:mtg-sdk`, `:mtg-sets` (incl. `CardDefinitionSnapshotTest` — no golden changes) suites pass.

## Notes
- No real card uses a life *threshold* on a player target (confirmed via Scryfall); real consumers are the turn-tracker shape (Rix Maadi Guildmage) and comparative restrictions (Oath cycle), which land when their sets are added. The mechanism is proven here with inline cards; the real driving card arrives with PR 2 ("deal damage to target creature or player").
- CR 608.2b / 115 rule numbers verified against the official Comprehensive Rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)