### PR TITLE
mtgish: push Onslaught auto-gen fidelity 31 → 78 verified

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -12,8 +12,9 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     envelope("And", "envelope: cost/action conjunction")
     envelope("If", "conditional envelope")
 
-    // The "you may / unless / if you do" gate cluster (Lesson 1).
-    envelope("MayAction", "gate envelope: 'you may' (Lesson 1 cluster)")
+    // The "you may / unless / if you do" gate cluster (Lesson 1). A "you may [effect]" realises as a
+    // `GatedEffect(gate = MayDecide)` (SerialName "Gated") in our trees, so the gate envelope composes it.
+    envelope("MayAction", "gate envelope: 'you may' (Lesson 1 cluster)", composes = listOf("Gated"))
     envelope("MayCost", "gate envelope: 'you may pay' (Lesson 1 cluster)")
     envelope("Unless", "gate envelope: 'unless ...' (Lesson 1 cluster)", composes = listOf("PayOrSuffer"))
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1,7 +1,10 @@
 package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.field
+import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
@@ -167,10 +170,9 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject): List<String>? {
 /** An Activated / ActivatedWithModifiers rule -> activatedAbility { cost; [target]; effect }. */
 internal fun EmitCtx.activatedBlock(rule: JsonObject): List<String>? {
     val args = rule["args"].asArr
-    var cost: String? = "AbilityCost.Tap"  // default; refine from the _Cost node
     val costNode = args?.firstOrNull() as? JsonObject
-    if (costNode?.strField("_Cost") == "TapPermanent") cost = "AbilityCost.Tap"
-    else if (costNode?.strField("_Cost") == "PayMana") cost = null  // mana costs need symbols -> SCAFFOLD
+    // Recover the exact activation cost. Anything we can't render exactly -> SCAFFOLD (never guess Tap).
+    val cost = costNode?.let { abilityCostDsl(it) }
     if (cost == null) { reasons.add("activated-cost"); return null }
     val (targets, actions) = extractEnvelope(rule)
     if (actions == null) { reasons.add("activated-actions"); return null }
@@ -182,6 +184,68 @@ internal fun EmitCtx.activatedBlock(rule: JsonObject): List<String>? {
     if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
     lines.addAll(listOf("        effect = $edsl", "    }"))
     return lines
+}
+
+/**
+ * mtgish activation-cost `_Cost` node -> the `Costs.*` AbilityCost DSL, or null (-> SCAFFOLD) for any
+ * shape we can't render exactly. Recurses on `And` -> `Costs.Composite(...)`. Conservative by design:
+ * a wrong cost is worse than a scaffold, so unknown atoms bail rather than approximate.
+ */
+internal fun EmitCtx.abilityCostDsl(node: JsonElement?): String? {
+    val obj = node as? JsonObject ?: return null
+    return when (obj.strField("_Cost")) {
+        "And" -> {
+            val parts = (obj["args"].asArr ?: return null).map { abilityCostDsl(it) ?: return null }
+            if (parts.size < 2) return null
+            "Costs.Composite(${parts.joinToString(", ")})"
+        }
+        "PayMana" -> renderMana(obj.field("args")).ifEmpty { null }?.let { "Costs.Mana(\"$it\")" }
+        "TapPermanent" ->
+            if (obj.field("args").strField("_Permanent") == "ThisPermanent") "Costs.Tap" else null
+        "SacrificePermanent" ->
+            if (obj.field("args").strField("_Permanent") == "ThisPermanent") "Costs.SacrificeSelf" else null
+        "SacrificeAPermanent" -> costFilterDsl(obj.field("args"))?.let {
+            if (it == "GameObjectFilter.Any") "Costs.Sacrifice()" else "Costs.Sacrifice($it)"
+        }
+        "PayLife" -> (findInteger(obj.field("args")) as? Int)?.let { "Costs.PayLife($it)" }
+        "TapNumberPermanents" -> {
+            val a = obj["args"].asArr ?: return null
+            val n = findInteger(a.getOrNull(0)) as? Int ?: return null
+            // "Tap N untapped X you control" — TapPermanents implies untapped + you-control, so only the
+            // creature-subtype distinguishes it; bail if there's no recognisable creature-type filter.
+            val ctype = creatureTypeIn(a.getOrNull(1)) ?: return null
+            "Costs.TapPermanents($n, GameObjectFilter.Creature.withSubtype(\"$ctype\"))"
+        }
+        else -> null
+    }
+}
+
+/** A sacrifice/cost permanent filter: the creature-subtype shape the general filter DSL skips, "any
+ *  permanent" -> the default Any, otherwise delegate to [gameObjectFilterDsl]. */
+private fun EmitCtx.costFilterDsl(node: JsonElement?): String? {
+    val obj = node as? JsonObject
+    when (obj?.strField("_Permanents")) {
+        "IsCreatureType" -> return obj["args"].asStr()?.let { "GameObjectFilter.Creature.withSubtype(\"$it\")" }
+        "AnyPermanent" -> return "GameObjectFilter.Permanent"
+    }
+    val base = gameObjectFilterDsl(node) ?: return null
+    // "Sacrifice a Goblin creature" = And[IsCreatureType X, IsCardtype Creature]: gameObjectFilterDsl
+    // sees the Creature cardtype but skips the creature subtype, so re-apply it here.
+    val ctype = creatureTypeIn(node)
+    return if (ctype != null && base == "GameObjectFilter.Creature") "GameObjectFilter.Creature.withSubtype(\"$ctype\")" else base
+}
+
+/** First `IsCreatureType` subtype anywhere in a (possibly `And`-nested) cost filter. */
+private fun creatureTypeIn(node: JsonElement?): String? {
+    when (node) {
+        is JsonObject -> {
+            if (node.strField("_Permanents") == "IsCreatureType") return node["args"].asStr()
+            node.values.forEach { creatureTypeIn(it)?.let { r -> return r } }
+        }
+        is JsonArray -> node.forEach { creatureTypeIn(it)?.let { r -> return r } }
+        else -> {}
+    }
+    return null
 }
 
 private fun EmitCtx.activationRestrictionLines(rule: JsonObject): List<String>? {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -147,7 +147,11 @@ internal fun EmitCtx.dynamicAmount(node: JsonElement?): String? {
             jsonContains(node, "_Player", "Opponent") -> "Player.Opponent"
             else -> "Player.You"
         }
-        return "DynamicAmount.AggregateBattlefield($player, ${landSearchFilterDsl(node)})"
+        // "for each Goblin/Bird/Elf on the battlefield": a creature subtype, which the land-oriented
+        // search filter misses; otherwise fall back to the land/type search filter.
+        val subtype = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").find(compact(node))?.groupValues?.get(1)
+        val filter = if (subtype != null) "GameObjectFilter.Creature.withSubtype(\"$subtype\")" else landSearchFilterDsl(node)
+        return "DynamicAmount.AggregateBattlefield($player, $filter)"
     }
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asObj
 import com.wingedsheep.tooling.coverage.asStr
+import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.asciiIdentifier
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
@@ -61,6 +62,9 @@ object Emitter {
                 rname == "TriggerA" -> block = ctx.triggerBlock(rule)
                 rname == "PermanentRuleEffect" -> block = ctx.staticBlock(rule)
                 rname == "Activated" || rname == "ActivatedWithModifiers" -> block = ctx.activatedBlock(rule)
+                rname == "Cycling" -> block = manaKeywordCost(rule)?.let { listOf("    keywordAbility(KeywordAbility.cycling(\"$it\"))") }
+                rname == "Morph" -> block = manaKeywordCost(rule)?.let { listOf("    morph = \"$it\"") }
+                rname == "Protection" -> block = protectionScopeDsl(rule)?.let { listOf("    keywordAbility(KeywordAbility.Protection($it))") }
                 rname != null && (rname in handledRules || Bridge[rname]?.kind == "keyword") -> continue
                 rname != null && pascalToUpperSnake(rname) in keywords -> continue  // auto-keyword rule
                 else -> { ctx.reasons.add(rname ?: "unknown-rule"); return incomplete(ctx, body, scryfall, pkg) }
@@ -76,6 +80,39 @@ object Emitter {
         body.addAll(metadataLines(scryfall))
         body.add("}")
         return RenderResult(assemble(body, pkg, complete = true), true, ctx.reasons)
+    }
+
+    /** A keyword-ability whose cost is pure mana (`Cycling {2}`, `Morph {4}{W}`). Returns the rendered
+     *  mana string, or null when the cost isn't simple mana — which downgrades the card to a scaffold
+     *  rather than emit an inexact cost. */
+    private fun manaKeywordCost(rule: JsonObject): String? {
+        val cost = rule.field("args")
+        if (cost.strField("_Cost") != "PayMana") return null
+        return renderMana(cost.field("args"))
+    }
+
+    /** `Protection from X` -> the `ProtectionScope.*` DSL, or null (scaffold) for scopes the emitter
+     *  can't render exactly yet. ONS only needs single/multi colour and creature-subtype. */
+    private fun protectionScopeDsl(rule: JsonObject): String? {
+        val inner = rule.field("args")
+        return when (inner.strField("_Protectable")) {
+            "FromColor" -> {
+                val colorsNode = inner.field("args")
+                if (colorsNode.strField("_ProtectableColor") != "Colors") return null
+                val colors = (colorsNode.field("args").asArr ?: return null).mapNotNull { it.strField("_Color")?.uppercase() }
+                when {
+                    colors.isEmpty() -> null
+                    colors.size == 1 -> "ProtectionScope.Color(Color.${colors[0]})"
+                    else -> "ProtectionScope.Colors(setOf(${colors.joinToString(", ") { "Color.$it" }}))"
+                }
+            }
+            "FromTypes" -> {
+                val typesNode = inner.field("args")
+                if (typesNode.strField("_Cards") != "IsCreatureType") return null
+                typesNode.field("args").asStr()?.let { "ProtectionScope.Subtype(\"$it\")" }
+            }
+            else -> null
+        }
     }
 
     /** Landwalk-keyword recovery, exposed for the fidelity scorer's generated-capability set. */

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Shells.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Shells.kt
@@ -132,6 +132,9 @@ internal fun keywordLines(card: JsonObject, keywords: Set<String>): Set<String> 
     Mtgish.extractTags(card["Rules"], tags)
     for ((disc, value) in tags.keys) {
         if (value == "Landwalk") continue
+        // Protection always carries a "from X" scope, so it renders as a scoped `keywordAbility(...)`
+        // (see Emitter.protectionScopeDsl), never a bare `keywords(Keyword.PROTECTION)`.
+        if (value == "Protection") continue
         val entry = Bridge.entry(disc, value)
         val auto = pascalToUpperSnake(value)
         if (entry is MappingEntry.Keyword) out.add(entry.tag)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Shells.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Shells.kt
@@ -1,7 +1,5 @@
 package com.wingedsheep.tooling.coverage.emitter
 
-import com.wingedsheep.tooling.coverage.Counter
-import com.wingedsheep.tooling.coverage.Mtgish
 import com.wingedsheep.tooling.coverage.Registry
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
@@ -127,16 +125,19 @@ internal fun findLandwalkKeywords(node: JsonElement?, keywords: Set<String>, out
 
 internal fun keywordLines(card: JsonObject, keywords: Set<String>): Set<String> {
     val out = mutableSetOf<String>()
-    findLandwalkKeywords(card["Rules"], keywords, out)
-    val tags = Counter<Pair<String, String>>()
-    Mtgish.extractTags(card["Rules"], tags)
-    for ((disc, value) in tags.keys) {
-        if (value == "Landwalk") continue
+    // Only TOP-LEVEL rules are intrinsic card keywords. A keyword nested inside an Activated/Triggered
+    // ability is GRANTED to a target ("target creature gains forestwalk"), not a card keyword — the old
+    // whole-tree scan wrongly stamped it on the card (Elvish Pathcutter, Spurred Wolverine, Krosan Groundshaker).
+    for (rule in card["Rules"].asArr ?: JsonArray(emptyList())) {
+        val r = rule as? JsonObject ?: continue
+        val rname = r.strField("_Rule") ?: continue
+        // Landwalk is a top-level rule too; scan only this rule so a granted landwalk stays off the card.
+        if (rname == "Landwalk") { findLandwalkKeywords(r, keywords, out); continue }
         // Protection always carries a "from X" scope, so it renders as a scoped `keywordAbility(...)`
         // (see Emitter.protectionScopeDsl), never a bare `keywords(Keyword.PROTECTION)`.
-        if (value == "Protection") continue
-        val entry = Bridge.entry(disc, value)
-        val auto = pascalToUpperSnake(value)
+        if (rname == "Protection") continue
+        val entry = Bridge.entry("_Rule", rname)
+        val auto = pascalToUpperSnake(rname)
         if (entry is MappingEntry.Keyword) out.add(entry.tag)
         else if (auto in keywords) out.add(auto)
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -15,8 +15,22 @@ import kotlinx.serialization.json.JsonObject
  * to SCAFFOLD rather than emitting a confidently-wrong target.
  */
 internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String {
-    var suffix = ""
     val blob = compact(filterNode)
+    // Whole-creature shapes whose helpers live on GameObjectFilter (not TargetFilter), or are a named
+    // TargetFilter constant. ONS targets use these in isolation, so render them as the whole filter.
+    if ("IsAttacking" in blob && "IsBlocking" in blob) {
+        // "...with flying" composes onto the attacking-or-blocking base (Venomspout Brackus).
+        return if ("\"Flying\"" in blob) "TargetFilter(GameObjectFilter.Creature.attackingOrBlocking().withKeyword(Keyword.FLYING))"
+        else "TargetFilter.AttackingOrBlockingCreature"
+    }
+    if ("IsFaceDown" in blob) return "TargetFilter(GameObjectFilter.Creature.faceDown())"
+    // "Goblin creature" / "Elf or Soldier creature": one subtype -> withSubtype; several -> an Or of
+    // per-subtype creature filters (matches golden's distributed Or[And[IsCreature, HasSubtype X]…]).
+    val subs = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").findAll(blob).map { it.groupValues[1] }.toList()
+    if (subs.isNotEmpty()) {
+        return "TargetFilter(${subs.joinToString(" or ") { "GameObjectFilter.Creature.withSubtype(\"$it\")" }})"
+    }
+    var suffix = ""
     Regex(""""IsNonColor".*?"_Color":\s*"(\w+)"""").find(blob)?.let {
         suffix += ".notColor(Color.${it.groupValues[1].uppercase()})"
     }
@@ -28,6 +42,9 @@ internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String {
     }
     if ("IsTapped" in blob) suffix += ".tapped()"
     if ("IsAttacking" in blob) suffix += ".attacking()"
+    Regex(""""PowerIs".*?"LessThanOrEqualTo".*?"Integer",\s*"args":\s*(\d+)""").find(blob)?.let {
+        suffix += ".powerAtMost(${it.groupValues[1]})"
+    }
     return "TargetFilter.Creature$suffix"
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -209,6 +209,9 @@ internal fun EmitCtx.revealedHandFilterDsl(filterNode: JsonElement?): String? {
 
 internal fun EmitCtx.landSearchFilterDsl(filterNode: JsonElement?): String {
     val subs = subtypes(filterNode)
+    // Dual-land fetch ("a Swamp or Mountain card") -> Land + Or[HasSubtype…], i.e. withAnySubtype;
+    // golden factors IsLand out (unlike the distributed creature-subtype form).
+    if (subs.size >= 2) return "GameObjectFilter.Land.withAnySubtype(${subs.joinToString(", ") { "\"$it\"" }})"
     if (subs.isNotEmpty()) return "GameObjectFilter.Land.withSubtype(${subtypeArg(subs[0])})"
     val blob = compact(filterNode)
     val oracle = oracleText?.lowercase() ?: ""

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -88,6 +88,7 @@ internal fun EmitCtx.renderSearch(args: JsonElement?): String? {
     val parts = mutableListOf("filter = $filt")
     if (count is Int && count != 1) parts.add("count = $count")
     parts.add("destination = SearchDestination.$dest")
+    if ("EntersTapped" in blob) parts.add("entersTapped = true")  // "...onto the battlefield tapped"
     if ("RevealFoundCards" in blob) parts.add("reveal = true")
     return "Patterns.Library.searchLibrary(${parts.joinToString(", ")})"
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -75,7 +75,15 @@ internal fun EmitCtx.renderSearch(args: JsonElement?): String? {
         "PutSetAsideCardsOnTopOfLibrary" in blob || "OnTopOfLibrary" in blob -> "TOP_OF_LIBRARY"
         else -> "HAND"
     }
-    val filt = landSearchFilterDsl(args)
+    // "search for a card named X" (Avarax, Daru Cavalier, …) -> a name filter, which the land/type
+    // search filter can't express.
+    val named = Regex(""""NamedCard",\s*"args":\s*"([^"]+)"""").find(blob)?.groupValues?.get(1)
+    val searchSubtype = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").find(blob)?.groupValues?.get(1)
+    val filt = when {
+        named != null -> "GameObjectFilter.Any.named(\"$named\")"
+        searchSubtype != null -> "GameObjectFilter.Any.withSubtype(\"$searchSubtype\")"  // "an Elf card"
+        else -> landSearchFilterDsl(args)
+    }
     val count = findInteger(args)
     val parts = mutableListOf("filter = $filt")
     if (count is Int && count != 1) parts.add("count = $count")


### PR DESCRIPTION
## What

Teaches the mtgish→Argentum coverage **emitter + bridge** the shapes that dominate Onslaught, so the auto-gen tooling can faithfully render far more of the set. This is tooling-only — no card content, engine, or SDK changes — and is **predictive/staging** as always (generated `.kt` are drafts; a passing scenario test stays the real gate).

ONS is already 100% hand-implemented, so this is a **fidelity** exercise: how much of Onslaught the emitter can auto-author *and* have it compile + serialize identically to the hand-authored golden.

## Results

| | before | after |
|---|---|---|
| **ONS verified** (compile + gameplay-tree match vs golden) | 31 | **78** (of 96 emitted) |
| ONS predictive AUTO (probe) | 48 | ~97 |
| **POR (calibration gate)** | 158/158 PASS | **158/158 PASS** (no regression) |

`just coverage-verify POR` was re-run after every change and stayed green throughout.

## Changes (all in `:mtgish-tooling`)

- **`Gated` capability mapping** — the "you may" gate envelope composes `Gated` (our SDK realises "you may [effect]" as `GatedEffect`), closing a ×40 capability-counting miss.
- **Morph + Cycling** — render `morph = "{cost}"` / `keywordAbility(KeywordAbility.cycling("{cost}"))`, scaffolding non-mana costs.
- **Protection from X** — render the scoped `keywordAbility(KeywordAbility.Protection(ProtectionScope.Color/Subtype(…)))` instead of a lossy bare `keywords(Keyword.PROTECTION)`, in IR order so it matches golden.
- **Composite activated costs** — recursive `abilityCostDsl` (`And`→`Composite`; mana / tap / sacrifice-self / sacrifice-filter / pay-life / tap-N-typed). **Removes the dangerous default-to-`Tap`** so unrecognised costs scaffold instead of emitting a wrong tap.
- **Richer target/creature filters** — attacking-or-blocking (+ flying), creature subtype(s), face-down, `powerAtMost`.
- **Count / fetch filters** — `AggregateBattlefield` by creature subtype; dual-land fetch via `Land.withAnySubtype`.
- **Library-search filters** — search by card name (`Any.named`), by creature subtype, and `entersTapped`.
- **Intrinsic-only keywords** — `keywordLines` now harvests only top-level rules, so a keyword *granted* by an ability is no longer stamped on the card.

## What's left (not in this PR)

The remaining 18 ONS mismatches are the hard tail: the **Modal charm cycle** (needs Modal-spell support — a real capability, best via `add-feature`), reused-`X` multi-recipient damage, combat-damage `eachOpponentDiscards`, and a handful of bespoke ×1 filters. Documented in the commit history / project memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)