### PR TITLE
Interactive mtgish coverage dashboard (TUI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,9 @@ whose scenario test passes. The mtgish→Argentum mapping is typed Kotlin in two
 First run auto-downloads the 29 MB mtgish IR into `mtgish-tooling/data/` (gitignored).
 
 ```bash
+# DASHBOARD — interactive TUI over all the analysis below (no flags; q to quit).
+just coverage-dashboard                 # navigate sets, drill into cards, c = cross-set capability index
+
 # COVERAGE — which missing cards need no engine work, and which feature unlocks the most.
 just coverage --set TMP                 # implemented / FREE-to-implement / blocked + feature leaderboard
 just coverage --set TMP --free          # also list the implementable-today cards

--- a/justfile
+++ b/justfile
@@ -79,6 +79,16 @@ _coverage-tool:
 coverage *ARGS: _coverage-tool
     @mtgish-tooling/build/install/mtgish-tooling/bin/mtgish-tooling probe {{ARGS}}
 
+# Interactive coverage dashboard (TUI) — navigate every set's implemented / free-to-add / blocked
+# breakdown + feature leaderboard, drill into the card list and per-card capability verdict, and
+# press `c` for the cross-set "what engine work unlocks the most cards everywhere" ranking.
+#   just coverage-dashboard            # lazy — sets analyze as you visit them
+#   just coverage-dashboard --scan     # analyze every set up front (fills all +N counts + global total)
+#   ↑↓ navigate · → drill in · ← back · tab Kotlin/capabilities · / filter · s sort · f scan-all · q quit
+[group: 'build']
+coverage-dashboard *ARGS: _coverage-tool
+    @mtgish-tooling/build/install/mtgish-tooling/bin/mtgish-tooling dashboard {{ARGS}}
+
 # Generation fidelity — could we AUTO-AUTHOR a card from mtgish? Diffs the bridge's output
 # against each card's compiled golden snapshot, tiering AUTO / SCAFFOLD / MISS.
 # Whole set:  just coverage-fidelity --set POR

--- a/mtgish-tooling/README.md
+++ b/mtgish-tooling/README.md
@@ -8,6 +8,7 @@ It is analysis and generation tooling, not a runtime dependency and not a card l
 Run through `just` from the repo root:
 
 ```bash
+just coverage-dashboard          # interactive TUI over everything below
 just coverage --set POR
 just coverage-fidelity --set POR
 just coverage-verify POR
@@ -15,13 +16,50 @@ just coverage-generate --set TMP
 just coverage-refresh-set POR
 ```
 
-The installed CLI has three subcommands:
+The installed CLI has four subcommands:
 
 ```bash
-mtgish-tooling probe     # coverage: can the SDK/engine express a card?
-mtgish-tooling fidelity  # calibration: does generated output match implemented cards?
-mtgish-tooling autogen   # write generated Kotlin drafts
+mtgish-tooling probe      # coverage: can the SDK/engine express a card?
+mtgish-tooling fidelity   # calibration: does generated output match implemented cards?
+mtgish-tooling autogen    # write generated Kotlin drafts
+mtgish-tooling dashboard  # interactive TUI (probe + autogen + a cross-set capability index)
 ```
+
+## Dashboard (TUI)
+
+`just coverage-dashboard` is a navigable, two-pane terminal UI over the same analysis the CLIs print
+— no flags. It composes the existing per-card primitives (`Probe.analyze`, `Emitter.renderCard`)
+rather than re-implementing coverage logic, and memoizes per-set results so a keypress never recomputes.
+
+- **Title** — corpus totals: implemented / total, and `+N auto-gen ready` (cards the generator can
+  render whole). The figure sums only the sets analyzed so far and grows as you browse; `f` (or
+  launching with `--scan`) analyzes every set up front so it's complete.
+- **Left pane** — every set (implemented ∪ Scryfall-cached) with its full name and release year,
+  sorted newest-first by default (`s` toggles alphabetical), showing `implemented/total` and `gN`
+  auto-gen coverage (cards the generator renders whole, `g?` until that set is analyzed). `/` searches
+  sets by name or code.
+- **Right pane** — the selected set's `implemented / auto-gen / free-to-add / blocked` breakdown.
+  **Auto-gen** spans *all* cards (implemented included) so a 100%-implemented set still shows how much
+  the generator could reproduce; **free-to-add** is the missing-card backlog. Plus the feature
+  leaderboard of engine work ranked by how many blocked cards it would unlock, and (for snapshot sets)
+  the golden-fidelity tiers.
+- **Drill in** (`→`/`enter`) — the set's card list, coloured by the generator's verdict (green WHOLE,
+  yellow SCAFFOLD, red BLOCKED) with a marker for implemented (`✓`) vs new (`+`/`~`/`✗`); a red `✓` is
+  an implemented card the generator *can't* reproduce. Filter with `/`.
+- **Card detail** — two tabs (`tab` to switch): **Kotlin** shows the emitter's generated `cardDef`
+  DSL, syntax-highlighted, above a `⚠ missing mappings` block listing the still-unmapped capabilities;
+  **capabilities** lists every required capability with its verdict + which sets implement the card.
+- **`c`** — the cross-set capability index: every set's leaderboard rolled into one ranking of "what
+  engine work unlocks the most cards everywhere" (computed on demand, with a progress bar).
+- **`f` / `--scan`** — full scan: analyze every set up front (fills all `gN` counts + the global
+  total; also makes `c` instant).
+- Keys: `↑↓`/`jk` move · `→`/`enter` drill in · `←`/`esc` back · `tab` Kotlin/capabilities · `/`
+  search/filter · `s` sort · `f` scan-all · `r` fetch a set from Scryfall · `c` cross-set · `q` quit.
+  Needs an interactive terminal (drives `/dev/tty` via `stty`).
+
+The dashboard adds no runtime dependency — it uses raw ANSI escapes and `stty` raw mode
+(`dashboard/Tui.kt`), keeping the module dependency-light. `dashboard --render` prints static frames
+to stdout (no raw mode) for smoke-testing outside a live terminal.
 
 ## Data Flow
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
@@ -111,9 +111,31 @@ object Fidelity {
         val avgRecall: Double get() = if (recalls.isEmpty()) 0.0 else recalls.sum() / recalls.size * 100
     }
 
-    private fun scoreSet(code: String, effects: Set<String>, keywords: Set<String>): SetScore {
+    /** Capability tiers for one set, vs its committed golden snapshot — null if the set has no snapshot. */
+    data class FidelitySummary(
+        val matched: Int, val auto: Int, val scaffold: Int, val miss: Int, val unmatched: Int, val avgRecall: Double,
+    )
+
+    /**
+     * Safe, dashboard-facing summary: returns null (instead of exiting the process) for sets without a
+     * committed golden snapshot. Pass a preloaded mtgish [idx] to reuse a shared index pass.
+     */
+    fun summarizeOrNull(code: String, effects: Set<String>, keywords: Set<String>, idx: Map<String, JsonObject>? = null): FidelitySummary? {
+        if (!java.io.File(SNAP_DIR, "${code.uppercase()}.json").exists()) return null
+        val s = scoreSet(code, effects, keywords, idx)
+        return FidelitySummary(
+            matched = s.matched,
+            auto = s.tiers["AUTO"]!!.size,
+            scaffold = s.tiers["SCAFFOLD"]!!.size,
+            miss = s.tiers["MISS"]!!.size,
+            unmatched = s.tiers["UNMATCHED"]!!.size,
+            avgRecall = s.avgRecall,
+        )
+    }
+
+    private fun scoreSet(code: String, effects: Set<String>, keywords: Set<String>, idx: Map<String, JsonObject>? = null): SetScore {
         val truth = parseSnapshot(code)
-        val mtgish = Mtgish.loadMtgishIndex(truth.keys)
+        val mtgish = idx ?: Mtgish.loadMtgishIndex(truth.keys)
         val s = SetScore()
         for (name in truth.keys.sorted()) {
             val mt = mtgish[name]

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Main.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Main.kt
@@ -1,21 +1,23 @@
 package com.wingedsheep.tooling.coverage
 
+import com.wingedsheep.tooling.coverage.dashboard.Dashboard
 import kotlin.system.exitProcess
 
 /**
- * Dispatch entrypoint for the mtgish coverage tooling. The first token selects one of the three
- * tools (probe / fidelity / autogen); the rest are that tool's own flags.
+ * Dispatch entrypoint for the mtgish coverage tooling. The first token selects one of the tools
+ * (probe / fidelity / autogen / dashboard); the rest are that tool's own flags.
  *
  *   probe     --set CODE | --card "NAME" | --calibrate CODE   [--free|--blocked|--all] [--refresh]
  *   fidelity  --set CODE [--list TIER] | --all | --emit "NAME" | --gate CODE
  *   autogen   --set CODE [--gaps|--write|--emit-all|--write-all] [--list CAT] [--out DIR]
  *             --all --gaps [--list CAT] [--unique]
+ *   dashboard                 interactive TUI over the same analysis (set / card / cross-set views)
  *
  * Wired into the justfile `coverage*` recipes and the mtg-sets `verifyGeneratedCards` gate.
  */
 fun main(args: Array<String>) {
     if (args.isEmpty()) {
-        System.err.println("usage: <probe|fidelity|autogen> [args...]")
+        System.err.println("usage: <probe|fidelity|autogen|dashboard> [args...]")
         exitProcess(2)
     }
     val rest = args.drop(1)
@@ -23,8 +25,9 @@ fun main(args: Array<String>) {
         "probe" -> Probe.run(rest)
         "fidelity" -> Fidelity.run(rest)
         "autogen" -> Autogen.run(rest)
+        "dashboard" -> Dashboard.run(rest)
         else -> {
-            System.err.println("unknown tool '${args[0]}' — expected probe | fidelity | autogen")
+            System.err.println("unknown tool '${args[0]}' — expected probe | fidelity | autogen | dashboard")
             2
         }
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Scryfall.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Scryfall.kt
@@ -41,7 +41,10 @@ object Scryfall {
     /** Strip ` // back` suffix from DFC / adventure names. */
     fun frontFace(name: String): String = name.split(" // ", limit = 2)[0].trim()
 
+    private var discoverSetsCache: List<SetInfo>? = null
+
     fun discoverSets(): List<SetInfo> {
+        discoverSetsCache?.let { return it }
         val out = mutableListOf<SetInfo>()
         val dirs = DEFINITIONS_ROOT.listFiles()?.sortedBy { it.name } ?: emptyList()
         for (dir in dirs) {
@@ -57,21 +60,70 @@ object Scryfall {
             val cardsDir = File(dir, "cards").let { if (it.isDirectory) it else dir }
             out.add(SetInfo(code, name, cardsDir))
         }
-        return out
+        return out.also { discoverSetsCache = it }
     }
 
-    fun scanImplementations(cardsDir: File): Set<String> {
-        if (!cardsDir.isDirectory) return emptySet()
+    private val scanCache = HashMap<String, Set<String>>()
+
+    fun scanImplementations(cardsDir: File): Set<String> = scanCache.getOrPut(cardsDir.path) {
+        if (!cardsDir.isDirectory) return@getOrPut emptySet()
         val names = mutableSetOf<String>()
         cardsDir.listFiles { f -> f.name.endsWith(".kt") }?.forEach { kt ->
             val text = kt.readText()
             CARD_DSL_RE.findAll(text).forEach { names.add(it.groupValues[1]) }
             PRINTING_NAME_RE.findAll(text).forEach { names.add(it.groupValues[1]) }
         }
-        return names
+        names
     }
 
     private fun cachePath(code: String): File = File(CACHE_ROOT, "${code.lowercase()}.json")
+
+    /** Uppercased set codes that already have a cached Scryfall canonical payload on disk. */
+    fun cachedSetCodes(): Set<String> =
+        CACHE_ROOT.listFiles { f -> f.isFile && f.extension == "json" && !f.name.startsWith("_") }
+            ?.map { it.nameWithoutExtension.uppercase() }?.toSet()
+            ?: emptySet()
+
+    /** A set's `released_at` (ISO date) read straight from the cache file — null, never a fetch, if absent. */
+    fun releaseDate(code: String): String? {
+        val path = cachePath(code)
+        if (!path.isFile) return null
+        return runCatching { (J.parseToJsonElement(path.readText()) as JsonObject)["released_at"].asStr() }.getOrNull()
+    }
+
+    private val SETNAMES_FILE: File get() = File(CACHE_ROOT, "_setnames.json")
+    private var setNamesCache: Map<String, String>? = null
+
+    /**
+     * Uppercased set code → human display name for every Scryfall set. Served from a local cache file
+     * (`~/.cache/scryfall/_setnames.json`); populated on first need from the Scryfall `/sets` endpoint
+     * with a bounded timeout. Degrades to an empty map when offline so callers fall back to the code.
+     */
+    fun setDisplayNames(): Map<String, String> {
+        setNamesCache?.let { return it }
+        if (SETNAMES_FILE.isFile) {
+            runCatching { (J.parseToJsonElement(SETNAMES_FILE.readText()) as JsonObject).mapValues { it.value.asStr() ?: "" } }
+                .getOrNull()?.let { setNamesCache = it; return it }
+        }
+        val map = runCatching {
+            val conn = URI("$SCRYFALL_BASE/sets").toURL().openConnection() as HttpURLConnection
+            conn.setRequestProperty("User-Agent", USER_AGENT)
+            conn.connectTimeout = 4000
+            conn.readTimeout = 8000
+            val text = conn.inputStream.readBytes().toString(StandardCharsets.UTF_8)
+            conn.disconnect()
+            ((J.parseToJsonElement(text) as JsonObject)["data"].asArr ?: JsonArray(emptyList()))
+                .filterIsInstance<JsonObject>()
+                .associate { ((it["code"].asStr() ?: "").uppercase()) to (it["name"].asStr() ?: "") }
+                .filterKeys { it.isNotEmpty() }
+        }.getOrDefault(emptyMap())
+        if (map.isNotEmpty()) runCatching {
+            CACHE_ROOT.mkdirs()
+            SETNAMES_FILE.writeText(PRETTY.encodeToString(JsonElement.serializer(), JsonObject(map.mapValues { JsonPrimitive(it.value) })))
+        }
+        setNamesCache = map
+        return map
+    }
 
     private fun isCacheFresh(payload: JsonObject): Boolean {
         if (payload["_v"].asInt() != CACHE_SCHEMA_VERSION) return false

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Analyzer.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Analyzer.kt
@@ -1,0 +1,249 @@
+package com.wingedsheep.tooling.coverage.dashboard
+
+import com.wingedsheep.tooling.coverage.Cards
+import com.wingedsheep.tooling.coverage.Counter
+import com.wingedsheep.tooling.coverage.Fidelity
+import com.wingedsheep.tooling.coverage.Mtgish
+import com.wingedsheep.tooling.coverage.Probe
+import com.wingedsheep.tooling.coverage.Registry
+import com.wingedsheep.tooling.coverage.Scryfall
+import com.wingedsheep.tooling.coverage.emitter.Emitter
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Data layer for the interactive coverage dashboard. Owns the (loaded-once) SDK capability registry
+ * and the shared mtgish IR index, and turns them into the per-set / per-card / cross-set models the
+ * TUI renders.
+ *
+ * It does NOT re-implement the coverage logic: the genuinely reusable per-card primitives already
+ * live in [Probe.analyze] (coverable? + blockers) and [Emitter.renderCard] (whole-render? = the
+ * AUTOGEN/SCAFFOLD split). This object only aggregates them per set and memoizes the result, so a
+ * keypress never recomputes work it has already done. The single 29MB mtgish stream is paid once,
+ * lazily, on the first set the user actually drills into.
+ */
+object Analyzer {
+    lateinit var effects: Set<String>
+        private set
+    lateinit var keywords: Set<String>
+        private set
+    private var initialized = false
+
+    fun init() {
+        if (initialized) return
+        effects = Registry.loadEffectSerialNames()
+        keywords = Registry.loadKeywords()
+        initialized = true
+    }
+
+    // --- set enumeration (implemented sets ∪ sets with a cached Scryfall payload) -----------------
+    data class SetRef(val code: String, val name: String, val released: String?)
+
+    private var setsCache: List<SetRef>? = null
+
+    fun sets(): List<SetRef> {
+        setsCache?.let { return it }
+        val implemented = Scryfall.discoverSets().associate { it.code.uppercase() to it.displayName }
+        val scryfallNames = Scryfall.setDisplayNames()
+        val codes = (implemented.keys + Scryfall.cachedSetCodes()).toSortedSet()
+        return codes.map { SetRef(it, implemented[it] ?: scryfallNames[it] ?: it, Scryfall.releaseDate(it)) }
+            .also { setsCache = it }
+    }
+
+    // --- cheap counts (no mtgish needed): drives the set-list coverage% instantly ----------------
+    data class Counts(val total: Int, val implemented: Int) {
+        val pct: Double get() = if (total == 0) 0.0 else implemented * 100.0 / total
+    }
+
+    private val countsCache = HashMap<String, Counts>()
+
+    fun counts(code: String): Counts = countsCache.getOrPut(code.uppercase()) {
+        val (draft, extra) = Cards.canonicalNames(code)
+        val canonical = (draft ?: emptySet()) + (extra ?: emptySet())
+        val implemented = Cards.implementedNames(code).count { it in canonical }
+        Counts(canonical.size, implemented)
+    }
+
+    // --- the shared mtgish index, loaded once for the union of every set's canonical names --------
+    private var index: Map<String, JsonObject>? = null
+
+    private fun index(): Map<String, JsonObject> {
+        index?.let { return it }
+        val union = sortedSetOf<String>()
+        for (s in sets()) {
+            val (draft, extra) = Cards.canonicalNames(s.code)
+            ((draft ?: emptySet()) + (extra ?: emptySet())).forEach { union.add(it) }
+        }
+        return Mtgish.loadMtgishIndex(union).also { index = it }
+    }
+
+    /** Has the 29MB mtgish IR been streamed yet? Lets the TUI show a one-time loading frame. */
+    fun indexLoaded(): Boolean = index != null
+
+    // --- per-set detail (the combined coverage + autogen pass) ------------------------------------
+    /** What the auto-generator can do with a card, independent of whether it's already implemented. */
+    enum class Gen { WHOLE, SCAFFOLD, BLOCKED, NONE }
+
+    data class CardVerdict(val name: String, val implemented: Boolean, val gen: Gen, val blockers: List<Probe.Blocker>)
+
+    data class LeaderRow(val disc: String, val value: String, val count: Int, val verdict: String)
+
+    data class Detail(
+        val code: String,
+        val name: String,
+        val total: Int,
+        val implemented: Int,
+        // backlog breakdown — cards NOT yet implemented, by what the generator could do with them:
+        val autogen: Int,
+        val scaffold: Int,
+        val blocked: Int,
+        val unmatched: Int,
+        // auto-gen coverage across ALL cards (implemented included) — answers "how much of this set
+        // could the generator reproduce?", so even a 100%-implemented set has a meaningful number:
+        val genWhole: Int,
+        val genScaffold: Int,
+        val genBlocked: Int,
+        val cards: List<CardVerdict>,
+        val leaderboard: List<LeaderRow>,
+        val fidelity: Fidelity.FidelitySummary?,
+    ) {
+        /** Missing-but-fully-coverable: zero engine work needed (AUTOGEN drafts + SCAFFOLD hand-wires). */
+        val free: Int get() = autogen + scaffold
+
+        /** Implemented + free — the share of the set reachable with no new engine capability. */
+        val reachable: Int get() = implemented + free
+
+        /** % of all cards the generator renders whole — the set's auto-gen coverage. */
+        val genCoveragePct: Double get() = if (total == 0) 0.0 else genWhole * 100.0 / total
+    }
+
+    private val detailCache = HashMap<String, Detail>()
+
+    fun isComputed(code: String): Boolean = detailCache.containsKey(code.uppercase())
+
+    fun detail(code: String): Detail = detailCache.getOrPut(code.uppercase()) { compute(code.uppercase()) }
+
+    fun verdictFor(code: String, name: String): CardVerdict? = detail(code).cards.firstOrNull { it.name == name }
+
+    private fun compute(code: String): Detail {
+        val (draft, extra) = Cards.canonicalNames(code)
+        val canonical = ((draft ?: emptySet()) + (extra ?: emptySet())).toSortedSet()
+        val implemented = Cards.implementedNames(code)
+        val ix = index()
+
+        val cards = ArrayList<CardVerdict>(canonical.size)
+        val leaderboard = Counter<Pair<String, String>>()
+        val leaderboardVerdict = HashMap<Pair<String, String>, String>()
+        var nImpl = 0; var nAuto = 0; var nScaffold = 0; var nBlocked = 0; var nUnmatched = 0
+        var genWhole = 0; var genScaffold = 0; var genBlocked = 0
+
+        for (name in canonical) {
+            val isImpl = name in implemented
+            val card = ix[name]
+            if (card == null) {
+                cards.add(CardVerdict(name, isImpl, Gen.NONE, emptyList()))
+                if (isImpl) nImpl++ else nUnmatched++
+                continue
+            }
+            val analysis = Probe.analyze(card, effects, keywords)
+            val gen = when {
+                !analysis.coverable -> Gen.BLOCKED
+                Emitter.renderCard(card, Cards.scryfallCard(code, name), effects, keywords).complete -> Gen.WHOLE
+                else -> Gen.SCAFFOLD
+            }
+            cards.add(CardVerdict(name, isImpl, gen, if (gen == Gen.BLOCKED) analysis.blockers else emptyList()))
+
+            when (gen) { Gen.WHOLE -> genWhole++; Gen.SCAFFOLD -> genScaffold++; Gen.BLOCKED -> genBlocked++; Gen.NONE -> {} }
+            if (isImpl) {
+                nImpl++
+            } else when (gen) {
+                Gen.WHOLE -> nAuto++
+                Gen.SCAFFOLD -> nScaffold++
+                Gen.BLOCKED -> {
+                    nBlocked++
+                    for (b in analysis.blockers) { leaderboard.add(b.disc to b.value); leaderboardVerdict[b.disc to b.value] = b.verdict }
+                }
+                Gen.NONE -> nUnmatched++
+            }
+        }
+
+        val rows = leaderboard.mostCommon().map { (key, c) ->
+            LeaderRow(key.first, key.second, c, leaderboardVerdict[key] ?: "")
+        }
+        val fidelity = runCatching { Fidelity.summarizeOrNull(code, effects, keywords, ix) }.getOrNull()
+        return Detail(
+            code = code,
+            name = sets().firstOrNull { it.code == code }?.name ?: code,
+            total = canonical.size,
+            implemented = nImpl, autogen = nAuto, scaffold = nScaffold, blocked = nBlocked, unmatched = nUnmatched,
+            genWhole = genWhole, genScaffold = genScaffold, genBlocked = genBlocked,
+            cards = cards, leaderboard = rows, fidelity = fidelity,
+        )
+    }
+
+    // --- per-card drill-down ----------------------------------------------------------------------
+    data class CardReport(
+        val name: String,
+        val coverable: Boolean,
+        val unmatched: Boolean,
+        val reqs: List<Probe.Req>,
+        val implementedIn: Set<String>,
+    )
+
+    private val sourceCache = HashMap<String, String?>()
+
+    /**
+     * The emitter's generated `cardDef` DSL for [name] as it would draft it for [setCode] (whole for
+     * AUTOGEN cards, a TODO/STRUCTURE scaffold otherwise). Null when the card has no mtgish IR entry.
+     * Memoized so scrolling the code view never re-renders.
+     */
+    fun cardSource(setCode: String, name: String): String? = sourceCache.getOrPut("$setCode/$name") {
+        val card = index()[name] ?: return@getOrPut null
+        Emitter.renderCard(
+            card, Cards.scryfallCard(setCode, name), effects, keywords,
+            pkg = "com.wingedsheep.mtg.sets.generated.${setCode.lowercase()}.cards",
+        ).text
+    }
+
+    fun cardReport(name: String): CardReport {
+        val card = index()[name]
+        val implementedIn = Cards.implementedNamesForCard(name)
+        if (card == null) return CardReport(name, coverable = false, unmatched = true, reqs = emptyList(), implementedIn)
+        val analysis = Probe.analyze(card, effects, keywords)
+        return CardReport(name, analysis.coverable, unmatched = false, reqs = analysis.reqs, implementedIn)
+    }
+
+    // --- cross-set capability index (aggregate every set's blocked-feature leaderboard) ----------
+    data class CrossRow(val disc: String, val value: String, val count: Int, val sets: Int, val verdict: String)
+
+    private var crossCache: List<CrossRow>? = null
+
+    /** Forces [detail] for every set (the slow path) — [progress] is invoked as (done, total). */
+    fun crossSet(progress: (Int, Int) -> Unit): List<CrossRow> {
+        crossCache?.let { return it }
+        val agg = Counter<Pair<String, String>>()
+        val setCount = HashMap<Pair<String, String>, Int>()
+        val verdict = HashMap<Pair<String, String>, String>()
+        val all = sets()
+        for ((i, ref) in all.withIndex()) {
+            progress(i + 1, all.size)
+            for (row in detail(ref.code).leaderboard) {
+                val key = row.disc to row.value
+                agg.add(key, row.count)
+                setCount[key] = (setCount[key] ?: 0) + 1
+                verdict[key] = row.verdict
+            }
+        }
+        return agg.mostCommon()
+            .map { (key, c) -> CrossRow(key.first, key.second, c, setCount[key] ?: 0, verdict[key] ?: "") }
+            .also { crossCache = it }
+    }
+
+    /** Drop memoized analysis for [code] (and the shared index + cross-set roll-up) so `r` recomputes. */
+    fun invalidate(code: String) {
+        countsCache.remove(code.uppercase())
+        detailCache.remove(code.uppercase())
+        sourceCache.clear()
+        crossCache = null
+        index = null
+    }
+}

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Dashboard.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Dashboard.kt
@@ -1,0 +1,543 @@
+package com.wingedsheep.tooling.coverage.dashboard
+
+import com.wingedsheep.tooling.coverage.Scryfall
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * Interactive TUI for the mtgish coverage tooling — a navigable, two-pane dashboard over the same
+ * analysis the `just coverage*` CLIs print. Left pane: every set with its implemented %. Right pane:
+ * the selected set's coverage breakdown (implemented / free-to-add / blocked) and the feature
+ * leaderboard, then drill into the card list and a per-card capability verdict. `c` rolls every set's
+ * leaderboard into one cross-set "what engine work unlocks the most cards everywhere" ranking.
+ *
+ * Wired into `just coverage-dashboard` (see Main.kt `dashboard` subcommand).
+ */
+object Dashboard {
+    private enum class Mode { SETS, CARDS, CARD, CROSS }
+    private enum class Sort { DATE, ALPHA }
+
+    private val tty = RawTerminal()
+    private lateinit var sets: List<Analyzer.SetRef>
+    private var sortMode = Sort.DATE
+
+    private var mode = Mode.SETS
+    private var setSel = 0
+    private var setScroll = 0
+    private var cardSel = 0
+    private var cardScroll = 0
+    private var reqScroll = 0
+    private var crossSel = 0
+    private var crossScroll = 0
+    private var filter = "" // card-list filter (CARDS mode)
+    private var setFilter = "" // set-list search (SETS mode)
+    private var filtering = false
+    private var cardName: String? = null
+    private var cardCodeView = true // card detail shows generated Kotlin (vs the capability list)
+    private var highlightName: String? = null // which card `highlightLines` was tokenized for
+    private var highlightLines: List<List<KotlinHighlight.Tok>> = emptyList()
+    private var cross: List<Analyzer.CrossRow>? = null
+
+    fun run(args: List<String>): Int {
+        Analyzer.init()
+        sets = sortedSets(Analyzer.sets())
+        if (sets.isEmpty()) {
+            System.err.println("no sets found — implement a set or cache one with `just coverage --set <CODE>`")
+            return 1
+        }
+        if ("--render" in args) return selfRender()
+        if (!RawTerminal.available()) {
+            System.err.println("coverage-dashboard needs an interactive terminal (no /dev/tty available).")
+            return 1
+        }
+        tty.enter()
+        try {
+            if ("--scan" in args) { val (rows, cols) = tty.size(); scanAll(rows, cols, "Full scan — analyzing every set") }
+            loop()
+        } finally {
+            tty.exit()
+        }
+        return 0
+    }
+
+    /**
+     * Non-interactive smoke path (`dashboard --render`): build and print static frames at a fixed size
+     * for the first set that has Scryfall data, without entering raw mode. Exercises the whole Analyzer
+     * pipeline + every render builder so the dashboard can be verified outside a live terminal.
+     */
+    private fun selfRender(): Int {
+        val rows = 34; val cols = 110
+        setSel = sets.indexOfFirst { Analyzer.counts(it.code).total > 0 }.coerceAtLeast(0)
+        val d = Analyzer.detail(currentCode())
+        mode = Mode.SETS; printFrame("SET DETAIL", rows, cols)
+        mode = Mode.CARDS; printFrame("CARD LIST", rows, cols)
+        cardName = (d.cards.firstOrNull { it.gen == Analyzer.Gen.WHOLE } ?: d.cards.first()).name
+        mode = Mode.CARD
+        cardCodeView = true; printFrame("CARD DETAIL (Kotlin) — $cardName", rows, cols)
+        cardCodeView = false; printFrame("CARD DETAIL (capabilities) — $cardName", rows, cols)
+        return 0
+    }
+
+    private fun printFrame(label: String, rows: Int, cols: Int) {
+        println("\n===== $label =====")
+        buildFrame(rows, cols).forEach(::println)
+    }
+
+    private fun loop() {
+        while (true) {
+            val (rows, cols) = tty.size()
+            ensureCurrentComputed(rows, cols)
+            tty.render(buildFrame(rows, cols))
+            if (!handle(tty.readKey(), rows, cols)) break
+        }
+    }
+
+    /** First visit to a set blocks on analysis (and, on the very first, the 29MB IR) — show a frame. */
+    private fun ensureCurrentComputed(rows: Int, cols: Int) {
+        if (mode == Mode.CROSS) return
+        val code = currentCode().ifEmpty { return }
+        if (!Analyzer.isComputed(code) && Analyzer.counts(code).total > 0) {
+            val note = if (Analyzer.indexLoaded()) "" else "  (loading mtgish IR, first run only)"
+            tty.render(centered(rows, cols, "Analyzing ${code}…$note"))
+            Analyzer.detail(code)
+        }
+    }
+
+    // ============================================================ rendering
+
+    private fun buildFrame(rows: Int, cols: Int): List<String> {
+        val bodyH = max(1, rows - 2)
+        val body: List<String> = if (mode == Mode.CROSS) {
+            buildCross(bodyH, cols)
+        } else {
+            val leftW = max(28, min(48, cols * 2 / 5))
+            val rightW = max(1, cols - leftW - 1)
+            val left = buildSetList(bodyH, leftW)
+            val right = when (mode) {
+                Mode.SETS -> buildSetDetail(bodyH, rightW)
+                Mode.CARDS -> buildCardList(bodyH, rightW)
+                Mode.CARD -> buildCardDetail(bodyH, rightW)
+                Mode.CROSS -> emptyList()
+            }
+            val sep = Ansi.style("│", Ansi.fg(Ansi.DARKGREY))
+            (0 until bodyH).map { i ->
+                left.getOrElse(i) { " ".repeat(leftW) } + sep + right.getOrElse(i) { " ".repeat(rightW) }
+            }
+        }
+        return listOf(buildTitle(cols)) + body + listOf(buildFooter(cols))
+    }
+
+    private fun buildTitle(cols: Int): String {
+        val totTotal = sets.sumOf { Analyzer.counts(it.code).total }
+        val totImpl = sets.sumOf { Analyzer.counts(it.code).implemented }
+        val pct = if (totTotal == 0) 0 else (totImpl * 100.0 / totTotal).roundToInt()
+        // Auto-gen total sums only the sets analyzed so far (browsing a set, or pressing `c`, analyzes
+        // it). The [k/n] note shows how complete the figure is; it drops once every set is analyzed.
+        var autoSum = 0
+        var analyzed = 0
+        for (s in sets) when {
+            Analyzer.isComputed(s.code) -> { analyzed++; autoSum += Analyzer.detail(s.code).autogen }
+            Analyzer.counts(s.code).total == 0 -> analyzed++
+        }
+        val autoNote = if (analyzed < sets.size) " [$analyzed/${sets.size} sets analyzed — press c]" else ""
+        val text = " mtgish coverage   ${sets.size} sets   $totImpl/$totTotal implemented ($pct%)   ·   +$autoSum auto-gen ready$autoNote"
+        return Ansi.style(Ansi.fit(text, cols), Ansi.BOLD, Ansi.fg(Ansi.WHITE), Ansi.bg(Ansi.BLUE))
+    }
+
+    private fun buildFooter(cols: Int): String {
+        if (filtering) {
+            val label = if (mode == Mode.SETS) "search sets" else "filter cards"
+            val text = if (mode == Mode.SETS) setFilter else filter
+            return Ansi.style(Ansi.fit(" $label: $text█   (enter apply · esc clear)", cols), Ansi.fg(Ansi.YELLOW))
+        }
+        val help = when (mode) {
+            Mode.SETS -> "↑↓ set · → cards · / search · s sort:${if (sortMode == Sort.DATE) "date" else "a-z"} · f scan-all · c cross · q quit"
+            Mode.CARDS -> "↑↓ card · → detail · ← sets · / filter · c cross-set · q quit"
+            Mode.CARD -> "↑↓ scroll · tab Kotlin/capabilities · ← cards · q quit"
+            Mode.CROSS -> "↑↓ scroll · ← back · q quit"
+        }
+        return Ansi.style(Ansi.fit(" $help", cols), Ansi.fg(Ansi.GREY))
+    }
+
+    private fun buildSetList(h: Int, w: Int): List<String> {
+        val shown = shownSets()
+        if (setSel >= shown.size) setSel = max(0, shown.size - 1)
+        val lines = ArrayList<String>()
+        val header = if (setFilter.isBlank()) " SETS (${sets.size})" else " SETS (${shown.size}/${sets.size}) · '$setFilter'"
+        lines.add(Ansi.style(Ansi.fit(header, w), Ansi.BOLD, Ansi.fg(Ansi.WHITE), Ansi.bg(Ansi.DARKGREY)))
+        val listH = h - 1
+        setScroll = clampScroll(setSel, setScroll, listH, shown.size)
+        for (row in 0 until listH) {
+            val idx = setScroll + row
+            if (idx >= shown.size) { lines.add(" ".repeat(w)); continue }
+            val s = shown[idx]
+            val c = Analyzer.counts(s.code)
+            // Right column: implemented/total and "gG" = cards the generator renders whole across the
+            // WHOLE set (so a 100%-implemented set still shows its auto-gen coverage). "g?" until analyzed.
+            val gen = when {
+                c.total == 0 -> ""
+                Analyzer.isComputed(s.code) -> "g${Analyzer.detail(s.code).genWhole}"
+                else -> "g?"
+            }
+            val stats = if (c.total == 0) "—" else "${c.implemented}/${c.total}${if (gen.isEmpty()) "" else " $gen"}"
+            val left = " ${s.code.padEnd(4)} ${year(s)} ${s.name}"
+            val leftW = max(0, w - stats.length - 1)
+            val plain = Ansi.fit(left, leftW) + " " + stats
+            lines.add(
+                when {
+                    idx == setSel && mode == Mode.SETS -> Ansi.style(Ansi.fit(plain, w), Ansi.REVERSE)
+                    idx == setSel -> Ansi.style(Ansi.fit(plain, w), Ansi.bg(238))
+                    c.total == 0 -> Ansi.style(Ansi.fit(plain, w), Ansi.fg(Ansi.DARKGREY))
+                    gen.isEmpty() -> Ansi.fit(plain, w)
+                    else -> Ansi.fit(left, leftW) + " ${c.implemented}/${c.total} " +
+                        Ansi.style(gen, Ansi.fg(if (Analyzer.isComputed(s.code)) Ansi.GREEN else Ansi.DARKGREY))
+                }
+            )
+        }
+        return lines
+    }
+
+    private fun buildSetDetail(h: Int, w: Int): List<String> {
+        val lines = ArrayList<String>()
+        fun add(s: String, vararg st: String) { lines.add(Ansi.style(Ansi.fit(s, w), *st)) }
+        val ref = currentSet() ?: return padTo(lines, h, w)
+        val c = Analyzer.counts(ref.code)
+        if (c.total == 0) {
+            add(" ${ref.code} — ${ref.name} (${year(ref)})", Ansi.BOLD, Ansi.fg(Ansi.WHITE))
+            add("")
+            add(" No Scryfall data cached for this set.", Ansi.fg(Ansi.GREY))
+            add(" Press r to fetch it (network), or run:", Ansi.fg(Ansi.GREY))
+            add("   just coverage --set ${ref.code}", Ansi.fg(Ansi.CYAN))
+            return padTo(lines, h, w)
+        }
+        val d = Analyzer.detail(ref.code)
+        fun stat(label: String, n: Int) = " ${label.padEnd(12)} ${n.toString().padStart(5)}  ${pct(n, d.total)}"
+        add(" ${d.code} — ${d.name} (${year(ref)})", Ansi.BOLD, Ansi.fg(Ansi.WHITE))
+        add(" ${d.total} cards", Ansi.fg(Ansi.GREY))
+        add("")
+        add(stat("Implemented", d.implemented), Ansi.fg(Ansi.GREEN))
+        // auto-gen coverage spans ALL cards (implemented included) — meaningful even at 100% implemented.
+        add(stat("Auto-gen", d.genWhole) + "  whole ${d.genWhole} · scaf ${d.genScaffold} · blk ${d.genBlocked}", Ansi.fg(Ansi.CYAN))
+        add(stat("Free to add", d.free) + "  AUTO ${d.autogen} · SCAFF ${d.scaffold}", Ansi.fg(Ansi.BLUE))
+        add(stat("Blocked", d.blocked), Ansi.fg(Ansi.RED))
+        if (d.unmatched > 0) add(stat("Unmatched", d.unmatched), Ansi.fg(Ansi.DARKGREY))
+        d.fidelity?.let { f ->
+            add("")
+            add(" fidelity (vs golden): AUTO ${f.auto} · SCAFFOLD ${f.scaffold} · MISS ${f.miss} · recall ${f.avgRecall.roundToInt()}%", Ansi.fg(Ansi.GREY))
+        }
+        add("")
+        add(" Feature leaderboard — engine work ranked", Ansi.BOLD, Ansi.fg(Ansi.WHITE))
+        add(" by # blocked cards it would unlock:", Ansi.BOLD, Ansi.fg(Ansi.WHITE))
+        val room = h - lines.size
+        if (d.leaderboard.isEmpty()) {
+            add(if (d.blocked == 0) " — nothing blocked, every missing card is free!" else " —", Ansi.fg(Ansi.GREY))
+        } else {
+            for (r in d.leaderboard.take(room)) {
+                val gap = r.verdict == "MISSING"
+                val tag = if (gap) "GAP" else "?? "
+                add(" [$tag] x${r.count.toString().padEnd(3)} ${r.disc} = ${r.value}", Ansi.fg(if (gap) Ansi.ORANGE else Ansi.GREY))
+            }
+        }
+        return padTo(lines, h, w)
+    }
+
+    private fun filteredCards(d: Analyzer.Detail): List<Analyzer.CardVerdict> =
+        if (filter.isBlank()) d.cards else d.cards.filter { it.name.contains(filter, ignoreCase = true) }
+
+    private fun buildCardList(h: Int, w: Int): List<String> {
+        val d = Analyzer.detail(currentCode())
+        val cards = filteredCards(d)
+        if (cardSel >= cards.size) cardSel = max(0, cards.size - 1)
+        val lines = ArrayList<String>()
+        val head = " ${d.code} cards (${cards.size}${if (filter.isNotBlank()) " · '$filter'" else ""})"
+        lines.add(Ansi.style(Ansi.fit(head, w), Ansi.BOLD, Ansi.fg(Ansi.WHITE), Ansi.bg(Ansi.DARKGREY)))
+        val listH = h - 1
+        cardScroll = clampScroll(cardSel, cardScroll, listH, cards.size)
+        for (row in 0 until listH) {
+            val idx = cardScroll + row
+            if (idx >= cards.size) { lines.add(" ".repeat(w)); continue }
+            val cv = cards[idx]
+            // marker = implemented? ✓ : new; colour = the generator's verdict (so an implemented card
+            // the generator can't reproduce shows a red ✓ — a hand-authored card needing engine work).
+            val plain = " ${marker(cv)} ${cv.name}"
+            lines.add(
+                if (idx == cardSel && mode == Mode.CARDS) Ansi.style(Ansi.fit(plain, w), Ansi.REVERSE)
+                else Ansi.style(Ansi.fit(plain, w), Ansi.fg(genColor(cv.gen)))
+            )
+        }
+        return lines
+    }
+
+    private fun buildCardDetail(h: Int, w: Int): List<String> {
+        val name = cardName ?: return padTo(ArrayList(), h, w)
+        val code = currentCode()
+        val rep = Analyzer.cardReport(name)
+        val cv = Analyzer.verdictFor(code, name)
+        val lines = ArrayList<String>()
+        fun add(s: String, vararg st: String) { lines.add(Ansi.style(Ansi.fit(s, w), *st)) }
+        val impl = if (cv?.implemented == true) "implemented · " else ""
+        add(" ${rep.name}", Ansi.BOLD, Ansi.fg(Ansi.WHITE))
+        when (cv?.gen) {
+            Analyzer.Gen.WHOLE -> add(" ${impl}auto-gen: WHOLE — generator renders the whole card", Ansi.fg(Ansi.GREEN))
+            Analyzer.Gen.SCAFFOLD -> add(" ${impl}auto-gen: SCAFFOLD — covered, structure needs hand-wiring", Ansi.fg(Ansi.YELLOW))
+            Analyzer.Gen.BLOCKED -> add(" ${impl}auto-gen: BLOCKED — needs engine work", Ansi.fg(Ansi.RED))
+            else -> add(" ${impl}not in mtgish IR (name join / Un-set / too new)", Ansi.fg(Ansi.GREY))
+        }
+        add(if (cardCodeView) " ▸ Kotlin    ·   capabilities" else "   Kotlin    ·  ▸ capabilities", Ansi.fg(Ansi.CYAN))
+        add("")
+        if (cardCodeView) appendCardSource(lines, code, name, rep, h, w, ::add) else appendCapabilities(lines, rep, h, ::add)
+        return padTo(lines, h, w)
+    }
+
+    private fun appendCardSource(lines: MutableList<String>, code: String, name: String, rep: Analyzer.CardReport, h: Int, w: Int, add: (String, Array<out String>) -> Unit) {
+        // Missing mappings first (fixed header) — the capabilities the bridge can't yet express, which
+        // are exactly why a BLOCKED card's generated source below is a scaffold rather than whole.
+        val missing = rep.reqs.filter { it.verdict == "MISSING" || it.verdict == "UNMAPPED" }
+        if (missing.isEmpty()) {
+            add(if (rep.unmatched) "" else " ✓ all capabilities mapped", arrayOf(Ansi.fg(Ansi.GREEN)))
+        } else {
+            add(" ⚠ missing mappings (${missing.size}):", arrayOf(Ansi.BOLD, Ansi.fg(Ansi.ORANGE)))
+            for (m in missing.take(4)) {
+                val tag = if (m.verdict == "MISSING") "GAP" else "?? "
+                add("   [$tag] ${m.disc} = ${m.value}", arrayOf(Ansi.fg(Ansi.ORANGE)))
+            }
+            if (missing.size > 4) add("   +${missing.size - 4} more — tab for full capability list", arrayOf(Ansi.fg(Ansi.DARKGREY)))
+        }
+        add(" ── generated cardDef ${"─".repeat(max(0, w - 18))}", arrayOf(Ansi.fg(Ansi.DARKGREY)))
+        val src = Analyzer.cardSource(code, name)
+        if (src == null) { add(" (no generated source — card absent from mtgish IR)", arrayOf(Ansi.fg(Ansi.GREY))); return }
+        val key = "$code/$name"
+        if (highlightName != key) { highlightLines = KotlinHighlight.highlight(src); highlightName = key }
+        val room = h - lines.size
+        reqScroll = reqScroll.coerceIn(0, max(0, highlightLines.size - room))
+        for (toks in highlightLines.drop(reqScroll).take(room)) lines.add(KotlinHighlight.renderLine(toks, w))
+        if (highlightLines.size > room) lines[lines.lastIndex] = Ansi.style(Ansi.fit(" … ${highlightLines.size - reqScroll - room} more lines (↑↓)", w), Ansi.fg(Ansi.DARKGREY))
+    }
+
+    private fun appendCapabilities(lines: MutableList<String>, rep: Analyzer.CardReport, h: Int, add: (String, Array<out String>) -> Unit) {
+        if (rep.implementedIn.isNotEmpty()) add(" implemented in: ${rep.implementedIn.sorted().joinToString(", ")}", arrayOf(Ansi.fg(Ansi.GREY)))
+        add(" Required capabilities:", arrayOf(Ansi.BOLD, Ansi.fg(Ansi.WHITE)))
+        val ordered = rep.reqs.sortedBy { VERDICT_ORDER[it.verdict] ?: 9 }
+        val room = h - lines.size
+        reqScroll = reqScroll.coerceIn(0, max(0, ordered.size - room))
+        if (ordered.isEmpty()) { add(" — none extracted", arrayOf(Ansi.fg(Ansi.GREY))); return }
+        for (r in ordered.drop(reqScroll).take(room)) {
+            val mark = MARK[r.verdict] ?: "?? "
+            val arrow = if (r.detail.isNotEmpty()) " → ${r.detail}" else ""
+            add(" [$mark] ${r.disc} ${r.value}$arrow", arrayOf(Ansi.fg(verdictColor(r.verdict))))
+        }
+    }
+
+    private fun buildCross(h: Int, w: Int): List<String> {
+        val rows = cross ?: emptyList()
+        if (crossSel >= rows.size) crossSel = max(0, rows.size - 1)
+        val lines = ArrayList<String>()
+        lines.add(Ansi.style(Ansi.fit(" CROSS-SET CAPABILITY INDEX — engine work ranked by # blocked cards across all sets (${rows.size} capabilities)", w), Ansi.BOLD, Ansi.fg(Ansi.WHITE), Ansi.bg(Ansi.DARKGREY)))
+        val listH = h - 1
+        crossScroll = clampScroll(crossSel, crossScroll, listH, rows.size)
+        for (row in 0 until listH) {
+            val idx = crossScroll + row
+            if (idx >= rows.size) { lines.add(" ".repeat(w)); continue }
+            val r = rows[idx]
+            val gap = r.verdict == "MISSING"
+            val tag = if (gap) "GAP" else "?? "
+            val plain = " [$tag] ${("x" + r.count).padEnd(6)} ${(r.sets.toString() + " sets").padEnd(9)} ${r.disc} = ${r.value}"
+            lines.add(
+                if (idx == crossSel) Ansi.style(Ansi.fit(plain, w), Ansi.REVERSE)
+                else Ansi.style(Ansi.fit(plain, w), Ansi.fg(if (gap) Ansi.ORANGE else Ansi.GREY))
+            )
+        }
+        return lines
+    }
+
+    // ============================================================ input
+
+    private fun handle(key: Key, rows: Int, cols: Int): Boolean {
+        if (filtering) {
+            val inSets = mode == Mode.SETS
+            when (key) {
+                Key.Enter -> filtering = false
+                Key.Esc -> { if (inSets) setFilter = "" else filter = ""; filtering = false; resetSelection(inSets) }
+                Key.Backspace -> { if (inSets) { if (setFilter.isNotEmpty()) setFilter = setFilter.dropLast(1) } else { if (filter.isNotEmpty()) filter = filter.dropLast(1) }; resetSelection(inSets) }
+                is Key.Char -> { if (inSets) setFilter += key.c else filter += key.c; resetSelection(inSets) }
+                else -> {}
+            }
+            return true
+        }
+        if (key == Key.Quit || key == Key.Char('q')) return false
+        if (key == Key.Char('c')) { enterCross(rows, cols); return true }
+        val pageStep = max(1, rows - 4)
+        when (mode) {
+            Mode.SETS -> {
+                val shown = shownSets()
+                when (key) {
+                    Key.Up, Key.Char('k') -> setSel = max(0, setSel - 1)
+                    Key.Down, Key.Char('j') -> setSel = min(max(0, shown.lastIndex), setSel + 1)
+                    Key.Home -> setSel = 0
+                    Key.End -> setSel = max(0, shown.lastIndex)
+                    Key.PageUp -> setSel = max(0, setSel - pageStep)
+                    Key.PageDown -> setSel = min(max(0, shown.lastIndex), setSel + pageStep)
+                    Key.Enter, Key.Right, Key.Char('l') -> if (Analyzer.counts(currentCode()).total > 0) { mode = Mode.CARDS; cardSel = 0; cardScroll = 0; filter = "" }
+                    Key.Char('/') -> filtering = true
+                    Key.Char('s') -> toggleSort()
+                    Key.Char('f') -> scanAll(rows, cols, "Full scan — analyzing every set")
+                    Key.Char('r') -> refresh(rows, cols)
+                    else -> {}
+                }
+            }
+            Mode.CARDS -> {
+                val cards = filteredCards(Analyzer.detail(currentCode()))
+                when (key) {
+                    Key.Up, Key.Char('k') -> cardSel = max(0, cardSel - 1)
+                    Key.Down, Key.Char('j') -> cardSel = min(max(0, cards.lastIndex), cardSel + 1)
+                    Key.Home -> cardSel = 0
+                    Key.End -> cardSel = max(0, cards.lastIndex)
+                    Key.PageUp -> cardSel = max(0, cardSel - pageStep)
+                    Key.PageDown -> cardSel = min(max(0, cards.lastIndex), cardSel + pageStep)
+                    Key.Enter, Key.Right, Key.Char('l') -> if (cards.isNotEmpty()) { cardName = cards[cardSel.coerceIn(0, cards.lastIndex)].name; mode = Mode.CARD; cardCodeView = true; reqScroll = 0 }
+                    Key.Esc, Key.Left, Key.Char('h') -> mode = Mode.SETS
+                    Key.Char('/') -> filtering = true
+                    else -> {}
+                }
+            }
+            Mode.CARD -> when (key) {
+                Key.Up, Key.Char('k') -> reqScroll = max(0, reqScroll - 1)
+                Key.Down, Key.Char('j') -> reqScroll += 1
+                Key.PageUp -> reqScroll = max(0, reqScroll - pageStep)
+                Key.PageDown -> reqScroll += pageStep
+                Key.Home -> reqScroll = 0
+                Key.Tab, Key.Char('t') -> { cardCodeView = !cardCodeView; reqScroll = 0 }
+                Key.Esc, Key.Left, Key.Char('h') -> mode = Mode.CARDS
+                else -> {}
+            }
+            Mode.CROSS -> {
+                val n = cross?.size ?: 0
+                when (key) {
+                    Key.Up, Key.Char('k') -> crossSel = max(0, crossSel - 1)
+                    Key.Down, Key.Char('j') -> crossSel = min(max(0, n - 1), crossSel + 1)
+                    Key.Home -> crossSel = 0
+                    Key.End -> crossSel = max(0, n - 1)
+                    Key.PageUp -> crossSel = max(0, crossSel - pageStep)
+                    Key.PageDown -> crossSel = min(max(0, n - 1), crossSel + pageStep)
+                    Key.Esc, Key.Left, Key.Char('h') -> mode = Mode.SETS
+                    else -> {}
+                }
+            }
+        }
+        return true
+    }
+
+    /**
+     * Analyze every set in one pass (with a progress bar): fills in each set's `+N` auto-gen count,
+     * completes the global auto-gen total, and builds the cross-set index — so `c` is then instant.
+     * Memoized via [Analyzer], so re-running is a no-op until a set is refreshed.
+     */
+    private fun scanAll(rows: Int, cols: Int, label: String) {
+        if (cross != null) return
+        cross = Analyzer.crossSet { done, total -> tty.render(progress(rows, cols, label, done, total)) }
+    }
+
+    private fun enterCross(rows: Int, cols: Int) {
+        scanAll(rows, cols, "Building cross-set index — analyzing every set")
+        mode = Mode.CROSS; crossSel = 0; crossScroll = 0
+    }
+
+    private fun refresh(rows: Int, cols: Int) {
+        val code = currentCode().ifEmpty { return }
+        tty.render(centered(rows, cols, "Fetching $code from Scryfall…"))
+        runCatching { Scryfall.loadCanonical(code, forceRefresh = true) }
+        Analyzer.invalidate(code)
+        cross = null
+    }
+
+    // ============================================================ helpers
+
+    private val VERDICT_ORDER = mapOf("UNMAPPED" to 0, "MISSING" to 1, "ok" to 2, "composed" to 3, "supported" to 4, "ignore" to 5)
+    private val MARK = mapOf("ok" to "ok ", "composed" to "cmp", "supported" to "sup", "ignore" to "-- ", "MISSING" to "GAP", "UNMAPPED" to "?? ")
+
+    private fun verdictColor(v: String) = when (v) {
+        "ok", "composed", "supported" -> Ansi.GREEN
+        "ignore" -> Ansi.DARKGREY
+        "MISSING" -> Ansi.ORANGE
+        else -> Ansi.GREY
+    }
+
+    private fun marker(cv: Analyzer.CardVerdict): String = when {
+        cv.implemented -> "✓"
+        cv.gen == Analyzer.Gen.WHOLE -> "+"
+        cv.gen == Analyzer.Gen.SCAFFOLD -> "~"
+        cv.gen == Analyzer.Gen.BLOCKED -> "✗"
+        else -> "?"
+    }
+
+    private fun genColor(g: Analyzer.Gen) = when (g) {
+        Analyzer.Gen.WHOLE -> Ansi.GREEN
+        Analyzer.Gen.SCAFFOLD -> Ansi.YELLOW
+        Analyzer.Gen.BLOCKED -> Ansi.RED
+        Analyzer.Gen.NONE -> Ansi.DARKGREY
+    }
+
+    private fun pct(n: Int, total: Int) = if (total == 0) "" else "${(n * 100.0 / total).roundToInt()}%"
+
+    /** Sets matching the current set search (by code or name); the full list when the search is blank. */
+    private fun shownSets(): List<Analyzer.SetRef> =
+        if (setFilter.isBlank()) sets
+        else sets.filter { it.code.contains(setFilter, true) || it.name.contains(setFilter, true) }
+
+    private fun currentSet(): Analyzer.SetRef? = shownSets().getOrNull(setSel)
+    private fun currentCode(): String = currentSet()?.code ?: ""
+
+    private fun resetSelection(inSets: Boolean) {
+        if (inSets) { setSel = 0; setScroll = 0 } else { cardSel = 0; cardScroll = 0 }
+    }
+    private fun year(s: Analyzer.SetRef): String = s.released?.takeIf { it.length >= 4 }?.substring(0, 4) ?: "????"
+
+    /** DATE = newest first (undated sets last); ALPHA = by set code. Both tie-break on code. */
+    private fun sortedSets(list: List<Analyzer.SetRef>): List<Analyzer.SetRef> = when (sortMode) {
+        Sort.DATE -> list.sortedWith(compareByDescending<Analyzer.SetRef> { it.released ?: "" }.thenBy { it.code })
+        Sort.ALPHA -> list.sortedBy { it.code }
+    }
+
+    /** Flip the sort and keep the cursor on the same set (within the current search view). */
+    private fun toggleSort() {
+        val current = currentCode()
+        sortMode = if (sortMode == Sort.DATE) Sort.ALPHA else Sort.DATE
+        sets = sortedSets(sets)
+        setSel = shownSets().indexOfFirst { it.code == current }.coerceAtLeast(0)
+        setScroll = 0
+    }
+
+    /** Keep [sel] inside the visible window of [height] rows over [size] items, returning new scroll. */
+    private fun clampScroll(sel: Int, scroll: Int, height: Int, size: Int): Int {
+        if (height <= 0 || size == 0) return 0
+        var s = scroll
+        if (sel < s) s = sel
+        if (sel >= s + height) s = sel - height + 1
+        return s.coerceIn(0, max(0, size - height))
+    }
+
+    private fun padTo(lines: MutableList<String>, h: Int, w: Int): List<String> {
+        while (lines.size < h) lines.add(" ".repeat(w))
+        return if (lines.size > h) lines.subList(0, h) else lines
+    }
+
+    private fun centered(rows: Int, cols: Int, msg: String): List<String> {
+        val mid = rows / 2
+        return (0 until rows).map { if (it == mid) Ansi.fit(" ".repeat(max(0, (cols - msg.length) / 2)) + msg, cols) else " ".repeat(cols) }
+    }
+
+    private fun progress(rows: Int, cols: Int, label: String, done: Int, total: Int): List<String> {
+        val mid = rows / 2
+        val barW = min(40, cols - 10)
+        val filled = if (total == 0) 0 else (barW * done / total)
+        val bar = "█".repeat(filled) + "░".repeat(max(0, barW - filled))
+        return (0 until rows).map {
+            when (it) {
+                mid - 1 -> Ansi.fit(" ".repeat(max(0, (cols - label.length) / 2)) + label, cols)
+                mid -> Ansi.fit(" ".repeat(max(0, (cols - barW - 8) / 2)) + "$bar $done/$total", cols)
+                else -> " ".repeat(cols)
+            }
+        }
+    }
+}

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/KotlinHighlight.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/KotlinHighlight.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.tooling.coverage.dashboard
+
+/**
+ * A small, line-based Kotlin syntax highlighter for the card-detail code view. It tokenizes the
+ * emitted `cardDef` source into coloured spans rather than returning pre-coloured strings, so the
+ * pane renderer can truncate a long line to its width token-by-token without an ANSI escape ever
+ * being split. Block comments and triple-quoted strings carry their open state across lines.
+ *
+ * Not a full Kotlin grammar — just enough lexing (keywords, strings, comments, numbers, types,
+ * call sites, annotations) to make a generated card pleasant to read at a glance.
+ */
+object KotlinHighlight {
+    data class Tok(val text: String, val color: Int?)
+
+    // colour roles (256-colour indices), chosen to read well over a dark terminal
+    private const val KEYWORD = 176   // purple
+    private const val TYPE = 80       // teal — PascalCase identifiers (SDK types)
+    private const val CALL = 222      // light yellow — function call sites
+    private const val STRING = 114    // green
+    private const val NUMBER = 215    // orange
+    private const val COMMENT = 244   // grey
+    private const val ANNOTATION = 215
+
+    private val KEYWORDS = setOf(
+        "package", "import", "val", "var", "fun", "object", "class", "interface", "enum", "sealed",
+        "data", "companion", "return", "if", "else", "when", "is", "in", "as", "by", "for", "while",
+        "do", "try", "catch", "finally", "throw", "true", "false", "null", "this", "super", "it",
+        "private", "internal", "public", "protected", "override", "open", "abstract", "const",
+        "lateinit", "vararg", "out", "typealias",
+    )
+
+    /** Tokenize [text] into per-line spans (one inner list per source line). */
+    fun highlight(text: String): List<List<Tok>> {
+        val out = ArrayList<List<Tok>>()
+        var inBlock = false
+        var inTriple = false
+        for (line in text.split("\n")) {
+            val toks = ArrayList<Tok>()
+            var i = 0
+            val n = line.length
+            while (i < n) {
+                if (inBlock) {
+                    val end = line.indexOf("*/", i)
+                    if (end < 0) { toks.add(Tok(line.substring(i), COMMENT)); i = n }
+                    else { toks.add(Tok(line.substring(i, end + 2), COMMENT)); i = end + 2; inBlock = false }
+                    continue
+                }
+                if (inTriple) {
+                    val end = line.indexOf("\"\"\"", i)
+                    if (end < 0) { toks.add(Tok(line.substring(i), STRING)); i = n }
+                    else { toks.add(Tok(line.substring(i, end + 3), STRING)); i = end + 3; inTriple = false }
+                    continue
+                }
+                val c = line[i]
+                when {
+                    c == '/' && i + 1 < n && line[i + 1] == '/' -> { toks.add(Tok(line.substring(i), COMMENT)); i = n }
+                    c == '/' && i + 1 < n && line[i + 1] == '*' -> {
+                        val end = line.indexOf("*/", i + 2)
+                        if (end < 0) { toks.add(Tok(line.substring(i), COMMENT)); inBlock = true; i = n }
+                        else { toks.add(Tok(line.substring(i, end + 2), COMMENT)); i = end + 2 }
+                    }
+                    c == '"' && i + 2 < n && line[i + 1] == '"' && line[i + 2] == '"' -> {
+                        val end = line.indexOf("\"\"\"", i + 3)
+                        if (end < 0) { toks.add(Tok(line.substring(i), STRING)); inTriple = true; i = n }
+                        else { toks.add(Tok(line.substring(i, end + 3), STRING)); i = end + 3 }
+                    }
+                    c == '"' -> {
+                        var j = i + 1
+                        while (j < n) {
+                            if (line[j] == '\\') { j += 2; continue }
+                            if (line[j] == '"') { j++; break }
+                            j++
+                        }
+                        toks.add(Tok(line.substring(i, minOf(j, n)), STRING)); i = minOf(j, n)
+                    }
+                    c == '@' && i + 1 < n && line[i + 1].isLetter() -> {
+                        var j = i + 1
+                        while (j < n && (line[j].isLetterOrDigit() || line[j] == '_')) j++
+                        toks.add(Tok(line.substring(i, j), ANNOTATION)); i = j
+                    }
+                    c.isLetter() || c == '_' -> {
+                        var j = i
+                        while (j < n && (line[j].isLetterOrDigit() || line[j] == '_')) j++
+                        val word = line.substring(i, j)
+                        val color = when {
+                            word in KEYWORDS -> KEYWORD
+                            word[0].isUpperCase() -> TYPE
+                            j < n && line[j] == '(' -> CALL
+                            else -> null
+                        }
+                        toks.add(Tok(word, color)); i = j
+                    }
+                    c.isDigit() -> {
+                        var j = i
+                        while (j < n && (line[j].isDigit() || line[j] == '.' || line[j] == '_')) j++
+                        toks.add(Tok(line.substring(i, j), NUMBER)); i = j
+                    }
+                    else -> { toks.add(Tok(c.toString(), null)); i++ }
+                }
+            }
+            out.add(toks)
+        }
+        return out
+    }
+
+    /** Render one tokenized line to ANSI, truncating with an ellipsis to exactly [width] columns. */
+    fun renderLine(toks: List<Tok>, width: Int): String {
+        if (width <= 0) return ""
+        val sb = StringBuilder()
+        var vis = 0
+        for (t in toks) {
+            if (vis >= width) break
+            val room = width - vis
+            val truncated = t.text.length > room
+            val text = if (!truncated) t.text else if (room == 1) "…" else t.text.take(room - 1) + "…"
+            sb.append(if (t.color != null) Ansi.fg(t.color) + text + Ansi.RESET else text)
+            vis += text.length
+            if (truncated) break
+        }
+        if (vis < width) sb.append(" ".repeat(width - vis))
+        return sb.toString()
+    }
+}

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Tui.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Tui.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.tooling.coverage.dashboard
+
+/**
+ * Minimal, dependency-free terminal toolkit for the coverage dashboard. The `:mtgish-tooling` module
+ * deliberately carries no runtime dependency beyond kotlinx-serialization (see its build.gradle.kts),
+ * so rather than pull in a TUI library we drive the terminal with raw ANSI escapes and put it into
+ * raw mode by shelling out to `stty` (POSIX; this tool only runs on the dev's mac/linux box).
+ */
+
+/** 256-colour ANSI styling. Cells are padded as plain text first, then wrapped, so widths stay exact. */
+object Ansi {
+    private const val ESC = ""
+    const val RESET = "$ESC[0m"
+    const val BOLD = "$ESC[1m"
+    const val DIM = "$ESC[2m"
+    const val REVERSE = "$ESC[7m"
+
+    fun fg(n: Int) = "$ESC[38;5;${n}m"
+    fun bg(n: Int) = "$ESC[48;5;${n}m"
+
+    // palette (256-colour indices)
+    const val GREEN = 42
+    const val YELLOW = 178
+    const val RED = 203
+    const val BLUE = 39
+    const val CYAN = 44
+    const val ORANGE = 215
+    const val GREY = 244
+    const val DARKGREY = 240
+    const val WHITE = 252
+
+    fun style(text: String, vararg codes: String): String =
+        if (codes.isEmpty()) text else codes.joinToString("") + text + RESET
+
+    /** Truncate (with an ellipsis) or right-pad [s] to exactly [width] visible columns. */
+    fun fit(s: String, width: Int): String = when {
+        width <= 0 -> ""
+        s.length <= width -> s + " ".repeat(width - s.length)
+        width == 1 -> "…"
+        else -> s.take(width - 1) + "…"
+    }
+}
+
+/** A decoded key press. */
+sealed interface Key {
+    data object Up : Key
+    data object Down : Key
+    data object Left : Key
+    data object Right : Key
+    data object Enter : Key
+    data object Tab : Key
+    data object Esc : Key
+    data object Backspace : Key
+    data object PageUp : Key
+    data object PageDown : Key
+    data object Home : Key
+    data object End : Key
+    data object Quit : Key
+    data class Char(val c: kotlin.Char) : Key
+    data object Unknown : Key
+}
+
+/**
+ * Raw-mode terminal: alternate screen buffer, hidden cursor, byte-level key reads. Always pair
+ * [enter] with [exit] in a finally block so the user's terminal is restored even if we crash.
+ */
+class RawTerminal {
+    private val esc = ""
+    private var savedStty: String? = null
+
+    fun enter() {
+        savedStty = sh("stty -g < /dev/tty").trim().ifEmpty { null }
+        sh("stty raw -echo < /dev/tty")
+        print("$esc[?1049h$esc[?25l$esc[2J") // alt screen, hide cursor, clear
+        System.out.flush()
+    }
+
+    fun exit() {
+        print("$esc[?25h$esc[?1049l") // show cursor, leave alt screen
+        System.out.flush()
+        savedStty?.let { sh("stty $it < /dev/tty") }
+    }
+
+    /** (rows, cols); falls back to 24x80 if the terminal can't be queried. */
+    fun size(): Pair<Int, Int> {
+        val parts = sh("stty size < /dev/tty").trim().split(Regex("\\s+"))
+        val rows = parts.getOrNull(0)?.toIntOrNull() ?: 24
+        val cols = parts.getOrNull(1)?.toIntOrNull() ?: 80
+        return rows to cols
+    }
+
+    /** Paint [lines] from the top-left, clearing each line's tail and everything below. */
+    fun render(lines: List<String>) {
+        val sb = StringBuilder("$esc[H")
+        for (i in lines.indices) {
+            sb.append(lines[i]).append("$esc[K")
+            if (i < lines.lastIndex) sb.append("\r\n")
+        }
+        sb.append("$esc[J")
+        System.out.print(sb)
+        System.out.flush()
+    }
+
+    fun readKey(): Key {
+        val b = System.`in`.read()
+        return when (b) {
+            -1, 3, 4 -> Key.Quit // EOF, Ctrl-C, Ctrl-D
+            13, 10 -> Key.Enter
+            9 -> Key.Tab
+            127, 8 -> Key.Backspace
+            27 -> readEscape()
+            else -> Key.Char(b.toChar())
+        }
+    }
+
+    /** ESC was read; an arrow/nav key follows immediately, a lone ESC means "back". */
+    private fun readEscape(): Key {
+        Thread.sleep(2) // give the rest of the sequence time to arrive in the input buffer
+        if (System.`in`.available() == 0) return Key.Esc
+        val intro = System.`in`.read().toChar()
+        if (intro != '[' && intro != 'O') return Key.Esc
+        return when (val c = System.`in`.read().toChar()) {
+            'A' -> Key.Up
+            'B' -> Key.Down
+            'C' -> Key.Right
+            'D' -> Key.Left
+            'H' -> Key.Home
+            'F' -> Key.End
+            '5', '6' -> { if (System.`in`.available() > 0) System.`in`.read(); if (c == '5') Key.PageUp else Key.PageDown }
+            else -> Key.Unknown
+        }
+    }
+
+    companion object {
+        /** Is there a controlling terminal we can switch into raw mode? */
+        fun available(): Boolean = sh("test -e /dev/tty && echo yes").contains("yes")
+
+        private fun sh(cmd: String): String = runCatching {
+            val p = ProcessBuilder("/bin/sh", "-c", cmd).redirectErrorStream(true).start()
+            val out = p.inputStream.readBytes().toString(Charsets.UTF_8)
+            p.waitFor()
+            out
+        }.getOrDefault("")
+    }
+}

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/dashboard/DashboardTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/dashboard/DashboardTest.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.tooling.coverage.dashboard
+
+import com.wingedsheep.tooling.coverage.MTGISH_LINES
+import com.wingedsheep.tooling.coverage.SDK_EFFECTS
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import java.io.File
+
+/**
+ * Dashboard data-layer + TUI-primitive tests. The [Analyzer] check is guarded on data availability
+ * exactly like [com.wingedsheep.tooling.coverage.EmitterSmokeTest] (the 29 MB mtgish IR + the shared
+ * Scryfall cache) so a clean CI box skips rather than fails; the [Ansi] cell-fitting test is pure and
+ * always runs, since exact cell widths are what keep the two-pane layout aligned.
+ */
+class DashboardTest : StringSpec({
+
+    val porCache = File(System.getProperty("user.home"), ".cache/scryfall/por.json")
+    val dataAvailable = MTGISH_LINES.exists() && porCache.isFile && SDK_EFFECTS.isDirectory
+
+    "Analyzer classifies a set's cards into a partition that sums to the whole".config(enabled = dataAvailable) {
+        Analyzer.init()
+        val d = Analyzer.detail("POR")
+
+        // implemented + the missing-card buckets partition every canonical card — none double-counted.
+        (d.implemented + d.autogen + d.scaffold + d.blocked + d.unmatched) shouldBe d.total
+        d.cards.size shouldBe d.total
+        d.total shouldBeGreaterThan 0
+        d.implemented shouldBeGreaterThan 0 // Portal is an implemented set
+        d.free shouldBe (d.autogen + d.scaffold)
+
+        // Auto-gen coverage spans ALL cards (implemented included), so a fully-implemented set still
+        // has a non-zero generatable count — the whole point of the cross-implementation metric.
+        d.genWhole shouldBeGreaterThan 0
+        (d.genWhole + d.genScaffold + d.genBlocked) shouldBeLessThanOrEqual d.total
+
+        // The leaderboard only ranks real blockers, so every row has a positive count.
+        d.leaderboard.forEach { it.count shouldBeGreaterThan 0 }
+
+        // An implemented Portal card reports its home set in the per-card drill-down.
+        val implementedCard = d.cards.first { it.implemented }
+        Analyzer.cardReport(implementedCard.name).implementedIn shouldContain "POR"
+    }
+
+    "Ansi.fit pads or ellipsis-truncates to an exact visible width" {
+        Ansi.fit("abc", 5) shouldBe "abc  "
+        Ansi.fit("abc", 3) shouldBe "abc"
+        Ansi.fit("abcdef", 4) shouldBe "abc…"
+        Ansi.fit("ab", 1) shouldBe "…"
+        Ansi.fit("anything", 0) shouldBe ""
+    }
+})


### PR DESCRIPTION
## What

A navigable, dependency-free terminal **coverage dashboard** over the mtgish tooling, launched with `just coverage-dashboard` (new `dashboard` subcommand). It surfaces, in one place, which sets are easy to add, which cards the auto-generator can draft, and which engine work would unlock the most cards.

It **composes the existing per-card primitives** (`Probe.analyze`, `Emitter.renderCard`) rather than re-implementing coverage logic, and memoizes per-set results so a keypress never recomputes. The 28MB mtgish IR is streamed once, lazily, on the first set you drill into.

## Views

- **Set list** — every set (implemented ∪ Scryfall-cached) with full name, release year, `implemented/total`, and `gN` auto-gen coverage. Sorted newest-first (`s` toggles alphabetical); `/` searches by name or code.
- **Set detail** — `implemented / auto-gen / free-to-add / blocked` breakdown + the feature leaderboard (engine work ranked by # blocked cards it unlocks) + golden-fidelity tiers where a snapshot exists. **Auto-gen spans all cards** (implemented included), so a 100%-implemented set still shows how much the generator can reproduce.
- **Card drill-down** — the emitter's generated `cardDef` DSL, **syntax-highlighted**, above a `⚠ missing mappings` block; `tab` flips to the capability list. A red `✓` in the list marks an implemented card the generator *can't* reproduce.
- **Cross-set capability index** (`c`) — every set's leaderboard rolled into one ranking of "what engine work unlocks the most cards everywhere".
- **Full scan** (`f` / `--scan`) — analyze every set up front (fills all counts + the global total; makes `c` instant).

Keys: `↑↓`/`jk` move · `→`/`enter` drill in · `←`/`esc` back · `tab` Kotlin/capabilities · `/` search/filter · `s` sort · `f` scan-all · `r` refresh a set from Scryfall · `c` cross-set · `q` quit.

## Implementation notes

- **No new runtime dependency** — raw ANSI escapes + `stty` raw mode (`dashboard/Tui.kt`), keeping `:mtgish-tooling` dependency-light by design. Needs an interactive terminal (`/dev/tty`).
- New files: `dashboard/{Analyzer,Dashboard,Tui,KotlinHighlight}.kt`.
- Additive, non-breaking changes to existing files: a `dashboard` dispatch case, a safe `Fidelity.summarizeOrNull` (returns null instead of exiting for snapshot-less sets), `Scryfall.cachedSetCodes/releaseDate/setDisplayNames` (set names fetched once with a bounded timeout, disk-cached to `_setnames.json`, graceful offline fallback), and memoized `discoverSets`/`scanImplementations` (a broad speedup). **Existing `probe`/`fidelity`/`autogen` output is unchanged** (POR calibration still 100%, POR fidelity still 95.6% AUTO).

## Testing

- `DashboardTest`: per-set partition + gen-coverage invariants (data-gated like `EmitterSmokeTest`, so a clean CI box skips) and the pure `Ansi.fit` cell-fitting (always runs).
- `dashboard --render` prints static frames to stdout (no raw mode) for verification outside a live terminal — used to confirm layout/highlighting/alignment.
- `just test` green; full `:mtgish-tooling:test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)