### PR TITLE
mtgish: push ONS auto-gen fidelity 27.8% → 41.3% AUTO

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
@@ -107,6 +107,8 @@ object Fidelity {
     private class SetScore {
         val tiers = mapOf("AUTO" to mutableListOf<String>(), "SCAFFOLD" to mutableListOf(), "MISS" to mutableListOf(), "UNMATCHED" to mutableListOf())
         val missTax = Counter<String>(); val scaffoldReasons = Counter<String>(); val recalls = mutableListOf<Double>()
+        // Per-card detail for `--list`: a MISS card's unmapped caps, a SCAFFOLD card's reasons.
+        val cardDetail = LinkedHashMap<String, List<String>>()
         var code = ""; var total = 0; var matched = 0
         val avgRecall: Double get() = if (recalls.isEmpty()) 0.0 else recalls.sum() / recalls.size * 100
     }
@@ -126,6 +128,8 @@ object Fidelity {
             s.recalls.add(recall)
             missing.forEach { s.missTax.add(it) }
             if (tier == "SCAFFOLD") res.reasons.forEach { s.scaffoldReasons.add(it) }
+            if (tier == "MISS") s.cardDetail[name] = missing.sorted()
+            else if (tier == "SCAFFOLD") s.cardDetail[name] = res.reasons.sorted()
         }
         s.code = code.uppercase()
         s.total = s.tiers.values.sumOf { it.size }
@@ -174,7 +178,11 @@ object Fidelity {
         if (listTier != null) {
             val names = s.tiers[listTier.uppercase()] ?: emptyList()
             println("\n${listTier.uppercase()} (${names.size}):")
-            names.forEach { println("  - $it") }
+            names.forEach { name ->
+                val detail = s.cardDetail[name]
+                if (detail.isNullOrEmpty()) println("  - $name")
+                else println("  - ${name.padEnd(28)} ${detail.joinToString(", ", "[", "]")}")
+            }
         }
         return 0
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Mtgish.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Mtgish.kt
@@ -25,7 +25,8 @@ class Counter<K> {
 /** mtgish IR access: download, the capability-bearing discriminators, the tag extractor, the index. */
 object Mtgish {
     val CAPABILITY_DISCRIMINATORS = listOf(
-        "_Rule", "_Action", "_Trigger", "_Cost", "_LayerEffect", "_ReplacementActionWouldEnter",
+        "_Rule", "_Action", "_Trigger", "_Cost", "_LayerEffect", "_StaticLayerEffect",
+        "_ReplacementActionWouldEnter",
     )
 
     fun ensureData() {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -11,6 +11,9 @@ internal fun BridgeBuilder.manaCountersAndState() {
     effect("AddColorlessMana", "AddColorlessMana", UNIVERSAL)
 
     effect("CreateTokens", "CreateToken", UNIVERSAL)
+    // "becomes the creature type of your choice" — a ChooseACreatureType + an AddCreatureTypeVariable
+    // layer effect collapse to one BecomeCreatureTypeEffect (Mistform cycle, Imagecrafter).
+    effect("AddCreatureTypeVariable", "BecomeCreatureType", UNIVERSAL)
     effects("PutACounterOfTypeOnPermanent", "PutNumberCountersOfTypeOnPermanent", tag = "AddCounters", note = UNIVERSAL)
 
     effect("RegeneratePermanent", "Regenerate", UNIVERSAL)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -3,7 +3,11 @@ package com.wingedsheep.tooling.coverage.bridge
 /** Mana, counters, control, and combat/untap-state effects. Mostly the "universal" verbs that Portal
  *  never exercised but every later set does — each line lifts recall on every set at once. */
 internal fun BridgeBuilder.manaCountersAndState() {
-    effects("AddMana", "AddManaRepeated", tag = "AddMana", note = UNIVERSAL)
+    // AddMana's exact Effect depends on the produced symbol — colorless ({C}) serialises as
+    // AddColorlessMana, "any color" as AddManaOfChoice, a fixed colour as AddMana — and the capability
+    // scorer can't see the symbol arg, so name the whole mana family the action can lower to.
+    composed("AddMana", UNIVERSAL, composes = listOf("AddMana", "AddColorlessMana", "AddManaOfChoice"))
+    composed("AddManaRepeated", UNIVERSAL, composes = listOf("AddMana", "AddColorlessMana", "AddManaOfChoice"))
     effect("AddColorlessMana", "AddColorlessMana", UNIVERSAL)
 
     effect("CreateTokens", "CreateToken", UNIVERSAL)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ActionHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ActionHandlers.kt
@@ -18,7 +18,8 @@ import kotlinx.serialization.json.JsonObject
  * rather than emit something confidently wrong.
  */
 internal val ACTION_HANDLERS: Map<String, ActionHandler> =
-    damageDrawLifeHandlers + zoneHandlers + tapLayerStateHandlers + playerContinuousHandlers + manaHandlers
+    damageDrawLifeHandlers + zoneHandlers + tapLayerStateHandlers + playerContinuousHandlers +
+        manaHandlers + tokenHandlers
 
 /** A per-`_Action` rendering rule. Returns the Effect DSL string, or null → SCAFFOLD. */
 internal typealias ActionHandler = EmitCtx.(node: JsonObject, args: JsonElement?, tvar: String?) -> String?

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ActionHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ActionHandlers.kt
@@ -17,9 +17,13 @@ import kotlinx.serialization.json.JsonObject
  * track them. Return `null` whenever exact rendering isn't possible: the card downgrades to SCAFFOLD
  * rather than emit something confidently wrong.
  */
-internal val ACTION_HANDLERS: Map<String, ActionHandler> =
+// Lazy so it's assembled on first use (renderAction), by which point every themed handler file's
+// top-level `val` is initialised. Eager init can cycle: a handler file's val calls `actionHandlers`
+// (defined here), which forces this sum to read that same val before it finishes initialising.
+internal val ACTION_HANDLERS: Map<String, ActionHandler> by lazy {
     damageDrawLifeHandlers + zoneHandlers + tapLayerStateHandlers + playerContinuousHandlers +
         manaHandlers + tokenHandlers
+}
 
 /** A per-`_Action` rendering rule. Returns the Effect DSL string, or null → SCAFFOLD. */
 internal typealias ActionHandler = EmitCtx.(node: JsonObject, args: JsonElement?, tvar: String?) -> String?

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ActionHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ActionHandlers.kt
@@ -18,7 +18,7 @@ import kotlinx.serialization.json.JsonObject
  * rather than emit something confidently wrong.
  */
 internal val ACTION_HANDLERS: Map<String, ActionHandler> =
-    damageDrawLifeHandlers + zoneHandlers + tapLayerStateHandlers + playerContinuousHandlers
+    damageDrawLifeHandlers + zoneHandlers + tapLayerStateHandlers + playerContinuousHandlers + manaHandlers
 
 /** A per-`_Action` rendering rule. Returns the Effect DSL string, or null → SCAFFOLD. */
 internal typealias ActionHandler = EmitCtx.(node: JsonObject, args: JsonElement?, tvar: String?) -> String?

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -168,6 +168,21 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject): List<String>? {
 }
 
 /**
+ * A characteristic-defining `CDA_Power` rule (with its matching `CDA_Toughness`) -> a single
+ * `dynamicStats(...)` line, when both power and toughness are the same dynamic count (the
+ * power-and-toughness-equal-to-the-number-of-X cycle). Differing power/toughness amounts scaffold.
+ */
+internal fun EmitCtx.cdaStatsBlock(card: JsonObject, rule: JsonObject): List<String>? {
+    val toughnessRule = (card["Rules"].asArr ?: JsonArray(emptyList()))
+        .filterIsInstance<JsonObject>().firstOrNull { it.strField("_Rule") == "CDA_Toughness" }
+    if (toughnessRule == null || compact(rule["args"]) != compact(toughnessRule["args"])) {
+        reasons.add("CDA_Power"); return null
+    }
+    val amount = dynamicAmount(rule["args"]) ?: run { reasons.add("CDA_Power"); return null }
+    return listOf("    dynamicStats($amount)")
+}
+
+/**
  * An `AsPermanentEnters` rule -> `replacementEffect(...)` line(s). The rule's second arg is a list of
  * `_ReplacementActionWouldEnter` nodes (enters tapped, choose a creature type as it enters, ...).
  * Any replacement we can't render exactly downgrades the card to SCAFFOLD rather than guess.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -167,6 +167,26 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject): List<String>? {
     return lines
 }
 
+/**
+ * An `AsPermanentEnters` rule -> `replacementEffect(...)` line(s). The rule's second arg is a list of
+ * `_ReplacementActionWouldEnter` nodes (enters tapped, choose a creature type as it enters, ...).
+ * Any replacement we can't render exactly downgrades the card to SCAFFOLD rather than guess.
+ */
+internal fun EmitCtx.asEntersBlock(rule: JsonObject): List<String>? {
+    val replacements = (rule["args"].asArr?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
+    if (replacements.isNullOrEmpty()) { reasons.add("AsPermanentEnters"); return null }
+    val lines = mutableListOf<String>()
+    for (rep in replacements) {
+        val dsl = when (rep.strField("_ReplacementActionWouldEnter")) {
+            "EntersTapped" -> "EntersTapped()"
+            "ChooseACreatureType" -> "EntersWithChoice(ChoiceType.CREATURE_TYPE)"
+            else -> { reasons.add("AsPermanentEnters"); return null }
+        }
+        lines.add("    replacementEffect($dsl)")
+    }
+    return lines
+}
+
 /** An Activated / ActivatedWithModifiers rule -> activatedAbility { cost; [target]; effect }. */
 internal fun EmitCtx.activatedBlock(rule: JsonObject): List<String>? {
     val args = rule["args"].asArr

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -182,7 +182,12 @@ internal fun EmitCtx.activatedBlock(rule: JsonObject): List<String>? {
     val lines = mutableListOf("    activatedAbility {", "        cost = $cost")
     activationRestrictionLines(rule)?.let { lines.addAll(it) } ?: return null
     if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
-    lines.addAll(listOf("        effect = $edsl", "    }"))
+    lines.add("        effect = $edsl")
+    if (isManaAbility(tvar, actions)) {
+        lines.add("        manaAbility = true")
+        lines.add("        timing = TimingRule.ManaAbility")
+    }
+    lines.add("    }")
     return lines
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -202,6 +202,30 @@ internal fun EmitCtx.asEntersBlock(rule: JsonObject): List<String>? {
     return lines
 }
 
+/**
+ * A `FromAnyZone { TriggerA { WhenAPlayerCyclesACard(You, this) ... } }` rule -> a triggered ability
+ * with `trigger = Triggers.YouCycleThis` ("When you cycle this card, [bonus]"). A lone `you may` bonus
+ * becomes `optional = true`, mirroring [triggerBlock].
+ */
+internal fun EmitCtx.fromAnyZoneBlock(rule: JsonObject): List<String>? {
+    val inner = rule["args"] as? JsonObject
+    if (inner?.strField("_Rule") != "TriggerA" ||
+        !jsonContains(inner, "_Trigger", "WhenAPlayerCyclesACard") ||
+        !jsonContains(inner, "_CardInHand", "ThisCardInHand")) { reasons.add("FromAnyZone"); return null }
+    val (targets, actions) = extractEnvelope(inner)
+    if (actions == null) { reasons.add("FromAnyZone"); return null }
+    val (tdsl, tvar) = spellTarget(targets, actions)
+    if (tdsl == null) return null
+    val mayWrapped = actions.singleOrNull()?.strField("_Action") == "MayAction"
+    val effectActions = if (mayWrapped) listOf(innerAction(actions.single()) ?: return null) else actions
+    val edsl = renderEffectList(effectActions, tvar) ?: return null
+    val lines = mutableListOf("    triggeredAbility {", "        trigger = Triggers.YouCycleThis")
+    if (mayWrapped) lines.add("        optional = true")
+    if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
+    lines.addAll(listOf("        effect = $edsl", "    }"))
+    return lines
+}
+
 /** An Activated / ActivatedWithModifiers rule -> activatedAbility { cost; [target]; effect }. */
 internal fun EmitCtx.activatedBlock(rule: JsonObject): List<String>? {
     val args = rule["args"].asArr

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -60,6 +60,7 @@ internal fun EmitCtx.renderAction(node: JsonObject, tvar: String?): String? {
 /** Render a list of mtgish actions to one Effect (Composite if >1). Null if any can't render. */
 internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?): String? {
     echoEffect(actions)?.let { return it }
+    becomeCreatureTypeEffect(actions, tvar)?.let { return it }
     val rendered = mutableListOf<String>()
     for (act in actions) {
         val r = renderAction(act, tvar)
@@ -216,6 +217,23 @@ internal fun EmitCtx.paycostDsl(costNode: JsonElement?): String? {
     }
     if ("Mana" in blob) return "Costs.pay.OwnManaCost"
     return null
+}
+
+/**
+ * [ChooseACreatureType, CreatePermanentLayerEffectUntil{AddCreatureTypeVariable}] -> a single
+ * `BecomeCreatureTypeEffect` ("becomes the creature type of your choice until end of turn"). Only the
+ * bare type-change (no riding +P/T or keyword grant) and only end-of-turn collapse to this effect.
+ */
+internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: String?): String? {
+    if (actions.none { it.strField("_Action") == "ChooseACreatureType" }) return null
+    val layer = actions.firstOrNull {
+        it.strField("_Action") in setOf("CreatePermanentLayerEffectUntil", "CreateEachPermanentLayerEffectUntil")
+    } ?: return null
+    if (!jsonContains(layer, "_LayerEffect", "AddCreatureTypeVariable")) return null
+    if (jsonContains(layer, "_LayerEffect", "AdjustPT") || jsonContains(layer, "_LayerEffect", "AddAbility")) return null
+    if (!jsonContains(layer, "_Expiration", "UntilEndOfTurn")) return null  // non-EOT -> SCAFFOLD
+    val target = refTarget(layer["args"], tvar) ?: return null
+    return "BecomeCreatureTypeEffect(target = $target)"
 }
 
 /** [MayCost(cost), Unless(CostWasPaid, [Sacrifice...])] -> PayOrSufferEffect (echo / upkeep cost). */

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -65,6 +65,7 @@ object Emitter {
                 rname == "TriggerA" -> block = ctx.triggerBlock(rule)
                 rname == "PermanentRuleEffect" -> block = ctx.staticBlock(rule)
                 rname == "AsPermanentEnters" -> block = ctx.asEntersBlock(rule)
+                rname == "EachPermanentLayerEffect" -> block = ctx.staticLordBlock(rule)
                 rname == "Activated" || rname == "ActivatedWithModifiers" -> block = ctx.activatedBlock(rule)
                 rname == "Cycling" -> block = manaKeywordCost(rule)?.let { listOf("    keywordAbility(KeywordAbility.cycling(\"$it\"))") }
                 rname == "Morph" -> block = manaKeywordCost(rule)?.let { listOf("    morph = \"$it\"") }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -66,6 +66,10 @@ object Emitter {
                 rname == "PermanentRuleEffect" -> block = ctx.staticBlock(rule)
                 rname == "AsPermanentEnters" -> block = ctx.asEntersBlock(rule)
                 rname == "EachPermanentLayerEffect" -> block = ctx.staticLordBlock(rule)
+                rname == "CDA_Power" -> block = ctx.cdaStatsBlock(card, rule)
+                rname == "CDA_Toughness" ->
+                    if (jsonContains(card["Rules"], "_Rule", "CDA_Power")) continue  // emitted with CDA_Power
+                    else { ctx.reasons.add("CDA_Toughness"); return incomplete(ctx, body, scryfall, pkg) }
                 rname == "Activated" || rname == "ActivatedWithModifiers" -> block = ctx.activatedBlock(rule)
                 rname == "Cycling" -> block = manaKeywordCost(rule)?.let { listOf("    keywordAbility(KeywordAbility.cycling(\"$it\"))") }
                 rname == "Morph" -> block = manaKeywordCost(rule)?.let { listOf("    morph = \"$it\"") }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -64,6 +64,7 @@ object Emitter {
                 rname == "SpellActions" -> block = ctx.spellBlock(card)
                 rname == "TriggerA" -> block = ctx.triggerBlock(rule)
                 rname == "PermanentRuleEffect" -> block = ctx.staticBlock(rule)
+                rname == "AsPermanentEnters" -> block = ctx.asEntersBlock(rule)
                 rname == "Activated" || rname == "ActivatedWithModifiers" -> block = ctx.activatedBlock(rule)
                 rname == "Cycling" -> block = manaKeywordCost(rule)?.let { listOf("    keywordAbility(KeywordAbility.cycling(\"$it\"))") }
                 rname == "Morph" -> block = manaKeywordCost(rule)?.let { listOf("    morph = \"$it\"") }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -66,6 +66,7 @@ object Emitter {
                 rname == "PermanentRuleEffect" -> block = ctx.staticBlock(rule)
                 rname == "AsPermanentEnters" -> block = ctx.asEntersBlock(rule)
                 rname == "EachPermanentLayerEffect" -> block = ctx.staticLordBlock(rule)
+                rname == "FromAnyZone" -> block = ctx.fromAnyZoneBlock(rule)
                 rname == "CDA_Power" -> block = ctx.cdaStatsBlock(card, rule)
                 rname == "CDA_Toughness" ->
                     if (jsonContains(card["Rules"], "_Rule", "CDA_Power")) continue  // emitted with CDA_Power

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.tooling.coverage.emitter
+
+import com.wingedsheep.tooling.coverage.strField
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Mana production: an `AddMana { _ManaProduce }` action -> the `Effects.Add*Mana` facade. Used both as
+ * the leaf effect of a mana ability ({T}: Add {C}) and inside a composite ({T}: Add any color, this
+ * deals 1 to you). The mana-ability flag itself is set by [EmitCtx.activatedBlock], which recognises a
+ * targetless ability whose actions add mana.
+ */
+internal val manaHandlers: Map<String, ActionHandler> = actionHandlers {
+    on("AddMana") { _, args, _ -> manaProduceDsl(args) }
+}
+
+private val MANA_PRODUCE_COLOR = mapOf(
+    "ManaProduceW" to "Color.WHITE", "ManaProduceU" to "Color.BLUE",
+    "ManaProduceB" to "Color.BLACK", "ManaProduceR" to "Color.RED", "ManaProduceG" to "Color.GREEN",
+)
+
+/** `{_ManaProduce}` -> the matching mana Effect, or null (-> SCAFFOLD) for shapes we don't render. */
+internal fun manaProduceDsl(node: JsonElement?): String? =
+    when (val produce = (node as? JsonObject)?.strField("_ManaProduce")) {
+        null -> null
+        "ManaProduceC" -> "Effects.AddColorlessMana(1)"
+        "AnyManaColor" -> "Effects.AddManaOfChoice()"
+        else -> MANA_PRODUCE_COLOR[produce]?.let { "Effects.AddMana($it)" }
+    }
+
+/** True when this ability is a mana ability: no target, and at least one action adds mana. */
+internal fun isManaAbility(tvar: String?, actions: List<JsonObject>): Boolean =
+    tvar == null && actions.any { it.strField("_Action") in setOf("AddMana", "AddManaRepeated") }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -1,5 +1,7 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.asInt
+import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
 import com.wingedsheep.tooling.coverage.subtypes
 import kotlinx.serialization.json.JsonArray
@@ -35,6 +37,49 @@ internal fun EmitCtx.staticBlock(rule: JsonObject): List<String>? {
         lines.addAll(listOf("    staticAbility {", "        ability = $dsl", "    }"))
     }
     return lines
+}
+
+/**
+ * A static `EachPermanentLayerEffect` "lord" rule -> one `staticAbility { ability = ... }` per static
+ * layer effect: AdjustPT -> `ModifyStats(powerBonus, toughnessBonus, filter)`, AddAbility{kw} ->
+ * `GrantKeyword(Keyword.X, filter)`. The affected group is a GroupFilter (a fixed creature subtype with
+ * excludeSelf for "other …", or `GroupFilter.ChosenSubtypeCreatures()` for "creatures of the chosen
+ * type"). Anything we can't render exactly scaffolds.
+ */
+internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<String>? {
+    val args = rule["args"] as? JsonArray
+    val layerEffects = (args?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
+    if (args == null || layerEffects.isNullOrEmpty()) { reasons.add("EachPermanentLayerEffect"); return null }
+    val group = lordGroupFilterDsl(args.getOrNull(0)) ?: run { reasons.add("EachPermanentLayerEffect"); return null }
+    val lines = mutableListOf<String>()
+    for (le in layerEffects) {
+        val ability = when (le.strField("_StaticLayerEffect")) {
+            "AdjustPT" -> {
+                val pt = le["args"] as? JsonArray ?: return scaffoldLord()
+                if (pt.size != 2) return scaffoldLord()
+                "ModifyStats(powerBonus = ${pt[0].asInt()}, toughnessBonus = ${pt[1].asInt()}, filter = $group)"
+            }
+            "AddAbility" -> {
+                val kw = keywordOf(le) ?: return scaffoldLord()
+                "GrantKeyword(Keyword.$kw, $group)"
+            }
+            else -> return scaffoldLord()
+        }
+        lines.addAll(listOf("    staticAbility {", "        ability = $ability", "    }"))
+    }
+    return lines
+}
+
+private fun EmitCtx.scaffoldLord(): List<String>? { reasons.add("EachPermanentLayerEffect"); return null }
+
+/** The affected-group GroupFilter for a lord: chosen-creature-type variable -> the named helper,
+ *  otherwise the generic group-filter recovery (fixed subtype, excludeSelf for "other"). */
+private fun EmitCtx.lordGroupFilterDsl(filterNode: kotlinx.serialization.json.JsonElement?): String? {
+    if (jsonContains(filterNode, "_CreatureTypeVariable", "TheChosenCreatureType") ||
+        jsonContains(filterNode, "_Permanents", "IsCreatureTypeVariable")) {
+        return "GroupFilter.ChosenSubtypeCreatures()"
+    }
+    return groupFilterDsl(filterNode)
 }
 
 private fun EmitCtx.staticAbilityDsl(ruleName: String, ruleNode: JsonObject): String? {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -28,6 +28,9 @@ internal fun EmitCtx.staticBlock(rule: JsonObject): List<String>? {
         if (name == "CantBeBlocked") {
             lines.add("    flags(AbilityFlag.CANT_BE_BLOCKED)"); continue
         }
+        if (name == "MayChooseNotToUntapDuringUntap") {
+            lines.add("    flags(AbilityFlag.MAY_NOT_UNTAP)"); continue
+        }
         val dsl = staticAbilityDsl(name, r) ?: run { reasons.add(name); return null }
         lines.addAll(listOf("    staticAbility {", "        ability = $dsl", "    }"))
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
 import com.wingedsheep.tooling.coverage.subtypes
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 /** Tap/untap, continuous P/T & keyword grants (CreatePermanentLayerEffectUntil), and turn-state
@@ -47,15 +48,23 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
 }
 
 /** CreatePermanentLayerEffectUntil / its each-permanent form -> ModifyStats / GrantKeyword,
- *  optionally over a group (ForEachInGroup). */
+ *  optionally over a group (ForEachInGroup). The `_Expiration` is honoured exactly: end-of-turn uses
+ *  the default-duration facade; "for as long as it remains tapped" carries an explicit
+ *  Duration.WhileSourceTapped(); any other expiration scaffolds rather than emit a wrong duration. */
 internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: String?): String? {
     val mass = action == "CreateEachPermanentLayerEffectUntil"
     val target = if (mass) "EffectTarget.Self" else refTarget(node["args"], tvar)
     if (target == null) return null
+    val duration = expirationDsl(node) ?: return null  // unknown expiration -> SCAFFOLD
+    val durArg = if (duration.isEmpty()) "" else ", $duration"
     val inner = mutableListOf<String>()
     val pt = findAdjustPt(node)
     if (pt is JsonArray && pt.size == 2) {
-        inner.add("Effects.ModifyStats(${pt[0].asInt()}, ${pt[1].asInt()}, $target)")
+        // ModifyStats' facade carries no duration param, so a non-default duration uses the raw effect.
+        inner.add(
+            if (duration.isEmpty()) "Effects.ModifyStats(${pt[0].asInt()}, ${pt[1].asInt()}, $target)"
+            else "ModifyStatsEffect(${pt[0].asInt()}, ${pt[1].asInt()}, $target, $duration)"
+        )
     }
     if (jsonContains(node, "_LayerEffect", "AddAbility")) {
         var kw: String? = null
@@ -65,7 +74,7 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
         }
         kw = kw ?: keywordOf(node)
         if (kw != null) {
-            inner.add("Effects.GrantKeyword(Keyword.$kw, $target)")
+            inner.add("Effects.GrantKeyword(Keyword.$kw, $target$durArg)")
         } else return null
     }
     if (inner.isEmpty()) return null
@@ -76,4 +85,27 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
         return "Effects.ForEachInGroup($filter, $effect)"
     }
     return effect
+}
+
+/** The layer effect's `_Expiration` -> "" for the default (end-of-turn) facade, an explicit
+ *  `Duration.*` DSL for a recognised non-default duration, or null (-> SCAFFOLD) for one we can't
+ *  render exactly (so the emitter never silently substitutes the wrong duration). */
+private fun expirationDsl(node: JsonObject): String? =
+    when (firstExpiration(node)) {
+        null, "UntilEndOfTurn" -> ""
+        "ForAsLongAsPermanentRemainsTapped" -> "Duration.WhileSourceTapped()"
+        else -> null
+    }
+
+/** The first `_Expiration` discriminator value anywhere in the subtree. */
+private fun firstExpiration(node: JsonElement?): String? {
+    when (node) {
+        is JsonObject -> {
+            node.strField("_Expiration")?.let { return it }
+            node.values.forEach { firstExpiration(it)?.let { v -> return v } }
+        }
+        is JsonArray -> node.forEach { firstExpiration(it)?.let { v -> return v } }
+        else -> {}
+    }
+    return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -151,7 +151,10 @@ internal fun EmitCtx.groupFilterDsl(filterNode: JsonElement?): String? {
     val filtered = gameObjectFilterDsl(filterNode) ?: return null
     val oracle = oracleText?.lowercase() ?: ""
     val args = mutableListOf(filtered)
-    if ("all other" in oracle || "each other" in oracle) args.add("excludeSelf = true")
+    // The IR's `Other(ThisPermanent)` is the authoritative "excludeSelf" signal; the oracle phrasing
+    // ("all other" / "each other" / "other ... creatures") is the fallback for shapes without it.
+    if (jsonContains(filterNode, "_Permanents", "Other") ||
+        "all other" in oracle || "each other" in oracle) args.add("excludeSelf = true")
     return "GroupFilter(${args.joinToString(", ")})"
 }
 
@@ -159,9 +162,13 @@ internal fun EmitCtx.gameObjectFilterDsl(filterNode: JsonElement?): String? {
     val blob = compact(filterNode)
     val types = targetTypes(filterNode)
     val subs = subtypes(filterNode)
+    // Creature subtypes come from IsCreatureType (subtypes() only collects land/card subtypes).
+    val creatureSubs = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").findAll(blob).map { it.groupValues[1] }.toList()
     var filtered = when {
         subs.isNotEmpty() && ("Land" in types || "IsLandType" in blob || "\"Land\"" in blob) ->
             "GameObjectFilter.Land.withSubtype(${subtypeArg(subs[0])})"
+        creatureSubs.isNotEmpty() && ("Creature" in types || "\"Creature\"" in blob) ->
+            "GameObjectFilter.Creature.withSubtype(${subtypeArg(creatureSubs[0])})"
         subs.isNotEmpty() && ("Creature" in types || "\"Creature\"" in blob) ->
             "GameObjectFilter.Creature.withSubtype(${subtypeArg(subs[0])})"
         types == setOf("Creature", "Land") -> "GameObjectFilter.CreatureOrLand"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.tooling.coverage.emitter
+
+import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.asInt
+import com.wingedsheep.tooling.coverage.asStr
+import com.wingedsheep.tooling.coverage.findInteger
+import com.wingedsheep.tooling.coverage.pascalToUpperSnake
+import com.wingedsheep.tooling.coverage.strField
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+
+/** Token creation: a `CreateTokens` action -> `Effects.CreateToken(...)`. Only plain creature tokens
+ *  with a P/T, colours, creature subtypes and (optionally) keyword abilities are rendered exactly;
+ *  anything else (artifact/enchantment tokens, copy tokens, tokens with full abilities) scaffolds. */
+internal val tokenHandlers: Map<String, ActionHandler> = actionHandlers {
+    on("CreateTokens") { _, args, _ ->
+        val spec = args.asArr?.firstOrNull() as? JsonObject ?: return@on null
+        createTokenDsl(spec)
+    }
+}
+
+private val TOKEN_COLOR = mapOf(
+    "White" to "WHITE", "Blue" to "BLUE", "Black" to "BLACK", "Red" to "RED", "Green" to "GREEN",
+)
+
+/** A `_CreatableToken` spec -> `Effects.CreateToken(...)`, or null (-> SCAFFOLD) for shapes we can't
+ *  render exactly. `NumberTokens` wraps a base spec with a fixed count. */
+internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1): String? {
+    when (spec.strField("_CreatableToken")) {
+        "NumberTokens" -> {
+            val a = spec["args"].asArr ?: return null
+            val n = findInteger(a.getOrNull(0)) as? Int ?: return null
+            val inner = a.getOrNull(1) as? JsonObject ?: return null
+            return createTokenDsl(inner, n)
+        }
+        "TokenWithPT" -> {
+            // args: [ {_PT [p,t]}, {_TokenColorList [names]}, [supertypes], [cardtypes],
+            //         {_TokenSubtypes [subs]}, [abilities] ]
+            val a = spec["args"].asArr ?: return null
+            val cardtypes = (a.getOrNull(3) as? JsonArray)?.mapNotNull { it.asStr() } ?: emptyList()
+            if (cardtypes != listOf("Creature")) return null  // only plain creature tokens
+            val pt = (a.getOrNull(0) as? JsonObject)?.get("args").asArr ?: return null
+            val power = pt.getOrNull(0).asInt() ?: return null
+            val toughness = pt.getOrNull(1).asInt() ?: return null
+            val colors = ((a.getOrNull(1) as? JsonObject)?.get("args").asArr ?: JsonArray(emptyList()))
+                .mapNotNull { it.asStr()?.let(TOKEN_COLOR::get) }
+            val subs = ((a.getOrNull(4) as? JsonObject)?.get("args").asArr ?: JsonArray(emptyList()))
+                .mapNotNull { it.asStr() }
+            if (subs.isEmpty()) return null
+            val tokenKeywords = ((a.getOrNull(5) as? JsonArray) ?: JsonArray(emptyList()))
+                .mapNotNull { (it as? JsonObject)?.strField("_Rule") }
+                .map { pascalToUpperSnake(it) }
+                .filter { it in keywords }
+            val parts = mutableListOf("power = $power", "toughness = $toughness")
+            if (colors.isNotEmpty()) parts.add("colors = setOf(${colors.joinToString(", ") { "Color.$it" }})")
+            parts.add("creatureTypes = setOf(${subs.joinToString(", ") { "\"$it\"" }})")
+            if (tokenKeywords.isNotEmpty()) parts.add("keywords = setOf(${tokenKeywords.joinToString(", ") { "Keyword.$it" }})")
+            if (count != 1) parts.add("count = $count")
+            return "Effects.CreateToken(${parts.joinToString(", ")})"
+        }
+    }
+    return null
+}


### PR DESCRIPTION
## What

Extends the `:mtgish-tooling` emitter + capability bridge to raise **Onslaught (ONS) generation fidelity** — the share of cards the emitter renders *whole* (`AUTO` tier) from the mtgish oracle IR. This continues the per-capability recovery work already in `main`.

`just coverage-fidelity --set ONS`:

| | before | after |
|---|--:|--:|
| **AUTO** (renders whole) | 91 (27.8%) | **135 (41.3%)** |
| SCAFFOLD | 106 (32.4%) | 77 (23.5%) |
| MISS | 130 (39.8%) | 115 (35.2%) |
| mean recall | 69.9% | 75.3% |

The handlers are universal, so every set benefits ("one fix helps all"): INV +recall, DOM/LGN/KTK AUTO up, etc.

## Capabilities added (one commit each)

1. **Activated mana abilities** (`{T}: Add …`) — `AddMana` → `AddColorlessMana`/`AddMana(Color)`/`AddManaOfChoice`; targetless mana producers emit `manaAbility = true` + `TimingRule.ManaAbility`. Utility lands.
2. **`AsPermanentEnters` replacements** — enters-tapped + "choose a creature type". Completes the cycling lands.
3. **`CreateTokens`** — `Effects.CreateToken(...)` for plain creature tokens (P/T, colours, subtypes, keywords, count).
4. **`MAY_NOT_UNTAP` + duration-aware layer effects** — `_Expiration` is now honoured exactly (`ForAsLongAsPermanentRemainsTapped` → `Duration.WhileSourceTapped()`, unknown → scaffold) instead of silently defaulting to end-of-turn. The Courier cycle.
5. **"becomes creature type of choice"** — collapses `ChooseACreatureType` + `AddCreatureTypeVariable` into one `BecomeCreatureTypeEffect`. The Mistform cycle.
6. **Static creature-type lords** (`EachPermanentLayerEffect`) — `ModifyStats`/`GrantKeyword` static abilities over a `GroupFilter` (incl. `ChosenSubtypeCreatures()`); also surfaces `_StaticLayerEffect` as a capability discriminator and recovers creature subtypes in group filters. Aven Brigadier, Cover of Darkness, Steely Resolve, Shared Triumph.
7. **Characteristic-defining P/T** (`CDA_Power`/`CDA_Toughness`) → `dynamicStats(...)`. The Nameless/Heedless/Reckless One cycle.
8. **"When you cycle this card" triggers** (`FromAnyZone`) → `triggeredAbility { trigger = Triggers.YouCycleThis }`. Renewed Faith, Krosan Tusker, etc.

Plus: `fidelity --list` now prints each MISS card's unmapped caps / each SCAFFOLD card's unrecovered reasons (per-card worklist), and `ACTION_HANDLERS` is `by lazy` to avoid a class-init cycle.

## Why not 100%

This is the conservative, predictive analyzer described in `mtgish-tooling/README.md`: it returns `null` (scaffolds) rather than emit a confidently-wrong card. The remaining ONS gap is dominated by capabilities that need genuine engine-feature emitters or risk wrong output — `ChainCopy` (the Chains), modal spells (the Charms), gated/`you-may` triggers (Gustcloaks), `Fight`, divided combat damage, `ReplaceNextDrawWith` (the Words), etc. Those are real `add-feature`/`add-card` work, not emitter mappings, so they're left as SCAFFOLD/MISS with the per-card worklist now visible.

## Verification

- `just coverage-verify POR` → **GATE PASS, 158/158** — every emitted Portal card still compiles and gameplay-tree-matches its golden snapshot (the calibration is intact; POR fidelity unchanged at 96.2%).
- `./gradlew :mtgish-tooling:test` green.
- Generated cards remain **drafts** — they still need a human review + scenario test before moving into a set's `cards/` package, exactly as the README requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)