### PR TITLE
Tournament host ban list for booster generation

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -1942,6 +1942,13 @@ class LobbyHandler(
 
         message.chaosBoosters?.let { lobby.chaosBoosters = it }
 
+        // Host ban list — the full list is sent each time (not a delta). Trim, drop blanks and
+        // duplicates; unknown names are kept as-is (they simply never match a card in the pool),
+        // so the editor round-trips exactly what the host typed/picked.
+        message.bannedCardNames?.let { names ->
+            lobby.bannedCardNames = names.map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        }
+
         ctx.broadcastLobbyUpdate(lobby)
         lobbyRepository.saveLobby(lobby)
     }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -239,6 +239,13 @@ class TournamentLobby(
      * — only [boosterCount] matters.
      */
     var chaosBoosters: Boolean = false,
+    /**
+     * Host-settable ban list: oracle card names excluded from every booster pack this lobby
+     * generates (sealed pool, draft pack, Winston/Grid deck). Matched case-insensitively by
+     * [BoosterGenerator]. Has no effect on [TournamentFormat.PREMADE_DECKS] (those bring their
+     * own decks) or on basic lands. Empty = no exclusions.
+     */
+    var bannedCardNames: Set<String> = emptySet(),
 ) {
 
     /**
@@ -533,7 +540,7 @@ class TournamentLobby(
 
         if (effectiveDistribution != null) {
             players.forEach { (playerId, playerState) ->
-                val pool = boosterGenerator.generateSealedPool(effectiveDistribution, strategy, chaos = chaosBoosters)
+                val pool = boosterGenerator.generateSealedPool(effectiveDistribution, strategy, chaos = chaosBoosters, bannedCardNames = bannedCardNames)
                 players[playerId] = playerState.copy(cardPool = pool)
             }
         } else {
@@ -547,6 +554,7 @@ class TournamentLobby(
                     distributionSeed,
                     strategy,
                     chaos = chaosBoosters,
+                    bannedCardNames = bannedCardNames,
                 )
                 players[playerId] = playerState.copy(cardPool = pool)
             }
@@ -608,9 +616,9 @@ class TournamentLobby(
 
         players.forEach { (_, playerState) ->
             val newPack = if (packSetCode != null) {
-                boosterGenerator.generateBooster(packSetCode, strategy)
+                boosterGenerator.generateBooster(packSetCode, strategy, bannedCardNames)
             } else {
-                boosterGenerator.generateBooster(setCodes, strategy, chaos = chaosBoosters)
+                boosterGenerator.generateBooster(setCodes, strategy, chaos = chaosBoosters, bannedCardNames = bannedCardNames)
             }
             playerState.currentPack = newPack
             playerState.packQueue.clear()
@@ -773,7 +781,7 @@ class TournamentLobby(
         // Generate boosters and shuffle into main deck
         val allCards = mutableListOf<CardDefinition>()
         repeat(boosterCount) {
-            allCards.addAll(boosterGenerator.generateBooster(setCodes, chaos = chaosBoosters))
+            allCards.addAll(boosterGenerator.generateBooster(setCodes, chaos = chaosBoosters, bannedCardNames = bannedCardNames))
         }
         allCards.shuffle()
 
@@ -819,7 +827,7 @@ class TournamentLobby(
             val boostersPerGroup = boosterCount / 2
             fun generateGroupPool(count: Int): MutableList<CardDefinition> {
                 val pool = mutableListOf<CardDefinition>()
-                repeat(count) { pool.addAll(boosterGenerator.generateBooster(setCodes, chaos = chaosBoosters)) }
+                repeat(count) { pool.addAll(boosterGenerator.generateBooster(setCodes, chaos = chaosBoosters, bannedCardNames = bannedCardNames)) }
                 pool.shuffle()
                 return pool
             }
@@ -830,7 +838,7 @@ class TournamentLobby(
         } else {
             // 2-3 players: 1 group with all players
             val pool = mutableListOf<CardDefinition>()
-            repeat(boosterCount) { pool.addAll(boosterGenerator.generateBooster(setCodes, chaos = chaosBoosters)) }
+            repeat(boosterCount) { pool.addAll(boosterGenerator.generateBooster(setCodes, chaos = chaosBoosters, bannedCardNames = bannedCardNames)) }
             pool.shuffle()
             gridGroups = listOf(
                 GridGroup(mainDeck = pool, playerOrder = allPlayers)
@@ -1417,6 +1425,7 @@ class TournamentLobby(
                 allowDuplicates = allowDuplicates,
                 commanderPreset = commanderPreset.name,
                 chaosBoosters = chaosBoosters,
+                bannedCardNames = bannedCardNames.sorted(),
             ),
             isHost = isHost(forPlayerId)
         )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -249,6 +249,11 @@ sealed interface ClientMessage {
         val commanderPreset: String? = null,
         /** Toggle Chaos boosters: each pack pulls from the union of selected sets. */
         val chaosBoosters: Boolean? = null,
+        /**
+         * Replace the host ban list — oracle card names excluded from generated boosters. The
+         * full list is sent each time (not a delta); null leaves the current ban list unchanged.
+         */
+        val bannedCardNames: List<String>? = null,
     ) : ClientMessage
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -413,6 +413,11 @@ sealed interface ServerMessage {
         val commanderPreset: String = "BRAWL",
         /** When true, each booster mixes cards from the union of all selected sets. */
         val chaosBoosters: Boolean = false,
+        /**
+         * Host ban list: oracle card names excluded from generated boosters. Sorted for a stable
+         * UI order. Empty = no exclusions. Ignored by [TournamentFormat.PREMADE_DECKS].
+         */
+        val bannedCardNames: List<String> = emptyList(),
     )
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
@@ -159,14 +159,20 @@ class BoosterGenerator(
      * @param strategy Optional override; when null, uses the set's configured strategy.
      *                 Pass an explicit strategy (e.g., [com.wingedsheep.sdk.limited.CommanderDraftBooster])
      *                 to ship Brawl / Commander Draft packs without mutating [SetConfig].
+     * @param bannedCardNames Oracle card names to exclude from the pool before packing (tournament
+     *                        host ban list). Matched case-insensitively; empty = no exclusions.
      * @return List of card definitions
      * @throws IllegalArgumentException if set code is not found
      */
-    fun generateBooster(setCode: String, strategy: BoosterStrategy? = null): List<CardDefinition> {
+    fun generateBooster(
+        setCode: String,
+        strategy: BoosterStrategy? = null,
+        bannedCardNames: Set<String> = emptySet(),
+    ): List<CardDefinition> {
         val setConfig = availableSets[setCode]
             ?: throw IllegalArgumentException("Unknown set code: $setCode")
         val effectiveStrategy = strategy ?: setConfig.boosterStrategy
-        val generated = effectiveStrategy.generate(boosterPool(setConfig.cards), Random.Default)
+        val generated = effectiveStrategy.generate(boosterPool(setConfig.cards, bannedCardNames), Random.Default)
         return applyVariantPrintings(generated, setConfig.printings, setConfig.variantChance, Random.Default)
     }
 
@@ -183,7 +189,12 @@ class BoosterGenerator(
      * @return List of card definitions
      * @throws IllegalArgumentException if any set code is not found
      */
-    fun generateBooster(setCodes: List<String>, strategy: BoosterStrategy? = null, chaos: Boolean = false): List<CardDefinition> {
+    fun generateBooster(
+        setCodes: List<String>,
+        strategy: BoosterStrategy? = null,
+        chaos: Boolean = false,
+        bannedCardNames: Set<String> = emptySet(),
+    ): List<CardDefinition> {
         if (setCodes.isEmpty()) {
             throw IllegalArgumentException("At least one set code is required")
         }
@@ -198,12 +209,12 @@ class BoosterGenerator(
         if (chaos || setConfigs.any { it.incomplete }) {
             val combinedCards = setConfigs.flatMap { it.cards }
             val effectiveStrategy = strategy ?: StandardBooster()
-            return effectiveStrategy.generate(boosterPool(combinedCards), Random.Default)
+            return effectiveStrategy.generate(boosterPool(combinedCards, bannedCardNames), Random.Default)
         }
 
         // Pick a random set and generate a booster from it
         val selectedSet = setCodes.random()
-        return generateBooster(selectedSet, strategy)
+        return generateBooster(selectedSet, strategy, bannedCardNames)
     }
 
     /**
@@ -219,8 +230,9 @@ class BoosterGenerator(
         setCode: String,
         boosterCount: Int = 6,
         strategy: BoosterStrategy? = null,
+        bannedCardNames: Set<String> = emptySet(),
     ): List<CardDefinition> {
-        return (1..boosterCount).flatMap { generateBooster(setCode, strategy) }
+        return (1..boosterCount).flatMap { generateBooster(setCode, strategy, bannedCardNames) }
     }
 
     /**
@@ -247,12 +259,13 @@ class BoosterGenerator(
         distributionSeed: Long? = null,
         strategy: BoosterStrategy? = null,
         chaos: Boolean = false,
+        bannedCardNames: Set<String> = emptySet(),
     ): List<CardDefinition> {
         if (setCodes.isEmpty()) {
             throw IllegalArgumentException("At least one set code is required")
         }
         if (setCodes.size == 1) {
-            return generateSealedPool(setCodes.first(), boosterCount, strategy)
+            return generateSealedPool(setCodes.first(), boosterCount, strategy, bannedCardNames)
         }
 
         // Validate all set codes exist
@@ -265,7 +278,7 @@ class BoosterGenerator(
         if (chaos || setConfigs.any { it.incomplete }) {
             val combinedCards = setConfigs.flatMap { it.cards }
             val combinedStrategy = strategy ?: StandardBooster()
-            val combinedPool = boosterPool(combinedCards)
+            val combinedPool = boosterPool(combinedCards, bannedCardNames)
             return (1..boosterCount).flatMap { combinedStrategy.generate(combinedPool, Random.Default) }
         }
 
@@ -294,7 +307,7 @@ class BoosterGenerator(
 
         // Note: We don't shuffle the final assignments - each player gets their
         // own random card contents anyway, only the set distribution needs to match
-        return boosterAssignments.flatMap { generateBooster(it, strategy) }
+        return boosterAssignments.flatMap { generateBooster(it, strategy, bannedCardNames) }
     }
 
     /**
@@ -308,6 +321,7 @@ class BoosterGenerator(
         boosterDistribution: Map<String, Int>,
         strategy: BoosterStrategy? = null,
         chaos: Boolean = false,
+        bannedCardNames: Set<String> = emptySet(),
     ): List<CardDefinition> {
         if (boosterDistribution.isEmpty()) {
             throw IllegalArgumentException("At least one set code is required")
@@ -324,13 +338,13 @@ class BoosterGenerator(
             val combinedCards = setConfigs.flatMap { it.cards }
             val totalBoosters = boosterDistribution.values.sum()
             val combinedStrategy = strategy ?: StandardBooster()
-            val combinedPool = boosterPool(combinedCards)
+            val combinedPool = boosterPool(combinedCards, bannedCardNames)
             return (1..totalBoosters).flatMap { combinedStrategy.generate(combinedPool, Random.Default) }
         }
 
         // Generate boosters per set according to distribution
         return boosterDistribution.flatMap { (setCode, count) ->
-            (1..count).flatMap { generateBooster(setCode, strategy) }
+            (1..count).flatMap { generateBooster(setCode, strategy, bannedCardNames) }
         }
     }
 
@@ -396,9 +410,21 @@ class BoosterGenerator(
     }
 
     /**
-     * Strip basic lands and non-booster cards (Special Guests / The List / promos);
-     * strategies operate on the booster pool only.
+     * Strip basic lands and non-booster cards (Special Guests / The List / promos), plus any
+     * cards on the tournament host's [bannedCardNames] ban list; strategies operate on the
+     * booster pool only. Banned names are matched case-insensitively so a host typo in casing
+     * still excludes the card.
      */
-    private fun boosterPool(allCards: List<CardDefinition>): List<CardDefinition> =
-        allCards.filter { !it.typeLine.isBasicLand && it.metadata.inBooster }
+    private fun boosterPool(
+        allCards: List<CardDefinition>,
+        bannedCardNames: Set<String> = emptySet(),
+    ): List<CardDefinition> {
+        if (bannedCardNames.isEmpty()) {
+            return allCards.filter { !it.typeLine.isBasicLand && it.metadata.inBooster }
+        }
+        val banned = bannedCardNames.mapTo(HashSet(bannedCardNames.size)) { it.trim().lowercase() }
+        return allCards.filter {
+            !it.typeLine.isBasicLand && it.metadata.inBooster && it.name.trim().lowercase() !in banned
+        }
+    }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorBanListTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorBanListTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.limited
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.ScryfallMetadata
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+
+/**
+ * Pins the tournament host ban list: any card name on [BoosterGenerator]'s `bannedCardNames`
+ * is filtered out of every generated booster / sealed pool, across the single-set, multi-set,
+ * chaos, and explicit-distribution paths. Matching is case-insensitive. The list never affects
+ * basic lands and an empty list is a no-op.
+ */
+class BoosterGeneratorBanListTest : DescribeSpec({
+
+    fun common(name: String) = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2,
+        metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString()),
+    )
+
+    // A pool of commons large enough that StandardBooster never exhausts it; one card is the
+    // ban target. With 14 commons, a pack draws 12 distinct, so the target shows up in nearly
+    // every unbanned pack — a sharp control for "banned ⇒ absent".
+    val banTarget = "Grizzly Bears"
+    fun poolOf(setCode: String) = (1..13).map { common("$setCode Common $it") } + common(banTarget)
+
+    fun generator(vararg setCodes: String) = BoosterGenerator(
+        setCodes.associateWith { code ->
+            BoosterGenerator.SetConfig(
+                setCode = code,
+                setName = "Set $code",
+                cards = poolOf(code),
+                basicLands = emptyList(),
+            )
+        }
+    )
+
+    describe("single-set booster") {
+        it("excludes a banned card across many packs") {
+            val gen = generator("AAA")
+            repeat(60) {
+                gen.generateBooster("AAA", bannedCardNames = setOf(banTarget)).map { it.name } shouldNotContain banTarget
+            }
+        }
+
+        it("still includes the card when not banned (control)") {
+            val gen = generator("AAA")
+            val names = (1..60).flatMap { gen.generateBooster("AAA").map { c -> c.name } }
+            names shouldContain banTarget
+        }
+
+        it("matches the ban name case-insensitively") {
+            val gen = generator("AAA")
+            repeat(40) {
+                gen.generateBooster("AAA", bannedCardNames = setOf("grizzly BEARS")).map { it.name } shouldNotContain banTarget
+            }
+        }
+
+        it("treats an empty ban list as a no-op") {
+            val gen = generator("AAA")
+            val names = (1..60).flatMap { gen.generateBooster("AAA", bannedCardNames = emptySet()).map { c -> c.name } }
+            names shouldContain banTarget
+        }
+    }
+
+    describe("sealed pool") {
+        it("excludes a banned card from a single-set pool") {
+            val gen = generator("AAA")
+            gen.generateSealedPool("AAA", boosterCount = 6, bannedCardNames = setOf(banTarget))
+                .map { it.name } shouldNotContain banTarget
+        }
+
+        it("excludes a banned card from a seeded multi-set pool") {
+            val gen = generator("AAA", "BBB")
+            gen.generateSealedPool(listOf("AAA", "BBB"), boosterCount = 6, distributionSeed = 42L, bannedCardNames = setOf(banTarget))
+                .map { it.name } shouldNotContain banTarget
+        }
+
+        it("excludes a banned card from an explicit-distribution pool") {
+            val gen = generator("AAA", "BBB")
+            gen.generateSealedPool(mapOf("AAA" to 3, "BBB" to 3), bannedCardNames = setOf(banTarget))
+                .map { it.name } shouldNotContain banTarget
+        }
+
+        it("excludes a banned card from a chaos pool") {
+            val gen = generator("AAA", "BBB")
+            gen.generateSealedPool(listOf("AAA", "BBB"), boosterCount = 6, chaos = true, bannedCardNames = setOf(banTarget))
+                .map { it.name } shouldNotContain banTarget
+        }
+    }
+})

--- a/web-client/src/components/ui/BanListEditor.module.css
+++ b/web-client/src/components/ui/BanListEditor.module.css
@@ -1,0 +1,277 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+}
+
+.headerLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.countBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 6px;
+  font-size: var(--font-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  background: var(--color-warning-light);
+  border-radius: 999px;
+}
+
+.chevron {
+  color: var(--text-disabled);
+  font-size: var(--font-xs);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: 0 var(--space-4) var(--space-3);
+}
+
+.caption {
+  margin: 0;
+  font-size: var(--font-xs);
+  color: var(--text-disabled);
+  line-height: 1.35;
+}
+
+.empty {
+  margin: 0;
+  font-size: var(--font-xs);
+  color: var(--text-disabled);
+}
+
+.searchWrap {
+  position: relative;
+}
+
+.input {
+  width: 100%;
+  padding: 6px var(--space-3);
+  font-size: var(--font-sm);
+  background-color: var(--bg-surface-4);
+  color: var(--text-primary);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-md);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  border-color: var(--color-accent-dark);
+}
+
+.results {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  background-color: var(--bg-panel-light);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-md);
+}
+
+.resultItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  width: 100%;
+  padding: 5px var(--space-3);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-primary);
+  font-size: var(--font-sm);
+  text-align: left;
+}
+
+.resultItem:hover {
+  background-color: var(--bg-surface-4);
+}
+
+.resultName {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resultSet {
+  font-size: var(--font-xs);
+  color: var(--text-disabled);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 6px 3px 10px;
+  font-size: var(--font-xs);
+  color: var(--text-primary);
+  background: rgba(214, 90, 90, 0.18);
+  border: 1px solid rgba(214, 90, 90, 0.5);
+  border-radius: 999px;
+}
+
+.chipRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  font-size: 13px;
+  line-height: 1;
+  color: #f0c4c4;
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: 999px;
+}
+
+.chipRemove:hover {
+  background: rgba(214, 90, 90, 0.35);
+  color: #fff;
+}
+
+.clearAll {
+  padding: 3px 10px;
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+  background: none;
+  border: 1px solid var(--border-medium);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.clearAll:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.savedSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: 2px;
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.saveRow {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.saveButton {
+  padding: 5px var(--space-3);
+  font-size: var(--font-sm);
+  white-space: nowrap;
+  color: var(--text-primary);
+  background-color: var(--bg-surface-4);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.saveButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.saveButton:not(:disabled):hover {
+  border-color: var(--color-accent-dark);
+}
+
+.savedList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.savedItem {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.savedLoad {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  flex: 1;
+  padding: 5px var(--space-3);
+  font-size: var(--font-sm);
+  color: var(--text-primary);
+  background-color: var(--bg-surface-4);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+}
+
+.savedLoad:hover {
+  border-color: var(--color-accent-dark);
+}
+
+.savedCount {
+  font-size: var(--font-xs);
+  color: var(--text-disabled);
+}
+
+.savedDelete {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 15px;
+  color: var(--text-muted);
+  background: none;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.savedDelete:hover {
+  color: #fff;
+  background: rgba(214, 90, 90, 0.35);
+  border-color: rgba(214, 90, 90, 0.5);
+}

--- a/web-client/src/components/ui/BanListEditor.tsx
+++ b/web-client/src/components/ui/BanListEditor.tsx
@@ -1,0 +1,252 @@
+/**
+ * BanListEditor — host control for a tournament's booster ban list.
+ *
+ * A ban list is a set of oracle card names excluded from every booster pack the lobby generates
+ * (see `BoosterGenerator.boosterPool`). The host adds cards by searching the catalog filtered to
+ * the selected sets, removes them via chips, and can save/load named ban lists per set the same
+ * way decks are saved (localStorage via {@link useBanListLibrary}).
+ *
+ * Server-authoritative: this component only edits the list and hands it back via [onChange] (which
+ * the lobby wires to `updateLobbySettings({ bannedCardNames })`). It never decides what a booster
+ * contains — the server filters the pool.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { CardSummary } from '@/components/deckbuilder/cardFilter'
+import { useBanListLibrary } from '@/store/banListLibrary'
+import styles from './BanListEditor.module.css'
+
+interface BanListEditorProps {
+  /** Currently selected set codes for the lobby. */
+  readonly setCodes: readonly string[]
+  /** Current ban list (oracle card names). */
+  readonly bannedCardNames: readonly string[]
+  /** Called with the full new ban list whenever the host adds/removes/loads cards. */
+  readonly onChange: (names: string[]) => void
+}
+
+/** Module-level cache so re-opening the panel doesn't refetch the whole catalog. */
+let cardCache: CardSummary[] | null = null
+
+export function BanListEditor({ setCodes, bannedCardNames, onChange }: BanListEditorProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [allCards, setAllCards] = useState<CardSummary[]>(cardCache ?? [])
+  const [query, setQuery] = useState('')
+  const [saveName, setSaveName] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { banLists, hydrate, saveBanList, deleteBanList, banListsForSet } = useBanListLibrary()
+
+  useEffect(() => {
+    hydrate()
+  }, [hydrate])
+
+  // Fetch the catalog once (cached across mounts).
+  useEffect(() => {
+    if (cardCache) return
+    let cancelled = false
+    fetch('/api/cards')
+      .then((r) => (r.ok ? r.json() : []))
+      .then((list: CardSummary[]) => {
+        if (cancelled) return
+        cardCache = list
+        setAllCards(list)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const setCodeSet = useMemo(() => new Set(setCodes), [setCodes])
+  const banned = useMemo(() => new Set(bannedCardNames.map((n) => n.toLowerCase())), [bannedCardNames])
+
+  /** Catalog cards that belong to any selected set, excluding basic lands. */
+  const candidates = useMemo(() => {
+    if (setCodeSet.size === 0) return []
+    return allCards
+      .filter((c) => !c.basicLand)
+      .filter((c) => {
+        if (c.setCode && setCodeSet.has(c.setCode)) return true
+        return (c.printingSetCodes ?? []).some((s) => setCodeSet.has(s))
+      })
+  }, [allCards, setCodeSet])
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return []
+    return candidates
+      .filter((c) => !banned.has(c.name.toLowerCase()) && c.name.toLowerCase().includes(q))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .slice(0, 25)
+  }, [candidates, banned, query])
+
+  const sortedBanned = useMemo(
+    () => [...bannedCardNames].sort((a, b) => a.localeCompare(b)),
+    [bannedCardNames],
+  )
+
+  const primarySet = setCodes[0]
+  const savedForSet = primarySet ? banListsForSet(primarySet) : []
+
+  function addCard(name: string) {
+    if (bannedCardNames.some((n) => n.toLowerCase() === name.toLowerCase())) return
+    onChange([...bannedCardNames, name])
+    setQuery('')
+    inputRef.current?.focus()
+  }
+
+  function removeCard(name: string) {
+    onChange(bannedCardNames.filter((n) => n !== name))
+  }
+
+  function handleSave() {
+    const name = saveName.trim()
+    if (!name || !primarySet) return
+    // Overwrite an existing list of the same name for this set, else create a new one.
+    const existing = savedForSet.find((b) => b.name.toLowerCase() === name.toLowerCase())
+    saveBanList({
+      ...(existing ? { id: existing.id } : {}),
+      name,
+      setCode: primarySet,
+      cards: bannedCardNames,
+    })
+    setSaveName('')
+  }
+
+  function handleLoad(id: string) {
+    const list = banLists.find((b) => b.id === id)
+    if (list) onChange([...list.cards])
+  }
+
+  return (
+    <div className={styles.container}>
+      <button
+        type="button"
+        className={styles.header}
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span className={styles.headerLabel}>
+          Banned cards
+          {bannedCardNames.length > 0 && (
+            <span className={styles.countBadge}>{bannedCardNames.length}</span>
+          )}
+        </span>
+        <span className={styles.chevron}>{expanded ? '▾' : '▸'}</span>
+      </button>
+
+      {expanded && (
+        <div className={styles.body}>
+          <p className={styles.caption}>
+            Cards on this list never appear in generated boosters. They don&apos;t affect
+            Premade-Decks tournaments.
+          </p>
+
+          {setCodes.length === 0 ? (
+            <p className={styles.empty}>Select a set first to search for cards to ban.</p>
+          ) : (
+            <div className={styles.searchWrap}>
+              <input
+                ref={inputRef}
+                type="text"
+                className={styles.input}
+                placeholder="Search cards to ban…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && results[0]) addCard(results[0].name)
+                }}
+              />
+              {results.length > 0 && (
+                <ul className={styles.results}>
+                  {results.map((c) => (
+                    <li key={c.name}>
+                      <button type="button" className={styles.resultItem} onClick={() => addCard(c.name)}>
+                        <span className={styles.resultName}>{c.name}</span>
+                        {c.setCode && <span className={styles.resultSet}>{c.setCode}</span>}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {sortedBanned.length > 0 ? (
+            <div className={styles.chips}>
+              {sortedBanned.map((name) => (
+                <span key={name} className={styles.chip}>
+                  {name}
+                  <button
+                    type="button"
+                    className={styles.chipRemove}
+                    onClick={() => removeCard(name)}
+                    aria-label={`Remove ${name}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+              <button type="button" className={styles.clearAll} onClick={() => onChange([])}>
+                Clear all
+              </button>
+            </div>
+          ) : (
+            <p className={styles.empty}>No cards banned.</p>
+          )}
+
+          {/* Save / load named ban lists per set, mirroring the deck library. */}
+          {primarySet && (
+            <div className={styles.savedSection}>
+              <div className={styles.saveRow}>
+                <input
+                  type="text"
+                  className={styles.input}
+                  placeholder={`Save ban list for ${primarySet}…`}
+                  value={saveName}
+                  onChange={(e) => setSaveName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleSave()
+                  }}
+                />
+                <button
+                  type="button"
+                  className={styles.saveButton}
+                  disabled={!saveName.trim() || bannedCardNames.length === 0}
+                  onClick={handleSave}
+                >
+                  Save
+                </button>
+              </div>
+              {savedForSet.length > 0 && (
+                <ul className={styles.savedList}>
+                  {savedForSet.map((list) => (
+                    <li key={list.id} className={styles.savedItem}>
+                      <button
+                        type="button"
+                        className={styles.savedLoad}
+                        title={list.cards.join(', ')}
+                        onClick={() => handleLoad(list.id)}
+                      >
+                        {list.name}
+                        <span className={styles.savedCount}>{list.cards.length}</span>
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.savedDelete}
+                        aria-label={`Delete ${list.name}`}
+                        onClick={() => deleteBanList(list.id)}
+                      >
+                        ×
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -11,6 +11,7 @@ import type { ReplayData } from '@/replay/reconstructSnapshots.ts'
 import { QuickGameLobbyOverlay } from './QuickGameLobbyOverlay'
 import { useDeckLibrary, buildDraftedDeckSave, type SavedDeckEntry } from '@/store/deckLibrary'
 import { DeckPicker } from './DeckPicker'
+import { BanListEditor } from './BanListEditor'
 import { labelForFormat } from '@/utils/deckLegality'
 import styles from './GameUI.module.css'
 
@@ -1106,6 +1107,14 @@ function LobbyOverlay({
                   </div>
                 </div>
               </div>
+            )}
+            {/* Booster ban list — host excludes named cards from generated boosters. Not for Premade. */}
+            {!isPremade && (
+              <BanListEditor
+                setCodes={lobbyState.settings.setCodes}
+                bannedCardNames={lobbyState.settings.bannedCardNames ?? []}
+                onChange={(names) => updateLobbySettings({ bannedCardNames: names })}
+              />
             )}
             {/* Boosters setting - for Sealed and Winston (Grid uses fixed counts) */}
             {(isSealed || isWinston || isCommanderSealed) && lobbyState.settings.setCodes.length > 1 && !lobbyState.settings.chaosBoosters && (

--- a/web-client/src/store/banListLibrary.ts
+++ b/web-client/src/store/banListLibrary.ts
@@ -1,0 +1,121 @@
+/**
+ * Ban list library — localStorage-backed list of saved tournament ban lists, scoped per set.
+ *
+ * Mirrors {@link ./deckLibrary deckLibrary}: a tiny standalone Zustand store with no WebSocket
+ * integration, so the lobby ban-list editor can save/load named ban lists the same way the
+ * deckbuilder saves decks. A ban list is just a named bag of oracle card names tied to the set
+ * code it was built for (so the editor can offer "your ban lists for this set").
+ *
+ * Storage is a versioned envelope so the shape can migrate later without losing users' lists.
+ *
+ * ## Storage versions
+ * - **v1** — `{ id, name, setCode, cards: string[], updatedAt }`.
+ */
+import { create } from 'zustand'
+
+export interface SavedBanList {
+  id: string
+  name: string
+  /** The set code this ban list was built for (e.g. "BLB"). Drives "ban lists for this set". */
+  setCode: string
+  /** Oracle card names to exclude from boosters. */
+  cards: readonly string[]
+  updatedAt: number
+}
+
+interface BanListStorageV1 {
+  version: 1
+  banLists: SavedBanList[]
+}
+
+type BanListStorage = BanListStorageV1
+
+const STORAGE_KEY = 'argentum.banlists'
+const STORAGE_VERSION = 1
+
+interface BanListLibraryState {
+  banLists: SavedBanList[]
+  hydrated: boolean
+
+  hydrate: () => void
+  saveBanList: (input: Omit<SavedBanList, 'id' | 'updatedAt'> & { id?: string }) => SavedBanList
+  deleteBanList: (id: string) => void
+  renameBanList: (id: string, newName: string) => void
+  getBanList: (id: string) => SavedBanList | undefined
+  /** All saved ban lists for a given set code, newest first. */
+  banListsForSet: (setCode: string) => SavedBanList[]
+}
+
+function loadFromStorage(): SavedBanList[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as BanListStorage
+    if (!parsed || !Array.isArray(parsed.banLists)) return []
+    if (parsed.version === STORAGE_VERSION) return parsed.banLists
+    return []
+  } catch {
+    return []
+  }
+}
+
+function persist(banLists: SavedBanList[]) {
+  if (typeof window === 'undefined') return
+  const envelope: BanListStorageV1 = { version: STORAGE_VERSION, banLists }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(envelope))
+}
+
+function generateId(): string {
+  return `banlist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+export const useBanListLibrary = create<BanListLibraryState>((set, get) => ({
+  banLists: [],
+  hydrated: false,
+
+  hydrate: () => {
+    if (get().hydrated) return
+    set({ banLists: loadFromStorage(), hydrated: true })
+  },
+
+  saveBanList: (input) => {
+    const now = Date.now()
+    const id = input.id ?? generateId()
+    const existing = input.id ? get().banLists.find((b) => b.id === input.id) : undefined
+    const saved: SavedBanList = {
+      id,
+      name: input.name,
+      setCode: input.setCode,
+      cards: [...input.cards],
+      updatedAt: now,
+    }
+    const banLists = existing
+      ? get().banLists.map((b) => (b.id === id ? saved : b))
+      : [...get().banLists, saved]
+    persist(banLists)
+    set({ banLists })
+    return saved
+  },
+
+  deleteBanList: (id) => {
+    const banLists = get().banLists.filter((b) => b.id !== id)
+    persist(banLists)
+    set({ banLists })
+  },
+
+  renameBanList: (id, newName) => {
+    const banLists = get().banLists.map((b) =>
+      b.id === id ? { ...b, name: newName, updatedAt: Date.now() } : b
+    )
+    persist(banLists)
+    set({ banLists })
+  },
+
+  getBanList: (id) => get().banLists.find((b) => b.id === id),
+
+  banListsForSet: (setCode) =>
+    get()
+      .banLists.filter((b) => b.setCode === setCode)
+      .sort((a, b) => b.updatedAt - a.updatedAt),
+}))

--- a/web-client/src/store/slices/handlers/lobbyHandlers.ts
+++ b/web-client/src/store/slices/handlers/lobbyHandlers.ts
@@ -21,7 +21,7 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
           lobbyId: msg.lobbyId,
           state: 'WAITING_FOR_PLAYERS',
           players: [],
-          settings: { setCodes: [], setNames: [], availableSets: [], format: 'SEALED', boosterCount: 6, boosterDistribution: {}, maxPlayers: 8, pickTimeSeconds: 45, picksPerRound: 1, gamesPerMatch: 1, isPublic: false, deckSizeMin: 60, allowDuplicates: true, commanderPreset: 'BRAWL', chaosBoosters: false },
+          settings: { setCodes: [], setNames: [], availableSets: [], format: 'SEALED', boosterCount: 6, boosterDistribution: {}, maxPlayers: 8, pickTimeSeconds: 45, picksPerRound: 1, gamesPerMatch: 1, isPublic: false, deckSizeMin: 60, allowDuplicates: true, commanderPreset: 'BRAWL', chaosBoosters: false, bannedCardNames: [] },
           isHost: true,
           draftState: null,
           winstonDraftState: null,

--- a/web-client/src/store/slices/lobbySlice.ts
+++ b/web-client/src/store/slices/lobbySlice.ts
@@ -37,7 +37,7 @@ export interface LobbySliceActions {
   startLobby: () => void
   leaveLobby: () => void
   stopLobby: () => void
-  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; chaosBoosters?: boolean }) => void
+  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; chaosBoosters?: boolean; bannedCardNames?: string[] }) => void
   addAiToLobby: () => void
   removeAiFromLobby: (playerId: string) => void
   readyForNextRound: () => void

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -754,7 +754,7 @@ export type GameStore = {
   addAiToLobby: () => void
   removeAiFromLobby: (playerId: string) => void
   stopLobby: () => void
-  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; deckSizeMin?: number; allowDuplicates?: boolean; commanderPreset?: CommanderPreset; chaosBoosters?: boolean }) => void
+  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; deckSizeMin?: number; allowDuplicates?: boolean; commanderPreset?: CommanderPreset; chaosBoosters?: boolean; bannedCardNames?: string[] }) => void
   /** Disconnected tournament players: playerId -> info */
   disconnectedPlayers: Record<string, { playerName: string; secondsRemaining: number; disconnectedAt: number }>
   readyForNextRound: () => void

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1076,6 +1076,8 @@ export interface LobbySettings {
   readonly commanderPreset: CommanderPreset
   /** When true, each booster mixes cards from the union of all selected sets. */
   readonly chaosBoosters: boolean
+  /** Host ban list — oracle card names excluded from generated boosters (sorted). */
+  readonly bannedCardNames: readonly string[]
 }
 
 export type TournamentFormat =
@@ -1948,6 +1950,8 @@ export interface UpdateLobbySettingsMessage {
   readonly commanderPreset?: CommanderPreset
   /** Toggle Chaos boosters: each pack pulls from the union of selected sets. */
   readonly chaosBoosters?: boolean
+  /** Replace the host ban list (full list, not a delta). Omit to leave unchanged. */
+  readonly bannedCardNames?: readonly string[]
 }
 
 // Tournament Client Messages
@@ -2131,6 +2135,7 @@ export function createUpdateLobbySettingsMessage(
     isPublic?: boolean
     deckFormat?: DeckFormat | '' | null
     chaosBoosters?: boolean
+    bannedCardNames?: readonly string[]
   }
 ): UpdateLobbySettingsMessage {
   return { type: 'updateLobbySettings', ...settings }


### PR DESCRIPTION
## What

Adds a **host-settable ban list** to tournament mode: a list of card names that are excluded from every booster pack the lobby generates. Ban lists can be **saved per set** in the browser, the same way decks are saved.

> Requested: *"add a ban list in tournament mode that the host of the tournament can set… a list of card names that will not appear in the boosters"* and *"make it possible to save ban lists per set like you can save decks."*

## How it works

**Engine (`BoosterGenerator`)** — the single pool chokepoint, `boosterPool(...)`, now also drops any card whose name is on an optional `bannedCardNames` set (case-insensitive). The set is threaded through every `generateBooster` / `generateSealedPool` overload, so it applies uniformly to sealed pools, draft packs, and Winston/Grid decks, including the chaos and explicit-distribution paths. Empty list = no-op; basic lands are never affected.

**Server** — `TournamentLobby` gains a `bannedCardNames` field, passed into all booster-generation call sites and surfaced in `LobbySettings`. `UpdateLobbySettings` carries the full list (host-only, while waiting for players); `LobbyHandler` trims/dedupes it. Unknown names are kept as-is (they simply never match a card), so the editor round-trips exactly what the host set.

**Client**
- `banListLibrary` store — localStorage-backed, scoped per set, mirroring `deckLibrary`.
- `BanListEditor` in the host lobby settings panel: search the catalog (filtered to the selected sets) to add cards, remove them via chips, **Clear all**, and **save / load / delete named ban lists for the current set**. Hidden for the Premade-Decks format (those bring their own decks).

## Screenshot

![Ban list editor in the lobby settings](https://raw.githubusercontent.com/wingedsheep/argentum-engine/tournament-banlist-screenshots/banlist-editor.png)

*Captured from a standalone mount of the component with the app theme — the live lobby couldn't be driven end-to-end because port 8080 was occupied by an unrelated running server. The screenshots branch is throwaway; the PNG is not committed to this feature branch.*

## Tests

`BoosterGeneratorBanListTest` (rules-engine) pins exclusion across the single-set, seeded multi-set, explicit-distribution, and chaos paths, plus case-insensitive matching, the empty no-op, and a control proving the card otherwise appears. `npm run typecheck` and `npm run build` pass; all touched Kotlin modules compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)