### PR TITLE
Add IsNonartifact predicate + unlock 4 more LEA cards for mtgish auto-gen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ just coverage-fidelity --all            # cross-set table (renders-whole AUTO: P
 just coverage-fidelity --emit "Lava Axe"  # print the generated cardDef DSL (complete metadata, no TODO)
 
 # AUTO-GEN — turn the bridge on a set's UNIMPLEMENTED cards.
-just coverage-gaps --set TMP            # AUTOGEN / SCAFFOLD / BLOCKED counts + blocked-capability leaderboard
+just coverage-gaps --set TMP            # AUTOGEN / SCAFFOLD / BLOCKED counts + scaffold-gap & blocked-capability leaderboards
 just coverage-generate --set TMP        # draft .kt for the AUTOGEN cards -> mtgish-tooling/generated/<set>/
 just coverage-relocate TMP              # backfill canonicals of cards whose earliest printing is another set
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -288,7 +288,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 ### Destruction & exile
 
-- `Destroy(target)` — destroy target (respects indestructible).
+- `Destroy(target, noRegenerate?)` — destroy target (respects indestructible). `noRegenerate = true`
+  marks the target so it "can't be regenerated" (composes `CantBeRegeneratedEffect` before the move) —
+  the single-target analogue of `DestroyAll(noRegenerate = …)`, for Terror / Smother / Tunnel.
 - `RegenerateEffect(target)` (raw — no facade) — drop a regeneration shield on `target`, lasting until end
   of turn. The next time `target` would be destroyed this turn, instead tap it, remove all damage marked on
   it, and remove it from combat. Consumed by the first destruction it intercepts.
@@ -916,6 +918,11 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
 - `CardPredicate.IsColored` — one or more colors (the complement of `IsColorless`). Used for "a
   permanent that's one or more colors" (Ugin, Eye of the Storms). Pair with `IsPermanent` for the
   colored-permanent target filter; pair `IsColorless` with `IsNonland` for "colorless nonland card".
+- **Type-negation predicates** `CardPredicate.IsNonland` / `IsNoncreature` / `IsNonenchantment` /
+  `IsNonartifact` — "is not a \<type\>". Named filter constants `GameObjectFilter.Nonland` /
+  `Noncreature` / `Nonenchantment` / `Nonartifact` wrap each. `IsNonartifact` is the "nonartifact
+  creature" leg of the Terror template ("destroy target nonartifact, nonblack creature") — pair with
+  `IsCreature` + `.notColor(...)`. FQL keys: `nonland` / `noncreature` / `nonartifact`.
 
 **Chained predicates**
 
@@ -929,6 +936,8 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
 - `.withSubtype(s)` / `.withKeyword(k)` — type/ability predicate.
 - `.ofColor(c)` / `.ofColors(set)` — color predicate.
 - `.withColor(c)` / `.withAnyColor(c…)` / `.notColor(c)` — fixed-color predicates (`CardPredicate.HasColor`/`NotColor`).
+- `.nonartifact()` — appends `CardPredicate.IsNonartifact` ("nonartifact creature", the Terror template);
+  the type-negation analogue of `.notColor(c)` / `.notSubtype(s)`.
 - `.withChosenColor()` — `CardPredicate.HasChosenColor`: matches the color chosen during the current
   effect's resolution (read from `EffectContext.chosenColor`, set by `Effects.ChooseColorThen`). Use with
   `AggregateBattlefield(Player.Each, …)` for "for each permanent of that color" (Coalition Dragon cycle).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.sdk.scripting.effects.AddOneManaOfEachColorAmongEffect
 import com.wingedsheep.sdk.scripting.effects.ManaRestriction
 import com.wingedsheep.sdk.scripting.effects.ManaSpellRider
 import com.wingedsheep.sdk.scripting.effects.AddCardTypeEffect
+import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
 import com.wingedsheep.sdk.scripting.effects.OpenLifeBidEffect
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
 import com.wingedsheep.sdk.scripting.effects.AddDynamicCountersEffect
@@ -407,9 +408,14 @@ object Effects {
 
     /**
      * Destroy a target.
+     *
+     * @param noRegenerate If true, the target can't be regenerated — composes the
+     *   "can't be regenerated" marker before the destroy (Terror, Smother, Tunnel).
      */
-    fun Destroy(target: EffectTarget): Effect =
-        MoveToZoneEffect(target, Zone.GRAVEYARD, byDestruction = true)
+    fun Destroy(target: EffectTarget, noRegenerate: Boolean = false): Effect {
+        val destroy = MoveToZoneEffect(target, Zone.GRAVEYARD, byDestruction = true)
+        return if (noRegenerate) CantBeRegeneratedEffect(target) then destroy else destroy
+    }
 
     /**
      * Destroy all permanents matching a filter using the pipeline.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -102,6 +102,7 @@ data class GameObjectFilter(
         )
         val Noncreature = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsNoncreature))
         val Nonenchantment = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsNonenchantment))
+        val Nonartifact = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsNonartifact))
         val Token = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsToken))
         val Multicolored = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsMulticolored))
 
@@ -197,6 +198,11 @@ data class GameObjectFilter(
     /** Exclude a subtype */
     fun notSubtype(subtype: Subtype) = copy(
         cardPredicates = cardPredicates + CardPredicate.NotSubtype(subtype)
+    )
+
+    /** Restrict to nonartifact objects ("nonartifact creature", the Terror template). */
+    fun nonartifact() = copy(
+        cardPredicates = cardPredicates + CardPredicate.IsNonartifact
     )
 
     /** Add a keyword requirement */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -225,6 +225,9 @@ data class TargetFilter(
     /** Exclude color */
     fun notColor(color: Color) = copy(baseFilter = baseFilter.notColor(color))
 
+    /** Restrict to nonartifact objects ("nonartifact creature", the Terror template). */
+    fun nonartifact() = copy(baseFilter = baseFilter.nonartifact())
+
     /** Add subtype requirement */
     fun withSubtype(subtype: Subtype) = copy(baseFilter = baseFilter.withSubtype(subtype))
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -97,6 +97,12 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override val description: String = "nonenchantment"
     }
 
+    @SerialName("IsNonartifact")
+    @Serializable
+    data object IsNonartifact : CardPredicate {
+        override val description: String = "nonartifact"
+    }
+
     @SerialName("IsToken")
     @Serializable
     data object IsToken : CardPredicate {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/FilterQueryLanguage.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/FilterQueryLanguage.kt
@@ -59,6 +59,7 @@ object FilterQueryLanguage {
         "permanent" to "IsPermanent",
         "nonland" to "IsNonland",
         "noncreature" to "IsNoncreature",
+        "nonartifact" to "IsNonartifact",
         "token" to "IsToken",
         "nontoken" to "IsNontoken",
         "basicland" to "IsBasicLand",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/DwarvenDemolitionTeam.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/DwarvenDemolitionTeam.kt
@@ -9,7 +9,9 @@ import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
 
 
 /**
@@ -28,7 +30,7 @@ val DwarvenDemolitionTeam = card("Dwarven Demolition Team") {
     toughness = 1
     activatedAbility {
         cost = Costs.Tap
-        val t = target("target", TargetPermanent())
+        val t = target("target", TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withSubtype("Wall"))))
         effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/GoblinKing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/GoblinKing.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.lea.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Goblin King
+ * {1}{R}{R}
+ * Creature — Goblin
+ * 2/2
+ * Other Goblins get +1/+1 and have mountainwalk.
+ */
+val GoblinKing = card("Goblin King") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    oracleText = "Other Goblins get +1/+1 and have mountainwalk."
+    power = 2
+    toughness = 2
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN), excludeSelf = true)
+        )
+    }
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.MOUNTAINWALK,
+            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN), excludeSelf = true)
+        )
+    }
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "154"
+        artist = "Jesper Myrfors"
+        flavorText = "To become king of the Goblins, one must assassinate the previous king. Thus, only the most foolish seek positions of leadership."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/5873672d-37ea-4c0f-97f3-12b74fde112d.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/LordOfAtlantis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/LordOfAtlantis.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.lea.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Lord of Atlantis
+ * {U}{U}
+ * Creature — Merfolk
+ * 2/2
+ * Other Merfolk get +1/+1 and have islandwalk.
+ */
+val LordOfAtlantis = card("Lord of Atlantis") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk"
+    oracleText = "Other Merfolk get +1/+1 and have islandwalk. (They can't be blocked as long as defending player controls an Island.)"
+    power = 2
+    toughness = 2
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.MERFOLK), excludeSelf = true)
+        )
+    }
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.ISLANDWALK,
+            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.MERFOLK), excludeSelf = true)
+        )
+    }
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "62"
+        artist = "Melissa A. Benson"
+        flavorText = "A master of tactics, the Lord of Atlantis makes his people bold in battle merely by arriving to lead them."
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/210c4a90-fc7a-4c76-aeaa-20a005e45386.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Terror.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Terror.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.lea.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Terror
+ * {1}{B}
+ * Instant
+ * Destroy target nonartifact, nonblack creature. It can't be regenerated.
+ */
+val Terror = card("Terror") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target nonartifact, nonblack creature. It can't be regenerated."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.nonartifact().notColor(Color.BLACK)))
+        effect = Effects.Destroy(t, noRegenerate = true)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Ron Spencer"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21004958-2c7e-4a55-bc80-411c4d780106.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Tunnel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Tunnel.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.lea.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Tunnel
+ * {R}
+ * Instant
+ * Destroy target Wall. It can't be regenerated.
+ *
+ * Oracle errata: the original "Bury target Wall" is now "Destroy … It can't be regenerated."
+ */
+val Tunnel = card("Tunnel") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Destroy target Wall. It can't be regenerated."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withSubtype("Wall"))))
+        effect = Effects.Destroy(t, noRegenerate = true)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Dan Frazier"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b21ebc9f-a93e-4d18-b3e8-8459e3abbf31.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TerrorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TerrorReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Terror reprint in MRD.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (the spell script) lives in
+ * Limited Edition Alpha's `cards/` package. This file contributes only the MRD-specific
+ * presentation row.
+ */
+val TerrorReprint = Printing(
+    oracleId = "b81f041d-98db-4408-9472-c483e4a502bc",
+    name = "Terror",
+    setCode = "MRD",
+    collectorNumber = "79",
+    scryfallId = "f41651db-619a-4ab4-86cf-a0d32297dbdf",
+    artist = "Puddnhead",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f41651db-619a-4ab4-86cf-a0d32297dbdf.jpg?1562163040",
+    releaseDate = "2003-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -1218,6 +1218,49 @@
     ]
 }
 
+// Goblin King
+{
+    "name": "Goblin King",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "Other Goblins get +1/+1 and have mountainwalk.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Goblin",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "MOUNTAINWALK",
+                "filter": {
+                    "baseFilter": "creature Goblin",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "rarity": "RARE",
+        "artist": "Jesper Myrfors",
+        "flavorText": "To become king of the Goblins, one must assassinate the previous king. Thus, only the most foolish seek positions of leadership.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/5873672d-37ea-4c0f-97f3-12b74fde112d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Granite Gargoyle
 {
     "name": "Granite Gargoyle",
@@ -1971,6 +2014,49 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Lord of Atlantis
+{
+    "name": "Lord of Atlantis",
+    "manaCost": "{U}{U}",
+    "typeLine": "Creature — Merfolk",
+    "oracleText": "Other Merfolk get +1/+1 and have islandwalk. (They can't be blocked as long as defending player controls an Island.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Merfolk",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "ISLANDWALK",
+                "filter": {
+                    "baseFilter": "creature Merfolk",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "RARE",
+        "artist": "Melissa A. Benson",
+        "flavorText": "A master of tactics, the Lord of Atlantis makes his people bold in battle merely by arriving to lead them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/210c4a90-fc7a-4c76-aeaa-20a005e45386.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -3243,6 +3329,63 @@
     ]
 }
 
+// Terror
+{
+    "name": "Terror",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CantBeRegenerated",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsNonartifact",
+                            {
+                                "type": "NotColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Ron Spencer",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21004958-2c7e-4a55-bc80-411c4d780106.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Timber Wolves
 {
     "name": "Timber Wolves",
@@ -3382,6 +3525,55 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Tunnel
+{
+    "name": "Tunnel",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target Wall. It can't be regenerated.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CantBeRegenerated",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature Wall"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Frazier",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b21ebc9f-a93e-4d18-b3e8-8459e3abbf31.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -810,7 +810,7 @@
                     {
                         "type": "TargetObject",
                         "filter": {
-                            "baseFilter": "permanent"
+                            "baseFilter": "creature Wall"
                         },
                         "id": "target"
                     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Autogen.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Autogen.kt
@@ -119,24 +119,33 @@ object Autogen {
         return names to Mtgish.loadMtgishIndex(names.toSet())
     }
 
-    private data class Classified(val missing: List<String>, val cats: Map<String, MutableList<String>>, val blockTax: Counter<String>)
+    private data class Classified(
+        val missing: List<String>,
+        val cats: Map<String, MutableList<String>>,
+        val blockTax: Counter<String>,
+        val scaffoldTax: Counter<String>,
+    )
 
     private fun classifyMissing(setCode: String, effects: Set<String>, keywords: Set<String>): Classified {
         val (missing, idx) = missingWithMtgish(setCode)
         val cats = mapOf("AUTOGEN" to mutableListOf<String>(), "SCAFFOLD" to mutableListOf(), "BLOCKED" to mutableListOf(), "UNMATCHED" to mutableListOf())
         val blockTax = Counter<String>()
+        val scaffoldTax = Counter<String>()
         for (name in missing) {
             val card = idx[name]
             if (card == null) { cats["UNMATCHED"]!!.add(name); continue }
             val cat = classify(card, setCode, effects, keywords)
             cats[cat]!!.add(name)
             if (cat == "BLOCKED") for (b in Probe.analyze(card, effects, keywords).blockers) blockTax.add(b.value)
+            // SCAFFOLD cards are coverable but the emitter declined: the reasons are the emitter-handler
+            // gaps that, once closed, would promote the card to AUTOGEN.
+            if (cat == "SCAFFOLD") for (r in render(card, setCode, effects, keywords, genPackage(setCode)).reasons) scaffoldTax.add(r)
         }
-        return Classified(missing, cats, blockTax)
+        return Classified(missing, cats, blockTax, scaffoldTax)
     }
 
     private fun modeGaps(setCode: String, effects: Set<String>, keywords: Set<String>, listCat: String?): Int {
-        val (missing, cats, blockTax) = classifyMissing(setCode, effects, keywords)
+        val (missing, cats, blockTax, scaffoldTax) = classifyMissing(setCode, effects, keywords)
         val n = missing.size
         println("== ${setCode.uppercase()} auto-generation gap — $n unimplemented cards ==\n")
         println("  AUTOGEN   ${cats["AUTOGEN"]!!.size.toString().padStart(4)}   emitter renders a whole compiling card now")
@@ -144,6 +153,10 @@ object Autogen {
         println("  BLOCKED   ${cats["BLOCKED"]!!.size.toString().padStart(4)}   capability gap (needs mapping or engine work)")
         if (cats["UNMATCHED"]!!.isNotEmpty()) println("  (unmatched in mtgish: ${cats["UNMATCHED"]!!.size} — name join / Un-set / too new)")
         println("\n  -> `just coverage-generate --set ${setCode.uppercase()}` drafts the ${cats["AUTOGEN"]!!.size} AUTOGEN cards into a staging dir.")
+        if (!scaffoldTax.isEmpty) {
+            println("\nSCAFFOLD leaderboard — emitter gap ranked by # coverable cards it would promote to AUTOGEN:")
+            for ((reason, c) in scaffoldTax.mostCommon(15)) println("  x${c.toString().padEnd(4)} $reason")
+        }
         if (!blockTax.isEmpty) {
             println("\nBLOCKED leaderboard — capability ranked by # cards it would unlock:")
             for ((cap, c) in blockTax.mostCommon(15)) println("  x${c.toString().padEnd(4)} $cap")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -62,7 +62,16 @@ internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<String>? {
                 "ModifyStats(powerBonus = ${pt[0].asInt()}, toughnessBonus = ${pt[1].asInt()}, filter = $group)"
             }
             "AddAbility" -> {
-                val kw = keywordOf(le) ?: return scaffoldLord()
+                // "Other Merfolk have islandwalk" (Lord of Atlantis / Goblin King): the granted ability is a
+                // Landwalk rule carrying a land subtype, not a plain keyword — recover the *WALK keyword.
+                val granted = (le["args"] as? JsonArray)?.getOrNull(0) as? JsonObject
+                val kw = if (granted?.strField("_Rule") == "Landwalk") {
+                    val lw = mutableSetOf<String>()
+                    findLandwalkKeywords(granted, keywords, lw)
+                    lw.singleOrNull() ?: return scaffoldLord()
+                } else {
+                    keywordOf(le) ?: return scaffoldLord()
+                }
                 "GrantKeyword(Keyword.$kw, $group)"
             }
             else -> return scaffoldLord()
@@ -168,7 +177,18 @@ private fun EmitCtx.staticAbilityDsl(ruleName: String, ruleNode: JsonObject): St
             val bf = if (kw != null) "GameObjectFilter.Creature.withKeyword(Keyword.$kw)" else "GameObjectFilter.Creature"
             return "CanOnlyBlockCreaturesWith(blockerFilter = $bf)"
         }
-        "CantBeBlockedExceptByDefenders", "CantBeBlockedByDefenders" -> {
+        "CantBeBlockedByDefenders" -> {
+            // mtgish "Defenders" means blockers generally; the rule's args carry the blocker restriction,
+            // so this is "can't be blocked BY [filtered creatures]" (Fleet-Footed Monk: power ≥ 2; Sacred
+            // Knight: black and/or red). Render the blocker filter generically; scaffold if it can't be
+            // expressed faithfully. (Distinct from CantBeBlockedExceptByDefenders, which RESTRICTS blockers.)
+            // gameObjectFilterDsl silently ignores predicates it can't render, so scaffold on any shape it
+            // doesn't cover (e.g. ToughnessIs) rather than emit a blocker filter missing a restriction.
+            if (Regex("\"(ToughnessIs|HasKeyword|ManaValueIs|HasSubtypeFrom)\"").containsMatchIn(compact(ruleNode))) return null
+            val filter = gameObjectFilterDsl(ruleNode["args"]) ?: return null
+            return "CantBeBlockedBy(blockerFilter = $filter)"
+        }
+        "CantBeBlockedExceptByDefenders" -> {
             if (oracleText?.contains("defender", ignoreCase = true) == true) {
                 return "CantBeBlockedExceptBy(blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER))"
             }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -14,8 +14,12 @@ import kotlinx.serialization.json.JsonObject
  * the Argentum target/filter DSL. A filter we can't faithfully render returns null → the card drops
  * to SCAFFOLD rather than emitting a confidently-wrong target.
  */
-internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String {
+internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String? {
     val blob = compact(filterNode)
+    // "nonartifact creature" (the Terror template) renders via .nonartifact(); any OTHER non-cardtype
+    // restriction has no faithful filter rendering yet, so drop to SCAFFOLD rather than omit it.
+    val nonCardtypes = Regex(""""IsNonCardtype",\s*"args":\s*"(\w+)"""").findAll(blob).map { it.groupValues[1] }.toList()
+    if (nonCardtypes.any { it != "Artifact" }) return null
     // Whole-creature shapes whose helpers live on GameObjectFilter (not TargetFilter), or are a named
     // TargetFilter constant. ONS targets use these in isolation, so render them as the whole filter.
     if ("IsAttacking" in blob && "IsBlocking" in blob) {
@@ -31,6 +35,7 @@ internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String {
         return "TargetFilter(${subs.joinToString(" or ") { "GameObjectFilter.Creature.withSubtype(\"$it\")" }})"
     }
     var suffix = ""
+    if ("Artifact" in nonCardtypes) suffix += ".nonartifact()"
     Regex(""""IsNonColor".*?"_Color":\s*"(\w+)"""").find(blob)?.let {
         suffix += ".notColor(Color.${it.groupValues[1].uppercase()})"
     }
@@ -69,8 +74,13 @@ internal fun EmitCtx.targetDsl(tnode: JsonObject, actionContext: List<JsonObject
     }
     if (ttype in setOf("TargetPermanent", "NumberTargetPermanents", "UptoNumberTargetPermanents", "OneOrTwoTargetPermanents")) {
         val types = targetTypes(args)
-        if (types == setOf("Creature")) {
-            val parts = mutableListOf("filter = ${creatureFilterDsl(args)}")
+        val blob = compact(args)
+        // A creature-subtype restriction ("target Wall") implies a creature target even with no explicit
+        // IsCardtype Creature; route it through the creature filter so the subtype isn't dropped (Tunnel).
+        val creatureTarget = types == setOf("Creature") || (types.isEmpty() && "IsCreatureType" in blob)
+        if (creatureTarget) {
+            val filter = creatureFilterDsl(args) ?: return null
+            val parts = mutableListOf("filter = $filter")
             if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, "count = $countInt")
             if (ttype == "OneOrTwoTargetPermanents") { parts.add(0, "minCount = 1"); parts.add(0, "count = 2") }
             if (ttype == "UptoNumberTargetPermanents") parts.add(0, "optional = true")
@@ -83,7 +93,7 @@ internal fun EmitCtx.targetDsl(tnode: JsonObject, actionContext: List<JsonObject
             if (ttype == "UptoNumberTargetPermanents") parts.add(0, "optional = true")
             return "TargetPermanent(${parts.joinToString(", ")})"
         }
-        if (types.isEmpty() && "IsCardtype" !in compact(args)) {
+        if (types.isEmpty() && "IsCardtype" !in blob && "IsCreatureType" !in blob) {
             return "TargetPermanent()"
         }
         val multiType = mapOf(
@@ -167,7 +177,10 @@ internal fun EmitCtx.gameObjectFilterDsl(filterNode: JsonElement?): String? {
     var filtered = when {
         subs.isNotEmpty() && ("Land" in types || "IsLandType" in blob || "\"Land\"" in blob) ->
             "GameObjectFilter.Land.withSubtype(${subtypeArg(subs[0])})"
-        creatureSubs.isNotEmpty() && ("Creature" in types || "\"Creature\"" in blob) ->
+        // A creature subtype always implies creature, so render Creature.withSubtype even when there's no
+        // explicit IsCardtype Creature (the "other Merfolk"/"other Goblins" lord groups) — otherwise the
+        // ThisPermanent marker below would wrongly widen it to GameObjectFilter.Permanent.
+        creatureSubs.isNotEmpty() ->
             "GameObjectFilter.Creature.withSubtype(${subtypeArg(creatureSubs[0])})"
         subs.isNotEmpty() && ("Creature" in types || "\"Creature\"" in blob) ->
             "GameObjectFilter.Creature.withSubtype(${subtypeArg(subs[0])})"
@@ -195,6 +208,9 @@ internal fun EmitCtx.gameObjectFilterDsl(filterNode: JsonElement?): String? {
     }
     Regex(""""PowerIs".*?"GreaterThanOrEqualTo".*?"Integer","args":(\d+)""").find(blob)?.let {
         filtered += ".powerAtLeast(${it.groupValues[1]})"
+    }
+    Regex(""""PowerIs".*?"LessThanOrEqualTo".*?"Integer","args":(\d+)""").find(blob)?.let {
+        filtered += ".powerAtMost(${it.groupValues[1]})"
     }
     if ("IsTapped" in blob) filtered += ".tapped()"
     if ("IsUntapped" in blob) filtered += ".untapped()"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -21,6 +21,10 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         val tgt = refTarget(args, tvar) ?: return@on null
         "Effects.Move($tgt, Zone.GRAVEYARD, byDestruction = true)"
     }
+    on("DestroyPermanentNoRegen") { _, args, tvar ->  // "Destroy …. It can't be regenerated." (Terror, Tunnel)
+        val tgt = refTarget(args, tvar) ?: return@on null
+        "Effects.Destroy($tgt, noRegenerate = true)"
+    }
     on("DestroyEachPermanent", "DestroyEachPermanentNoRegen") { node, args, _ ->
         if (jsonContains(args, "_Permanents", "Ref_TargetPermanents")) {
             val noregen = if (node.strField("_Action") == "DestroyEachPermanentNoRegen") ", noRegenerate = true" else ""

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1395,6 +1395,8 @@ class TriggerDetector(
                     !cardComponent.typeLine.isLand
                 is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNoncreature ->
                     !cardComponent.typeLine.isCreature
+                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonartifact ->
+                    !cardComponent.typeLine.isArtifact
                 is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
                     cardComponent.typeLine.hasSubtype(predicate.subtype)
                 else -> true
@@ -1702,6 +1704,7 @@ class TriggerDetector(
                             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature -> info.cardComponent.typeLine.isCreature
                             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNoncreature -> !info.cardComponent.typeLine.isCreature
                             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonland -> !info.cardComponent.typeLine.isLand
+                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonartifact -> !info.cardComponent.typeLine.isArtifact
                             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPermanent -> info.cardComponent.typeLine.isPermanent
                             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype -> info.cardComponent.typeLine.hasSubtype(predicate.subtype)
                             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact -> info.cardComponent.typeLine.isArtifact

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -632,6 +632,7 @@ class TriggerMatcher(
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonland -> !cardComponent.typeLine.isLand
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNoncreature -> !cardComponent.typeLine.isCreature
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonenchantment -> !cardComponent.typeLine.isEnchantment
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonartifact -> !cardComponent.typeLine.isArtifact
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLegendary -> cardComponent.typeLine.isLegendary
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonlegendary -> !cardComponent.typeLine.isLegendary
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -181,6 +181,7 @@ class PredicateEvaluator {
             CardPredicate.IsNonland -> "LAND" !in types
             CardPredicate.IsNoncreature -> "CREATURE" !in types
             CardPredicate.IsNonenchantment -> "ENCHANTMENT" !in types
+            CardPredicate.IsNonartifact -> "ARTIFACT" !in types
             CardPredicate.IsToken -> container.has<TokenComponent>()
             CardPredicate.IsNontoken -> !container.has<TokenComponent>()
             CardPredicate.IsLegendary -> "LEGENDARY" in types
@@ -856,6 +857,7 @@ class PredicateEvaluator {
             CardPredicate.IsNonland -> !typeLine.isLand
             CardPredicate.IsNoncreature -> !typeLine.isCreature
             CardPredicate.IsNonenchantment -> !typeLine.isEnchantment
+            CardPredicate.IsNonartifact -> !typeLine.isArtifact
             CardPredicate.IsToken -> false // cast spells are never tokens
             CardPredicate.IsNontoken -> true
             CardPredicate.IsLegendary -> typeLine.isLegendary

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -514,6 +514,7 @@ object ZoneMovementUtils {
                 CardPredicate.IsNonland -> !cardComponent.typeLine.isLand
                 CardPredicate.IsNoncreature -> !cardComponent.typeLine.isCreature
                 CardPredicate.IsNonenchantment -> !cardComponent.typeLine.isEnchantment
+                CardPredicate.IsNonartifact -> !cardComponent.typeLine.isArtifact
                 CardPredicate.IsPermanent -> cardComponent.typeLine.isPermanent
                 CardPredicate.IsLegendary -> cardComponent.typeLine.isLegendary
                 CardPredicate.IsNonlegendary -> !cardComponent.typeLine.isLegendary

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -629,6 +629,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         is CardPredicate.IsNonland -> !exiledCard.typeLine.isLand
                         is CardPredicate.IsCreature -> exiledCard.typeLine.isCreature
                         is CardPredicate.IsArtifact -> exiledCard.typeLine.isArtifact
+                        is CardPredicate.IsNonartifact -> !exiledCard.typeLine.isArtifact
                         else -> true
                     }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -447,6 +447,7 @@ internal class AffectsFilterResolver {
         CardPredicate.IsNonland -> "LAND" !in types
         CardPredicate.IsNoncreature -> "CREATURE" !in types
         CardPredicate.IsNonenchantment -> "ENCHANTMENT" !in types
+        CardPredicate.IsNonartifact -> "ARTIFACT" !in types
         CardPredicate.IsBasicLand -> "LAND" in types && card.typeLine.supertypes.any { it.name == "BASIC" }
         CardPredicate.IsToken -> container.has<com.wingedsheep.engine.state.components.identity.TokenComponent>()
         CardPredicate.IsNontoken -> !container.has<com.wingedsheep.engine.state.components.identity.TokenComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -861,6 +861,7 @@ class CostCalculator(
             CardPredicate.IsNonland -> !typeLine.isLand
             CardPredicate.IsNoncreature -> !typeLine.isCreature
             CardPredicate.IsNonenchantment -> !typeLine.isEnchantment
+            CardPredicate.IsNonartifact -> !typeLine.isArtifact
             CardPredicate.IsToken -> false
             CardPredicate.IsNontoken -> true
             CardPredicate.IsLegendary -> typeLine.isLegendary

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/GrantedKeywordResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/GrantedKeywordResolver.kt
@@ -89,6 +89,7 @@ class GrantedKeywordResolver(
                 CardPredicate.IsNonlegendary -> !cardDef.typeLine.isLegendary
                 CardPredicate.IsPermanent -> cardDef.typeLine.isPermanent
                 CardPredicate.IsNonenchantment -> !cardDef.typeLine.isEnchantment
+                CardPredicate.IsNonartifact -> !cardDef.typeLine.isArtifact
                 CardPredicate.IsToken, CardPredicate.IsNontoken -> true
                 is CardPredicate.HasSubtype -> cardDef.typeLine.subtypes.any { it == predicate.subtype }
                 is CardPredicate.HasAnyOfSubtypes -> cardDef.typeLine.subtypes.any { predicate.subtypes.contains(it) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -329,6 +329,7 @@ class ClientStateTransformer(
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonland -> !cardComp.typeLine.isLand
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature -> cardComp.typeLine.isCreature
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact -> cardComp.typeLine.isArtifact
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonartifact -> !cardComp.typeLine.isArtifact
                     else -> true
                 }
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluatorRecordTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluatorRecordTest.kt
@@ -134,6 +134,15 @@ class PredicateEvaluatorRecordTest : FunSpec({
                 record(TypeLine.enchantment()),
                 filter(CardPredicate.IsNonenchantment)
             ) shouldBe false
+
+            evaluator.matchesFilter(
+                record(TypeLine.creature()),
+                filter(CardPredicate.IsNonartifact)
+            ) shouldBe true
+            evaluator.matchesFilter(
+                record(TypeLine.artifact()),
+                filter(CardPredicate.IsNonartifact)
+            ) shouldBe false
         }
 
         test("token predicates: spells are never tokens") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NonartifactTargetFilterTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NonartifactTargetFilterTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Covers the `CardPredicate.IsNonartifact` predicate end-to-end on the battlefield, via a
+ * Terror-style spell: "Destroy target nonartifact, nonblack creature. It can't be regenerated."
+ * (`TargetFilter.Creature.nonartifact().notColor(Color.BLACK)` + `Effects.Destroy(noRegenerate = true)`).
+ *
+ * The predicate is the new vocabulary; the test pins that target enumeration / validation treats an
+ * artifact creature (and a black creature) as illegal targets while a plain creature is legal — i.e.
+ * `IsNonartifact` is evaluated against projected battlefield state, not silently passed through.
+ */
+class NonartifactTargetFilterTest : FunSpec({
+
+    // Inline "Terror"-shaped instant exercising the nonartifact filter (mirrors the mtgish AUTOGEN draft).
+    val terrorLike = card("Nonartifact Slayer") {
+        manaCost = "{1}{B}"
+        typeLine = "Instant"
+        spell {
+            val t = target(
+                "target",
+                TargetCreature(filter = TargetFilter.Creature.nonartifact().notColor(Color.BLACK))
+            )
+            effect = Effects.Destroy(t, noRegenerate = true)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(terrorLike)
+        return driver
+    }
+
+    fun setup(): GameTestDriver {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("can destroy a nonartifact, nonblack creature — and it can't be regenerated") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+
+        val centaur = driver.putCreatureOnBattlefield(player, "Centaur Courser") // green vanilla creature
+        val spell = driver.putCardInHand(player, "Nonartifact Slayer")
+        driver.giveMana(player, Color.BLACK, 2) // pays {1}{B}
+
+        val result = driver.castSpellWithTargets(player, spell, listOf(ChosenTarget.Permanent(centaur)))
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(player, "Centaur Courser") shouldBe null
+        driver.getGraveyardCardNames(player).contains("Centaur Courser") shouldBe true
+    }
+
+    test("cannot target an artifact creature — IsNonartifact excludes it") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+
+        val golem = driver.putCreatureOnBattlefield(player, "Artifact Creature") // artifact creature
+        val spell = driver.putCardInHand(player, "Nonartifact Slayer")
+        driver.giveMana(player, Color.BLACK, 2) // pays {1}{B}
+
+        val result = driver.castSpellWithTargets(player, spell, listOf(ChosenTarget.Permanent(golem)))
+        result.isSuccess shouldBe false
+        // The artifact creature survives the illegal cast attempt.
+        driver.findPermanent(player, "Artifact Creature") shouldBe golem
+    }
+
+    test("cannot target a black creature — the notColor leg still holds alongside nonartifact") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+
+        val zombie = driver.putCreatureOnBattlefield(player, "Black Creature")
+        val spell = driver.putCardInHand(player, "Nonartifact Slayer")
+        driver.giveMana(player, Color.BLACK, 2) // pays {1}{B}
+
+        val result = driver.castSpellWithTargets(player, spell, listOf(ChosenTarget.Permanent(zombie)))
+        result.isSuccess shouldBe false
+        driver.findPermanent(player, "Black Creature") shouldBe zombie
+    }
+})


### PR DESCRIPTION
## Summary

Makes **4 more Limited Edition Alpha cards auto-generatable** via `:mtgish-tooling` (AUTOGEN 5 → 9: **Terror, Tunnel, Lord of Atlantis, Goblin King**) and adds the one engine primitive that required. Also takes **Portal fidelity to 158/158** by correctly rendering the `CantBeBlockedBy` family.

## Engine / SDK feature — `CardPredicate.IsNonartifact`

Sibling of `IsNonland` / `IsNoncreature` / `IsNonenchantment`, wired through **all 11 evaluation sites** (`PredicateEvaluator` ×2, `AffectsFilterResolver`, `CostCalculator`, `GrantedKeywordResolver`, `TriggerMatcher`, `TriggerDetector` ×2, `CastFromZoneEnumerator`, `ZoneMovementUtils`, `ClientStateTransformer`), plus `GameObjectFilter.Nonartifact`, a `.nonartifact()` fluent builder, and the FQL key. Lets the "nonartifact creature" target template (Terror) render faithfully — ~54 corpus cards.

- `Effects.Destroy(target, noRegenerate = true)` — single-target analogue of `DestroyAll(noRegenerate)`; composes `CantBeRegeneratedEffect` (Terror, Tunnel, Smother shape).
- Tests: `NonartifactTargetFilterTest` (battlefield targeting — artifact/black creatures rejected, vanilla destroyed) + cast-record unit assertions. Docs updated in `card-sdk-language-reference.md`.

## mtgish-tooling emitter

- `DestroyPermanentNoRegen` handler (Terror, Tunnel).
- Lord landwalk grants → `GrantKeyword(ISLANDWALK/MOUNTAINWALK, group)` (Lord of Atlantis, Goblin King).
- **Split `CantBeBlockedByDefenders`**: the mtgish tag's args are the *blocker* filter, so it maps to `CantBeBlockedBy(blockerFilter=…)`, distinct from `CantBeBlockedExceptByDefenders`. Fixes **135 corpus cards** and takes Portal to **158/158**. Added `power ≤ N` (`powerAtMost`) to `gameObjectFilterDsl`.
- **Faithful target/group recovery**: creature-subtype-only targets ("target Wall") and creature-subtype groups ("other Merfolk") no longer widen to `permanent`; unrenderable restrictions scaffold instead of dropping silently.
- New **SCAFFOLD-gap leaderboard** in `coverage-gaps` (ranks emitter gaps by cards they'd promote to AUTOGEN).

## Bug fix surfaced

`Dwarven Demolition Team` (LEA) used a bare `TargetPermanent()` for "Destroy target Wall" — it could destroy *any* permanent. Corrected to a Wall-creature target + re-blessed its golden (the only golden line changed by this PR, confirming the new predicate altered no other card).

## Verification

- **POR `coverage-verify`: GATE PASS 158/158** (was 156/158).
- `mtg-sdk`, `CardDefinitionSnapshotTest`, `FacadeBoundaryTest`, and the new engine tests all green.
- Swept 8 sets (POR, DOM, INV, TMP, BLB, KTK, ECL, TMT): **zero `blockerFilter`/`CantBeBlocked`/power-filter regressions**. Pre-existing `GATE FAIL`s in unfinished modern sets (X-values, planeswalkers) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)