### PR TITLE
Add DynamicAmount.CastX — cast-time X that survives onto the permanent

### DIFF
--- a/backlog/cast-time-choices-and-inherited-x.md
+++ b/backlog/cast-time-choices-and-inherited-x.md
@@ -1,6 +1,8 @@
 # Scoping: cast-time choices & inherited X (the "declare directive" problem)
 
-**Status:** Not started — design proposed, ready to pick up. **Owner:** TBD. **Related:**
+**Status:** Phase 1 done — `DynamicAmount.CastX` + durable `CastChoicesComponent`; Hydroid Krasis
+implemented and tested (RNA set scaffolded). Phases 2–4 (slot generalization, `declare { }` DSL,
+emitter payoff) not started. **Owner:** TBD. **Related:**
 [`sdk-language-design.md`](sdk-language-design.md), [`forge-parity-harness.md`](forge-parity-harness.md),
 and the `:mtgish-tooling` *"Creator's note: extra costs & chosen / inherited values"* in
 [`../mtgish-tooling/README.md`](../mtgish-tooling/README.md) (this doc is the design that note asks for).
@@ -230,15 +232,19 @@ cards read like the hand-authored targets in §5.3.
 
 ## 9. Definition of done
 
-- [ ] `DynamicAmount.CastX` resolves from a durable component, working from the spell's own resolution,
+- [x] `DynamicAmount.CastX` resolves from a durable component, working from the spell's own resolution,
       a "when you cast this" trigger, an ETB trigger, and a later activated ability.
-- [ ] **Hydroid Krasis** implemented with a passing scenario test: cast for X=6 → gain 3 life, draw 3,
+      (`CastXDurableValueTest` covers all four; the evaluator reads `CastChoicesComponent` on the
+      permanent, `SpellOnStackComponent.xValue` while on the stack, then the context as LKI.)
+- [x] **Hydroid Krasis** implemented with a passing scenario test: cast for X=6 → gain 3 life, draw 3,
       enters with six +1/+1 counters (6/6); cast for X=0 → no draw, 0/0 dies as SBA.
-- [ ] X survives a dies-trigger (LKI) and is *not* inherited by a copy (CR 706).
+      (`HydroidKrasisScenarioTest`, plus an X=5 round-down case.)
+- [x] X survives a dies-trigger (LKI, via the leave `ZoneChangeEvent.xValue`) and is *not* inherited by
+      a copy (CR 707.2; `CastXNotInheritedByCopyTest` clones an X-cast creature → no counters/component).
 - [ ] (Phase 2+) `CastChoicesComponent` unifies X + chosen color/type/mode + kicked + blight; Riptide
       Replicator migrated off `CreateChosenTokenEffect`.
-- [ ] `docs/card-sdk-language-reference.md` updated for `declare { }`, `DynamicAmount.CastX`, and the
-      slot readers (required on any SDK change).
+- [x] `docs/card-sdk-language-reference.md` updated for `DynamicAmount.CastX` (the `declare { }` DSL and
+      slot readers remain Phase 2/3).
 
 > Build with the **`add-feature`** skill — this is a cross-layer SDK primitive (SDK → engine →
 > projection/triggers → continuations → server DTO if X is shown), not a single card.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2278,7 +2278,17 @@ Numbers computed at resolution time.
 ### Math
 
 - `Fixed(n)` — literal constant.
-- `XValue` — the X chosen for the spell/ability.
+- `XValue` — the X chosen for the spell/ability, read from the transient resolution context. Populated
+  only while the spell/ability itself is resolving — an ETB trigger or a later activated ability can't
+  see it. Use `CastX` for the durable, object-scoped reading.
+- `CastX` — the `{X}` this object was cast with, read off the *current object* regardless of zone, so it
+  survives onto the permanent. The same X feeds a "when you cast this spell" trigger, an enters-the-
+  battlefield trigger, the enters-with-counters replacement, and a later activated ability — the analogue
+  of mtgish's `ValueX` / `Trigger_ValueXOfThatSpell`. Backed by a durable `CastChoicesComponent` that
+  rides the spell's stable entity onto the battlefield (and `SpellOnStackComponent.xValue` while still on
+  the stack); preserved as last-known information for dies/leaves triggers. A copy of a *permanent*
+  (Clone) does not inherit it (CR 707.2); a copy of a *spell* on the stack does. Hydroid Krasis reads
+  `CastX` for both its cast trigger ("draw half X") and its enters-with-X-counters replacement.
 - `TotalManaSpent` — total mana paid from the pool to cast the current spell (sum of every per-color
   bucket; for X spells the X portion is included). E.g. Memory Deluge "where X is the mana spent."
 - `ManaSpentOnX(color)` — the amount of `{color}` mana spent on the `{X}` portion specifically, broken

--- a/manual-scenarios/cards/h/hydroid-krasis.json
+++ b/manual-scenarios/cards/h/hydroid-krasis.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Hydroid Krasis"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Forest", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -261,6 +261,32 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
+     * The value of `{X}` this object was cast with, read off the *current object* regardless of
+     * what zone it is in.
+     *
+     * Contrast [XValue], which resolves from the transient resolution context
+     * (`EffectContext.xValue`) and is therefore only populated while the spell itself is
+     * resolving. [CastX] is the durable, object-scoped reading: it survives onto the permanent
+     * after the spell resolves, so a "when you cast this spell" trigger, an enters-the-battlefield
+     * trigger, the enters-with-counters replacement, and a later activated ability all read the
+     * *same* X — the immutable-ECS analogue of mtgish's `ValueX` / `Trigger_ValueXOfThatSpell`.
+     *
+     * It is backed by a durable component that rides the spell's stable entity onto the
+     * battlefield; a card that changes zones becomes a new object (CR 400.7) and stops carrying
+     * it, but the value is preserved as last-known information for dies/leaves triggers. A copy of
+     * a *permanent* (Clone) does not inherit it (X is not a copiable value, CR 707.2), while a copy
+     * of a *spell* on the stack does (it copies the value of X).
+     *
+     * Example — Hydroid Krasis "enters with X +1/+1 counters" and "when you cast this spell, draw
+     * half X cards" both read `DynamicAmount.CastX`.
+     */
+    @SerialName("CastX")
+    @Serializable
+    data object CastX : DynamicAmount {
+        override val description: String = "X"
+    }
+
+    /**
      * The total amount of mana paid from the pool to cast the current spell.
      *
      * Sums every per-color and colorless bucket recorded on the spell's stack object.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -56,6 +56,7 @@ import com.wingedsheep.mtg.sets.definitions.p02.PortalSecondAgeSet
 import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.definitions.pz2.TreasureChestSet
 import com.wingedsheep.mtg.sets.definitions.rix.RivalsOfIxalanSet
+import com.wingedsheep.mtg.sets.definitions.rna.RavnicaAllegianceSet
 import com.wingedsheep.mtg.sets.definitions.xln.IxalanSet
 import com.wingedsheep.mtg.sets.definitions.roe.RiseOfTheEldraziSet
 import com.wingedsheep.mtg.sets.definitions.scg.ScourgeSet
@@ -150,6 +151,7 @@ object MtgSetCatalog {
         AvatarTheLastAirbenderSet,
         TeenageMutantNinjaTurtlesSet,
         WarOfTheSparkSet,
+        RavnicaAllegianceSet,
         OdysseySet,
         JudgmentSet,
         GuildpactSet,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/RavnicaAllegianceSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/RavnicaAllegianceSet.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.rna
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Ravnica Allegiance (2019)
+ *
+ * The second half of the Guilds of Ravnica block — Azorius, Gruul, Orzhov, Rakdos, and Simic.
+ *
+ * Set Code: RNA
+ * Release Date: January 25, 2019
+ */
+object RavnicaAllegianceSet : MtgSet {
+
+    override val code = "RNA"
+    override val displayName = "Ravnica Allegiance"
+    override val releaseDate = "2019-01-25"
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.rna.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/HydroidKrasis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/HydroidKrasis.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Hydroid Krasis — Ravnica Allegiance #183
+ * {X}{G}{U} · Creature — Jellyfish Hydra Beast · 0/0
+ *
+ * When you cast this spell, you gain half X life and draw half X cards. Round down each time.
+ * Flying, trample
+ * This creature enters with X +1/+1 counters on it.
+ *
+ * The cleanest "inherited X" card: the same `{X}` chosen as you cast feeds both the
+ * "when you cast this spell" trigger (gain/draw half X) and the enters-with-counters
+ * replacement (X +1/+1 counters). Both read [DynamicAmount.CastX], which resolves the
+ * cast-time X off the spell's stable entity — from `SpellOnStackComponent` while the cast
+ * trigger resolves on the stack, then from the durable `CastChoicesComponent` that rides the
+ * same entity onto the battlefield. No counter laundering: the half-X draw cannot be fed by
+ * +1/+1 counters, so it relies on `CastX` directly.
+ *
+ * "Half X, round down each time" is `Divide(CastX, Fixed(2), roundUp = false)`, evaluated
+ * independently for the life gain and the draw (so X = 5 → gain 2, draw 2).
+ */
+val HydroidKrasis = card("Hydroid Krasis") {
+    manaCost = "{X}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Jellyfish Hydra Beast"
+    power = 0
+    toughness = 0
+    oracleText = "When you cast this spell, you gain half X life and draw half X cards. " +
+        "Round down each time.\nFlying, trample\nThis creature enters with X +1/+1 counters on it."
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    // "When you cast this spell, you gain half X life and draw half X cards. Round down each time."
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.Composite(
+            Effects.GainLife(DynamicAmount.Divide(DynamicAmount.CastX, DynamicAmount.Fixed(2), roundUp = false)),
+            Effects.DrawCards(DynamicAmount.Divide(DynamicAmount.CastX, DynamicAmount.Fixed(2), roundUp = false)),
+        )
+        description = "When you cast this spell, you gain half X life and draw half X cards. Round down each time."
+    }
+
+    // "This creature enters with X +1/+1 counters on it." — reads the SAME cast-time X.
+    replacementEffect(EntersWithDynamicCounters(count = DynamicAmount.CastX))
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "183"
+        artist = "Jason Felix"
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/801dd9c6-b159-4e1c-af2c-214c1f573633.jpg?1584833616"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RNA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RNA.json
@@ -1,0 +1,69 @@
+// Hydroid Krasis
+{
+    "name": "Hydroid Krasis",
+    "manaCost": "{X}{G}{U}",
+    "typeLine": "Creature — Jellyfish Hydra Beast",
+    "oracleText": "When you cast this spell, you gain half X life and draw half X cards. Round down each time.\nFlying, trample\nThis creature enters with X +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Divide",
+                                "numerator": "CastX",
+                                "denominator": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "roundUp": false
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Divide",
+                                "numerator": "CastX",
+                                "denominator": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "roundUp": false
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When you cast this spell, you gain half X life and draw half X cards. Round down each time."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "CastX"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "MYTHIC",
+        "artist": "Jason Felix",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/801dd9c6-b159-4e1c-af2c-214c1f573633.jpg?1584833616"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -79,7 +79,12 @@ data class ZoneChangeEvent(
      * (e.g., "+1/+1", "-1/-1", "loyalty", "charge", ...).
      */
     val lastKnownCounters: Map<String, Int> = emptyMap(),
-    /** X value from the spell that put this permanent onto the battlefield (for ETB triggers using DynamicAmount.XValue) */
+    /**
+     * The `{X}` associated with this object's zone change. On entry to the battlefield it is the X
+     * of the spell that put the permanent there (for ETB triggers using `DynamicAmount.XValue`). On
+     * leaving the battlefield it is the cast-time X carried by `CastChoicesComponent`, captured as
+     * last-known information so dies/leaves triggers can still read `DynamicAmount.CastX`.
+     */
     val xValue: Int? = null,
     /**
      * Per-player damage dealt to this entity this turn (keyed by source-controller player id),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -380,6 +380,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CastForImpendingComponent::class)
         subclass(SuspendedComponent::class)
         subclass(CastRecordComponent::class)
+        subclass(CastChoicesComponent::class)
 
         // Combat components
         subclass(AttackingComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsStationUsingToughnessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -76,6 +77,21 @@ class DynamicAmountEvaluator(
             is DynamicAmount.Fixed -> amount.amount
 
             is DynamicAmount.XValue -> context.xValue ?: 0
+
+            // The {X} this object was cast with, read off the current object regardless of zone.
+            // Reads, in order: the durable CastChoicesComponent on the battlefield permanent (and
+            // for a later activated ability); the SpellOnStackComponent while the object is still
+            // on the stack (its own resolution and a "when you cast this spell" trigger, since the
+            // trigger source is the spell entity); then the resolution context's xValue, which
+            // carries the cast X as last-known information into dies/leaves triggers (from the
+            // leave ZoneChangeEvent).
+            is DynamicAmount.CastX -> {
+                val source = context.sourceId?.let { state.getEntity(it) }
+                source?.get<CastChoicesComponent>()?.x
+                    ?: source?.get<SpellOnStackComponent>()?.xValue
+                    ?: context.xValue
+                    ?: 0
+            }
 
             is DynamicAmount.TotalManaSpent -> context.totalManaSpent
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -282,6 +282,10 @@ object ZoneMovementUtils {
             .without<WasKickedComponent>()
             .without<WarpedComponent>()
             .without<EvokedComponent>()
+            // Cast-time X (DynamicAmount.CastX) is forgotten when the object changes zones
+            // (CR 400.7). It is captured as last-known info on the leave ZoneChangeEvent so
+            // dies/leaves triggers can still read it.
+            .without<com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent>()
             .without<com.wingedsheep.engine.state.components.battlefield.CastForImpendingComponent>()
             .without<com.wingedsheep.engine.state.components.battlefield.SuspendedComponent>()
             // Note: CastRecordComponent is NOT stripped here — it needs to persist

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -150,6 +150,10 @@ object ZoneTransitionService {
         var lastKnownAttachedTo = options.lastKnownAttachedTo
         var lastKnownWasToken = false
         var lastKnownDamageDealtByPlayers: Map<EntityId, Int> = emptyMap()
+        // The {X} this permanent was cast with (DynamicAmount.CastX), captured before the
+        // CastChoicesComponent is stripped so dies/leaves triggers reading CastX still see it
+        // as last-known information (CR 603.10a).
+        var lastKnownCastX: Int? = null
 
         if (leavingBattlefield) {
             val countersComponent = container.get<CountersComponent>()
@@ -183,6 +187,8 @@ object ZoneTransitionService {
             lastKnownWasToken = container.has<TokenComponent>()
             lastKnownDamageDealtByPlayers =
                 container.get<DamageDealtByPlayersThisTurnComponent>()?.perPlayer ?: emptyMap()
+            lastKnownCastX = container
+                .get<com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent>()?.x
         }
 
         // 3. Check zone change redirect (unless skipped)
@@ -386,7 +392,8 @@ object ZoneTransitionService {
                 lastKnownLostAllAbilities = lastKnownLostAllAbilities,
                 lastKnownAttachedTo = if (leavingBattlefield) lastKnownAttachedTo else null,
                 lastKnownCardDefinitionId = if (leavingBattlefield) cardComponent.cardDefinitionId else null,
-                lastKnownDamageDealtByPlayers = lastKnownDamageDealtByPlayers
+                lastKnownDamageDealtByPlayers = lastKnownDamageDealtByPlayers,
+                xValue = lastKnownCastX
             )
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1021,6 +1021,17 @@ class StackResolver(
                 updated = updated.with(WasKickedComponent)
             }
 
+            // Carry the cast-time X durably onto the permanent (CR 601.2b choices ride the stable
+            // entity onto the battlefield) so triggered/activated abilities can read "the X this
+            // was cast with" via DynamicAmount.CastX for its whole life on the battlefield, with no
+            // counter laundering. The component is stripped when the permanent leaves the
+            // battlefield (new object, CR 400.7) — see ZoneMovementUtils.stripBattlefieldComponents.
+            spellComponent.xValue?.let { castX ->
+                updated = updated.with(
+                    com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent(x = castX)
+                )
+            }
+
             // Track if this permanent was cast for its warp cost
             if (spellComponent.wasWarped) {
                 updated = updated.with(WarpedComponent)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.engine.state.components.battlefield
+
+import com.wingedsheep.engine.state.Component
+import kotlinx.serialization.Serializable
+
+/**
+ * The choices locked in as a spell was cast (CR 601.2b), carried durably on the same entity as it
+ * resolves onto the battlefield. This is the immutable-ECS analogue of Forge's per-object SVar bag
+ * and mtgish's named bindings (`ValueX` / `TheChosenColor`): a permanent can read "the X I was cast
+ * with" from a triggered or activated ability long after the spell has left the stack, via
+ * [com.wingedsheep.sdk.scripting.values.DynamicAmount.CastX].
+ *
+ * Lifecycle (relies on the entity id being stable across the stack→battlefield boundary):
+ *  - Attached in `StackResolver.enterPermanentOnBattlefield` when the resolving spell had a chosen
+ *    `{X}`, in addition to the (now removed) stack-presence marker. While on the stack the cast X
+ *    still lives on `SpellOnStackComponent.xValue`, so `CastX` reads that there.
+ *  - Stripped on leaving the battlefield ([com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.stripBattlefieldComponents]):
+ *    a card that changes zones is a new object (CR 400.7) and no longer remembers how it was cast.
+ *    The cast X is preserved as last-known information on the leave
+ *    [com.wingedsheep.engine.core.ZoneChangeEvent] so dies/leaves triggers can still read it.
+ *  - Not a copiable value (CR 707.2): a copy of a *permanent* (Clone) never receives it.
+ *
+ * Phase 1 of the cast-time-choices design (`backlog/cast-time-choices-and-inherited-x.md`) records
+ * only [x]. The cast-time chosen color / creature type / mode / kicked-ness still live on their own
+ * components; folding them into this bag is Phase 2.
+ */
+@Serializable
+data class CastChoicesComponent(
+    /** The value chosen for `{X}` as this object was cast. Only present for spells cast with `{X}`. */
+    val x: Int
+) : Component

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastXDurableValueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastXDurableValueTest.kt
@@ -1,0 +1,166 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Proves [DynamicAmount.CastX] — "the X this object was cast with" — resolves correctly across every
+ * site the cast-time-X design must reach, using minimal inline cards so each context is isolated:
+ *
+ *  - the spell's own resolution (X read off the stack object),
+ *  - an enters-the-battlefield *trigger* (X read off the durable component on the new permanent),
+ *  - a later activated ability (same durable component, after the spell has fully resolved),
+ *  - a dies trigger (X read as last-known information after the permanent has left the battlefield).
+ *
+ * Hydroid Krasis itself ([HydroidKrasisScenarioTest]) covers the "when you cast this spell" trigger
+ * and the enters-with-counters replacement.
+ */
+class CastXDurableValueTest : ScenarioTestBase() {
+
+    init {
+        // Instant: "You gain X life." Reads CastX during the spell's own resolution.
+        cardRegistry.register(
+            card("CastX Lifebolt") {
+                manaCost = "{X}{G}"
+                typeLine = "Instant"
+                spell {
+                    effect = Effects.GainLife(DynamicAmount.CastX)
+                }
+            }
+        )
+
+        // 2/2 creature: "When this enters, draw X cards." Reads CastX from an ETB trigger.
+        cardRegistry.register(
+            card("CastX Drawer") {
+                manaCost = "{X}{G}"
+                typeLine = "Creature — Sponge"
+                power = 2
+                toughness = 2
+                triggeredAbility {
+                    trigger = Triggers.EntersBattlefield
+                    effect = Effects.DrawCards(DynamicAmount.CastX)
+                }
+            }
+        )
+
+        // 2/2 creature: "{1}: You gain X life." Reads CastX from a later activated ability.
+        cardRegistry.register(
+            card("CastX Fountain") {
+                manaCost = "{X}{G}"
+                typeLine = "Creature — Sponge"
+                power = 2
+                toughness = 2
+                activatedAbility {
+                    cost = Costs.Mana("{1}")
+                    effect = Effects.GainLife(DynamicAmount.CastX)
+                }
+            }
+        )
+
+        // 0/0 creature: "When this dies, you gain X life." A 0/0 dies to SBAs the instant it
+        // enters, so CastX must be read as last-known information after the entity has left.
+        cardRegistry.register(
+            card("CastX Martyr") {
+                manaCost = "{X}{G}"
+                typeLine = "Creature — Sponge"
+                power = 0
+                toughness = 0
+                triggeredAbility {
+                    trigger = Triggers.Dies
+                    effect = Effects.GainLife(DynamicAmount.CastX)
+                }
+            }
+        )
+
+        context("DynamicAmount.CastX") {
+
+            test("resolves during the spell's own resolution (CastX Lifebolt cast for X=4 gains 4 life)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "CastX Lifebolt")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castXSpell(1, "CastX Lifebolt", xValue = 4).error shouldBe null
+                game.resolveStack()
+
+                game.getLifeTotal(1) shouldBe 24
+            }
+
+            test("resolves from an enters-the-battlefield trigger (CastX Drawer cast for X=2 draws 2)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "CastX Drawer")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castXSpell(1, "CastX Drawer", xValue = 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("ETB trigger drew CastX = 2 cards") {
+                    game.handSize(1) shouldBe (handBefore - 1 + 2)
+                }
+            }
+
+            test("resolves from a later activated ability (CastX Fountain cast for X=3, then {1} gains 3 life)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "CastX Fountain")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castXSpell(1, "CastX Fountain", xValue = 3).error shouldBe null
+                game.resolveStack()
+                withClue("the activated ability has not resolved yet, so no life gained from it") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+
+                val fountain = game.findPermanent("CastX Fountain")!!
+                val abilityId = cardRegistry.getCard("CastX Fountain")!!.activatedAbilities[0].id
+                game.execute(ActivateAbility(game.player1Id, fountain, abilityId)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the activated ability read the durable cast X = 3 off the permanent") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+            }
+
+            test("resolves from a dies trigger as last-known information (CastX Martyr cast for X=5 gains 5 life)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "CastX Martyr")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castXSpell(1, "CastX Martyr", xValue = 5).error shouldBe null
+                game.resolveStack()
+
+                withClue("the 0/0 died, and its dies trigger read the cast X = 5 from last-known info") {
+                    game.getLifeTotal(1) shouldBe 25
+                    game.findPermanent("CastX Martyr") shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastXNotInheritedByCopyTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CastXNotInheritedByCopyTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * A copy of a *permanent* does not inherit the cast-time X (CR 707.2: X is a choice made on the
+ * stack, not a copiable value of a permanent; counters are not copied either). Cloning a creature
+ * that entered with X +1/+1 counters therefore produces a copy with no counters and no
+ * [CastChoicesComponent] — proving [com.wingedsheep.sdk.scripting.values.DynamicAmount.CastX] is not
+ * carried across the copy.
+ *
+ * Uses a 3/3 base "enters with X +1/+1 counters" creature (rather than Hydroid Krasis, a 0/0) so the
+ * counter-less copy survives state-based actions and can be inspected.
+ */
+class CastXNotInheritedByCopyTest : FunSpec({
+
+    // {X}{G} 3/3 "This creature enters with X +1/+1 counters on it." — reads CastX.
+    val castXGolem = card("CastX Golem") {
+        manaCost = "{X}{G}"
+        typeLine = "Creature — Golem"
+        power = 3
+        toughness = 3
+        replacementEffect(EntersWithDynamicCounters(count = DynamicAmount.CastX))
+    }
+
+    test("Clone of an X-cast creature inherits no cast X (no counters, no CastChoicesComponent)") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(castXGolem)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cast CastX Golem for X=4 → a 7/7 with four +1/+1 counters and CastChoicesComponent(x = 4).
+        val golem = driver.putCardInHand(player, "CastX Golem")
+        driver.giveMana(player, Color.GREEN, 5)
+        driver.castXSpell(player, golem, xValue = 4).error shouldBe null
+        repeat(6) { if (driver.state.stack.isNotEmpty() && driver.pendingDecision == null) driver.bothPass() }
+
+        driver.state.getEntity(golem)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 4
+        driver.state.getEntity(golem)?.get<CastChoicesComponent>()?.x shouldBe 4
+
+        // Clone it.
+        val clone = driver.putCardInHand(player, "Clone")
+        driver.giveMana(player, Color.BLUE, 4)
+        driver.castSpell(player, clone)
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options shouldContain golem
+        driver.submitCardSelection(player, listOf(golem))
+
+        // The clone is a copy of CastX Golem and survives (3/3 base)...
+        driver.state.getBattlefield() shouldContain clone
+        driver.state.getEntity(clone)?.get<CardComponent>()?.name shouldBe "CastX Golem"
+        // ...but it was not cast with X, so it inherits neither the cast X nor the counters.
+        driver.state.getEntity(clone)?.get<CastChoicesComponent>().shouldBeNull()
+        (driver.state.getEntity(clone)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HydroidKrasisScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HydroidKrasisScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Hydroid Krasis (RNA #183) — {X}{G}{U} Creature — Jellyfish Hydra Beast 0/0.
+ *
+ * "When you cast this spell, you gain half X life and draw half X cards. Round down each time.
+ *  Flying, trample
+ *  This creature enters with X +1/+1 counters on it."
+ *
+ * The proof that the cast-time X survives onto the permanent via DynamicAmount.CastX: the cast
+ * trigger (gain/draw half X) and the enters-with-counters replacement (X +1/+1 counters) both read
+ * the same X chosen as the spell was cast — the cast trigger off the stack object, the counters off
+ * the durable component on the entering permanent.
+ */
+class HydroidKrasisScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private fun plusOneCounters(game: TestGame, name: String): Int {
+        val permanent = game.findPermanent(name)!!
+        return game.state.getEntity(permanent)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Hydroid Krasis") {
+
+            test("cast for X=6: gain 3 life, draw 3 cards, enters as a 6/6 with six +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hydroid Krasis")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withLandsOnBattlefield(1, "Island", 8)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castXSpell(1, "Hydroid Krasis", xValue = 6).error shouldBe null
+                game.resolveStack()
+
+                withClue("half of 6, rounded down, is 3 life gained") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+                // Hand: started with N (Hydroid removed on cast) then drew 3.
+                withClue("half of 6, rounded down, is 3 cards drawn") {
+                    game.handSize(1) shouldBe (handBefore - 1 + 3)
+                }
+                withClue("enters with six +1/+1 counters") {
+                    plusOneCounters(game, "Hydroid Krasis") shouldBe 6
+                }
+                val hydroid = game.findPermanent("Hydroid Krasis")!!
+                withClue("0/0 base + six +1/+1 counters = 6/6") {
+                    projector.getProjectedPower(game.state, hydroid) shouldBe 6
+                    projector.getProjectedToughness(game.state, hydroid) shouldBe 6
+                }
+            }
+
+            test("cast for X=5: gain 2 life and draw 2 cards (round down each independently)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hydroid Krasis")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withLandsOnBattlefield(1, "Island", 8)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castXSpell(1, "Hydroid Krasis", xValue = 5).error shouldBe null
+                game.resolveStack()
+
+                withClue("half of 5, rounded down, is 2") {
+                    game.getLifeTotal(1) shouldBe 22
+                    game.handSize(1) shouldBe (handBefore - 1 + 2)
+                    plusOneCounters(game, "Hydroid Krasis") shouldBe 5
+                }
+            }
+
+            test("cast for X=0: no life gained, no cards drawn, 0/0 dies as a state-based action") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hydroid Krasis")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castXSpell(1, "Hydroid Krasis", xValue = 0).error shouldBe null
+                game.resolveStack()
+
+                withClue("half of 0 is 0 — no life gained") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+                withClue("half of 0 is 0 — no cards drawn (only the cast Hydroid left hand)") {
+                    game.handSize(1) shouldBe (handBefore - 1)
+                }
+                withClue("a 0/0 with no counters dies to state-based actions") {
+                    game.findPermanent("Hydroid Krasis") shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Phase 1 of [`backlog/cast-time-choices-and-inherited-x.md`](backlog/cast-time-choices-and-inherited-x.md) — the **"inherited X"** problem. Carry the `{X}` chosen as a spell is cast durably onto the permanent, so a triggered or activated ability can read *"the X this was cast with"* long after the spell left the stack — with no counter laundering.

Built with the `add-feature` skill (cross-layer SDK primitive: SDK → engine → triggers/projection → DTO-neutral). Scope confirmed with the requester as **Phase 1 only**; Phases 2–4 (slot generalization, `declare { }` DSL, mtgish-emitter payoff) remain.

## How

- **SDK** — new `DynamicAmount.CastX`: object-scoped X, in contrast to `XValue` which resolves from the transient `EffectContext.xValue` and is only populated while the spell itself resolves (so an ETB trigger or a later ability can't see it).
- **Engine** — durable `CastChoicesComponent(x)` attached on battlefield entry (the immutable analogue of Forge's SVar bag / mtgish's `ValueX`), stripped on leaving the battlefield (CR 400.7 — new object). The evaluator reads, in order:
  1. `CastChoicesComponent.x` off the permanent (ETB replacement/trigger, later activated ability),
  2. `SpellOnStackComponent.xValue` while the object is still on the stack (the spell's own resolution and a *"when you cast this spell"* trigger, whose source is the spell entity),
  3. the resolution context's `xValue` as **last-known information** for dies/leaves triggers — captured onto the leave `ZoneChangeEvent.xValue`.
- **Copies (CR 707.2)** — a copy of a *permanent* (Clone) does not inherit it: X isn't a copiable value and counters aren't copied. A copy of a *spell* on the stack does (it resolves through the normal entry path with the copied X).
- **Content** — scaffolded the **Ravnica Allegiance (RNA)** set (Hydroid's earliest printing, per the canonical-home rule) and implemented **Hydroid Krasis**; its cast trigger (gain/draw half X) and its enters-with-X-counters replacement both read `CastX`.

## Tests (rules-engine, the source of truth)

- `HydroidKrasisScenarioTest` — X=6 → gain 3, draw 3, 6/6 with six +1/+1 counters; X=5 → round down each to 2; X=0 → no draw, 0/0 dies as SBA.
- `CastXDurableValueTest` — `CastX` resolves from the spell's own resolution, an ETB trigger, a later activated ability, and a dies trigger (LKI).
- `CastXNotInheritedByCopyTest` — cloning an X-cast creature yields no counters and no `CastChoicesComponent`.
- Full `:rules-engine:test` and `:mtg-sets:test` (snapshot + printing-canonical rule) green; RNA golden snapshot added.

## Docs

- `docs/card-sdk-language-reference.md` §13 documents `CastX` vs `XValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)