### PR TITLE
Fix Traveling Botanist: any declined top card can be binned, not just a land

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TravelingBotanist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TravelingBotanist.kt
@@ -28,10 +28,13 @@ import com.wingedsheep.sdk.dsl.Effects
  *
  * Modeled as the standard look-at-top peek pipeline (Gather → Filter → Select → Move):
  *  1. Look at (peek, controller-only) the top card → "looked".
- *  2. Partition into land / non-land. Only a land card is actionable.
- *  3. The player may choose the land to reveal + put into hand (ChooseUpTo 1).
- *  4. Any land NOT put into hand may then be put into the graveyard (a second ChooseUpTo 1).
- *  5. Cards left unmoved (a declined land, or a non-land top card) stay on top of the library.
+ *  2. Partition out the land — only a land card may go to hand → "landCard".
+ *  3. The player may choose the land to reveal + put into hand (ChooseUpTo 1) → "toHand".
+ *  4. Compute "notInHand" = looked − toHand: the top card if it was NOT put into hand. Per the
+ *     oracle, "if you don't put the card into your hand" refers to the looked-at top card, land
+ *     or not — so a non-land top card is eligible for the graveyard too, not just a declined land.
+ *  5. The player may put that card into the graveyard (a second ChooseUpTo 1).
+ *  6. A card left unmoved (declined at both steps) stays on top of the library.
  */
 val TravelingBotanist = card("Traveling Botanist") {
     manaCost = "{1}{G}"
@@ -52,19 +55,17 @@ val TravelingBotanist = card("Traveling Botanist") {
                     source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
                     storeAs = "looked"
                 ),
-                // Only a land card is actionable.
+                // Only a land card may be put into hand.
                 FilterCollectionEffect(
                     from = "looked",
                     filter = CollectionFilter.MatchesFilter(GameObjectFilter.Land),
-                    storeMatching = "landCard",
-                    storeNonMatching = "nonLand"
+                    storeMatching = "landCard"
                 ),
                 // You may reveal the land and put it into your hand.
                 SelectFromCollectionEffect(
                     from = "landCard",
                     selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
                     storeSelected = "toHand",
-                    storeRemainder = "landNotTaken",
                     selectedLabel = "Reveal and put into your hand",
                     remainderLabel = "Leave on top of your library"
                 ),
@@ -74,9 +75,16 @@ val TravelingBotanist = card("Traveling Botanist") {
                     revealed = true,
                     revealToSelf = false
                 ),
-                // If you don't put the land into your hand, you may put it into your graveyard.
+                // "the card" you didn't put into your hand = the looked-at top card minus whatever
+                // went to hand. This is any top card (land or not), not just a declined land.
+                FilterCollectionEffect(
+                    from = "looked",
+                    filter = CollectionFilter.ExcludeOtherCollection("toHand"),
+                    storeMatching = "notInHand"
+                ),
+                // If you didn't put the card into your hand, you may put it into your graveyard.
                 SelectFromCollectionEffect(
-                    from = "landNotTaken",
+                    from = "notInHand",
                     selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
                     storeSelected = "toGraveyard",
                     selectedLabel = "Put into your graveyard",
@@ -86,7 +94,7 @@ val TravelingBotanist = card("Traveling Botanist") {
                     from = "toGraveyard",
                     destination = CardDestination.ToZone(Zone.GRAVEYARD)
                 )
-                // "nonLand" and any declined land stay on top of the library (never gathered out).
+                // A card declined at both steps stays on top of the library (never gathered out).
             )
         )
         description = "look at the top card of your library. If it's a land card, you may reveal it " +

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -16528,7 +16528,8 @@
                     ],
                     "creatureTypes": [
                         "Soldier"
-                    ]
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/d/7ddd5153-2d16-4a4e-b9bc-f20313d322da.jpg?1743176203"
                 },
                 "descriptionOverride": "When this enchantment enters, create two 2/2 white Soldier creature tokens."
             },
@@ -17397,8 +17398,7 @@
                                 "type": "MatchesFilter",
                                 "filter": "land"
                             },
-                            "storeMatching": "landCard",
-                            "storeNonMatching": "nonLand"
+                            "storeMatching": "landCard"
                         },
                         {
                             "type": "SelectFromCollection",
@@ -17411,7 +17411,6 @@
                                 }
                             },
                             "storeSelected": "toHand",
-                            "storeRemainder": "landNotTaken",
                             "selectedLabel": "Reveal and put into your hand",
                             "remainderLabel": "Leave on top of your library"
                         },
@@ -17426,8 +17425,17 @@
                             "revealToSelf": false
                         },
                         {
+                            "type": "FilterCollection",
+                            "from": "looked",
+                            "filter": {
+                                "type": "ExcludeOtherCollection",
+                                "otherCollectionName": "toHand"
+                            },
+                            "storeMatching": "notInHand"
+                        },
+                        {
                             "type": "SelectFromCollection",
-                            "from": "landNotTaken",
+                            "from": "notInHand",
                             "selection": {
                                 "type": "ChooseUpTo",
                                 "count": {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmGreenBatchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TdmGreenBatchScenarioTest.kt
@@ -12,7 +12,7 @@ import io.kotest.matchers.shouldBe
  *  - Temur Monument (#248): ETB tutors a basic Forest/Island/Mountain to hand.
  *  - Sagu Wildling (#157): ETB gains 3 life (Omen back face Roost Seek exercised by other paths).
  *  - Traveling Botanist (#164): on becoming tapped, peeks the top card and (if a land) may take it
- *    to hand, else may bin it.
+ *    to hand; whether land or not, any top card not put into hand may then be binned.
  *
  * Undergrowth Leopard reuses the well-covered Capashen Unicorn sac-to-destroy pattern, so it has
  * no bespoke scenario here.
@@ -149,6 +149,67 @@ class TdmGreenBatchScenarioTest : ScenarioTestBase() {
                 }
                 withClue("The Forest should not be in hand") {
                     game.findCardsInHand(1, "Forest").size shouldBe 0
+                }
+            }
+
+            test("a non-land top card still offers the put-into-graveyard choice") {
+                // Oracle: "If you don't put the card into your hand, you may put it into your
+                // graveyard." "the card" is the looked-at top card, land or not — so a non-land
+                // top card (which can never go to hand) must still get the graveyard option.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Traveling Botanist", summoningSickness = false)
+                    .withCardInLibrary(1, "Sagu Wildling")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Traveling Botanist" to 2))
+                game.resolveStack()
+
+                // No land to take, so the hand step is a silent no-op; the first prompt is the
+                // put-into-graveyard choice for the non-land top card.
+                withClue("A non-land top card should still prompt the put-into-graveyard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val binDecision = game.getPendingDecision() as SelectCardsDecision
+                withClue("The non-land card should be the bin option") {
+                    binDecision.options.size shouldBe 1
+                }
+                game.selectCards(listOf(binDecision.options.first()))
+                game.resolveStack()
+
+                withClue("The Sagu Wildling should be in the graveyard") {
+                    game.findCardsInGraveyard(1, "Sagu Wildling").size shouldBe 1
+                }
+                withClue("The Sagu Wildling should have left the library") {
+                    game.findCardsInLibrary(1, "Sagu Wildling").size shouldBe 0
+                }
+            }
+
+            test("declining a non-land top card leaves it on top of the library") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Traveling Botanist", summoningSickness = false)
+                    .withCardInLibrary(1, "Sagu Wildling")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Traveling Botanist" to 2))
+                game.resolveStack()
+
+                withClue("The non-land top card should prompt the put-into-graveyard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("Declining leaves the Sagu Wildling in the library") {
+                    game.findCardsInLibrary(1, "Sagu Wildling").size shouldBe 1
+                }
+                withClue("The Sagu Wildling should not be in the graveyard") {
+                    game.findCardsInGraveyard(1, "Sagu Wildling").size shouldBe 0
                 }
             }
         }


### PR DESCRIPTION
## Bug

When Traveling Botanist becomes tapped (e.g. by attacking) and the top card of your library is **not** a land, you got no "may put it into your graveyard" prompt at all — the card just stayed on top.

## Root cause

Oracle: *"…look at the top card of your library. If it's a land card, you may reveal it and put it into your hand. **If you don't put the card into your hand, you may put it into your graveyard.**"*

"the card" refers to the looked-at top card — land or not. The pipeline, however, routed only a **declined land** (the remainder of the land selection) into the graveyard step. A non-land top card never reached that step, so no second prompt appeared.

## Fix

Recompute the graveyard candidate as `looked − toHand` using `CollectionFilter.ExcludeOtherCollection("toHand")` — i.e. whatever top card wasn't put into hand, regardless of type. A land you take to hand is excluded; a declined land or any non-land is offered for the graveyard.

No SDK/engine changes — composes existing pipeline primitives.

## Tests

Extended `TdmGreenBatchScenarioTest`:
- non-land top card still offers the put-into-graveyard choice (and bins correctly)
- declining a non-land top card leaves it on top of the library

All 6 cases in the suite pass.

## Note — unrelated golden sync

Re-blessing `TDM.json` also picks up one line that was already stale on `main`: commit `42aaba497` added the TeemingDragonstorm Soldier-token `imageUri` to the card def without re-blessing the golden, so the snapshot test was already red on `main`. The bless brings the golden in line with that already-merged code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)