### PR TITLE
Widen mtgish emitter: ONS auto-gen 139→155 cards

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -25,6 +25,9 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("ExileGraveyardCard", UNIVERSAL, composes = listOf("MoveToZone"))
 
     composed("ShuffleHandIntoLibrary", "MoveCollection hand->library + ShuffleLibrary", composes = listOf("MoveCollection", "ShuffleLibrary"))
+    composed("ShuffleGraveyardIntoLibrary", "Patterns.Library.shuffleGraveyardIntoLibrary -> Gather + MoveCollection (shuffled)", composes = listOf("MoveCollection"))
+
+    composed("Surveil", "Patterns.Library.surveil -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
 
     composed("PutPermanentIntoItsOwnersHand", "bounce: MoveToZone/ForceReturnOwnPermanent", composes = listOf("MoveToZone"))
     composed("PutEachPermanentIntoItsOwnersHand", "EachPlayerReturnsPermanentToHand", composes = listOf("MoveCollection", "MoveToZone"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -29,6 +29,10 @@ internal fun BridgeBuilder.zoneMovement() {
 
     composed("Surveil", "Patterns.Library.surveil -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
 
+    composed("PutACardFromHandOnBattlefield", "Patterns.Hand.putFromHand -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
+    composed("PutTopOfLibraryInHand", "look-top pipeline -> MoveCollection (library->hand)", composes = listOf("MoveCollection", "MoveToZone"))
+    composed("PutTopOfLibraryInGraveyard", "look-top pipeline -> MoveCollection (library->graveyard)", composes = listOf("MoveCollection", "MoveToZone"))
+
     composed("PutPermanentIntoItsOwnersHand", "bounce: MoveToZone/ForceReturnOwnPermanent", composes = listOf("MoveToZone"))
     composed("PutEachPermanentIntoItsOwnersHand", "EachPlayerReturnsPermanentToHand", composes = listOf("MoveCollection", "MoveToZone"))
     composed("PutPermanentOnTopOfOwnersLibrary", "PutOnLibraryPositionOfChoice", composes = listOf("MoveToZone"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -178,15 +178,17 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     val trig = rule["args"].asArr?.firstOrNull() as? JsonObject ?: return null
 
     // SELF self-triggers (this permanent enters / dies / attacks / deals combat damage to a player).
+    // `isSelf` distinguishes "the subject IS this permanent" from an `Other(ThisPermanent)` clause
+    // ("another …"), which contains ThisPermanent only as the exclusion reference.
     for ((mtTrigger, dsl) in TRIGGER_SPEC) {
-        if (jsonContains(trig, "_Trigger", mtTrigger) && jsonContains(trig, "_Permanent", "ThisPermanent")) return dsl
+        if (jsonContains(trig, "_Trigger", mtTrigger) && isSelf(trig)) return dsl
     }
 
     // "Whenever ~ deals damage" / "Whenever ~ is dealt damage" (SELF) — paired with a "that much"
     // gain/lose-life or token effect.
-    if (jsonContains(trig, "_Trigger", "WhenAPermanentDealsDamage") && jsonContains(trig, "_Permanent", "ThisPermanent"))
+    if (jsonContains(trig, "_Trigger", "WhenAPermanentDealsDamage") && isSelf(trig))
         return "Triggers.DealsDamage"
-    if (jsonContains(trig, "_Trigger", "WhenAPermanentIsDealtDamage") && jsonContains(trig, "_Permanent", "ThisPermanent"))
+    if (jsonContains(trig, "_Trigger", "WhenAPermanentIsDealtDamage") && isSelf(trig))
         return "Triggers.TakesDamage"
 
     // Phase/step triggers. "your upkeep" is scoped to You; "each end step" to any player.
@@ -204,12 +206,13 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     if (jsonContains(trig, "_Trigger", "WhenACreatureAttacks") && isPlainCreatureFilter(trig))
         return "Triggers.attacks(binding = TriggerBinding.ANY)"
 
-    // "Whenever a [filtered] permanent enters the battlefield" (not this permanent) — a typed/coloured
-    // enters trigger, ANY binding (Wirewood Savage's "Whenever a Beast enters").
-    if (jsonContains(trig, "_Trigger", "WhenAPermanentEntersTheBattlefield") &&
-        !jsonContains(trig, "_Permanent", "ThisPermanent")) {
+    // "Whenever a [filtered] permanent enters the battlefield" (the SELF case returned above): an
+    // `Other(ThisPermanent)` clause means "another …" -> OTHER binding (Elvish Vanguard's "another
+    // Elf", Wretched Anurid's "another creature"); otherwise "a …" -> ANY (Wirewood Savage's "a Beast").
+    if (jsonContains(trig, "_Trigger", "WhenAPermanentEntersTheBattlefield")) {
+        val binding = if (jsonContains(trig, "_Permanents", "Other")) "TriggerBinding.OTHER" else "TriggerBinding.ANY"
         val filter = gameObjectFilterDsl(trig) ?: return null
-        return "Triggers.entersBattlefield(filter = $filter, binding = TriggerBinding.ANY)"
+        return "Triggers.entersBattlefield(filter = $filter, binding = $binding)"
     }
 
     // "Whenever you cast a [type] spell" — WhenAPlayerCastsASpell scoped to You + a spell-type filter.
@@ -225,6 +228,11 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     }
     return null
 }
+
+/** True when a trigger's subject IS this permanent — ThisPermanent present, but NOT merely as the
+ *  reference inside an `Other(ThisPermanent)` "another permanent" exclusion clause. */
+private fun isSelf(trig: JsonObject): Boolean =
+    jsonContains(trig, "_Permanent", "ThisPermanent") && !jsonContains(trig, "_Permanents", "Other")
 
 /** True when a trigger's permanent filter is a plain "creature" with no subtype / controller / count
  *  restriction — the only attacks shape we can render as a filterless ANY-binding trigger. */

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -171,19 +171,68 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false
 }
 
 /** The triggered-ability trigger spec for a TriggerA / TriggerOnceEachTurn rule, or null (-> SCAFFOLD)
- *  for a trigger shape we can't render exactly. */
+ *  for a trigger shape we can't render exactly. The first arg of a TriggerA rule is the `_Trigger`
+ *  node; scoping checks to it (not the whole rule) keeps an action's `You`/`ThisPermanent` markers from
+ *  being mistaken for trigger scopes. */
 private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
+    val trig = rule["args"].asArr?.firstOrNull() as? JsonObject ?: return null
+
+    // SELF self-triggers (this permanent enters / dies / attacks / deals combat damage to a player).
     for ((mtTrigger, dsl) in TRIGGER_SPEC) {
-        if (jsonContains(rule, "_Trigger", mtTrigger) && jsonContains(rule, "_Permanent", "ThisPermanent")) return dsl
+        if (jsonContains(trig, "_Trigger", mtTrigger) && jsonContains(trig, "_Permanent", "ThisPermanent")) return dsl
     }
-    // "Whenever you cast a historic spell" — WhenAPlayerCastsASpell scoped to {You, IsHistoric}.
-    // Require all three so only the you-cast-historic shape maps (an opponent/any-player or a
-    // non-historic spell filter is a different trigger and must scaffold).
-    if (jsonContains(rule, "_Trigger", "WhenAPlayerCastsASpell") &&
-        jsonContains(rule, "_Player", "You") && jsonContains(rule, "_Spells", "IsHistoric")) {
-        return "Triggers.YouCastHistoric"
+
+    // "Whenever ~ deals damage" / "Whenever ~ is dealt damage" (SELF) — paired with a "that much"
+    // gain/lose-life or token effect.
+    if (jsonContains(trig, "_Trigger", "WhenAPermanentDealsDamage") && jsonContains(trig, "_Permanent", "ThisPermanent"))
+        return "Triggers.DealsDamage"
+    if (jsonContains(trig, "_Trigger", "WhenAPermanentIsDealtDamage") && jsonContains(trig, "_Permanent", "ThisPermanent"))
+        return "Triggers.TakesDamage"
+
+    // Phase/step triggers. "your upkeep" is scoped to You; "each end step" to any player.
+    if (jsonContains(trig, "_Trigger", "AtTheBeginningOfAPlayersUpkeep") && jsonContains(trig, "_Player", "You"))
+        return "Triggers.YourUpkeep"
+    if (jsonContains(trig, "_Trigger", "AtTheBeginningOfAPlayersEndStep") && jsonContains(trig, "_Players", "AnyPlayer"))
+        return "Triggers.EachEndStep"
+
+    // "Whenever a player cycles a card" (any player) — Fleeting Aven, Invigorating Boon.
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerCyclesACard") && jsonContains(trig, "_Players", "AnyPlayer"))
+        return "Triggers.AnyPlayerCycles"
+
+    // "Whenever a creature attacks" — only the unrestricted any-creature shape (no subtype / controller /
+    // count clause), which maps to a filterless ANY-binding attacks trigger (Righteous Cause).
+    if (jsonContains(trig, "_Trigger", "WhenACreatureAttacks") && isPlainCreatureFilter(trig))
+        return "Triggers.attacks(binding = TriggerBinding.ANY)"
+
+    // "Whenever a [filtered] permanent enters the battlefield" (not this permanent) — a typed/coloured
+    // enters trigger, ANY binding (Wirewood Savage's "Whenever a Beast enters").
+    if (jsonContains(trig, "_Trigger", "WhenAPermanentEntersTheBattlefield") &&
+        !jsonContains(trig, "_Permanent", "ThisPermanent")) {
+        val filter = gameObjectFilterDsl(trig) ?: return null
+        return "Triggers.entersBattlefield(filter = $filter, binding = TriggerBinding.ANY)"
+    }
+
+    // "Whenever you cast a [type] spell" — WhenAPlayerCastsASpell scoped to You + a spell-type filter.
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerCastsASpell") && jsonContains(trig, "_Player", "You")) {
+        if (jsonContains(trig, "_Spells", "IsHistoric")) return "Triggers.YouCastHistoric"
+        val types = Regex(""""IsCardtype",\s*"args":\s*"(\w+)"""").findAll(compact(trig)).map { it.groupValues[1] }.toSet()
+        return when (types) {
+            setOf("Creature") -> "Triggers.YouCastCreature"
+            setOf("Enchantment") -> "Triggers.YouCastEnchantment"
+            setOf("Instant", "Sorcery") -> "Triggers.YouCastInstantOrSorcery"
+            else -> null
+        }
     }
     return null
+}
+
+/** True when a trigger's permanent filter is a plain "creature" with no subtype / controller / count
+ *  restriction — the only attacks shape we can render as a filterless ANY-binding trigger. */
+private fun isPlainCreatureFilter(trig: JsonObject): Boolean {
+    val blob = compact(trig)
+    if (""""IsCardtype",\s*"args":\s*"Creature"""".toRegex().containsMatchIn(blob).not()) return false
+    return "IsCreatureType" !in blob && "ControlledByAPlayer" !in blob &&
+        "\"Other\"" !in blob && "_Comparison" !in blob && "_Color" !in blob
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -138,6 +138,10 @@ internal fun EmitCtx.spellBlock(card: JsonObject): List<String>? {
 
 private fun spellOf(effect: String) = listOf("    spell {", "        effect = $effect", "    }")
 
+/** mtgish actions whose Argentum rendering already embeds the "you may" choice (so a wrapping
+ *  MayAction must NOT also set the ability's `optional = true`). */
+private val SELF_OPTIONAL_ACTIONS = setOf("PutACardFromHandOnBattlefield")
+
 private val TRIGGER_SPEC = mapOf(
     "WhenAPermanentEntersTheBattlefield" to "Triggers.EntersBattlefield",
     "WhenACreatureOrPlaneswalkerDies" to "Triggers.Dies",
@@ -159,12 +163,17 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false
     // by choosing no targets), not a resolution-time MayEffect. Unwrap a lone MayAction so the
     // ability carries `optional = true` and a plain effect — the engine's idiom for "may [target]".
     val mayWrapped = actions.singleOrNull()?.strField("_Action") == "MayAction"
-    val effectActions = if (mayWrapped) listOf(innerAction(actions.single()) ?: return null) else actions
+    val mayInner = if (mayWrapped) innerAction(actions.single()) ?: return null else null
+    val effectActions = if (mayWrapped) listOf(mayInner!!) else actions
+    // Some effects already carry their own "you may" choice (putFromHand prompts whether to put the
+    // card), so the MayAction wrapper is absorbed by the effect, not re-expressed as `optional = true`
+    // (which would double-wrap vs the golden — Elvish Pioneer).
+    val selfOptional = mayInner?.strField("_Action") in SELF_OPTIONAL_ACTIONS
     val edsl = renderEffectList(effectActions, tvar) ?: return null
 
     val lines = mutableListOf("    triggeredAbility {", "        trigger = $spec")
     if (oncePerTurn) lines.add("        oncePerTurn = true")
-    if (mayWrapped) lines.add("        optional = true")
+    if (mayWrapped && !selfOptional) lines.add("        optional = true")
     if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
     lines.addAll(listOf("        effect = $edsl", "    }"))
     return lines

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -64,7 +64,9 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
     simple("DiscardACardAtRandom", dsl = "Patterns.Hand.discardRandom(1)")
 
     on("GainLife") { _, args, _ ->
-        val amt = amount(args) ?: return@on null
+        // A fixed Integer renders `GainLifeEffect(1)`; a recognised dynamic amount (e.g. a damage
+        // trigger's "gain that much life") renders `GainLifeEffect(DynamicAmount…)`.
+        val amt = amount(args) ?: dynamicAmount(amountNode(args)) ?: return@on null
         "GainLifeEffect($amt)"
     }
     on("LoseLife") { _, args, _ ->

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -122,6 +122,9 @@ internal fun EmitCtx.dynamicAmount(node: JsonElement?): String? {
     when (gn) {
         "Integer" -> return "DynamicAmount.Fixed(${node["args"].asInt()})"
         "XValue", "X", "ValueX" -> return "DynamicAmount.XValue"
+        // "that much" in a damage trigger — the amount of damage the trigger fired on (Doubtless One's
+        // "gain that much life", Thrashing Mudspawn's "lose that much life").
+        "Trigger_AmountOfDamageDealt" -> return "DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)"
         "PowerOfTheSacrificedCreature" -> return "DynamicAmounts.sacrificedPower()"
         "LifeTotalOfPlayer" -> {
             val player = if (jsonContains(node, "_Player", "Opponent")) "Player.Opponent" else "Player.You"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -61,6 +61,7 @@ internal fun EmitCtx.renderAction(node: JsonObject, tvar: String?): String? {
 internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?): String? {
     echoEffect(actions)?.let { return it }
     becomeCreatureTypeEffect(actions, tvar)?.let { return it }
+    chooseCreatureTypeRevealTopEffect(actions)?.let { return it }
     val rendered = mutableListOf<String>()
     for (act in actions) {
         val r = renderAction(act, tvar)
@@ -254,6 +255,24 @@ internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: S
     if (!jsonContains(layer, "_Expiration", "UntilEndOfTurn")) return null  // non-EOT -> SCAFFOLD
     val target = refTarget(layer["args"], tvar) ?: return null
     return "BecomeCreatureTypeEffect(target = $target)"
+}
+
+/**
+ * [ChooseACreatureType, RevealTopCardOfLibrary, IfElse(revealed creature is of the chosen type ->
+ * hand, else -> graveyard)] -> the single `Patterns.CreatureType.chooseCreatureTypeRevealTop()` pattern
+ * (Bloodline Shaman). The whole three-action chain collapses to the named SDK pattern, so it renders
+ * as one effect rather than three; any deviation from this exact shape declines (null -> SCAFFOLD).
+ */
+internal fun EmitCtx.chooseCreatureTypeRevealTopEffect(actions: List<JsonObject>): String? {
+    if (actions.size != 3) return null
+    if (actions[0].strField("_Action") != "ChooseACreatureType") return null
+    if (actions[1].strField("_Action") != "RevealTopCardOfLibrary") return null
+    if (actions[2].strField("_Action") != "IfElse") return null
+    val blob = compact(actions[2])
+    if ("ACardWasRevealedThisWay" !in blob || "IsCreatureTypeVariable" !in blob ||
+        "TheChosenCreatureType" !in blob) return null
+    if ("PutTopOfLibraryInHand" !in blob || "PutTopOfLibraryInGraveyard" !in blob) return null
+    return "Patterns.CreatureType.chooseCreatureTypeRevealTop()"
 }
 
 /** [MayCost(cost), Unless(CostWasPaid, [Sacrifice...])] -> PayOrSufferEffect (echo / upkeep cost). */

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -46,7 +46,10 @@ object Emitter {
         // engine still derives behaviour from the structured keywords/effects below, never from this string.
         scryfall?.strField("oracle_text")?.takeIf { it.isNotEmpty() }?.let { body.add("    oracleText = \"${ktStr(it)}\"") }
         if (pt != null) { body.add("    power = ${pt["Power"].asInt()}"); body.add("    toughness = ${pt["Toughness"].asInt()}") }
-        if (kw.isNotEmpty()) body.add("    keywords(${kw.sorted().joinToString(", ") { "Keyword.$it" }})")
+        // Emit keywords in printed (rule) order, not alphabetical — `keywordLines` collects them in the
+        // card's rule order, which matches the hand-authored golden's `keywords(...)` order (e.g.
+        // "Trample, haste" stays TRAMPLE, HASTE rather than re-sorting to HASTE, TRAMPLE).
+        if (kw.isNotEmpty()) body.add("    keywords(${kw.joinToString(", ") { "Keyword.$it" }})")
         val cardLevelLines = ctx.cardLevelCastEffectLines(card) ?: return incomplete(ctx, body, scryfall, pkg)
         body.addAll(cardLevelLines)
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -97,6 +97,11 @@ internal fun EmitCtx.renderPlayerAction(node: JsonObject, tvar: String?): String
         "RevealHand" -> {
             return if (ptv != null) "RevealHandEffect($ptv)" else "RevealHandEffect()"
         }
+        "ShuffleGraveyardIntoLibrary" -> {
+            // "target player shuffles their graveyard into their library" (Reminisce). Only the
+            // bound-target-player form renders; an untargeted/you form scaffolds rather than guess.
+            return if (ptv != null) "Patterns.Library.shuffleGraveyardIntoLibrary($ptv)" else null
+        }
     }
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -39,6 +39,22 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         "Effects.ForEachInGroup($filter, Effects.$verb(EffectTarget.Self))"
     }
 
+    on("PutACounterOfTypeOnPermanent") { _, args, tvar ->
+        // "Put a +1/+1 (or -1/-1) counter on <permanent>." Only the bare ±1/±1 PTCounter renders; any
+        // other counter kind scaffolds rather than guess. The subject ref is self or the bound target.
+        val arr = args.asArr ?: return@on null
+        val counterNode = arr.getOrNull(0) as? JsonObject ?: return@on null
+        if (counterNode.strField("_CounterType") != "PTCounter") return@on null
+        val pt = counterNode["args"].asArr ?: return@on null
+        val counter = when (Pair(pt.getOrNull(0).asInt(), pt.getOrNull(1).asInt())) {
+            Pair(1, 1) -> "Counters.PLUS_ONE_PLUS_ONE"
+            Pair(-1, -1) -> "Counters.MINUS_ONE_MINUS_ONE"
+            else -> return@on null
+        }
+        val tgt = refTarget(arr.getOrNull(1), tvar) ?: return@on null
+        "AddCountersEffect(counterType = $counter, count = 1, target = $tgt)"
+    }
+
     on("CreatePermanentLayerEffectUntil", "CreateEachPermanentLayerEffectUntil") { node, _, tvar ->
         renderLayerEffect(node, node.strField("_Action")!!, tvar)
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -43,6 +43,10 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         "Effects.Move($tgt, Zone.HAND)"
     }
 
+    on("SacrificePermanent") { _, args, _ ->  // "sacrifice ~" (Blistering Firecat's end-step sacrifice)
+        if (jsonContains(args, "_Permanent", "ThisPermanent")) "SacrificeSelfEffect" else null
+    }
+
     on("ShuffleGraveyardCardIntoLibrary") { _, args, tvar ->  // e.g. Alabaster Dragon
         val tgt = refTarget(args, tvar) ?: "EffectTarget.Self"
         "Effects.Move($tgt, Zone.LIBRARY, ZonePlacement.Shuffled)"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -52,6 +52,10 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         "Effects.Move($tgt, Zone.LIBRARY, ZonePlacement.Shuffled)"
     }
 
+    on("Surveil") { _, args, _ ->  // "Surveil N" -> the look-top / keep-or-bin pipeline
+        (findInteger(args) as? Int)?.let { "Patterns.Library.surveil($it)" }
+    }
+
     on("SearchLibrary") { _, args, _ -> renderSearch(args) }
     on("LookAtTheTopNumberCardsOfLibrary", "LookAtTheTopNumberCardsOfPlayersLibrary") { node, args, tvar -> renderLook(node, args, tvar) }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
@@ -54,6 +55,20 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
 
     on("Surveil") { _, args, _ ->  // "Surveil N" -> the look-top / keep-or-bin pipeline
         (findInteger(args) as? Int)?.let { "Patterns.Library.surveil($it)" }
+    }
+
+    on("PutACardFromHandOnBattlefield") { _, args, _ ->  // "you may put a [basic land] card from your hand …"
+        val arr = args.asArr ?: return@on null
+        val blob = compact(arr.getOrNull(0))
+        val filter = when {
+            "IsSupertype" in blob && "\"Basic\"" in blob && "\"Land\"" in blob -> "GameObjectFilter.BasicLand"
+            "\"Land\"" in blob && "IsSupertype" !in blob && "IsLandType" !in blob -> "GameObjectFilter.Land"
+            else -> return@on null
+        }
+        val entersTapped = "EntersTapped" in compact(arr.getOrNull(1))
+        val parts = mutableListOf("filter = $filter")
+        if (entersTapped) parts.add("entersTapped = true")
+        "Patterns.Hand.putFromHand(${parts.joinToString(", ")})"
     }
 
     on("SearchLibrary") { _, args, _ -> renderSearch(args) }


### PR DESCRIPTION
## What

Widens the `:mtgish-tooling` emitter so it renders more **already-implemented** Onslaught cards *whole* (the AUTO tier) — pure mtgish→SDK mapping work in the bridge + emitter dictionaries. No card, engine, or SDK changes.

**Onslaught auto-gen: 139 → 155 cards** (42.5% → 47.4%). Because the emitter is shared, every other snapshot set rose too, and **POR held at its calibrated 158/158, 0-mismatch gate**.

## How it's verified

Every newly-AUTO card is proven by `coverage-verify ONS` — it compiles in `:mtg-sets` and its serialized gameplay tree is **identical to the committed golden snapshot**. The ONS tree-match gate went **124 → 132** with **no new mismatches** (24 pre-existing, all on cards untouched here), and several pre-existing wrong emissions were *removed* (27 → 24) by tightening self-trigger detection. POR stays **158/158, 0 mismatch**; `:mtgish-tooling:test` is green.

> Note: fidelity AUTO % is a *tier* metric (capability recall), not proof of correctness — the real gate is `coverage-verify`, which is what these numbers are checked against.

## Commits

1. **Widen trigger recovery + printed keyword order** — typed/colored `entersBattlefield`, any-creature `attacks(ANY)`, `YourUpkeep`/`EachEndStep`, `AnyPlayerCycles`, self `DealsDamage`/`TakesDamage`, `YouCast<type>`; `Trigger_AmountOfDamageDealt` → `ContextProperty(TRIGGER_DAMAGE_AMOUNT)`; `GainLife` dynamic-amount fallback; self `SacrificePermanent`; emit keywords in printed (not alphabetical) order to match hand-authored goldens.
2. **+1/+1 counter action + `Other(ThisPermanent)` self-detection fix** — `PutACounterOfTypeOnPermanent` → `AddCountersEffect`; `isSelf()` stops "another creature dies/attacks" mis-emitting a SELF trigger (declines, or maps enters to OTHER binding), which also *fixed* a pre-existing wrong card (Wretched Anurid binding).
3. **MoveCollection MISS bucket, part 1** — `Surveil` → `Patterns.Library.surveil(N)`; `ShuffleGraveyardIntoLibrary` → `Patterns.Library.shuffleGraveyardIntoLibrary(target)`.
4. **MoveCollection MISS bucket, part 2** — Elvish Pioneer (`PutACardFromHandOnBattlefield` → `putFromHand`, with its built-in "may" absorbed rather than double-wrapped as `optional`); Bloodline Shaman (`ChooseACreatureType` + reveal-top + `IfElse` chain → `Patterns.CreatureType.chooseCreatureTypeRevealTop()`).

## New AUTO cards (18)

Blistering Firecat, Doubtless One, Enchantress's Presence, Exalted Angel, Fleeting Aven, Goblin Pyromancer, Grinning Demon, Profane Prayers, Righteous Cause, Thrashing Mudspawn, Wirewood Savage, Elvish Vanguard, Invigorating Boon, Rummaging Wizard, Reminisce, Elvish Pioneer, Bloodline Shaman (+ Wretched Anurid corrected).

## Out of scope (left to hand)

The remaining `MoveCollection`-MISS cards are bespoke multi-step / pile mechanics (reveal-and-choose, multi-target discard+draw, mass put-from-hand) the emitter rightly declines rather than guess — they want a scenario test, not a predictive render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)