### PR TITLE
Widen mtgish emitter: ONS auto-gen 155→162 (7 cards SCAFFOLD→AUTO)

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -147,6 +147,7 @@ private val TRIGGER_SPEC = mapOf(
     "WhenACreatureOrPlaneswalkerDies" to "Triggers.Dies",
     "WhenACreatureAttacks" to "Triggers.Attacks",
     "WhenACreatureDealsCombatDamageToAPlayer" to "Triggers.DealsCombatDamageToPlayer",
+    "WhenACreatureBecomesBlocked" to "Triggers.BecomesBlocked",
 )
 
 /** A TriggerA rule (self-triggered) -> triggeredAbility { trigger; [target]; effect }.
@@ -215,6 +216,20 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     if (jsonContains(trig, "_Trigger", "WhenACreatureAttacks") && isPlainCreatureFilter(trig))
         return "Triggers.attacks(binding = TriggerBinding.ANY)"
 
+    // "Whenever you attack with N or more creatures" — WhenAPlayerAttacksWithANumberOfCreatures scoped to
+    // You + a `>= N` comparison + a plain creature filter (Overwhelming Instinct). Only the
+    // greater-than-or-equal (N-or-more) shape maps to YouAttackEvent(minAttackers); any other comparison
+    // or a typed/controlled attacker filter declines.
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerAttacksWithANumberOfCreatures") &&
+        jsonContains(trig, "_Player", "You") && jsonContains(trig, "_Comparison", "GreaterThanOrEqualTo")
+    ) {
+        val blob = compact(trig)
+        val plainCreature = """"IsCardtype",\s*"args":\s*"Creature"""".toRegex().containsMatchIn(blob) &&
+            "IsCreatureType" !in blob && "ControlledByAPlayer" !in blob && "\"Other\"" !in blob && "_Color" !in blob
+        val n = findInteger(trig) as? Int
+        if (plainCreature && n != null) return "TriggerSpec(EventPattern.YouAttackEvent(minAttackers = $n), TriggerBinding.ANY)"
+    }
+
     // "Whenever a [filtered] permanent enters the battlefield" (the SELF case returned above): an
     // `Other(ThisPermanent)` clause means "another …" -> OTHER binding (Elvish Vanguard's "another
     // Elf", Wretched Anurid's "another creature"); otherwise "a …" -> ANY (Wirewood Savage's "a Beast").
@@ -222,6 +237,22 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         val binding = if (jsonContains(trig, "_Permanents", "Other")) "TriggerBinding.OTHER" else "TriggerBinding.ANY"
         val filter = gameObjectFilterDsl(trig) ?: return null
         return "Triggers.entersBattlefield(filter = $filter, binding = $binding)"
+    }
+
+    // "Whenever a [creature type] deals combat damage to a player, …" — non-self
+    // WhenACreatureDealsCombatDamageToAPlayer whose source filter is purely a creature subtype, to any
+    // player (Cabal Slaver's "a Goblin"). Anything beyond a bare subtype (controller / colour / count /
+    // "another") declines so we never widen the source filter.
+    if (jsonContains(trig, "_Trigger", "WhenACreatureDealsCombatDamageToAPlayer") && !isSelf(trig) &&
+        jsonContains(trig, "_Players", "AnyPlayer")
+    ) {
+        val subtype = creatureTypeIn(trig)
+        val blob = compact(trig)
+        val bareSubtype = subtype != null && "ControlledByAPlayer" !in blob &&
+            "_Color" !in blob && "_Comparison" !in blob && "\"Other\"" !in blob
+        if (bareSubtype) return "TriggerSpec(EventPattern.DealsDamageEvent(damageType = DamageType.Combat, " +
+            "recipient = RecipientFilter.AnyPlayer, sourceFilter = GameObjectFilter.Creature.withSubtype(\"$subtype\")), " +
+            "TriggerBinding.ANY)"
     }
 
     // "Whenever you cast a [type] spell" — WhenAPlayerCastsASpell scoped to You + a spell-type filter.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
+import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.findRef
@@ -192,6 +193,8 @@ internal fun EmitCtx.refTargetIn(args: JsonElement?, markerKey: String, tvar: St
 private fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
     if (ref in setOf("Ref_TargetPermanent", "Ref_TargetPlayer", "Ref_TargetGraveyardCard")) return tvar
     if (ref in SELF_REFS) return "EffectTarget.Self"
+    // "that player" in a trigger ("the player ~ dealt combat damage to") -> the triggering player.
+    if (ref == "Trigger_ThatPlayer") return "EffectTarget.PlayerRef(Player.TriggeringPlayer)"
     return tvar
 }
 
@@ -244,9 +247,13 @@ internal fun EmitCtx.paycostDsl(costNode: JsonElement?): String? {
  * [ChooseACreatureType, CreatePermanentLayerEffectUntil{AddCreatureTypeVariable}] -> a single
  * `BecomeCreatureTypeEffect` ("becomes the creature type of your choice until end of turn"). Only the
  * bare type-change (no riding +P/T or keyword grant) and only end-of-turn collapse to this effect.
+ * `ChooseACreatureTypeOtherThan X` carries an excluded type (Imagecrafter / Mistform Mutant's "other
+ * than Wall") -> `excludedTypes = listOf("X")`.
  */
 internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: String?): String? {
-    if (actions.none { it.strField("_Action") == "ChooseACreatureType" }) return null
+    val chooser = actions.firstOrNull {
+        it.strField("_Action") in setOf("ChooseACreatureType", "ChooseACreatureTypeOtherThan")
+    } ?: return null
     val layer = actions.firstOrNull {
         it.strField("_Action") in setOf("CreatePermanentLayerEffectUntil", "CreateEachPermanentLayerEffectUntil")
     } ?: return null
@@ -254,7 +261,9 @@ internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: S
     if (jsonContains(layer, "_LayerEffect", "AdjustPT") || jsonContains(layer, "_LayerEffect", "AddAbility")) return null
     if (!jsonContains(layer, "_Expiration", "UntilEndOfTurn")) return null  // non-EOT -> SCAFFOLD
     val target = refTarget(layer["args"], tvar) ?: return null
-    return "BecomeCreatureTypeEffect(target = $target)"
+    val excluded = if (chooser.strField("_Action") == "ChooseACreatureTypeOtherThan") chooser["args"].asStr() else null
+    return if (excluded != null) "BecomeCreatureTypeEffect(target = $target, excludedTypes = listOf(\"${ktStr(excluded)}\"))"
+    else "BecomeCreatureTypeEffect(target = $target)"
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -82,6 +82,7 @@ object Emitter {
                 rname == "TriggerA" -> block = ctx.triggerBlock(rule)
                 rname == "TriggerOnceEachTurn" -> block = ctx.triggerBlock(rule, oncePerTurn = true)
                 rname == "PermanentRuleEffect" -> block = ctx.staticBlock(rule)
+                rname == "PlayerEffect" -> block = ctx.playerEffectBlock(rule)
                 rname == "EnchantPermanent" -> block = ctx.auraTargetBlock(rule)
                 rname == "PermanentLayerEffect" -> block = ctx.staticHostBlock(rule)
                 rname == "AsPermanentEnters" -> block = ctx.asEntersBlock(rule)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -20,11 +20,18 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
     on("PlayerAction", "HavePlayerTakeAction") { node, _, tvar -> renderPlayerAction(node, tvar) }
 
     on("CreateReplaceWouldDealDamageUntil") { node, _, _ ->
-        // "prevent all damage attacking creatures would deal to you this turn" (Deep Wood)
         val blob = compact(node)
-        if ("IsAttacking" in blob && "PreventThatDamage" in blob && jsonContains(node, "_Player", "You")) {
-            "Effects.PreventDamageFromAttackingCreatures()"
-        } else null
+        when {
+            // "prevent all damage attacking creatures would deal to you this turn" (Deep Wood)
+            "IsAttacking" in blob && "PreventThatDamage" in blob && jsonContains(node, "_Player", "You") ->
+                "Effects.PreventDamageFromAttackingCreatures()"
+            // "prevent all combat damage that would be dealt this turn" (Leery Fogbeast): the unrestricted
+            // CombatDamageWouldBeDealt event (no source/recipient filter) + PreventThatDamage until EOT.
+            jsonContains(node, "_ReplacableEventWouldDealDamage", "CombatDamageWouldBeDealt") &&
+                "PreventThatDamage" in blob && jsonContains(node, "_Expiration", "UntilEndOfTurn") ->
+                "Effects.PreventAllCombatDamage()"
+            else -> null
+        }
     }
     on("CreateTriggerUntil") { node, _, _ ->
         // Harsh Justice: reflect attackers' combat damage back to their controller.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -207,6 +207,31 @@ private fun EmitCtx.staticAbilityDsl(ruleName: String, ruleNode: JsonObject): St
         }
         "MustBlockAttacker" -> return "MustBlock()"
         "MustAttackPlayer" -> return "MustAttack()"
+        "CanBlockAnyNumberOfCreatures" -> return "CanBlockAnyNumber()"
     }
     return null
+}
+
+/**
+ * A top-level `PlayerEffect(You, [...])` rule -> one `staticAbility { ability = ... }` per recognised
+ * player-static. Only shapes with an exact controller-scoped StaticAbility render; anything else (the
+ * top-of-library / cost-reduction player statics) scaffolds rather than guess. Currently: "you have
+ * shroud" (True Believer).
+ */
+internal fun EmitCtx.playerEffectBlock(rule: JsonObject): List<String>? {
+    val args = rule["args"] as? JsonArray
+    val player = args?.getOrNull(0)
+    val effects = (args?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
+    if (player == null || effects.isNullOrEmpty() || !jsonContains(player, "_Player", "You")) {
+        reasons.add("PlayerEffect"); return null
+    }
+    val lines = mutableListOf<String>()
+    for (e in effects) {
+        val ability = when (e.strField("_PlayerEffect")) {
+            "Shroud" -> "GrantShroudToController"
+            else -> { reasons.add("PlayerEffect"); return null }
+        }
+        lines.addAll(listOf("    staticAbility {", "        ability = $ability", "    }"))
+    }
+    return lines
 }


### PR DESCRIPTION
## Summary

Increases how many already-implemented Onslaught cards the `:mtgish-tooling` emitter can render **whole** (AUTO tier), purely by mapping more mtgish IR shapes onto existing SDK constructs — no engine/SDK changes, no card edits.

- **ONS AUTO 155 → 162**, gate-verified **134 → 139**.
- **POR gate stays 158/158, 0 mismatch** (calibration set).
- ONS gameplay-tree mismatches **hold at 24** — none added; all 7 new AUTO cards are compile-gate verified against their hand-authored golden trees.
- No other set regressed (`fidelity --all` unchanged elsewhere).

## Cards unlocked (SCAFFOLD → AUTO, all gate-verified)

| Card | Mapping added |
|------|---------------|
| Overwhelming Instinct | "attack with N+ creatures" → raw `TriggerSpec(EventPattern.YouAttackEvent(minAttackers=N), ANY)` |
| Leery Fogbeast | `BecomesBlocked` self-trigger + `CombatDamageWouldBeDealt`→`Effects.PreventAllCombatDamage()` |
| Cabal Slaver | "a [type] deals combat damage to a player" → `DealsDamageEvent(...)` + `Trigger_ThatPlayer`→`PlayerRef(TriggeringPlayer)` |
| Imagecrafter / Mistform Mutant | `ChooseACreatureTypeOtherThan X` → `BecomeCreatureTypeEffect(excludedTypes=listOf("X"))` |
| Ironfist Crusher | `CanBlockAnyNumberOfCreatures` → `CanBlockAnyNumber()` static |
| True Believer | new `PlayerEffect(You,[Shroud])` rule handler → `GrantShroudToController` |

## How it works

The reusable mechanism: emitting **raw `TriggerSpec(EventPattern.X(...), TriggerBinding.Y)`** now auto-imports correctly. The top-level `EventPattern`/`TriggerSpec`/`TriggerBinding`/`DamageType`/`RecipientFilter` are resolved by the import Registry, with nested classes (e.g. `YouAttackEvent`) written member-qualified so the qualifier carries the import. These branches help **every set**, not just ONS.

## Deliberately declined

Rotlung Reanimator (Or-dies → two abilities), Serpentine Basilisk (delayed-trigger destroy), Tephraderm (damage redirect), and the X-cost / counterspell / replacement-effect clusters — they'd risk confidently-wrong output, which the fidelity policy says is worse than a scaffold.

## Test plan

- `just coverage-verify POR` → PASS 158/158, 0 mismatch
- `just coverage-verify ONS` → 24 mismatches (unchanged baseline), 7 new cards verified
- `just coverage-fidelity --all` → no set regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)