### PR TITLE
Make the replays screen scrollable

### DIFF
--- a/web-client/src/components/admin/ReplayViewer.tsx
+++ b/web-client/src/components/admin/ReplayViewer.tsx
@@ -439,7 +439,7 @@ function formatDate(iso: string): string {
 
 const styles: Record<string, React.CSSProperties> = {
   pageContainer: {
-    minHeight: '100vh',
+    height: '100vh',
     backgroundColor: '#0a0a12',
     color: '#ccc',
     display: 'flex',


### PR DESCRIPTION
## Problem

The Game Replays list (`GameListView` in `ReplayViewer.tsx`) couldn't scroll. When enough completed games accumulate, the bottom of the list is clipped and unreachable.

## Cause

The scroll container (`styles.pageContainer`) used `minHeight: '100vh'` together with `overflowY: 'auto'`. The global root in `index.html` is:

```css
html, body, #root { height: 100%; overflow: hidden; }
```

With `minHeight`, the container simply grows taller than the viewport to fit its content. It never overflows *itself*, so `overflowY: 'auto'` never engages — and the surrounding `#root` clips the overflow with `overflow: hidden`. Net result: a long list is cut off with no scrollbar.

## Fix

Change `minHeight: '100vh'` → `height: '100vh'`. The container is now pinned to viewport height, so when the list is taller than the screen `overflowY: 'auto'` produces a scrollbar and the full list becomes reachable.

One-line CSS change; no behavior change for short lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)