### PR TITLE
Widen mtgish emitter: ONS auto-gen 162->175 (3 cycles SCAFFOLD/MISS->AUTO)

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Mtgish.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Mtgish.kt
@@ -27,6 +27,9 @@ object Mtgish {
     val CAPABILITY_DISCRIMINATORS = listOf(
         "_Rule", "_Action", "_Trigger", "_Cost", "_LayerEffect", "_StaticLayerEffect",
         "_ReplacementActionWouldEnter",
+        // The replacement actions of a "next time you would draw …" effect (the Words cycle) reuse the
+        // ordinary action vocabulary under this discriminator, so surface it to score their capability.
+        "_ReplacementActionWouldDraw",
     )
 
     fun ensureData() {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -7,6 +7,9 @@ internal fun BridgeBuilder.damageLifeAndCards() {
 
     effects("DrawNumberCards", "DrawACard", tag = "DrawCards")
     effect("DrawUptoNumberCards", "DrawUpTo")
+    // "The next time you would draw a card this turn, [do X] instead" (the Onslaught Words cycle); the
+    // replacement action's own capability is surfaced via the `_ReplacementActionWouldDraw` discriminator.
+    effect("CreateFutureReplaceWouldDraw", "ReplaceNextDrawWith")
     composed("GainLifeForEach", "GainLife + DynamicAmount", composes = listOf("GainLife"))
     effect("GainLife", "GainLife")
     effect("LoseLife", "LoseLife")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -41,14 +41,22 @@ internal fun BridgeBuilder.structuralEnvelopes() {
 
     // Continuous-effect envelopes (the capability is the nested _LayerEffect / _Rule).
     envelope("CreatePermanentLayerEffectUntil", "envelope: continuous effect (capability is the _LayerEffect)")
-    envelope("CreateEachPermanentLayerEffectUntil", "envelope: continuous effect, each")
+    // "Each matching permanent gets … until end of turn." The capability is normally the nested
+    // _LayerEffect (ModifyStats / GrantKeyword), but when the group is keyed to an Aura's host permanent
+    // ("enchanted creature and creatures that share a type with it", the Onslaught Crowns) it lowers to
+    // the dedicated GrantToEnchantedCreatureTypeGroupEffect — which the emitter renders for that shape.
+    envelope("CreateEachPermanentLayerEffectUntil", "envelope: continuous effect, each",
+        composes = listOf("GrantToEnchantedCreatureTypeGroup"))
     envelope("CreateEachPermanentRuleEffectUntil", "envelope: continuous rule, each")
     envelope("CreatePlayerEffectUntil", "envelope: player-scoped continuous effect")
     envelope("CreatePermanentLayerEffect", UNIVERSAL)
     envelope("CreatePermanentRuleEffectUntil", UNIVERSAL)
 
     // Cross-set "may" / choice / branch envelopes surfaced by calibration on later sets.
-    envelopes("PlayerMayAction", "PlayerMayCost", "MayActions", note = UNIVERSAL, composes = listOf("May"))
+    envelopes("PlayerMayAction", "PlayerMayCost", note = UNIVERSAL, composes = listOf("May"))
+    // "you may [X and Y]" — a single optional choice gating a sequence (Gustcloak cycle); like MayAction
+    // it realises as `GatedEffect(gate = MayDecide)` (SerialName "Gated").
+    envelope("MayActions", "gate envelope: 'you may [X and Y]'", composes = listOf("Gated"))
     envelope("ChooseACreatureType", UNIVERSAL)
     envelope("ChooseAColor", UNIVERSAL)
     envelope("IfElse", UNIVERSAL)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -358,6 +358,9 @@ internal fun EmitCtx.activatedBlock(rule: JsonObject): List<String>? {
     activationRestrictionLines(rule)?.let { lines.addAll(it) } ?: return null
     if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
     lines.add("        effect = $edsl")
+    // A ReplaceNextDraw effect ("the next time you would draw … instead") prompts on the replaced draw,
+    // not at activation — the activated-ability flag the Words cycle's golden carries.
+    if (actions.any { it.strField("_Action") == "CreateFutureReplaceWouldDraw" }) lines.add("        promptOnDraw = true")
     if (isManaAbility(tvar, actions)) {
         lines.add("        manaAbility = true")
         lines.add("        timing = TimingRule.ManaAbility")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -1,11 +1,17 @@
 package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.amountNode
+import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 /** Direct effects on life totals, damage, and the player's own cards (draw / discard / look). */
 internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers {
@@ -84,4 +90,45 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         val tgt = refTarget(args, tvar)
         if (tgt != null) "LookAtTargetHandEffect($tgt)" else "LookAtTargetHandEffect()"
     }
+
+    // "{cost}: The next time you would draw a card this turn, [do X] instead." (the Onslaught Words
+    // cycle.) Only the controller's-own-next-draw shape maps to ReplaceNextDraw; the replacement
+    // action(s) reuse the normal action vocabulary under a `_ReplacementActionWouldDraw` discriminator,
+    // so [asReplacementActions] rekeys them and the shared action renderer renders the inner effect.
+    // (The activated-ability emitter pairs this with `promptOnDraw = true`.)
+    on("CreateFutureReplaceWouldDraw") { _, args, tvar ->
+        val a = args.asArr ?: return@on null
+        val event = a.getOrNull(0)
+        if (!jsonContains(event, "_FutureReplacableEventWouldDraw", "NextTimePlayerWouldDrawACardThisTurn") ||
+            !jsonContains(event, "_Player", "You")) return@on null
+        // A targeted replacement (Words of War's "deals 2 damage to any target") threads the ability's
+        // bound target into the deferred effect; the golden labels that target with card-specific prompt
+        // text we can't reconstruct, so decline rather than emit a non-equivalent target name.
+        if (tvar != null) return@on null
+        val inner = asReplacementActions(a.getOrNull(1)) ?: return@on null
+        val edsl = renderEffectList(inner, tvar) ?: return@on null
+        "Effects.ReplaceNextDraw($edsl)"
+    }
+}
+
+/** Rekey a `_ReplacementActionWouldDraw` list into the normal `_Action` vocabulary so the shared action
+ *  renderer can render it: the replacement actions ARE the ordinary actions (GainLife, CreateTokens,
+ *  PermanentDealsDamage, …) under a different discriminator, plus `_DamageRecipients` for the singular
+ *  `_DamageRecipient` the damage handler reads. Returns null if the arg isn't an action list. */
+private fun asReplacementActions(node: JsonElement?): List<JsonObject>? =
+    (node as? JsonArray)?.map { rekeyReplacementDraw(it) }?.filterIsInstance<JsonObject>()
+
+private fun rekeyReplacementDraw(el: JsonElement): JsonElement = when (el) {
+    is JsonObject -> buildJsonObject {
+        for ((k, v) in el) {
+            val nk = when (k) {
+                "_ReplacementActionWouldDraw" -> "_Action"
+                "_DamageRecipients" -> "_DamageRecipient"
+                else -> k
+            }
+            put(nk, rekeyReplacementDraw(v))
+        }
+    }
+    is JsonArray -> buildJsonArray { el.forEach { add(rekeyReplacementDraw(it)) } }
+    else -> el
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asObj
 import com.wingedsheep.tooling.coverage.asStr
+import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.asciiIdentifier
 import com.wingedsheep.tooling.coverage.jsonContains
@@ -61,9 +62,13 @@ object Emitter {
         if (jsonContains(card["Rules"], "_Rule", "EnchantPermanent")) {
             val unfaithfulOnAuras = setOf("Activated", "ActivatedWithModifiers", "TriggerA", "AsPermanentEnters", "FromAnyZone")
             (card["Rules"].asArr ?: JsonArray(emptyList())).forEach { r ->
-                (r as? JsonObject)?.strField("_Rule")?.takeIf { it in unfaithfulOnAuras }?.let {
-                    ctx.reasons.add("aura-with-$it"); return incomplete(ctx, body, scryfall, pkg)
-                }
+                val rn = (r as? JsonObject)?.strField("_Rule")?.takeIf { it in unfaithfulOnAuras } ?: return@forEach
+                // A "sacrifice this Aura: enchanted creature and creatures sharing its type get …" activated
+                // ability (the Crowns) IS modelled exactly via GrantToEnchantedCreatureTypeGroupEffect, so it
+                // renders rather than scaffolds; every other ability on an Aura still scaffolds.
+                if ((rn == "Activated" || rn == "ActivatedWithModifiers") &&
+                    "SharesACreatureTypeWithPermanent" in compact(r)) return@forEach
+                ctx.reasons.add("aura-with-$rn"); return incomplete(ctx, body, scryfall, pkg)
             }
         }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
@@ -14,6 +15,15 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
         val inner = innerAction(node) ?: return@on null
         val rendered = renderAction(inner, tvar) ?: return@on null
         "MayEffect($rendered)"
+    }
+
+    // "you may [X and Y]" — a single optional choice gating a sequence of actions (Gustcloak cycle's
+    // "you may untap it and remove it from combat"). Renders the whole sequence as one MayEffect, so a
+    // partial render (only one arm) declines via renderEffectList rather than dropping an action.
+    on("MayActions") { node, _, tvar ->
+        val inner = node["args"].asArr?.filterIsInstance<JsonObject>() ?: return@on null
+        val edsl = renderEffectList(inner, tvar) ?: return@on null
+        "MayEffect($edsl)"
     }
 
     on("EachPlayerAction") { node, _, _ -> renderEachPlayer(node) }
@@ -115,6 +125,9 @@ internal fun EmitCtx.renderPlayerAction(node: JsonObject, tvar: String?): String
 
 internal fun EmitCtx.renderEachPlayer(node: JsonObject): String? {
     val blob = compact(node)
+    // "each player returns a permanent they control to its owner's hand" (Words of Wind's replacement).
+    if (jsonContains(node, "_Players", "AnyPlayer") && "PutAPermanentIntoItsOwnersHand" in blob)
+        return "Effects.EachPlayerReturnPermanentToHand()"
     if (jsonContains(node, "_Players", "Opponent") && "Discard" in blob) return "Patterns.Hand.eachOpponentDiscards(1)"  // Noxious Toad
     if (jsonContains(node, "_Action", "DrawNumberCards") || jsonContains(node, "_GameNumber", "ValueX"))
         return "Patterns.Hand.eachPlayerDrawsX(includeController = true, includeOpponents = true)"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -125,8 +125,10 @@ internal fun EmitCtx.staticHostBlock(rule: JsonObject): List<String>? {
             }
             "AddAbility" -> {
                 val granted = (le["args"] as? JsonArray)?.getOrNull(0) as? JsonObject
-                if (granted?.strField("_Rule") == "ProtectionAndDoesntRemovePermanents") {
-                    val colors = protectionGrantColors(granted) ?: run { reasons.add("PermanentLayerEffect"); return null }
+                // "Enchanted creature has protection from <color>": the Ward cycle uses a
+                // `ProtectionAndDoesntRemovePermanents` rule, the Crowns a plain `Protection` rule.
+                if (granted?.strField("_Rule") in setOf("Protection", "ProtectionAndDoesntRemovePermanents")) {
+                    val colors = protectionGrantColors(granted!!) ?: run { reasons.add("PermanentLayerEffect"); return null }
                     colors.map { "GrantProtection(Color.$it)" }
                 } else {
                     val kw = keywordOf(le) ?: run { reasons.add("PermanentLayerEffect"); return null }
@@ -146,15 +148,13 @@ internal fun EmitCtx.staticHostBlock(rule: JsonObject): List<String>? {
     return lines
 }
 
-/** The colors of a `ProtectionAndDoesntRemovePermanents` host grant ("enchanted creature has protection
- *  from <color>", the Ward cycle), uppercased for `Color.X`; null for non-color or empty protection
- *  scopes (protection from a type/quality), which scaffold. */
-private fun protectionGrantColors(granted: JsonObject): List<String>? {
-    val protectable = (granted["args"] as? JsonArray)?.getOrNull(0) as? JsonObject ?: return null
-    if (protectable.strField("_Protectable") != "FromColor") return null
-    val colorsNode = protectable["args"] as? JsonObject ?: return null
-    if (colorsNode.strField("_ProtectableColor") != "Colors") return null
-    val colors = (colorsNode["args"] as? JsonArray ?: return null).mapNotNull { it.strField("_Color")?.uppercase() }
+/** The colors of a host protection grant ("enchanted creature has protection from <color>" — the Ward
+ *  cycle's `ProtectionAndDoesntRemovePermanents` or the Crowns' plain `Protection`), uppercased for
+ *  `Color.X`; null for a non-color protection scope (from a type/quality) or none, which scaffolds.
+ *  Works regardless of whether the grant wraps its `_Protectable` in an array (Ward) or directly (Crown). */
+internal fun protectionGrantColors(granted: JsonObject): List<String>? {
+    if (!jsonContains(granted, "_Protectable", "FromColor")) return null
+    val colors = Regex(""""_Color":\s*"(\w+)"""").findAll(compact(granted)).map { it.groupValues[1].uppercase() }.toList()
     return colors.ifEmpty { null }
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
+import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
@@ -22,6 +23,10 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
     on("GoadCreature") { _, args, tvar ->  // CR 701.15: goad target creature
         val tgt = refTarget(args, tvar) ?: return@on null
         "Effects.Goad($tgt)"
+    }
+    on("RemoveCreatureFromCombat") { _, args, tvar ->  // "remove it from combat" (Gustcloak cycle)
+        val tgt = refTarget(args, tvar) ?: return@on null
+        "Effects.RemoveFromCombat($tgt)"
     }
     on("RegeneratePermanent") { _, args, _ ->
         // Self-regeneration ("{cost}: Regenerate this") renders faithfully. A chosen target's
@@ -56,6 +61,9 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
     }
 
     on("CreatePermanentLayerEffectUntil", "CreateEachPermanentLayerEffectUntil") { node, _, tvar ->
+        // "Enchanted creature and other creatures that share a creature type with it get …" (Onslaught
+        // Crowns) — a group keyed to the host permanent, which the generic ForEachInGroup can't express.
+        enchantedTypeGroupGrant(node)?.let { return@on it }
         renderLayerEffect(node, node.strField("_Action")!!, tvar)
     }
 
@@ -121,6 +129,47 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
         return "Effects.ForEachInGroup($filter, $effect)"
     }
     return effect
+}
+
+/**
+ * The Onslaught Crowns' activated effect: "Enchanted creature and other creatures that share a creature
+ * type with it get +P/+T / gain <keyword> / gain protection from <colors> until end of turn." mtgish
+ * shapes this as a `CreateEachPermanentLayerEffectUntil` over the group `Or[HostPermanent,
+ * And[Creature, SharesACreatureTypeWithPermanent(HostPermanent)]]` — a host-keyed group the generic
+ * ForEachInGroup can't express. Recognise exactly that shape (+ end-of-turn) and render the dedicated
+ * `GrantToEnchantedCreatureTypeGroupEffect`; anything else returns null so the generic path / scaffold runs.
+ */
+internal fun EmitCtx.enchantedTypeGroupGrant(node: JsonObject): String? {
+    val args = node["args"].asArr ?: return null
+    val blob = compact(args.getOrNull(0))
+    if ("SharesACreatureTypeWithPermanent" !in blob || "HostPermanent" !in blob) return null
+    if (firstExpiration(node) !in setOf(null, "UntilEndOfTurn")) return null  // non-EOT -> decline
+    val layerEffects = (args.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (layerEffects.isEmpty()) return null
+    val params = mutableListOf<String>()
+    for (le in layerEffects) {
+        when (le.strField("_LayerEffect")) {
+            "AdjustPT" -> {
+                val pt = le["args"].asArr ?: return null
+                if (pt.size != 2) return null
+                params.add("powerModifier = ${pt[0].asInt()}")
+                params.add("toughnessModifier = ${pt[1].asInt()}")
+            }
+            "AddAbility" -> {
+                val granted = (le["args"].asArr)?.getOrNull(0) as? JsonObject
+                if (granted != null && jsonContains(granted, "_Protectable", "FromColor")) {
+                    val colors = protectionGrantColors(granted) ?: return null
+                    params.add("protectionColors = setOf(${colors.joinToString(", ") { "Color.$it" }})")
+                } else {
+                    val kw = grantedKeyword(le) ?: return null
+                    params.add("keyword = Keyword.$kw")
+                }
+            }
+            else -> return null
+        }
+    }
+    if (params.isEmpty()) return null
+    return "GrantToEnchantedCreatureTypeGroupEffect(${params.joinToString(", ")})"
 }
 
 /** The granted [Keyword] for an `AddAbility` layer effect, or null (-> SCAFFOLD) when the grant is not


### PR DESCRIPTION
## Summary

Widens the `:mtgish-tooling` emitter + bridge so **13 more already-implemented ONS cards render WHOLE (AUTO): 162 → 175**. Tooling-only change — **no card definitions touched**; these are predictive drafts of cards that already pass their scenario tests.

Three cycles moved SCAFFOLD/MISS → AUTO:

- **Gustcloak (4)** — Harrier, Runner, Sentinel, Skirmisher: new `MayActions` plural handler → `MayEffect(...)`, and `RemoveCreatureFromCombat` → `Effects.RemoveFromCombat`.
- **Crown (5)** — Ascension, Awe, Fury, Suspicion, Vigor: recognize `CreateEachPermanentLayerEffectUntil` over the `Or[HostPermanent, And[Creature, SharesACreatureTypeWithPermanent]]` group → `GrantToEnchantedCreatureTypeGroupEffect(...)`; relax the aura-guard to allow that Activated rule; `staticHostBlock` now accepts the Crowns' plain `Protection` rule (Awe), not just Ward's `ProtectionAndDoesntRemovePermanents`.
- **Words (4 of 5)** — Worship, Wind, Waste, Wilding: `CreateFutureReplaceWouldDraw` → `Effects.ReplaceNextDraw(inner)` + `promptOnDraw = true`; inner replacement actions rekeyed `_ReplacementActionWouldDraw` → `_Action` so the shared renderer handles them. **Words of War (targeted variant) is deliberately declined** — its golden labels the bound target `"any target"` while the generic emitter always names targets `"target"`, which would tree-mismatch; declining keeps it SCAFFOLD and the gate clean.

Bridge entries added so the fidelity tier (which is gated on **bridge** capability recall, not just emitter completeness) actually flips: `MayActions` composes `Gated`; `CreateFutureReplaceWouldDraw` → `ReplaceNextDrawWith` (+ surface the narrow `_ReplacementActionWouldDraw` discriminator); `CreateEachPermanentLayerEffectUntil` lowers to `GrantToEnchantedCreatureTypeGroup`.

## Verification

- **POR `coverage-verify`: GATE PASS, 158/158, 0 mismatch** (calibrated regression gate — unchanged).
- **POR `--calibrate`: 100%**.
- **ONS `coverage-verify`:** 24 tree-mismatches, **all pre-existing — 0 added** (every emitted Gustcloak/Crown/Word tree-matches its golden).
- **Cross-set `--all`:** no regressions (other sets byte-identical).
- `:mtgish-tooling:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)