### PR TITLE
Scaffold RAV set + auto-gen Perilous Forays via mtgish-tooling

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/MtgSetCatalog.kt
@@ -69,6 +69,7 @@ import com.wingedsheep.mtg.sets.definitions.p02.PortalSecondAgeSet
 import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.definitions.pz2.TreasureChestSet
 import com.wingedsheep.mtg.sets.definitions.rix.RivalsOfIxalanSet
+import com.wingedsheep.mtg.sets.definitions.rav.RavnicaCityOfGuildsSet
 import com.wingedsheep.mtg.sets.definitions.rna.RavnicaAllegianceSet
 import com.wingedsheep.mtg.sets.definitions.xln.IxalanSet
 import com.wingedsheep.mtg.sets.definitions.roe.RiseOfTheEldraziSet
@@ -178,6 +179,7 @@ object MtgSetCatalog {
         AvatarTheLastAirbenderSet,
         TeenageMutantNinjaTurtlesSet,
         WarOfTheSparkSet,
+        RavnicaCityOfGuildsSet,
         RavnicaAllegianceSet,
         OdysseySet,
         JudgmentSet,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/RavnicaCityOfGuildsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/RavnicaCityOfGuildsSet.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.rav
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Ravnica: City of Guilds (2005)
+ *
+ * Set Code: RAV
+ * Release Date: October 7, 2005
+ */
+object RavnicaCityOfGuildsSet : MtgSet {
+
+    override val code = "RAV"
+    override val displayName = "Ravnica: City of Guilds"
+    override val releaseDate = "2005-10-07"
+    override val block = "Ravnica"
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE).map { it.copy(setCode = code) }
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.rav.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PerilousForays.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PerilousForays.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Perilous Forays
+ * {3}{G}{G}
+ * Enchantment
+ * {1}, Sacrifice a creature: Search your library for a land card with a basic land type, put it onto the battlefield tapped, then shuffle.
+ */
+val PerilousForays = card("Perilous Forays") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "{1}, Sacrifice a creature: Search your library for a land card with a basic land type, put it onto the battlefield tapped, then shuffle."
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        effect = Patterns.Library.searchLibrary(
+            // "a land card with a basic land type" — any land whose type line includes a basic
+            // land type (Plains/Island/Swamp/Mountain/Forest), e.g. the Ravnica shocklands, not
+            // just basic lands. Mirrors Farseek's withAnySubtype rendering.
+            filter = GameObjectFilter.Land.withAnySubtype("Plains", "Island", "Swamp", "Mountain", "Forest"),
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "176"
+        artist = "Chris Dien"
+        flavorText = "\"This is the place? This map has got to be wrong . . . .\"\n—Svania Trul, wayfinder novice, last words"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/4210a148-d16c-42de-b0d6-83c05c553dd4.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RavnicaBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RavnicaBasicLands.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Ravnica: City of Guilds Basic Lands
+ *
+ * Ravnica contains 4 art variants of each basic land type.
+ * Cards 287-306 (Plains 287-290, Island 291-294, Swamp 295-298, Mountain 299-302, Forest 303-306)
+ */
+
+// =============================================================================
+// Plains (Cards 287-290)
+// =============================================================================
+
+val Plains287 = basicLand("Plains") {
+    collectorNumber = "287"
+    artist = "Stephan Martiniere"
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d8d3cd4-0f5f-4424-82ee-d8ba81da47fd.jpg"
+}
+
+val Plains288 = basicLand("Plains") {
+    collectorNumber = "288"
+    artist = "Christopher Moeller"
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/97b7beb9-0805-47b9-8e62-ff110e9e086a.jpg"
+}
+
+val Plains289 = basicLand("Plains") {
+    collectorNumber = "289"
+    artist = "Anthony S. Waters"
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7ab3d0fe-6af6-4d02-b41d-0b88b510be4f.jpg"
+}
+
+val Plains290 = basicLand("Plains") {
+    collectorNumber = "290"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c2839fa-33eb-47fb-9541-77c68612aa02.jpg"
+}
+
+// =============================================================================
+// Island (Cards 291-294)
+// =============================================================================
+
+val Island291 = basicLand("Island") {
+    collectorNumber = "291"
+    artist = "Stephan Martiniere"
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db6c8056-f155-434c-a4cb-a532a4707245.jpg"
+}
+
+val Island292 = basicLand("Island") {
+    collectorNumber = "292"
+    artist = "Christopher Moeller"
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1d603978-3877-454e-8910-53a4cc95431d.jpg"
+}
+
+val Island293 = basicLand("Island") {
+    collectorNumber = "293"
+    artist = "Anthony S. Waters"
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/42a272ca-98a7-4887-b6b7-903a1adc33e0.jpg"
+}
+
+val Island294 = basicLand("Island") {
+    collectorNumber = "294"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/f/9/f9cba2b8-d865-46e8-81f1-752598a0d729.jpg"
+}
+
+// =============================================================================
+// Swamp (Cards 295-298)
+// =============================================================================
+
+val Swamp295 = basicLand("Swamp") {
+    collectorNumber = "295"
+    artist = "Stephan Martiniere"
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/2755f9f7-95f9-4907-8ec9-21853eb376f4.jpg"
+}
+
+val Swamp296 = basicLand("Swamp") {
+    collectorNumber = "296"
+    artist = "Christopher Moeller"
+    imageUri = "https://cards.scryfall.io/normal/front/f/1/f18dd43d-0d9e-4d61-90f9-63822cf0cb2d.jpg"
+}
+
+val Swamp297 = basicLand("Swamp") {
+    collectorNumber = "297"
+    artist = "Anthony S. Waters"
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fbd659b0-1f79-4e3b-bc20-8f384aa43670.jpg"
+}
+
+val Swamp298 = basicLand("Swamp") {
+    collectorNumber = "298"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0d1a1df0-e6dc-4815-bb73-9d100ee6e0b2.jpg"
+}
+
+// =============================================================================
+// Mountain (Cards 299-302)
+// =============================================================================
+
+val Mountain299 = basicLand("Mountain") {
+    collectorNumber = "299"
+    artist = "Stephan Martiniere"
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/dad3662a-f7b4-45d5-a35e-fc6c38474692.jpg"
+}
+
+val Mountain300 = basicLand("Mountain") {
+    collectorNumber = "300"
+    artist = "Christopher Moeller"
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/6477ebad-e1e5-4508-aa20-39b47e39a5c6.jpg"
+}
+
+val Mountain301 = basicLand("Mountain") {
+    collectorNumber = "301"
+    artist = "Anthony S. Waters"
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4f312d7b-f505-45c3-bb87-650259e5db50.jpg"
+}
+
+val Mountain302 = basicLand("Mountain") {
+    collectorNumber = "302"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e135c9f9-5099-4029-bc19-dd9a0760d86f.jpg"
+}
+
+// =============================================================================
+// Forest (Cards 303-306)
+// =============================================================================
+
+val Forest303 = basicLand("Forest") {
+    collectorNumber = "303"
+    artist = "Stephan Martiniere"
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/706be1bd-720d-4e74-b71f-568081afcab1.jpg"
+}
+
+val Forest304 = basicLand("Forest") {
+    collectorNumber = "304"
+    artist = "Christopher Moeller"
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/839f63ad-476a-4344-b6c3-911c1075c2b8.jpg"
+}
+
+val Forest305 = basicLand("Forest") {
+    collectorNumber = "305"
+    artist = "Anthony S. Waters"
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe2e6db4-94a4-4fa9-be52-1ec235d2b137.jpg"
+}
+
+val Forest306 = basicLand("Forest") {
+    collectorNumber = "306"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/ade29c12-43f6-473d-bcc8-1e3f2cf4ee8f.jpg"
+}
+
+/**
+ * All Ravnica: City of Guilds basic land variants.
+ */
+val RavnicaBasicLands = listOf(
+    Plains287, Plains288, Plains289, Plains290,
+    Island291, Island292, Island293, Island294,
+    Swamp295, Swamp296, Swamp297, Swamp298,
+    Mountain299, Mountain300, Mountain301, Mountain302,
+    Forest303, Forest304, Forest305, Forest306
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1,0 +1,73 @@
+// Perilous Forays
+{
+    "name": "Perilous Forays",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "{1}, Sacrifice a creature: Search your library for a land card with a basic land type, put it onto the battlefield tapped, then shuffle.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{1}"
+                        },
+                        {
+                            "type": "CostSacrifice",
+                            "filter": "creature"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "land Plains|Island|Swamp|Mountain|Forest"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Dien",
+        "flavorText": "\"This is the place? This map has got to be wrong . . . .\"\n—Svania Trul, wayfinder novice, last words",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/4210a148-d16c-42de-b0d6-83c05c553dd4.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PerilousForaysTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PerilousForaysTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.PerilousForays
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Perilous Forays (Ravnica: City of Guilds).
+ *
+ * Perilous Forays: {3}{G}{G}
+ * Enchantment
+ * {1}, Sacrifice a creature: Search your library for a land card with a basic land type,
+ * put it onto the battlefield tapped, then shuffle.
+ *
+ * The interesting subtlety is the search filter: "a land card with a basic land type" is
+ * broader than "a basic land" — it includes nonbasic lands whose type line carries a basic
+ * land type (e.g. the Ravnica shocklands) but excludes typeless lands.
+ */
+class PerilousForaysTest : FunSpec({
+
+    // A nonbasic land that carries basic land types (à la a Ravnica shockland).
+    val DualBasicTypeLand = CardDefinition(
+        name = "Test Dual Type Land",
+        manaCost = ManaCost.ZERO,
+        typeLine = TypeLine(
+            cardTypes = setOf(CardType.LAND),
+            subtypes = setOf(Subtype("Forest"), Subtype("Mountain"))
+        ),
+        oracleText = "{T}: Add {R} or {G}."
+    )
+
+    // A nonbasic land with no basic land type at all — must NOT be findable.
+    val TypelessLand = CardDefinition(
+        name = "Test Typeless Land",
+        manaCost = ManaCost.ZERO,
+        typeLine = TypeLine(cardTypes = setOf(CardType.LAND)),
+        oracleText = "{T}: Add {C}."
+    )
+
+    val foraysAbilityId = PerilousForays.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(PerilousForays)
+        driver.registerCard(DualBasicTypeLand)
+        driver.registerCard(TypelessLand)
+        return driver
+    }
+
+    test("searches a basic land and puts it onto the battlefield tapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(activePlayer, "Perilous Forays")
+        val fodder = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+
+        // Only land in the library is a Forest.
+        driver.putCardOnTopOfLibrary(activePlayer, "Forest")
+
+        driver.giveMana(activePlayer, Color.GREEN, 1)
+
+        val source = driver.findPermanent(activePlayer, "Perilous Forays")!!
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = source,
+                abilityId = foraysAbilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder))
+            )
+        )
+        result.isSuccess shouldBe true
+
+        // The creature was sacrificed to pay the cost.
+        driver.findPermanent(activePlayer, "Grizzly Bears") shouldBe null
+
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options.size shouldBe 1
+
+        driver.submitDecision(activePlayer, CardsSelectedResponse(decision.id, decision.options))
+
+        val forest = driver.findPermanent(activePlayer, "Forest")
+        forest shouldNotBe null
+        driver.isTapped(forest!!) shouldBe true
+    }
+
+    test("matches a nonbasic land with a basic land type but excludes typeless lands") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(activePlayer, "Perilous Forays")
+        val fodder = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+
+        // Library holds a typeless land and a dual land with basic land types.
+        driver.putCardOnTopOfLibrary(activePlayer, "Test Typeless Land")
+        driver.putCardOnTopOfLibrary(activePlayer, "Test Dual Type Land")
+
+        driver.giveMana(activePlayer, Color.GREEN, 1)
+
+        val source = driver.findPermanent(activePlayer, "Perilous Forays")!!
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = source,
+                abilityId = foraysAbilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder))
+            )
+        )
+
+        driver.bothPass()
+
+        // Only the dual land qualifies — the typeless land is filtered out.
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options.size shouldBe 1
+
+        driver.submitDecision(activePlayer, CardsSelectedResponse(decision.id, decision.options))
+
+        driver.findPermanent(activePlayer, "Test Dual Type Land") shouldNotBe null
+        driver.findPermanent(activePlayer, "Test Typeless Land") shouldBe null
+    }
+})


### PR DESCRIPTION
## Summary

Implements a random unimplemented **Ravnica: City of Guilds (RAV)** card, drafted by the `mtgish-tooling` emitter rather than hand-written, per request.

RAV wasn't scaffolded yet, so this PR also stands up the set.

### What's here
- **Scaffold RAV** (`RavnicaCityOfGuildsSet`, 2005) + register it in `MtgSetCatalog`.
- **20 basic-land art variants** (collectors 287–306, Martiniere/Moeller/Waters/Wright), discovered from the cards package so RAV has its own basics rather than falling back to Portal.
- **Perilous Forays** (collector 176, uncommon) — randomly selected (`jot`) from the 85 AUTOGEN drafts produced by `just coverage-generate --set RAV`.

### Emitter draft → human review
The emitter rendered a complete card, but mapped *"a land card with a basic land type"* to the narrower `GameObjectFilter.BasicLand`. Corrected to:

```kotlin
GameObjectFilter.Land.withAnySubtype("Plains", "Island", "Swamp", "Mountain", "Forest")
```

(mirrors how the emitter already renders Farseek). This matters in Ravnica specifically — the shocklands carry basic land types and should be findable; plain typeless lands should not.

### Tests
`PerilousForaysTest` (the real gate — the snapshot only proves compile + capability shape):
- end-to-end: `{1}`, sacrifice a creature → search a basic onto the battlefield **tapped**
- filter precision: a nonbasic land **with** a basic land type is findable; a **typeless** land is excluded

Card-tree snapshot golden blessed for RAV (`RAV.json`).

### Verification
- `./gradlew :rules-engine:test --tests "PerilousForaysTest"` — both pass
- `./gradlew :mtg-sets:test` — green (incl. blessed RAV snapshot)
- `game-server` / `gym` / `gym-server` / `ai` compile clean
- `scripts/card-status --set RAV` → 6/291 done (5 basic types + Perilous Forays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)