### PR TITLE
mtgish-tooling Phase 2: centralize verdict resolution + unify filter renderers

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
@@ -1,7 +1,6 @@
 package com.wingedsheep.tooling.coverage
 
 import com.wingedsheep.tooling.coverage.bridge.Bridge
-import com.wingedsheep.tooling.coverage.bridge.MappingEntry
 import com.wingedsheep.tooling.coverage.emitter.Emitter
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -70,22 +69,19 @@ object Fidelity {
         return types.filter { it in effects && it !in PLUMBING }.toSet() to keywords
     }
 
-    // Generated side (prediction): what the mtgish->mapping bridge names in Argentum tags.
+    // Generated side (prediction): what the mtgish->mapping bridge names in Argentum tags. Each tag is
+    // resolved through the shared Bridge.resolve so this can't drift from the coverage probe; PLUMBING is
+    // stripped here (the fidelity-scoring filter applied symmetrically to truthCaps).
     private fun genCaps(mtgishCard: JsonObject, effects: Set<String>, keywords: Set<String>): Pair<Set<String>, Set<String>> {
         val tags = Counter<Pair<String, String>>()
         Mtgish.extractTags(mtgishCard["Rules"], tags)
         val eff = mutableSetOf<String>(); val kw = mutableSetOf<String>()
         Emitter.findLandwalkKeywords(mtgishCard["Rules"], keywords, kw)
         for ((disc, value) in tags.keys) {
-            val entry = Bridge.entry(disc, value)
-            if (entry == null) {
-                val auto = pascalToUpperSnake(value)
-                if (auto in keywords) kw.add(auto)
-                continue
-            }
-            if (entry is MappingEntry.Effect && entry.tag in effects) eff.add(entry.tag)
-            else if (entry is MappingEntry.Keyword && entry.tag in keywords) kw.add(entry.tag)
-            entry.composes.forEach { if (it in effects && it !in PLUMBING) eff.add(it) }
+            val r = Bridge.resolve(disc, value, effects, keywords)
+            r.effectTag?.let { eff.add(it) }
+            r.composedEffects.forEach { if (it !in PLUMBING) eff.add(it) }
+            r.keyword?.let { kw.add(it) }
         }
         return eff to kw
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Probe.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Probe.kt
@@ -1,7 +1,6 @@
 package com.wingedsheep.tooling.coverage
 
 import com.wingedsheep.tooling.coverage.bridge.Bridge
-import com.wingedsheep.tooling.coverage.bridge.MappingEntry
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import java.util.Locale
@@ -22,32 +21,9 @@ object Probe {
         val reqs = mutableListOf<Req>()
         val blockers = mutableListOf<Blocker>()
         for ((disc, value) in tags.keys) {
-            val entry = Bridge.entry(disc, value)
-            if (entry == null) {
-                // Principled fallback: a tag that IS a Keyword enum member is covered (registry-validated,
-                // so envelopes like Activated / SpellActions stay correctly unmapped).
-                val kw = pascalToUpperSnake(value)
-                if (kw in keywords) {
-                    reqs.add(Req(disc, value, "ok", "$kw (keyword auto)"))
-                    continue
-                }
-                reqs.add(Req(disc, value, "UNMAPPED", ""))
-                blockers.add(Blocker(disc, value, "UNMAPPED"))
-                continue
-            }
-            when (entry) {
-                is MappingEntry.Effect -> {
-                    val ok = entry.tag in effects
-                    reqs.add(Req(disc, value, if (ok) "ok" else "MISSING", entry.tag))
-                    if (!ok) blockers.add(Blocker(disc, value, "MISSING"))
-                }
-                is MappingEntry.Keyword -> {
-                    val ok = entry.tag in keywords
-                    reqs.add(Req(disc, value, if (ok) "ok" else "MISSING", entry.tag))
-                    if (!ok) blockers.add(Blocker(disc, value, "MISSING"))
-                }
-                else -> reqs.add(Req(disc, value, entry.kind, entry.note ?: ""))
-            }
+            val r = Bridge.resolve(disc, value, effects, keywords)
+            reqs.add(Req(r.disc, r.value, r.status, r.detail))
+            if (r.blocking) blockers.add(Blocker(r.disc, r.value, r.status))
         }
         return Analysis(blockers.isEmpty(), reqs, blockers)
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Bridge.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Bridge.kt
@@ -1,5 +1,7 @@
 package com.wingedsheep.tooling.coverage.bridge
 
+import com.wingedsheep.tooling.coverage.pascalToUpperSnake
+
 /**
  * The hand-authored mtgish→Argentum bridge: a mtgish IR tag mapped to the Argentum capability that
  * realises it. This is the CAPABILITY dictionary — "can Argentum express this tag?" Its sibling, the
@@ -38,6 +40,62 @@ object Bridge {
 
     /** Bare-key lookup (the emitter's rule-name keyword check). */
     operator fun get(value: String): MappingEntry? = entries[value]
+
+    /**
+     * Resolve one mtgish tag against the bridge map + the scanned SDK registries, in ONE place so the
+     * coverage [com.wingedsheep.tooling.coverage.Probe] (which renders [Resolution.status]/[Resolution.detail])
+     * and the [com.wingedsheep.tooling.coverage.Fidelity] scorer (which collects the contributed
+     * [Resolution.effectTag]/[Resolution.composedEffects]/[Resolution.keyword]) can't drift. Mirrors the
+     * per-call logic both used to inline:
+     *  - an unmapped tag whose PascalCase IS a `Keyword` enum member → auto keyword (`ok`),
+     *  - an Effect/Keyword entry → `ok` iff its SerialName is in the registry, else `MISSING`,
+     *  - a composed/envelope/supported entry → its own [MappingEntry.kind] label (never blocking),
+     *  - any other unmapped tag → `UNMAPPED` (blocking).
+     */
+    fun resolve(disc: String, value: String, effects: Set<String>, keywords: Set<String>): Resolution {
+        val entry = entry(disc, value)
+        if (entry == null) {
+            val auto = pascalToUpperSnake(value)
+            return if (auto in keywords) Resolution(disc, value, "ok", "$auto (keyword auto)", keyword = auto)
+            else Resolution(disc, value, "UNMAPPED", "")
+        }
+        return when (entry) {
+            is MappingEntry.Effect -> {
+                val ok = entry.tag in effects
+                Resolution(disc, value, if (ok) "ok" else "MISSING", entry.tag, effectTag = entry.tag.takeIf { ok })
+            }
+            is MappingEntry.Keyword -> {
+                val ok = entry.tag in keywords
+                Resolution(disc, value, if (ok) "ok" else "MISSING", entry.tag, keyword = entry.tag.takeIf { ok })
+            }
+            // Composed / Envelope / Supported: the verdict is the entry's own kind label and never blocks;
+            // its capability (if any) is the registry-present subset of `composes`, read by fidelity.
+            else -> Resolution(disc, value, entry.kind, entry.note ?: "",
+                composedEffects = entry.composes.filter { it in effects }.toSet())
+        }
+    }
+
+    /**
+     * One resolved tag, shared by the coverage probe and the fidelity scorer. [status]/[detail] are what
+     * the probe prints; [effectTag]/[composedEffects]/[keyword] are the capabilities fidelity collects.
+     */
+    data class Resolution(
+        val disc: String,
+        val value: String,
+        /** Probe verdict label: `ok` | `MISSING` | `UNMAPPED` | `composed` | `supported` | `ignore`. */
+        val status: String,
+        /** The probe's `-> detail` text (the resolved tag, the auto-keyword note, or the entry note). */
+        val detail: String,
+        /** Leaf Effect SerialName this tag contributes, present in the registry — else null. */
+        val effectTag: String? = null,
+        /** Composed primitives this tag lowers to (registry-present subset of `composes`). */
+        val composedEffects: Set<String> = emptySet(),
+        /** Keyword (mapped or PascalCase-auto) this tag contributes, present in the registry — else null. */
+        val keyword: String? = null,
+    ) {
+        /** A tag that gates coverage: an absent capability (`MISSING`) or an unrecognised tag (`UNMAPPED`). */
+        val blocking: Boolean get() = status == "MISSING" || status == "UNMAPPED"
+    }
 }
 
 /** A bridge entry. `kind` is the verdict label the probe prints; `composes` are the primitives a

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -14,6 +14,41 @@ import kotlinx.serialization.json.JsonObject
  * the Argentum target/filter DSL. A filter we can't faithfully render returns null → the card drops
  * to SCAFFOLD rather than emitting a confidently-wrong target.
  */
+
+/**
+ * Single source of truth for the filter-predicate suffixes recovered from the mtgish filter IR. The
+ * TargetFilter renderer ([creatureFilterDsl]) and the GameObjectFilter renderer ([gameObjectFilterDsl])
+ * read the SAME predicate vocabulary onto two parallel fluent surfaces; defining each predicate's
+ * regex/condition→DSL fragment ONCE here keeps them from drifting (the regexes were duplicated, and a
+ * fix in one renderer had to be mirrored by hand). Each caller still composes these in its own order —
+ * the two surfaces are not identical (TargetFilter has no multi-color form, and the renderers append in
+ * different orders) — but the per-predicate recovery now lives in one place.
+ */
+internal object FilterPredicates {
+    // mtgish encodes power bounds as `PowerIs <op> Integer`; `compact()` emits no whitespace, but the
+    // permissive `,\s*`/`:\s*` matches both spaced and compact encodings identically.
+    private val POWER_AT_LEAST = Regex(""""PowerIs".*?"GreaterThanOrEqualTo".*?"Integer",\s*"args":\s*(\d+)""")
+    private val POWER_AT_MOST = Regex(""""PowerIs".*?"LessThanOrEqualTo".*?"Integer",\s*"args":\s*(\d+)""")
+
+    /** `.powerAtLeast(N)` for a `PowerIs >= N` clause, else null. */
+    fun powerAtLeast(blob: String): String? = POWER_AT_LEAST.find(blob)?.let { ".powerAtLeast(${it.groupValues[1]})" }
+
+    /** `.powerAtMost(N)` for a `PowerIs <= N` clause, else null. */
+    fun powerAtMost(blob: String): String? = POWER_AT_MOST.find(blob)?.let { ".powerAtMost(${it.groupValues[1]})" }
+
+    fun tapped(blob: String): String? = if ("IsTapped" in blob) ".tapped()" else null
+    fun untapped(blob: String): String? = if ("IsUntapped" in blob) ".untapped()" else null
+    fun attacking(blob: String): String? = if ("IsAttacking" in blob) ".attacking()" else null
+
+    /** `.withoutKeyword(Keyword.FLYING)` for a `DoesntHaveAbility Flying` clause, else null. */
+    fun withoutFlying(filterNode: JsonElement?, blob: String): String? =
+        if (jsonContains(filterNode, "_Permanents", "DoesntHaveAbility") && "\"Flying\"" in blob)
+            ".withoutKeyword(Keyword.FLYING)" else null
+
+    /** `.withKeyword(Keyword.FLYING)` for a plain `Flying` clause, else null. */
+    fun withFlying(blob: String): String? = if ("\"Flying\"" in blob) ".withKeyword(Keyword.FLYING)" else null
+}
+
 internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String? {
     val blob = compact(filterNode)
     // "nonartifact creature" (the Terror template) renders via .nonartifact(); any OTHER non-cardtype
@@ -51,23 +86,19 @@ internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String? {
     }
     var suffix = ""
     if ("Artifact" in nonCardtypes) suffix += ".nonartifact()"
+    // Color stays inline: TargetFilter has no multi-color form, so the creature target uses the
+    // IsColor/IsNonColor-scoped single-color recovery rather than gameObjectFilterDsl's collect-all.
     Regex(""""IsNonColor".*?"_Color":\s*"(\w+)"""").find(blob)?.let {
         suffix += ".notColor(Color.${it.groupValues[1].uppercase()})"
     }
     Regex(""""IsColor".*?"_Color":\s*"(\w+)"""").find(blob)?.let {
         suffix += ".withColor(Color.${it.groupValues[1].uppercase()})"
     }
-    if (jsonContains(filterNode, "_Permanents", "DoesntHaveAbility") && "\"Flying\"" in blob) {
-        suffix += ".withoutKeyword(Keyword.FLYING)"
-    }
-    if ("IsTapped" in blob) suffix += ".tapped()"
-    if ("IsAttacking" in blob) suffix += ".attacking()"
-    Regex(""""PowerIs".*?"LessThanOrEqualTo".*?"Integer",\s*"args":\s*(\d+)""").find(blob)?.let {
-        suffix += ".powerAtMost(${it.groupValues[1]})"
-    }
-    Regex(""""PowerIs".*?"GreaterThanOrEqualTo".*?"Integer",\s*"args":\s*(\d+)""").find(blob)?.let {
-        suffix += ".powerAtLeast(${it.groupValues[1]})"
-    }
+    FilterPredicates.withoutFlying(filterNode, blob)?.let { suffix += it }
+    FilterPredicates.tapped(blob)?.let { suffix += it }
+    FilterPredicates.attacking(blob)?.let { suffix += it }
+    FilterPredicates.powerAtMost(blob)?.let { suffix += it }
+    FilterPredicates.powerAtLeast(blob)?.let { suffix += it }
     return "TargetFilter.Creature$suffix$controller"
 }
 
@@ -219,20 +250,12 @@ internal fun EmitCtx.gameObjectFilterDsl(filterNode: JsonElement?): String? {
     } else if (colors.size == 1) {
         filtered += if ("IsNonColor" in blob) ".notColor(Color.${colors[0]})" else ".withColor(Color.${colors[0]})"
     }
-    if (jsonContains(filterNode, "_Permanents", "DoesntHaveAbility") && "\"Flying\"" in blob) {
-        filtered += ".withoutKeyword(Keyword.FLYING)"
-    } else if ("\"Flying\"" in blob) {
-        filtered += ".withKeyword(Keyword.FLYING)"
-    }
-    Regex(""""PowerIs".*?"GreaterThanOrEqualTo".*?"Integer","args":(\d+)""").find(blob)?.let {
-        filtered += ".powerAtLeast(${it.groupValues[1]})"
-    }
-    Regex(""""PowerIs".*?"LessThanOrEqualTo".*?"Integer","args":(\d+)""").find(blob)?.let {
-        filtered += ".powerAtMost(${it.groupValues[1]})"
-    }
-    if ("IsTapped" in blob) filtered += ".tapped()"
-    if ("IsUntapped" in blob) filtered += ".untapped()"
-    if ("IsAttacking" in blob) filtered += ".attacking()"
+    filtered += FilterPredicates.withoutFlying(filterNode, blob) ?: FilterPredicates.withFlying(blob) ?: ""
+    FilterPredicates.powerAtLeast(blob)?.let { filtered += it }
+    FilterPredicates.powerAtMost(blob)?.let { filtered += it }
+    FilterPredicates.tapped(blob)?.let { filtered += it }
+    FilterPredicates.untapped(blob)?.let { filtered += it }
+    FilterPredicates.attacking(blob)?.let { filtered += it }
     if ("\"You\"" in blob) filtered += ".youControl()"
     if ("\"Opponent\"" in blob) filtered += ".opponentControls()"
     return filtered

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/bridge/BridgeResolveTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/bridge/BridgeResolveTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.tooling.coverage.bridge
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Locks [Bridge.resolve] — the single tag→verdict resolver shared by the coverage probe and the
+ * fidelity scorer. The fidelity capability collection (`genCaps`) has no other in-suite net, so this
+ * pins the contract both consumers derive from: the verdict label/blocking flag the probe renders and
+ * the effect/keyword capabilities fidelity collects. Uses synthetic registry sets so it depends only
+ * on the bridge map, not on the live SDK scan.
+ */
+class BridgeResolveTest : StringSpec({
+
+    // Synthetic registries: only the names a happy-path resolution needs are "present".
+    val effects = setOf("GrantProtection", "DealDamage")
+    val keywords = setOf("FLYING", "TRAMPLE")
+
+    "a Keyword entry present in the registry resolves ok and contributes the keyword" {
+        // Keywords.kt: keyword("Flying", "FLYING")
+        val r = Bridge.resolve("Keyword", "Flying", effects, keywords)
+        r.status shouldBe "ok"
+        r.detail shouldBe "FLYING"
+        r.blocking.shouldBeFalse()
+        r.keyword shouldBe "FLYING"
+        r.effectTag.shouldBeNull()
+        r.composedEffects.shouldContainExactly()
+    }
+
+    "a Keyword entry absent from the registry is MISSING and blocking, contributing nothing" {
+        // FLYING is mapped, but drop it from the synthetic registry to force the gap.
+        val r = Bridge.resolve("Keyword", "Flying", effects, keywords = emptySet())
+        r.status shouldBe "MISSING"
+        r.detail shouldBe "FLYING"
+        r.blocking.shouldBeTrue()
+        r.keyword.shouldBeNull()
+    }
+
+    "an unmapped tag whose PascalCase is a Keyword enum member auto-resolves ok" {
+        // No bridge entry for "Trample"; PascalCase→TRAMPLE is in the registry.
+        val r = Bridge.resolve("Keyword", "Trample", effects, keywords)
+        r.status shouldBe "ok"
+        r.detail shouldBe "TRAMPLE (keyword auto)"
+        r.blocking.shouldBeFalse()
+        r.keyword shouldBe "TRAMPLE"
+    }
+
+    "a fully unmapped tag is UNMAPPED and blocking" {
+        val r = Bridge.resolve("SpellAction", "SomethingNobodyMapped", effects, keywords)
+        r.status shouldBe "UNMAPPED"
+        r.detail shouldBe ""
+        r.blocking.shouldBeTrue()
+        r.keyword.shouldBeNull()
+        r.effectTag.shouldBeNull()
+    }
+
+    "a composed entry reports its kind, never blocks, and contributes its registry-present primitives" {
+        // Envelopes.kt: composed("ProtectionAndDoesntRemovePermanents", composes = ["GrantProtection"])
+        val r = Bridge.resolve("Rule", "ProtectionAndDoesntRemovePermanents", effects, keywords)
+        r.status shouldBe "composed"
+        r.blocking.shouldBeFalse()
+        r.effectTag.shouldBeNull()
+        r.composedEffects shouldBe setOf("GrantProtection")
+    }
+
+    "a composed primitive absent from the registry is dropped from the contributed capabilities" {
+        val r = Bridge.resolve("Rule", "ProtectionAndDoesntRemovePermanents", effects = emptySet(), keywords)
+        r.status shouldBe "composed"
+        r.blocking.shouldBeFalse()
+        r.composedEffects.shouldContainExactly()
+    }
+
+    "an envelope entry reports the ignore kind and never blocks" {
+        // Envelopes.kt: envelope("SpellActions", ...)
+        val r = Bridge.resolve("Rule", "SpellActions", effects, keywords)
+        r.status shouldBe "ignore"
+        r.blocking.shouldBeFalse()
+    }
+
+    "the disc:value composite key wins over the bare value key" {
+        // A disc-qualified lookup falls back to the bare key when no composite is registered.
+        val bare = Bridge.resolve("AnyDiscriminator", "Flying", effects, keywords)
+        bare.value shouldBe "Flying"
+        bare.keyword shouldBe "FLYING"
+    }
+})

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/FilterPredicatesTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/FilterPredicatesTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.tooling.coverage.emitter
+
+import com.wingedsheep.tooling.coverage.J
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Pins the shared filter-predicate recovery the two filter renderers ([creatureFilterDsl] /
+ * [gameObjectFilterDsl]) now compose, so the regex/condition→DSL fragments stay in one place. The
+ * power detector reads `compact()`'s whitespace-free encoding; the spaced inputs here confirm the
+ * permissive regex matches both forms identically.
+ */
+class FilterPredicatesTest : StringSpec({
+
+    fun node(json: String): JsonElement = J.parseToJsonElement(json)
+
+    "power bounds recover from both compact and spaced encodings" {
+        val compact = """[{"_Permanents":"PowerIs","args":["GreaterThanOrEqualTo",{"_GameNumber":"Integer","args":3}]}]"""
+        FilterPredicates.powerAtLeast(compact) shouldBe ".powerAtLeast(3)"
+        FilterPredicates.powerAtMost(compact).shouldBeNull()
+
+        val spaced = """[ {"_Permanents": "PowerIs", "args": [ "LessThanOrEqualTo", {"_GameNumber": "Integer", "args": 2} ]} ]"""
+        FilterPredicates.powerAtMost(spaced) shouldBe ".powerAtMost(2)"
+        FilterPredicates.powerAtLeast(spaced).shouldBeNull()
+    }
+
+    "tap / attack state predicates map to their fluent suffixes" {
+        FilterPredicates.tapped("""{"_Permanents":"IsTapped"}""") shouldBe ".tapped()"
+        FilterPredicates.untapped("""{"_Permanents":"IsUntapped"}""") shouldBe ".untapped()"
+        FilterPredicates.attacking("""{"_Permanents":"IsAttacking"}""") shouldBe ".attacking()"
+        FilterPredicates.tapped("{}").shouldBeNull()
+    }
+
+    "flying recovers as with/without keyword, distinguished by the DoesntHaveAbility marker" {
+        val without = node("""{"_Permanents":"DoesntHaveAbility","args":[{"_Keyword":"Flying"}]}""")
+        FilterPredicates.withoutFlying(without, J.encodeToString(JsonElement.serializer(), without)) shouldBe
+            ".withoutKeyword(Keyword.FLYING)"
+
+        val plain = node("""{"_Permanents":"HasAbility","args":[{"_Keyword":"Flying"}]}""")
+        val plainBlob = J.encodeToString(JsonElement.serializer(), plain)
+        FilterPredicates.withoutFlying(plain, plainBlob).shouldBeNull()
+        FilterPredicates.withFlying(plainBlob) shouldBe ".withKeyword(Keyword.FLYING)"
+    }
+})


### PR DESCRIPTION
Phase 2 of the `:mtgish-tooling` maintainability work (Phase 1 = #517, the hermetic emitter-regression net). This phase attacks the two duplications the review flagged: the verdict logic copy-pasted between probe and fidelity, and the two filter renderers' mirrored predicate regexes.

## 1. Centralize the tag→verdict resolution — `Bridge.resolve`

`Probe.analyze` and `Fidelity.genCaps` each inlined the *same* tag resolution — the `Bridge.entry` lookup, the PascalCase→`Keyword` auto-resolve fallback, and the Effect/Keyword/composed classification. They could silently drift (the review's exact concern), and `genCaps` had **no in-suite regression net**.

- New `Bridge.resolve(disc, value, effects, keywords): Resolution`, the single resolver. `Resolution` carries both what the probe renders (`status`/`detail`/`blocking`) and what fidelity collects (`effectTag`/`composedEffects`/`keyword`).
- Both callers now derive from it; `MappingEntry`/`pascalToUpperSnake` plumbing drops out of `Probe`/`Fidelity`.
- `BridgeResolveTest` pins the resolver across every entry kind + auto-keyword + unmapped + registry-absence — the net `genCaps` lacked.

## 2. Unify the two filter renderers — `FilterPredicates`

`creatureFilterDsl` (TargetFilter) and `gameObjectFilterDsl` (GameObjectFilter) reimplemented the same predicate recovery (power≤/≥, tapped, untapped, attacking, flying) with **subtly different regexes** — one used `,\s*`, the other didn't — so a fix in one had to be mirrored by hand.

- New `FilterPredicates` object defines each predicate's regex/condition→DSL fragment **once**; both renderers compose it.
- Each caller still appends in its own order and keeps its own color/subtype handling — the two fluent surfaces genuinely differ (TargetFilter has no multi-color form), and forcing those together would change behavior. Documented inline.
- `FilterPredicatesTest` pins the shared detectors (incl. the compact-vs-spaced encoding the unified power regex now handles).

## Verification (this is a pure refactor — zero behavior change)

- **Hermetic POR golden** (`EmitterGoldenTest`): unchanged, no re-bless.
- **Emitter output byte-for-byte identical** pre/post across **all 8 calibrated sets** (POR/INV/ONS/KTK/DOM/LGN/SCG/ARN) — verified by diffing `autogen --emit-all` drafts.
- **`fidelity --all`, per-set AUTO listings, and calibration**: byte-identical across all 8 sets.
- **POR gameplay-tree gate** (`coverage-verify`): stays **158/158, 0 mismatch, GATE PASS**.
- Full `:mtgish-tooling` test suite green (13 tests incl. the 2 new specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)