### PR TITLE
mtgish-tooling Phase 3: typed IR matcher + migrate filter/trigger/amount handlers off regex

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/IrQuery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/IrQuery.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.tooling.coverage
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Typed, scope-correct queries over the dynamic mtgish IR tree.
+ *
+ * The IR is a tree of *discriminated nodes* — each a `JsonObject` shaped `{ "_Disc": "<tag>", "args":
+ * <payload> }`, where the `_`-prefixed key names the node kind and its value is the *tag* (e.g.
+ * `{"_Permanents":"IsCreatureType","args":"Goblin"}`). Handlers historically read these by serialising a
+ * subtree with [compact] and running a regex/substring over the blob. That works but leaks scope: a blob
+ * match (`"Flying" in blob`, `Regex(""""IsCreatureType",…"""")`) sees the *whole* flattened subtree, so a
+ * marker meant for one clause can be picked up from an unrelated sibling or a nested action — the bug the
+ * scattered "scope this to the trigger, not the whole rule" comments keep fighting by hand.
+ *
+ * These accessors walk the parsed tree instead, so a query is bounded by the node you ask it on. Each is
+ * documented with the exact `compact()`+regex idiom it replaces, and every one preserves that idiom's
+ * result on the IR corpus (proven byte-identical by the emitter-regression net) — the `(\w+)` captures
+ * become a [WORD] filter, document (left-to-right blob) order is the pre-order traversal in [objects].
+ *
+ * Shared by the emitter handlers (filters / triggers / amounts) and available to the bridge.
+ */
+
+private const val ARGS = "args"
+private val WORD = Regex("""\w+""")
+
+/** Self + every descendant `JsonObject`, pre-order — i.e. the order a left-to-right scan of [compact] would
+ *  visit them (parent before children, keys in insertion order). */
+fun JsonElement?.objects(): Sequence<JsonObject> = sequence {
+    when (val n = this@objects) {
+        is JsonObject -> { yield(n); n.values.forEach { yieldAll(it.objects()) } }
+        is JsonArray -> n.forEach { yieldAll(it.objects()) }
+        else -> {}
+    }
+}
+
+/** True iff this object is a node discriminated by [tag] — carries a `"_key": "tag"` entry (the `args`
+ *  payload excluded). Key-agnostic, matching the regexes that keyed off the discriminator *value*. */
+fun JsonObject.discriminatedBy(tag: String): Boolean =
+    entries.any { (k, v) -> k != ARGS && v.asStr() == tag }
+
+/** Every node in the subtree discriminated by [tag], in document order. */
+fun JsonElement?.nodesTagged(tag: String): List<JsonObject> =
+    objects().filter { it.discriminatedBy(tag) }.toList()
+
+/** True iff any node in the subtree is discriminated by [tag] — the typed form of `"tag" in compact(node)`
+ *  for a `tag` that is a discriminator value (e.g. `"IsTapped" in blob`). */
+fun JsonElement?.hasTag(tag: String): Boolean = objects().any { it.discriminatedBy(tag) }
+
+/** The single-word `args` string of every node discriminated by [tag], document order — the typed
+ *  replacement for `Regex(""""tag","args":"(\w+)"""").findAll(compact(node))`. Non-word args (multi-token
+ *  strings, arrays, objects) are skipped, mirroring the `(\w+)` capture's failure to match them. */
+fun JsonElement?.argWordsTagged(tag: String): List<String> =
+    nodesTagged(tag).mapNotNull { it[ARGS].asStr()?.takeIf(WORD::matches) }
+
+/** The first single-word `args` of a node discriminated by [tag], or null. The `.find()`-then-group-1
+ *  form of [argWordsTagged]. */
+fun JsonElement?.firstArgWordTagged(tag: String): String? = argWordsTagged(tag).firstOrNull()
+
+/** The full `args` string of the first node discriminated by [tag] (any string, mirroring a `[^"]+`
+ *  capture rather than `(\w+)`), or null. */
+fun JsonElement?.firstArgStringTagged(tag: String): String? =
+    nodesTagged(tag).firstOrNull()?.get(ARGS).asStr()
+
+/** Every single-word string value at key [key] in the subtree, document order — the typed form of
+ *  `Regex(""""key":"(\w+)"""").findAll(compact(node))` (e.g. all `_Color` values). */
+fun JsonElement?.wordsAtKey(key: String): List<String> =
+    objects().mapNotNull { it[key].asStr()?.takeIf(WORD::matches) }.toList()
+
+/** The first single-word value at [key] anywhere in the subtree, or null. */
+fun JsonElement?.firstWordAtKey(key: String): String? = wordsAtKey(key).firstOrNull()
+
+/** The first single-word `_Color`-keyed value inside the first node discriminated by [tag] (e.g. the
+ *  colour carried by an `IsColor` / `IsNonColor` clause), or null — the scoped, node-bounded form of
+ *  `Regex(""""tag".*?"_Color":\s*"(\w+)"""")`. */
+fun JsonElement?.firstColorOf(tag: String): String? =
+    nodesTagged(tag).firstOrNull()?.firstWordAtKey("_Color")
+
+/** True iff any string-primitive *value* in the subtree equals [value] — the typed form of
+ *  `"\"value\"" in compact(node)` (keys are `_`-prefixed / `args`, so only values can match). */
+fun JsonElement?.hasStringValue(value: String): Boolean = anyStringValue { it == value }
+
+private fun JsonElement?.anyStringValue(pred: (String) -> Boolean): Boolean = when (this) {
+    is JsonObject -> values.any { it.anyStringValue(pred) }
+    is JsonArray -> any { it.anyStringValue(pred) }
+    is JsonPrimitive -> isString && pred(content)
+    else -> false
+}

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.argWordsTagged
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.compact
@@ -224,7 +225,7 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         jsonContains(trig, "_Player", "You") && jsonContains(trig, "_Comparison", "GreaterThanOrEqualTo")
     ) {
         val blob = compact(trig)
-        val plainCreature = """"IsCardtype",\s*"args":\s*"Creature"""".toRegex().containsMatchIn(blob) &&
+        val plainCreature = "Creature" in trig.argWordsTagged("IsCardtype") &&
             "IsCreatureType" !in blob && "ControlledByAPlayer" !in blob && "\"Other\"" !in blob && "_Color" !in blob
         val n = findInteger(trig) as? Int
         if (plainCreature && n != null) return "TriggerSpec(EventPattern.YouAttackEvent(minAttackers = $n), TriggerBinding.ANY)"
@@ -258,7 +259,7 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     // "Whenever you cast a [type] spell" — WhenAPlayerCastsASpell scoped to You + a spell-type filter.
     if (jsonContains(trig, "_Trigger", "WhenAPlayerCastsASpell") && jsonContains(trig, "_Player", "You")) {
         if (jsonContains(trig, "_Spells", "IsHistoric")) return "Triggers.YouCastHistoric"
-        val types = Regex(""""IsCardtype",\s*"args":\s*"(\w+)"""").findAll(compact(trig)).map { it.groupValues[1] }.toSet()
+        val types = trig.argWordsTagged("IsCardtype").toSet()
         return when (types) {
             setOf("Creature") -> "Triggers.YouCastCreature"
             setOf("Enchantment") -> "Triggers.YouCastEnchantment"
@@ -277,8 +278,8 @@ private fun isSelf(trig: JsonObject): Boolean =
 /** True when a trigger's permanent filter is a plain "creature" with no subtype / controller / count
  *  restriction — the only attacks shape we can render as a filterless ANY-binding trigger. */
 private fun isPlainCreatureFilter(trig: JsonObject): Boolean {
+    if ("Creature" !in trig.argWordsTagged("IsCardtype")) return false
     val blob = compact(trig)
-    if (""""IsCardtype",\s*"args":\s*"Creature"""".toRegex().containsMatchIn(blob).not()) return false
     return "IsCreatureType" !in blob && "ControlledByAPlayer" !in blob &&
         "\"Other\"" !in blob && "_Comparison" !in blob && "_Color" !in blob
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.findRef
 import com.wingedsheep.tooling.coverage.findRefIn
+import com.wingedsheep.tooling.coverage.firstArgWordTagged
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
 import com.wingedsheep.tooling.coverage.strField
@@ -172,7 +173,7 @@ internal fun EmitCtx.dynamicAmount(node: JsonElement?): String? {
         }
         // "for each Goblin/Bird/Elf on the battlefield": a creature subtype, which the land-oriented
         // search filter misses; otherwise fall back to the land/type search filter.
-        val subtype = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").find(compact(node))?.groupValues?.get(1)
+        val subtype = node.firstArgWordTagged("IsCreatureType")
         val filter = if (subtype != null) "GameObjectFilter.Creature.withSubtype(\"$subtype\")" else landSearchFilterDsl(node)
         return "DynamicAmount.AggregateBattlefield($player, $filter)"
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -1,11 +1,19 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.argWordsTagged
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
+import com.wingedsheep.tooling.coverage.firstArgStringTagged
+import com.wingedsheep.tooling.coverage.firstColorOf
+import com.wingedsheep.tooling.coverage.firstWordAtKey
+import com.wingedsheep.tooling.coverage.hasStringValue
+import com.wingedsheep.tooling.coverage.hasTag
 import com.wingedsheep.tooling.coverage.jsonContains
+import com.wingedsheep.tooling.coverage.nodesTagged
 import com.wingedsheep.tooling.coverage.strField
 import com.wingedsheep.tooling.coverage.subtypes
+import com.wingedsheep.tooling.coverage.wordsAtKey
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
@@ -19,41 +27,46 @@ import kotlinx.serialization.json.JsonObject
  * Single source of truth for the filter-predicate suffixes recovered from the mtgish filter IR. The
  * TargetFilter renderer ([creatureFilterDsl]) and the GameObjectFilter renderer ([gameObjectFilterDsl])
  * read the SAME predicate vocabulary onto two parallel fluent surfaces; defining each predicate's
- * regex/condition→DSL fragment ONCE here keeps them from drifting (the regexes were duplicated, and a
- * fix in one renderer had to be mirrored by hand). Each caller still composes these in its own order —
- * the two surfaces are not identical (TargetFilter has no multi-color form, and the renderers append in
+ * IR→DSL recovery ONCE here keeps them from drifting (the regexes were duplicated, and a fix in one
+ * renderer had to be mirrored by hand). Each caller still composes these in its own order — the two
+ * surfaces are not identical (TargetFilter has no multi-color form, and the renderers append in
  * different orders) — but the per-predicate recovery now lives in one place.
+ *
+ * Each predicate reads the parsed filter subtree through the typed [IrQuery][hasTag] accessors (bounded
+ * by the node, vs. a `compact()`+substring/regex that scanned the whole flattened blob).
  */
 internal object FilterPredicates {
-    // mtgish encodes power bounds as `PowerIs <op> Integer`; `compact()` emits no whitespace, but the
-    // permissive `,\s*`/`:\s*` matches both spaced and compact encodings identically.
-    private val POWER_AT_LEAST = Regex(""""PowerIs".*?"GreaterThanOrEqualTo".*?"Integer",\s*"args":\s*(\d+)""")
-    private val POWER_AT_MOST = Regex(""""PowerIs".*?"LessThanOrEqualTo".*?"Integer",\s*"args":\s*(\d+)""")
-
     /** `.powerAtLeast(N)` for a `PowerIs >= N` clause, else null. */
-    fun powerAtLeast(blob: String): String? = POWER_AT_LEAST.find(blob)?.let { ".powerAtLeast(${it.groupValues[1]})" }
+    fun powerAtLeast(node: JsonElement?): String? = powerBound(node, "GreaterThanOrEqualTo")?.let { ".powerAtLeast($it)" }
 
     /** `.powerAtMost(N)` for a `PowerIs <= N` clause, else null. */
-    fun powerAtMost(blob: String): String? = POWER_AT_MOST.find(blob)?.let { ".powerAtMost(${it.groupValues[1]})" }
+    fun powerAtMost(node: JsonElement?): String? = powerBound(node, "LessThanOrEqualTo")?.let { ".powerAtMost($it)" }
 
-    fun tapped(blob: String): String? = if ("IsTapped" in blob) ".tapped()" else null
-    fun untapped(blob: String): String? = if ("IsUntapped" in blob) ".untapped()" else null
-    fun attacking(blob: String): String? = if ("IsAttacking" in blob) ".attacking()" else null
+    fun tapped(node: JsonElement?): String? = if (node.hasTag("IsTapped")) ".tapped()" else null
+    fun untapped(node: JsonElement?): String? = if (node.hasTag("IsUntapped")) ".untapped()" else null
+    fun attacking(node: JsonElement?): String? = if (node.hasTag("IsAttacking")) ".attacking()" else null
 
     /** `.withoutKeyword(Keyword.FLYING)` for a `DoesntHaveAbility Flying` clause, else null. */
-    fun withoutFlying(filterNode: JsonElement?, blob: String): String? =
-        if (jsonContains(filterNode, "_Permanents", "DoesntHaveAbility") && "\"Flying\"" in blob)
+    fun withoutFlying(node: JsonElement?): String? =
+        if (jsonContains(node, "_Permanents", "DoesntHaveAbility") && node.hasStringValue("Flying"))
             ".withoutKeyword(Keyword.FLYING)" else null
 
     /** `.withKeyword(Keyword.FLYING)` for a plain `Flying` clause, else null. */
-    fun withFlying(blob: String): String? = if ("\"Flying\"" in blob) ".withKeyword(Keyword.FLYING)" else null
+    fun withFlying(node: JsonElement?): String? = if (node.hasStringValue("Flying")) ".withKeyword(Keyword.FLYING)" else null
+
+    /** The integer bound of a `PowerIs` clause whose `args` is `{ _Comparison: <comparison>, args: Integer }`,
+     *  scoped to the matching `PowerIs` node so a power range's two bounds stay distinct. */
+    private fun powerBound(node: JsonElement?, comparison: String): Int? =
+        node.nodesTagged("PowerIs")
+            .firstOrNull { it["args"].strField("_Comparison") == comparison }
+            ?.let { findInteger(it["args"]) as? Int }
 }
 
 internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String? {
     val blob = compact(filterNode)
     // "nonartifact creature" (the Terror template) renders via .nonartifact(); any OTHER non-cardtype
     // restriction has no faithful filter rendering yet, so drop to SCAFFOLD rather than omit it.
-    val nonCardtypes = Regex(""""IsNonCardtype",\s*"args":\s*"(\w+)"""").findAll(blob).map { it.groupValues[1] }.toList()
+    val nonCardtypes = filterNode.argWordsTagged("IsNonCardtype")
     if (nonCardtypes.any { it != "Artifact" }) return null
     // "target creature you control" / "...an opponent controls" — the controller restriction is a
     // ControlledByAPlayer clause. Preserve it as a `.youControl()` / `.opponentControls()` suffix; never
@@ -79,7 +92,7 @@ internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String? {
     }
     // "Goblin creature" / "Elf or Soldier creature": one subtype -> withSubtype; several -> an Or of
     // per-subtype creature filters (matches golden's distributed Or[And[IsCreature, HasSubtype X]…]).
-    val subs = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").findAll(blob).map { it.groupValues[1] }.toList()
+    val subs = filterNode.argWordsTagged("IsCreatureType")
     if (subs.isNotEmpty()) {
         if (controller.isNotEmpty()) return null
         return "TargetFilter(${subs.joinToString(" or ") { "GameObjectFilter.Creature.withSubtype(\"$it\")" }})"
@@ -88,22 +101,17 @@ internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String? {
     if ("Artifact" in nonCardtypes) suffix += ".nonartifact()"
     // Color stays inline: TargetFilter has no multi-color form, so the creature target uses the
     // IsColor/IsNonColor-scoped single-color recovery rather than gameObjectFilterDsl's collect-all.
-    Regex(""""IsNonColor".*?"_Color":\s*"(\w+)"""").find(blob)?.let {
-        suffix += ".notColor(Color.${it.groupValues[1].uppercase()})"
-    }
-    Regex(""""IsColor".*?"_Color":\s*"(\w+)"""").find(blob)?.let {
-        suffix += ".withColor(Color.${it.groupValues[1].uppercase()})"
-    }
-    FilterPredicates.withoutFlying(filterNode, blob)?.let { suffix += it }
-    FilterPredicates.tapped(blob)?.let { suffix += it }
-    FilterPredicates.attacking(blob)?.let { suffix += it }
-    FilterPredicates.powerAtMost(blob)?.let { suffix += it }
-    FilterPredicates.powerAtLeast(blob)?.let { suffix += it }
+    filterNode.firstColorOf("IsNonColor")?.let { suffix += ".notColor(Color.${it.uppercase()})" }
+    filterNode.firstColorOf("IsColor")?.let { suffix += ".withColor(Color.${it.uppercase()})" }
+    FilterPredicates.withoutFlying(filterNode)?.let { suffix += it }
+    FilterPredicates.tapped(filterNode)?.let { suffix += it }
+    FilterPredicates.attacking(filterNode)?.let { suffix += it }
+    FilterPredicates.powerAtMost(filterNode)?.let { suffix += it }
+    FilterPredicates.powerAtLeast(filterNode)?.let { suffix += it }
     return "TargetFilter.Creature$suffix$controller"
 }
 
-private fun targetTypes(args: JsonElement?): Set<String> =
-    Regex(""""IsCardtype",\s*"args":\s*"(\w+)"""").findAll(compact(args)).map { it.groupValues[1] }.toSet()
+private fun targetTypes(args: JsonElement?): Set<String> = args.argWordsTagged("IsCardtype").toSet()
 
 /** Faithful Argentum target DSL, or null if the filter can't be rendered (-> not AUTO). */
 internal fun EmitCtx.targetDsl(tnode: JsonObject, actionContext: List<JsonObject>? = null): String? {
@@ -222,7 +230,7 @@ internal fun EmitCtx.gameObjectFilterDsl(filterNode: JsonElement?): String? {
     val types = targetTypes(filterNode)
     val subs = subtypes(filterNode)
     // Creature subtypes come from IsCreatureType (subtypes() only collects land/card subtypes).
-    val creatureSubs = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").findAll(blob).map { it.groupValues[1] }.toList()
+    val creatureSubs = filterNode.argWordsTagged("IsCreatureType")
     var filtered = when {
         subs.isNotEmpty() && ("Land" in types || "IsLandType" in blob || "\"Land\"" in blob) ->
             "GameObjectFilter.Land.withSubtype(${subtypeArg(subs[0])})"
@@ -244,27 +252,26 @@ internal fun EmitCtx.gameObjectFilterDsl(filterNode: JsonElement?): String? {
         "Permanent" in blob -> "GameObjectFilter.Permanent"
         else -> return null
     }
-    val colors = Regex(""""_Color":\s*"(\w+)"""").findAll(blob).map { it.groupValues[1].uppercase() }.distinct().toList()
+    val colors = filterNode.wordsAtKey("_Color").map { it.uppercase() }.distinct()
     if (colors.size > 1 && "\"Or\"" in blob) {
         filtered += ".withAnyColor(${colors.joinToString(", ") { "Color.$it" }})"
     } else if (colors.size == 1) {
-        filtered += if ("IsNonColor" in blob) ".notColor(Color.${colors[0]})" else ".withColor(Color.${colors[0]})"
+        filtered += if (filterNode.hasTag("IsNonColor")) ".notColor(Color.${colors[0]})" else ".withColor(Color.${colors[0]})"
     }
-    filtered += FilterPredicates.withoutFlying(filterNode, blob) ?: FilterPredicates.withFlying(blob) ?: ""
-    FilterPredicates.powerAtLeast(blob)?.let { filtered += it }
-    FilterPredicates.powerAtMost(blob)?.let { filtered += it }
-    FilterPredicates.tapped(blob)?.let { filtered += it }
-    FilterPredicates.untapped(blob)?.let { filtered += it }
-    FilterPredicates.attacking(blob)?.let { filtered += it }
+    filtered += FilterPredicates.withoutFlying(filterNode) ?: FilterPredicates.withFlying(filterNode) ?: ""
+    FilterPredicates.powerAtLeast(filterNode)?.let { filtered += it }
+    FilterPredicates.powerAtMost(filterNode)?.let { filtered += it }
+    FilterPredicates.tapped(filterNode)?.let { filtered += it }
+    FilterPredicates.untapped(filterNode)?.let { filtered += it }
+    FilterPredicates.attacking(filterNode)?.let { filtered += it }
     if ("\"You\"" in blob) filtered += ".youControl()"
     if ("\"Opponent\"" in blob) filtered += ".opponentControls()"
     return filtered
 }
 
 internal fun EmitCtx.revealedHandFilterDsl(filterNode: JsonElement?): String? {
-    val blob = compact(filterNode)
-    val landType = Regex(""""IsLandType","args":"([^"]+)"""").find(blob)?.groupValues?.get(1)
-    val color = Regex(""""_Color":"(\w+)"""").find(blob)?.groupValues?.get(1)
+    val landType = filterNode.firstArgStringTagged("IsLandType")
+    val color = filterNode.firstWordAtKey("_Color")
     if (landType == null && color == null) return null
     val parts = mutableListOf<String>()
     if (landType != null) parts.add("GameObjectFilter.Land.withSubtype(${subtypeArg(landType)})")
@@ -288,7 +295,7 @@ internal fun EmitCtx.landSearchFilterDsl(filterNode: JsonElement?): String {
         "\"Creature\"" in blob || "creature" in oracle -> {
             var out = "GameObjectFilter.Creature"
             if ("black creature" in oracle) out += ".withColor(Color.BLACK)"
-            else Regex(""""_Color":\s*"(\w+)"""").find(blob)?.let { out += ".withColor(Color.${it.groupValues[1].uppercase()})" }
+            else filterNode.firstWordAtKey("_Color")?.let { out += ".withColor(Color.${it.uppercase()})" }
             if ("tapped creature" in oracle) out += ".tapped()"
             if ("attacking" in oracle) out += ".attacking()"
             out

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/IrQueryTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/IrQueryTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.tooling.coverage
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Locks the typed IR matcher ([IrQuery]) — the scope-correct accessors the emitter's filter / trigger /
+ * amount handlers read the mtgish IR through, replacing the `compact()`+regex/substring idiom. Each spec
+ * pins both the value the accessor recovers AND the scope discipline that a flattened-blob match lacked
+ * (a tag is matched as a discriminator value, not as an arbitrary substring of the serialised subtree).
+ */
+class IrQueryTest : StringSpec({
+
+    fun node(json: String): JsonElement = J.parseToJsonElement(json)
+
+    "argWordsTagged collects each tagged node's word arg in document order" {
+        // The `Or[Goblin, Soldier]` creature-subtype shape: two IsCreatureType nodes.
+        val filter = node(
+            """{"_Filter":"Or","args":[""" +
+                """{"_Permanents":"IsCreatureType","args":"Goblin"},""" +
+                """{"_Permanents":"IsCreatureType","args":"Soldier"}]}""",
+        )
+        filter.argWordsTagged("IsCreatureType") shouldBe listOf("Goblin", "Soldier")
+        filter.firstArgWordTagged("IsCreatureType") shouldBe "Goblin"
+        filter.argWordsTagged("IsCardtype") shouldBe emptyList()
+    }
+
+    "argWordsTagged skips non-word args, mirroring the (\\w+) capture" {
+        // An args that is a nested object (not a string word) does not count.
+        val n = node("""{"_Permanents":"IsCreatureType","args":{"_Ref":"ThatCreature"}}""")
+        n.argWordsTagged("IsCreatureType") shouldBe emptyList()
+    }
+
+    "hasTag matches a discriminator value, not a substring of a longer tag" {
+        node("""{"_Permanents":"IsTapped"}""").hasTag("IsTapped").shouldBeTrue()
+        // "IsUntapped" must NOT satisfy hasTag("IsTapped") — substring `"IsTapped" in blob` likewise
+        // wouldn't, but a careless `Tapped` check would; the typed form is exact by construction.
+        node("""{"_Permanents":"IsUntapped"}""").hasTag("IsTapped").shouldBeFalse()
+        node("""{"_Permanents":"IsUntapped"}""").hasTag("IsUntapped").shouldBeTrue()
+    }
+
+    "wordsAtKey / firstColorOf read values at a key, scoping the colour to its clause" {
+        val anyColor = node(
+            """{"_Filter":"Or","args":[""" +
+                """{"_Permanents":"IsColor","args":{"_Color":"White"}},""" +
+                """{"_Permanents":"IsColor","args":{"_Color":"Blue"}}]}""",
+        )
+        anyColor.wordsAtKey("_Color") shouldBe listOf("White", "Blue")
+        anyColor.firstColorOf("IsColor") shouldBe "White"
+
+        val nonColor = node("""{"_Permanents":"IsNonColor","args":{"_Color":"Red"}}""")
+        nonColor.firstColorOf("IsNonColor") shouldBe "Red"
+        nonColor.firstColorOf("IsColor").shouldBeNull()  // IsColor must not match IsNonColor
+    }
+
+    "hasStringValue matches a string VALUE anywhere, the typed form of a quoted-token blob check" {
+        val flying = node("""{"_Permanents":"DoesntHaveAbility","args":[{"_Keyword":"Flying"}]}""")
+        flying.hasStringValue("Flying").shouldBeTrue()
+        flying.hasStringValue("Trample").shouldBeFalse()
+    }
+
+    "firstArgStringTagged returns the full arg string (a [^\"]+ capture, not just a word)" {
+        val n = node("""{"_CardsInLibrary":"IsLandType","args":"Island"}""")
+        n.firstArgStringTagged("IsLandType") shouldBe "Island"
+        n.firstArgStringTagged("IsCreatureType").shouldBeNull()
+    }
+})

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/FilterPredicatesTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/FilterPredicatesTest.kt
@@ -8,39 +8,51 @@ import kotlinx.serialization.json.JsonElement
 
 /**
  * Pins the shared filter-predicate recovery the two filter renderers ([creatureFilterDsl] /
- * [gameObjectFilterDsl]) now compose, so the regex/condition→DSL fragments stay in one place. The
- * power detector reads `compact()`'s whitespace-free encoding; the spaced inputs here confirm the
- * permissive regex matches both forms identically.
+ * [gameObjectFilterDsl]) compose, so the IR→DSL fragments stay in one place. The predicates now read the
+ * parsed filter subtree through the typed [com.wingedsheep.tooling.coverage] IrQuery accessors (the
+ * power bound is scoped to its `PowerIs` node), rather than regexing a flattened blob.
  */
 class FilterPredicatesTest : StringSpec({
 
     fun node(json: String): JsonElement = J.parseToJsonElement(json)
 
-    "power bounds recover from both compact and spaced encodings" {
-        val compact = """[{"_Permanents":"PowerIs","args":["GreaterThanOrEqualTo",{"_GameNumber":"Integer","args":3}]}]"""
-        FilterPredicates.powerAtLeast(compact) shouldBe ".powerAtLeast(3)"
-        FilterPredicates.powerAtMost(compact).shouldBeNull()
+    // mtgish encodes a power bound as `PowerIs { _Comparison, args: Integer }` (Fleet-Footed Monk's
+    // "creatures with power 2 or greater").
+    fun powerIs(comparison: String, n: Int): String =
+        """{"_Permanents":"PowerIs","args":{"_Comparison":"$comparison","args":{"_GameNumber":"Integer","args":$n}}}"""
 
-        val spaced = """[ {"_Permanents": "PowerIs", "args": [ "LessThanOrEqualTo", {"_GameNumber": "Integer", "args": 2} ]} ]"""
-        FilterPredicates.powerAtMost(spaced) shouldBe ".powerAtMost(2)"
-        FilterPredicates.powerAtLeast(spaced).shouldBeNull()
+    "power bounds recover from the scoped PowerIs node" {
+        val atLeast = node(powerIs("GreaterThanOrEqualTo", 3))
+        FilterPredicates.powerAtLeast(atLeast) shouldBe ".powerAtLeast(3)"
+        FilterPredicates.powerAtMost(atLeast).shouldBeNull()
+
+        val atMost = node(powerIs("LessThanOrEqualTo", 2))
+        FilterPredicates.powerAtMost(atMost) shouldBe ".powerAtMost(2)"
+        FilterPredicates.powerAtLeast(atMost).shouldBeNull()
+    }
+
+    "a power range keeps its two bounds distinct (scoped per PowerIs node)" {
+        // power >= 2 AND power <= 4: each bound must read its OWN PowerIs clause, not the nearest integer.
+        val range = node("""[${powerIs("GreaterThanOrEqualTo", 2)},${powerIs("LessThanOrEqualTo", 4)}]""")
+        FilterPredicates.powerAtLeast(range) shouldBe ".powerAtLeast(2)"
+        FilterPredicates.powerAtMost(range) shouldBe ".powerAtMost(4)"
     }
 
     "tap / attack state predicates map to their fluent suffixes" {
-        FilterPredicates.tapped("""{"_Permanents":"IsTapped"}""") shouldBe ".tapped()"
-        FilterPredicates.untapped("""{"_Permanents":"IsUntapped"}""") shouldBe ".untapped()"
-        FilterPredicates.attacking("""{"_Permanents":"IsAttacking"}""") shouldBe ".attacking()"
-        FilterPredicates.tapped("{}").shouldBeNull()
+        FilterPredicates.tapped(node("""{"_Permanents":"IsTapped"}""")) shouldBe ".tapped()"
+        FilterPredicates.untapped(node("""{"_Permanents":"IsUntapped"}""")) shouldBe ".untapped()"
+        FilterPredicates.attacking(node("""{"_Permanents":"IsAttacking"}""")) shouldBe ".attacking()"
+        FilterPredicates.tapped(node("{}")).shouldBeNull()
+        // IsUntapped must not be mistaken for IsTapped (substring containment would have).
+        FilterPredicates.tapped(node("""{"_Permanents":"IsUntapped"}""")).shouldBeNull()
     }
 
     "flying recovers as with/without keyword, distinguished by the DoesntHaveAbility marker" {
         val without = node("""{"_Permanents":"DoesntHaveAbility","args":[{"_Keyword":"Flying"}]}""")
-        FilterPredicates.withoutFlying(without, J.encodeToString(JsonElement.serializer(), without)) shouldBe
-            ".withoutKeyword(Keyword.FLYING)"
+        FilterPredicates.withoutFlying(without) shouldBe ".withoutKeyword(Keyword.FLYING)"
 
         val plain = node("""{"_Permanents":"HasAbility","args":[{"_Keyword":"Flying"}]}""")
-        val plainBlob = J.encodeToString(JsonElement.serializer(), plain)
-        FilterPredicates.withoutFlying(plain, plainBlob).shouldBeNull()
-        FilterPredicates.withFlying(plainBlob) shouldBe ".withKeyword(Keyword.FLYING)"
+        FilterPredicates.withoutFlying(plain).shouldBeNull()
+        FilterPredicates.withFlying(plain) shouldBe ".withKeyword(Keyword.FLYING)"
     }
 })


### PR DESCRIPTION
Phase 3 of the `:mtgish-tooling` maintainability sequence (Phase 1 = hermetic regression net #517; Phase 2 = centralized verdict + unified filter renderers #519). This is the review's item 3: **introduce a typed matcher layer over the IR and migrate the hot paths (filters, triggers, amounts) off `compact()`+regex.**

## The problem

Emitter handlers read the dynamic mtgish IR by serialising a subtree with `compact()` and running a regex/substring over the flattened blob. That works but leaks scope — a blob match sees the *whole* subtree, so a marker meant for one clause can be picked up from an unrelated sibling or a nested action. It's the bug the scattered "scope this to the trigger, not the whole rule" comments keep fighting by hand, and the same `Regex(""""tag","args":"(\w+)"""")` discriminator→args idiom was hand-rolled in 7 places with subtly different whitespace.

## What changed

**`IrQuery.kt`** (new) — a small typed accessor library that walks the parsed tree, so a query is bounded by the node it's asked on. Each accessor documents the exact `compact()`+regex idiom it replaces and reproduces its result on the corpus: `argWordsTagged`, `wordsAtKey`/`firstColorOf`, `hasTag`, `hasStringValue`, `firstArgStringTagged`.

**Migrated the three hot paths onto it:**
- **filters** (`TargetRecovery`): `targetTypes` (IsCardtype), the IsCreatureType / IsNonCardtype subtype scans, the `_Color` / IsColor / IsNonColor colour recovery, and `FilterPredicates` — now typed `JsonElement?` instead of a blob string, with the power bound scoped to its own `PowerIs` node so a power range keeps its two bounds distinct.
- **triggers** (`CardStructure`): the IsCardtype spell-type set and the two plain-creature IsCardtype checks.
- **amounts** (`EmitCtx`): the for-each IsCreatureType subtype.

## Proven behavior-preserving

This is a pure refactor; correctness is the regression net, leaned on hard:
- `autogen --emit-all` **byte-for-byte identical** across all 8 calibrated sets (POR/INV/ONS/KTK/DOM/LGN/SCG/ARN — 754 drafts, same aggregate hash)
- `fidelity --all` byte-identical
- hermetic `EmitterGoldenTest` passes (no re-bless)
- POR gameplay-tree gate stays **158/158, 0 mismatch**
- full `:mtgish-tooling` suite green (incl. new `IrQueryTest` + the typed `FilterPredicatesTest`)

The golden net earned its keep mid-migration: it caught that `PowerIs` `args` is an object `{_Comparison, args:Integer}`, not the `[comparison, int]` array I first assumed (Fleet-Footed Monk lost its `.powerAtLeast(2)`), which I then fixed.

## Scope / follow-ups

This converts the value-extraction idiom and the filter-predicate vocabulary. The loose `"x" in blob` presence checks in the non-extraction branches are deliberately left as a follow-up — converting them changes substring-vs-typed scope semantics, which is a behavior change better done as its own reviewable step. Remaining review items: per-handler table tests (4) and the output AST (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)