### PR TITLE
Add Mm'menon, the Right Hand to Edge of Eternities

### DIFF
--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 257 / 261
+**Implemented:** 258 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -143,7 +143,7 @@
 - [x] Memorial Vault
 - [x] Mental Modulation
 - [x] Mightform Harmonizer
-- [ ] Mm'menon, the Right Hand
+- [x] Mm'menon, the Right Hand
 - [x] Mm'menon, Uthros Exile
 - [x] Molecular Modifier
 - [x] Monoist Circuit-Feeder

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2450,6 +2450,10 @@ restriction matches the spell context.
   variant). Maelstrom of the Spirit Dragon: `SubtypeSpellsOnly(setOf("Dragon", "Omen"))`
   ("a Dragon spell or an Omen spell").
 - `ManaRestriction.CastFromExileOnly` — only spells cast from exile.
+- `ManaRestriction.CastFromNonHandOnly` — only spells cast from anywhere other than
+  hand (exile, graveyard, top of library, command zone, …). Mm'menon, the Right Hand's
+  granted artifact mana ability. Generalizes `CastFromExileOnly` by allowing all non-hand
+  origins instead of exile alone; rejects ability activations.
 - `ManaRestriction.CardTypeSpellsOrAbilitiesOnly(cardType, allowSpells?, allowAbilities?)` —
   Steelswarm Operator shape.
 

--- a/manual-scenarios/cards/m/mmmenon-the-right-hand.json
+++ b/manual-scenarios/cards/m/mmmenon-the-right-hand.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Cryogen Relic"],
+    "battlefield": [
+      {"name": "Mm'menon, the Right Hand"},
+      {"name": "Cryogen Relic"},
+      {"name": "Cryogen Relic"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Cryogen Relic", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
@@ -112,6 +112,21 @@ sealed interface ManaRestriction {
     }
 
     /**
+     * "Spend this mana only to cast a spell from anywhere other than your hand."
+     *
+     * Used by Mm'menon, the Right Hand's granted artifact ability. Generalizes
+     * [CastFromExileOnly] by accepting any non-hand origin (exile, graveyard, top of
+     * library, command zone, …), not exile alone — mirroring the printed text. Rejects
+     * ability activations (the oracle says "cast a spell," not "activate an ability").
+     */
+    @SerialName("CastFromNonHandOnly")
+    @Serializable
+    data object CastFromNonHandOnly : ManaRestriction {
+        override val description: String =
+            "Spend this mana only to cast a spell from anywhere other than your hand"
+    }
+
+    /**
      * "Spend this mana only to cast a spell that has any of the given subtypes."
      *
      * Generalizes [SubtypeSpellsOrAbilitiesOnly] to a *set* of subtypes joined by OR, for

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MmmenonTheRightHand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MmmenonTheRightHand.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Mm'menon, the Right Hand
+ * {3}{U}{U}
+ * Legendary Creature — Jellyfish Advisor
+ * 3/4
+ *
+ * Flying
+ * You may look at the top card of your library any time.
+ * You may cast artifact spells from the top of your library.
+ * Artifacts you control have "{T}: Add {U}. Spend this mana only to cast a spell
+ *   from anywhere other than your hand."
+ */
+val MmmenonTheRightHand = card("Mm'menon, the Right Hand") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Jellyfish Advisor"
+    oracleText = "Flying\n" +
+        "You may look at the top card of your library any time.\n" +
+        "You may cast artifact spells from the top of your library.\n" +
+        "Artifacts you control have \"{T}: Add {U}. Spend this mana only to cast a spell from anywhere other than your hand.\""
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = LookAtTopOfLibrary
+    }
+
+    staticAbility {
+        ability = CastSpellTypesFromTopOfLibrary(filter = GameObjectFilter.Artifact)
+    }
+
+    // The granted ability is a mana ability (single colored payment, no triggers). The
+    // CastFromNonHandOnly restriction is enforced by ManaPool.isSatisfiedBy: only spell
+    // casts whose SpellPaymentContext reports isFromHand=false consume this mana, so the
+    // {U} can pay for casts from exile/graveyard/library/command zone but not from hand,
+    // and never for activated-ability costs.
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                cost = Costs.Tap,
+                effect = Effects.AddMana(Color.BLUE, 1, restriction = ManaRestriction.CastFromNonHandOnly),
+                isManaAbility = true
+            ),
+            filter = GroupFilter(GameObjectFilter.Artifact.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "68"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82add0a0-e402-4b31-b101-81c0bf332015.jpg?1752946825"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -10083,6 +10083,55 @@
     ]
 }
 
+// Mm'menon, the Right Hand
+{
+    "name": "Mm'menon, the Right Hand",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Legendary Creature — Jellyfish Advisor",
+    "oracleText": "Flying\nYou may look at the top card of your library any time.\nYou may cast artifact spells from the top of your library.\nArtifacts you control have \"{T}: Add {U}. Spend this mana only to cast a spell from anywhere other than your hand.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            "LookAtTopOfLibrary",
+            {
+                "type": "CastSpellTypesFromTopOfLibrary",
+                "filter": "artifact"
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "BLUE",
+                        "restriction": "CastFromNonHandOnly"
+                    },
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": "artifact ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "rarity": "RARE",
+        "artist": "Joshua Raphael",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/82add0a0-e402-4b31-b101-81c0bf332015.jpg?1752946825"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Molecular Modifier
 {
     "name": "Molecular Modifier",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -657,6 +657,7 @@ class CastSpellHandler(
                 hasXInCost = cardComponent.manaCost.hasX,
                 subtypes = cardComponent.typeLine.subtypes.map { it.value }.toSet(),
                 isFromExile = isCastFromExile(state, action.cardId),
+                isFromHand = isCastFromHand(state, action.cardId),
                 cardTypes = cardComponent.typeLine.cardTypes,
             )
         } else null
@@ -752,6 +753,9 @@ class CastSpellHandler(
 
     private fun isCastFromExile(state: GameState, cardId: EntityId): Boolean =
         state.turnOrder.any { ownerId -> cardId in state.getZone(ZoneKey(ownerId, Zone.EXILE)) }
+
+    private fun isCastFromHand(state: GameState, cardId: EntityId): Boolean =
+        state.turnOrder.any { ownerId -> cardId in state.getZone(ZoneKey(ownerId, Zone.HAND)) }
 
     private fun validateConspire(
         state: GameState,
@@ -1946,6 +1950,7 @@ class CastSpellHandler(
             hasXInCost = cardComponent.manaCost.hasX,
             subtypes = cardComponent.typeLine.subtypes.map { it.value }.toSet(),
             isFromExile = isCastFromExile(currentState, action.cardId),
+            isFromHand = isCastFromHand(currentState, action.cardId),
             cardTypes = cardComponent.typeLine.cardTypes,
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -1750,6 +1750,10 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 hasXInCost = cardComponent.manaCost.hasX,
                 subtypes = cardComponent.typeLine.subtypes.map { it.value }.toSet(),
                 cardTypes = cardComponent.typeLine.cardTypes,
+                // This enumerator only enumerates non-hand-zone casts (command, library, exile,
+                // graveyard, …) — `sourceZone` is never "HAND" here. Mark accordingly so
+                // [ManaRestriction.CastFromNonHandOnly] mana is eligible for the kicked variant.
+                isFromHand = false,
             )
             val canAffordKickedMana = context.manaSolver.canPay(
                 state, playerId, kickedCost,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
@@ -35,6 +35,16 @@ data class SpellPaymentContext(
     val isAbilityActivation: Boolean = false,
     /** Card types of the source whose ability is being activated (empty for spell-cast contexts). */
     val abilitySourceCardTypes: Set<com.wingedsheep.sdk.core.CardType> = emptySet(),
+    /**
+     * True when the spell is being cast from the caster's hand. Defaults to `true` because most
+     * spell casts originate from hand and the standard [CastSpellEnumerator] path is hand-only;
+     * cast-from-non-hand paths (top of library, exile, graveyard, command zone) must set this to
+     * `false` so restrictions like [ManaRestriction.CastFromNonHandOnly] recognize the cast.
+     *
+     * The field is irrelevant for ability activations because every restriction that reads it
+     * also requires `!isAbilityActivation`.
+     */
+    val isFromHand: Boolean = true,
 )
 
 /**
@@ -52,6 +62,7 @@ fun ManaRestriction.isSatisfiedBy(context: SpellPaymentContext): Boolean = when 
         (!creatureOnly || (!context.isAbilityActivation && context.isCreature)) &&
             context.subtypes.any { it.equals(subtype, ignoreCase = true) }
     is ManaRestriction.CastFromExileOnly -> !context.isAbilityActivation && context.isFromExile
+    is ManaRestriction.CastFromNonHandOnly -> !context.isAbilityActivation && !context.isFromHand
     is ManaRestriction.SubtypeSpellsOnly ->
         !context.isAbilityActivation &&
             subtypes.any { sub -> context.subtypes.any { it.equals(sub, ignoreCase = true) } }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/mana/ManaSpendRestrictionOnlyToCastSpellsFromNonHandTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/mana/ManaSpendRestrictionOnlyToCastSpellsFromNonHandTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.handlers.mana
+
+import com.wingedsheep.engine.mechanics.mana.ManaPool
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * BDD test: restricted mana annotated with [ManaRestriction.CastFromNonHandOnly] (Mm'menon,
+ * the Right Hand's granted artifact mana) must satisfy any spell cast originating outside
+ * the caster's hand — exile, graveyard, top of library, command zone — but never a hand
+ * cast and never an activated-ability payment.
+ *
+ * GIVEN  A player's mana pool contains one mana annotated with CastFromNonHandOnly
+ * AND    The cost of a hypothetical {U} spell or ability
+ * WHEN   The engine validates payment with several spell payment contexts
+ * THEN   Hand-cast and ability-activation contexts reject the payment
+ * AND    Exile / graveyard / library / command-zone casts accept it (default isFromExile only
+ *        differentiates exile-specific restrictions; CastFromNonHandOnly looks at isFromHand)
+ */
+class ManaSpendRestrictionOnlyToCastSpellsFromNonHandTest : FunSpec({
+
+    val cost = ManaCost.parse("{U}")
+    val pool = ManaPool().addRestricted(Color.BLUE, 1, ManaRestriction.CastFromNonHandOnly)
+
+    test("CastFromNonHandOnly rejects hand cast") {
+        // Default context has isFromHand = true (most spells originate from hand).
+        pool.canPay(cost, SpellPaymentContext()) shouldBe false
+    }
+
+    test("CastFromNonHandOnly accepts non-hand casts (graveyard / library / exile / command zone)") {
+        // CastSpellHandler sets isFromHand = false for cast paths that don't originate in the
+        // caster's hand; from the restriction's perspective the specific non-hand zone does not
+        // matter. The isFromExile flag is set additionally so the existing exile-specific
+        // restriction can be tested independently in [ManaSpendRestrictionOnlyToCastSpellsFromExileTest].
+        val fromExile = SpellPaymentContext(isFromHand = false, isFromExile = true)
+        val fromNonExileNonHand = SpellPaymentContext(isFromHand = false, isFromExile = false)
+
+        pool.canPay(cost, fromExile) shouldBe true
+        pool.canPay(cost, fromNonExileNonHand) shouldBe true
+    }
+
+    test("CastFromNonHandOnly rejects ability activation regardless of isFromHand") {
+        // "Spend this mana only to cast a spell" — abilities don't count even when the source
+        // isn't in hand (which is the normal case for activated abilities anyway).
+        val abilityFromNonHand = SpellPaymentContext(isAbilityActivation = true, isFromHand = false)
+        pool.canPay(cost, abilityFromNonHand) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MmmenonTheRightHandTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MmmenonTheRightHandTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario test for Mm'menon, the Right Hand ({3}{U}{U}, 3/4 Legendary Creature — Jellyfish Advisor):
+ *   Flying
+ *   You may look at the top card of your library any time.
+ *   You may cast artifact spells from the top of your library.
+ *   Artifacts you control have "{T}: Add {U}. Spend this mana only to cast a spell from anywhere
+ *     other than your hand."
+ *
+ * Anchors the integration claim that the unit
+ * [com.wingedsheep.engine.handlers.mana.ManaSpendRestrictionOnlyToCastSpellsFromNonHandTest] makes
+ * at the [com.wingedsheep.engine.mechanics.mana.ManaPool] level: that
+ * [com.wingedsheep.sdk.scripting.effects.ManaRestriction.CastFromNonHandOnly] mana, sourced through
+ * Mm'menon's granted artifact ability, funds a top-of-library cast but does NOT fund a hand cast of
+ * the same spell. The symmetry depends on `SpellPaymentContext.isFromHand` being populated by
+ * [com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler] (true for hand casts, false for
+ * the non-hand paths) and the source's restriction being honoured during enumeration.
+ */
+class MmmenonTheRightHandTest : ScenarioTestBase() {
+
+    init {
+        context("Mm'menon, the Right Hand — restricted artifact mana funds non-hand casts only") {
+
+            test("top-of-library artifact cast is legal when only restricted-mana sources are available") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mm'menon, the Right Hand")
+                    .withCardOnBattlefield(1, "Cryogen Relic")
+                    .withCardOnBattlefield(1, "Cryogen Relic")
+                    .withCardInLibrary(1, "Cryogen Relic")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val topOfLibrary = game.state.getLibrary(game.player1Id).first()
+                withClue("Top of library must be the Cryogen Relic we seeded") {
+                    game.state.getEntity(topOfLibrary)?.get<CardComponent>()?.name shouldBe "Cryogen Relic"
+                }
+
+                val legalActions = game.getLegalActions(1)
+
+                val topOfLibraryCast = legalActions.find { info ->
+                    info.actionType == "CastSpell" &&
+                        info.sourceZone == "LIBRARY" &&
+                        (info.action as? CastSpell)?.cardId == topOfLibrary
+                }
+                withClue(
+                    "Top-of-library Cryogen Relic should be castable using Mm'menon's granted {U} " +
+                        "mana from the two on-battlefield artifacts (no other mana exists). " +
+                        "If this fails, the granted ability isn't reaching artifacts you control " +
+                        "or CastFromNonHandOnly mana is being filtered out of non-hand cast " +
+                        "enumeration."
+                ) {
+                    topOfLibraryCast shouldNotBe null
+                }
+            }
+
+            test("hand-cast of the same spell is NOT legal — restricted mana stays out of hand-cast enumeration") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mm'menon, the Right Hand")
+                    .withCardOnBattlefield(1, "Cryogen Relic")
+                    .withCardOnBattlefield(1, "Cryogen Relic")
+                    .withCardInHand(1, "Cryogen Relic")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handCryogenRelic = game.state.getHand(game.player1Id).single { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Cryogen Relic"
+                }
+
+                val legalActions = game.getLegalActions(1)
+
+                val handCast = legalActions.find { info ->
+                    info.actionType == "CastSpell" &&
+                        (info.action as? CastSpell)?.cardId == handCryogenRelic
+                }
+                withClue(
+                    "Hand Cryogen Relic must NOT be castable from only CastFromNonHandOnly mana — " +
+                        "if it is, the restriction is leaking past hand-cast enumeration."
+                ) {
+                    handCast shouldBe null
+                }
+            }
+
+            test("executing the top-of-library cast taps the artifacts and puts the spell on the stack") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mm'menon, the Right Hand")
+                    .withCardOnBattlefield(1, "Cryogen Relic")
+                    .withCardOnBattlefield(1, "Cryogen Relic")
+                    .withCardInLibrary(1, "Cryogen Relic")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val topOfLibrary = game.state.getLibrary(game.player1Id).first()
+
+                val result = game.execute(CastSpell(game.player1Id, topOfLibrary))
+                withClue("CastSpell from top of library should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                withClue("Cryogen Relic should be on the stack after the cast") {
+                    game.state.stack.contains(topOfLibrary) shouldBe true
+                }
+                withClue("Cryogen Relic should no longer be in the library after going to the stack") {
+                    game.state.getLibrary(game.player1Id).contains(topOfLibrary) shouldBe false
+                }
+
+                // Both artifacts must have been tapped to produce the {1}{U} payment — the only
+                // mana sources available were the two CastFromNonHandOnly producers.
+                val onBattlefieldRelics = game.findPermanents("Cryogen Relic")
+                val tappedRelics = onBattlefieldRelics.count { entityId ->
+                    game.state.getEntity(entityId)
+                        ?.has<com.wingedsheep.engine.state.components.battlefield.TappedComponent>() == true
+                }
+                withClue("Both on-battlefield Cryogen Relics should be tapped to fund the cast") {
+                    tappedRelics shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a new ManaRestriction.CastFromNonHandOnly for the granted artifact mana ability ({T}: Add {U}. Spend this mana only to cast a spell from anywhere other than your hand.). The check generalizes CastFromExileOnly: any non-hand origin (exile, graveyard, top of library, command zone) qualifies, and ability activations are rejected.

SpellPaymentContext gains an isFromHand flag (default true) populated by CastSpellHandler from the card's current zone; CastFromZoneEnumerator's kicker variant sets it to false since that path only enumerates non-hand casts.

Covered by ManaSpendRestrictionOnlyToCastSpellsFromNonHandTest (ManaPool predicate, with hand / non-hand / ability-activation cases) and the new MmmenonTheRightHandTest scenario, which anchors the integration claim end-to-end: a top-of-library artifact cast is legal when the only mana available is sourced through the granted artifact ability, the symmetric hand-cast of the same spell is NOT legal, and executing the cast taps both artifact sources and lands the spell on the stack.