### PR TITLE
mtgish-tooling: typed output AST (the emitter's full card tree)

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Dsl.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Dsl.kt
@@ -70,9 +70,11 @@ fun arg(name: String, text: String): Arg = Arg(Lit(text), name)
 fun call(callee: String, vararg args: Arg): Call = Call(callee, args.toList())
 
 /** `base.method(args…)` — a single-link chain. */
-fun Dsl.dot(method: String, vararg args: Arg): Chain =
-    if (this is Chain) Chain(base, links + Link(method, args.toList()))
-    else Chain(this, listOf(Link(method, args.toList())))
+fun Dsl.dot(method: String, vararg args: Arg): Chain = dot(Link(method, args.toList()))
+
+/** Append a pre-built [Link] to this receiver as a chain. */
+fun Dsl.dot(link: Link): Chain =
+    if (this is Chain) Chain(base, links + link) else Chain(this, listOf(link))
 
 // ---------------------------------------------------------------------------
 // Rendering — the single node → pre-wrap source text mapping.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Dsl.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Dsl.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.tooling.coverage
+
+/**
+ * The emitter's typed OUTPUT model — a tiny AST for the Argentum cardDef DSL the emitter generates.
+ *
+ * The emitter translates the (untyped, irregular) mtgish IR into Argentum DSL *source*. That output is
+ * a single, regular language, so it earns a typed tree: handlers build [Dsl] nodes instead of
+ * interpolating strings, and [render] is the ONE place a node becomes text. This kills the per-handler
+ * `"Name($a, $b)"` string-stitching (every comma/quote/paren hand-placed) in favour of structural
+ * construction that's unit-testable without asserting on whitespace.
+ *
+ * Note this models the OUTPUT only — it is NOT a shared IR between mtgish and Argentum, so the lossy,
+ * many-to-one mtgish→Argentum mapping stays where it belongs: inside the handlers, which decide WHICH
+ * node to build. A shape with no faithful Argentum rendering still returns null (→ SCAFFOLD).
+ *
+ * [render] reproduces the emitter's historical *pre-wrap* line strings exactly: a [Call] is one line,
+ * only [Composite] is multi-line (mirroring the old `composite()` helper). The downstream
+ * `Shells.assemble` pass (`wrapLine` + `importsFor`) then reflows long lines and derives imports as
+ * before — so swapping a handler from string-building to node-building is a behaviour-free change,
+ * provable against the committed golden. [Raw] is the escape hatch for an already-formatted fragment a
+ * node doesn't model yet (e.g. the hand-indented look-and-distribute literal).
+ */
+sealed interface Dsl
+
+/** A literal token rendered verbatim: an enum ref (`Color.WHITE`), an int, the bound `t` target var,
+ *  a string literal, or any sub-expression still carried as text. */
+data class Lit(val text: String) : Dsl
+
+/** A call/constructor expression `callee(arg, name = arg, …)`. [callee] may be dotted
+ *  (`Effects.DrawCards`, `Patterns.Library.surveil`). No args → `callee()`. */
+data class Call(val callee: String, val args: List<Arg> = emptyList()) : Dsl
+
+/** A receiver with chained `.method(args)` links: `base.withSubtype("Goblin").tapped()`. */
+data class Chain(val base: Dsl, val links: List<Link>) : Dsl
+
+/** One `.method(args)` link in a [Chain]. */
+data class Link(val method: String, val args: List<Arg> = emptyList())
+
+/** An infix chain `a op b op c`, optionally wrapped in parens (the filter `or`). */
+data class Infix(val op: String, val parts: List<Dsl>, val parenthesized: Boolean = false) : Dsl
+
+/** `Effects.Composite(...)` with one element per line — the one intrinsically multi-line node, matching
+ *  the historical `composite()` layout (12-space element indent, 8-space close). Callers pass ≥2 parts. */
+data class Composite(val parts: List<Dsl>) : Dsl
+
+/** Verbatim, already-formatted source for a shape no node models yet. The pressure-relief valve that
+ *  lets the tree coexist with un-migrated output; such fragments still flow through `wrapLine`/`importsFor`. */
+data class Raw(val text: String) : Dsl
+
+/** A positional (name == null) or named (`name = value`) argument. */
+data class Arg(val value: Dsl, val name: String? = null)
+
+// ---------------------------------------------------------------------------
+// Construction helpers — keep handler call-sites terse.
+// ---------------------------------------------------------------------------
+
+/** A positional argument from a node. */
+fun arg(value: Dsl): Arg = Arg(value)
+
+/** A positional argument from a literal token. */
+fun arg(text: String): Arg = Arg(Lit(text))
+
+/** A named argument from a node. */
+fun arg(name: String, value: Dsl): Arg = Arg(value, name)
+
+/** A named argument from a literal token. */
+fun arg(name: String, text: String): Arg = Arg(Lit(text), name)
+
+/** `callee(args…)` from inline [Arg]s. */
+fun call(callee: String, vararg args: Arg): Call = Call(callee, args.toList())
+
+/** `base.method(args…)` — a single-link chain. */
+fun Dsl.dot(method: String, vararg args: Arg): Chain =
+    if (this is Chain) Chain(base, links + Link(method, args.toList()))
+    else Chain(this, listOf(Link(method, args.toList())))
+
+// ---------------------------------------------------------------------------
+// Rendering — the single node → pre-wrap source text mapping.
+// ---------------------------------------------------------------------------
+
+/** Render a node to the emitter's historical pre-wrap line string (one line except [Composite]). */
+fun render(node: Dsl): String = when (node) {
+    is Lit -> node.text
+    is Raw -> node.text
+    is Call -> node.callee + "(" + node.args.joinToString(", ") { renderArg(it) } + ")"
+    is Chain -> render(node.base) + node.links.joinToString("") { link ->
+        "." + link.method + "(" + link.args.joinToString(", ") { renderArg(it) } + ")"
+    }
+    is Infix -> {
+        val joined = node.parts.joinToString(" ${node.op} ") { render(it) }
+        if (node.parenthesized) "($joined)" else joined
+    }
+    // Matches the old `composite()`: prefix, each element at 12 spaces, comma-separated, 8-space close.
+    is Composite -> node.parts.joinToString(
+        ",\n", prefix = "Effects.Composite(\n", postfix = "\n        )",
+    ) { "            ${render(it)}" }
+}
+
+private fun renderArg(a: Arg): String = (a.name?.let { "$it = " } ?: "") + render(a.value)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Dsl.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Dsl.kt
@@ -51,6 +51,53 @@ data class Raw(val text: String) : Dsl
 data class Arg(val value: Dsl, val name: String? = null)
 
 // ---------------------------------------------------------------------------
+// Statement / block layer — the card-body structure above the expression nodes.
+// An expression [Dsl] renders to ONE token/line; a [Stmt]/[Block] renders to indented source LINES
+// (an ability builder block, the metadata block, the whole `card(...) { }`). This is what lets the
+// emitter assemble a card as a single tree instead of stitching `List<String>` line lists.
+// ---------------------------------------------------------------------------
+
+/** One line (or builder block) inside a [Block] body. */
+sealed interface Stmt
+
+/** `name = <value>` (e.g. `effect = …`, `cost = …`, `auraTarget = …`). */
+data class Assign(val name: String, val value: Dsl) : Stmt
+
+/** `val name = <value>` (e.g. `val t = target("target", …)`). */
+data class Local(val name: String, val value: Dsl) : Stmt
+
+/** A bare expression statement: `<value>` (e.g. `keywordAbility(…)`, `flags(…)`, `dynamicStats(…)`). */
+data class Eval(val value: Dsl) : Stmt
+
+/** A nested builder block as a statement (`spell { … }`, `staticAbility { … }`, `metadata { … }`). */
+data class Sub(val block: Block) : Stmt
+
+/** A pre-formatted verbatim line — the shell scaffolding (mana/typeline/KDoc/metadata text) and the
+ *  occasional multi-line restriction list a node doesn't model yet. The [Stmt]-level [Raw]. */
+data class RawLine(val text: String) : Stmt
+
+/** A `header { body }` builder block (an ability, the metadata block, the whole card). */
+data class Block(val header: String, val body: List<Stmt>)
+
+/** Render a [Block] to source lines at [indent]; the body sits one level (4 spaces) deeper. */
+fun renderBlock(block: Block, indent: String = ""): List<String> {
+    val out = mutableListOf("$indent${block.header} {")
+    block.body.forEach { out += renderStmt(it, "$indent    ") }
+    out += "$indent}"
+    return out
+}
+
+/** Render one [Stmt] to source lines at [indent]. A [RawLine] is emitted verbatim (it already carries
+ *  its own indentation); everything else is placed at [indent]. */
+fun renderStmt(stmt: Stmt, indent: String): List<String> = when (stmt) {
+    is Assign -> listOf("$indent${stmt.name} = ${render(stmt.value)}")
+    is Local -> listOf("${indent}val ${stmt.name} = ${render(stmt.value)}")
+    is Eval -> listOf("$indent${render(stmt.value)}")
+    is Sub -> renderBlock(stmt.block, indent)
+    is RawLine -> listOf(stmt.text)
+}
+
+// ---------------------------------------------------------------------------
 // Construction helpers — keep handler call-sites terse.
 // ---------------------------------------------------------------------------
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ActionHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ActionHandlers.kt
@@ -1,5 +1,7 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Lit
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
@@ -21,12 +23,14 @@ import kotlinx.serialization.json.JsonObject
 // top-level `val` is initialised. Eager init can cycle: a handler file's val calls `actionHandlers`
 // (defined here), which forces this sum to read that same val before it finishes initialising.
 internal val ACTION_HANDLERS: Map<String, ActionHandler> by lazy {
-    damageDrawLifeHandlers + zoneHandlers + tapLayerStateHandlers + playerContinuousHandlers +
-        manaHandlers + tokenHandlers
+    buildMap<String, ActionHandler> {
+        putAll(damageDrawLifeHandlers); putAll(zoneHandlers); putAll(tapLayerStateHandlers)
+        putAll(playerContinuousHandlers); putAll(manaHandlers); putAll(tokenHandlers)
+    }
 }
 
-/** A per-`_Action` rendering rule. Returns the Effect DSL string, or null → SCAFFOLD. */
-internal typealias ActionHandler = EmitCtx.(node: JsonObject, args: JsonElement?, tvar: String?) -> String?
+/** A per-`_Action` rendering rule. Returns the Effect [Dsl] node it emits, or null → SCAFFOLD. */
+internal typealias ActionHandler = EmitCtx.(node: JsonObject, args: JsonElement?, tvar: String?) -> Dsl?
 
 /** Fluent builder shared by every themed handler file (mirrors `bridge.BridgeBuilder`). */
 internal class ActionRegistry {
@@ -35,8 +39,8 @@ internal class ActionRegistry {
     /** Register a handler under one or more tags. */
     fun on(vararg tags: String, handler: ActionHandler) = tags.forEach { map[it] = handler }
 
-    /** A constant 1:1 effect — `tag → fixed DSL string` (imports auto-derived from the string). */
-    fun simple(vararg tags: String, dsl: String) = on(*tags) { _, _, _ -> dsl }
+    /** A constant 1:1 effect — `tag → fixed DSL token` rendered as a [Lit] (imports auto-derived). */
+    fun simple(vararg tags: String, dsl: String) = on(*tags) { _, _, _ -> Lit(dsl) }
 
     fun build(): Map<String, ActionHandler> = map
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
+import com.wingedsheep.tooling.coverage.render
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -110,7 +111,7 @@ private fun EmitCtx.conditionalSpell(card: JsonObject): List<String>? {
     val inner = if (body != null && body.size > 1 && body[1] is JsonArray) (body[1] as JsonArray).filterIsInstance<JsonObject>() else null
     if (inner == null) return null
     val edsl = renderEffectList(inner, null) ?: return null
-    return listOf("    spell {", "        condition = $cond", "        effect = $edsl", "    }")
+    return listOf("    spell {", "        condition = $cond", "        effect = ${render(edsl)}", "    }")
 }
 
 internal fun EmitCtx.spellBlock(card: JsonObject): List<String>? {
@@ -119,10 +120,10 @@ internal fun EmitCtx.spellBlock(card: JsonObject): List<String>? {
     // silently drop the rest, so scaffold the whole card rather than emit one arm of a modal spell.
     if ("\"Modal_" in compact(card["Rules"])) { reasons.add("modal-spell"); return null }
     // One-line `effect =` shortcuts, then whole-block shortcuts, then the generic envelope path.
-    eachplayerMaydraw(card)?.let { return spellOf(it) }
-    fluxEffect(card)?.let { return spellOf(it) }
-    windsEffect(card)?.let { return spellOf(it) }
-    extraTurnEffect(card)?.let { return spellOf(it) }
+    eachplayerMaydraw(card)?.let { return spellOf(render(it)) }
+    fluxEffect(card)?.let { return spellOf(render(it)) }
+    windsEffect(card)?.let { return spellOf(render(it)) }
+    extraTurnEffect(card)?.let { return spellOf(render(it)) }
     distributedSpell(card)?.let { return it }
     balanceEffect(card)?.let { return it }
     conditionalSpell(card)?.let { return it }
@@ -134,7 +135,7 @@ internal fun EmitCtx.spellBlock(card: JsonObject): List<String>? {
     val edsl = renderEffectList(actions, tvar) ?: return null
     val restrictions = castRestrictionLines((card["Rules"].asArr ?: JsonArray(emptyList())).filterIsInstance<JsonObject>()) ?: return null
     val inner = if (tvar != null) listOf("        val t = target(\"target\", $tdsl)") else emptyList()
-    return listOf("    spell {") + restrictions + inner + listOf("        effect = $edsl", "    }")
+    return listOf("    spell {") + restrictions + inner + listOf("        effect = ${render(edsl)}", "    }")
 }
 
 private fun spellOf(effect: String) = listOf("    spell {", "        effect = $effect", "    }")
@@ -177,7 +178,7 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false
     if (oncePerTurn) lines.add("        oncePerTurn = true")
     if (mayWrapped && !selfOptional) lines.add("        optional = true")
     if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
-    lines.addAll(listOf("        effect = $edsl", "    }"))
+    lines.addAll(listOf("        effect = ${render(edsl)}", "    }"))
     return lines
 }
 
@@ -339,7 +340,7 @@ internal fun EmitCtx.fromAnyZoneBlock(rule: JsonObject): List<String>? {
     val lines = mutableListOf("    triggeredAbility {", "        trigger = Triggers.YouCycleThis")
     if (mayWrapped) lines.add("        optional = true")
     if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
-    lines.addAll(listOf("        effect = $edsl", "    }"))
+    lines.addAll(listOf("        effect = ${render(edsl)}", "    }"))
     return lines
 }
 
@@ -358,7 +359,7 @@ internal fun EmitCtx.activatedBlock(rule: JsonObject): List<String>? {
     val lines = mutableListOf("    activatedAbility {", "        cost = $cost")
     activationRestrictionLines(rule)?.let { lines.addAll(it) } ?: return null
     if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
-    lines.add("        effect = $edsl")
+    lines.add("        effect = ${render(edsl)}")
     // A ReplaceNextDraw effect ("the next time you would draw … instead") prompts on the replaced draw,
     // not at activation — the activated-ability flag the Words cycle's golden carries.
     if (actions.any { it.strField("_Action") == "CreateFutureReplaceWouldDraw" }) lines.add("        promptOnDraw = true")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1,13 +1,23 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Assign
+import com.wingedsheep.tooling.coverage.Block
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Eval
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.Local
+import com.wingedsheep.tooling.coverage.RawLine
+import com.wingedsheep.tooling.coverage.Stmt
+import com.wingedsheep.tooling.coverage.Sub
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.argWordsTagged
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asStr
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
-import com.wingedsheep.tooling.coverage.render
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -41,13 +51,16 @@ internal fun extractEnvelope(node: JsonElement?): Pair<List<JsonObject>?, List<J
     return foundTargets to foundActions
 }
 
-/** (tdsl, tvar) for an envelope's targets; (null,null) if unrenderable; ("",null) if none. */
-internal fun EmitCtx.spellTarget(targets: List<JsonObject>?, actions: List<JsonObject>? = null): Pair<String?, String?> {
-    if (targets.isNullOrEmpty()) return "" to null
-    if (targets.size > 1) { reasons.add("multi-target"); return null to null }
-    val tdsl = targetDsl(targets[0], actions) ?: run { reasons.add("target:${targets[0].strField("_Target")}"); return null to null }
-    return tdsl to "t"
+/** (targetNode, tvar) for an envelope's targets; null if unrenderable (bail); (null, null) if none. */
+internal fun EmitCtx.spellTargetExpr(targets: List<JsonObject>?, actions: List<JsonObject>? = null): Pair<Dsl?, String?>? {
+    if (targets.isNullOrEmpty()) return null to null
+    if (targets.size > 1) { reasons.add("multi-target"); return null }
+    val t = targetExpr(targets[0], actions) ?: run { reasons.add("target:${targets[0].strField("_Target")}"); return null }
+    return t to "t"
 }
+
+/** `val t = target("target", <node>)` — the bound-target local statement. */
+private fun targetLocal(node: Dsl): Stmt = Local("t", call("target", arg("\"target\""), arg(node)))
 
 private fun EmitCtx.conditionDsl(ifNode: JsonElement?): String? {
     val blob = compact(ifNode)
@@ -102,7 +115,7 @@ private fun EmitCtx.castRestrictionLines(rules: List<JsonObject>): List<String>?
 }
 
 /** Top-level `If{cond}[effect]` -> spell `condition =` gate + the inner effect (Gift of Estates). */
-private fun EmitCtx.conditionalSpell(card: JsonObject): List<String>? {
+private fun EmitCtx.conditionalSpell(card: JsonObject): List<Stmt>? {
     val (_, actions) = extractEnvelope(card["Rules"])
     if (actions == null || actions.size != 1 || actions[0].strField("_Action") != "If") return null
     val ifNode = actions[0]
@@ -111,34 +124,36 @@ private fun EmitCtx.conditionalSpell(card: JsonObject): List<String>? {
     val inner = if (body != null && body.size > 1 && body[1] is JsonArray) (body[1] as JsonArray).filterIsInstance<JsonObject>() else null
     if (inner == null) return null
     val edsl = renderEffectList(inner, null) ?: return null
-    return listOf("    spell {", "        condition = $cond", "        effect = ${render(edsl)}", "    }")
+    return listOf(Sub(Block("spell", listOf(Assign("condition", Lit(cond)), Assign("effect", edsl)))))
 }
 
-internal fun EmitCtx.spellBlock(card: JsonObject): List<String>? {
+internal fun EmitCtx.spellBlock(card: JsonObject): List<Stmt>? {
     // Modal spells ("Choose one —", "Choose up to four", …) carry a `Modal_*` envelope whose children
     // are the individual modes. The generic envelope path below would grab only the FIRST mode and
     // silently drop the rest, so scaffold the whole card rather than emit one arm of a modal spell.
     if ("\"Modal_" in compact(card["Rules"])) { reasons.add("modal-spell"); return null }
     // One-line `effect =` shortcuts, then whole-block shortcuts, then the generic envelope path.
-    eachplayerMaydraw(card)?.let { return spellOf(render(it)) }
-    fluxEffect(card)?.let { return spellOf(render(it)) }
-    windsEffect(card)?.let { return spellOf(render(it)) }
-    extraTurnEffect(card)?.let { return spellOf(render(it)) }
+    eachplayerMaydraw(card)?.let { return spellOf(it) }
+    fluxEffect(card)?.let { return spellOf(it) }
+    windsEffect(card)?.let { return spellOf(it) }
+    extraTurnEffect(card)?.let { return spellOf(it) }
     distributedSpell(card)?.let { return it }
     balanceEffect(card)?.let { return it }
     conditionalSpell(card)?.let { return it }
 
     val (targets, actions) = extractEnvelope(card["Rules"])
     if (actions == null) return null
-    val (tdsl, tvar) = spellTarget(targets, actions)
-    if (tdsl == null) return null
+    val (tnode, tvar) = spellTargetExpr(targets, actions) ?: return null
     val edsl = renderEffectList(actions, tvar) ?: return null
     val restrictions = castRestrictionLines((card["Rules"].asArr ?: JsonArray(emptyList())).filterIsInstance<JsonObject>()) ?: return null
-    val inner = if (tvar != null) listOf("        val t = target(\"target\", $tdsl)") else emptyList()
-    return listOf("    spell {") + restrictions + inner + listOf("        effect = ${render(edsl)}", "    }")
+    val stmts = mutableListOf<Stmt>()
+    restrictions.forEach { stmts.add(RawLine(it)) }
+    if (tvar != null) stmts.add(targetLocal(tnode!!))
+    stmts.add(Assign("effect", edsl))
+    return listOf(Sub(Block("spell", stmts)))
 }
 
-private fun spellOf(effect: String) = listOf("    spell {", "        effect = $effect", "    }")
+private fun spellOf(effect: Dsl): List<Stmt> = listOf(Sub(Block("spell", listOf(Assign("effect", effect)))))
 
 /** mtgish actions whose Argentum rendering already embeds the "you may" choice (so a wrapping
  *  MayAction must NOT also set the ability's `optional = true`). */
@@ -155,12 +170,11 @@ private val TRIGGER_SPEC = mapOf(
 /** A TriggerA rule (self-triggered) -> triggeredAbility { trigger; [target]; effect }.
  *  [oncePerTurn] is set by the `TriggerOnceEachTurn` rule envelope, whose body is otherwise shaped
  *  identically to a TriggerA. */
-internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false): List<String>? {
+internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false): List<Stmt>? {
     val spec = triggerSpecFor(rule) ?: run { reasons.add("trigger-shape"); return null }
     val (targets, actions) = extractEnvelope(rule)
     if (actions == null) { reasons.add("trigger-actions"); return null }
-    val (tdsl, tvar) = spellTarget(targets, actions)
-    if (tdsl == null) return null
+    val (tnode, tvar) = spellTargetExpr(targets, actions) ?: return null
 
     // "you may [do X]" on a triggered ability is an OPTIONAL ability (declined at announcement /
     // by choosing no targets), not a resolution-time MayEffect. Unwrap a lone MayAction so the
@@ -174,12 +188,12 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false
     val selfOptional = mayInner?.strField("_Action") in SELF_OPTIONAL_ACTIONS
     val edsl = renderEffectList(effectActions, tvar) ?: return null
 
-    val lines = mutableListOf("    triggeredAbility {", "        trigger = $spec")
-    if (oncePerTurn) lines.add("        oncePerTurn = true")
-    if (mayWrapped && !selfOptional) lines.add("        optional = true")
-    if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
-    lines.addAll(listOf("        effect = ${render(edsl)}", "    }"))
-    return lines
+    val stmts = mutableListOf<Stmt>(Assign("trigger", Lit(spec)))
+    if (oncePerTurn) stmts.add(Assign("oncePerTurn", Lit("true")))
+    if (mayWrapped && !selfOptional) stmts.add(Assign("optional", Lit("true")))
+    if (tvar != null) stmts.add(targetLocal(tnode!!))
+    stmts.add(Assign("effect", edsl))
+    return listOf(Sub(Block("triggeredAbility", stmts)))
 }
 
 /** The triggered-ability trigger spec for a TriggerA / TriggerOnceEachTurn rule, or null (-> SCAFFOLD)
@@ -290,14 +304,14 @@ private fun isPlainCreatureFilter(trig: JsonObject): Boolean {
  * `dynamicStats(...)` line, when both power and toughness are the same dynamic count (the
  * power-and-toughness-equal-to-the-number-of-X cycle). Differing power/toughness amounts scaffold.
  */
-internal fun EmitCtx.cdaStatsBlock(card: JsonObject, rule: JsonObject): List<String>? {
+internal fun EmitCtx.cdaStatsBlock(card: JsonObject, rule: JsonObject): List<Stmt>? {
     val toughnessRule = (card["Rules"].asArr ?: JsonArray(emptyList()))
         .filterIsInstance<JsonObject>().firstOrNull { it.strField("_Rule") == "CDA_Toughness" }
     if (toughnessRule == null || compact(rule["args"]) != compact(toughnessRule["args"])) {
         reasons.add("CDA_Power"); return null
     }
-    val amount = dynamicAmount(rule["args"]) ?: run { reasons.add("CDA_Power"); return null }
-    return listOf("    dynamicStats($amount)")
+    val amount = dynamicAmountExpr(rule["args"]) ?: run { reasons.add("CDA_Power"); return null }
+    return listOf(Eval(call("dynamicStats", arg(amount))))
 }
 
 /**
@@ -305,19 +319,19 @@ internal fun EmitCtx.cdaStatsBlock(card: JsonObject, rule: JsonObject): List<Str
  * `_ReplacementActionWouldEnter` nodes (enters tapped, choose a creature type as it enters, ...).
  * Any replacement we can't render exactly downgrades the card to SCAFFOLD rather than guess.
  */
-internal fun EmitCtx.asEntersBlock(rule: JsonObject): List<String>? {
+internal fun EmitCtx.asEntersBlock(rule: JsonObject): List<Stmt>? {
     val replacements = (rule["args"].asArr?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
     if (replacements.isNullOrEmpty()) { reasons.add("AsPermanentEnters"); return null }
-    val lines = mutableListOf<String>()
+    val stmts = mutableListOf<Stmt>()
     for (rep in replacements) {
-        val dsl = when (rep.strField("_ReplacementActionWouldEnter")) {
-            "EntersTapped" -> "EntersTapped()"
-            "ChooseACreatureType" -> "EntersWithChoice(ChoiceType.CREATURE_TYPE)"
+        val dsl: Dsl = when (rep.strField("_ReplacementActionWouldEnter")) {
+            "EntersTapped" -> call("EntersTapped")
+            "ChooseACreatureType" -> call("EntersWithChoice", arg("ChoiceType.CREATURE_TYPE"))
             else -> { reasons.add("AsPermanentEnters"); return null }
         }
-        lines.add("    replacementEffect($dsl)")
+        stmts.add(Eval(call("replacementEffect", arg(dsl))))
     }
-    return lines
+    return stmts
 }
 
 /**
@@ -325,27 +339,26 @@ internal fun EmitCtx.asEntersBlock(rule: JsonObject): List<String>? {
  * with `trigger = Triggers.YouCycleThis` ("When you cycle this card, [bonus]"). A lone `you may` bonus
  * becomes `optional = true`, mirroring [triggerBlock].
  */
-internal fun EmitCtx.fromAnyZoneBlock(rule: JsonObject): List<String>? {
+internal fun EmitCtx.fromAnyZoneBlock(rule: JsonObject): List<Stmt>? {
     val inner = rule["args"] as? JsonObject
     if (inner?.strField("_Rule") != "TriggerA" ||
         !jsonContains(inner, "_Trigger", "WhenAPlayerCyclesACard") ||
         !jsonContains(inner, "_CardInHand", "ThisCardInHand")) { reasons.add("FromAnyZone"); return null }
     val (targets, actions) = extractEnvelope(inner)
     if (actions == null) { reasons.add("FromAnyZone"); return null }
-    val (tdsl, tvar) = spellTarget(targets, actions)
-    if (tdsl == null) return null
+    val (tnode, tvar) = spellTargetExpr(targets, actions) ?: return null
     val mayWrapped = actions.singleOrNull()?.strField("_Action") == "MayAction"
     val effectActions = if (mayWrapped) listOf(innerAction(actions.single()) ?: return null) else actions
     val edsl = renderEffectList(effectActions, tvar) ?: return null
-    val lines = mutableListOf("    triggeredAbility {", "        trigger = Triggers.YouCycleThis")
-    if (mayWrapped) lines.add("        optional = true")
-    if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
-    lines.addAll(listOf("        effect = ${render(edsl)}", "    }"))
-    return lines
+    val stmts = mutableListOf<Stmt>(Assign("trigger", Lit("Triggers.YouCycleThis")))
+    if (mayWrapped) stmts.add(Assign("optional", Lit("true")))
+    if (tvar != null) stmts.add(targetLocal(tnode!!))
+    stmts.add(Assign("effect", edsl))
+    return listOf(Sub(Block("triggeredAbility", stmts)))
 }
 
 /** An Activated / ActivatedWithModifiers rule -> activatedAbility { cost; [target]; effect }. */
-internal fun EmitCtx.activatedBlock(rule: JsonObject): List<String>? {
+internal fun EmitCtx.activatedBlock(rule: JsonObject): List<Stmt>? {
     val args = rule["args"].asArr
     val costNode = args?.firstOrNull() as? JsonObject
     // Recover the exact activation cost. Anything we can't render exactly -> SCAFFOLD (never guess Tap).
@@ -353,22 +366,20 @@ internal fun EmitCtx.activatedBlock(rule: JsonObject): List<String>? {
     if (cost == null) { reasons.add("activated-cost"); return null }
     val (targets, actions) = extractEnvelope(rule)
     if (actions == null) { reasons.add("activated-actions"); return null }
-    val (tdsl, tvar) = spellTarget(targets, actions)
-    if (tdsl == null) return null
+    val (tnode, tvar) = spellTargetExpr(targets, actions) ?: return null
     val edsl = renderEffectList(actions, tvar) ?: return null
-    val lines = mutableListOf("    activatedAbility {", "        cost = $cost")
-    activationRestrictionLines(rule)?.let { lines.addAll(it) } ?: return null
-    if (tvar != null) lines.add("        val t = target(\"target\", $tdsl)")
-    lines.add("        effect = ${render(edsl)}")
+    val stmts = mutableListOf<Stmt>(Assign("cost", Lit(cost)))
+    activationRestrictionLines(rule)?.let { lines -> lines.forEach { stmts.add(RawLine(it)) } } ?: return null
+    if (tvar != null) stmts.add(targetLocal(tnode!!))
+    stmts.add(Assign("effect", edsl))
     // A ReplaceNextDraw effect ("the next time you would draw … instead") prompts on the replaced draw,
     // not at activation — the activated-ability flag the Words cycle's golden carries.
-    if (actions.any { it.strField("_Action") == "CreateFutureReplaceWouldDraw" }) lines.add("        promptOnDraw = true")
+    if (actions.any { it.strField("_Action") == "CreateFutureReplaceWouldDraw" }) stmts.add(Assign("promptOnDraw", Lit("true")))
     if (isManaAbility(tvar, actions)) {
-        lines.add("        manaAbility = true")
-        lines.add("        timing = TimingRule.ManaAbility")
+        stmts.add(Assign("manaAbility", Lit("true")))
+        stmts.add(Assign("timing", Lit("TimingRule.ManaAbility")))
     }
-    lines.add("    }")
-    return lines
+    return listOf(Sub(Block("activatedAbility", stmts)))
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -1,7 +1,11 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Composite
+import com.wingedsheep.tooling.coverage.Lit
 import com.wingedsheep.tooling.coverage.amountNode
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
@@ -17,31 +21,37 @@ import kotlinx.serialization.json.put
 internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers {
 
     on("SpellDealsDamage", "PermanentDealsDamage") { _, args, tvar ->
-        val amt = amount(args) ?: dynamicAmount(amountNode(args)) ?: return@on null
+        val amt = amountExpr(args) ?: dynamicAmountExpr(amountNode(args)) ?: return@on null
         if (jsonContains(args, "_DamageRecipient", "EachPermanent")) {  // mass: deal N to each creature
-            val filter = groupFilterDsl(args) ?: return@on null
-            val eachPermanent = "Effects.ForEachInGroup($filter, DealDamageEffect($amt, EffectTarget.Self))"
+            val filter = groupFilterExpr(args) ?: return@on null
+            val eachPermanent = call(
+                "Effects.ForEachInGroup", arg(filter),
+                arg(call("DealDamageEffect", arg(amt), arg("EffectTarget.Self"))),
+            )
             if (jsonContains(args, "_DamageRecipient", "EachPlayer")) {
-                return@on composite(listOf(
+                return@on Composite(listOf(
                     eachPermanent,
-                    "ForEachPlayerEffect(Player.Each, listOf(DealDamageEffect($amt, EffectTarget.Controller)))",
+                    call(
+                        "ForEachPlayerEffect", arg("Player.Each"),
+                        arg(call("listOf", arg(call("DealDamageEffect", arg(amt), arg("EffectTarget.Controller"))))),
+                    ),
                 ))
             }
             return@on eachPermanent
         }
         val tgt = refTargetIn(args, "_DamageRecipient", tvar) ?: return@on null
-        "DealDamageEffect($amt, $tgt)"
+        call("DealDamageEffect", arg(amt), arg(Lit(tgt)))
     }
 
     on("SpellDealsDistributedDamage") { _, args, _ ->
         val total = findInteger(args)
         if (total !is Int) return@on null
-        "DividedDamageEffect(totalDamage = $total)"
+        call("DividedDamageEffect", arg("totalDamage", "$total"))
     }
 
     on("GainLifeForEach") { _, args, _ ->
-        val dyn = dynamicAmount(gainForEachAmount(args)) ?: return@on null
-        "GainLifeEffect($dyn)"
+        val dyn = dynamicAmountExpr(gainForEachAmount(args)) ?: return@on null
+        call("GainLifeEffect", arg(dyn))
     }
 
     on("DrawNumberCards", "DrawACard") { node, args, _ ->
@@ -52,7 +62,7 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         val amt = if (node.strField("_Action") == "DrawACard") "1"
                   else strictCardCount(amountNode(args), forX = "DynamicAmount.XValue")
                       ?: dynamicAmount(amountNode(args))
-        if (amt != null) "DrawCardsEffect($amt)" else null
+        if (amt != null) call("DrawCardsEffect", arg(Lit(amt))) else null
     }
 
     on("PlayerAction") { node, _, tvar ->
@@ -61,7 +71,7 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         val action = arr.firstOrNull { it is JsonObject && it.containsKey("_Action") } as? JsonObject ?: return@on null
         if (action.strField("_Action") != "RevealHand") return@on null
         val target = if (jsonContains(playerRef, "_Player", "Ref_TargetPlayer")) tvar else null
-        if (target != null) "RevealHandEffect($target)" else "RevealHandEffect()"
+        if (target != null) call("RevealHandEffect", arg(Lit(target))) else call("RevealHandEffect")
     }
 
     simple("CounterSpell", dsl = "CounterEffect()")
@@ -72,23 +82,23 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
     on("GainLife") { _, args, _ ->
         // A fixed Integer renders `GainLifeEffect(1)`; a recognised dynamic amount (e.g. a damage
         // trigger's "gain that much life") renders `GainLifeEffect(DynamicAmount…)`.
-        val amt = amount(args) ?: dynamicAmount(amountNode(args)) ?: return@on null
-        "GainLifeEffect($amt)"
+        val amt = amountExpr(args) ?: dynamicAmountExpr(amountNode(args)) ?: return@on null
+        call("GainLifeEffect", arg(amt))
     }
     on("LoseLife") { _, args, _ ->
-        val amt = amount(args) ?: dynamicAmount(amountNode(args)) ?: return@on null
-        "LoseLifeEffect($amt, EffectTarget.Controller)"
+        val amt = amountExpr(args) ?: dynamicAmountExpr(amountNode(args)) ?: return@on null
+        call("LoseLifeEffect", arg(amt), arg("EffectTarget.Controller"))
     }
 
     on("DiscardACard", "DiscardNumberCards", "DiscardAnyNumberOfCards") { node, args, _ ->
         // discardCards takes a fixed Int; a derived/X count can't be expressed, so scaffold.
         val n = if (node.strField("_Action") == "DiscardACard") "1" else strictCardCount(amountNode(args))
-        if (n != null) "Patterns.Hand.discardCards($n)" else null
+        if (n != null) call("Patterns.Hand.discardCards", arg(Lit(n))) else null
     }
 
     on("LookAtPlayersHand") { _, args, tvar ->
         val tgt = refTarget(args, tvar)
-        if (tgt != null) "LookAtTargetHandEffect($tgt)" else "LookAtTargetHandEffect()"
+        if (tgt != null) call("LookAtTargetHandEffect", arg(Lit(tgt))) else call("LookAtTargetHandEffect")
     }
 
     // "{cost}: The next time you would draw a card this turn, [do X] instead." (the Onslaught Words
@@ -107,7 +117,7 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         if (tvar != null) return@on null
         val inner = asReplacementActions(a.getOrNull(1)) ?: return@on null
         val edsl = renderEffectList(inner, tvar) ?: return@on null
-        "Effects.ReplaceNextDraw($edsl)"
+        call("Effects.ReplaceNextDraw", arg(edsl))
     }
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.dot
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.findRef
 import com.wingedsheep.tooling.coverage.findRefIn
@@ -156,8 +157,8 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         }
     }
     if (gn == "TheNumberOfCardsOfTypeRevealedFromHandThisWay") {
-        val filter = revealedHandFilterDsl(node["args"]) ?: return null
-        return call("DynamicAmount.Count", arg("Player.TargetOpponent"), arg("Zone.HAND"), arg(Lit(filter)))
+        val filter = revealedHandFilterExpr(node["args"]) ?: return null
+        return call("DynamicAmount.Count", arg("Player.TargetOpponent"), arg("Zone.HAND"), arg(filter))
     }
     if (gn == "Multiply" && node["args"].asArr?.size == 2) {
         val arr = node["args"].asArr!!
@@ -190,8 +191,9 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         // "for each Goblin/Bird/Elf on the battlefield": a creature subtype, which the land-oriented
         // search filter misses; otherwise fall back to the land/type search filter.
         val subtype = node.firstArgWordTagged("IsCreatureType")
-        val filter = if (subtype != null) "GameObjectFilter.Creature.withSubtype(\"$subtype\")" else landSearchFilterDsl(node)
-        return call("DynamicAmount.AggregateBattlefield", arg(player), arg(Lit(filter)))
+        val filter = if (subtype != null) Lit("GameObjectFilter.Creature").dot("withSubtype", arg("\"$subtype\""))
+                     else landSearchFilterExpr(node)
+        return call("DynamicAmount.AggregateBattlefield", arg(player), arg(filter))
     }
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -1,8 +1,12 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.findRef
@@ -10,6 +14,7 @@ import com.wingedsheep.tooling.coverage.findRefIn
 import com.wingedsheep.tooling.coverage.firstArgWordTagged
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
+import com.wingedsheep.tooling.coverage.render
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -88,10 +93,13 @@ internal fun composite(parts: List<String>): String =
 // ---------------------------------------------------------------------------
 
 /** A DSL amount for a plain int / X, or null (-> SCAFFOLD, never a broken emit). */
-internal fun EmitCtx.amount(node: JsonElement?): String? {
+internal fun EmitCtx.amount(node: JsonElement?): String? = amountExpr(node)?.let(::render)
+
+/** The [Dsl] node behind [amount] — a bare int literal or `DynamicAmount.XValue`. */
+internal fun EmitCtx.amountExpr(node: JsonElement?): Dsl? {
     val n = findInteger(node) ?: return null
-    if (n == "X") return "DynamicAmount.XValue"
-    return n.toString()
+    if (n == "X") return Lit("DynamicAmount.XValue")
+    return Lit(n.toString())
 }
 
 /** A "draw/discard N cards" count read from the amount's TOP-LEVEL `_GameNumber` only: a fixed Integer
@@ -119,29 +127,37 @@ internal fun gainForEachAmount(args: JsonElement?): JsonElement? {
 }
 
 /** A DynamicAmount DSL for a dynamic mtgish _GameNumber, or null if unrecognised. */
-internal fun EmitCtx.dynamicAmount(node: JsonElement?): String? {
+internal fun EmitCtx.dynamicAmount(node: JsonElement?): String? = dynamicAmountExpr(node)?.let(::render)
+
+/** The [Dsl] node behind [dynamicAmount]. Filters it embeds are still carried as [Lit] text (they are
+ *  migrated in the filter layer); the structure around them is typed. */
+internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
     if (node !is JsonObject) return null
     val gn = node.strField("_GameNumber")
     when (gn) {
-        "Integer" -> return "DynamicAmount.Fixed(${node["args"].asInt()})"
-        "XValue", "X", "ValueX" -> return "DynamicAmount.XValue"
+        "Integer" -> return call("DynamicAmount.Fixed", arg("${node["args"].asInt()}"))
+        "XValue", "X", "ValueX" -> return Lit("DynamicAmount.XValue")
         // "that much" in a damage trigger — the amount of damage the trigger fired on (Doubtless One's
         // "gain that much life", Thrashing Mudspawn's "lose that much life").
-        "Trigger_AmountOfDamageDealt" -> return "DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)"
-        "PowerOfTheSacrificedCreature" -> return "DynamicAmounts.sacrificedPower()"
+        "Trigger_AmountOfDamageDealt" ->
+            return call("DynamicAmount.ContextProperty", arg("ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT"))
+        "PowerOfTheSacrificedCreature" -> return call("DynamicAmounts.sacrificedPower")
         "LifeTotalOfPlayer" -> {
             val player = if (jsonContains(node, "_Player", "Opponent")) "Player.Opponent" else "Player.You"
-            return "DynamicAmount.LifeTotal($player)"
+            return call("DynamicAmount.LifeTotal", arg(player))
         }
         "HalfRoundedUp", "HalfRoundedDown" -> {
-            val inner = dynamicAmount(node["args"]) ?: return null
+            val inner = dynamicAmountExpr(node["args"]) ?: return null
             val roundup = if (gn == "HalfRoundedUp") "true" else "false"
-            return "DynamicAmount.Divide($inner, DynamicAmount.Fixed(2), roundUp = $roundup)"
+            return call(
+                "DynamicAmount.Divide",
+                arg(inner), arg(call("DynamicAmount.Fixed", arg("2"))), arg("roundUp", roundup),
+            )
         }
     }
     if (gn == "TheNumberOfCardsOfTypeRevealedFromHandThisWay") {
         val filter = revealedHandFilterDsl(node["args"]) ?: return null
-        return "DynamicAmount.Count(Player.TargetOpponent, Zone.HAND, $filter)"
+        return call("DynamicAmount.Count", arg("Player.TargetOpponent"), arg("Zone.HAND"), arg(Lit(filter)))
     }
     if (gn == "Multiply" && node["args"].asArr?.size == 2) {
         val arr = node["args"].asArr!!
@@ -149,9 +165,9 @@ internal fun EmitCtx.dynamicAmount(node: JsonElement?): String? {
         val intA = findInteger(a)
         val mult = if (intA is Int) intA else findInteger(b)
         val cnt = if (findInteger(a) == mult) b else a
-        val inner = dynamicAmount(cnt)
+        val inner = dynamicAmountExpr(cnt)
         if (inner != null && mult is Int) {
-            return if (mult == 1) inner else "DynamicAmount.Multiply($inner, $mult)"
+            return if (mult == 1) inner else call("DynamicAmount.Multiply", arg(inner), arg("$mult"))
         }
         return null
     }
@@ -175,7 +191,7 @@ internal fun EmitCtx.dynamicAmount(node: JsonElement?): String? {
         // search filter misses; otherwise fall back to the land/type search filter.
         val subtype = node.firstArgWordTagged("IsCreatureType")
         val filter = if (subtype != null) "GameObjectFilter.Creature.withSubtype(\"$subtype\")" else landSearchFilterDsl(node)
-        return "DynamicAmount.AggregateBattlefield($player, $filter)"
+        return call("DynamicAmount.AggregateBattlefield", arg(player), arg(Lit(filter)))
     }
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -1,5 +1,7 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Call
+import com.wingedsheep.tooling.coverage.Composite
 import com.wingedsheep.tooling.coverage.Dsl
 import com.wingedsheep.tooling.coverage.Lit
 import com.wingedsheep.tooling.coverage.arg
@@ -59,18 +61,16 @@ internal val SELF_REFS = setOf(
 // Dispatch + effect-list assembly.
 // ---------------------------------------------------------------------------
 
-/** Render one mtgish action to an Effect DSL string via the [ACTION_HANDLERS] registry. */
-internal fun EmitCtx.renderAction(node: JsonObject, tvar: String?): String? {
-    val handler = ACTION_HANDLERS[node.strField("_Action")] ?: return null
-    return handler(node, node["args"], tvar)
-}
+/** Render one mtgish action to an Effect [Dsl] node via the [ACTION_HANDLERS] registry. */
+internal fun EmitCtx.renderAction(node: JsonObject, tvar: String?): Dsl? =
+    ACTION_HANDLERS[node.strField("_Action")]?.invoke(this, node, node["args"], tvar)
 
-/** Render a list of mtgish actions to one Effect (Composite if >1). Null if any can't render. */
-internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?): String? {
+/** Render a list of mtgish actions to one Effect ([Composite] if >1). Null if any can't render. */
+internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?): Dsl? {
     echoEffect(actions)?.let { return it }
     becomeCreatureTypeEffect(actions, tvar)?.let { return it }
     chooseCreatureTypeRevealTopEffect(actions)?.let { return it }
-    val rendered = mutableListOf<String>()
+    val rendered = mutableListOf<Dsl>()
     for (act in actions) {
         val r = renderAction(act, tvar)
         if (r == null) { reasons.add(act.strField("_Action") ?: act.strField("_Rule") ?: "unknown-action"); return null }
@@ -78,16 +78,8 @@ internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?):
     }
     if (rendered.isEmpty()) return null
     if (rendered.size == 1) return rendered[0]
-    return composite(rendered)
+    return Composite(rendered)
 }
-
-/**
- * `Effects.Composite(...)` with one element per line, indented to sit in the `effect = ` (8-space)
- * slot. Each element's first line is placed at 12 spaces; multi-line elements keep their own inner
- * indentation. Callers pass ≥2 elements (a single effect is emitted directly, never wrapped).
- */
-internal fun composite(parts: List<String>): String =
-    parts.joinToString(",\n", prefix = "Effects.Composite(\n", postfix = "\n        )") { "            $it" }
 
 // ---------------------------------------------------------------------------
 // Generic amount / reference / keyword toolkit (shared by every handler).
@@ -269,7 +261,7 @@ internal fun EmitCtx.paycostDsl(costNode: JsonElement?): String? {
  * `ChooseACreatureTypeOtherThan X` carries an excluded type (Imagecrafter / Mistform Mutant's "other
  * than Wall") -> `excludedTypes = listOf("X")`.
  */
-internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: String?): String? {
+internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: String?): Dsl? {
     val chooser = actions.firstOrNull {
         it.strField("_Action") in setOf("ChooseACreatureType", "ChooseACreatureTypeOtherThan")
     } ?: return null
@@ -281,8 +273,9 @@ internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: S
     if (!jsonContains(layer, "_Expiration", "UntilEndOfTurn")) return null  // non-EOT -> SCAFFOLD
     val target = refTarget(layer["args"], tvar) ?: return null
     val excluded = if (chooser.strField("_Action") == "ChooseACreatureTypeOtherThan") chooser["args"].asStr() else null
-    return if (excluded != null) "BecomeCreatureTypeEffect(target = $target, excludedTypes = listOf(\"${ktStr(excluded)}\"))"
-    else "BecomeCreatureTypeEffect(target = $target)"
+    val parts = mutableListOf(arg("target", Lit(target)))
+    if (excluded != null) parts.add(arg("excludedTypes", "listOf(\"${ktStr(excluded)}\")"))
+    return Call("BecomeCreatureTypeEffect", parts)
 }
 
 /**
@@ -291,7 +284,7 @@ internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: S
  * (Bloodline Shaman). The whole three-action chain collapses to the named SDK pattern, so it renders
  * as one effect rather than three; any deviation from this exact shape declines (null -> SCAFFOLD).
  */
-internal fun EmitCtx.chooseCreatureTypeRevealTopEffect(actions: List<JsonObject>): String? {
+internal fun EmitCtx.chooseCreatureTypeRevealTopEffect(actions: List<JsonObject>): Dsl? {
     if (actions.size != 3) return null
     if (actions[0].strField("_Action") != "ChooseACreatureType") return null
     if (actions[1].strField("_Action") != "RevealTopCardOfLibrary") return null
@@ -300,15 +293,15 @@ internal fun EmitCtx.chooseCreatureTypeRevealTopEffect(actions: List<JsonObject>
     if ("ACardWasRevealedThisWay" !in blob || "IsCreatureTypeVariable" !in blob ||
         "TheChosenCreatureType" !in blob) return null
     if ("PutTopOfLibraryInHand" !in blob || "PutTopOfLibraryInGraveyard" !in blob) return null
-    return "Patterns.CreatureType.chooseCreatureTypeRevealTop()"
+    return call("Patterns.CreatureType.chooseCreatureTypeRevealTop")
 }
 
 /** [MayCost(cost), Unless(CostWasPaid, [Sacrifice...])] -> PayOrSufferEffect (echo / upkeep cost). */
-internal fun EmitCtx.echoEffect(actions: List<JsonObject>): String? {
+internal fun EmitCtx.echoEffect(actions: List<JsonObject>): Dsl? {
     if (actions.size != 2) return null
     val (a0, a1) = actions
     if (a0.strField("_Action") != "MayCost" || a1.strField("_Action") != "Unless") return null
     if (!jsonContains(a1, "_Condition", "CostWasPaid") || !jsonContains(a1, "_Action", "SacrificePermanent")) return null
     val cost = paycostDsl(a0["args"]) ?: return null
-    return "PayOrSufferEffect(cost = $cost, suffer = SacrificeSelfEffect)"
+    return call("PayOrSufferEffect", arg("cost", Lit(cost)), arg("suffer", "SacrificeSelfEffect"))
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -1,6 +1,14 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Assign
+import com.wingedsheep.tooling.coverage.Block
+import com.wingedsheep.tooling.coverage.Eval
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.RawLine
+import com.wingedsheep.tooling.coverage.Stmt
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asObj
 import com.wingedsheep.tooling.coverage.asStr
@@ -9,6 +17,7 @@ import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.asciiIdentifier
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
+import com.wingedsheep.tooling.coverage.renderBlock
 import com.wingedsheep.tooling.coverage.strField
 import com.wingedsheep.tooling.coverage.bridge.Bridge
 import kotlinx.serialization.json.JsonArray
@@ -37,22 +46,26 @@ object Emitter {
         val permanent = isPermanent(card)
         val kw = if (permanent) keywordLines(card, keywords) else emptySet()
 
-        val body = mutableListOf<String>()
-        body.addAll(docCommentLines(card, scryfall))
-        body.add("val $ident = card(\"${ktStr(name)}\") {")
-        body.add("    manaCost = \"${renderMana(card["ManaCost"])}\"")
-        colorIdentityDsl(scryfall)?.let { body.add("    colorIdentity = \"$it\"") }
-        body.add("    typeLine = \"${renderTypeline(card["Typeline"])}\"")
+        // The whole card is one Block tree: the KDoc precedes it, the shell/ability lines are its body
+        // statements, and the renderer turns it into source. Shell scaffolding (mana/typeline/metadata)
+        // stays as RawLine — the formatted, un-modeled leaves the Raw escape-hatch is for — while the
+        // ability builders contribute structured statements.
+        val pre = docCommentLines(card, scryfall)
+        val header = "val $ident = card(\"${ktStr(name)}\")"
+        val body = mutableListOf<Stmt>()
+        body.add(RawLine("    manaCost = \"${renderMana(card["ManaCost"])}\""))
+        colorIdentityDsl(scryfall)?.let { body.add(RawLine("    colorIdentity = \"$it\"")) }
+        body.add(RawLine("    typeLine = \"${renderTypeline(card["Typeline"])}\""))
         // Printed oracle text is display/training data (the gym observation surfaces it to agents); the
         // engine still derives behaviour from the structured keywords/effects below, never from this string.
-        scryfall?.strField("oracle_text")?.takeIf { it.isNotEmpty() }?.let { body.add("    oracleText = \"${ktStr(it)}\"") }
-        if (pt != null) { body.add("    power = ${pt["Power"].asInt()}"); body.add("    toughness = ${pt["Toughness"].asInt()}") }
+        scryfall?.strField("oracle_text")?.takeIf { it.isNotEmpty() }?.let { body.add(RawLine("    oracleText = \"${ktStr(it)}\"")) }
+        if (pt != null) { body.add(RawLine("    power = ${pt["Power"].asInt()}")); body.add(RawLine("    toughness = ${pt["Toughness"].asInt()}")) }
         // Emit keywords in printed (rule) order, not alphabetical — `keywordLines` collects them in the
         // card's rule order, which matches the hand-authored golden's `keywords(...)` order (e.g.
         // "Trample, haste" stays TRAMPLE, HASTE rather than re-sorting to HASTE, TRAMPLE).
-        if (kw.isNotEmpty()) body.add("    keywords(${kw.joinToString(", ") { "Keyword.$it" }})")
-        val cardLevelLines = ctx.cardLevelCastEffectLines(card) ?: return incomplete(ctx, body, scryfall, pkg)
-        body.addAll(cardLevelLines)
+        if (kw.isNotEmpty()) body.add(RawLine("    keywords(${kw.joinToString(", ") { "Keyword.$it" }})"))
+        val cardLevelLines = ctx.cardLevelCastEffectLines(card) ?: return incomplete(ctx, pre, header, body, scryfall, pkg)
+        body.addAll(cardLevelLines.map { RawLine(it) })
 
         // Auras: the pure static-buff shape (EnchantPermanent + PermanentLayerEffect) renders faithfully,
         // but an activated/triggered ability on an Aura references its "enchanted creature" — context the
@@ -68,7 +81,7 @@ object Emitter {
                 // renders rather than scaffolds; every other ability on an Aura still scaffolds.
                 if ((rn == "Activated" || rn == "ActivatedWithModifiers") &&
                     "SharesACreatureTypeWithPermanent" in compact(r)) return@forEach
-                ctx.reasons.add("aura-with-$rn"); return incomplete(ctx, body, scryfall, pkg)
+                ctx.reasons.add("aura-with-$rn"); return incomplete(ctx, pre, header, body, scryfall, pkg)
             }
         }
 
@@ -77,10 +90,12 @@ object Emitter {
         for (rule in (card["Rules"].asArr ?: JsonArray(emptyList()))) {
             if (rule !is JsonObject) continue
             val rname = rule.strField("_Rule")
-            val block: List<String>?
+            // Every ability builder returns structured statements; the renderer turns the whole card
+            // tree into source lines.
+            val block: List<Stmt>?
             when {
                 rname == "CastEffect" -> {
-                    if (!ctx.castEffectHandled(rule)) return incomplete(ctx, body, scryfall, pkg)
+                    if (!ctx.castEffectHandled(rule)) return incomplete(ctx, pre, header, body, scryfall, pkg)
                     continue
                 }
                 rname == "SpellActions" -> block = ctx.spellBlock(card)
@@ -96,32 +111,31 @@ object Emitter {
                 rname == "CDA_Power" -> block = ctx.cdaStatsBlock(card, rule)
                 rname == "CDA_Toughness" ->
                     if (jsonContains(card["Rules"], "_Rule", "CDA_Power")) continue  // emitted with CDA_Power
-                    else { ctx.reasons.add("CDA_Toughness"); return incomplete(ctx, body, scryfall, pkg) }
+                    else { ctx.reasons.add("CDA_Toughness"); return incomplete(ctx, pre, header, body, scryfall, pkg) }
                 rname == "Activated" || rname == "ActivatedWithModifiers" -> block = ctx.activatedBlock(rule)
-                rname == "Cycling" -> block = manaKeywordCost(rule)?.let { listOf("    keywordAbility(KeywordAbility.cycling(\"$it\"))") }
-                rname == "Morph" -> block = manaKeywordCost(rule)?.let { listOf("    morph = \"$it\"") }
-                rname == "Flashback" -> block = manaKeywordCost(rule)?.let { listOf("    keywordAbility(KeywordAbility.flashback(\"$it\"))") }
-                rname == "Crew" -> block = rule["args"].asInt()?.let { listOf("    keywordAbility(KeywordAbility.crew($it))") }
-                rname == "Protection" -> block = protectionScopeDsl(rule)?.let { listOf("    keywordAbility(KeywordAbility.Protection($it))") }
+                rname == "Cycling" -> block = manaKeywordCost(rule)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.cycling", arg("\"$it\"")))))) }
+                rname == "Morph" -> block = manaKeywordCost(rule)?.let { listOf(Assign("morph", Lit("\"$it\""))) }
+                rname == "Flashback" -> block = manaKeywordCost(rule)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.flashback", arg("\"$it\"")))))) }
+                rname == "Crew" -> block = rule["args"].asInt()?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.crew", arg("$it")))))) }
+                rname == "Protection" -> block = protectionScopeDsl(rule)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.Protection", arg(Lit(it))))))) }
                 rname != null && (rname in handledRules || Bridge[rname]?.kind == "keyword") -> continue
                 // A bare auto-keyword rule (Flying, Menace, …) carries no args. A keyword rule that DOES
                 // carry args is parameterized (Crew N, Flashback {cost}, Bushido N, …) — those must be
                 // rendered exactly by an explicit case above or scaffold; never silently stamped bare,
                 // which would drop the parameter.
                 rname != null && pascalToUpperSnake(rname) in keywords && rule["args"] == null -> continue
-                else -> { ctx.reasons.add(rname ?: "unknown-rule"); return incomplete(ctx, body, scryfall, pkg) }
+                else -> { ctx.reasons.add(rname ?: "unknown-rule"); return incomplete(ctx, pre, header, body, scryfall, pkg) }
             }
-            if (block == null) return incomplete(ctx, body, scryfall, pkg)
+            if (block == null) return incomplete(ctx, pre, header, body, scryfall, pkg)
             body.addAll(block)
         }
 
         if (!permanent && !jsonContains(card["Rules"], "_Rule", "SpellActions")) {
-            ctx.reasons.add("no-renderable-effect"); return incomplete(ctx, body, scryfall, pkg)
+            ctx.reasons.add("no-renderable-effect"); return incomplete(ctx, pre, header, body, scryfall, pkg)
         }
 
-        body.addAll(metadataLines(scryfall))
-        body.add("}")
-        return RenderResult(assemble(body, pkg, complete = true), true, ctx.reasons)
+        body.addAll(metadataLines(scryfall).map { RawLine(it) })
+        return RenderResult(assemble(pre + renderBlock(Block(header, body)), pkg, complete = true), true, ctx.reasons)
     }
 
     /** A keyword-ability whose cost is pure mana (`Cycling {2}`, `Morph {4}{W}`). Returns the rendered
@@ -161,11 +175,10 @@ object Emitter {
     fun findLandwalkKeywords(node: JsonElement?, keywords: Set<String>, out: MutableSet<String>) =
         com.wingedsheep.tooling.coverage.emitter.findLandwalkKeywords(node, keywords, out)
 
-    private fun incomplete(ctx: EmitCtx, body: List<String>, scryfall: JsonObject?, pkg: String): RenderResult {
+    private fun incomplete(ctx: EmitCtx, pre: List<String>, header: String, body: List<Stmt>, scryfall: JsonObject?, pkg: String): RenderResult {
         val b = body.toMutableList()
-        b.add("    // STRUCTURE needs human wiring: ${ctx.reasons.sorted().joinToString(", ")}")
-        b.addAll(metadataLines(scryfall))
-        b.add("}")
-        return RenderResult(assemble(b, pkg, complete = false), false, ctx.reasons)
+        b.add(RawLine("    // STRUCTURE needs human wiring: ${ctx.reasons.sorted().joinToString(", ")}"))
+        b.addAll(metadataLines(scryfall).map { RawLine(it) })
+        return RenderResult(assemble(pre + renderBlock(Block(header, b)), pkg, complete = false), false, ctx.reasons)
     }
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
@@ -1,5 +1,9 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Call
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.arg
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -21,28 +25,31 @@ private val MANA_PRODUCE_COLOR = mapOf(
 )
 
 /** `{_ManaProduce}` -> the matching mana Effect, or null (-> SCAFFOLD) for shapes we don't render. */
-internal fun manaProduceDsl(node: JsonElement?): String? =
+internal fun manaProduceDsl(node: JsonElement?): Dsl? =
     when (val produce = (node as? JsonObject)?.strField("_ManaProduce")) {
         null -> null
-        "ManaProduceC" -> "Effects.AddColorlessMana(1)"
-        "AnyManaColor" -> "Effects.AddManaOfChoice()"
-        "And" -> manaAndDsl(node as JsonObject)  // {B}{B}{B} (Dark Ritual), {C}{C}{C} (Basalt Monolith), …
-        else -> MANA_PRODUCE_COLOR[produce]?.let { "Effects.AddMana($it)" }
+        "ManaProduceC" -> call("Effects.AddColorlessMana", arg("1"))
+        "AnyManaColor" -> call("Effects.AddManaOfChoice")
+        "And" -> manaAndDsl(node)  // {B}{B}{B} (Dark Ritual), {C}{C}{C} (Basalt Monolith), …
+        else -> MANA_PRODUCE_COLOR[produce]?.let { call("Effects.AddMana", arg(it)) }
     }
 
-/** `And[<produce>…]` -> one `Effects.Add*Mana(color, count)` per distinct mana, composited when the
- *  pool mixes colors. Null (-> SCAFFOLD) if any child is itself a non-leaf produce (nested And /
+/** `And[<produce>…]` -> one `Effects.Add*Mana(color, count)` per distinct mana, composited (inline) when
+ *  the pool mixes colors. Null (-> SCAFFOLD) if any child is itself a non-leaf produce (nested And /
  *  choice), so we never emit a partial pool. */
-private fun manaAndDsl(node: JsonObject): String? {
+private fun manaAndDsl(node: JsonObject): Dsl? {
     val children = node["args"] as? JsonArray ?: return null
     val produces = children.map { (it as? JsonObject)?.strField("_ManaProduce") ?: return null }
     if (produces.any { it != "ManaProduceC" && it !in MANA_PRODUCE_COLOR }) return null
     val counts = LinkedHashMap<String, Int>()
     produces.forEach { counts[it] = (counts[it] ?: 0) + 1 }
     val parts = counts.map { (p, n) ->
-        if (p == "ManaProduceC") "Effects.AddColorlessMana($n)" else "Effects.AddMana(${MANA_PRODUCE_COLOR[p]}, $n)"
+        if (p == "ManaProduceC") call("Effects.AddColorlessMana", arg("$n"))
+        else call("Effects.AddMana", arg(MANA_PRODUCE_COLOR.getValue(p)), arg("$n"))
     }
-    return if (parts.size == 1) parts[0] else "Effects.Composite(${parts.joinToString(", ")})"
+    // The mana pool uses an INLINE Effects.Composite(...) (single line), distinct from the multi-line
+    // Composite node the effect-list builder emits.
+    return if (parts.size == 1) parts[0] else Call("Effects.Composite", parts.map { arg(it) })
 }
 
 /** True when this ability is a mana ability: no target, and at least one action adds mana. */

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -1,6 +1,10 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
@@ -14,7 +18,7 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
     on("MayAction") { node, _, tvar ->  // "you may X" -> MayEffect wrapper
         val inner = innerAction(node) ?: return@on null
         val rendered = renderAction(inner, tvar) ?: return@on null
-        "MayEffect($rendered)"
+        call("MayEffect", arg(rendered))
     }
 
     // "you may [X and Y]" — a single optional choice gating a sequence of actions (Gustcloak cycle's
@@ -23,7 +27,7 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
     on("MayActions") { node, _, tvar ->
         val inner = node["args"].asArr?.filterIsInstance<JsonObject>() ?: return@on null
         val edsl = renderEffectList(inner, tvar) ?: return@on null
-        "MayEffect($edsl)"
+        call("MayEffect", arg(edsl))
     }
 
     on("EachPlayerAction") { node, _, _ -> renderEachPlayer(node) }
@@ -34,12 +38,12 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
         when {
             // "prevent all damage attacking creatures would deal to you this turn" (Deep Wood)
             "IsAttacking" in blob && "PreventThatDamage" in blob && jsonContains(node, "_Player", "You") ->
-                "Effects.PreventDamageFromAttackingCreatures()"
+                call("Effects.PreventDamageFromAttackingCreatures")
             // "prevent all combat damage that would be dealt this turn" (Leery Fogbeast): the unrestricted
             // CombatDamageWouldBeDealt event (no source/recipient filter) + PreventThatDamage until EOT.
             jsonContains(node, "_ReplacableEventWouldDealDamage", "CombatDamageWouldBeDealt") &&
                 "PreventThatDamage" in blob && jsonContains(node, "_Expiration", "UntilEndOfTurn") ->
-                "Effects.PreventAllCombatDamage()"
+                call("Effects.PreventAllCombatDamage")
             else -> null
         }
     }
@@ -47,37 +51,37 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
         // Harsh Justice: reflect attackers' combat damage back to their controller.
         val blob = compact(node)
         if ("WhenACreatureDealsCombatDamageToAPlayer" in blob && "ControllerOfPermanent" in blob && "Trigger_ThatMuch" in blob) {
-            "ReflectCombatDamageEffect()"
+            call("ReflectCombatDamageEffect")
         } else null
     }
     on("CreateEachPermanentRuleEffectUntil") { node, _, tvar -> renderGrantToGroup(node, tvar) }
 }
 
 /** A spell that grants a combat rule to a group / target (Alluring Scent, Taunt, Dread Charge). */
-internal fun EmitCtx.renderGrantToGroup(node: JsonObject, tvar: String?): String? {
+internal fun EmitCtx.renderGrantToGroup(node: JsonObject, tvar: String?): Dsl? {
     if (jsonContains(node, "_PermanentRule", "MustBlockAttacker")) {  // "all creatures must block target"
         val tgt = refTarget(node["args"], tvar) ?: return null
-        return "MustBeBlockedEffect($tgt)"
+        return call("MustBeBlockedEffect", arg(Lit(tgt)))
     }
     if (jsonContains(node, "_PermanentRule", "MustAttackPlayer")) {  // Taunt
-        return if (tvar != null) "TauntEffect($tvar)" else "TauntEffect()"
+        return if (tvar != null) call("TauntEffect", arg(Lit(tvar))) else call("TauntEffect")
     }
     val blob = compact(node)
     if (("CantBeBlockedExceptByColor" in blob || "CantBeBlockedExceptByDefenders" in blob) && "\"_Color\"" in blob) {
         val m = Regex(""""_Color":\s*"(\w+)"""").find(blob)
         val color = if (m != null) "Color.${m.groupValues[1].uppercase()}" else "Color.BLACK"
-        val filter = groupFilterDsl(node["args"]) ?: return null
-        return "GrantCantBeBlockedExceptByColorEffect(filter = $filter, canOnlyBeBlockedByColor = $color)"
+        val filter = groupFilterExpr(node["args"]) ?: return null
+        return call("GrantCantBeBlockedExceptByColorEffect", arg("filter", filter), arg("canOnlyBeBlockedByColor", color))
     }
     return null
 }
 
 /** `target player does X` — render X scoped to the referenced player. */
-internal fun EmitCtx.renderPlayerAction(node: JsonObject, tvar: String?): String? {
+internal fun EmitCtx.renderPlayerAction(node: JsonObject, tvar: String?): Dsl? {
     val args = node["args"]
     if (jsonContains(node, "_Player", "OwnerOfPermanent") && jsonContains(node, "_Action", "GainLife")) {
         // Path of Peace: destroyed permanent's owner gains N
-        return "OwnerGainsLifeEffect(${findInteger(args)})"
+        return call("OwnerGainsLifeEffect", arg("${findInteger(args)}"))
     }
     val inner = innerAction(node) ?: return null
     val ptv = refTarget(args, tvar)  // the player the action applies to
@@ -87,49 +91,49 @@ internal fun EmitCtx.renderPlayerAction(node: JsonObject, tvar: String?): String
             // can't be expressed, so scaffold rather than default to a wrong fixed amount.
             val n = if (inner.strField("_Action") == "DiscardACard") "1" else strictCardCount(inner["args"])
             if (n == null) return null
-            return if (ptv != null) "Patterns.Hand.discardCards($n, $ptv)" else "Patterns.Hand.discardCards($n)"
+            return if (ptv != null) call("Patterns.Hand.discardCards", arg(Lit(n)), arg(Lit(ptv))) else call("Patterns.Hand.discardCards", arg(Lit(n)))
         }
         "DrawNumberCards", "DrawACard" -> {
             // Only a fixed Integer or X count renders; a derived count (Mathemagics' "2ˣ") scaffolds.
             val amt = if (inner.strField("_Action") == "DrawACard") "1"
                       else strictCardCount(inner["args"], forX = "DynamicAmount.XValue")
             if (amt == null) return null
-            return if (ptv != null) "DrawCardsEffect($amt, $ptv)" else "DrawCardsEffect($amt)"
+            return if (ptv != null) call("DrawCardsEffect", arg(Lit(amt)), arg(Lit(ptv))) else call("DrawCardsEffect", arg(Lit(amt)))
         }
         "GainLife" -> {
             val amt = amount(inner["args"])
-            return if (amt != null && ptv != null) "GainLifeEffect($amt, $ptv)" else if (amt != null) "GainLifeEffect($amt)" else null
+            return if (amt != null && ptv != null) call("GainLifeEffect", arg(Lit(amt)), arg(Lit(ptv))) else if (amt != null) call("GainLifeEffect", arg(Lit(amt))) else null
         }
         "LoseLife" -> {
             val amt = amount(inner["args"])
             if (amt == null || ptv == null) return null
-            return "LoseLifeEffect($amt, $ptv)"
+            return call("LoseLifeEffect", arg(Lit(amt)), arg(Lit(ptv)))
         }
         "DiscardACardAtRandom" -> {
-            return if (ptv != null) "Patterns.Hand.discardRandom(1, $ptv)" else "Patterns.Hand.discardRandom(1)"
+            return if (ptv != null) call("Patterns.Hand.discardRandom", arg("1"), arg(Lit(ptv))) else call("Patterns.Hand.discardRandom", arg("1"))
         }
         "SkipAllCombatPhasesTheirNextTurn" -> {
-            return if (ptv != null) "SkipCombatPhasesEffect($ptv)" else "SkipCombatPhasesEffect()"
+            return if (ptv != null) call("SkipCombatPhasesEffect", arg(Lit(ptv))) else call("SkipCombatPhasesEffect")
         }
         "RevealHand" -> {
-            return if (ptv != null) "RevealHandEffect($ptv)" else "RevealHandEffect()"
+            return if (ptv != null) call("RevealHandEffect", arg(Lit(ptv))) else call("RevealHandEffect")
         }
         "ShuffleGraveyardIntoLibrary" -> {
             // "target player shuffles their graveyard into their library" (Reminisce). Only the
             // bound-target-player form renders; an untargeted/you form scaffolds rather than guess.
-            return if (ptv != null) "Patterns.Library.shuffleGraveyardIntoLibrary($ptv)" else null
+            return if (ptv != null) call("Patterns.Library.shuffleGraveyardIntoLibrary", arg(Lit(ptv))) else null
         }
     }
     return null
 }
 
-internal fun EmitCtx.renderEachPlayer(node: JsonObject): String? {
+internal fun EmitCtx.renderEachPlayer(node: JsonObject): Dsl? {
     val blob = compact(node)
     // "each player returns a permanent they control to its owner's hand" (Words of Wind's replacement).
     if (jsonContains(node, "_Players", "AnyPlayer") && "PutAPermanentIntoItsOwnersHand" in blob)
-        return "Effects.EachPlayerReturnPermanentToHand()"
-    if (jsonContains(node, "_Players", "Opponent") && "Discard" in blob) return "Patterns.Hand.eachOpponentDiscards(1)"  // Noxious Toad
+        return call("Effects.EachPlayerReturnPermanentToHand")
+    if (jsonContains(node, "_Players", "Opponent") && "Discard" in blob) return call("Patterns.Hand.eachOpponentDiscards", arg("1"))  // Noxious Toad
     if (jsonContains(node, "_Action", "DrawNumberCards") || jsonContains(node, "_GameNumber", "ValueX"))
-        return "Patterns.Hand.eachPlayerDrawsX(includeController = true, includeOpponents = true)"
+        return call("Patterns.Hand.eachPlayerDrawsX", arg("includeController", "true"), arg("includeOpponents", "true"))
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SpellShortcuts.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SpellShortcuts.kt
@@ -1,5 +1,9 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Call
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.arg
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
@@ -10,42 +14,43 @@ import kotlinx.serialization.json.JsonObject
  * than rendered action-by-action. [spellBlock] tries each before falling back to the generic path.
  * A `String?` shortcut yields a one-line `effect =`; a `List<String>?` shortcut yields a whole block.
  */
-internal fun EmitCtx.eachplayerMaydraw(card: JsonObject): String? {
+internal fun EmitCtx.eachplayerMaydraw(card: JsonObject): Dsl? {
     val rules = card["Rules"]
     if (!jsonContains(rules, "_Action", "EachPlayerActions") || !jsonContains(rules, "_Action", "DrawUptoNumberCards")) return null
     val blob = compact(rules)
     val mx = Regex(""""DrawUptoNumberCards".*?"args":\s*(\d+)""").find(blob) ?: return null
     val life = Regex(""""GainLifeForEach".*?"args":\s*(\d+)""").find(blob)
-    val lpc = if (life != null) ", lifePerCardNotDrawn = ${life.groupValues[1]}" else ""
-    return "Patterns.Hand.eachPlayerMayDraw(maxCards = ${mx.groupValues[1]}$lpc)"
+    val parts = mutableListOf(arg("maxCards", mx.groupValues[1]))
+    if (life != null) parts.add(arg("lifePerCardNotDrawn", life.groupValues[1]))
+    return Call("Patterns.Hand.eachPlayerMayDraw", parts)
 }
 
 /** Each player discards any number, then draws that many; you draw 1 (Flux). */
-internal fun EmitCtx.fluxEffect(card: JsonObject): String? {
+internal fun EmitCtx.fluxEffect(card: JsonObject): Dsl? {
     val blob = compact(card["Rules"])
     if ("TheNumberOfCardsDiscardedByPlayerThisWay" in blob && "DiscardAnyNumberOfCards" in blob) {
         val bonus = if ("\"DrawACard\"" in blob) 1 else 0
-        return "Patterns.Hand.eachPlayerDiscardsDraws(controllerBonusDraw = $bonus)"
+        return call("Patterns.Hand.eachPlayerDiscardsDraws", arg("controllerBonusDraw", "$bonus"))
     }
     return null
 }
 
 /** Each player shuffles their hand into their library, then draws that many (Winds of Change). */
-internal fun EmitCtx.windsEffect(card: JsonObject): String? {
+internal fun EmitCtx.windsEffect(card: JsonObject): Dsl? {
     val blob = compact(card["Rules"])
     if ("ShuffleHandIntoLibrary" in blob && "NumCardsShuffledIntoLibraryThisWay" in blob) {
-        return "Patterns.Hand.wheelEffect(Player.Each)"
+        return call("Patterns.Hand.wheelEffect", arg("Player.Each"))
     }
     return null
 }
 
 /** Take an extra turn, then lose at that turn's end step (Last Chance / Final Fortune). */
-internal fun EmitCtx.extraTurnEffect(card: JsonObject): String? {
+internal fun EmitCtx.extraTurnEffect(card: JsonObject): Dsl? {
     val (_, actions) = extractEnvelope(card["Rules"])
     if (actions == null) return null
     val hasExtra = actions.any { it.strField("_Action") == "TakeAnExtraTurn" }
     val loseAfter = actions.any { it.strField("_Action") == "CreateFutureTrigger" && jsonContains(it, "_Action", "LoseTheGame") }
-    if (hasExtra && loseAfter) return "TakeExtraTurnEffect(loseAtEndStep = true)"
+    if (hasExtra && loseAfter) return call("TakeExtraTurnEffect", arg("loseAtEndStep", "true"))
     return null
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SpellShortcuts.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SpellShortcuts.kt
@@ -1,7 +1,11 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Assign
+import com.wingedsheep.tooling.coverage.Block
 import com.wingedsheep.tooling.coverage.Call
 import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Stmt
+import com.wingedsheep.tooling.coverage.Sub
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
@@ -55,31 +59,27 @@ internal fun EmitCtx.extraTurnEffect(card: JsonObject): Dsl? {
 }
 
 /** Forked-Lightning shape: TargetedDistributed -> TargetCreature(count) + DividedDamageEffect. */
-internal fun EmitCtx.distributedSpell(card: JsonObject): List<String>? {
+internal fun EmitCtx.distributedSpell(card: JsonObject): List<Stmt>? {
     val blob = compact(card["Rules"])
     if ("\"TargetedDistributed\"" !in blob) return null
     val total = Regex(""""DistributeNumberAmongTargets","args":\{"_GameNumber":"Integer","args":(\d+)""").find(blob)
     val mx = Regex(""""BetweenOneAndNumberTargetPermanents","args":\[\{"_GameNumber":"Integer","args":(\d+)""").find(blob)
     if (total == null || mx == null) return null
     val m = mx.groupValues[1]
-    return listOf(
-        "    spell {",
-        "        target = TargetCreature(count = $m, minCount = 1)",
-        "        effect = DividedDamageEffect(totalDamage = ${total.groupValues[1]}, minTargets = 1, maxTargets = $m)",
-        "    }",
-    )
+    return listOf(Sub(Block("spell", listOf(
+        Assign("target", call("TargetCreature", arg("count", m), arg("minCount", "1"))),
+        Assign("effect", call("DividedDamageEffect", arg("totalDamage", total.groupValues[1]), arg("minTargets", "1"), arg("maxTargets", m))),
+    ))))
 }
 
 /** Draw the difference between target opponent's hand and yours (Balance of Power). */
-internal fun EmitCtx.balanceEffect(card: JsonObject): List<String>? {
+internal fun EmitCtx.balanceEffect(card: JsonObject): List<Stmt>? {
     val blob = compact(card["Rules"])
     if ("NumCardsInHandIs" in blob && "\"Minus\"" in blob && "TheNumberOfCardsInPlayersHand" in blob) {
-        return listOf(
-            "    spell {",
-            "        target = TargetOpponent()",
-            "        effect = DrawCardsEffect(DynamicAmounts.handSizeDifferenceFromTargetOpponent())",
-            "    }",
-        )
+        return listOf(Sub(Block("spell", listOf(
+            Assign("target", call("TargetOpponent")),
+            Assign("effect", call("DrawCardsEffect", arg(call("DynamicAmounts.handSizeDifferenceFromTargetOpponent")))),
+        ))))
     }
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -1,7 +1,16 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Assign
+import com.wingedsheep.tooling.coverage.Block
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Eval
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.Stmt
+import com.wingedsheep.tooling.coverage.Sub
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
@@ -10,12 +19,15 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
+/** `staticAbility { ability = <ability> }` as one card-body statement. */
+internal fun staticAbilityStmt(ability: Dsl): Stmt = Sub(Block("staticAbility", listOf(Assign("ability", ability))))
+
 /**
  * PermanentRuleEffect → `flags()` / `staticAbility { ability = ... }`. These classes live outside the
  * effects registry, so the capability gate is vacuous for them; the generated static is best-effort
  * and (like every draft) flagged for rules-text review.
  */
-internal fun EmitCtx.staticBlock(rule: JsonObject): List<String>? {
+internal fun EmitCtx.staticBlock(rule: JsonObject): List<Stmt>? {
     val rules = mutableListOf<JsonObject>()
     fun collect(n: JsonElement?) {
         when (n) {
@@ -26,19 +38,19 @@ internal fun EmitCtx.staticBlock(rule: JsonObject): List<String>? {
     }
     collect(rule)
     if (rules.isEmpty()) { reasons.add("PermanentRuleEffect"); return null }
-    val lines = mutableListOf<String>()
+    val stmts = mutableListOf<Stmt>()
     for (r in rules) {
         val name = r.strField("_PermanentRule")!!
         if (name == "CantBeBlocked") {
-            lines.add("    flags(AbilityFlag.CANT_BE_BLOCKED)"); continue
+            stmts.add(Eval(call("flags", arg("AbilityFlag.CANT_BE_BLOCKED")))); continue
         }
         if (name == "MayChooseNotToUntapDuringUntap") {
-            lines.add("    flags(AbilityFlag.MAY_NOT_UNTAP)"); continue
+            stmts.add(Eval(call("flags", arg("AbilityFlag.MAY_NOT_UNTAP")))); continue
         }
-        val dsl = staticAbilityDsl(name, r) ?: run { reasons.add(name); return null }
-        lines.addAll(listOf("    staticAbility {", "        ability = $dsl", "    }"))
+        val ability = staticAbilityExpr(name, r) ?: run { reasons.add(name); return null }
+        stmts.add(staticAbilityStmt(ability))
     }
-    return lines
+    return stmts
 }
 
 /**
@@ -48,18 +60,18 @@ internal fun EmitCtx.staticBlock(rule: JsonObject): List<String>? {
  * excludeSelf for "other …", or `GroupFilter.ChosenSubtypeCreatures()` for "creatures of the chosen
  * type"). Anything we can't render exactly scaffolds.
  */
-internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<String>? {
+internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<Stmt>? {
     val args = rule["args"] as? JsonArray
     val layerEffects = (args?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
     if (args == null || layerEffects.isNullOrEmpty()) { reasons.add("EachPermanentLayerEffect"); return null }
-    val group = lordGroupFilterDsl(args.getOrNull(0)) ?: run { reasons.add("EachPermanentLayerEffect"); return null }
-    val lines = mutableListOf<String>()
+    val group = lordGroupFilterExpr(args.getOrNull(0)) ?: run { reasons.add("EachPermanentLayerEffect"); return null }
+    val stmts = mutableListOf<Stmt>()
     for (le in layerEffects) {
-        val ability = when (le.strField("_StaticLayerEffect")) {
+        val ability: Dsl = when (le.strField("_StaticLayerEffect")) {
             "AdjustPT" -> {
                 val pt = le["args"] as? JsonArray ?: return scaffoldLord()
                 if (pt.size != 2) return scaffoldLord()
-                "ModifyStats(powerBonus = ${pt[0].asInt()}, toughnessBonus = ${pt[1].asInt()}, filter = $group)"
+                call("ModifyStats", arg("powerBonus", "${pt[0].asInt()}"), arg("toughnessBonus", "${pt[1].asInt()}"), arg("filter", group))
             }
             "AddAbility" -> {
                 // "Other Merfolk have islandwalk" (Lord of Atlantis / Goblin King): the granted ability is a
@@ -72,23 +84,23 @@ internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<String>? {
                 } else {
                     keywordOf(le) ?: return scaffoldLord()
                 }
-                "GrantKeyword(Keyword.$kw, $group)"
+                call("GrantKeyword", arg("Keyword.$kw"), arg(group))
             }
             else -> return scaffoldLord()
         }
-        lines.addAll(listOf("    staticAbility {", "        ability = $ability", "    }"))
+        stmts.add(staticAbilityStmt(ability))
     }
-    return lines
+    return stmts
 }
 
-private fun EmitCtx.scaffoldLord(): List<String>? { reasons.add("EachPermanentLayerEffect"); return null }
+private fun EmitCtx.scaffoldLord(): List<Stmt>? { reasons.add("EachPermanentLayerEffect"); return null }
 
 /**
  * `EnchantPermanent` -> the card-level `auraTarget = Targets.X` line. The enchant restriction is a
  * cardtype filter ("Enchant creature / land / artifact / enchantment"); anything more specific than a
  * bare cardtype (e.g. "enchant tapped creature") scaffolds rather than emit an inexact restriction.
  */
-internal fun EmitCtx.auraTargetBlock(rule: JsonObject): List<String>? {
+internal fun EmitCtx.auraTargetBlock(rule: JsonObject): List<Stmt>? {
     val filter = rule["args"] as? JsonObject
     if (filter?.strField("_Permanents") != "IsCardtype") { reasons.add("EnchantPermanent"); return null }
     val target = when (filter["args"].asStr()) {
@@ -98,7 +110,7 @@ internal fun EmitCtx.auraTargetBlock(rule: JsonObject): List<String>? {
         "Enchantment" -> "Targets.Enchantment"
         else -> { reasons.add("EnchantPermanent"); return null }
     }
-    return listOf("    auraTarget = $target")
+    return listOf(Assign("auraTarget", Lit(target)))
 }
 
 /**
@@ -108,20 +120,20 @@ internal fun EmitCtx.auraTargetBlock(rule: JsonObject): List<String>? {
  * `GrantKeyword(Keyword.X)`, AddAbility{protection-from-color} -> `GrantProtection(Color.X)` (the Ward
  * cycle). A layer effect we can't render exactly scaffolds.
  */
-internal fun EmitCtx.staticHostBlock(rule: JsonObject): List<String>? {
+internal fun EmitCtx.staticHostBlock(rule: JsonObject): List<Stmt>? {
     val args = rule["args"] as? JsonArray
     if (args == null || !jsonContains(args.getOrNull(0), "_Permanent", "HostPermanent")) {
         reasons.add("PermanentLayerEffect"); return null
     }
     val layerEffects = (args.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
     if (layerEffects.isNullOrEmpty()) { reasons.add("PermanentLayerEffect"); return null }
-    val lines = mutableListOf<String>()
+    val stmts = mutableListOf<Stmt>()
     for (le in layerEffects) {
-        val abilities: List<String> = when (le.strField("_StaticLayerEffect")) {
+        val abilities: List<Dsl> = when (le.strField("_StaticLayerEffect")) {
             "AdjustPT" -> {
                 val pt = le["args"] as? JsonArray
                 if (pt?.size != 2) { reasons.add("PermanentLayerEffect"); return null }
-                listOf("ModifyStats(${pt[0].asInt()}, ${pt[1].asInt()})")
+                listOf(call("ModifyStats", arg("${pt[0].asInt()}"), arg("${pt[1].asInt()}")))
             }
             "AddAbility" -> {
                 val granted = (le["args"] as? JsonArray)?.getOrNull(0) as? JsonObject
@@ -129,23 +141,23 @@ internal fun EmitCtx.staticHostBlock(rule: JsonObject): List<String>? {
                 // `ProtectionAndDoesntRemovePermanents` rule, the Crowns a plain `Protection` rule.
                 if (granted?.strField("_Rule") in setOf("Protection", "ProtectionAndDoesntRemovePermanents")) {
                     val colors = protectionGrantColors(granted!!) ?: run { reasons.add("PermanentLayerEffect"); return null }
-                    colors.map { "GrantProtection(Color.$it)" }
+                    colors.map { call("GrantProtection", arg("Color.$it")) }
                 } else {
                     val kw = keywordOf(le) ?: run { reasons.add("PermanentLayerEffect"); return null }
-                    listOf("GrantKeyword(Keyword.$kw)")
+                    listOf(call("GrantKeyword", arg("Keyword.$kw")))
                 }
             }
             "SetController" -> {
                 // "you control enchanted permanent" (Control Magic, Steal Artifact). Only controller=You
                 // maps to the parameterless ControlEnchantedPermanent; any other player scaffolds.
                 if (!jsonContains(le["args"], "_Player", "You")) { reasons.add("PermanentLayerEffect"); return null }
-                listOf("ControlEnchantedPermanent")
+                listOf(Lit("ControlEnchantedPermanent"))
             }
             else -> { reasons.add("PermanentLayerEffect"); return null }
         }
-        abilities.forEach { lines.addAll(listOf("    staticAbility {", "        ability = $it", "    }")) }
+        abilities.forEach { stmts.add(staticAbilityStmt(it)) }
     }
-    return lines
+    return stmts
 }
 
 /** The colors of a host protection grant ("enchanted creature has protection from <color>" — the Ward
@@ -160,22 +172,22 @@ internal fun protectionGrantColors(granted: JsonObject): List<String>? {
 
 /** The affected-group GroupFilter for a lord: chosen-creature-type variable -> the named helper,
  *  otherwise the generic group-filter recovery (fixed subtype, excludeSelf for "other"). */
-private fun EmitCtx.lordGroupFilterDsl(filterNode: kotlinx.serialization.json.JsonElement?): String? {
+private fun EmitCtx.lordGroupFilterExpr(filterNode: JsonElement?): Dsl? {
     if (jsonContains(filterNode, "_CreatureTypeVariable", "TheChosenCreatureType") ||
         jsonContains(filterNode, "_Permanents", "IsCreatureTypeVariable")) {
-        return "GroupFilter.ChosenSubtypeCreatures()"
+        return call("GroupFilter.ChosenSubtypeCreatures")
     }
-    return groupFilterDsl(filterNode)
+    return groupFilterExpr(filterNode)
 }
 
-private fun EmitCtx.staticAbilityDsl(ruleName: String, ruleNode: JsonObject): String? {
+private fun EmitCtx.staticAbilityExpr(ruleName: String, ruleNode: JsonObject): Dsl? {
     when (ruleName) {
-        "CantBlock" -> return "CantBlock()"
-        "CantBeBlockedByMoreThanOne" -> return "CantBeBlockedByMoreThan(maxBlockers = 1)"
+        "CantBlock" -> return call("CantBlock")
+        "CantBeBlockedByMoreThanOne" -> return call("CantBeBlockedByMoreThan", arg("maxBlockers", "1"))
         "CanBlockOnly" -> {
             val kw = keywordOf(ruleNode)
             val bf = if (kw != null) "GameObjectFilter.Creature.withKeyword(Keyword.$kw)" else "GameObjectFilter.Creature"
-            return "CanOnlyBlockCreaturesWith(blockerFilter = $bf)"
+            return call("CanOnlyBlockCreaturesWith", arg("blockerFilter", bf))
         }
         "CantBeBlockedByDefenders" -> {
             // mtgish "Defenders" means blockers generally; the rule's args carry the blocker restriction,
@@ -185,12 +197,12 @@ private fun EmitCtx.staticAbilityDsl(ruleName: String, ruleNode: JsonObject): St
             // gameObjectFilterDsl silently ignores predicates it can't render, so scaffold on any shape it
             // doesn't cover (e.g. ToughnessIs) rather than emit a blocker filter missing a restriction.
             if (Regex("\"(ToughnessIs|HasKeyword|ManaValueIs|HasSubtypeFrom)\"").containsMatchIn(compact(ruleNode))) return null
-            val filter = gameObjectFilterDsl(ruleNode["args"]) ?: return null
-            return "CantBeBlockedBy(blockerFilter = $filter)"
+            val filter = gameObjectFilterExpr(ruleNode["args"]) ?: return null
+            return call("CantBeBlockedBy", arg("blockerFilter", filter))
         }
         "CantBeBlockedExceptByDefenders" -> {
             if (oracleText?.contains("defender", ignoreCase = true) == true) {
-                return "CantBeBlockedExceptBy(blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER))"
+                return call("CantBeBlockedExceptBy", arg("blockerFilter", "GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER)"))
             }
             // "can't be blocked except by [creature subtype]" (Invisibility: except by Walls). The rule
             // names the *only* legal blockers, so it must render CantBeBlockedExceptBy with that subtype.
@@ -198,16 +210,16 @@ private fun EmitCtx.staticAbilityDsl(ruleName: String, ruleNode: JsonObject): St
             // invert the meaning (it removes those blockers rather than restricting to them).
             val sub = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").find(compact(ruleNode))?.groupValues?.get(1)
                 ?: return null
-            return "CantBeBlockedExceptBy(blockerFilter = GameObjectFilter.Creature.withSubtype(${subtypeArg(sub)}))"
+            return call("CantBeBlockedExceptBy", arg("blockerFilter", "GameObjectFilter.Creature.withSubtype(${subtypeArg(sub)})"))
         }
         "CantAttackUnlessDefendingPlayer" -> {  // Deep-Sea Serpent: defender must control an Island
             val subs = subtypes(ruleNode)
             if (subs.isEmpty()) return null
-            return "CantAttackUnless(Conditions.OpponentControlsLandType(\"${subs[0]}\"))"
+            return call("CantAttackUnless", arg(call("Conditions.OpponentControlsLandType", arg("\"${subs[0]}\""))))
         }
-        "MustBlockAttacker" -> return "MustBlock()"
-        "MustAttackPlayer" -> return "MustAttack()"
-        "CanBlockAnyNumberOfCreatures" -> return "CanBlockAnyNumber()"
+        "MustBlockAttacker" -> return call("MustBlock")
+        "MustAttackPlayer" -> return call("MustAttack")
+        "CanBlockAnyNumberOfCreatures" -> return call("CanBlockAnyNumber")
     }
     return null
 }
@@ -218,20 +230,20 @@ private fun EmitCtx.staticAbilityDsl(ruleName: String, ruleNode: JsonObject): St
  * top-of-library / cost-reduction player statics) scaffolds rather than guess. Currently: "you have
  * shroud" (True Believer).
  */
-internal fun EmitCtx.playerEffectBlock(rule: JsonObject): List<String>? {
+internal fun EmitCtx.playerEffectBlock(rule: JsonObject): List<Stmt>? {
     val args = rule["args"] as? JsonArray
     val player = args?.getOrNull(0)
     val effects = (args?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
     if (player == null || effects.isNullOrEmpty() || !jsonContains(player, "_Player", "You")) {
         reasons.add("PlayerEffect"); return null
     }
-    val lines = mutableListOf<String>()
+    val stmts = mutableListOf<Stmt>()
     for (e in effects) {
         val ability = when (e.strField("_PlayerEffect")) {
-            "Shroud" -> "GrantShroudToController"
+            "Shroud" -> Lit("GrantShroudToController")
             else -> { reasons.add("PlayerEffect"); return null }
         }
-        lines.addAll(listOf("    staticAbility {", "        ability = $ability", "    }"))
+        stmts.add(staticAbilityStmt(ability))
     }
-    return lines
+    return stmts
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -1,7 +1,14 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Arg
+import com.wingedsheep.tooling.coverage.Call
+import com.wingedsheep.tooling.coverage.Composite
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
@@ -18,30 +25,30 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
 
     on("TapPermanent", "UntapPermanent") { node, args, tvar ->
         val tgt = refTarget(args, tvar) ?: return@on null
-        "Effects.${if (node.strField("_Action") == "TapPermanent") "Tap" else "Untap"}($tgt)"
+        call("Effects.${if (node.strField("_Action") == "TapPermanent") "Tap" else "Untap"}", arg(Lit(tgt)))
     }
     on("GoadCreature") { _, args, tvar ->  // CR 701.15: goad target creature
         val tgt = refTarget(args, tvar) ?: return@on null
-        "Effects.Goad($tgt)"
+        call("Effects.Goad", arg(Lit(tgt)))
     }
     on("RemoveCreatureFromCombat") { _, args, tvar ->  // "remove it from combat" (Gustcloak cycle)
         val tgt = refTarget(args, tvar) ?: return@on null
-        "Effects.RemoveFromCombat($tgt)"
+        call("Effects.RemoveFromCombat", arg(Lit(tgt)))
     }
     on("RegeneratePermanent") { _, args, _ ->
         // Self-regeneration ("{cost}: Regenerate this") renders faithfully. A chosen target's
         // requirement isn't always recovered exactly (e.g. "Regenerate target Zombie" flattens the
         // subtype to "permanent"), so scaffold the targeted case rather than emit a too-broad target.
         if (!jsonContains(args, "_Permanent", "ThisPermanent")) return@on null
-        "RegenerateEffect(EffectTarget.Self)"
+        call("RegenerateEffect", arg("EffectTarget.Self"))
     }
     on("TapEachPermanent", "UntapEachPermanent") { node, args, _ ->
         val verb = if (node.strField("_Action") == "TapEachPermanent") "Tap" else "Untap"
         if (jsonContains(node, "_Permanents", "Ref_TargetPermanents")) {  // Tidal Surge: each chosen target
-            return@on "Effects.${verb}EachTarget()"
+            return@on call("Effects.${verb}EachTarget")
         }
-        val filter = groupFilterDsl(args) ?: return@on null  // mass: tap/untap a group
-        "Effects.ForEachInGroup($filter, Effects.$verb(EffectTarget.Self))"
+        val filter = groupFilterExpr(args) ?: return@on null  // mass: tap/untap a group
+        call("Effects.ForEachInGroup", arg(filter), arg(call("Effects.$verb", arg("EffectTarget.Self"))))
     }
 
     on("PutACounterOfTypeOnPermanent") { _, args, tvar ->
@@ -57,7 +64,7 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
             else -> return@on null
         }
         val tgt = refTarget(arr.getOrNull(1), tvar) ?: return@on null
-        "AddCountersEffect(counterType = $counter, count = 1, target = $tgt)"
+        call("AddCountersEffect", arg("counterType", counter), arg("count", "1"), arg("target", tgt))
     }
 
     on("CreatePermanentLayerEffectUntil", "CreateEachPermanentLayerEffectUntil") { node, _, tvar ->
@@ -70,15 +77,15 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
     on("CreatePlayerEffectUntil") { node, _, _ ->  // Summer Bloom: may play N additional lands
         val n = findInteger(node)
         if (jsonContains(node, "_PlayerEffect", "MayPlayAdditionalLands") && n is Int) {
-            "PlayAdditionalLandsEffect($n)"
+            call("PlayAdditionalLandsEffect", arg("$n"))
         } else null
     }
 
     on("EachPermanentDoesntUntapDuringControllersNextUntap") { _, _, tvar ->
-        if (tvar != null) "SkipUntapEffect($tvar)" else "SkipUntapEffect()"
+        if (tvar != null) call("SkipUntapEffect", arg(Lit(tvar))) else call("SkipUntapEffect")
     }
     on("SkipAllCombatPhasesTheirNextTurn") { _, _, tvar ->
-        if (tvar != null) "SkipCombatPhasesEffect($tvar)" else "SkipCombatPhasesEffect()"
+        if (tvar != null) call("SkipCombatPhasesEffect", arg(Lit(tvar))) else call("SkipCombatPhasesEffect")
     }
 }
 
@@ -89,17 +96,16 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
  *  buff) would emit a confidently-wrong card. The `_Expiration` is honoured exactly: end-of-turn uses
  *  the default-duration facade; "for as long as it remains tapped" carries an explicit
  *  Duration.WhileSourceTapped(); any other expiration scaffolds rather than emit a wrong duration. */
-internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: String?): String? {
+internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: String?): Dsl? {
     val mass = action == "CreateEachPermanentLayerEffectUntil"
     val target = if (mass) "EffectTarget.Self" else refTarget(node["args"], tvar)
     if (target == null) return null
     val duration = expirationDsl(node) ?: return null  // unknown expiration -> SCAFFOLD
-    val durArg = if (duration.isEmpty()) "" else ", $duration"
 
     // The layer-effects list (mtgish always shapes the action's args as [target/filter, list, expiration]).
     val layerEffects = (node["args"].asArr)?.getOrNull(1) as? JsonArray ?: return null
     if (layerEffects.isEmpty()) return null
-    val inner = mutableListOf<String>()
+    val inner = mutableListOf<Dsl>()
     for (le in layerEffects) {
         val leObj = le as? JsonObject ?: return null
         when (leObj.strField("_LayerEffect")) {
@@ -108,25 +114,27 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
                 if (pt == null || pt.size != 2) return null
                 // ModifyStats' facade carries no duration param, so a non-default duration uses the raw effect.
                 inner.add(
-                    if (duration.isEmpty()) "Effects.ModifyStats(${pt[0].asInt()}, ${pt[1].asInt()}, $target)"
-                    else "ModifyStatsEffect(${pt[0].asInt()}, ${pt[1].asInt()}, $target, $duration)"
+                    if (duration.isEmpty()) call("Effects.ModifyStats", arg("${pt[0].asInt()}"), arg("${pt[1].asInt()}"), arg(Lit(target)))
+                    else call("ModifyStatsEffect", arg("${pt[0].asInt()}"), arg("${pt[1].asInt()}"), arg(Lit(target)), arg(Lit(duration))),
                 )
             }
             "AddAbility" -> {
                 // Only a bare keyword grant renders faithfully; a granted triggered/activated ability or a
                 // parameterized keyword can't be reproduced here, so scaffold instead of dropping it.
                 val kw = grantedKeyword(leObj) ?: return null
-                inner.add("Effects.GrantKeyword(Keyword.$kw, $target$durArg)")
+                val gkArgs = mutableListOf(arg("Keyword.$kw"), arg(Lit(target)))
+                if (duration.isNotEmpty()) gkArgs.add(arg(Lit(duration)))
+                inner.add(Call("Effects.GrantKeyword", gkArgs))
             }
             else -> return null  // any other layer effect (e.g. set base P/T, lose abilities) -> SCAFFOLD
         }
     }
     if (inner.isEmpty()) return null
-    val effect = if (inner.size == 1) inner[0] else composite(inner)
+    val effect = if (inner.size == 1) inner[0] else Composite(inner)
     if (mass) {
         val gfArg = (node["args"].asArr)?.getOrNull(0) ?: JsonObject(emptyMap())
-        val filter = groupFilterDsl(gfArg) ?: return null
-        return "Effects.ForEachInGroup($filter, $effect)"
+        val filter = groupFilterExpr(gfArg) ?: return null
+        return call("Effects.ForEachInGroup", arg(filter), arg(effect))
     }
     return effect
 }
@@ -139,37 +147,37 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
  * ForEachInGroup can't express. Recognise exactly that shape (+ end-of-turn) and render the dedicated
  * `GrantToEnchantedCreatureTypeGroupEffect`; anything else returns null so the generic path / scaffold runs.
  */
-internal fun EmitCtx.enchantedTypeGroupGrant(node: JsonObject): String? {
+internal fun EmitCtx.enchantedTypeGroupGrant(node: JsonObject): Dsl? {
     val args = node["args"].asArr ?: return null
     val blob = compact(args.getOrNull(0))
     if ("SharesACreatureTypeWithPermanent" !in blob || "HostPermanent" !in blob) return null
     if (firstExpiration(node) !in setOf(null, "UntilEndOfTurn")) return null  // non-EOT -> decline
     val layerEffects = (args.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
     if (layerEffects.isEmpty()) return null
-    val params = mutableListOf<String>()
+    val params = mutableListOf<Arg>()
     for (le in layerEffects) {
         when (le.strField("_LayerEffect")) {
             "AdjustPT" -> {
                 val pt = le["args"].asArr ?: return null
                 if (pt.size != 2) return null
-                params.add("powerModifier = ${pt[0].asInt()}")
-                params.add("toughnessModifier = ${pt[1].asInt()}")
+                params.add(arg("powerModifier", "${pt[0].asInt()}"))
+                params.add(arg("toughnessModifier", "${pt[1].asInt()}"))
             }
             "AddAbility" -> {
                 val granted = (le["args"].asArr)?.getOrNull(0) as? JsonObject
                 if (granted != null && jsonContains(granted, "_Protectable", "FromColor")) {
                     val colors = protectionGrantColors(granted) ?: return null
-                    params.add("protectionColors = setOf(${colors.joinToString(", ") { "Color.$it" }})")
+                    params.add(arg("protectionColors", "setOf(${colors.joinToString(", ") { "Color.$it" }})"))
                 } else {
                     val kw = grantedKeyword(le) ?: return null
-                    params.add("keyword = Keyword.$kw")
+                    params.add(arg("keyword", "Keyword.$kw"))
                 }
             }
             else -> return null
         }
     }
     if (params.isEmpty()) return null
-    return "GrantToEnchantedCreatureTypeGroupEffect(${params.joinToString(", ")})"
+    return Call("GrantToEnchantedCreatureTypeGroupEffect", params)
 }
 
 /** The granted [Keyword] for an `AddAbility` layer effect, or null (-> SCAFFOLD) when the grant is not

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -1,8 +1,14 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Call
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Infix
+import com.wingedsheep.tooling.coverage.Link
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.argWordsTagged
-import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.dot
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.firstArgStringTagged
 import com.wingedsheep.tooling.coverage.firstColorOf
@@ -11,6 +17,7 @@ import com.wingedsheep.tooling.coverage.hasStringValue
 import com.wingedsheep.tooling.coverage.hasTag
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.nodesTagged
+import com.wingedsheep.tooling.coverage.render
 import com.wingedsheep.tooling.coverage.strField
 import com.wingedsheep.tooling.coverage.subtypes
 import com.wingedsheep.tooling.coverage.wordsAtKey
@@ -21,38 +28,44 @@ import kotlinx.serialization.json.JsonObject
  * Target / filter recovery — reads the mtgish target vocabulary the coverage map discards and rebuilds
  * the Argentum target/filter DSL. A filter we can't faithfully render returns null → the card drops
  * to SCAFFOLD rather than emitting a confidently-wrong target.
+ *
+ * The recovery builds the typed output [Dsl] tree (a base [Lit] + fluent `.method()` [Link]s as a
+ * [com.wingedsheep.tooling.coverage.Chain], `or`-joins as an [Infix]); each public `…Dsl` is a thin
+ * `…Expr(…)?.let(::render)` wrapper so callers above still receive the historical String.
  */
 
 /**
  * Single source of truth for the filter-predicate suffixes recovered from the mtgish filter IR. The
- * TargetFilter renderer ([creatureFilterDsl]) and the GameObjectFilter renderer ([gameObjectFilterDsl])
+ * TargetFilter renderer ([creatureFilterExpr]) and the GameObjectFilter renderer ([gameObjectFilterExpr])
  * read the SAME predicate vocabulary onto two parallel fluent surfaces; defining each predicate's
  * IR→DSL recovery ONCE here keeps them from drifting (the regexes were duplicated, and a fix in one
  * renderer had to be mirrored by hand). Each caller still composes these in its own order — the two
  * surfaces are not identical (TargetFilter has no multi-color form, and the renderers append in
  * different orders) — but the per-predicate recovery now lives in one place.
  *
- * Each predicate reads the parsed filter subtree through the typed [IrQuery][hasTag] accessors (bounded
- * by the node, vs. a `compact()`+substring/regex that scanned the whole flattened blob).
+ * Each predicate returns the fluent [Link] (`.tapped()`, `.powerAtLeast(2)`) it recovers from the parsed
+ * filter subtree through the typed [IrQuery][hasTag] accessors (bounded by the node, vs. a `compact()`
+ * +substring/regex that scanned the whole flattened blob), or null when the clause is absent.
  */
 internal object FilterPredicates {
     /** `.powerAtLeast(N)` for a `PowerIs >= N` clause, else null. */
-    fun powerAtLeast(node: JsonElement?): String? = powerBound(node, "GreaterThanOrEqualTo")?.let { ".powerAtLeast($it)" }
+    fun powerAtLeast(node: JsonElement?): Link? = powerBound(node, "GreaterThanOrEqualTo")?.let { Link("powerAtLeast", listOf(arg("$it"))) }
 
     /** `.powerAtMost(N)` for a `PowerIs <= N` clause, else null. */
-    fun powerAtMost(node: JsonElement?): String? = powerBound(node, "LessThanOrEqualTo")?.let { ".powerAtMost($it)" }
+    fun powerAtMost(node: JsonElement?): Link? = powerBound(node, "LessThanOrEqualTo")?.let { Link("powerAtMost", listOf(arg("$it"))) }
 
-    fun tapped(node: JsonElement?): String? = if (node.hasTag("IsTapped")) ".tapped()" else null
-    fun untapped(node: JsonElement?): String? = if (node.hasTag("IsUntapped")) ".untapped()" else null
-    fun attacking(node: JsonElement?): String? = if (node.hasTag("IsAttacking")) ".attacking()" else null
+    fun tapped(node: JsonElement?): Link? = if (node.hasTag("IsTapped")) Link("tapped") else null
+    fun untapped(node: JsonElement?): Link? = if (node.hasTag("IsUntapped")) Link("untapped") else null
+    fun attacking(node: JsonElement?): Link? = if (node.hasTag("IsAttacking")) Link("attacking") else null
 
     /** `.withoutKeyword(Keyword.FLYING)` for a `DoesntHaveAbility Flying` clause, else null. */
-    fun withoutFlying(node: JsonElement?): String? =
+    fun withoutFlying(node: JsonElement?): Link? =
         if (jsonContains(node, "_Permanents", "DoesntHaveAbility") && node.hasStringValue("Flying"))
-            ".withoutKeyword(Keyword.FLYING)" else null
+            Link("withoutKeyword", listOf(arg("Keyword.FLYING"))) else null
 
     /** `.withKeyword(Keyword.FLYING)` for a plain `Flying` clause, else null. */
-    fun withFlying(node: JsonElement?): String? = if (node.hasStringValue("Flying")) ".withKeyword(Keyword.FLYING)" else null
+    fun withFlying(node: JsonElement?): Link? =
+        if (node.hasStringValue("Flying")) Link("withKeyword", listOf(arg("Keyword.FLYING"))) else null
 
     /** The integer bound of a `PowerIs` clause whose `args` is `{ _Comparison: <comparison>, args: Integer }`,
      *  scoped to the matching `PowerIs` node so a power range's two bounds stay distinct. */
@@ -62,7 +75,9 @@ internal object FilterPredicates {
             ?.let { findInteger(it["args"]) as? Int }
 }
 
-internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String? {
+internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String? = creatureFilterExpr(filterNode)?.let(::render)
+
+internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
     val blob = compact(filterNode)
     // "nonartifact creature" (the Terror template) renders via .nonartifact(); any OTHER non-cardtype
     // restriction has no faithful filter rendering yet, so drop to SCAFFOLD rather than omit it.
@@ -72,62 +87,68 @@ internal fun EmitCtx.creatureFilterDsl(filterNode: JsonElement?): String? {
     // ControlledByAPlayer clause. Preserve it as a `.youControl()` / `.opponentControls()` suffix; never
     // drop it (an unrestricted target would let the spell hit any creature). Only the plain-creature
     // path below can compose it, so the special shapes scaffold when a controller clause is present.
-    val controller = when {
-        "ControlledByAPlayer" !in blob -> ""
-        "\"Opponent\"" in blob -> ".opponentControls()"
-        "\"You\"" in blob -> ".youControl()"
+    val controller: Link? = when {
+        "ControlledByAPlayer" !in blob -> null
+        "\"Opponent\"" in blob -> Link("opponentControls")
+        "\"You\"" in blob -> Link("youControl")
         else -> return null
     }
+    val hasController = "ControlledByAPlayer" in blob
     // Whole-creature shapes whose helpers live on GameObjectFilter (not TargetFilter), or are a named
     // TargetFilter constant. ONS targets use these in isolation, so render them as the whole filter.
     if ("IsAttacking" in blob && "IsBlocking" in blob) {
-        if (controller.isNotEmpty()) return null
+        if (hasController) return null
         // "...with flying" composes onto the attacking-or-blocking base (Venomspout Brackus).
-        return if ("\"Flying\"" in blob) "TargetFilter(GameObjectFilter.Creature.attackingOrBlocking().withKeyword(Keyword.FLYING))"
-        else "TargetFilter.AttackingOrBlockingCreature"
+        return if ("\"Flying\"" in blob)
+            Call("TargetFilter", listOf(arg(Lit("GameObjectFilter.Creature").dot("attackingOrBlocking").dot("withKeyword", arg("Keyword.FLYING")))))
+        else Lit("TargetFilter.AttackingOrBlockingCreature")
     }
     if ("IsFaceDown" in blob) {
-        if (controller.isNotEmpty()) return null
-        return "TargetFilter(GameObjectFilter.Creature.faceDown())"
+        if (hasController) return null
+        return Call("TargetFilter", listOf(arg(Lit("GameObjectFilter.Creature").dot("faceDown"))))
     }
     // "Goblin creature" / "Elf or Soldier creature": one subtype -> withSubtype; several -> an Or of
     // per-subtype creature filters (matches golden's distributed Or[And[IsCreature, HasSubtype X]…]).
     val subs = filterNode.argWordsTagged("IsCreatureType")
     if (subs.isNotEmpty()) {
-        if (controller.isNotEmpty()) return null
-        return "TargetFilter(${subs.joinToString(" or ") { "GameObjectFilter.Creature.withSubtype(\"$it\")" }})"
+        if (hasController) return null
+        return Call("TargetFilter", listOf(arg(Infix("or", subs.map { Lit("GameObjectFilter.Creature").dot("withSubtype", arg("\"$it\"")) }))))
     }
-    var suffix = ""
-    if ("Artifact" in nonCardtypes) suffix += ".nonartifact()"
+    var node: Dsl = Lit("TargetFilter.Creature")
+    if ("Artifact" in nonCardtypes) node = node.dot("nonartifact")
     // Color stays inline: TargetFilter has no multi-color form, so the creature target uses the
     // IsColor/IsNonColor-scoped single-color recovery rather than gameObjectFilterDsl's collect-all.
-    filterNode.firstColorOf("IsNonColor")?.let { suffix += ".notColor(Color.${it.uppercase()})" }
-    filterNode.firstColorOf("IsColor")?.let { suffix += ".withColor(Color.${it.uppercase()})" }
-    FilterPredicates.withoutFlying(filterNode)?.let { suffix += it }
-    FilterPredicates.tapped(filterNode)?.let { suffix += it }
-    FilterPredicates.attacking(filterNode)?.let { suffix += it }
-    FilterPredicates.powerAtMost(filterNode)?.let { suffix += it }
-    FilterPredicates.powerAtLeast(filterNode)?.let { suffix += it }
-    return "TargetFilter.Creature$suffix$controller"
+    filterNode.firstColorOf("IsNonColor")?.let { node = node.dot("notColor", arg("Color.${it.uppercase()}")) }
+    filterNode.firstColorOf("IsColor")?.let { node = node.dot("withColor", arg("Color.${it.uppercase()}")) }
+    FilterPredicates.withoutFlying(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.tapped(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.attacking(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.powerAtMost(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.powerAtLeast(filterNode)?.let { node = node.dot(it) }
+    controller?.let { node = node.dot(it) }
+    return node
 }
 
 private fun targetTypes(args: JsonElement?): Set<String> = args.argWordsTagged("IsCardtype").toSet()
 
-/** Faithful Argentum target DSL, or null if the filter can't be rendered (-> not AUTO). */
-internal fun EmitCtx.targetDsl(tnode: JsonObject, actionContext: List<JsonObject>? = null): String? {
+internal fun EmitCtx.targetDsl(tnode: JsonObject, actionContext: List<JsonObject>? = null): String? =
+    targetExpr(tnode, actionContext)?.let(::render)
+
+/** Faithful Argentum target DSL node, or null if the filter can't be rendered (-> not AUTO). */
+internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObject>? = null): Dsl? {
     val ttype = tnode.strField("_Target")
     val args = tnode["args"]
     val countInt = findInteger(tnode)
     if (ttype == "TargetPlayer") {
-        return if (jsonContains(tnode, "_Players", "Opponent")) "TargetOpponent()" else "TargetPlayer()"
+        return if (jsonContains(tnode, "_Players", "Opponent")) Call("TargetOpponent") else Call("TargetPlayer")
     }
     if (ttype == "AnyTarget" || ttype == "TargetPlayerOrPermanent") {
         val blob = compact(tnode)
-        if ("Planeswalker" in blob && "Player" in blob && "Opponent" in blob) return "TargetOpponentOrPlaneswalker()"
-        if ("Planeswalker" in blob && "Player" in blob) return "TargetPlayerOrPlaneswalker()"
-        if ("Planeswalker" in blob && "Creature" in blob) return "TargetCreatureOrPlaneswalker()"
-        if (actionContext != null && actionContext.consumesOnlyTargetPlayer()) return "TargetPlayer()"
-        return "AnyTarget()"
+        if ("Planeswalker" in blob && "Player" in blob && "Opponent" in blob) return Call("TargetOpponentOrPlaneswalker")
+        if ("Planeswalker" in blob && "Player" in blob) return Call("TargetPlayerOrPlaneswalker")
+        if ("Planeswalker" in blob && "Creature" in blob) return Call("TargetCreatureOrPlaneswalker")
+        if (actionContext != null && actionContext.consumesOnlyTargetPlayer()) return Call("TargetPlayer")
+        return Call("AnyTarget")
     }
     if (ttype in setOf("TargetPermanent", "NumberTargetPermanents", "UptoNumberTargetPermanents", "OneOrTwoTargetPermanents")) {
         val types = targetTypes(args)
@@ -136,22 +157,22 @@ internal fun EmitCtx.targetDsl(tnode: JsonObject, actionContext: List<JsonObject
         // IsCardtype Creature; route it through the creature filter so the subtype isn't dropped (Tunnel).
         val creatureTarget = types == setOf("Creature") || (types.isEmpty() && "IsCreatureType" in blob)
         if (creatureTarget) {
-            val filter = creatureFilterDsl(args) ?: return null
-            val parts = mutableListOf("filter = $filter")
-            if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, "count = $countInt")
-            if (ttype == "OneOrTwoTargetPermanents") { parts.add(0, "minCount = 1"); parts.add(0, "count = 2") }
-            if (ttype == "UptoNumberTargetPermanents") parts.add(0, "optional = true")
-            return "TargetCreature(${parts.joinToString(", ")})"
+            val filter = creatureFilterExpr(args) ?: return null
+            val parts = mutableListOf(arg("filter", filter))
+            if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, arg("count", "$countInt"))
+            if (ttype == "OneOrTwoTargetPermanents") { parts.add(0, arg("minCount", "1")); parts.add(0, arg("count", "2")) }
+            if (ttype == "UptoNumberTargetPermanents") parts.add(0, arg("optional", "true"))
+            return Call("TargetCreature", parts)
         }
         val singleType = mapOf("Land" to "TargetFilter.Land", "Artifact" to "TargetFilter.Artifact", "Enchantment" to "TargetFilter.Enchantment")
         if (types.size == 1 && types.first() in singleType) {
-            val parts = mutableListOf("filter = ${singleType[types.first()]}")
-            if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, "count = $countInt")
-            if (ttype == "UptoNumberTargetPermanents") parts.add(0, "optional = true")
-            return "TargetPermanent(${parts.joinToString(", ")})"
+            val parts = mutableListOf(arg("filter", singleType.getValue(types.first())))
+            if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, arg("count", "$countInt"))
+            if (ttype == "UptoNumberTargetPermanents") parts.add(0, arg("optional", "true"))
+            return Call("TargetPermanent", parts)
         }
         if (types.isEmpty() && "IsCardtype" !in blob && "IsCreatureType" !in blob) {
-            return "TargetPermanent()"
+            return Call("TargetPermanent")
         }
         val multiType = mapOf(
             setOf("Creature", "Land") to "TargetFilter.CreatureOrLandPermanent",
@@ -160,31 +181,30 @@ internal fun EmitCtx.targetDsl(tnode: JsonObject, actionContext: List<JsonObject
             setOf("Artifact", "Enchantment") to "TargetFilter.ArtifactOrEnchantment",
         )
         multiType[types]?.let {
-            return "TargetPermanent(filter = $it)"
+            return Call("TargetPermanent", listOf(arg("filter", it)))
         }
         return null  // unusual filters: not rendered yet -> SCAFFOLD
     }
     if (ttype == "TargetSpell") {
         val types = targetTypes(args)
-        if (types == setOf("Creature", "Sorcery")) return "TargetSpell(filter = TargetFilter.CreatureOrSorcerySpellOnStack)"
-        if (types == setOf("Instant", "Sorcery")) return "TargetSpell(filter = TargetFilter.InstantOrSorcerySpellOnStack)"
-        if (types == setOf("Creature")) return "TargetSpell(filter = TargetFilter.CreatureSpellOnStack)"
-        if (types.isEmpty()) return "TargetSpell()"
+        if (types == setOf("Creature", "Sorcery")) return Call("TargetSpell", listOf(arg("filter", "TargetFilter.CreatureOrSorcerySpellOnStack")))
+        if (types == setOf("Instant", "Sorcery")) return Call("TargetSpell", listOf(arg("filter", "TargetFilter.InstantOrSorcerySpellOnStack")))
+        if (types == setOf("Creature")) return Call("TargetSpell", listOf(arg("filter", "TargetFilter.CreatureSpellOnStack")))
+        if (types.isEmpty()) return Call("TargetSpell")
         return null
     }
     if (ttype == "TargetGraveyardCard") {
         val blob = compact(args)
         val types = targetTypes(args)
-        val filt = when {
-            types.isEmpty() && "IsCardtype" !in blob -> "TargetFilter.CardInGraveyard"
-            types == setOf("Creature") -> {
-                if ("\"You\"" in blob) "TargetFilter.CreatureInYourGraveyard" else "TargetFilter.CreatureInGraveyard"
-            }
+        val filt: Dsl = when {
+            types.isEmpty() && "IsCardtype" !in blob -> Lit("TargetFilter.CardInGraveyard")
+            types == setOf("Creature") ->
+                Lit(if ("\"You\"" in blob) "TargetFilter.CreatureInYourGraveyard" else "TargetFilter.CreatureInGraveyard")
             types == setOf("Instant", "Sorcery") -> graveyardFilter("InstantOrSorcery", blob)
             types.size == 1 && types.first() in graveyardSingleTypeFilters -> graveyardFilter(graveyardSingleTypeFilters.getValue(types.first()), blob)
             else -> return null
         }
-        return "TargetObject(filter = $filt)"
+        return Call("TargetObject", listOf(arg("filter", filt)))
     }
     return null
 }
@@ -197,13 +217,15 @@ private val graveyardSingleTypeFilters = mapOf(
     "Sorcery" to "Sorcery",
 )
 
-private fun graveyardFilter(gameObjectFilter: String, blob: String): String {
-    val owner = when {
-        "\"You\"" in blob -> ".ownedByYou()"
-        "\"Opponent\"" in blob -> ".ownedByOpponent()"
-        else -> ""
+private fun graveyardFilter(gameObjectFilter: String, blob: String): Dsl {
+    val owner: Link? = when {
+        "\"You\"" in blob -> Link("ownedByYou")
+        "\"Opponent\"" in blob -> Link("ownedByOpponent")
+        else -> null
     }
-    return "TargetFilter(GameObjectFilter.$gameObjectFilter$owner, zone = Zone.GRAVEYARD)"
+    var base: Dsl = Lit("GameObjectFilter.$gameObjectFilter")
+    owner?.let { base = base.dot(it) }
+    return Call("TargetFilter", listOf(arg(base), arg("zone", "Zone.GRAVEYARD")))
 }
 
 private fun List<JsonObject>.consumesOnlyTargetPlayer(): Boolean {
@@ -214,92 +236,100 @@ private fun List<JsonObject>.consumesOnlyTargetPlayer(): Boolean {
 }
 
 /** GroupFilter for mass effects. If we can't preserve the filter, scaffold rather than widen. */
-internal fun EmitCtx.groupFilterDsl(filterNode: JsonElement?): String? {
-    val filtered = gameObjectFilterDsl(filterNode) ?: return null
+internal fun EmitCtx.groupFilterDsl(filterNode: JsonElement?): String? = groupFilterExpr(filterNode)?.let(::render)
+
+internal fun EmitCtx.groupFilterExpr(filterNode: JsonElement?): Dsl? {
+    val filtered = gameObjectFilterExpr(filterNode) ?: return null
     val oracle = oracleText?.lowercase() ?: ""
-    val args = mutableListOf(filtered)
+    val args = mutableListOf(arg(filtered))
     // The IR's `Other(ThisPermanent)` is the authoritative "excludeSelf" signal; the oracle phrasing
     // ("all other" / "each other" / "other ... creatures") is the fallback for shapes without it.
     if (jsonContains(filterNode, "_Permanents", "Other") ||
-        "all other" in oracle || "each other" in oracle) args.add("excludeSelf = true")
-    return "GroupFilter(${args.joinToString(", ")})"
+        "all other" in oracle || "each other" in oracle) args.add(arg("excludeSelf", "true"))
+    return Call("GroupFilter", args)
 }
 
-internal fun EmitCtx.gameObjectFilterDsl(filterNode: JsonElement?): String? {
+internal fun EmitCtx.gameObjectFilterDsl(filterNode: JsonElement?): String? = gameObjectFilterExpr(filterNode)?.let(::render)
+
+internal fun EmitCtx.gameObjectFilterExpr(filterNode: JsonElement?): Dsl? {
     val blob = compact(filterNode)
     val types = targetTypes(filterNode)
     val subs = subtypes(filterNode)
     // Creature subtypes come from IsCreatureType (subtypes() only collects land/card subtypes).
     val creatureSubs = filterNode.argWordsTagged("IsCreatureType")
-    var filtered = when {
+    var node: Dsl = when {
         subs.isNotEmpty() && ("Land" in types || "IsLandType" in blob || "\"Land\"" in blob) ->
-            "GameObjectFilter.Land.withSubtype(${subtypeArg(subs[0])})"
+            Lit("GameObjectFilter.Land").dot("withSubtype", arg(subtypeArg(subs[0])))
         // A creature subtype always implies creature, so render Creature.withSubtype even when there's no
         // explicit IsCardtype Creature (the "other Merfolk"/"other Goblins" lord groups) — otherwise the
         // ThisPermanent marker below would wrongly widen it to GameObjectFilter.Permanent.
         creatureSubs.isNotEmpty() ->
-            "GameObjectFilter.Creature.withSubtype(${subtypeArg(creatureSubs[0])})"
+            Lit("GameObjectFilter.Creature").dot("withSubtype", arg(subtypeArg(creatureSubs[0])))
         subs.isNotEmpty() && ("Creature" in types || "\"Creature\"" in blob) ->
-            "GameObjectFilter.Creature.withSubtype(${subtypeArg(subs[0])})"
-        types == setOf("Creature", "Land") -> "GameObjectFilter.CreatureOrLand"
-        types == setOf("Creature", "Artifact") -> "GameObjectFilter.CreatureOrArtifact"
-        types == setOf("Creature", "Enchantment") -> "GameObjectFilter.CreatureOrEnchantment"
-        types == setOf("Artifact", "Enchantment") -> "GameObjectFilter.ArtifactOrEnchantment"
-        "Creature" in types || "\"Creature\"" in blob -> "GameObjectFilter.Creature"
-        "Land" in types || "\"Land\"" in blob -> "GameObjectFilter.Land"
-        "Artifact" in types || "\"Artifact\"" in blob -> "GameObjectFilter.Artifact"
-        "Enchantment" in types || "\"Enchantment\"" in blob -> "GameObjectFilter.Enchantment"
-        "Permanent" in blob -> "GameObjectFilter.Permanent"
+            Lit("GameObjectFilter.Creature").dot("withSubtype", arg(subtypeArg(subs[0])))
+        types == setOf("Creature", "Land") -> Lit("GameObjectFilter.CreatureOrLand")
+        types == setOf("Creature", "Artifact") -> Lit("GameObjectFilter.CreatureOrArtifact")
+        types == setOf("Creature", "Enchantment") -> Lit("GameObjectFilter.CreatureOrEnchantment")
+        types == setOf("Artifact", "Enchantment") -> Lit("GameObjectFilter.ArtifactOrEnchantment")
+        "Creature" in types || "\"Creature\"" in blob -> Lit("GameObjectFilter.Creature")
+        "Land" in types || "\"Land\"" in blob -> Lit("GameObjectFilter.Land")
+        "Artifact" in types || "\"Artifact\"" in blob -> Lit("GameObjectFilter.Artifact")
+        "Enchantment" in types || "\"Enchantment\"" in blob -> Lit("GameObjectFilter.Enchantment")
+        "Permanent" in blob -> Lit("GameObjectFilter.Permanent")
         else -> return null
     }
     val colors = filterNode.wordsAtKey("_Color").map { it.uppercase() }.distinct()
     if (colors.size > 1 && "\"Or\"" in blob) {
-        filtered += ".withAnyColor(${colors.joinToString(", ") { "Color.$it" }})"
+        node = node.dot("withAnyColor", *colors.map { arg("Color.$it") }.toTypedArray())
     } else if (colors.size == 1) {
-        filtered += if (filterNode.hasTag("IsNonColor")) ".notColor(Color.${colors[0]})" else ".withColor(Color.${colors[0]})"
+        node = if (filterNode.hasTag("IsNonColor")) node.dot("notColor", arg("Color.${colors[0]}")) else node.dot("withColor", arg("Color.${colors[0]}"))
     }
-    filtered += FilterPredicates.withoutFlying(filterNode) ?: FilterPredicates.withFlying(filterNode) ?: ""
-    FilterPredicates.powerAtLeast(filterNode)?.let { filtered += it }
-    FilterPredicates.powerAtMost(filterNode)?.let { filtered += it }
-    FilterPredicates.tapped(filterNode)?.let { filtered += it }
-    FilterPredicates.untapped(filterNode)?.let { filtered += it }
-    FilterPredicates.attacking(filterNode)?.let { filtered += it }
-    if ("\"You\"" in blob) filtered += ".youControl()"
-    if ("\"Opponent\"" in blob) filtered += ".opponentControls()"
-    return filtered
+    (FilterPredicates.withoutFlying(filterNode) ?: FilterPredicates.withFlying(filterNode))?.let { node = node.dot(it) }
+    FilterPredicates.powerAtLeast(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.powerAtMost(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.tapped(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.untapped(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.attacking(filterNode)?.let { node = node.dot(it) }
+    if ("\"You\"" in blob) node = node.dot("youControl")
+    if ("\"Opponent\"" in blob) node = node.dot("opponentControls")
+    return node
 }
 
-internal fun EmitCtx.revealedHandFilterDsl(filterNode: JsonElement?): String? {
+internal fun EmitCtx.revealedHandFilterDsl(filterNode: JsonElement?): String? = revealedHandFilterExpr(filterNode)?.let(::render)
+
+internal fun EmitCtx.revealedHandFilterExpr(filterNode: JsonElement?): Dsl? {
     val landType = filterNode.firstArgStringTagged("IsLandType")
     val color = filterNode.firstWordAtKey("_Color")
     if (landType == null && color == null) return null
-    val parts = mutableListOf<String>()
-    if (landType != null) parts.add("GameObjectFilter.Land.withSubtype(${subtypeArg(landType)})")
-    if (color != null) parts.add("GameObjectFilter.Any.withColor(Color.${color.uppercase()})")
-    return parts.joinToString(" or ").let { if (parts.size > 1) "($it)" else it }
+    val parts = mutableListOf<Dsl>()
+    if (landType != null) parts.add(Lit("GameObjectFilter.Land").dot("withSubtype", arg(subtypeArg(landType))))
+    if (color != null) parts.add(Lit("GameObjectFilter.Any").dot("withColor", arg("Color.${color.uppercase()}")))
+    return Infix("or", parts, parenthesized = parts.size > 1)
 }
 
-internal fun EmitCtx.landSearchFilterDsl(filterNode: JsonElement?): String {
+internal fun EmitCtx.landSearchFilterDsl(filterNode: JsonElement?): String = render(landSearchFilterExpr(filterNode))
+
+internal fun EmitCtx.landSearchFilterExpr(filterNode: JsonElement?): Dsl {
     val subs = subtypes(filterNode)
     // Dual-land fetch ("a Swamp or Mountain card") -> Land + Or[HasSubtype…], i.e. withAnySubtype;
     // golden factors IsLand out (unlike the distributed creature-subtype form).
-    if (subs.size >= 2) return "GameObjectFilter.Land.withAnySubtype(${subs.joinToString(", ") { "\"$it\"" }})"
-    if (subs.isNotEmpty()) return "GameObjectFilter.Land.withSubtype(${subtypeArg(subs[0])})"
+    if (subs.size >= 2) return Lit("GameObjectFilter.Land").dot("withAnySubtype", *subs.map { arg("\"$it\"") }.toTypedArray())
+    if (subs.isNotEmpty()) return Lit("GameObjectFilter.Land").dot("withSubtype", arg(subtypeArg(subs[0])))
     val blob = compact(filterNode)
     val oracle = oracleText?.lowercase() ?: ""
     return when {
-        "basic land" in oracle || "IsBasicLand" in blob -> "GameObjectFilter.BasicLand"
-        "sorcery card" in oracle || "\"Sorcery\"" in blob -> "GameObjectFilter.Sorcery"
-        "instant card" in oracle || "\"Instant\"" in blob -> "GameObjectFilter.Instant"
-        "\"Land\"" in blob -> "GameObjectFilter.Land"
+        "basic land" in oracle || "IsBasicLand" in blob -> Lit("GameObjectFilter.BasicLand")
+        "sorcery card" in oracle || "\"Sorcery\"" in blob -> Lit("GameObjectFilter.Sorcery")
+        "instant card" in oracle || "\"Instant\"" in blob -> Lit("GameObjectFilter.Instant")
+        "\"Land\"" in blob -> Lit("GameObjectFilter.Land")
         "\"Creature\"" in blob || "creature" in oracle -> {
-            var out = "GameObjectFilter.Creature"
-            if ("black creature" in oracle) out += ".withColor(Color.BLACK)"
-            else filterNode.firstWordAtKey("_Color")?.let { out += ".withColor(Color.${it.uppercase()})" }
-            if ("tapped creature" in oracle) out += ".tapped()"
-            if ("attacking" in oracle) out += ".attacking()"
+            var out: Dsl = Lit("GameObjectFilter.Creature")
+            if ("black creature" in oracle) out = out.dot("withColor", arg("Color.BLACK"))
+            else filterNode.firstWordAtKey("_Color")?.let { out = out.dot("withColor", arg("Color.${it.uppercase()}")) }
+            if ("tapped creature" in oracle) out = out.dot("tapped")
+            if ("attacking" in oracle) out = out.dot("attacking")
             out
         }
-        else -> "GameObjectFilter.Any"
+        else -> Lit("GameObjectFilter.Any")
     }
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
@@ -1,8 +1,12 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Call
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
 import com.wingedsheep.tooling.coverage.strField
@@ -26,7 +30,7 @@ private val TOKEN_COLOR = mapOf(
 
 /** A `_CreatableToken` spec -> `Effects.CreateToken(...)`, or null (-> SCAFFOLD) for shapes we can't
  *  render exactly. `NumberTokens` wraps a base spec with a fixed count. */
-internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1): String? {
+internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1): Dsl? {
     when (spec.strField("_CreatableToken")) {
         "NumberTokens" -> {
             val a = spec["args"].asArr ?: return null
@@ -36,7 +40,7 @@ internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1): String? {
         }
         // Predefined artifact token with fixed characteristics -> its dedicated facade
         // (serialises as CreatePredefinedToken, not the generic CreateToken).
-        "TreasureToken" -> return "Effects.CreateTreasure($count)"
+        "TreasureToken" -> return call("Effects.CreateTreasure", arg("$count"))
         "TokenWithPT" -> {
             // args: [ {_PT [p,t]}, {_TokenColorList [names]}, [supertypes], [cardtypes],
             //         {_TokenSubtypes [subs]}, [abilities] ]
@@ -64,12 +68,12 @@ internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1): String? {
                 if (kw !in keywords) return null
                 tokenKeywords.add(kw)
             }
-            val parts = mutableListOf("power = $power", "toughness = $toughness")
-            if (colors.isNotEmpty()) parts.add("colors = setOf(${colors.joinToString(", ") { "Color.$it" }})")
-            parts.add("creatureTypes = setOf(${subs.joinToString(", ") { "\"$it\"" }})")
-            if (tokenKeywords.isNotEmpty()) parts.add("keywords = setOf(${tokenKeywords.joinToString(", ") { "Keyword.$it" }})")
-            if (count != 1) parts.add("count = $count")
-            return "Effects.CreateToken(${parts.joinToString(", ")})"
+            val parts = mutableListOf(arg("power", "$power"), arg("toughness", "$toughness"))
+            if (colors.isNotEmpty()) parts.add(arg("colors", "setOf(${colors.joinToString(", ") { "Color.$it" }})"))
+            parts.add(arg("creatureTypes", "setOf(${subs.joinToString(", ") { "\"$it\"" }})"))
+            if (tokenKeywords.isNotEmpty()) parts.add(arg("keywords", "setOf(${tokenKeywords.joinToString(", ") { "Keyword.$it" }})"))
+            if (count != 1) parts.add(arg("count", "$count"))
+            return Call("Effects.CreateToken", parts)
         }
     }
     return null

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -1,6 +1,13 @@
 package com.wingedsheep.tooling.coverage.emitter
 
+import com.wingedsheep.tooling.coverage.Call
+import com.wingedsheep.tooling.coverage.Composite
+import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.Raw
+import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
@@ -14,47 +21,50 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
 
     on("PutEachPermanentIntoItsOwnersHand") { node, _, _ ->  // bounce each chosen target
         if (jsonContains(node, "_Permanents", "Ref_TargetPermanents")) {
-            "ForEachTargetEffect(listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND)))"
+            call("ForEachTargetEffect", arg(call("listOf", arg(call("Effects.Move", arg("EffectTarget.ContextTarget(0)"), arg("Zone.HAND"))))))
         } else null
     }
 
     on("DestroyPermanent") { _, args, tvar ->
         val tgt = refTarget(args, tvar) ?: return@on null
-        "Effects.Move($tgt, Zone.GRAVEYARD, byDestruction = true)"
+        call("Effects.Move", arg(Lit(tgt)), arg("Zone.GRAVEYARD"), arg("byDestruction", "true"))
     }
     on("DestroyPermanentNoRegen") { _, args, tvar ->  // "Destroy …. It can't be regenerated." (Terror, Tunnel)
         val tgt = refTarget(args, tvar) ?: return@on null
-        "Effects.Destroy($tgt, noRegenerate = true)"
+        call("Effects.Destroy", arg(Lit(tgt)), arg("noRegenerate", "true"))
     }
     on("DestroyEachPermanent", "DestroyEachPermanentNoRegen") { node, args, _ ->
         if (jsonContains(args, "_Permanents", "Ref_TargetPermanents")) {
-            val noregen = if (node.strField("_Action") == "DestroyEachPermanentNoRegen") ", noRegenerate = true" else ""
-            return@on "ForEachTargetEffect(listOf(Effects.Move(EffectTarget.ContextTarget(0), " +
-                "Zone.GRAVEYARD, byDestruction = true$noregen)))"
+            val moveArgs = mutableListOf(arg("EffectTarget.ContextTarget(0)"), arg("Zone.GRAVEYARD"), arg("byDestruction", "true"))
+            if (node.strField("_Action") == "DestroyEachPermanentNoRegen") moveArgs.add(arg("noRegenerate", "true"))
+            return@on call("ForEachTargetEffect", arg(call("listOf", arg(Call("Effects.Move", moveArgs)))))
         }
         if (oracleText?.contains("target", ignoreCase = true) == true) return@on null
         val noregen = if (node.strField("_Action") == "DestroyEachPermanentNoRegen") "true" else "false"
-        val filter = groupFilterDsl(args) ?: return@on null
-        "Effects.ForEachInGroup($filter, Effects.Move(EffectTarget.Self, " +
-            "Zone.GRAVEYARD, byDestruction = true), noRegenerate = $noregen)"
+        val filter = groupFilterExpr(args) ?: return@on null
+        call(
+            "Effects.ForEachInGroup", arg(filter),
+            arg(call("Effects.Move", arg("EffectTarget.Self"), arg("Zone.GRAVEYARD"), arg("byDestruction", "true"))),
+            arg("noRegenerate", noregen),
+        )
     }
 
     on("PutPermanentIntoItsOwnersHand") { _, args, tvar ->  // bounce
         val tgt = refTarget(args, tvar) ?: return@on null
-        "Effects.Move($tgt, Zone.HAND)"
+        call("Effects.Move", arg(Lit(tgt)), arg("Zone.HAND"))
     }
 
     on("SacrificePermanent") { _, args, _ ->  // "sacrifice ~" (Blistering Firecat's end-step sacrifice)
-        if (jsonContains(args, "_Permanent", "ThisPermanent")) "SacrificeSelfEffect" else null
+        if (jsonContains(args, "_Permanent", "ThisPermanent")) Lit("SacrificeSelfEffect") else null
     }
 
     on("ShuffleGraveyardCardIntoLibrary") { _, args, tvar ->  // e.g. Alabaster Dragon
         val tgt = refTarget(args, tvar) ?: "EffectTarget.Self"
-        "Effects.Move($tgt, Zone.LIBRARY, ZonePlacement.Shuffled)"
+        call("Effects.Move", arg(Lit(tgt)), arg("Zone.LIBRARY"), arg("ZonePlacement.Shuffled"))
     }
 
     on("Surveil") { _, args, _ ->  // "Surveil N" -> the look-top / keep-or-bin pipeline
-        (findInteger(args) as? Int)?.let { "Patterns.Library.surveil($it)" }
+        (findInteger(args) as? Int)?.let { call("Patterns.Library.surveil", arg("$it")) }
     }
 
     on("PutACardFromHandOnBattlefield") { _, args, _ ->  // "you may put a [basic land] card from your hand …"
@@ -66,9 +76,9 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
             else -> return@on null
         }
         val entersTapped = "EntersTapped" in compact(arr.getOrNull(1))
-        val parts = mutableListOf("filter = $filter")
-        if (entersTapped) parts.add("entersTapped = true")
-        "Patterns.Hand.putFromHand(${parts.joinToString(", ")})"
+        val parts = mutableListOf(arg("filter", filter))
+        if (entersTapped) parts.add(arg("entersTapped", "true"))
+        Call("Patterns.Hand.putFromHand", parts)
     }
 
     on("SearchLibrary") { _, args, _ -> renderSearch(args) }
@@ -87,14 +97,14 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
             "ReturnDeadGraveyardCardToTopOfLibrary" to "LIBRARY", "PutPermanentOnTopOfOwnersLibrary" to "LIBRARY",
         )[a]
         if (a == "PutPermanentOnTopOfOwnersLibrary" || a == "ReturnDeadGraveyardCardToTopOfLibrary") {
-            "Effects.Move($tgt, Zone.$zone, ZonePlacement.Top)"
+            call("Effects.Move", arg(Lit(tgt)), arg("Zone.$zone"), arg("ZonePlacement.Top"))
         } else {
-            "Effects.Move($tgt, Zone.$zone)"
+            call("Effects.Move", arg(Lit(tgt)), arg("Zone.$zone"))
         }
     }
 }
 
-internal fun EmitCtx.renderSearch(args: JsonElement?): String? {
+internal fun EmitCtx.renderSearch(args: JsonElement?): Dsl? {
     val blob = compact(args)
     // A destination CHOICE ("put it into your hand or graveyard") or a destination we don't model
     // (graveyard) can't be rendered as a single fixed SearchDestination — scaffold rather than silently
@@ -116,15 +126,15 @@ internal fun EmitCtx.renderSearch(args: JsonElement?): String? {
         else -> landSearchFilterDsl(args)
     }
     val count = findInteger(args)
-    val parts = mutableListOf("filter = $filt")
-    if (count is Int && count != 1) parts.add("count = $count")
-    parts.add("destination = SearchDestination.$dest")
-    if ("EntersTapped" in blob) parts.add("entersTapped = true")  // "...onto the battlefield tapped"
-    if ("RevealFoundCards" in blob) parts.add("reveal = true")
-    return "Patterns.Library.searchLibrary(${parts.joinToString(", ")})"
+    val parts = mutableListOf(arg("filter", filt))
+    if (count is Int && count != 1) parts.add(arg("count", "$count"))
+    parts.add(arg("destination", "SearchDestination.$dest"))
+    if ("EntersTapped" in blob) parts.add(arg("entersTapped", "true"))  // "...onto the battlefield tapped"
+    if ("RevealFoundCards" in blob) parts.add(arg("reveal", "true"))
+    return Call("Patterns.Library.searchLibrary", parts)
 }
 
-internal fun EmitCtx.renderLook(node: JsonObject, args: JsonElement?, tvar: String?): String? {
+internal fun EmitCtx.renderLook(node: JsonObject, args: JsonElement?, tvar: String?): Dsl? {
     val look = findInteger(node) ?: return null
     val blob = compact(node)
     // A conditional look ("...if there is an instant and a sorcery card in your graveyard, instead put
@@ -134,27 +144,33 @@ internal fun EmitCtx.renderLook(node: JsonObject, args: JsonElement?, tvar: Stri
     if (oracleText?.contains("target", ignoreCase = true) == true) {
         if (node.strField("_Action") != "LookAtTheTopNumberCardsOfPlayersLibrary" || tvar == null) return null
         if ("PutAGenericCardIntoGraveyard" !in blob || "PutTheRemainingCardsOnTopOfLibraryInAnyOrder" !in blob) return null
-        return composite(listOf(
-            "GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed($look), Player.TargetOpponent), storeAs = \"looked\")",
-            "SelectFromCollectionEffect(\n" +
-                "                from = \"looked\",\n" +
-                "                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),\n" +
-                "                storeSelected = \"toGraveyard\",\n" +
-                "                storeRemainder = \"toTop\",\n" +
-                "                selectedLabel = \"Put in graveyard\",\n" +
-                "                remainderLabel = \"Put on top\"\n" +
-                "            )",
-            "MoveCollectionEffect(from = \"toGraveyard\", destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.TargetOpponent))",
-            "MoveCollectionEffect(\n" +
-                "                from = \"toTop\",\n" +
-                "                destination = CardDestination.ToZone(Zone.LIBRARY, Player.TargetOpponent, ZonePlacement.Top),\n" +
-                "                order = CardOrder.ControllerChooses\n" +
-                "            )",
+        // The look-and-distribute pipeline keeps its hand-indented multi-line element strings as Raw —
+        // a shape no leaf node models yet — inside the multi-line Composite node.
+        return Composite(listOf(
+            Lit("GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed($look), Player.TargetOpponent), storeAs = \"looked\")"),
+            Raw(
+                "SelectFromCollectionEffect(\n" +
+                    "                from = \"looked\",\n" +
+                    "                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),\n" +
+                    "                storeSelected = \"toGraveyard\",\n" +
+                    "                storeRemainder = \"toTop\",\n" +
+                    "                selectedLabel = \"Put in graveyard\",\n" +
+                    "                remainderLabel = \"Put on top\"\n" +
+                    "            )",
+            ),
+            Lit("MoveCollectionEffect(from = \"toGraveyard\", destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.TargetOpponent))"),
+            Raw(
+                "MoveCollectionEffect(\n" +
+                    "                from = \"toTop\",\n" +
+                    "                destination = CardDestination.ToZone(Zone.LIBRARY, Player.TargetOpponent, ZonePlacement.Top),\n" +
+                    "                order = CardOrder.ControllerChooses\n" +
+                    "            )",
+            ),
         ))
     }
     var keep: Int? = null
     for (m in Regex(""""PutNumber\w*IntoHand".*?"args":\s*(\d+)""").findAll(blob)) keep = m.groupValues[1].toInt()
-    if (keep != null) return "Patterns.Library.lookAtTopAndKeep(count = $look, keepCount = $keep)"
-    if ("PutTheRemainingCardsOnTopOfLibraryInAnyOrder" in blob) return "Patterns.Library.lookAtTopAndReorder(count = $look)"
+    if (keep != null) return call("Patterns.Library.lookAtTopAndKeep", arg("count", "$look"), arg("keepCount", "$keep"))
+    if ("PutTheRemainingCardsOnTopOfLibraryInAnyOrder" in blob) return call("Patterns.Library.lookAtTopAndReorder", arg("count", "$look"))
     return null
 }

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/DslTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/DslTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.tooling.coverage
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins the emitter output AST renderer ([render]) — the ONE place a [Dsl] node becomes pre-wrap source
+ * text. Each spec locks a node shape to the exact string the emitter historically hand-stitched, so the
+ * leaf/effect/ability handlers can build nodes instead of interpolating strings with no risk of a
+ * whitespace/comma/paren drift. (Long-line reflow stays downstream in `wrapLine`; these are pre-wrap.)
+ */
+class DslTest : StringSpec({
+
+    "a literal renders verbatim" {
+        render(Lit("DynamicAmount.XValue")) shouldBe "DynamicAmount.XValue"
+        render(Lit("3")) shouldBe "3"
+    }
+
+    "a no-arg call renders as callee()" {
+        render(call("DynamicAmounts.sacrificedPower")) shouldBe "DynamicAmounts.sacrificedPower()"
+    }
+
+    "positional args join with ', '" {
+        render(call("DealDamageEffect", arg("2"), arg("t"))) shouldBe "DealDamageEffect(2, t)"
+    }
+
+    "a named arg renders as 'name = value'" {
+        render(call("DynamicAmount.Fixed", arg("2"))) shouldBe "DynamicAmount.Fixed(2)"
+        render(call("AddCountersEffect", arg("count", "1"), arg("target", "t"))) shouldBe
+            "AddCountersEffect(count = 1, target = t)"
+    }
+
+    "nested calls render inline (downstream wrapLine handles width)" {
+        val node = call(
+            "DynamicAmount.Divide",
+            arg(Lit("DynamicAmount.XValue")), arg(call("DynamicAmount.Fixed", arg("2"))), arg("roundUp", "true"),
+        )
+        render(node) shouldBe "DynamicAmount.Divide(DynamicAmount.XValue, DynamicAmount.Fixed(2), roundUp = true)"
+    }
+
+    "a chain renders base.method(args).method(args)" {
+        val node = Lit("GameObjectFilter.Creature").dot("withSubtype", arg("\"Goblin\"")).dot("tapped")
+        render(node) shouldBe "GameObjectFilter.Creature.withSubtype(\"Goblin\").tapped()"
+    }
+
+    "an infix joins with the operator, parenthesized when asked" {
+        render(Infix("or", listOf(Lit("A"), Lit("B")))) shouldBe "A or B"
+        render(Infix("or", listOf(Lit("A"), Lit("B")), parenthesized = true)) shouldBe "(A or B)"
+    }
+
+    "a Composite lays each element at 12 spaces with an 8-space close (matches the old composite())" {
+        val node = Composite(listOf(Lit("Effects.ModifyStats(3, 3, t)"), Lit("Effects.GrantKeyword(Keyword.FLYING, t)")))
+        render(node) shouldBe
+            "Effects.Composite(\n" +
+            "            Effects.ModifyStats(3, 3, t),\n" +
+            "            Effects.GrantKeyword(Keyword.FLYING, t)\n" +
+            "        )"
+    }
+
+    "Raw passes its text through untouched" {
+        render(Raw("anything\n    indented")) shouldBe "anything\n    indented"
+    }
+})

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/DslTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/DslTest.kt
@@ -60,4 +60,40 @@ class DslTest : StringSpec({
     "Raw passes its text through untouched" {
         render(Raw("anything\n    indented")) shouldBe "anything\n    indented"
     }
+
+    "a block renders `header { body }` with the body one indent level deeper" {
+        val block = Block(
+            "spell",
+            listOf(
+                Local("t", call("target", arg("\"target\""), arg(Lit("TargetCreature()")))),
+                Assign("effect", call("DealDamageEffect", arg("2"), arg("t"))),
+            ),
+        )
+        renderBlock(block) shouldBe listOf(
+            "spell {",
+            "    val t = target(\"target\", TargetCreature())",
+            "    effect = DealDamageEffect(2, t)",
+            "}",
+        )
+    }
+
+    "statements: Eval is bare, Sub nests, RawLine is verbatim (ignoring the block indent)" {
+        val block = Block(
+            "card(\"X\")",
+            listOf(
+                RawLine("    manaCost = \"{R}\""),                       // shell scaffolding, pre-indented
+                Eval(call("dynamicStats", arg("DynamicAmount.XValue"))),  // a bare expression statement
+                Sub(Block("staticAbility", listOf(Assign("ability", call("CantBlock"))))),
+            ),
+        )
+        renderBlock(block) shouldBe listOf(
+            "card(\"X\") {",
+            "    manaCost = \"{R}\"",
+            "    dynamicStats(DynamicAmount.XValue)",
+            "    staticAbility {",
+            "        ability = CantBlock()",
+            "    }",
+            "}",
+        )
+    }
 })

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/EffectHandlerTest.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.tooling.coverage.emitter
+
+import com.wingedsheep.tooling.coverage.J
+import com.wingedsheep.tooling.coverage.render
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Per-handler table test for the effect layer: a handful of mtgish `_Action` fragments dispatched
+ * through [renderAction] (the ACTION_HANDLERS registry) and rendered, pinned to the exact Argentum
+ * Effect DSL. Fast and local; the committed golden remains the exhaustive net.
+ */
+class EffectHandlerTest : StringSpec({
+
+    val ctx = EmitCtx(emptySet())
+    fun obj(json: String): JsonObject = J.parseToJsonElement(json) as JsonObject
+    fun effect(json: String): String? = ctx.renderAction(obj(json), null)?.let(::render)
+
+    "constant 1:1 effects render as their fixed token (a Lit)" {
+        effect("""{"_Action":"CounterSpell"}""") shouldBe "CounterEffect()"
+        effect("""{"_Action":"Shuffle"}""") shouldBe "ShuffleLibraryEffect()"
+        effect("""{"_Action":"DiscardACardAtRandom"}""") shouldBe "Patterns.Hand.discardRandom(1)"
+    }
+
+    "mana production maps the produce tag to the Add*Mana facade" {
+        effect("""{"_Action":"AddMana","args":{"_ManaProduce":"ManaProduceC"}}""") shouldBe "Effects.AddColorlessMana(1)"
+        effect("""{"_Action":"AddMana","args":{"_ManaProduce":"ManaProduceR"}}""") shouldBe "Effects.AddMana(Color.RED)"
+        effect("""{"_Action":"AddMana","args":{"_ManaProduce":"AnyManaColor"}}""") shouldBe "Effects.AddManaOfChoice()"
+    }
+
+    "a mixed mana pool composites inline (single line, not the multi-line Composite)" {
+        // And[ManaProduceB, ManaProduceB, ManaProduceB] -> Dark Ritual's {B}{B}{B}.
+        val ritual = """{"_Action":"AddMana","args":{"_ManaProduce":"And","args":[""" +
+            """{"_ManaProduce":"ManaProduceB"},{"_ManaProduce":"ManaProduceB"},{"_ManaProduce":"ManaProduceB"}]}}"""
+        effect(ritual) shouldBe "Effects.AddMana(Color.BLACK, 3)"
+    }
+
+    "an unrecognised action declines (-> SCAFFOLD)" {
+        effect("""{"_Action":"SomeActionWeDoNotModel"}""").shouldBeNull()
+    }
+})

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/FilterPredicatesTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/FilterPredicatesTest.kt
@@ -1,20 +1,28 @@
 package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.J
+import com.wingedsheep.tooling.coverage.Link
+import com.wingedsheep.tooling.coverage.Lit
+import com.wingedsheep.tooling.coverage.dot
+import com.wingedsheep.tooling.coverage.render
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Pins the shared filter-predicate recovery the two filter renderers ([creatureFilterDsl] /
- * [gameObjectFilterDsl]) compose, so the IR→DSL fragments stay in one place. The predicates now read the
- * parsed filter subtree through the typed [com.wingedsheep.tooling.coverage] IrQuery accessors (the
- * power bound is scoped to its `PowerIs` node), rather than regexing a flattened blob.
+ * Pins the shared filter-predicate recovery the two filter renderers ([creatureFilterExpr] /
+ * [gameObjectFilterExpr]) compose, so the IR→DSL fragments stay in one place. The predicates now return
+ * the fluent chain [Link] they recover (read through the typed [com.wingedsheep.tooling.coverage] IrQuery
+ * accessors, the power bound scoped to its `PowerIs` node), rendered here onto an empty base to assert
+ * the historical `.suffix()` text.
  */
 class FilterPredicatesTest : StringSpec({
 
     fun node(json: String): JsonElement = J.parseToJsonElement(json)
+
+    /** The fluent suffix a recovered [Link] renders to (`.tapped()`), or null when absent. */
+    fun suffix(link: Link?): String? = link?.let { render(Lit("").dot(it)) }
 
     // mtgish encodes a power bound as `PowerIs { _Comparison, args: Integer }` (Fleet-Footed Monk's
     // "creatures with power 2 or greater").
@@ -23,25 +31,25 @@ class FilterPredicatesTest : StringSpec({
 
     "power bounds recover from the scoped PowerIs node" {
         val atLeast = node(powerIs("GreaterThanOrEqualTo", 3))
-        FilterPredicates.powerAtLeast(atLeast) shouldBe ".powerAtLeast(3)"
+        suffix(FilterPredicates.powerAtLeast(atLeast)) shouldBe ".powerAtLeast(3)"
         FilterPredicates.powerAtMost(atLeast).shouldBeNull()
 
         val atMost = node(powerIs("LessThanOrEqualTo", 2))
-        FilterPredicates.powerAtMost(atMost) shouldBe ".powerAtMost(2)"
+        suffix(FilterPredicates.powerAtMost(atMost)) shouldBe ".powerAtMost(2)"
         FilterPredicates.powerAtLeast(atMost).shouldBeNull()
     }
 
     "a power range keeps its two bounds distinct (scoped per PowerIs node)" {
         // power >= 2 AND power <= 4: each bound must read its OWN PowerIs clause, not the nearest integer.
         val range = node("""[${powerIs("GreaterThanOrEqualTo", 2)},${powerIs("LessThanOrEqualTo", 4)}]""")
-        FilterPredicates.powerAtLeast(range) shouldBe ".powerAtLeast(2)"
-        FilterPredicates.powerAtMost(range) shouldBe ".powerAtMost(4)"
+        suffix(FilterPredicates.powerAtLeast(range)) shouldBe ".powerAtLeast(2)"
+        suffix(FilterPredicates.powerAtMost(range)) shouldBe ".powerAtMost(4)"
     }
 
     "tap / attack state predicates map to their fluent suffixes" {
-        FilterPredicates.tapped(node("""{"_Permanents":"IsTapped"}""")) shouldBe ".tapped()"
-        FilterPredicates.untapped(node("""{"_Permanents":"IsUntapped"}""")) shouldBe ".untapped()"
-        FilterPredicates.attacking(node("""{"_Permanents":"IsAttacking"}""")) shouldBe ".attacking()"
+        suffix(FilterPredicates.tapped(node("""{"_Permanents":"IsTapped"}"""))) shouldBe ".tapped()"
+        suffix(FilterPredicates.untapped(node("""{"_Permanents":"IsUntapped"}"""))) shouldBe ".untapped()"
+        suffix(FilterPredicates.attacking(node("""{"_Permanents":"IsAttacking"}"""))) shouldBe ".attacking()"
         FilterPredicates.tapped(node("{}")).shouldBeNull()
         // IsUntapped must not be mistaken for IsTapped (substring containment would have).
         FilterPredicates.tapped(node("""{"_Permanents":"IsUntapped"}""")).shouldBeNull()
@@ -49,10 +57,10 @@ class FilterPredicatesTest : StringSpec({
 
     "flying recovers as with/without keyword, distinguished by the DoesntHaveAbility marker" {
         val without = node("""{"_Permanents":"DoesntHaveAbility","args":[{"_Keyword":"Flying"}]}""")
-        FilterPredicates.withoutFlying(without) shouldBe ".withoutKeyword(Keyword.FLYING)"
+        suffix(FilterPredicates.withoutFlying(without)) shouldBe ".withoutKeyword(Keyword.FLYING)"
 
         val plain = node("""{"_Permanents":"HasAbility","args":[{"_Keyword":"Flying"}]}""")
         FilterPredicates.withoutFlying(plain).shouldBeNull()
-        FilterPredicates.withFlying(plain) shouldBe ".withKeyword(Keyword.FLYING)"
+        suffix(FilterPredicates.withFlying(plain)) shouldBe ".withKeyword(Keyword.FLYING)"
     }
 })

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.tooling.coverage.emitter
+
+import com.wingedsheep.tooling.coverage.J
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Per-handler table test for the target/filter recovery layer: pins a handful of mtgish IR fragments to
+ * the exact Argentum DSL the [creatureFilterExpr] / [gameObjectFilterExpr] / [targetExpr] node builders
+ * render. Fast and local (no IR download / compile); the committed golden remains the exhaustive net.
+ */
+class TargetRecoveryTest : StringSpec({
+
+    val ctx = EmitCtx(emptySet())
+    fun obj(json: String): JsonObject = J.parseToJsonElement(json) as JsonObject
+
+    // PowerIs clauses (Fleet-Footed Monk's "power 2 or greater").
+    val pow2 = """{"_Permanents":"PowerIs","args":{"_Comparison":"GreaterThanOrEqualTo","args":{"_GameNumber":"Integer","args":2}}}"""
+
+    "creatureFilterDsl composes the plain-creature base with recovered suffixes" {
+        ctx.creatureFilterDsl(obj("""{"_Permanents":"IsTapped"}""")) shouldBe "TargetFilter.Creature.tapped()"
+        ctx.creatureFilterDsl(obj(pow2)) shouldBe "TargetFilter.Creature.powerAtLeast(2)"
+    }
+
+    "creatureFilterDsl distributes an Or of per-subtype creature filters" {
+        val orSubs = obj(
+            """{"_Filter":"Or","args":[""" +
+                """{"_Permanents":"IsCreatureType","args":"Goblin"},""" +
+                """{"_Permanents":"IsCreatureType","args":"Soldier"}]}""",
+        )
+        ctx.creatureFilterDsl(orSubs) shouldBe
+            "TargetFilter(GameObjectFilter.Creature.withSubtype(\"Goblin\") or GameObjectFilter.Creature.withSubtype(\"Soldier\"))"
+    }
+
+    "gameObjectFilterDsl reads the base cardtype and appends the tapped suffix" {
+        val tappedCreature = obj(
+            """{"_Filter":"And","args":[""" +
+                """{"_Permanents":"IsCardtype","args":"Creature"},{"_Permanents":"IsTapped"}]}""",
+        )
+        ctx.gameObjectFilterDsl(tappedCreature) shouldBe "GameObjectFilter.Creature.tapped()"
+    }
+
+    "gameObjectFilterDsl declines a filter with no recoverable base type" {
+        // No cardtype, subtype, or "Permanent" token anywhere -> SCAFFOLD rather than a widened filter.
+        ctx.gameObjectFilterDsl(obj("""{"_Color":"Red"}""")).shouldBeNull()
+    }
+
+    "targetExpr maps the player / spell / graveyard target shapes" {
+        ctx.targetDsl(obj("""{"_Target":"TargetPlayer"}""")) shouldBe "TargetPlayer()"
+        ctx.targetDsl(obj("""{"_Target":"TargetSpell","args":{}}""")) shouldBe "TargetSpell()"
+        ctx.targetDsl(obj("""{"_Target":"TargetGraveyardCard","args":{}}""")) shouldBe
+            "TargetObject(filter = TargetFilter.CardInGraveyard)"
+    }
+})


### PR DESCRIPTION
## What

Completes the `:mtgish-tooling` maintainability sequence (review item 5, the "north-star"): replaces the emitter's raw-string DSL emission with a **typed output model** — a small `Dsl` AST that handlers build, rendered to source by one renderer. The whole card is now a single tree, not stitched `List<String>` line lists.

This is the output-side counterpart to Phase 3's typed *input* matcher (`IrQuery`). The lossy mtgish→Argentum mapping stays where it belongs — inside the handlers, which decide *which* node to build; the AST models only the (regular) output language.

## The AST

- **Expression nodes** — `Lit` / `Call` / `Chain` / `Infix` / `Composite` / `Raw`, plus `Arg` (named/positional). `render(Dsl)` is the one place a node becomes a token/line.
- **Statement/block layer** — `Stmt` (`Assign` / `Local` / `Eval` / `Sub` / `RawLine`) + `Block`, with `renderBlock`/`renderStmt`. Lets the emitter assemble a card as a tree.
- **`Raw`/`RawLine`** are the escape-hatch for formatted scaffolding a node doesn't model yet (the hand-indented look-and-distribute literal; the card shell's mana/typeline/metadata/KDoc).

## Migrated, leaf-up — every step proven byte-identical

| Commit | Layer |
|--------|-------|
| Add AST + amount | `amount`/`dynamicAmount` → `Lit`/`Call` |
| Filter/target | `creatureFilter`/`gameObjectFilter`/`targetDsl`/`groupFilter`/… → `Chain`/`Infix`; `FilterPredicates` returns chain `Link`s |
| Effect handlers | `ActionHandler` typealias flips `String? → Dsl?`; all 6 themed handler files + dispatch + effect helpers build nodes |
| Ability + shell | StaticAbilities + CardStructure ability builders → `Sub(Block)` statements (cost/target/effect held as nodes); `Emitter.renderCard` assembles the card `Block` |

`wrapLine` + `importsFor` remain the downstream whitespace/import post-pass over the rendered lines — the accepted `Raw`-fallback role; the card tree feeds them.

## Verification

Every layer is **byte-identical** to `origin/main`:
- hermetic `EmitterGoldenTest` (POR) passes un-blessed at each step;
- `autogen --emit-all` across all 8 calibrated sets reproduces the `origin/main` aggregate sha (**754 cards, `07924dd42e324871451064685f8e168e07cf4d42`**);
- deeper gate: `coverage-verify POR` = **GATE PASS, 158/158, 0 mismatch**.

New tests: `DslTest` (expression + block renderer), `TargetRecoveryTest`, `EffectHandlerTest`; `FilterPredicatesTest` ported to the `Link` shape.

## Why it matters / what's next

The typed tree is the structural foundation for making the dashboard report **how much of a card is renderable and which parts still need wiring** — a `Hole` node + partial render gives located, per-ability gaps instead of today's flat reason bag. That feature is a separate follow-up PR on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)