### PR TITLE
mtgish-tooling: Hole nodes + partial render (locate per-card gaps for the TUI)

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Dsl.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Dsl.kt
@@ -47,6 +47,14 @@ data class Composite(val parts: List<Dsl>) : Dsl
  *  lets the tree coexist with un-migrated output; such fragments still flow through `wrapLine`/`importsFor`. */
 data class Raw(val text: String) : Dsl
 
+/** A LOCATED GAP — an expression the emitter could not render. Unlike a [null] decline (which bails the
+ *  whole card to a bare scaffold), a [Hole] keeps the parts that DID map and marks this one in place, so
+ *  a partially-rendered card pinpoints exactly what still needs hand-authoring. [reason] is the
+ *  worklist tag (the declined rule/action); [irShape] optionally carries a snippet of the mtgish node.
+ *  Renders to a greppable `/* TODO(hole): … */` comment. Holes appear only in the partial-render path
+ *  ([Emitter.renderCard] `partial = true`); the default emit still declines to a scaffold. */
+data class Hole(val reason: String, val irShape: String? = null) : Dsl
+
 /** A positional (name == null) or named (`name = value`) argument. */
 data class Arg(val value: Dsl, val name: String? = null)
 
@@ -76,6 +84,12 @@ data class Sub(val block: Block) : Stmt
  *  occasional multi-line restriction list a node doesn't model yet. The [Stmt]-level [Raw]. */
 data class RawLine(val text: String) : Stmt
 
+/** A LOCATED GAP at statement level — an ability/rule the emitter could not render. The [Stmt]-level
+ *  [Hole]: it renders as a `// TODO(hole): …` comment line in place of the missing builder block, so a
+ *  partially-rendered card still parses (a comment is valid Kotlin) while naming the part to hand-wire.
+ *  See [Hole] for the partial-render rationale. */
+data class HoleLine(val reason: String, val irShape: String? = null) : Stmt
+
 /** A `header { body }` builder block (an ability, the metadata block, the whole card). */
 data class Block(val header: String, val body: List<Stmt>)
 
@@ -95,6 +109,36 @@ fun renderStmt(stmt: Stmt, indent: String): List<String> = when (stmt) {
     is Eval -> listOf("$indent${render(stmt.value)}")
     is Sub -> renderBlock(stmt.block, indent)
     is RawLine -> listOf(stmt.text)
+    is HoleLine -> listOf("$indent// TODO(hole): ${stmt.reason}" + (stmt.irShape?.let { " — $it" } ?: ""))
+}
+
+// ---------------------------------------------------------------------------
+// Hole accounting — walk a rendered statement tree to surface the located gaps and a renderable %.
+// This is what lets the TUI answer "how much of this card could be implemented, and which parts can't".
+// ---------------------------------------------------------------------------
+
+/** Every [HoleLine]/[Hole] reason in a statement tree, in document (top-to-bottom) order — the located
+ *  gap list a partial render leaves behind. */
+fun holesIn(stmts: List<Stmt>): List<String> {
+    val out = mutableListOf<String>()
+    fun visit(d: Dsl) { when (d) {
+        is Hole -> out.add(d.reason)
+        is Call -> d.args.forEach { visit(it.value) }
+        is Chain -> { visit(d.base); d.links.forEach { l -> l.args.forEach { visit(it.value) } } }
+        is Infix -> d.parts.forEach(::visit)
+        is Composite -> d.parts.forEach(::visit)
+        is Lit, is Raw -> {}
+    } }
+    fun visit(s: Stmt) { when (s) {
+        is HoleLine -> out.add(s.reason)
+        is Sub -> s.block.body.forEach(::visit)
+        is Assign -> visit(s.value)
+        is Local -> visit(s.value)
+        is Eval -> visit(s.value)
+        is RawLine -> {}
+    } }
+    stmts.forEach(::visit)
+    return out
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +175,7 @@ fun Dsl.dot(link: Link): Chain =
 fun render(node: Dsl): String = when (node) {
     is Lit -> node.text
     is Raw -> node.text
+    is Hole -> "/* TODO(hole): ${node.reason}" + (node.irShape?.let { " — $it" } ?: "") + " */"
     is Call -> node.callee + "(" + node.args.joinToString(", ") { renderArg(it) } + ")"
     is Chain -> render(node.base) + node.links.joinToString("") { link ->
         "." + link.method + "(" + link.args.joinToString(", ") { renderArg(it) } + ")"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Analyzer.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Analyzer.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.tooling.coverage.Probe
 import com.wingedsheep.tooling.coverage.Registry
 import com.wingedsheep.tooling.coverage.Scryfall
 import com.wingedsheep.tooling.coverage.emitter.Emitter
+import com.wingedsheep.tooling.coverage.emitter.RenderResult
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -189,20 +190,28 @@ object Analyzer {
         val implementedIn: Set<String>,
     )
 
-    private val sourceCache = HashMap<String, String?>()
+    private val renderCache = HashMap<String, RenderResult?>()
 
     /**
-     * The emitter's generated `cardDef` DSL for [name] as it would draft it for [setCode] (whole for
-     * AUTOGEN cards, a TODO/STRUCTURE scaffold otherwise). Null when the card has no mtgish IR entry.
+     * The emitter's PARTIAL render of [name] for [setCode]: every part that maps is emitted and each
+     * un-renderable part becomes a located `// TODO(hole)` line, so the result carries a renderable
+     * fraction + the list of holes. This is the dashboard view — "how much of this card could be
+     * implemented, and which parts can't". (The autogen WRITE path stays non-partial: it still declines
+     * a card to a scaffold rather than ship a half-card.) Null when the card has no mtgish IR entry.
      * Memoized so scrolling the code view never re-renders.
      */
-    fun cardSource(setCode: String, name: String): String? = sourceCache.getOrPut("$setCode/$name") {
+    fun cardRender(setCode: String, name: String): RenderResult? = renderCache.getOrPut("$setCode/$name") {
         val card = index()[name] ?: return@getOrPut null
         Emitter.renderCard(
             card, Cards.scryfallCard(setCode, name), effects, keywords,
             pkg = "com.wingedsheep.mtg.sets.generated.${setCode.lowercase()}.cards",
-        ).text
+            partial = true,
+        )
     }
+
+    /** The generated `cardDef` DSL text from the partial render (with `// TODO(hole)` lines in place of
+     *  the parts that don't map yet). Null when the card has no mtgish IR entry. */
+    fun cardSource(setCode: String, name: String): String? = cardRender(setCode, name)?.text
 
     fun cardReport(name: String): CardReport {
         val card = index()[name]
@@ -242,7 +251,7 @@ object Analyzer {
     fun invalidate(code: String) {
         countsCache.remove(code.uppercase())
         detailCache.remove(code.uppercase())
-        sourceCache.clear()
+        renderCache.clear()
         crossCache = null
         index = null
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Dashboard.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Dashboard.kt
@@ -284,7 +284,11 @@ object Dashboard {
         add(" ${rep.name}", Ansi.BOLD, Ansi.fg(Ansi.WHITE))
         when (cv?.gen) {
             Analyzer.Gen.WHOLE -> add(" ${impl}auto-gen: WHOLE — generator renders the whole card", Ansi.fg(Ansi.GREEN))
-            Analyzer.Gen.SCAFFOLD -> add(" ${impl}auto-gen: SCAFFOLD — covered, structure needs hand-wiring", Ansi.fg(Ansi.YELLOW))
+            Analyzer.Gen.SCAFFOLD -> {
+                val r = Analyzer.cardRender(code, name)
+                val note = r?.let { " — ${(it.renderableFraction * 100).roundToInt()}% renderable, ${it.holes.size} part${if (it.holes.size == 1) "" else "s"} to hand-wire" } ?: " — covered, structure needs hand-wiring"
+                add(" ${impl}auto-gen: SCAFFOLD$note", Ansi.fg(Ansi.YELLOW))
+            }
             Analyzer.Gen.BLOCKED -> add(" ${impl}auto-gen: BLOCKED — needs engine work", Ansi.fg(Ansi.RED))
             else -> add(" ${impl}not in mtgish IR (name join / Un-set / too new)", Ansi.fg(Ansi.GREY))
         }
@@ -307,6 +311,15 @@ object Dashboard {
                 add("   [$tag] ${m.disc} = ${m.value}", arrayOf(Ansi.fg(Ansi.ORANGE)))
             }
             if (missing.size > 4) add("   +${missing.size - 4} more — tab for full capability list", arrayOf(Ansi.fg(Ansi.DARKGREY)))
+        }
+        // Located holes — the parts the emitter could not render (the `// TODO(hole)` lines below). This
+        // is the per-part "still to implement" list, distinct from the capability gaps above: a card can
+        // have every capability mapped yet still hole an ability whose STRUCTURE the emitter can't recover.
+        val render = Analyzer.cardRender(code, name)
+        if (render != null && render.holes.isNotEmpty()) {
+            add(" ⌗ parts to hand-wire (${render.holes.size}, ${(render.renderableFraction * 100).roundToInt()}% renderable):", arrayOf(Ansi.BOLD, Ansi.fg(Ansi.YELLOW)))
+            for (hole in render.holes.take(4)) add("   • $hole", arrayOf(Ansi.fg(Ansi.YELLOW)))
+            if (render.holes.size > 4) add("   +${render.holes.size - 4} more", arrayOf(Ansi.fg(Ansi.DARKGREY)))
         }
         add(" ── generated cardDef ${"─".repeat(max(0, w - 18))}", arrayOf(Ansi.fg(Ansi.DARKGREY)))
         val src = Analyzer.cardSource(code, name)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -31,8 +31,24 @@ import kotlinx.serialization.json.put
 /**
  * Result of rendering a whole card: the emitted DSL text, whether it renders WHOLE, and the
  * unrecovered-structure reasons (the SCAFFOLD worklist).
+ *
+ * In partial-render mode ([Emitter.renderCard] `partial = true`) the card no longer bails to a bare
+ * scaffold on the first un-renderable part: the parts that map are emitted and the rest become located
+ * [holes]. [parts] is how many ability-bearing parts were attempted, so [renderableFraction] answers
+ * "how much of this card could be implemented?" and [holes] answers "which parts still can't". In the
+ * default (non-partial) path [holes] is empty and [parts] is 0 — `complete`/`reasons` are unchanged.
  */
-data class RenderResult(val text: String, val complete: Boolean, val reasons: Set<String>)
+data class RenderResult(
+    val text: String,
+    val complete: Boolean,
+    val reasons: Set<String>,
+    val holes: List<String> = emptyList(),
+    val parts: Int = 0,
+) {
+    /** Fraction of attempted parts the emitter rendered (1.0 = whole). Defined as 1.0 when nothing
+     *  ability-bearing was attempted (a vanilla creature is fully renderable). */
+    val renderableFraction: Double get() = if (parts == 0) 1.0 else (parts - holes.size).toDouble() / parts
+}
 
 /**
  * Per-render state for the emitter. Created once per card; threaded implicitly as the receiver of

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.tooling.coverage.emitter
 import com.wingedsheep.tooling.coverage.Assign
 import com.wingedsheep.tooling.coverage.Block
 import com.wingedsheep.tooling.coverage.Eval
+import com.wingedsheep.tooling.coverage.HoleLine
 import com.wingedsheep.tooling.coverage.Lit
 import com.wingedsheep.tooling.coverage.RawLine
 import com.wingedsheep.tooling.coverage.Stmt
@@ -34,9 +35,18 @@ import kotlinx.serialization.json.JsonObject
  * (see [EmitCtx]). Imports resolve from a live SDK source scan so they can't rot.
  */
 object Emitter {
+    /**
+     * Render [card] to Argentum cardDef DSL. By default the emitter declines the WHOLE card to a bare
+     * scaffold on the first un-renderable part. With [partial] = true it instead keeps every part that
+     * maps and replaces each un-renderable part with a located `// TODO(hole)` line, so the result
+     * carries a renderable fraction + the list of holes (what the dashboard/TUI shows). The default
+     * (non-partial) path is byte-for-byte unchanged — it is what the autogen write path and the golden
+     * test depend on.
+     */
     fun renderCard(
         card: JsonObject, scryfall: JsonObject?, effects: Set<String>, keywords: Set<String>,
         pkg: String = "com.wingedsheep.mtg.sets.generated.demo.cards",
+        partial: Boolean = false,
     ): RenderResult {
         val ctx = EmitCtx(keywords, scryfall?.strField("oracle_text"))
         val name = card["Name"].asStr() ?: ""
@@ -53,6 +63,22 @@ object Emitter {
         val pre = docCommentLines(card, scryfall)
         val header = "val $ident = card(\"${ktStr(name)}\")"
         val body = mutableListOf<Stmt>()
+
+        // A part the emitter can't render. In the default path this bails the whole card to a scaffold
+        // (returns the [incomplete] result, which the caller `return`s). In [partial] mode it records a
+        // located hole, drops a `// TODO(hole)` line in place, and returns null so the loop continues
+        // with the parts that DO map. [addReason] mirrors the historical `ctx.reasons` mutation at each
+        // site exactly, so the non-partial output stays byte-identical.
+        val holes = mutableListOf<String>()
+        val skipRules = mutableSetOf<JsonObject>()
+        var parts = 0
+        fun gap(holeLabel: String, addReason: String? = null): RenderResult? {
+            addReason?.let { ctx.reasons.add(it) }
+            parts++
+            if (partial) { holes.add(holeLabel); body.add(HoleLine(holeLabel)); return null }
+            return incomplete(ctx, pre, header, body, scryfall, pkg)
+        }
+
         body.add(RawLine("    manaCost = \"${renderMana(card["ManaCost"])}\""))
         colorIdentityDsl(scryfall)?.let { body.add(RawLine("    colorIdentity = \"$it\"")) }
         body.add(RawLine("    typeLine = \"${renderTypeline(card["Typeline"])}\""))
@@ -64,8 +90,9 @@ object Emitter {
         // card's rule order, which matches the hand-authored golden's `keywords(...)` order (e.g.
         // "Trample, haste" stays TRAMPLE, HASTE rather than re-sorting to HASTE, TRAMPLE).
         if (kw.isNotEmpty()) body.add(RawLine("    keywords(${kw.joinToString(", ") { "Keyword.$it" }})"))
-        val cardLevelLines = ctx.cardLevelCastEffectLines(card) ?: return incomplete(ctx, pre, header, body, scryfall, pkg)
-        body.addAll(cardLevelLines.map { RawLine(it) })
+        val cardLevelLines = ctx.cardLevelCastEffectLines(card)
+        if (cardLevelLines == null) gap("CastEffect")?.let { return it }
+        else body.addAll(cardLevelLines.map { RawLine(it) })
 
         // Auras: the pure static-buff shape (EnchantPermanent + PermanentLayerEffect) renders faithfully,
         // but an activated/triggered ability on an Aura references its "enchanted creature" — context the
@@ -81,7 +108,10 @@ object Emitter {
                 // renders rather than scaffolds; every other ability on an Aura still scaffolds.
                 if ((rn == "Activated" || rn == "ActivatedWithModifiers") &&
                     "SharesACreatureTypeWithPermanent" in compact(r)) return@forEach
-                ctx.reasons.add("aura-with-$rn"); return incomplete(ctx, pre, header, body, scryfall, pkg)
+                // In partial mode the offending ability becomes a located hole and is skipped in the
+                // main loop below (so the generic activated/trigger emitter doesn't render it wrongly).
+                gap("aura-with-$rn", addReason = "aura-with-$rn")?.let { return it }
+                skipRules.add(r as JsonObject)
             }
         }
 
@@ -89,13 +119,16 @@ object Emitter {
             "Vigilance", "Reach", "Defender", "Landwalk", "FirstStrike", "Trample", "CastEffect")
         for (rule in (card["Rules"].asArr ?: JsonArray(emptyList()))) {
             if (rule !is JsonObject) continue
+            if (rule in skipRules) continue  // already holed by the aura pre-check (partial mode)
             val rname = rule.strField("_Rule")
             // Every ability builder returns structured statements; the renderer turns the whole card
             // tree into source lines.
             val block: List<Stmt>?
             when {
                 rname == "CastEffect" -> {
-                    if (!ctx.castEffectHandled(rule)) return incomplete(ctx, pre, header, body, scryfall, pkg)
+                    // Already accounted for by the pre-loop cardLevelCastEffectLines pass; this is
+                    // defensive (castEffectHandled is true for every CastEffect that survived it).
+                    if (!ctx.castEffectHandled(rule)) gap("CastEffect")?.let { return it }
                     continue
                 }
                 rname == "SpellActions" -> block = ctx.spellBlock(card)
@@ -111,7 +144,7 @@ object Emitter {
                 rname == "CDA_Power" -> block = ctx.cdaStatsBlock(card, rule)
                 rname == "CDA_Toughness" ->
                     if (jsonContains(card["Rules"], "_Rule", "CDA_Power")) continue  // emitted with CDA_Power
-                    else { ctx.reasons.add("CDA_Toughness"); return incomplete(ctx, pre, header, body, scryfall, pkg) }
+                    else { gap("CDA_Toughness", addReason = "CDA_Toughness")?.let { return it }; continue }
                 rname == "Activated" || rname == "ActivatedWithModifiers" -> block = ctx.activatedBlock(rule)
                 rname == "Cycling" -> block = manaKeywordCost(rule)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.cycling", arg("\"$it\"")))))) }
                 rname == "Morph" -> block = manaKeywordCost(rule)?.let { listOf(Assign("morph", Lit("\"$it\""))) }
@@ -124,18 +157,25 @@ object Emitter {
                 // rendered exactly by an explicit case above or scaffold; never silently stamped bare,
                 // which would drop the parameter.
                 rname != null && pascalToUpperSnake(rname) in keywords && rule["args"] == null -> continue
-                else -> { ctx.reasons.add(rname ?: "unknown-rule"); return incomplete(ctx, pre, header, body, scryfall, pkg) }
+                else -> { gap(rname ?: "unknown-rule", addReason = rname ?: "unknown-rule")?.let { return it }; continue }
             }
-            if (block == null) return incomplete(ctx, pre, header, body, scryfall, pkg)
+            if (block == null) { gap(rname ?: "ability")?.let { return it }; continue }
+            parts++
             body.addAll(block)
         }
 
         if (!permanent && !jsonContains(card["Rules"], "_Rule", "SpellActions")) {
-            ctx.reasons.add("no-renderable-effect"); return incomplete(ctx, pre, header, body, scryfall, pkg)
+            gap("no-renderable-effect", addReason = "no-renderable-effect")?.let { return it }
         }
 
         body.addAll(metadataLines(scryfall).map { RawLine(it) })
-        return RenderResult(assemble(pre + renderBlock(Block(header, body)), pkg, complete = true), true, ctx.reasons)
+        // In partial mode the card is "complete" only if no part holed; the non-partial path never
+        // reaches here with holes (gap returned the scaffold), so this stays `true`/empty as before.
+        val complete = holes.isEmpty()
+        return RenderResult(
+            assemble(pre + renderBlock(Block(header, body)), pkg, complete = complete),
+            complete, ctx.reasons, holes = holes, parts = parts,
+        )
     }
 
     /** A keyword-ability whose cost is pure mana (`Cycling {2}`, `Morph {4}{W}`). Returns the rendered

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/DslTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/DslTest.kt
@@ -96,4 +96,30 @@ class DslTest : StringSpec({
             "}",
         )
     }
+
+    "a HoleLine renders as a greppable TODO comment at the block indent" {
+        renderBlock(Block("spell", listOf(HoleLine("Unless")))) shouldBe listOf(
+            "spell {",
+            "    // TODO(hole): Unless",
+            "}",
+        )
+        render(Hole("AggregateBattlefield")) shouldBe "/* TODO(hole): AggregateBattlefield */"
+    }
+
+    "an irShape annotates the hole when present" {
+        renderStmt(HoleLine("Activated", "PayLife"), "") shouldBe listOf("// TODO(hole): Activated — PayLife")
+    }
+
+    "holesIn collects every hole reason in document order, recursing into nested blocks" {
+        val stmts = listOf(
+            Assign("manaCost", Lit("\"{R}\"")),
+            HoleLine("CastEffect"),
+            Sub(Block("spell", listOf(
+                Assign("effect", call("Effects.DrawCards", arg(Hole("amount")))),
+                HoleLine("Unless"),
+            ))),
+            Eval(call("keywordAbility", arg("Keyword.FLYING"))),
+        )
+        holesIn(stmts) shouldBe listOf("CastEffect", "amount", "Unless")
+    }
 })

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/EmitterPartialTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/EmitterPartialTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.tooling.coverage
+
+import com.wingedsheep.tooling.coverage.emitter.Emitter
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Partial-render regression net — the hole feature. Runs entirely off the committed POR fixture slice
+ * (no 29 MB IR, no network), mirroring [EmitterGoldenTest]. Two invariants make the feature safe and
+ * useful at once:
+ *
+ *  1. WHOLE cards are untouched — a card the default path renders complete renders byte-identically in
+ *     partial mode, with zero holes and a 1.0 fraction. So switching the dashboard to the partial path
+ *     can never degrade a card that already rendered.
+ *  2. SCAFFOLD cards become LOCATED — a card the default path declines to a scaffold instead renders
+ *     its mapped parts and surfaces the rest as `// TODO(hole)` lines, a sub-1.0 fraction, and a
+ *     non-empty hole list. That is exactly the "how much / which parts" the TUI shows.
+ */
+class EmitterPartialTest : StringSpec({
+
+    val effects = Registry.loadEffectSerialNames()
+    val keywords = Registry.loadKeywords()
+    val fs = if ("POR" in Fixtures.committedSets()) Fixtures.load("POR") else null
+
+    if (fs == null) {
+        "no committed POR fixture (run: just coverage-fixtures POR)".config(enabled = false) {}
+    } else {
+        "a WHOLE card renders identically in partial mode, with no holes" {
+            var checkedWhole = 0
+            for (name in fs.names) {
+                val ir = fs.mtgish[name] ?: continue
+                val sf = fs.scryfall[name]
+                val full = Emitter.renderCard(ir, sf, effects, keywords)
+                if (!full.complete) continue
+                checkedWhole++
+                val partial = Emitter.renderCard(ir, sf, effects, keywords, partial = true)
+                partial.holes shouldBe emptyList()
+                partial.complete shouldBe true
+                partial.renderableFraction shouldBe 1.0
+                partial.text shouldBe full.text  // byte-identical: holes only appear for declined parts
+            }
+            (checkedWhole > 0).shouldBeTrue()
+        }
+
+        // POR's committed slice is 100% AUTO, so to exercise the located-holes path hermetically we
+        // inject one bogus rule into a known-complete card: the default path would now decline the WHOLE
+        // card, but the partial path must keep every real part and hole only the injected one.
+        "an injected un-renderable rule holes ONLY that part; the rest still renders" {
+            val name = fs.names.first { fs.mtgish[it]?.let { ir -> Emitter.renderCard(ir, fs.scryfall[it], effects, keywords).complete } == true }
+            val ir = fs.mtgish.getValue(name)
+            val sf = fs.scryfall[name]
+            val whole = Emitter.renderCard(ir, sf, effects, keywords, partial = true)  // baseline: no holes
+
+            val bogus = buildJsonObject { put("_Rule", JsonPrimitive("TotallyUnknownRule_zzz")) }
+            val rules = (ir["Rules"] as JsonArray).toMutableList().apply { add(bogus) }
+            val injected = JsonObject(ir.toMutableMap().apply { put("Rules", JsonArray(rules)) })
+
+            // Default path: the whole card declines to a scaffold (one bad rule poisons it).
+            Emitter.renderCard(injected, sf, effects, keywords).complete shouldBe false
+
+            // Partial path: exactly one located hole for the injected rule; every other part survives.
+            val partial = Emitter.renderCard(injected, sf, effects, keywords, partial = true)
+            partial.complete shouldBe false
+            partial.holes shouldBe listOf("TotallyUnknownRule_zzz")
+            partial.parts shouldBe whole.parts + 1            // baseline parts + the one injected
+            partial.renderableFraction shouldBeLessThan 1.0
+            partial.text shouldContain "// TODO(hole): TotallyUnknownRule_zzz"
+            // The real abilities the baseline rendered are still present (holes are additive, not a reset).
+            whole.holes shouldBe emptyList()
+            partial.holes.shouldNotBeEmpty()
+        }
+    }
+})


### PR DESCRIPTION
## Why

The emitter declines a card to a bare scaffold the moment any one part won't map, so the coverage dashboard could only ever say **AUTO vs SCAFFOLD** — never *how much* of a card could be implemented, or *which* parts can't. Now that a card is a typed statement tree (#522), every ability is a locatable node, so a **partial render** can keep the parts that map and mark the rest in place.

## What

- **`Hole` / `HoleLine` AST nodes** (siblings of `Raw`/`RawLine`) rendering to a greppable `/* TODO(hole) */` / `// TODO(hole)` marker, plus `holesIn()` to walk a statement tree for the located gap list.
- **`Emitter.renderCard(partial = true)`** — instead of bailing on the first un-renderable part, a `gap()` records a *located* hole and continues. Every existing bail (cast-effect, aura, CDA, unknown rule, block-null, no-renderable-effect) routes through `gap()`; a held aura ability is also skipped in the main loop so the generic emitter doesn't render it wrongly. The result carries `holes` + a `renderableFraction`.
- **TUI** — `Analyzer.cardRender()` (partial, memoized) feeds the card view: `SCAFFOLD — NN% renderable, K parts to hand-wire`, plus the located hole list above the generated cardDef.

## Safety

The default (non-partial) path is **byte-for-byte unchanged** — `gap()` reproduces each site's exact `ctx.reasons` mutation:
- POR golden passes card-for-card (`EmitterGoldenTest`).
- 8-set `emit-all` aggregate sha identical: `07924dd…` (754 files).

The autogen **write** path stays non-partial — it still declines a card to a scaffold rather than ship a half-card. Partial render is the **dashboard view only**.

## Tests

- `DslTest` — hole render forms + `holesIn` document-order walk (recursing nested blocks).
- `EmitterPartialTest` (hermetic, off the committed POR slice) — WHOLE cards render *identically* with zero holes & fraction 1.0; an injected un-renderable rule holes **only** that part while every other part still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)