### PR TITLE
Add Ydwen Efreet to Arabian Nights

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 59 / 78
+**Implemented:** 60 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -58,7 +58,7 @@
 - [ ] Magnetic Mountain
 - [x] Mijae Djinn
 - [x] Rukh Egg
-- [ ] Ydwen Efreet
+- [x] Ydwen Efreet
 - [ ] Cyclone
 - [x] Desert Twister
 - [ ] Drop of Honey

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -518,7 +518,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CantAttackGroupEffect(filter, condition?)` — group-scoped can't-attack.
 - `CantBlockGroupEffect(filter, condition?)` — group-scoped can't-block.
 - `Effects.Suspect(target)` — target becomes Suspected (MKM keyword). Composite: `SetSuspectedEffect` (named status, CR 701.60d dedup) + `GrantKeywordEffect(MENACE)` + `CantBlockEffect`.
-- `RemoveFromCombatEffect(target)` — yank target out of combat.
+- `RemoveFromCombatEffect(target, unblockSoleBlockedAttackers = false)` — yank target out of combat.
+  Set `unblockSoleBlockedAttackers = true` for the old-rules behavior (Ydwen Efreet): attackers the
+  target was sole blocker of become unblocked (CR 509.1h normally keeps them blocked).
 - `Effects.CanAttackDespiteDefenderThisTurn(target = Self)` (`CanAttackDespiteDefenderThisTurnEffect`) — target can attack this
   turn as though it didn't have defender. Adds a transient `CanAttackDespiteDefenderThisTurnComponent`
   honored by the defender attack-restriction rule and cleaned up at end of turn. The

--- a/manual-scenarios/cards/y/ydwen-efreet.json
+++ b/manual-scenarios/cards/y/ydwen-efreet.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Attacker",
+  "player2Name": "Ydwen's Controller",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Hill Giant"},
+      {"name": "Grizzly Bears"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Ydwen Efreet"},
+      {"name": "Grizzly Bears"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2351,9 +2351,15 @@ object Effects {
 
     /**
      * Remove a creature from combat.
+     *
+     * @param unblockSoleBlockedAttackers If true, attackers the target was sole blocker
+     *   of become unblocked (their `BlockedComponent` is cleared). Defaults to false; only
+     *   set for cards whose oracle text explicitly says creatures become unblocked, e.g.
+     *   Ydwen Efreet's "Creatures it was blocking that had become blocked by only this
+     *   creature this combat become unblocked."
      */
-    fun RemoveFromCombat(target: EffectTarget): Effect =
-        RemoveFromCombatEffect(target)
+    fun RemoveFromCombat(target: EffectTarget, unblockSoleBlockedAttackers: Boolean = false): Effect =
+        RemoveFromCombatEffect(target, unblockSoleBlockedAttackers)
 
     /**
      * Let a creature attack this turn as though it didn't have defender (Krotiq Nestguard).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
@@ -376,13 +376,27 @@ data class CantAttackEffect(
  * Removes all combat-related components (attacking, blocking, blocked, damage assignment).
  * Also cleans up any blockers that were blocking the removed creature.
  * Used for Gustcloak creatures: "you may untap it and remove it from combat."
+ *
+ * @property unblockSoleBlockedAttackers When true, any attacker the target was sole blocker
+ *   of becomes unblocked — its `BlockedComponent` and damage-assignment components are
+ *   cleared. Defaults to false (modern CR 509.1h: a blocked creature stays blocked even if
+ *   all blockers leave combat). Set to true for cards like Ydwen Efreet whose oracle text
+ *   explicitly overrides 509.1h: "Creatures it was blocking that had become blocked by only
+ *   this creature this combat become unblocked."
  */
 @SerialName("RemoveFromCombat")
 @Serializable
 data class RemoveFromCombatEffect(
-    val target: EffectTarget
+    val target: EffectTarget,
+    val unblockSoleBlockedAttackers: Boolean = false
 ) : Effect {
-    override val description: String = "Remove ${target.description} from combat"
+    override val description: String = buildString {
+        append("Remove ${target.description} from combat")
+        if (unblockSoleBlockedAttackers) {
+            append(". Creatures it was blocking that had become blocked by only this creature ")
+            append("this combat become unblocked")
+        }
+    }
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/YdwenEfreet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/YdwenEfreet.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.FlipCoinEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ydwen Efreet
+ * {R}{R}{R}
+ * Creature — Efreet
+ * 3/6
+ * Whenever this creature blocks, flip a coin. If you lose the flip, remove this creature
+ * from combat and it can't block this turn. Creatures it was blocking that had become
+ * blocked by only this creature this combat become unblocked.
+ *
+ * The "become unblocked" clause is the pre-modern remove-from-combat behavior preserved on
+ * the card; modern CR 509.1h normally keeps a creature blocked after all its blockers leave
+ * combat. Toggled via [com.wingedsheep.sdk.scripting.effects.RemoveFromCombatEffect.unblockSoleBlockedAttackers].
+ */
+val YdwenEfreet = card("Ydwen Efreet") {
+    manaCost = "{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Efreet"
+    power = 3
+    toughness = 6
+    oracleText = "Whenever this creature blocks, flip a coin. If you lose the flip, remove this creature from combat and it can't block this turn. Creatures it was blocking that had become blocked by only this creature this combat become unblocked."
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = FlipCoinEffect(
+            lostEffect = Effects
+                .RemoveFromCombat(EffectTarget.Self, unblockSoleBlockedAttackers = true)
+                .then(Effects.CantBlock(EffectTarget.Self)),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "44"
+        artist = "Drew Tucker"
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efdba2a9-d171-45ed-8dd4-9d0046128f68.jpg?1562940066"
+        ruling("2009-10-01", "The ability triggers any time Ydwen Efreet blocks.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -2759,3 +2759,55 @@
         "GREEN"
     ]
 }
+
+// Ydwen Efreet
+{
+    "name": "Ydwen Efreet",
+    "manaCost": "{R}{R}{R}",
+    "typeLine": "Creature — Efreet",
+    "oracleText": "Whenever this creature blocks, flip a coin. If you lose the flip, remove this creature from combat and it can't block this turn. Creatures it was blocking that had become blocked by only this creature this combat become unblocked.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "FlipCoin",
+                    "lostEffect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "RemoveFromCombat",
+                                "target": "Self",
+                                "unblockSoleBlockedAttackers": true
+                            },
+                            {
+                                "type": "CantBlockTargetCreatures",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "RARE",
+        "artist": "Drew Tucker",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efdba2a9-d171-45ed-8dd4-9d0046128f68.jpg?1562940066",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "The ability triggers any time Ydwen Efreet blocks."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -22,6 +22,12 @@ internal fun BridgeBuilder.manaCountersAndState() {
     effect("RegeneratePermanent", "Regenerate", UNIVERSAL)
     effects("GainControlOfPermanent", "GainControlOfPermanentUntil", tag = "GainControl", note = UNIVERSAL)
     effect("RemoveCreatureFromCombat", "RemoveFromCombat", UNIVERSAL)
+    // Ydwen Efreet's "remove from combat and creatures it solely blocked become unblocked" — the same
+    // RemoveFromCombat effect (the emitter sets its unblockSoleBlockedAttackers flag).
+    effect("RemoveCreatureFromCombatAndUnblockBlockers", "RemoveFromCombat", UNIVERSAL)
+    // "Flip a coin. If you lose the flip, …" — a generic control-flow effect (Ydwen Efreet); its nested
+    // on-lose actions are resolved by the recursive tree walk.
+    effect("FlipACoin_OnLose", "FlipCoin", "flip a coin, on-lose actions nested")
     // Goad (CR 701.15): targeted GoadCreature renders; mass GoadEachCreature carries the same
     // capability but its group filter often scaffolds in the emitter.
     effects("GoadCreature", "GoadEachCreature", tag = "Goad", note = UNIVERSAL)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -7,6 +7,7 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("WhenAPermanentEntersTheBattlefield", "trigger: ETB (Triggers.* scan validates in P1)")
     supported("WhenACreatureOrPlaneswalkerDies", "trigger: dies")
     supported("WhenACreatureAttacks", "trigger: attacks")
+    supported("WhenACreatureBlocks", "trigger: blocks (Ydwen Efreet)")
     supported("WhenACreatureDealsCombatDamageToAPlayer", "trigger: combat damage to player")
 
     // Costs.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -163,6 +163,7 @@ private val TRIGGER_SPEC = mapOf(
     "WhenAPermanentEntersTheBattlefield" to "Triggers.EntersBattlefield",
     "WhenACreatureOrPlaneswalkerDies" to "Triggers.Dies",
     "WhenACreatureAttacks" to "Triggers.Attacks",
+    "WhenACreatureBlocks" to "Triggers.Blocks",
     "WhenACreatureDealsCombatDamageToAPlayer" to "Triggers.DealsCombatDamageToPlayer",
     "WhenACreatureBecomesBlocked" to "Triggers.BecomesBlocked",
 )

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -30,6 +30,15 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
         call("MayEffect", arg(edsl))
     }
 
+    on("FlipACoin_OnLose") { _, args, tvar ->
+        // "Flip a coin. If you lose the flip, [actions]." (Ydwen Efreet). `args` is the on-lose action
+        // list, rendered as the FlipCoinEffect's lostEffect; if any on-lose action can't render the
+        // whole flip scaffolds rather than emit a partial coin flip.
+        val lost = args.asArr?.filterIsInstance<JsonObject>() ?: return@on null
+        val edsl = renderEffectList(lost, tvar) ?: return@on null
+        call("FlipCoinEffect", arg("lostEffect", edsl))
+    }
+
     on("EachPlayerAction") { node, _, _ -> renderEachPlayer(node) }
     on("PlayerAction", "HavePlayerTakeAction") { node, _, tvar -> renderPlayerAction(node, tvar) }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -35,6 +35,25 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         val tgt = refTarget(args, tvar) ?: return@on null
         call("Effects.RemoveFromCombat", arg(Lit(tgt)))
     }
+    on("RemoveCreatureFromCombatAndUnblockBlockers") { _, args, tvar ->
+        // Ydwen Efreet: "remove this creature from combat … creatures it was blocking that had become
+        // blocked by only this creature become unblocked" — the pre-modern override of CR 509.1h,
+        // carried by RemoveFromCombat's unblockSoleBlockedAttackers flag.
+        val tgt = refTarget(args, tvar) ?: return@on null
+        call("Effects.RemoveFromCombat", arg(Lit(tgt)), arg("unblockSoleBlockedAttackers", "true"))
+    }
+    on("CreatePermanentRuleEffectUntil") { node, args, tvar ->
+        // "[permanent] can't block / can't attack this turn" (Ydwen Efreet's "it can't block this
+        // turn"). Only the bare CantBlock/CantAttack rule until end of turn maps to the matching
+        // Effects facade; any other rule or a non-EOT duration scaffolds rather than guess.
+        if (firstExpiration(node) !in setOf(null, "UntilEndOfTurn")) return@on null
+        val tgt = refTarget(args, tvar) ?: return@on null
+        when {
+            jsonContains(node, "_PermanentRule", "CantBlock") -> call("Effects.CantBlock", arg(Lit(tgt)))
+            jsonContains(node, "_PermanentRule", "CantAttack") -> call("Effects.CantAttack", arg(Lit(tgt)))
+            else -> null
+        }
+    }
     on("RegeneratePermanent") { _, args, _ ->
         // Self-regeneration ("{cost}: Regenerate this") renders faithfully. A chosen target's
         // requirement isn't always recovered exactly (e.g. "Regenerate target Zombie" flattens the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/RemoveFromCombatExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/RemoveFromCombatExecutor.kt
@@ -25,6 +25,12 @@ class RemoveFromCombatExecutor : EffectExecutor<RemoveFromCombatEffect> {
     ): EffectResult {
         val targetId = context.resolveTarget(effect.target)
             ?: return EffectResult.success(state)
-        return EffectResult.success(CombatRemovalHelper.removeFromCombat(state, targetId))
+        return EffectResult.success(
+            CombatRemovalHelper.removeFromCombat(
+                state,
+                targetId,
+                unblockSoleBlockedAttackers = effect.unblockSoleBlockedAttackers,
+            )
+        )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatRemovalHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatRemovalHelper.kt
@@ -22,8 +22,19 @@ object CombatRemovalHelper {
     /**
      * Remove [targetId] from combat in [state]. Returns the new state, or [state] unchanged
      * if the entity wasn't in combat. Idempotent.
+     *
+     * @param unblockSoleBlockedAttackers When true and [targetId] was a blocker, attackers
+     *   whose blocker list becomes empty after this removal have their [BlockedComponent]
+     *   and damage-assignment components stripped — they become unblocked. Defaults to
+     *   false (CR 509.1h: a blocked creature stays blocked even if all blockers leave
+     *   combat). Ydwen Efreet's oracle text explicitly overrides 509.1h and is the only
+     *   current use site.
      */
-    fun removeFromCombat(state: GameState, targetId: EntityId): GameState {
+    fun removeFromCombat(
+        state: GameState,
+        targetId: EntityId,
+        unblockSoleBlockedAttackers: Boolean = false,
+    ): GameState {
         val entity = state.getEntity(targetId) ?: return state
         val isAttacking = entity.has<AttackingComponent>()
         val isBlocking = entity.has<BlockingComponent>()
@@ -71,8 +82,18 @@ object CombatRemovalHelper {
                 val attackerEntity = newState.getEntity(attackerId) ?: continue
                 val blockedComponent = attackerEntity.get<BlockedComponent>() ?: continue
                 val updatedBlockerIds = blockedComponent.blockerIds - targetId
-                newState = newState.updateEntity(attackerId) { container ->
-                    container.with(BlockedComponent(updatedBlockerIds))
+                newState = if (unblockSoleBlockedAttackers && updatedBlockerIds.isEmpty()) {
+                    newState.updateEntity(attackerId) { container ->
+                        container
+                            .without<BlockedComponent>()
+                            .without<DamageAssignmentComponent>()
+                            .without<DamageAssignmentOrderComponent>()
+                            .without<RequiresManualDamageAssignmentComponent>()
+                    }
+                } else {
+                    newState.updateEntity(attackerId) { container ->
+                        container.with(BlockedComponent(updatedBlockerIds))
+                    }
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatRemovalHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatRemovalHelper.kt
@@ -82,6 +82,10 @@ object CombatRemovalHelper {
                 val attackerEntity = newState.getEntity(attackerId) ?: continue
                 val blockedComponent = attackerEntity.get<BlockedComponent>() ?: continue
                 val updatedBlockerIds = blockedComponent.blockerIds - targetId
+                // "Sole blocker" is judged from the CURRENT blocker set (empty after removing this
+                // creature), not from who blocked it when combat began. Ydwen's oracle says "blocked by
+                // only this creature this combat"; we have no per-combat became-blocked-by history, so a
+                // contrived case (another blocker left earlier in the same combat) is treated as sole.
                 newState = if (unblockSoleBlockedAttackers && updatedBlockerIds.isEmpty()) {
                     newState.updateEntity(attackerId) { container ->
                         container

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YdwenEfreetTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YdwenEfreetTest.kt
@@ -1,0 +1,185 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.state.components.combat.BlockedComponent
+import com.wingedsheep.engine.state.components.combat.BlockingComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.arn.cards.YdwenEfreet
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Ydwen Efreet.
+ *
+ * Ydwen Efreet: {R}{R}{R}
+ * Creature — Efreet 3/6
+ * Whenever this creature blocks, flip a coin. If you lose the flip, remove this creature
+ * from combat and it can't block this turn. Creatures it was blocking that had become
+ * blocked by only this creature this combat become unblocked.
+ */
+class YdwenEfreetTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(YdwenEfreet)
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            startingLife = 20
+        )
+        return driver
+    }
+
+    /**
+     * Walk the driver from the active player's first main phase to the opponent's declare-blockers
+     * step with [attacker] (controlled by the active player) attacking the opponent and [blockers]
+     * (controlled by the opponent) declared as blockers of [attacker].
+     */
+    fun setupAttackAndBlock(
+        driver: GameTestDriver,
+        attacker: EntityId,
+        blockers: List<EntityId>,
+    ): Pair<EntityId, EntityId> {
+        val attackingPlayer = driver.activePlayer!!
+        val defendingPlayer = driver.getOpponent(attackingPlayer)
+        driver.removeSummoningSickness(attacker)
+        blockers.forEach(driver::removeSummoningSickness)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attackingPlayer, listOf(attacker), defendingPlayer)
+        driver.bothPass()
+
+        driver.declareBlockers(defendingPlayer, blockers.associateWith { listOf(attacker) })
+        return attackingPlayer to defendingPlayer
+    }
+
+    test("blocking triggers the coin flip ability") {
+        val driver = createDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val active = driver.activePlayer!!
+        val defender = driver.getOpponent(active)
+        val attacker = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        val ydwen = driver.putCreatureOnBattlefield(defender, "Ydwen Efreet")
+
+        setupAttackAndBlock(driver, attacker, listOf(ydwen))
+
+        // After blockers are declared, the flip-coin ability is on the stack.
+        driver.stackSize shouldBe 1
+
+        // Resolve the trigger
+        val result = driver.bothPass()
+        val flips = result.events.filterIsInstance<CoinFlipEvent>()
+        flips.size shouldBe 1
+        flips[0].sourceName shouldBe "Ydwen Efreet"
+    }
+
+    test("losing the flip removes Ydwen from combat and unblocks its sole-blocked attacker") {
+        var sawLoss = false
+        repeat(50) {
+            if (sawLoss) return@repeat
+
+            val driver = createDriver()
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val active = driver.activePlayer!!
+            val defender = driver.getOpponent(active)
+            val attacker = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+            val ydwen = driver.putCreatureOnBattlefield(defender, "Ydwen Efreet")
+
+            setupAttackAndBlock(driver, attacker, listOf(ydwen))
+            val result = driver.bothPass()
+
+            val flip = result.events.filterIsInstance<CoinFlipEvent>().firstOrNull() ?: return@repeat
+            if (flip.won) return@repeat
+            sawLoss = true
+
+            // Ydwen left combat: no BlockingComponent, no BlockedComponent.
+            driver.state.getEntity(ydwen)!!.has<BlockingComponent>().shouldBeFalse()
+
+            // Sole-blocked attacker becomes unblocked: BlockedComponent is gone, defending
+            // player takes the attacker's full damage in the damage step.
+            driver.state.getEntity(attacker)!!.has<BlockedComponent>().shouldBeFalse()
+
+            val defenderLifeBefore = driver.getLifeTotal(defender)
+            driver.passPriorityUntil(Step.END_COMBAT)
+            driver.getLifeTotal(defender) shouldBe defenderLifeBefore - 2  // Grizzly Bears is 2/2
+        }
+        sawLoss.shouldBeTrue()
+    }
+
+    test("winning the flip keeps Ydwen blocking and combat damage resolves normally") {
+        var sawWin = false
+        repeat(50) {
+            if (sawWin) return@repeat
+
+            val driver = createDriver()
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val active = driver.activePlayer!!
+            val defender = driver.getOpponent(active)
+            val attacker = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+            val ydwen = driver.putCreatureOnBattlefield(defender, "Ydwen Efreet")
+
+            setupAttackAndBlock(driver, attacker, listOf(ydwen))
+            val result = driver.bothPass()
+
+            val flip = result.events.filterIsInstance<CoinFlipEvent>().firstOrNull() ?: return@repeat
+            if (!flip.won) return@repeat
+            sawWin = true
+
+            // Ydwen stays in combat, the attacker stays blocked.
+            driver.state.getEntity(ydwen)!!.get<BlockingComponent>()
+                ?.blockedAttackerIds?.contains(attacker)?.shouldBeTrue()
+            driver.state.getEntity(attacker)!!.has<BlockedComponent>().shouldBeTrue()
+
+            // Resolve combat damage. Grizzly Bears (2/2) deals 2 to Ydwen (3/6), Ydwen deals 3
+            // back, Grizzly Bears dies. Defending player takes no damage.
+            val defenderLifeBefore = driver.getLifeTotal(defender)
+            driver.passPriorityUntil(Step.END_COMBAT)
+            driver.getLifeTotal(defender) shouldBe defenderLifeBefore
+            driver.findPermanent(active, "Grizzly Bears").shouldBeNull()
+            driver.findPermanent(defender, "Ydwen Efreet") shouldNotBe null
+        }
+        sawWin.shouldBeTrue()
+    }
+
+    test("with a second blocker, losing the flip keeps the attacker blocked by the other blocker") {
+        var sawLoss = false
+        repeat(50) {
+            if (sawLoss) return@repeat
+
+            val driver = createDriver()
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val active = driver.activePlayer!!
+            val defender = driver.getOpponent(active)
+            val attacker = driver.putCreatureOnBattlefield(active, "Centaur Courser")
+            val ydwen = driver.putCreatureOnBattlefield(defender, "Ydwen Efreet")
+            val coBlocker = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+
+            setupAttackAndBlock(driver, attacker, listOf(ydwen, coBlocker))
+            val result = driver.bothPass()
+
+            val flip = result.events.filterIsInstance<CoinFlipEvent>().firstOrNull() ?: return@repeat
+            if (flip.won) return@repeat
+            sawLoss = true
+
+            // Ydwen is out of combat...
+            driver.state.getEntity(ydwen)!!.has<BlockingComponent>().shouldBeFalse()
+            // ...but the attacker remains blocked — it was NOT blocked by only Ydwen.
+            val blocked = driver.state.getEntity(attacker)!!.get<BlockedComponent>()
+            blocked shouldNotBe null
+            blocked!!.blockerIds shouldBe listOf(coBlocker)
+        }
+        sawLoss.shouldBeTrue()
+    }
+})


### PR DESCRIPTION
Whenever it blocks, flip a coin; on a loss it leaves combat and can't block this turn, and any attacker it was sole blocker of becomes unblocked — the pre-modern remove-from-combat behavior the oracle text preserves over modern CR 509.1h. Adds an `unblockSoleBlockedAttackers` flag to RemoveFromCombatEffect and threads it through CombatRemovalHelper so the override is opt-in.