### PR TITLE
Widen mtgish emitter: ONS auto-gen verified 152→179 (+27)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/InformationDealer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/InformationDealer.kt
@@ -14,7 +14,7 @@ import com.wingedsheep.sdk.scripting.references.Player
  * Creature — Human Wizard
  * 1/1
  * {T}: Look at the top X cards of your library, where X is the number of
- * Wizards you control, then put them back in any order.
+ * Wizards on the battlefield, then put them back in any order.
  */
 val InformationDealer = card("Information Dealer") {
     manaCost = "{1}{U}"
@@ -22,13 +22,13 @@ val InformationDealer = card("Information Dealer") {
     typeLine = "Creature — Human Wizard"
     power = 1
     toughness = 1
-    oracleText = "{T}: Look at the top X cards of your library, where X is the number of Wizards you control, then put them back in any order."
+    oracleText = "{T}: Look at the top X cards of your library, where X is the number of Wizards on the battlefield, then put them back in any order."
 
     activatedAbility {
         cost = AbilityCost.Tap
         effect = Patterns.Library.lookAtTopAndReorder(
             DynamicAmount.AggregateBattlefield(
-                Player.You,
+                Player.Each,
                 GameObjectFilter.Creature.withSubtype("Wizard")
             )
         )

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -8658,7 +8658,7 @@
     "name": "Information Dealer",
     "manaCost": "{1}{U}",
     "typeLine": "Creature — Human Wizard",
-    "oracleText": "{T}: Look at the top X cards of your library, where X is the number of Wizards you control, then put them back in any order.",
+    "oracleText": "{T}: Look at the top X cards of your library, where X is the number of Wizards on the battlefield, then put them back in any order.",
     "creatureStats": {
         "power": 1,
         "toughness": 1
@@ -8677,7 +8677,7 @@
                                 "type": "TopOfLibrary",
                                 "count": {
                                     "type": "AggregateBattlefield",
-                                    "player": "You",
+                                    "player": "Each",
                                     "filter": "creature Wizard"
                                 }
                             },

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Fidelity.kt
@@ -364,7 +364,10 @@ object Fidelity {
             .associate { (key, value) -> key to normalizeForFidelity(value) })
     }
 
-    private val NON_GAMEPLAY_KEYS = setOf("metadata", "oracleText", "colorIdentityOverride")
+    // `imageUri` is purely cosmetic art (a created token's picture, like a card's), never a rules input —
+    // the same reason `oracleText`/`metadata` are excluded. The emitter doesn't resolve a token's Scryfall
+    // image, so a hand-authored card carrying it would diverge on art alone; ignore it like the others.
+    private val NON_GAMEPLAY_KEYS = setOf("metadata", "oracleText", "colorIdentityOverride", "imageUri")
 
     private fun JsonObject.isAbilityNode(): Boolean {
         return containsKey("effect") && (containsKey("trigger") || containsKey("cost"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -2,7 +2,14 @@ package com.wingedsheep.tooling.coverage.bridge
 
 /** Direct one-to-one effects: damage, life, card draw, and the common single-permanent verbs. */
 internal fun BridgeBuilder.damageLifeAndCards() {
-    effects("SpellDealsDamage", "PermanentDealsDamage", tag = "DealDamage")
+    effects(
+        "SpellDealsDamage", "PermanentDealsDamage",
+        // "this spell deals N damage … that can't be prevented" (Pinpoint Avalanche) and "have <permanent>
+        // deal N damage to <recipient>" (Skirk Commando, Snapping Thragg, Aether Charge) — both realise as
+        // a DealDamageEffect, so they carry the same DealDamage capability as the plain spell/permanent forms.
+        "SpellDealsDamageCantBePrevented", "HavePermanentDealDamage",
+        tag = "DealDamage",
+    )
     effect("SpellDealsDistributedDamage", "DividedDamage")
 
     effects("DrawNumberCards", "DrawACard", tag = "DrawCards")
@@ -26,6 +33,9 @@ internal fun BridgeBuilder.damageLifeAndCards() {
     composed("TapEachPermanent", composes = listOf("TapUntap"))
     composed("UntapEachPermanent", composes = listOf("TapUntap"))
 
-    effect("AdjustPT", "ModifyStats")
+    // Plain ±P/T and the two dynamic-amount variants (AdjustPTX uses a ±X modifier over a game number —
+    // Wirewood Pride / Feeding Frenzy / Tribal Unity; AdjustPTForEach scales a fixed base by a count —
+    // Goblin Piledriver / Shaleskin Bruiser) all realise as a ModifyStatsEffect.
+    effects("AdjustPT", "AdjustPTX", "AdjustPTForEach", tag = "ModifyStats")
     effect("AddAbility", "GrantKeyword")
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.tooling.coverage.Sub
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.argWordsTagged
 import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
@@ -327,6 +328,19 @@ internal fun EmitCtx.asEntersBlock(rule: JsonObject): List<Stmt>? {
         val dsl: Dsl = when (rep.strField("_ReplacementActionWouldEnter")) {
             "EntersTapped" -> call("EntersTapped")
             "ChooseACreatureType" -> call("EntersWithChoice", arg("ChoiceType.CREATURE_TYPE"))
+            "EntersWithNumberCounters" -> {
+                // "enters with X +1/+1 counters" where X is a dynamic count (Stag Beetle: number of other
+                // creatures — as it enters, self isn't on the battlefield, so the plain count IS "other").
+                // Only the ±1/±1 counter with a recoverable dynamic amount renders; anything else scaffolds.
+                val a = rep["args"].asArr ?: run { reasons.add("AsPermanentEnters"); return null }
+                val counter = a.getOrNull(1) as? JsonObject
+                val pt = counter?.get("args").asArr
+                if (counter?.strField("_CounterType") != "PTCounter" || pt?.getOrNull(0).asInt() != 1 || pt?.getOrNull(1).asInt() != 1) {
+                    reasons.add("AsPermanentEnters"); return null
+                }
+                val amt = dynamicAmountExpr(a.getOrNull(0)) ?: run { reasons.add("AsPermanentEnters"); return null }
+                call("EntersWithDynamicCounters", arg("count", amt))
+            }
             else -> { reasons.add("AsPermanentEnters"); return null }
         }
         stmts.add(Eval(call("replacementEffect", arg(dsl))))
@@ -357,8 +371,21 @@ internal fun EmitCtx.fromAnyZoneBlock(rule: JsonObject): List<Stmt>? {
     return listOf(Sub(Block("triggeredAbility", stmts)))
 }
 
+/**
+ * A `FromGraveyard { Activated { … } }` rule -> the inner activated ability with
+ * `activateFromZone = Zone.GRAVEYARD` ("{cost}, … : Return this card from your graveyard to your hand",
+ * Gangrenous Goliath). Only a plain Activated inner renders; anything else scaffolds.
+ */
+internal fun EmitCtx.fromGraveyardBlock(rule: JsonObject): List<Stmt>? {
+    val inner = rule["args"] as? JsonObject
+    return when (inner?.strField("_Rule")) {
+        "Activated", "ActivatedWithModifiers" -> activatedBlock(inner, activateFromZone = "Zone.GRAVEYARD")
+        else -> { reasons.add("FromGraveyard"); return null }
+    }
+}
+
 /** An Activated / ActivatedWithModifiers rule -> activatedAbility { cost; [target]; effect }. */
-internal fun EmitCtx.activatedBlock(rule: JsonObject): List<Stmt>? {
+internal fun EmitCtx.activatedBlock(rule: JsonObject, activateFromZone: String? = null): List<Stmt>? {
     val args = rule["args"].asArr
     val costNode = args?.firstOrNull() as? JsonObject
     // Recover the exact activation cost. Anything we can't render exactly -> SCAFFOLD (never guess Tap).
@@ -372,6 +399,7 @@ internal fun EmitCtx.activatedBlock(rule: JsonObject): List<Stmt>? {
     activationRestrictionLines(rule)?.let { lines -> lines.forEach { stmts.add(RawLine(it)) } } ?: return null
     if (tvar != null) stmts.add(targetLocal(tnode!!))
     stmts.add(Assign("effect", edsl))
+    if (activateFromZone != null) stmts.add(Assign("activateFromZone", Lit(activateFromZone)))
     // A ReplaceNextDraw effect ("the next time you would draw … instead") prompts on the replaced draw,
     // not at activation — the activated-ability flag the Words cycle's golden carries.
     if (actions.any { it.strField("_Action") == "CreateFutureReplaceWouldDraw" }) stmts.add(Assign("promptOnDraw", Lit("true")))
@@ -396,6 +424,10 @@ internal fun EmitCtx.abilityCostDsl(node: JsonElement?): String? {
             "Costs.Composite(${parts.joinToString(", ")})"
         }
         "PayMana" -> renderMana(obj.field("args")).ifEmpty { null }?.let { "Costs.Mana(\"$it\")" }
+        // "{X}{G}{G}" activation cost — args are [symbol-list, the X game number]; render the symbol list
+        // (ManaCostX -> "{X}") as the mana cost (Silklash Spider).
+        "PayManaX" -> renderMana((obj["args"].asArr)?.getOrNull(0)).ifEmpty { null }?.let { "Costs.Mana(\"$it\")" }
+        "DiscardHand" -> "Costs.DiscardHand"  // "Discard your hand" (Slate of Ancestry)
         "TapPermanent" ->
             if (obj.field("args").strField("_Permanent") == "ThisPermanent") "Costs.Tap" else null
         "SacrificePermanent" ->

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -43,6 +43,24 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         call("DealDamageEffect", arg(amt), arg(Lit(tgt)))
     }
 
+    on("SpellDealsDamageCantBePrevented") { _, args, tvar ->
+        // "[This] deals N damage … that can't be prevented" (Pinpoint Avalanche). Same shape as
+        // SpellDealsDamage, with the can't-be-prevented flag set on the DealDamageEffect.
+        val amt = amountExpr(args) ?: dynamicAmountExpr(amountNode(args)) ?: return@on null
+        val tgt = refTargetIn(args, "_DamageRecipient", tvar) ?: return@on null
+        call("DealDamageEffect", arg(amt), arg(Lit(tgt)), arg("cantBePrevented", "true"))
+    }
+
+    on("HavePermanentDealDamage") { _, args, tvar ->
+        // "<permanent> deals N damage to <recipient>" (Skirk Commando, Snapping Thragg, Aether Charge).
+        // The acting permanent is the trigger source; the golden models it as a plain DealDamageEffect to
+        // the recipient (the damage-source attribution isn't carried), so render that and decline anything
+        // we can't resolve to a recipient exactly.
+        val amt = amountExpr(args) ?: dynamicAmountExpr(amountNode(args)) ?: return@on null
+        val tgt = refTargetIn(args, "_DamageRecipient", tvar) ?: return@on null
+        call("DealDamageEffect", arg(amt), arg(Lit(tgt)))
+    }
+
     on("SpellDealsDistributedDamage") { _, args, _ ->
         val total = findInteger(args)
         if (total !is Int) return@on null

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -187,6 +187,10 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
     // than misrender it as a battlefield tally. (Recognised "...ThisWay" shapes are handled above.)
     if (gn != null && "ThisWay" in gn) return null
     if ((gn != null && "NumberOf" in gn) || gn == "TheNumberOfPermanentsOnTheBattlefield") {
+        // A "shares a creature type with <it>" relational predicate (Mana Echoes) can't be expressed by
+        // the flat type/subtype/controller filter below — emitting the aggregate without it would silently
+        // over-count, so decline (-> SCAFFOLD) rather than misrender.
+        if ("SharesACreatureTypeWithPermanent" in compact(node)) return null
         val oracle = oracleText?.lowercase() ?: ""
         // The hand/"in it" guard catches a generic "NumberOf" count that's really about hand cards. It must
         // NOT fire for an explicit battlefield count (TheNumberOfPermanentsOnTheBattlefield) — a card may

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -85,6 +85,7 @@ internal fun EmitCtx.renderAction(node: JsonObject, tvar: String?): Dsl? =
 internal fun EmitCtx.renderEffectList(actions: List<JsonObject>, tvar: String?): Dsl? {
     echoEffect(actions)?.let { return it }
     becomeCreatureTypeEffect(actions, tvar)?.let { return it }
+    chooseTypeModifyStatsEffect(actions)?.let { return it }
     chooseCreatureTypeRevealTopEffect(actions)?.let { return it }
     val rendered = mutableListOf<Dsl>()
     for (act in actions) {
@@ -292,6 +293,31 @@ internal fun EmitCtx.becomeCreatureTypeEffect(actions: List<JsonObject>, tvar: S
     val parts = mutableListOf(arg("target", Lit(target)))
     if (excluded != null) parts.add(arg("excludedTypes", "listOf(\"${ktStr(excluded)}\")"))
     return Call("BecomeCreatureTypeEffect", parts)
+}
+
+/**
+ * [ChooseACreatureType, CreateEachPermanentLayerEffectUntil(creatures of the chosen type get ±X/±X)] ->
+ * a single `Effects.ChooseCreatureTypeModifyStats(...)` (Tribal Unity: "Creatures of the creature type
+ * of your choice get +X/+X until end of turn"). Only the bare ±X/±X over the chosen-type group at
+ * end-of-turn collapses; a riding keyword grant or any other shape declines (null -> SCAFFOLD).
+ */
+internal fun EmitCtx.chooseTypeModifyStatsEffect(actions: List<JsonObject>): Dsl? {
+    if (actions.size != 2) return null
+    if (actions.none { it.strField("_Action") == "ChooseACreatureType" }) return null
+    val layer = actions.firstOrNull { it.strField("_Action") == "CreateEachPermanentLayerEffectUntil" } ?: return null
+    val blob = compact(layer)
+    if ("IsCreatureTypeVariable" !in blob || "TheChosenCreatureType" !in blob) return null
+    if (!jsonContains(layer, "_Expiration", "UntilEndOfTurn")) return null
+    val layerEffects = (layer["args"].asArr)?.getOrNull(1) as? JsonArray ?: return null
+    if (layerEffects.size != 1) return null  // a lone ±X/±X; a riding grant would need grantKeyword
+    val le = layerEffects[0] as? JsonObject ?: return null
+    if (le.strField("_LayerEffect") != "AdjustPTX") return null
+    val a = le["args"].asArr ?: return null
+    if (a.size != 3) return null
+    val amt = dynamicAmountExpr(a[2]) ?: return null
+    val power = adjustModX(a.getOrNull(0), amt) ?: return null
+    val toughness = adjustModX(a.getOrNull(1), amt) ?: return null
+    return Call("Effects.ChooseCreatureTypeModifyStats", listOf(arg(power), arg(toughness)))
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -188,7 +188,12 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
     if (gn != null && "ThisWay" in gn) return null
     if ((gn != null && "NumberOf" in gn) || gn == "TheNumberOfPermanentsOnTheBattlefield") {
         val oracle = oracleText?.lowercase() ?: ""
-        if (" hand" in oracle || " in it" in oracle) return null
+        // The hand/"in it" guard catches a generic "NumberOf" count that's really about hand cards. It must
+        // NOT fire for an explicit battlefield count (TheNumberOfPermanentsOnTheBattlefield) — a card may
+        // mention "hand" elsewhere in its text (e.g. Slate of Ancestry's "Discard your hand" cost) while the
+        // count itself is unambiguously a battlefield tally.
+        val battlefieldCount = gn == "TheNumberOfPermanentsOnTheBattlefield"
+        if (!battlefieldCount && (" hand" in oracle || " in it" in oracle)) return null
         val player = when {
             "attacking you" in oracle -> "Player.Opponent"
             "on the battlefield" in oracle -> "Player.Each"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -141,6 +141,7 @@ object Emitter {
                 rname == "AsPermanentEnters" -> block = ctx.asEntersBlock(rule)
                 rname == "EachPermanentLayerEffect" -> block = ctx.staticLordBlock(rule)
                 rname == "FromAnyZone" -> block = ctx.fromAnyZoneBlock(rule)
+                rname == "FromGraveyard" -> block = ctx.fromGraveyardBlock(rule)
                 rname == "CDA_Power" -> block = ctx.cdaStatsBlock(card, rule)
                 rname == "CDA_Toughness" ->
                     if (jsonContains(card["Rules"], "_Rule", "CDA_Power")) continue  // emitted with CDA_Power

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ManaHandlers.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.tooling.coverage.emitter
 import com.wingedsheep.tooling.coverage.Call
 import com.wingedsheep.tooling.coverage.Dsl
 import com.wingedsheep.tooling.coverage.arg
+import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
@@ -17,6 +18,17 @@ import kotlinx.serialization.json.JsonObject
  */
 internal val manaHandlers: Map<String, ActionHandler> = actionHandlers {
     on("AddMana") { _, args, _ -> manaProduceDsl(args) }
+    on("AddManaRepeated") { _, args, _ ->
+        // "Add {R} for each Goblin on the battlefield" (Brightstone Ritual): a single mana symbol produced
+        // a dynamic number of times -> Effects.AddMana(color, <count>). Only one colour/colourless symbol
+        // with a recoverable dynamic count renders; anything else scaffolds.
+        val arr = args.asArr ?: return@on null
+        val amt = dynamicAmount(arr.getOrNull(1)) ?: return@on null
+        when (val produce = (arr.getOrNull(0) as? JsonObject)?.strField("_ManaProduce")) {
+            "ManaProduceC" -> call("Effects.AddColorlessMana", arg(amt))
+            else -> MANA_PRODUCE_COLOR[produce]?.let { call("Effects.AddMana", arg(it), arg(amt)) }
+        }
+    }
 }
 
 private val MANA_PRODUCE_COLOR = mapOf(

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -153,6 +153,11 @@ internal fun EmitCtx.staticHostBlock(rule: JsonObject): List<Stmt>? {
                 if (!jsonContains(le["args"], "_Player", "You")) { reasons.add("PermanentLayerEffect"); return null }
                 listOf(Lit("ControlEnchantedPermanent"))
             }
+            "SetLandType" -> {
+                // "Enchanted land is an Island" (Sea's Claim) — replace the host land's subtypes.
+                val landType = le["args"].asStr() ?: run { reasons.add("PermanentLayerEffect"); return null }
+                listOf(call("SetEnchantedLandType", arg("\"${ktStr(landType)}\"")))
+            }
             else -> { reasons.add("PermanentLayerEffect"); return null }
         }
         abilities.forEach { stmts.add(staticAbilityStmt(it)) }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -10,7 +10,9 @@ import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.dot
 import com.wingedsheep.tooling.coverage.findInteger
+import com.wingedsheep.tooling.coverage.firstArgWordTagged
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
 import com.wingedsheep.tooling.coverage.strField
@@ -74,6 +76,20 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         renderLayerEffect(node, node.strField("_Action")!!, tvar)
     }
 
+    on("CreatePermanentRuleEffectUntil") { node, _, tvar ->
+        // "target <permanent> can't be blocked this turn" (Crafty Pathmage). Only the single CantBeBlocked
+        // rule at end-of-turn renders, as a CANT_BE_BLOCKED ability-flag grant; anything else scaffolds.
+        val args = node["args"].asArr ?: return@on null
+        val tgt = refTarget(args, tvar) ?: return@on null
+        if (!jsonContains(node, "_Expiration", "UntilEndOfTurn")) return@on null
+        val rules = (args.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return@on null
+        if (rules.size != 1) return@on null
+        when (rules[0].strField("_PermanentRule")) {
+            "CantBeBlocked" -> call("GrantKeywordEffect", arg("AbilityFlag.CANT_BE_BLOCKED.name"), arg(Lit(tgt)))
+            else -> null
+        }
+    }
+
     on("CreatePlayerEffectUntil") { node, _, _ ->  // Summer Bloom: may play N additional lands
         val n = findInteger(node)
         if (jsonContains(node, "_PlayerEffect", "MayPlayAdditionalLands") && n is Int) {
@@ -118,6 +134,30 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
                     else call("ModifyStatsEffect", arg("${pt[0].asInt()}"), arg("${pt[1].asInt()}"), arg(Lit(target)), arg(Lit(duration))),
                 )
             }
+            "AdjustPTX" -> {
+                // "+X/+X" / "-X/-X" where X is a dynamic game number (Wirewood Pride: +Elf-count, Feeding
+                // Frenzy: -Zombie-count). The DynamicAmount ModifyStats facade carries no duration, so a
+                // non-default duration scaffolds rather than emit a wrong one.
+                if (duration.isNotEmpty()) return null
+                val a = leObj["args"].asArr
+                if (a == null || a.size != 3) return null
+                val amt = dynamicAmountExpr(a[2]) ?: return null
+                val power = adjustModX(a.getOrNull(0), amt) ?: return null
+                val toughness = adjustModX(a.getOrNull(1), amt) ?: return null
+                inner.add(call("Effects.ModifyStats", arg(power), arg(toughness), arg(Lit(target))))
+            }
+            "AdjustPTForEach" -> {
+                // "+P/+T for each <count>" (Goblin Piledriver +2/+0 per other attacking Goblin). The base
+                // P/T are fixed ints scaled by the dynamic count; only the "other attacking <subtype>" count
+                // renders exactly (see adjustForEachCount), anything else scaffolds.
+                if (duration.isNotEmpty()) return null
+                val a = leObj["args"].asArr
+                if (a == null || a.size != 3) return null
+                val pBase = a.getOrNull(0).asInt() ?: return null
+                val tBase = a.getOrNull(1).asInt() ?: return null
+                val count = adjustForEachCount(a.getOrNull(2)) ?: return null
+                inner.add(call("Effects.ModifyStats", arg(scaleByBase(count, pBase)), arg(scaleByBase(count, tBase)), arg(Lit(target))))
+            }
             "AddAbility" -> {
                 // Only a bare keyword grant renders faithfully; a granted triggered/activated ability or a
                 // parameterized keyword can't be reproduced here, so scaffold instead of dropping it.
@@ -137,6 +177,38 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
         return call("Effects.ForEachInGroup", arg(filter), arg(effect))
     }
     return effect
+}
+
+/** A ±X modifier (`PlusX` / `MinusX`) applied to a dynamic amount: PlusX keeps it; MinusX negates it via
+ *  `Multiply(amt, -1)` (the golden's negated-count idiom — Feeding Frenzy's "-X/-X"). */
+internal fun EmitCtx.adjustModX(modNode: JsonElement?, amt: Dsl): Dsl? =
+    when ((modNode as? JsonObject)?.strField("_ModX")) {
+        "PlusX" -> amt
+        "MinusX" -> call("DynamicAmount.Multiply", arg(amt), arg("-1"))
+        else -> null
+    }
+
+/** A fixed per-each base scaled by a dynamic [count]: 0 -> `Fixed(0)`, 1 -> the bare count, else
+ *  `Multiply(count, base)` (Goblin Piledriver's +2/+0 -> power = Multiply(count, 2), toughness = Fixed(0)). */
+private fun EmitCtx.scaleByBase(count: Dsl, base: Int): Dsl = when (base) {
+    0 -> call("DynamicAmount.Fixed", arg("0"))
+    1 -> count
+    else -> call("DynamicAmount.Multiply", arg(count), arg("$base"))
+}
+
+/** The dynamic count of an `AdjustPTForEach` game number — only the "other attacking <subtype>" shape
+ *  renders exactly: `AggregateBattlefield(You, Creature.withSubtype(X).attacking())`, minus one when the
+ *  filter carries an `Other(self)` clause ("each OTHER attacking …"). Anything else returns null (-> SCAFFOLD). */
+private fun EmitCtx.adjustForEachCount(gn: JsonElement?): Dsl? {
+    val gnObj = gn as? JsonObject ?: return null
+    if (gnObj.strField("_GameNumber") != "TheNumberOfPermanentsOnTheBattlefield") return null
+    val subtype = gnObj.firstArgWordTagged("IsCreatureType") ?: return null
+    val blob = compact(gnObj)
+    if ("IsAttacking" !in blob) return null
+    val filter = Lit("GameObjectFilter.Creature").dot("withSubtype", arg("\"$subtype\"")).dot("attacking")
+    var count: Dsl = call("DynamicAmount.AggregateBattlefield", arg("Player.You"), arg(filter))
+    if ("\"Other\"" in blob) count = call("DynamicAmount.Subtract", arg(count), arg(call("DynamicAmount.Fixed", arg("1"))))
+    return count
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -54,6 +54,12 @@ internal object FilterPredicates {
     /** `.powerAtMost(N)` for a `PowerIs <= N` clause, else null. */
     fun powerAtMost(node: JsonElement?): Link? = powerBound(node, "LessThanOrEqualTo")?.let { Link("powerAtMost", listOf(arg("$it"))) }
 
+    /** `.manaValueAtMost(N)` for a `ManaValueIs <= N` clause, else null (Smother's "mana value 3 or less"). */
+    fun manaValueAtMost(node: JsonElement?): Link? = manaValueBound(node, "LessThanOrEqualTo")?.let { Link("manaValueAtMost", listOf(arg("$it"))) }
+
+    /** `.manaValueAtLeast(N)` for a `ManaValueIs >= N` clause, else null. */
+    fun manaValueAtLeast(node: JsonElement?): Link? = manaValueBound(node, "GreaterThanOrEqualTo")?.let { Link("manaValueAtLeast", listOf(arg("$it"))) }
+
     fun tapped(node: JsonElement?): Link? = if (node.hasTag("IsTapped")) Link("tapped") else null
     fun untapped(node: JsonElement?): Link? = if (node.hasTag("IsUntapped")) Link("untapped") else null
     fun attacking(node: JsonElement?): Link? = if (node.hasTag("IsAttacking")) Link("attacking") else null
@@ -71,6 +77,13 @@ internal object FilterPredicates {
      *  scoped to the matching `PowerIs` node so a power range's two bounds stay distinct. */
     private fun powerBound(node: JsonElement?, comparison: String): Int? =
         node.nodesTagged("PowerIs")
+            .firstOrNull { it["args"].strField("_Comparison") == comparison }
+            ?.let { findInteger(it["args"]) as? Int }
+
+    /** The integer bound of a `ManaValueIs` clause whose `args` is `{ _Comparison, args: Integer }`; null for
+     *  a non-integer (e.g. X) bound, leaving the filter unrestricted rather than emitting a wrong number. */
+    private fun manaValueBound(node: JsonElement?, comparison: String): Int? =
+        node.nodesTagged("ManaValueIs")
             .firstOrNull { it["args"].strField("_Comparison") == comparison }
             ?.let { findInteger(it["args"]) as? Int }
 }
@@ -91,6 +104,9 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
         "ControlledByAPlayer" !in blob -> null
         "\"Opponent\"" in blob -> Link("opponentControls")
         "\"You\"" in blob -> Link("youControl")
+        // "a creature that player controls" in a combat-damage trigger: the player ~ dealt damage to is an
+        // opponent (your creature dealt them combat damage), so it's that opponent's creature (Skirk Commando).
+        "\"Trigger_ThatPlayer\"" in blob -> Link("opponentControls")
         else -> return null
     }
     val hasController = "ControlledByAPlayer" in blob
@@ -125,6 +141,8 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
     FilterPredicates.attacking(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.powerAtMost(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.powerAtLeast(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.manaValueAtMost(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.manaValueAtLeast(filterNode)?.let { node = node.dot(it) }
     controller?.let { node = node.dot(it) }
     return node
 }
@@ -287,6 +305,8 @@ internal fun EmitCtx.gameObjectFilterExpr(filterNode: JsonElement?): Dsl? {
     (FilterPredicates.withoutFlying(filterNode) ?: FilterPredicates.withFlying(filterNode))?.let { node = node.dot(it) }
     FilterPredicates.powerAtLeast(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.powerAtMost(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.manaValueAtMost(filterNode)?.let { node = node.dot(it) }
+    FilterPredicates.manaValueAtLeast(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.tapped(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.untapped(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.attacking(filterNode)?.let { node = node.dot(it) }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -55,6 +55,14 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         call("Effects.Move", arg(Lit(tgt)), arg("Zone.HAND"))
     }
 
+    on("GainControlOfPermanentUntil") { _, args, tvar ->
+        // "gain control of <permanent> until end of turn" (Threaten). Only the end-of-turn duration renders;
+        // a permanent gain-control uses a different action, and any other expiration scaffolds.
+        val tgt = refTarget(args, tvar) ?: return@on null
+        if (!jsonContains(args, "_Expiration", "UntilEndOfTurn")) return@on null
+        call("Effects.GainControl", arg(Lit(tgt)), arg("Duration.EndOfTurn"))
+    }
+
     on("SacrificePermanent") { _, args, _ ->  // "sacrifice ~" (Blistering Firecat's end-step sacrifice)
         if (jsonContains(args, "_Permanent", "ThisPermanent")) Lit("SacrificeSelfEffect") else null
     }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -57,6 +57,13 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
     on("SacrificePermanent") { _, args, _ ->  // "sacrifice ~" (Blistering Firecat's end-step sacrifice)
         if (jsonContains(args, "_Permanent", "ThisPermanent")) Lit("SacrificeSelfEffect") else null
     }
+    on("SacrificeAPermanent") { _, args, _ ->
+        // "sacrifice a <filter>" by the resolving player (Accursed Centaur's ETB "sacrifice a creature").
+        // A player-directed sacrifice ("that player sacrifices …") arrives wrapped in a PlayerAction and is
+        // handled there; the bare effect sacrifices via the controller, so render SacrificeEffect(filter).
+        val filter = gameObjectFilterExpr(args) ?: return@on null
+        call("SacrificeEffect", arg(filter))
+    }
 
     on("ShuffleGraveyardCardIntoLibrary") { _, args, tvar ->  // e.g. Alabaster Dragon
         val tgt = refTarget(args, tvar) ?: "EffectTarget.Self"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.tooling.coverage.Composite
 import com.wingedsheep.tooling.coverage.Dsl
 import com.wingedsheep.tooling.coverage.Lit
 import com.wingedsheep.tooling.coverage.Raw
+import com.wingedsheep.tooling.coverage.amountNode
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.call
@@ -72,6 +73,13 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
 
     on("Surveil") { _, args, _ ->  // "Surveil N" -> the look-top / keep-or-bin pipeline
         (findInteger(args) as? Int)?.let { call("Patterns.Library.surveil", arg("$it")) }
+    }
+
+    on("ReturnGraveyardCardToHand") { _, args, _ ->
+        // "Return this card from your graveyard to your hand" (Gangrenous Goliath's graveyard ability). Only
+        // the self (this graveyard card) form renders; a chosen graveyard-card target scaffolds.
+        if (jsonContains(args, "_GraveyardCard", "ThisGraveyardCard"))
+            call("Effects.Move", arg("EffectTarget.Self"), arg("Zone.HAND")) else null
     }
 
     on("PutACardFromHandOnBattlefield") { _, args, _ ->  // "you may put a [basic land] card from your hand …"
@@ -142,14 +150,17 @@ internal fun EmitCtx.renderSearch(args: JsonElement?): Dsl? {
 }
 
 internal fun EmitCtx.renderLook(node: JsonObject, args: JsonElement?, tvar: String?): Dsl? {
-    val look = findInteger(node) ?: return null
     val blob = compact(node)
     // A conditional look ("...if there is an instant and a sorcery card in your graveyard, instead put
     // two of them...") branches the kept count; the flat lookAtTopAndKeep can't express it (and the
     // keep-count regex below would wrongly read the conditional branch's number), so scaffold.
     if ("IfElse" in blob || "_Condition" in blob) return null
-    if (oracleText?.contains("target", ignoreCase = true) == true) {
-        if (node.strField("_Action") != "LookAtTheTopNumberCardsOfPlayersLibrary" || tvar == null) return null
+    // "look at the top N of TARGET player's library, put one in their graveyard, the rest back" — the
+    // distribute pipeline. Gate it on the player-targeted ACTION, not on the oracle mentioning "target"
+    // (a card may target a spell/creature elsewhere — Discombobulate's "counter target spell").
+    if (node.strField("_Action") == "LookAtTheTopNumberCardsOfPlayersLibrary") {
+        val look = findInteger(node) ?: return null
+        if (tvar == null) return null
         if ("PutAGenericCardIntoGraveyard" !in blob || "PutTheRemainingCardsOnTopOfLibraryInAnyOrder" !in blob) return null
         // The look-and-distribute pipeline keeps its hand-indented multi-line element strings as Raw —
         // a shape no leaf node models yet — inside the multi-line Composite node.
@@ -175,9 +186,16 @@ internal fun EmitCtx.renderLook(node: JsonObject, args: JsonElement?, tvar: Stri
             ),
         ))
     }
+    // "Look at the top N, put some into your hand" — only a fixed look/keep count renders this way.
+    val look = findInteger(node)
     var keep: Int? = null
     for (m in Regex(""""PutNumber\w*IntoHand".*?"args":\s*(\d+)""").findAll(blob)) keep = m.groupValues[1].toInt()
-    if (keep != null) return call("Patterns.Library.lookAtTopAndKeep", arg("count", "$look"), arg("keepCount", "$keep"))
-    if ("PutTheRemainingCardsOnTopOfLibraryInAnyOrder" in blob) return call("Patterns.Library.lookAtTopAndReorder", arg("count", "$look"))
+    if (keep != null && look != null) return call("Patterns.Library.lookAtTopAndKeep", arg("count", "$look"), arg("keepCount", "$keep"))
+    // "Look at the top N, then put them back in any order." N may be fixed (Discombobulate: 4) or a
+    // dynamic count (Information Dealer: number of Wizards you control).
+    if ("PutTheRemainingCardsOnTopOfLibraryInAnyOrder" in blob) {
+        val count = look?.toString() ?: dynamicAmount(amountNode(node)) ?: return null
+        return call("Patterns.Library.lookAtTopAndReorder", arg("count", count))
+    }
     return null
 }


### PR DESCRIPTION
Widens the `:mtgish-tooling` emitter so 27 more already-implemented **Onslaught** cards render whole and gameplay-tree match their golden, taking ONS gate-verified auto-gen from **152 → 179**. Every change is shared across sets; **POR calibration stays 158/158 (0 mismatch)**, the hermetic `EmitterGoldenTest` is unchanged, and the cross-set `--all` shows no regression.

## Verification

| Gate | Before | After |
|---|---|---|
| ONS gameplay-tree **verified** (`just coverage-verify ONS`) | 152 | **179** |
| ONS mismatches | 24 | **16** (no net new; 8 fixed) |
| ONS fidelity AUTO tier | 175 | **189** |
| POR calibration (`just coverage-verify POR`) | 158/158 PASS | **158/158 PASS** |
| `EmitterGoldenTest` (hermetic, in `just test`) | PASS | PASS |

The remaining ONS "GATE FAIL" is the pre-existing tail of 16 bespoke mismatches (delayed/global triggers, replacement-damage, modal charms, etc.) — this PR reduced that set, it did not grow it.

## What changed (all in `:mtgish-tooling`, conservative null→SCAFFOLD)

**Gate normalization**
- Token `imageUri` is cosmetic art (like `oracleText`/`metadata`), never a rules input, and the emitter doesn't resolve a token's Scryfall image → added to `NON_GAMEPLAY_KEYS`. Fixed 7 token-creators that diverged on art alone (Centaur Glade, Dragon Roost, Mobilization, Symbiotic Beast/Elf/Wurm, Voice of the Woods).

**New / widened emitter shapes**
- Dynamic P/T: `AdjustPTX` (±X over a game number) and `AdjustPTForEach` (fixed base × count) → dynamic `Effects.ModifyStats` (Wirewood Pride, Feeding Frenzy, Goblin Piledriver, Shaleskin Bruiser); `ChooseCreatureTypeModifyStats` shortcut (Tribal Unity).
- Damage: `SpellDealsDamageCantBePrevented` (Pinpoint Avalanche), `HavePermanentDealDamage` (Skirk Commando, Snapping Thragg).
- Costs: `PayManaX` ("{X}{G}{G}", Silklash Spider), `DiscardHand` (Slate of Ancestry).
- Zones: `FromGraveyard { Activated }` → `activateFromZone = Zone.GRAVEYARD` (Gangrenous Goliath); `EntersWithNumberCounters` → `EntersWithDynamicCounters` (Stag Beetle); `SacrificeAPermanent` effect (Accursed Centaur); `GainControlOfPermanentUntil` (Threaten); `SetLandType` aura static (Sea's Claim); dynamic-count `lookAtTopAndReorder` (Information Dealer, Discombobulate).
- Mana: `AddManaRepeated` → `Effects.AddMana(color, <dynamic>)` (Brightstone Ritual).
- Filters: `ManaValueIs <=/>= N` → `.manaValueAtMost/atLeast(N)` (Smother); `Trigger_ThatPlayer` controller → `.opponentControls()`.

**Correctness fixes surfaced by the tooling**
- **Golden bug fixed**: *Information Dealer* counted "Wizards you control" (`Player.You`) but the printed card is "Wizards on the battlefield" (`Player.Each`) — corrected the card + oracle text and re-blessed `snapshots/cards/ONS.json`.
- `dynamicAmount` no longer silently drops a `SharesACreatureTypeWithPermanent` relational count (Mana Echoes) and no longer mis-fires its hand-count guard on a battlefield count whose card merely mentions "hand" elsewhere (Slate of Ancestry's discard-hand cost).
- `renderLook`'s target-player branch is gated on the player-targeted action, not on the oracle merely containing "target" (which wrongly declined Discombobulate's "counter target spell").

🤖 Generated with [Claude Code](https://claude.com/claude-code)