### PR TITLE
Set picker: min-cards filter, switch UI, outlined blocks + enable DOM/EOE

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
@@ -19,8 +19,11 @@ data class HandSmootherProperties(
 /**
  * Set enablement is configured by set code (e.g. "EOE", "DOM").
  *
- * - All sets are enabled by default.
- * - Codes in [disabledByDefault] are off unless explicitly enabled in [enabled].
+ * - All sets are enabled by default — every set is selectable in the lobby (not-fully-implemented
+ *   ones ride along as "partial" behind the picker's default-off toggle).
+ * - Codes in [disabledByDefault] are off unless explicitly enabled in [enabled]. Empty by default;
+ *   this is a deliberate admin kill-switch for a set that must be hidden entirely, not a way to
+ *   gate work-in-progress sets (the partial-sets toggle handles those).
  * - Codes in [enabled] override [disabledByDefault].
  *
  * Example application.yml:
@@ -28,11 +31,11 @@ data class HandSmootherProperties(
  * game:
  *   sets:
  *     enabled:
- *       EOE: true
+ *       SOMESET: false
  * ```
  */
 data class SetsProperties(
-    val disabledByDefault: Set<String> = setOf("DOM", "EOE"),
+    val disabledByDefault: Set<String> = emptySet(),
     val enabled: Map<String, Boolean> = emptyMap(),
 ) {
     fun isEnabled(setCode: String): Boolean {

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1418,36 +1418,109 @@
   color: var(--text-disabled);
 }
 
-.setPickerToggle {
+/* Filter bar: partial-sets switch on the left, min-cards stepper on the right. */
+.setPickerFilters {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
   gap: var(--space-2);
   margin-bottom: var(--space-2);
-  padding: 8px 10px;
+  padding: 7px 10px;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--border-medium);
   border-radius: var(--radius-md);
+}
+
+/* iOS-style toggle switch (the native checkbox is replaced by track + thumb). */
+.setPickerSwitch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0;
+  background: none;
+  border: none;
   cursor: pointer;
   user-select: none;
-}
-
-.setPickerToggle:hover {
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.setPickerToggle input {
-  cursor: pointer;
-  accent-color: var(--color-accent-dark);
-}
-
-.setPickerToggleLabel {
   font-size: var(--font-sm);
   color: var(--text-secondary);
 }
 
-.setPickerToggleCount {
-  color: var(--text-disabled);
+.setPickerSwitchTrack {
+  position: relative;
+  flex-shrink: 0;
+  width: 34px;
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--border-strong);
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.setPickerSwitchThumb {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  transition: transform var(--transition-fast), background var(--transition-fast);
+}
+
+.setPickerSwitchOn .setPickerSwitchTrack {
+  background: var(--color-accent-dark);
+  border-color: var(--color-accent-dark);
+}
+
+.setPickerSwitchOn .setPickerSwitchThumb {
+  background: #fff;
+  transform: translateX(16px);
+}
+
+.setPickerSwitch:hover .setPickerSwitchLabel {
+  color: var(--text-primary);
+}
+
+.setPickerSwitchLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.setPickerSwitchCount {
+  padding: 0 6px;
+  font-size: 10px;
   font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 999px;
+}
+
+.setPickerMinCards {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+  cursor: default;
+}
+
+.setPickerMinCardsInput {
+  width: 64px;
+  padding: 4px 8px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--font-sm);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  outline: none;
+}
+
+.setPickerMinCardsInput:focus {
+  border-color: var(--color-accent-dark);
 }
 
 .setPickerNote {
@@ -1465,23 +1538,36 @@
   overflow-y: auto;
 }
 
+/* A block (Onslaught, Invasion, …) is drawn as one outlined, inset card so its member sets
+ * read as a group, visually distinct from the standalone sets rendered as bare rows. */
 .setPickerGroup {
   display: flex;
   flex-direction: column;
   gap: 3px;
+  padding: 6px;
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
 }
 
 .setPickerGroupLabel {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-  padding: 4px 2px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 4px 6px;
   font-size: var(--font-xs);
   font-weight: var(--font-weight-semibold);
   color: var(--text-tertiary);
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  background: linear-gradient(180deg, rgba(20, 20, 30, 0.98), rgba(20, 20, 30, 0.92));
+}
+
+/* Trailing rule so the label reads as a header for the grouped rows below it. */
+.setPickerGroupLabel::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-medium);
 }
 
 .setPickerRow {

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -703,6 +703,8 @@ function LobbyOverlay({
   const [setSearch, setSetSearch] = useState('')
   // Partially-implemented sets are hidden by default; the host opts into them with this toggle.
   const [showPartialSets, setShowPartialSets] = useState(false)
+  // Hide thin sets (lots of partial sets have only a handful of cards). Defaults to 50.
+  const [minCards, setMinCards] = useState(50)
 
   // Show tournament standings when tournament is active
   if (tournamentState) {
@@ -759,12 +761,18 @@ function LobbyOverlay({
     .map((code) => allSets.find((s) => s.code === code))
     .filter((s): s is AvailableSet => s != null)
 
-  // Partial (not-fully-implemented) sets are hidden unless the host flips the toggle. A partial set
-  // that's already selected stays visible regardless, so the host can still see/untick it here.
+  // Picker visibility rules (an already-selected set always stays visible so it can be un-ticked):
+  //  - partial sets are hidden unless the host flips the toggle, and
+  //  - sets with fewer than `minCards` implemented cards are pruned (kills the long tail of
+  //    near-empty sets you'd otherwise see once partial sets are shown).
   const partialSetCount = allSets.filter((s) => s.partial).length
-  const pickerSets = showPartialSets
-    ? allSets
-    : allSets.filter((s) => !s.partial || lobbyState.settings.setCodes.includes(s.code))
+  const isSetSelected = (s: AvailableSet) => lobbyState.settings.setCodes.includes(s.code)
+  const pickerSets = allSets.filter((s) => {
+    if (isSetSelected(s)) return true
+    if (s.partial && !showPartialSets) return false
+    if ((s.implementedCount ?? 0) < minCards) return false
+    return true
+  })
 
   // Searchable multi-select inside the modal — match on set name or code, like the deckbuilder picker.
   const setSearchNeedle = setSearch.trim().toLowerCase()
@@ -1512,29 +1520,54 @@ function LobbyOverlay({
                 autoFocus
                 onChange={(e) => setSetSearch(e.target.value)}
               />
-              <label className={styles.setPickerToggle}>
-                <input
-                  type="checkbox"
-                  checked={showPartialSets}
-                  onChange={(e) => setShowPartialSets(e.target.checked)}
-                />
-                <span className={styles.setPickerToggleLabel}>
-                  Show partially implemented sets
-                  {partialSetCount > 0 && (
-                    <span className={styles.setPickerToggleCount}> ({partialSetCount})</span>
-                  )}
-                </span>
-              </label>
+              <div className={styles.setPickerFilters}>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={showPartialSets}
+                  className={`${styles.setPickerSwitch} ${showPartialSets ? styles.setPickerSwitchOn : ''}`}
+                  onClick={() => setShowPartialSets((v) => !v)}
+                >
+                  <span className={styles.setPickerSwitchTrack} aria-hidden>
+                    <span className={styles.setPickerSwitchThumb} />
+                  </span>
+                  <span className={styles.setPickerSwitchLabel}>
+                    Show partial sets
+                    {partialSetCount > 0 && (
+                      <span className={styles.setPickerSwitchCount}>{partialSetCount}</span>
+                    )}
+                  </span>
+                </button>
+                <label className={styles.setPickerMinCards}>
+                  <span className={styles.setPickerMinCardsLabel}>Min cards</span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={10}
+                    inputMode="numeric"
+                    className={styles.setPickerMinCardsInput}
+                    value={minCards}
+                    onChange={(e) => setMinCards(Math.max(0, Math.floor(Number(e.target.value) || 0)))}
+                  />
+                </label>
+              </div>
               <p className={styles.setPickerNote}>
                 Sets tagged <span className={styles.setPartialBadge}>partial</span> aren't fully
-                implemented — their boosters draw from a reduced pool of the cards that exist. They're
-                hidden by default; tick the box above to pick from every set.
+                implemented — their boosters draw from a reduced pool of the cards that exist.
               </p>
               <div className={styles.setPickerList}>
                 {filteredPickerSets.length > 0 ? (
                   renderGroupedSetRows(filteredPickerSets)
                 ) : (
-                  <div className={styles.setPickerEmpty}>No sets match your search.</div>
+                  <div className={styles.setPickerEmpty}>
+                    No sets match.{' '}
+                    {!showPartialSets && partialSetCount > 0
+                      ? 'Try enabling partial sets'
+                      : minCards > 0
+                        ? 'Try lowering the minimum card count'
+                        : 'Try a different search'}
+                    .
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
Follow-up to #526 (the "every set selectable + partial-sets toggle" feature, now merged). This adds the remaining polish and a min-cards filter, plus enables DOM/EOE.

## Changes

**game-server**
- **`SetsProperties.disabledByDefault` is now empty** (was `setOf("DOM", "EOE")`). The shipped `application.yml` already set `disabled-by-default: []`, so DOM/EOE were already enabled at runtime — the Kotlin default was dead, misleading config. Now no set is admin-disabled by default, so **all sets are truly available**. The kill-switch remains for fully hiding a set (distinct from work-in-progress sets, which the partial toggle handles).

**web-client** (set picker)
- Replaced the plain checkbox with an **iOS-style toggle switch** ("Show partial sets"), grouped with the new control in a single filter bar.
- Added a **"Min cards" filter (default 50)** that prunes the long tail of near-empty sets you'd otherwise see once partial sets are shown (Final Fantasy with 8 cards, Aetherdrift with 8, …). An already-selected set always stays visible regardless of the filters.
- **Multi-set blocks** (Onslaught, Invasion, …) are now drawn as outlined, inset cards with a header rule, so member sets read as one group, distinct from standalone sets rendered as bare rows.
- Smarter empty-state hint (suggests enabling partial sets / lowering the minimum depending on which filter is excluding everything).

The min-cards filter applies to all sets, not just partial ones — harmless for fully-implemented sets (all well over 50 cards) and keeps behavior predictable.

## Screenshots

Default — partial off, min cards 50; multi-set blocks outlined:

![blocks](https://raw.githubusercontent.com/wingedsheep/argentum-engine/partial-sets-toggle-screenshots/picker-blocks.png?v=2)

Partial **on** (min 50) — every substantial set, partial ones tagged; thin sets stay pruned:

![partial on](https://raw.githubusercontent.com/wingedsheep/argentum-engine/partial-sets-toggle-screenshots/picker-on.png?v=2)

_(Screenshots hosted on the throwaway `partial-sets-toggle-screenshots` branch.)_

## Verification
- `web-client` typecheck passes.
- `:game-server:compileKotlin` passes (cherry-picked clean onto latest main).
- Manually drove the lobby: default view shows curated full sets with blocks outlined; partial-on + min-cards behaves as designed (see screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)