### PR TITLE
Fix reprint handling in the set list: count reprints + show all-reprint sets

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/SetsController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/SetsController.kt
@@ -65,7 +65,7 @@ class SetsController(
                 BoosterSetDTO(
                     setCode = config.setCode,
                     setName = config.setName,
-                    implementedCount = config.cards.size,
+                    implementedCount = config.distinctCardCount,
                     incomplete = config.incomplete
                 )
             }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -35,7 +35,7 @@ class ConnectionHandler(
             name = config.setName,
             partial = !config.fullyImplemented,
             block = config.block,
-            implementedCount = config.cards.size,
+            implementedCount = config.distinctCardCount,
             releaseDate = config.releaseDate
         )
     }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -1399,7 +1399,7 @@ class TournamentLobby(
                 name = config.setName,
                 partial = !config.fullyImplemented,
                 block = config.block,
-                implementedCount = config.cards.size,
+                implementedCount = config.distinctCardCount,
                 releaseDate = config.releaseDate
             )
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
@@ -63,6 +63,18 @@ class BoosterGenerator(
          * "partial": still selectable, but hidden behind the lobby's partial-sets toggle.
          */
         val fullyImplemented: Boolean get() = sealedSupported && !incomplete
+
+        /**
+         * Number of distinct cards the set contributes, for "X cards" displays in set pickers.
+         *
+         * Counts reprint [printings] — a Commander/precon set's reprints have their canonical
+         * [CardDefinition] in an earlier set, so they never appear in [cards] and would otherwise
+         * be undercounted. De-duplicating by name collapses any alternate-frame printing of a card
+         * already defined here, while still counting reprint-only names exactly once.
+         */
+        val distinctCardCount: Int
+            get() = (cards.asSequence().map { it.name } + printings.asSequence().map { it.name })
+                .distinct().count()
     }
 
     companion object {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorCardCountTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorCardCountTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.limited
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.ScryfallMetadata
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins [BoosterGenerator.SetConfig.distinctCardCount], the "X cards" number shown in set pickers.
+ *
+ * Commander / precon sets carry most of their cards as reprint [Printing] rows whose canonical
+ * [CardDefinition] lives in an earlier set — those reprints never appear in [SetConfig.cards], so a
+ * naive `cards.size` undercounts the set (Bloomburrow Commander showed 50 instead of ~109).
+ */
+class BoosterGeneratorCardCountTest : DescribeSpec({
+
+    fun card(name: String) = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2,
+        metadata = ScryfallMetadata(collectorNumber = "1", imageUri = "canonical/$name.jpg"),
+    ).copy(setCode = "BLC")
+
+    fun reprint(name: String, frame: Boolean = false) = Printing(
+        oracleId = name,
+        name = name,
+        setCode = "BLC",
+        collectorNumber = "200",
+        imageUri = "reprint/$name.jpg",
+        frameEffects = if (frame) listOf("showcase") else emptyList(),
+        borderColor = if (frame) "borderless" else null,
+    )
+
+    fun config(cards: List<CardDefinition>, printings: List<Printing>) =
+        BoosterGenerator.SetConfig(
+            setCode = "BLC",
+            setName = "Bloomburrow Commander",
+            cards = cards,
+            basicLands = emptyList(),
+            printings = printings,
+        )
+
+    describe("distinctCardCount") {
+
+        it("counts only full card definitions when there are no printings") {
+            config(listOf(card("Abrade"), card("Beast Within")), emptyList())
+                .distinctCardCount shouldBe 2
+        }
+
+        it("counts reprint printings whose canonical lives in another set") {
+            // 2 new cards + 3 reprints (canonicals elsewhere) = 5 distinct cards.
+            config(
+                cards = listOf(card("Abrade"), card("Beast Within")),
+                printings = listOf(reprint("Adarkar Wastes"), reprint("Barren Moor"), reprint("Command Tower")),
+            ).distinctCardCount shouldBe 5
+        }
+
+        it("does not double-count an alternate-frame printing of a card defined in the set") {
+            // "Abrade" appears as both a full definition and a showcase printing — still one card.
+            config(
+                cards = listOf(card("Abrade")),
+                printings = listOf(reprint("Abrade", frame = true), reprint("Command Tower")),
+            ).distinctCardCount shouldBe 2
+        }
+    }
+})


### PR DESCRIPTION
Two related fixes to how reprint-heavy sets are handled in the tournament lobby's set selection.

## 1. Count reprints in set picker card counts

Bloomburrow Commander showed only **50 cards** despite having ~109 implemented. The "X cards" count came from `config.cards.size`, which only counts full `CardDefinition`s. Commander/precon sets carry most cards as reprint `Printing` rows whose canonical `CardDefinition` lives in an earlier set — never in `cards`.

Added `BoosterGenerator.SetConfig.distinctCardCount` (distinct names across `cards` + `printings`; de-dupes alternate-frame variants, counts reprint-only names once). Used from all three set-list builders (`TournamentLobby`, `ConnectionHandler`, `SetsController`).

## 2. Make all-reprint sets (Eighth Edition) selectable

8th Edition didn't appear in the set list at all. `boosterGenerator` filtered out any set with an empty `cards` list, but 8ED is an **all-reprint core set** — zero own definitions, all 187 cards are reprint `Printing` rows — so it was silently dropped.

Now an all-reprint set's booster pool is **resolved from its printings**: each reprint's canonical is looked up in the `CardRegistry` by name and overlaid with the reprint's presentation (set code, art) and per-set `rarity` (a card's rarity varies by set, and booster generation slots by rarity). All 187 of 8ED's reprints resolve to implemented canonicals, so it becomes a complete, draftable set (still "partial" while flagged `incomplete`). Sets that author their own cards are untouched; reprints with no implemented canonical are skipped, so genuinely-empty sets stay excluded.

## Tests

- `BoosterGeneratorCardCountTest` — pins `distinctCardCount`: cards-only, cards + reprints, alternate-frame de-dup.
- `GameBeansConfigBoosterPoolTest` — boots the beans and asserts 8ED is selectable, its pool resolves to >150 cards stamped `8ED`, spanning multiple rarities.

All compile; new and existing config tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)