### PR TITLE
GPT: implement 5 Gruul cards + mtgish auto-gen support

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/GruulSignet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/GruulSignet.kt
@@ -1,40 +1,22 @@
 package com.wingedsheep.mtg.sets.definitions.blc.cards
 
-import com.wingedsheep.sdk.core.Color
-import com.wingedsheep.sdk.dsl.Costs
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Printing
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.TimingRule
 
 /**
- * Gruul Signet
- * {2}
- * Artifact
- *
- * {1}, {T}: Add {R}{G}.
+ * Gruul Signet reprint in Bloomburrow Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Guildpact set's `cards/`
+ * package (Guildpact is the card's earliest real printing); this file contributes
+ * only presentation data for the Bloomburrow Commander printing.
  */
-val GruulSignet = card("Gruul Signet") {
-    manaCost = "{2}"
-    colorIdentity = "RG"
-    typeLine = "Artifact"
-    oracleText = "{1}, {T}: Add {R}{G}."
-
-    activatedAbility {
-        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
-        effect = Effects.Composite(
-            Effects.AddMana(Color.RED),
-            Effects.AddMana(Color.GREEN),
-        )
-        manaAbility = true
-        timing = TimingRule.ManaAbility
-    }
-
-    metadata {
-        rarity = Rarity.UNCOMMON
-        collectorNumber = "273"
-        artist = "Efrem Palacios"
-        flavorText = "Gruul territorial markings need not be legible. The blood, snot, and muck used to smear them are unmistakably Gruul."
-        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e71ad66-28ae-4cd6-ac71-d8710e9ea9cd.jpg?1721975455"
-    }
-}
+val GruulSignetReprint = Printing(
+    oracleId = "d36e0c9f-c025-4dfe-9644-9cad2461ce38",
+    name = "Gruul Signet",
+    setCode = "BLC",
+    collectorNumber = "273",
+    scryfallId = "1e71ad66-28ae-4cd6-ac71-d8710e9ea9cd",
+    artist = "Efrem Palacios",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e71ad66-28ae-4cd6-ac71-d8710e9ea9cd.jpg?1721975455",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/GruulSignetReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/GruulSignetReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gruul Signet reprint in Commander 2011. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Guildpact set's `cards/`
+ * package (Guildpact is the card's earliest real printing); this file contributes
+ * only presentation data for the Commander 2011 printing.
+ */
+val GruulSignetReprint = Printing(
+    oracleId = "d36e0c9f-c025-4dfe-9644-9cad2461ce38",
+    name = "Gruul Signet",
+    setCode = "CMD",
+    collectorNumber = "250",
+    scryfallId = "a677212a-c275-41e3-90c9-be2a866f8091",
+    artist = "Greg Hildebrandt",
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a677212a-c275-41e3-90c9-be2a866f8091.jpg?1592714439",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/SavageTwisterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/SavageTwisterReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Savage Twister reprint in Commander 2011. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Mirage set's `cards/`
+ * package (Mirage is the card's earliest real printing); this file contributes
+ * only presentation data for the Commander 2011 printing.
+ */
+val SavageTwisterReprint = Printing(
+    oracleId = "5268518e-7631-4149-8eea-c2475b9b14df",
+    name = "Savage Twister",
+    setCode = "CMD",
+    collectorNumber = "222",
+    scryfallId = "5aa253a6-2513-4dfd-b34a-88c341d0372c",
+    artist = "Bob Eggleton",
+    imageUri = "https://cards.scryfall.io/normal/front/5/a/5aa253a6-2513-4dfd-b34a-88c341d0372c.jpg?1592714244",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/GruulSignet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/GruulSignet.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Gruul Signet
+ * {2}
+ * Artifact
+ *
+ * {1}, {T}: Add {R}{G}.
+ */
+val GruulSignet = card("Gruul Signet") {
+    manaCost = "{2}"
+    colorIdentity = "RG"
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}: Add {R}{G}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.RED),
+            Effects.AddMana(Color.GREEN),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Greg Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1bb30340-96a4-49d8-838b-8788900401a0.jpg?1593272924"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/SavageTwisterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/SavageTwisterReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Savage Twister reprint in Guildpact. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Mirage set's `cards/`
+ * package (Mirage is the card's earliest real printing); this file contributes
+ * only presentation data for the Guildpact printing.
+ */
+val SavageTwisterReprint = Printing(
+    oracleId = "5268518e-7631-4149-8eea-c2475b9b14df",
+    name = "Savage Twister",
+    setCode = "GPT",
+    collectorNumber = "127",
+    scryfallId = "682ee5a9-2995-4868-b7ea-8735b2aee77e",
+    artist = "Luca Zontini",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/682ee5a9-2995-4868-b7ea-8735b2aee77e.jpg?1593272763",
+    releaseDate = "2006-02-03",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/StreetbreakerWurm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/StreetbreakerWurm.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Streetbreaker Wurm
+ * {3}{R}{G}
+ * Creature — Wurm
+ * 6/4
+ *
+ * Vanilla creature (no abilities).
+ */
+val StreetbreakerWurm = card("Streetbreaker Wurm") {
+    manaCost = "{3}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Wurm"
+    power = 6
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Greg Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5313054-91a5-401c-84d1-03a2cd265060.jpg?1593272809"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/WildCantor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/WildCantor.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Wild Cantor
+ * {R/G}
+ * Creature — Human Druid
+ * 1/1
+ *
+ * ({R/G} can be paid with either {R} or {G}.)
+ * Sacrifice this creature: Add one mana of any color.
+ */
+val WildCantor = card("Wild Cantor") {
+    manaCost = "{R/G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Human Druid"
+    oracleText = "({R/G} can be paid with either {R} or {G}.)\n" +
+        "Sacrifice this creature: Add one mana of any color."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Glenn Fabry"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/242dc29e-d8f5-4207-abbf-cf5425f08551.jpg?1593272918"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Wildsize.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Wildsize.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wildsize
+ * {2}{G}
+ * Instant
+ *
+ * Target creature gets +2/+2 and gains trample until end of turn.
+ * Draw a card.
+ */
+val Wildsize = card("Wildsize") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t),
+            Effects.DrawCards(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "98"
+        artist = "Jim Murray"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eef061ed-736c-41ba-b692-d1fbfaca242e.jpg?1593272542"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BLC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLC.json
@@ -2004,57 +2004,6 @@
     ]
 }
 
-// Gruul Signet
-{
-    "name": "Gruul Signet",
-    "manaCost": "{2}",
-    "typeLine": "Artifact",
-    "oracleText": "{1}, {T}: Add {R}{G}.",
-    "script": {
-        "activatedAbilities": [
-            {
-                "id": "ability_1",
-                "cost": {
-                    "type": "CostComposite",
-                    "costs": [
-                        {
-                            "type": "CostMana",
-                            "cost": "{1}"
-                        },
-                        "CostTap"
-                    ]
-                },
-                "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "AddMana",
-                            "color": "RED"
-                        },
-                        {
-                            "type": "AddMana",
-                            "color": "GREEN"
-                        }
-                    ]
-                },
-                "timing": "ManaAbility",
-                "isManaAbility": true
-            }
-        ]
-    },
-    "metadata": {
-        "collectorNumber": "273",
-        "rarity": "UNCOMMON",
-        "artist": "Efrem Palacios",
-        "flavorText": "Gruul territorial markings need not be legible. The blood, snot, and muck used to smear them are unmistakably Gruul.",
-        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e71ad66-28ae-4cd6-ac71-d8710e9ea9cd.jpg?1721975455"
-    },
-    "colorIdentityOverride": [
-        "RED",
-        "GREEN"
-    ]
-}
-
 // Harmonize
 {
     "name": "Harmonize",

--- a/mtg-sets/src/test/resources/snapshots/cards/GPT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GPT.json
@@ -1,3 +1,52 @@
+// Gruul Signet
+{
+    "name": "Gruul Signet",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}: Add {R}{G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{1}"
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "RED"
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "GREEN"
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "artist": "Greg Hildebrandt",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1bb30340-96a4-49d8-838b-8788900401a0.jpg?1593272924"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Gruul Turf
 {
     "name": "Gruul Turf",
@@ -61,6 +110,120 @@
     },
     "colorIdentityOverride": [
         "RED",
+        "GREEN"
+    ]
+}
+
+// Streetbreaker Wurm
+{
+    "name": "Streetbreaker Wurm",
+    "manaCost": "{3}{R}{G}",
+    "typeLine": "Creature — Wurm",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "artist": "Greg Hildebrandt",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5313054-91a5-401c-84d1-03a2cd265060.jpg?1593272809"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Wild Cantor
+{
+    "name": "Wild Cantor",
+    "manaCost": "{R/G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "({R/G} can be paid with either {R} or {G}.)\nSacrifice this creature: Add one mana of any color.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "artist": "Glenn Fabry",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/242dc29e-d8f5-4207-abbf-cf5425f08551.jpg?1593272918"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Wildsize
+{
+    "name": "Wildsize",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "artist": "Jim Murray",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/eef061ed-736c-41ba-b692-d1fbfaca242e.jpg?1593272542"
+    },
+    "colorIdentityOverride": [
         "GREEN"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GptGruulCardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GptGruulCardsScenarioTest.kt
@@ -1,0 +1,167 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the Guildpact (GPT) Gruul cards.
+ *
+ * These cards reuse existing SDK primitives (mana abilities, stat modification, keyword
+ * grant, card draw, X-damage-to-each-creature), so the tests just confirm the composed
+ * behaviour resolves as the oracle text reads.
+ */
+class GptGruulCardsScenarioTest : ScenarioTestBase() {
+
+    private fun ManaPoolComponent.total() =
+        white + blue + black + red + green + colorless
+
+    init {
+        context("Gruul Signet — {1}, {T}: Add {R}{G}") {
+            test("produces one red and one green when activated") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Gruul Signet", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1) // pays the {1} activation cost
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val signet = game.findPermanent("Gruul Signet")!!
+                val abilityId = cardRegistry.getCard("Gruul Signet")!!.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = signet, abilityId = abilityId)
+                )
+                withClue("Activating Gruul Signet should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()!!
+                withClue("Should add exactly one red and one green") {
+                    pool.red shouldBe 1
+                    pool.green shouldBe 1
+                }
+            }
+        }
+
+        context("Wild Cantor — Sacrifice this creature: Add one mana of any color") {
+            test("sacrifices itself and adds one mana of the chosen color") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wild Cantor", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cantor = game.findPermanent("Wild Cantor")!!
+                val abilityId = cardRegistry.getCard("Wild Cantor")!!.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = cantor, abilityId = abilityId)
+                )
+
+                // Pauses for a color choice; Wild Cantor is already sacrificed (cost paid).
+                withClue("Wild Cantor should leave the battlefield (sacrificed as a cost)") {
+                    game.isOnBattlefield("Wild Cantor") shouldBe false
+                }
+
+                val decision = game.getPendingDecision()
+                    ?: error("Expected a color-choice decision after activating Wild Cantor")
+                game.submitDecision(ColorChosenResponse(decision.id, Color.BLUE))
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()!!
+                withClue("Should add exactly one mana of the chosen color (blue)") {
+                    pool.blue shouldBe 1
+                    pool.total() shouldBe 1
+                }
+            }
+        }
+
+        context("Wildsize — target creature gets +2/+2 and gains trample; draw a card") {
+            test("buffs the target, grants trample, and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Wildsize")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withLandsOnBattlefield(1, "Forest", 3) // {2}{G}
+                    .withCardInLibrary(1, "Mountain") // something to draw
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val handBefore = game.handSize(1)
+
+                val result = game.castSpell(1, "Wildsize", bears)
+                withClue("Casting Wildsize should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be 4/4 after +2/+2") {
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                    game.state.projectedState.getToughness(bears) shouldBe 4
+                }
+                withClue("Grizzly Bears should have trample") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("Casting Wildsize ({2}{G}) and drawing should net +0 cards in hand (spent Wildsize, drew one)") {
+                    // started with Wildsize in hand (handBefore includes it); after cast it leaves
+                    // hand and we draw 1 -> hand size returns to handBefore.
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+
+        context("Streetbreaker Wurm — vanilla 6/4") {
+            test("enters as a 6/4 Wurm with no abilities") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Streetbreaker Wurm", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Streetbreaker Wurm")!!
+                withClue("Streetbreaker Wurm is a 6/4") {
+                    game.state.projectedState.getPower(wurm) shouldBe 6
+                    game.state.projectedState.getToughness(wurm) shouldBe 4
+                }
+            }
+        }
+
+        context("Savage Twister — deals X damage to each creature") {
+            test("X=2 kills 2-toughness creatures on both sides") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Savage Twister")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withCardOnBattlefield(2, "Glory Seeker", summoningSickness = false)  // 2/2
+                    .withLandsOnBattlefield(1, "Mountain", 4) // {X=2}{R}{G}
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val result = game.castXSpell(1, "Savage Twister", xValue = 2)
+                withClue("Casting Savage Twister should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Both 2/2 creatures should be destroyed by 2 damage each") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isOnBattlefield("Glory Seeker") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements five Guildpact (GPT) Gruul (R/G) cards, with reprint/canonical-home placement verified by `check-card-printing` and mtgish auto-gen coverage proven by `coverage-verify`.

## Cards

| Card | Type | Canonical home | mtgish tier |
|------|------|----------------|-------------|
| Gruul Signet | `{2}` Artifact — `{1},{T}: Add {R}{G}` | **GPT** (moved here from blc) | AUTO |
| Savage Twister | `{X}{R}{G}` Sorcery — X damage to each creature | mir (1996, earliest); GPT = Printing row | AUTO |
| Wildsize | `{2}{G}` Instant — +2/+2 + trample + draw a card | GPT | AUTO |
| Streetbreaker Wurm | `{3}{R}{G}` 6/4 vanilla Wurm | GPT | AUTO |
| Wild Cantor | `{R/G}` 1/1 — `Sacrifice: Add one mana of any color` | GPT | AUTO |

## Reprint / canonical-home bookkeeping

- **Gruul Signet**: its earliest real printing is GPT (2006), but the canonical `CardDefinition` previously lived in Bloomburrow Commander (blc). Per `check-card-printing`, the canonical is now in `gpt/cards/`, the blc file becomes a `Printing` row, and the missing **cmd** Printing row is added.
- **Savage Twister**: canonical already lives in Mirage (`mir`, 1996); GPT and the scaffolded **cmd** set each gain a `Printing` row (no duplicate canonical).
- `just check-card-printing` is clean for all five cards.

## mtgish auto-gen

No bridge or emitter changes were required: all five cards' mechanics (signet mana ability, X-damage-to-each-creature, pump + grant-keyword + draw instant, vanilla creature, sacrifice-for-any-color) are already covered by existing bridge capabilities and emitter handlers. All five render whole at the **AUTO** tier, so the principle of "decline to SCAFFOLD rather than fake-render" did not need to be exercised. (Wild Cantor's emitter output uses `Effects.AddManaOfChoice()`, which is the same `AddManaOfChoiceEffect(AnyColor, 1)` as the hand-authored `Effects.AddAnyColorMana(1)` — identical serialized capability.)

## Verification

- New `GptGruulCardsScenarioTest` — all 5 cards pass (mana, sac+color choice, pump/trample/draw, vanilla stats, X-damage board wipe).
- `CardDefinitionSnapshotTest` re-blessed: GPT golden gains the 4 canonicals; BLC golden drops Gruul Signet (now a Printing). Diffs are scoped to these cards only.
- `just coverage-verify GPT` → **GATE PASS** (GPT canonicals match golden; Savage Twister verifies against mir's golden as expected).
- Portal not regressed: `just coverage-verify POR` → 158/158, `just coverage --calibrate POR` → 200/200 (0 mismatch).
- `EmitterGoldenTest` passes (no emitter fixture drift; nothing re-blessed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)