### PR TITLE
GPT: implement 5 Orzhov cards + mtgish auto-gen support

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/CremateReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/CremateReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cremate reprint in Guildpact. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Invasion (INV) set's `cards/` package — Cremate's earliest real printing —
+ * so this file contributes only Guildpact presentation data.
+ */
+val CremateReprint = Printing(
+    oracleId = "c6a2e410-b182-48d1-aeb2-bc8de27e9cd2",
+    name = "Cremate",
+    setCode = "GPT",
+    collectorNumber = "45",
+    scryfallId = "39a9ce8f-df8a-44bc-8d34-9f42135a3a23",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/39a9ce8f-df8a-44bc-8d34-9f42135a3a23.jpg?1593272158",
+    releaseDate = "2006-02-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/DouseInGloom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/DouseInGloom.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Douse in Gloom
+ * {2}{B}
+ * Instant
+ * Douse in Gloom deals 2 damage to target creature and you gain 2 life.
+ */
+val DouseInGloom = card("Douse in Gloom") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Douse in Gloom deals 2 damage to target creature and you gain 2 life."
+
+    spell {
+        val t = target("creature", Targets.Creature)
+        effect = Effects.DealDamage(2, t)
+            .then(Effects.GainLife(2))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Kev Walker"
+        flavorText = "Orzhov prisoners are steeped in a blackened brew that robs their souls of strength. Patriarchs drink that brew to extend their own lives."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50a4fe4d-460d-4143-9a8e-14e16b211722.jpg?1593272187"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Mortify.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Mortify.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mortify
+ * {1}{W}{B}
+ * Instant
+ * Destroy target creature or enchantment.
+ */
+val Mortify = card("Mortify") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature or enchantment."
+
+    spell {
+        val t = target("creature or enchantment", Targets.CreatureOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "122"
+        artist = "Glen Angus"
+        flavorText = "The eyes let flow with tears, then blood, then the very soul—the whole wrung inside out, dripping down into the blackened puddle of the past."
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b2c5187-71c7-4801-8a76-339c67322d35.jpg?1593272729"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/OrzhovSignet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/OrzhovSignet.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Orzhov Signet
+ * {2}
+ * Artifact
+ * {1}, {T}: Add {W}{B}.
+ */
+val OrzhovSignet = card("Orzhov Signet") {
+    manaCost = "{2}"
+    colorIdentity = "WB"
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}: Add {W}{B}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.Composite(Effects.AddMana(Color.WHITE, 1), Effects.AddMana(Color.BLACK, 1))
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Greg Hildebrandt"
+        flavorText = "The form of the sigil is just as important as the sigil itself. If it's carried on a medallion, its bearer is a master. If it's tattooed on the body, its bearer is a slave."
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9298a1d-5b41-46d8-929c-b6980d1e6eb7.jpg?1753108346"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/OstiaryThrull.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/OstiaryThrull.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ostiary Thrull
+ * {3}{B}
+ * Creature — Thrull
+ * 2/2
+ * {W}, {T}: Tap target creature.
+ */
+val OstiaryThrull = card("Ostiary Thrull") {
+    manaCost = "{3}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Thrull"
+    power = 2
+    toughness = 2
+    oracleText = "{W}, {T}: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target("creature", Targets.Creature)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "Ron Spencer"
+        flavorText = "Orzhov churches don't pass the plate for collection. They charge for admission."
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26407330-d7a1-4915-b7c6-e08e166cf638.jpg?1593272233"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/GPT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GPT.json
@@ -1,3 +1,54 @@
+// Douse in Gloom
+{
+    "name": "Douse in Gloom",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Douse in Gloom deals 2 damage to target creature and you gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Kev Walker",
+        "flavorText": "Orzhov prisoners are steeped in a blackened brew that robs their souls of strength. Patriarchs drink that brew to extend their own lives.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50a4fe4d-460d-4143-9a8e-14e16b211722.jpg?1593272187"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Gruul Turf
 {
     "name": "Gruul Turf",
@@ -62,5 +113,149 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Mortify
+{
+    "name": "Mortify",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature or enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "creature or enchantment"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|enchantment"
+                },
+                "id": "creature or enchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "UNCOMMON",
+        "artist": "Glen Angus",
+        "flavorText": "The eyes let flow with tears, then blood, then the very soul—the whole wrung inside out, dripping down into the blackened puddle of the past.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b2c5187-71c7-4801-8a76-339c67322d35.jpg?1593272729"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
+// Orzhov Signet
+{
+    "name": "Orzhov Signet",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}: Add {W}{B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{1}"
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "WHITE"
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "BLACK"
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "Greg Hildebrandt",
+        "flavorText": "The form of the sigil is just as important as the sigil itself. If it's carried on a medallion, its bearer is a master. If it's tattooed on the body, its bearer is a slave.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f9298a1d-5b41-46d8-929c-b6980d1e6eb7.jpg?1753108346"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
+// Ostiary Thrull
+{
+    "name": "Ostiary Thrull",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Thrull",
+    "oracleText": "{W}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{W}"
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "Ron Spencer",
+        "flavorText": "Orzhov churches don't pass the plate for collection. They charge for admission.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26407330-d7a1-4915-b7c6-e08e166cf638.jpg?1593272233"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -90,6 +90,14 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
             call("Effects.Move", arg("EffectTarget.Self"), arg("Zone.HAND")) else null
     }
 
+    on("ExileGraveyardCard") { _, args, tvar ->
+        // "Exile target card from a graveyard" (Cremate, Withered Wretch). The target graveyard card was
+        // already recovered into the bound `tvar`; exile is a plain Move to the exile zone. Self ("exile
+        // this card from your graveyard") falls back to EffectTarget.Self.
+        val tgt = refTarget(args, tvar) ?: "EffectTarget.Self"
+        call("Effects.Move", arg(Lit(tgt)), arg("Zone.EXILE"))
+    }
+
     on("PutACardFromHandOnBattlefield") { _, args, _ ->  // "you may put a [basic land] card from your hand …"
         val arr = args.asArr ?: return@on null
         val blob = compact(arr.getOrNull(0))

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DouseInGloomScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DouseInGloomScenarioTest.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Douse in Gloom (GPT #49) — {2}{B} Instant.
+ *
+ * "Douse in Gloom deals 2 damage to target creature and you gain 2 life."
+ *
+ * Verifies the spell deals 2 damage to the targeted creature and the caster gains 2 life.
+ */
+class DouseInGloomScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Douse in Gloom deals damage and gains life") {
+
+            test("deals 2 damage to a creature and the caster gains 2 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Douse in Gloom")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLifeTotal(1, 20)
+                    // Centaur Courser is a 3/3, so 2 damage marks it without killing it.
+                    .withCardOnBattlefield(2, "Centaur Courser", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val result = game.castSpell(1, "Douse in Gloom", targetId = courser)
+                withClue("Casting Douse in Gloom should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Caster should have gained 2 life (20 -> 22)") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                withClue("Centaur Courser should have 2 damage marked on it") {
+                    game.state.getEntity(courser)?.get<DamageComponent>()?.amount shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MortifyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MortifyScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario test for Mortify (GPT #122) — {1}{W}{B} Instant.
+ *
+ * "Destroy target creature or enchantment."
+ *
+ * Verifies the spell can destroy a creature and (separately) an enchantment.
+ */
+class MortifyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Mortify destroys target creature or enchantment") {
+
+            test("destroys a target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Mortify")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val result = game.castSpell(1, "Mortify", targetId = courser)
+                withClue("Casting Mortify should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Centaur Courser should be destroyed") {
+                    game.findPermanent("Centaur Courser") shouldBe null
+                }
+            }
+
+            test("destroys a target enchantment") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Mortify")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardOnBattlefield(2, "Test Enchantment", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val enchantment = game.findPermanent("Test Enchantment")
+                withClue("Test Enchantment should be on the battlefield") { enchantment shouldNotBe null }
+
+                val result = game.castSpell(1, "Mortify", targetId = enchantment!!)
+                withClue("Casting Mortify on enchantment should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Test Enchantment should be destroyed") {
+                    game.findPermanent("Test Enchantment") shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrzhovSignetScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrzhovSignetScenarioTest.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Orzhov Signet (GPT #155) — {2} Artifact.
+ *
+ * "{1}, {T}: Add {W}{B}."
+ *
+ * Verifies the mana ability: paying {1} (from a Swamp) plus tapping the Signet adds {W}{B}
+ * to the controller's mana pool.
+ */
+class OrzhovSignetScenarioTest : ScenarioTestBase() {
+
+    private val signetAbilityId by lazy {
+        cardRegistry.requireCard("Orzhov Signet").activatedAbilities[0].id
+    }
+
+    init {
+        context("Orzhov Signet mana ability") {
+
+            test("paying {1} and tapping adds {W}{B} to the pool") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Orzhov Signet", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Fill the pool with one {B} from the Swamp to pay the {1} activation cost.
+                val swamp = game.findPermanent("Swamp")!!
+                val swampAbility = cardRegistry.requireCard("Swamp").activatedAbilities[0].id
+                game.execute(ActivateAbility(game.player1Id, swamp, swampAbility)).error shouldBe null
+
+                val signet = game.findPermanent("Orzhov Signet")!!
+                val result = game.execute(ActivateAbility(game.player1Id, signet, signetAbilityId))
+                withClue("Activating Orzhov Signet should succeed: ${result.error}") { result.error shouldBe null }
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()!!
+                withClue("Signet should net one white mana") { pool.white shouldBe 1 }
+                withClue("Signet should net one black mana (the {B} from Swamp was spent on {1})") {
+                    pool.black shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OstiaryThrullScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OstiaryThrullScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Ostiary Thrull (GPT #55) — {3}{B} Creature — Thrull, 2/2.
+ *
+ * "{W}, {T}: Tap target creature."
+ *
+ * Verifies the activated ability taps the targeted creature when {W} is paid and the Thrull taps.
+ */
+class OstiaryThrullScenarioTest : ScenarioTestBase() {
+
+    private val tapAbilityId by lazy {
+        cardRegistry.requireCard("Ostiary Thrull").activatedAbilities[0].id
+    }
+
+    init {
+        context("Ostiary Thrull tap ability") {
+
+            test("paying {W} and tapping the Thrull taps the target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ostiary Thrull", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Fill the pool with {W} to pay the activation cost.
+                val plains = game.findPermanent("Plains")!!
+                val plainsAbility = cardRegistry.requireCard("Plains").activatedAbilities[0].id
+                game.execute(ActivateAbility(game.player1Id, plains, plainsAbility)).error shouldBe null
+
+                val thrull = game.findPermanent("Ostiary Thrull")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = thrull,
+                        abilityId = tapAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(courser))
+                    )
+                )
+                withClue("Activating Ostiary Thrull's tap ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Targeted creature should be tapped") {
+                    game.state.getEntity(courser)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("Ostiary Thrull should be tapped from paying its {T} cost") {
+                    game.state.getEntity(thrull)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements 5 Guildpact (GPT) Orzhov (W/B) cards, each with a passing scenario test, and extends the mtgish auto-gen tooling so all 5 reach the **AUTO** fidelity tier and pass capability verification.

## Cards

| Card | Cost / Type | Text | Canonical home | Auto-gen tier |
|------|-------------|------|----------------|---------------|
| Orzhov Signet (#155) | {2} Artifact | `{1}, {T}: Add {W}{B}.` | GPT | AUTO (no tooling change) |
| Mortify (#122) | {1}{W}{B} Instant | Destroy target creature or enchantment. | GPT | AUTO (no tooling change) |
| Douse in Gloom (#49) | {2}{B} Instant | Deals 2 damage to target creature and you gain 2 life. | GPT | AUTO (no tooling change) |
| Ostiary Thrull (#55) | {3}{B} 2/2 Thrull | `{W}, {T}: Tap target creature.` | GPT | AUTO (no tooling change) |
| Cremate (#45) | {B} Instant | Exile target card from a graveyard. Draw a card. | **INV** (reprint) | AUTO (after handler) |

**Reprint placement:** Cremate's earliest real printing is Invasion (INV, 2000), where the canonical `CardDefinition` already lives. GPT therefore gets a `Printing(...)` row only (`CremateReprint.kt`), not a duplicate canonical. The other four have GPT as their earliest printing. `check-card-printing` confirms canonical placement for all five.

## mtgish auto-gen support

Four cards already emitted **AUTO** with no tooling change. Cremate scaffolded on the unhandled `ExileGraveyardCard` IR tag (the bridge already maps the tag as coverable; only the rendering handler was missing). Added a faithful emitter handler in `emitter/ZoneHandlers.kt`:

```kotlin
on("ExileGraveyardCard") { _, args, tvar ->
    val tgt = refTarget(args, tvar) ?: "EffectTarget.Self"
    call("Effects.Move", arg(Lit(tgt)), arg("Zone.EXILE"))
}
```

The graveyard-card target is already recovered into the bound target var by `TargetRecovery`, so exile is just a `Move` to the exile zone — semantically identical to the hand-authored INV Cremate. Cremate now emits AUTO. The handler is faithful (no widening / fake-render): it declines to `EffectTarget.Self` only for the self form, and the existing `DrawACard` handler composes the second clause.

## Verification

- 4 new scenario tests pass (`MortifyScenarioTest`, `DouseInGloomScenarioTest`, `OrzhovSignetScenarioTest`, `OstiaryThrullScenarioTest`). Cremate is a behavior-unchanged reprint, so no new test (its INV canonical is the source of truth).
- GPT card snapshot golden re-blessed — diff adds only the 4 new canonical cards, nothing else moved.
- `coverage-verify GPT`: **GATE PASS**, 0 gameplay-tree / 0 capability mismatch. Cremate shows as "emitted outside golden" for GPT because its golden lives in INV — expected for a reprint.
- `coverage-verify POR`: **158/158, GATE PASS** — Portal not regressed.
- `EmitterGoldenTest` (committed fixtures) unchanged — the new handler only newly renders previously-SCAFFOLD cards; no drift to existing renders.

## Caveats

- The "missing Printing rows in scaffolded sets" warnings from `check-card-printing` for Orzhov Signet / Mortify / Douse in Gloom refer to *other* scaffolded sets (CMD, RNA, FDN, FRF, etc.) that also reprint these cards — pre-existing gaps outside this PR's GPT scope, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)