### PR TITLE
Fix reprint handling in the set list: count reprints + show all-reprint sets

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
@@ -68,14 +68,19 @@ class GameBeansConfig(
     }
 
     @Bean
-    fun boosterGenerator(): BoosterGenerator = BoosterGenerator(
+    fun boosterGenerator(cardRegistry: CardRegistry): BoosterGenerator = BoosterGenerator(
         // Every set with a non-empty card pool is selectable, not just the sealed-curated few.
         // Sets that aren't `sealedSupported` (or are flagged incomplete) ride along as "partial":
         // clients hide them behind a default-off toggle, but a host can still pick them. An empty
-        // pool can't produce a booster, so those are the only sets excluded here.
+        // pool can't produce a booster, so those are the only sets excluded here — and an
+        // all-reprint set's pool is resolved from its printings (see [boosterCardPool]) so it
+        // isn't wrongly treated as empty.
         activeSets()
-            .filter { it.cards.isNotEmpty() }
-            .associate { it.code to it.toBoosterSetConfig() }
+            .mapNotNull { set ->
+                val pool = set.boosterCardPool(cardRegistry)
+                if (pool.isEmpty()) null else set.code to set.toBoosterSetConfig(pool)
+            }
+            .toMap()
     )
 
     @Bean
@@ -119,7 +124,30 @@ private fun List<CardDefinition>.stamp(set: MtgSet): List<CardDefinition> =
 private fun List<CardDefinition>.withLegalities(): List<CardDefinition> =
     map { LegalityData.stamp(it) }
 
-private fun MtgSet.toBoosterSetConfig(): BoosterGenerator.SetConfig =
+/**
+ * The card pool a set contributes to booster / sealed / draft generation.
+ *
+ * Sets that author their own [MtgSet.cards] use those as-is. An all-reprint set (e.g. Eighth
+ * Edition) declares no own definitions — every card is a [Printing] whose canonical
+ * [CardDefinition] lives in an earlier set — so each reprint is resolved to its canonical via
+ * [registry] and overlaid with the reprint's presentation (set code, art) and its per-set
+ * [com.wingedsheep.sdk.model.Printing.rarity] (a card's rarity differs between sets, and booster
+ * generation slots by rarity). Reprints whose canonical isn't implemented anywhere are skipped.
+ *
+ * Without this, an all-reprint set has an empty `cards` list, is filtered out of
+ * [boosterGenerator], and never appears in the selectable-set list (the Eighth Edition bug).
+ */
+private fun MtgSet.boosterCardPool(registry: CardRegistry): List<CardDefinition> {
+    if (cards.isNotEmpty()) return cards
+    return printings.mapNotNull { printing ->
+        registry.getCardsByName(printing.name).firstOrNull()?.let { canonical ->
+            val withArt = canonical.withPrinting(printing)
+            withArt.copy(metadata = withArt.metadata.copy(rarity = printing.rarity))
+        }
+    }
+}
+
+private fun MtgSet.toBoosterSetConfig(cards: List<CardDefinition>): BoosterGenerator.SetConfig =
     BoosterGenerator.SetConfig(
         setCode = code,
         setName = displayName,

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/config/GameBeansConfigBoosterPoolTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/config/GameBeansConfigBoosterPoolTest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.gameserver.config
+
+import com.wingedsheep.sdk.model.Rarity
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Guards the regression where an all-reprint set (Eighth Edition) was missing from the selectable
+ * set list. `boosterGenerator` filtered out any set with an empty `cards` list, but 8ED authors no
+ * own `CardDefinition`s — every card is a reprint `Printing` whose canonical lives in an earlier
+ * set — so it was silently dropped. The pool is now resolved from those printings.
+ */
+class GameBeansConfigBoosterPoolTest : FunSpec({
+
+    val config = GameBeansConfig(GameProperties())
+    val cardRegistry = config.cardRegistry()
+    val boosterGenerator = config.boosterGenerator(cardRegistry)
+
+    test("Eighth Edition appears as a selectable set") {
+        boosterGenerator.availableSets shouldContainKey "8ED"
+    }
+
+    test("Eighth Edition's booster pool is resolved from its reprints") {
+        val ed8 = boosterGenerator.availableSets["8ED"].shouldNotBeNull()
+        // 8ED is an all-reprint set: its ~187 cards are resolved from printings, not own definitions.
+        ed8.cards.size shouldBeGreaterThan 150
+        ed8.distinctCardCount shouldBeGreaterThan 150
+        // Every resolved card is stamped as the 8ED printing.
+        ed8.cards.all { it.setCode == "8ED" } shouldBe true
+    }
+
+    test("resolved reprints span multiple rarities so booster slots can be filled") {
+        val ed8 = boosterGenerator.availableSets["8ED"].shouldNotBeNull()
+        val rarities = ed8.cards.map { it.metadata.rarity }.toSet()
+        rarities shouldContain Rarity.COMMON
+        rarities shouldContain Rarity.RARE
+    }
+})


### PR DESCRIPTION
Two related fixes to how reprint-heavy sets are handled in the tournament lobby's set selection.

## 1. Count reprints in set picker card counts

Bloomburrow Commander showed only **50 cards** despite having ~109 implemented. The "X cards" count came from `config.cards.size`, which only counts full `CardDefinition`s. Commander/precon sets carry most cards as reprint `Printing` rows whose canonical `CardDefinition` lives in an earlier set — never in `cards`.

Added `BoosterGenerator.SetConfig.distinctCardCount` (distinct names across `cards` + `printings`; de-dupes alternate-frame variants, counts reprint-only names once). Used from all three set-list builders (`TournamentLobby`, `ConnectionHandler`, `SetsController`).

## 2. Make all-reprint sets (Eighth Edition) selectable

8th Edition didn't appear in the set list at all. `boosterGenerator` filtered out any set with an empty `cards` list, but 8ED is an **all-reprint core set** — zero own definitions, all 187 cards are reprint `Printing` rows — so it was silently dropped.

Now an all-reprint set's booster pool is **resolved from its printings**: each reprint's canonical is looked up in the `CardRegistry` by name and overlaid with the reprint's presentation (set code, art) and per-set `rarity` (a card's rarity varies by set, and booster generation slots by rarity). All 187 of 8ED's reprints resolve to implemented canonicals, so it becomes a complete, draftable set (still "partial" while flagged `incomplete`). Sets that author their own cards are untouched; reprints with no implemented canonical are skipped, so genuinely-empty sets stay excluded.

## Tests

- `BoosterGeneratorCardCountTest` — pins `distinctCardCount`: cards-only, cards + reprints, alternate-frame de-dup.
- `GameBeansConfigBoosterPoolTest` — boots the beans and asserts 8ED is selectable, its pool resolves to >150 cards stamped `8ED`, spanning multiple rarities.

All compile; new and existing config tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)