### PR TITLE
GPT: implement 5 Izzet cards + mtgish auto-gen support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -983,8 +983,10 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
 - `.power(n)` / `.minPower(n)` / `.maxPower(n)` — P/T comparator.
 - `.manaValue(n)` / `.manaValueAtMost(n)` / `.manaValueAtLeast(n)` — mana-value comparator.
 - `.manaValueAtMostX()` — mana value ≤ the X chosen for the source spell/ability.
-- `.manaValueEqualsX()` — mana value **exactly equal** to the number chosen for the source spell/ability
-  (set by `Effects.ChooseNumberThen`; resolution-time only — matches nothing without a chosen number). Used by Void.
+- `.manaValueEqualsX()` — mana value **exactly equal** to the X chosen for the source spell/ability (the chosen
+  number, or the X paid in an `{X}…` mana cost; resolution-time only — matches nothing without a chosen number).
+  Available on both the object-filter builders and on `TargetFilter` (mirrors `.manaValueAtMostX()`). Used by Void
+  (`Effects.ChooseNumberThen`) and Repeal (`{X}{U}` — return target nonland permanent with mana value X).
 - `.manaValueAtMostEntity(ref)` — mana value ≤ a referenced entity's mana value (e.g. Kodama of the East Tree).
 - `.powerGreaterThanEntity(ref)` — power strictly greater than a referenced entity's projected power. Used by
   Éowyn, Fearless Knight ("exile target creature an opponent controls with greater power") — combine

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -252,6 +252,9 @@ data class TargetFilter(
     /** Mana value at most the X chosen for the source spell/ability */
     fun manaValueAtMostX() = copy(baseFilter = baseFilter.manaValueAtMostX())
 
+    /** Mana value exactly equal to the X chosen for the source spell/ability (Repeal, Spell Blast). */
+    fun manaValueEqualsX() = copy(baseFilter = baseFilter.manaValueEqualsX())
+
     /** Mana value at least */
     fun manaValueAtLeast(min: Int) = copy(baseFilter = baseFilter.manaValueAtLeast(min))
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/IzzetSignetReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/IzzetSignetReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Izzet Signet reprint in Bloomburrow Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guildpact's `cards/` package; this file
+ * contributes only the Bloomburrow Commander presentation row.
+ */
+val IzzetSignetReprint = Printing(
+    oracleId = "2fda4fe7-8b0c-489c-a000-6d358e614e34",
+    name = "Izzet Signet",
+    setCode = "BLC",
+    collectorNumber = "278",
+    scryfallId = "a39b4b15-cd3e-4d30-8de2-8e584524d018",
+    artist = "Raoul Vitale",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a39b4b15-cd3e-4d30-8de2-8e584524d018.jpg?1779241848",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/IzzetSignetReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/IzzetSignetReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Izzet Signet reprint in Commander 2015. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guildpact's `cards/` package; this file
+ * contributes only the Commander 2015 presentation row.
+ */
+val IzzetSignetReprint = Printing(
+    oracleId = "2fda4fe7-8b0c-489c-a000-6d358e614e34",
+    name = "Izzet Signet",
+    setCode = "C15",
+    collectorNumber = "256",
+    scryfallId = "f6b88bc9-375f-411f-8bb8-6d2546196fd6",
+    artist = "Raoul Vitale",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f6b88bc9-375f-411f-8bb8-6d2546196fd6.jpg?1562711605",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/RepealReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/RepealReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Repeal reprint in Commander 2015. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guildpact's `cards/` package; this file
+ * contributes only the Commander 2015 presentation row.
+ */
+val RepealReprint = Printing(
+    oracleId = "b1f2b26c-91b2-4f3c-9f48-6429ec3fde48",
+    name = "Repeal",
+    setCode = "C15",
+    collectorNumber = "104",
+    scryfallId = "db5f59ca-6125-45ca-a9db-1962be003741",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db5f59ca-6125-45ca-a9db-1962be003741.jpg?1562710399",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/IzzetChronarchReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/IzzetChronarchReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Izzet Chronarch reprint in Commander 2017. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guildpact's `cards/` package; this file
+ * contributes only the Commander 2017 presentation row.
+ */
+val IzzetChronarchReprint = Printing(
+    oracleId = "1da438f3-db1c-4713-a60c-e078f31d809c",
+    name = "Izzet Chronarch",
+    setCode = "C17",
+    collectorNumber = "175",
+    scryfallId = "d2f8fe93-8d20-41d4-8205-597a9c9b8bbe",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/d/2/d2f8fe93-8d20-41d4-8205-597a9c9b8bbe.jpg?1562624723",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ElectrolyzeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ElectrolyzeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Electrolyze reprint in Commander 2011. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guildpact's `cards/` package; this file
+ * contributes only the Commander 2011 presentation row.
+ */
+val ElectrolyzeReprint = Printing(
+    oracleId = "07b222d7-24f2-4994-9004-ff6672ebe161",
+    name = "Electrolyze",
+    setCode = "CMD",
+    collectorNumber = "197",
+    scryfallId = "dfd8ac90-48fa-4107-8671-316bb2eb81f5",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/dfd8ac90-48fa-4107-8671-316bb2eb81f5.jpg?1592714039",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/IzzetChronarchReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/IzzetChronarchReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Izzet Chronarch reprint in Commander 2011. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guildpact's `cards/` package; this file
+ * contributes only the Commander 2011 presentation row.
+ */
+val IzzetChronarchReprint = Printing(
+    oracleId = "1da438f3-db1c-4713-a60c-e078f31d809c",
+    name = "Izzet Chronarch",
+    setCode = "CMD",
+    collectorNumber = "205",
+    scryfallId = "29681b0d-1aed-4b50-9710-9c15f3c83c72",
+    artist = "Nick Percival",
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/29681b0d-1aed-4b50-9710-9c15f3c83c72.jpg?1592714111",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/IzzetSignetReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/IzzetSignetReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Izzet Signet reprint in Commander 2011. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guildpact's `cards/` package; this file
+ * contributes only the Commander 2011 presentation row.
+ */
+val IzzetSignetReprint = Printing(
+    oracleId = "2fda4fe7-8b0c-489c-a000-6d358e614e34",
+    name = "Izzet Signet",
+    setCode = "CMD",
+    collectorNumber = "252",
+    scryfallId = "ff0a314e-4705-4777-a44c-fdf7ec5171fd",
+    artist = "Greg Hildebrandt",
+    imageUri = "https://cards.scryfall.io/normal/front/f/f/ff0a314e-4705-4777-a44c-fdf7ec5171fd.jpg?1592714452",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Electrolyze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Electrolyze.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Electrolyze
+ * {1}{U}{R}
+ * Instant
+ * Electrolyze deals 2 damage divided as you choose among one or two targets.
+ * Draw a card.
+ */
+val Electrolyze = card("Electrolyze") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Instant"
+    oracleText = "Electrolyze deals 2 damage divided as you choose among one or two targets.\nDraw a card."
+
+    spell {
+        target = AnyTarget(count = 2, minCount = 1)
+        effect = Effects.Composite(
+            DividedDamageEffect(
+                totalDamage = 2,
+                minTargets = 1,
+                maxTargets = 2
+            ),
+            Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "111"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef42b5b2-6504-486c-aaa0-9d5e4769ba1d.jpg?1593272648"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Frazzle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Frazzle.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Frazzle
+ * {3}{U}
+ * Instant
+ * Counter target nonblue spell.
+ */
+val Frazzle = card("Frazzle") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target nonblue spell."
+
+    spell {
+        target = TargetSpell(filter = TargetFilter.SpellOnStack.notColor(Color.BLUE))
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "25"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68b7f705-4d64-4551-8d76-826d91324e9e.jpg?1593271993"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/IzzetChronarch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/IzzetChronarch.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Izzet Chronarch
+ * {3}{U}{R}
+ * Creature — Human Wizard
+ * 2/2
+ * When this creature enters, return target instant or sorcery card from your graveyard to your hand.
+ */
+val IzzetChronarch = card("Izzet Chronarch") {
+    manaCost = "{3}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, return target instant or sorcery card from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        // "from your graveyard" — restrict to instant/sorcery cards you own (oracle wording).
+        val t = target("target", TargetObject(filter = TargetFilter.InstantOrSorceryInGraveyard.ownedByYou()))
+        effect = Effects.Move(
+            target = t,
+            destination = Zone.HAND
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Nick Percival"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c82dc47-38db-4ee1-9031-f8ea68d05389.jpg?1593272708"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/IzzetSignet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/IzzetSignet.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Izzet Signet
+ * {2}
+ * Artifact
+ * {1}, {T}: Add {U}{R}.
+ */
+val IzzetSignet = card("Izzet Signet") {
+    manaCost = "{2}"
+    colorIdentity = "UR"
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}: Add {U}{R}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.Composite(Effects.AddMana(Color.BLUE, 1), Effects.AddMana(Color.RED, 1))
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Greg Hildebrandt"
+        flavorText = "The Izzet signet is redesigned often, each time becoming closer to a vanity portrait of Niv-Mizzet."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f823be95-bef4-4e86-a924-239be62394bf.jpg?1593272937"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Repeal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/Repeal.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Repeal
+ * {X}{U}
+ * Instant
+ * Return target nonland permanent with mana value X to its owner's hand.
+ * Draw a card.
+ *
+ * X is chosen as the spell is cast (paid as part of its {X}{U} mana cost). The targeted
+ * nonland permanent must have mana value exactly X (CardPredicate.ManaValueEqualsX, the
+ * same chosen-number target restriction as Spell Blast / Blue Sun's Twilight).
+ */
+val Repeal = card("Repeal") {
+    manaCost = "{X}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target nonland permanent with mana value X to its owner's hand.\nDraw a card."
+
+    spell {
+        val t = target(
+            "nonland permanent",
+            TargetObject(filter = TargetFilter.NonlandPermanent.manaValueEqualsX())
+        )
+        effect = Effects.ReturnToHand(t).then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Dan Murayama Scott"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e7dd929-4bba-46a6-86c9-b8ed853eb721.jpg?1593272056"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/IzzetSignetReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/IzzetSignetReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Izzet Signet reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guildpact's `cards/` package; this file
+ * contributes only the New Capenna Commander presentation row.
+ */
+val IzzetSignetReprint = Printing(
+    oracleId = "2fda4fe7-8b0c-489c-a000-6d358e614e34",
+    name = "Izzet Signet",
+    setCode = "NCC",
+    collectorNumber = "369",
+    scryfallId = "932dff99-8cc1-4ce5-951c-974bd2632dd2",
+    artist = "Raoul Vitale",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/932dff99-8cc1-4ce5-951c-974bd2632dd2.jpg?1673485368",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/GPT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GPT.json
@@ -1,3 +1,83 @@
+// Electrolyze
+{
+    "name": "Electrolyze",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Electrolyze deals 2 damage divided as you choose among one or two targets.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DividedDamage",
+                    "totalDamage": 2,
+                    "maxTargets": 2
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "count": 2,
+                "minCount": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef42b5b2-6504-486c-aaa0-9d5e4769ba1d.jpg?1593272648"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
+// Frazzle
+{
+    "name": "Frazzle",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target nonblue spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "NotColor",
+                                "color": "BLUE"
+                            }
+                        ]
+                    },
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "UNCOMMON",
+        "artist": "Pete Venters",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68b7f705-4d64-4551-8d76-826d91324e9e.jpg?1593271993"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Gruul Turf
 {
     "name": "Gruul Turf",
@@ -62,5 +142,156 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Izzet Chronarch
+{
+    "name": "Izzet Chronarch",
+    "manaCost": "{3}{U}{R}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, return target instant or sorcery card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "instant|sorcery own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Nick Percival",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c82dc47-38db-4ee1-9031-f8ea68d05389.jpg?1593272708"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
+// Izzet Signet
+{
+    "name": "Izzet Signet",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}: Add {U}{R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{1}"
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "BLUE"
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "RED"
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Greg Hildebrandt",
+        "flavorText": "The Izzet signet is redesigned often, each time becoming closer to a vanity portrait of Niv-Mizzet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f823be95-bef4-4e86-a924-239be62394bf.jpg?1593272937"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
+// Repeal
+{
+    "name": "Repeal",
+    "manaCost": "{X}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target nonland permanent with mana value X to its owner's hand.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "nonland permanent"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsNonland",
+                            "IsPermanent",
+                            "ManaValueEqualsX"
+                        ]
+                    }
+                },
+                "id": "nonland permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Dan Murayama Scott",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e7dd929-4bba-46a6-86c9-b8ed853eb721.jpg?1593272056"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/GPT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GPT.json
@@ -49,6 +49,86 @@
     ]
 }
 
+// Electrolyze
+{
+    "name": "Electrolyze",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Electrolyze deals 2 damage divided as you choose among one or two targets.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DividedDamage",
+                    "totalDamage": 2,
+                    "maxTargets": 2
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "count": 2,
+                "minCount": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef42b5b2-6504-486c-aaa0-9d5e4769ba1d.jpg?1593272648"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
+// Frazzle
+{
+    "name": "Frazzle",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target nonblue spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "NotColor",
+                                "color": "BLUE"
+                            }
+                        ]
+                    },
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "UNCOMMON",
+        "artist": "Pete Venters",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68b7f705-4d64-4551-8d76-826d91324e9e.jpg?1593271993"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Gruul Signet
 {
     "name": "Gruul Signet",
@@ -162,6 +242,104 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Izzet Chronarch
+{
+    "name": "Izzet Chronarch",
+    "manaCost": "{3}{U}{R}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, return target instant or sorcery card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "instant|sorcery own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Nick Percival",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c82dc47-38db-4ee1-9031-f8ea68d05389.jpg?1593272708"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
+// Izzet Signet
+{
+    "name": "Izzet Signet",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}: Add {U}{R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{1}"
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "BLUE"
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "RED"
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Greg Hildebrandt",
+        "flavorText": "The Izzet signet is redesigned often, each time becoming closer to a vanity portrait of Niv-Mizzet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f823be95-bef4-4e86-a924-239be62394bf.jpg?1593272937"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 
@@ -306,6 +484,59 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Repeal
+{
+    "name": "Repeal",
+    "manaCost": "{X}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target nonland permanent with mana value X to its owner's hand.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "nonland permanent"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsNonland",
+                            "IsPermanent",
+                            "ManaValueEqualsX"
+                        ]
+                    }
+                },
+                "id": "nonland permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Dan Murayama Scott",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e7dd929-4bba-46a6-86c9-b8ed853eb721.jpg?1593272056"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SpellShortcuts.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/SpellShortcuts.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.tooling.coverage.emitter
 import com.wingedsheep.tooling.coverage.Assign
 import com.wingedsheep.tooling.coverage.Block
 import com.wingedsheep.tooling.coverage.Call
+import com.wingedsheep.tooling.coverage.Composite
 import com.wingedsheep.tooling.coverage.Dsl
 import com.wingedsheep.tooling.coverage.Stmt
 import com.wingedsheep.tooling.coverage.Sub
@@ -58,17 +59,42 @@ internal fun EmitCtx.extraTurnEffect(card: JsonObject): Dsl? {
     return null
 }
 
-/** Forked-Lightning shape: TargetedDistributed -> TargetCreature(count) + DividedDamageEffect. */
+/**
+ * Distributed-damage spells (TargetedDistributed): `N damage divided as you choose among one or
+ * <max> targets`, optionally followed by more actions ("Draw a card." — Electrolyze).
+ *
+ * Recovers the total and the target-count cap, picks the target requirement by the distributed-target
+ * shape (`…AnyTargets` -> AnyTarget; `…TargetPermanents` -> TargetCreature, the Forked-Lightning form),
+ * renders the leading `DividedDamageEffect(total, 1, max)`, and composes any trailing actions through
+ * the generic renderer. If a trailing action can't be rendered exactly, decline so the card scaffolds
+ * rather than dropping it.
+ */
 internal fun EmitCtx.distributedSpell(card: JsonObject): List<Stmt>? {
     val blob = compact(card["Rules"])
     if ("\"TargetedDistributed\"" !in blob) return null
-    val total = Regex(""""DistributeNumberAmongTargets","args":\{"_GameNumber":"Integer","args":(\d+)""").find(blob)
-    val mx = Regex(""""BetweenOneAndNumberTargetPermanents","args":\[\{"_GameNumber":"Integer","args":(\d+)""").find(blob)
-    if (total == null || mx == null) return null
-    val m = mx.groupValues[1]
+    val total = Regex(""""DistributeNumberAmongTargets","args":\{"_GameNumber":"Integer","args":(\d+)""").find(blob) ?: return null
+    val anyMax = Regex(""""BetweenOneAndNumberAnyTargets","args":\{"_GameNumber":"Integer","args":(\d+)""").find(blob)
+    val permMax = Regex(""""BetweenOneAndNumberTargetPermanents","args":\[\{"_GameNumber":"Integer","args":(\d+)""").find(blob)
+    val (target, m) = when {
+        anyMax != null -> call("AnyTarget", arg("count", anyMax.groupValues[1]), arg("minCount", "1")) to anyMax.groupValues[1]
+        permMax != null -> call("TargetCreature", arg("count", permMax.groupValues[1]), arg("minCount", "1")) to permMax.groupValues[1]
+        else -> return null
+    }
+    val divided = call("DividedDamageEffect", arg("totalDamage", total.groupValues[1]), arg("minTargets", "1"), arg("maxTargets", m))
+    // Compose any actions after the distributed-damage one (e.g. Electrolyze's trailing "Draw a card").
+    val (_, actions) = extractEnvelope(card["Rules"])
+    val trailing = actions?.dropWhile { it.strField("_Action") != "SpellDealsDistributedDamage" }?.drop(1).orEmpty()
+    val effect: Dsl = if (trailing.isEmpty()) {
+        divided
+    } else {
+        val rest = renderEffectList(trailing, null) ?: return null
+        val parts = mutableListOf<Dsl>(divided)
+        if (rest is Composite) parts.addAll(rest.parts) else parts.add(rest)
+        Composite(parts)
+    }
     return listOf(Sub(Block("spell", listOf(
-        Assign("target", call("TargetCreature", arg("count", m), arg("minCount", "1"))),
-        Assign("effect", call("DividedDamageEffect", arg("totalDamage", total.groupValues[1]), arg("minTargets", "1"), arg("maxTargets", m))),
+        Assign("target", target),
+        Assign("effect", effect),
     ))))
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -207,6 +207,18 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
 
 private fun targetTypes(args: JsonElement?): Set<String> = args.argWordsTagged("IsCardtype").toSet()
 
+/**
+ * True for a `ManaValueIs { _Comparison: EqualTo, args: { _GameNumber: ValueX } }` clause — "mana value
+ * X", where X is the value chosen for the source spell's `{X}…` cost (Repeal). Renders as
+ * `.manaValueEqualsX()`. Any other ManaValueIs shape (a fixed integer, a different comparison) is NOT
+ * matched here, so the caller declines rather than mis-rendering.
+ */
+private fun manaValueEqualsXClause(args: JsonElement?): Boolean =
+    args.nodesTagged("ManaValueIs").any { mv ->
+        val cmp = mv["args"]
+        cmp.strField("_Comparison") == "EqualTo" && "ValueX" in compact(cmp)
+    }
+
 internal fun EmitCtx.targetDsl(tnode: JsonObject, actionContext: List<JsonObject>? = null): String? =
     targetExpr(tnode, actionContext)?.let(::render)
 
@@ -248,9 +260,16 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
             return Call("TargetPermanent", parts)
         }
         // "target nonland permanent" — an IsNonCardtype "Land" with no positive cardtype restriction
-        // (Thistledown Players' "untap target nonland permanent").
+        // (Thistledown Players' "untap target nonland permanent"). An optional "with mana value X"
+        // clause (ManaValueIs EqualTo ValueX, from an {X}… cast cost) renders as .manaValueEqualsX()
+        // (Repeal). A ManaValueIs clause we DON'T render (any other shape) must decline rather than
+        // silently drop the restriction — an unrestricted bounce would hit any permanent.
         if (types.isEmpty() && args.argWordsTagged("IsNonCardtype") == listOf("Land") && "IsCreatureType" !in blob) {
-            val parts = mutableListOf(arg("filter", "TargetFilter.NonlandPermanent"))
+            val manaValueX = manaValueEqualsXClause(args)
+            if ("ManaValueIs" in blob && !manaValueX) return null  // unrendered MV restriction -> SCAFFOLD
+            var f: Dsl = Lit("TargetFilter.NonlandPermanent")
+            if (manaValueX) f = f.dot("manaValueEqualsX")
+            val parts = mutableListOf(arg("filter", f))
             if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, arg("count", "$countInt"))
             if (ttype == "UptoNumberTargetPermanents") parts.add(0, arg("optional", "true"))
             return Call("TargetPermanent", parts)
@@ -278,6 +297,15 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
         if ("TargetsA" in blob) return null
         val types = targetTypes(args)
         val colors = args.colorsOf("IsColor")
+        val nonColors = args.colorsOf("IsNonColor")
+        // "counter target nonblue spell" (Frazzle) — an IsNonColor clause on a stack spell. AND-of-not =
+        // "neither X nor Y"; each excluded colour chains as .notColor. SDK supports it on SpellOnStack.
+        if (types.isEmpty() && colors.isEmpty() && nonColors.isNotEmpty()) {
+            var f: Dsl = Lit("TargetFilter.SpellOnStack")
+            nonColors.forEach { f = f.dot("notColor", arg("Color.${it.uppercase()}")) }
+            return Call("TargetSpell", listOf(arg("filter", f)))
+        }
+        if (nonColors.isNotEmpty()) return null  // nonColor + (type | positive colour) combo not rendered -> SCAFFOLD
         // "counter target blue spell" — a colour-restricted spell on the stack.
         if (types.isEmpty() && colors.isNotEmpty()) {
             var f: Dsl = Lit("TargetFilter.SpellOnStack")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElectrolyzeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElectrolyzeScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.DistributeDecision
+import com.wingedsheep.engine.core.DistributionResponse
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.gpt.cards.Electrolyze
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Electrolyze: 2 damage divided among one or two targets, then draw a card. Covers both the
+ * single-target (2 to one creature) and split (1 + 1 across two creatures) divisions, and that
+ * the caster always draws a card.
+ */
+class ElectrolyzeScenarioTest : FunSpec({
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(Electrolyze)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("Electrolyze deals 2 damage to a single target and draws a card") {
+        val driver = setup()
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        val electrolyze = driver.putCardInHand(caster, "Electrolyze")
+        driver.giveMana(caster, Color.BLUE, 1)
+        driver.giveMana(caster, Color.RED, 1)
+        driver.giveColorlessMana(caster, 1) // {1}{U}{R}
+
+        val handBefore = driver.getHandSize(caster)
+        // Single target: the opponent player.
+        driver.castSpellWithTargets(caster, electrolyze, listOf(ChosenTarget.Player(opponent))).isSuccess shouldBe true
+
+        resolveDistributing(driver, caster) { d -> mapOf(d.targets.first() to d.totalAmount) }
+
+        driver.getLifeTotal(opponent) shouldBe 18
+        // Cast Electrolyze (-1) then drew a card (+1) → hand size unchanged.
+        driver.getHandSize(caster) shouldBe handBefore
+    }
+
+    test("Electrolyze splits 1 damage to each of two targets and draws a card") {
+        val driver = setup()
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        // Two 2/2 creatures (Phantom Warrior) opponent controls.
+        val c1 = driver.putCreatureOnBattlefield(opponent, "Phantom Warrior")
+        val c2 = driver.putCreatureOnBattlefield(opponent, "Phantom Warrior")
+
+        val electrolyze = driver.putCardInHand(caster, "Electrolyze")
+        driver.giveMana(caster, Color.BLUE, 1)
+        driver.giveMana(caster, Color.RED, 1)
+        driver.giveColorlessMana(caster, 1)
+
+        val handBefore = driver.getHandSize(caster)
+        driver.castSpellWithTargets(
+            caster, electrolyze,
+            listOf(ChosenTarget.Permanent(c1), ChosenTarget.Permanent(c2))
+        ).isSuccess shouldBe true
+
+        resolveDistributing(driver, caster) { mapOf(c1 to 1, c2 to 1) }
+
+        // Both 2/2s survive 1 damage each, and the draw still happens.
+        driver.findPermanent(opponent, "Phantom Warrior") shouldNotBe null
+        driver.getHandSize(caster) shouldBe handBefore
+    }
+}) {
+    companion object {
+        /**
+         * Resolve a spell that pauses for a DividedDamage DistributeDecision: pass priority until the
+         * decision appears, submit it via [planner], then finish resolving the stack.
+         */
+        private fun resolveDistributing(
+            driver: GameTestDriver,
+            chooser: EntityId,
+            planner: (DistributeDecision) -> Map<EntityId, Int>,
+        ) {
+            repeat(8) {
+                val decision = driver.state.pendingDecision
+                if (decision is DistributeDecision) {
+                    driver.submitDecision(chooser, DistributionResponse(decision.id, planner(decision)))
+                } else if (driver.stackSize > 0 || driver.state.priorityPlayerId != null) {
+                    driver.bothPass()
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrazzleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrazzleScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.gpt.cards.Frazzle
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Frazzle: Counter target nonblue spell. The notColor(BLUE) filter must let a nonblue spell on the
+ * stack be countered while rejecting a blue spell as an illegal target.
+ *
+ * Both spells are cast by the active player, who retains priority after the first cast and then
+ * targets it with Frazzle — this keeps the targeted spell on the stack without needing the
+ * non-active player to gain priority.
+ */
+class FrazzleScenarioTest : FunSpec({
+
+    // A no-target blue instant, so we can put a blue spell on the stack to prove Frazzle can't hit it.
+    val blueGainer = card("Azure Gainer") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        spell { effect = Effects.GainLife(1) }
+    }
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(Frazzle)
+        driver.registerCard(blueGainer)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun spellOnStackNamed(driver: GameTestDriver, name: String) =
+        driver.state.stack.first { id ->
+            driver.state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+
+    test("Frazzle counters a nonblue (red) spell on the stack") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        // Active player casts a red spell (Lightning Bolt) at the opponent, retains priority.
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpellWithTargets(player, bolt, listOf(ChosenTarget.Player(opponent))).isSuccess shouldBe true
+        val boltOnStack = spellOnStackNamed(driver, "Lightning Bolt")
+
+        // ...and responds with Frazzle, countering the nonblue Bolt.
+        val frazzle = driver.putCardInHand(player, "Frazzle")
+        driver.giveMana(player, Color.BLUE, 4) // {3}{U}
+        driver.castSpellWithTargets(player, frazzle, listOf(ChosenTarget.Spell(boltOnStack))).isSuccess shouldBe true
+
+        driver.bothPass()
+        driver.bothPass()
+
+        // Bolt is countered → opponent never took damage and the Bolt is in the graveyard.
+        driver.getLifeTotal(opponent) shouldBe 20
+        driver.getGraveyardCardNames(player).contains("Lightning Bolt") shouldBe true
+    }
+
+    test("Frazzle cannot target a blue spell") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+
+        // Active player casts a blue instant, retains priority.
+        val blue = driver.putCardInHand(player, "Azure Gainer")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.castSpell(player, blue).isSuccess shouldBe true
+        val blueOnStack = spellOnStackNamed(driver, "Azure Gainer")
+
+        val frazzle = driver.putCardInHand(player, "Frazzle")
+        driver.giveMana(player, Color.BLUE, 4)
+        val result = driver.castSpellWithTargets(player, frazzle, listOf(ChosenTarget.Spell(blueOnStack)))
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IzzetChronarchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IzzetChronarchScenarioTest.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.gpt.cards.IzzetChronarch
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Izzet Chronarch: When this creature enters, return target instant or sorcery card from your
+ * graveyard to your hand. Casting it with a Lightning Bolt (instant) in the graveyard returns
+ * that Bolt to hand on the ETB trigger.
+ */
+class IzzetChronarchScenarioTest : FunSpec({
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(IzzetChronarch)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("Izzet Chronarch ETB returns an instant from the graveyard to hand") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+
+        val bolt = driver.putCardInGraveyard(player, "Lightning Bolt")
+        driver.getGraveyardCardNames(player).contains("Lightning Bolt") shouldBe true
+
+        val chronarch = driver.putCardInHand(player, "Izzet Chronarch")
+        driver.giveMana(player, Color.BLUE, 3)
+        driver.giveMana(player, Color.RED, 2) // {3}{U}{R}
+
+        driver.castSpell(player, chronarch).isSuccess shouldBe true
+        // Resolve the creature spell so it enters and the ETB trigger goes on the stack.
+        driver.bothPass()
+
+        // The ETB trigger prompts to choose the instant/sorcery target in the graveyard.
+        if (driver.state.pendingDecision != null) {
+            driver.submitTargetSelection(player, listOf(bolt))
+        }
+        // Resolve the ETB trigger.
+        driver.bothPass()
+
+        driver.findPermanent(player, "Izzet Chronarch") shouldNotBe null
+        driver.findCardInHand(player, "Lightning Bolt") shouldNotBe null
+        driver.getGraveyardCardNames(player).contains("Lightning Bolt") shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IzzetSignetScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IzzetSignetScenarioTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.gpt.cards.IzzetSignet
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Izzet Signet: {1}, {T}: Add {U}{R}. Pins that paying {1} (from pool) + tapping the artifact
+ * yields one blue and one red mana in the pool.
+ */
+class IzzetSignetScenarioTest : FunSpec({
+
+    val signetAbilityId = IzzetSignet.activatedAbilities[0].id
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(IzzetSignet)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("activating Izzet Signet adds one blue and one red mana") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+
+        val signet = driver.putPermanentOnBattlefield(player, "Izzet Signet")
+        driver.giveColorlessMana(player, 1) // pays the {1} portion of the cost
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = signet,
+                abilityId = signetAbilityId,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        result.isSuccess shouldBe true
+
+        val pool = driver.state.getEntity(player)!!.get<ManaPoolComponent>()!!
+        pool.blue shouldBe 1
+        pool.red shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RepealScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RepealScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.gpt.cards.Repeal
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Repeal: {X}{U} — return target nonland permanent with mana value X to its owner's hand, then
+ * draw a card. Exercises CardPredicate.ManaValueEqualsX target restriction with X bound from the
+ * spell's {X}{U} mana cost.
+ */
+class RepealScenarioTest : FunSpec({
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(Repeal)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("Repeal with X=2 returns a mana value 2 permanent and draws a card") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+
+        // Forest Walker is {1}{G} → mana value 2.
+        val target = driver.putCreatureOnBattlefield(player, "Forest Walker")
+        val repeal = driver.putCardInHand(player, "Repeal")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, 2) // X = 2
+
+        val result = driver.castXSpell(player, repeal, xValue = 2, targets = listOf(target))
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        // Forest Walker bounced back to its owner's hand.
+        driver.findPermanent(player, "Forest Walker") shouldBe null
+        driver.findCardInHand(player, "Forest Walker") shouldNotBe null
+    }
+
+    test("Repeal with X=2 cannot target a mana value 3 permanent") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+
+        // Phantom Warrior is {1}{U}{U} → mana value 3.
+        val tooBig = driver.putCreatureOnBattlefield(player, "Phantom Warrior")
+        val repeal = driver.putCardInHand(player, "Repeal")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, 2) // X = 2
+
+        val result = driver.castXSpell(player, repeal, xValue = 2, targets = listOf(tooBig))
+        result.isSuccess shouldBe false
+        driver.findPermanent(player, "Phantom Warrior") shouldBe tooBig
+    }
+})


### PR DESCRIPTION
Implements five Guildpact (GPT) Izzet (U/R) cards via the `add-card` flow, each with a passing scenario test, then extends the mtgish tooling so all five reach the **AUTO** tier and pass the real `coverage-verify` gate (compile + gameplay-tree capability match).

## Cards (canonical home = GPT — earliest real printing)
| Card | Effect | Auto-gen tier |
|------|--------|---------------|
| Izzet Signet | `{1},{T}: Add {U}{R}` | **AUTO** |
| Electrolyze | 2 damage divided among one or two targets, then draw | **AUTO** |
| Repeal | `{X}{U}` — bounce target nonland permanent with mana value X, then draw | **AUTO** |
| Izzet Chronarch | ETB: return target instant/sorcery from your graveyard | **AUTO** |
| Frazzle | Counter target nonblue spell | **AUTO** |

All five emit AUTO and gameplay-tree match their golden snapshot.

## Reprint placement
Each card's canonical `CardDefinition` lives in GPT. `check-card-printing` flagged later scaffolded sets that reprint these cards, so `Printing(...)` rows were added: Izzet Signet → CMD/C15/NCC/BLC, Electrolyze → CMD, Repeal → C15, Izzet Chronarch → CMD/C17. No duplicate canonicals.

## SDK
- Added `TargetFilter.manaValueEqualsX()` (mirrors the existing `manaValueAtMostX()`), used by Repeal — the same chosen-X target restriction as Spell Blast / Blue Sun's Twilight. Documented in `card-sdk-language-reference.md`.

## mtgish emitter (faithful renders only — decline, don't widen)
- **Frazzle**: `TargetSpell` now reads an `IsNonColor` clause → `.notColor(Color.X)`.
- **Repeal**: the nonland-permanent target recovers a `ManaValueIs == ValueX` clause → `.manaValueEqualsX()`. Any *other* unrendered `ManaValueIs` shape declines to SCAFFOLD rather than silently dropping the restriction (which would let the bounce hit any permanent).
- **Electrolyze**: `distributedSpell` now handles `BetweenOneAndNumberAnyTargets` (→ `AnyTarget`) and composes trailing actions after the distributed damage (the "Draw a card"); declines if a trailing action can't render exactly.

These additions only add handling for shapes Portal doesn't use — `EmitterGoldenTest` (POR) is unchanged.

## Verification
- `coverage-verify GPT` → **GATE PASS**: 5/6 AUTO-emitted & compiled, gameplay-tree match, **0 mismatch / 0 capability mismatch**.
- POR unchanged: `--calibrate POR` = 100% (200/200), `coverage-verify POR` = **158/158 GATE PASS** — no Portal regression.
- 8 new scenario tests pass; `CardDefinitionSnapshotTest` re-blessed (GPT golden adds exactly the 5 cards); `EmitterGoldenTest` + `TargetRecoveryTest` pass.

## Caveats
- The 6th GPT golden card, **Gruul Turf** (pre-existing, not in scope), stays SCAFFOLD — its `PutAPermanentIntoItsOwnersHand` ("return a land you control") self-bounce isn't recovered by the emitter; left declined rather than widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)