### PR TITLE
fix(quick-game): only pick viable sets for random sealed decks

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
@@ -13,9 +13,19 @@ class SealedDeckGenerator(
     private val boosterGenerator: BoosterGenerator
 ) {
     /**
-     * Picks a random available set code.
+     * Picks a random set code that can actually produce a sealed deck.
+     *
+     * Only [BoosterGenerator.SetConfig.fullyImplemented] sets are eligible: a partial set
+     * (incomplete, or not curated for sealed) can have a card pool too thin for the single-set
+     * booster strategy, which then throws `No cards available for booster generation`. Random
+     * quick/AI games have no host to opt into a partial set, so they must draw from a playable one.
+     * Falls back to all available sets only if — unexpectedly — none are fully implemented.
      */
-    fun randomSetCode(): String = boosterGenerator.availableSets.keys.random()
+    fun randomSetCode(): String {
+        val playable = boosterGenerator.availableSets.values.filter { it.fullyImplemented }
+        val pool = playable.ifEmpty { boosterGenerator.availableSets.values.toList() }
+        return pool.random().setCode
+    }
 
     /**
      * Generates a sealed deck from 8 boosters of a random available set.

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/SealedDeckGeneratorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/SealedDeckGeneratorTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.model.ScryfallMetadata
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * Guards the random-set selection used by quick/AI games against picking a set whose pool is too
+ * thin to open a booster.
+ *
+ * Regression: `randomSetCode()` used to draw from *every* available set, including partial ones
+ * (incomplete or not sealed-curated) whose single-set booster generation throws
+ * `No cards available for booster generation`. With ~25% of the catalog unviable, the empty-deck
+ * CreateGame path failed intermittently — surfacing as a flaky `GameConnectionTest` timeout because
+ * the server never replied with `GameCreated`. The fix restricts random selection to
+ * [BoosterGenerator.SetConfig.fullyImplemented] sets.
+ */
+class SealedDeckGeneratorTest : FunSpec({
+
+    fun card(name: String, rarity: Rarity, inBooster: Boolean = true) = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2,
+        metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString(), rarity = rarity, inBooster = inBooster),
+    )
+
+    // A pool deep enough to fill 8 standard boosters without exhausting any rarity.
+    fun viablePool(prefix: String): List<CardDefinition> =
+        (1..15).map { card("$prefix Common $it", Rarity.COMMON) } +
+            (1..8).map { card("$prefix Uncommon $it", Rarity.UNCOMMON) } +
+            (1..5).map { card("$prefix Rare $it", Rarity.RARE) }
+
+    fun config(code: String, cards: List<CardDefinition>, sealedSupported: Boolean, incomplete: Boolean = false) =
+        BoosterGenerator.SetConfig(
+            setCode = code,
+            setName = "Set $code",
+            cards = cards,
+            basicLands = emptyList(),
+            sealedSupported = sealedSupported,
+            incomplete = incomplete,
+        )
+
+    test("randomSetCode only returns fully-implemented sets") {
+        // One viable, curated set; several partial ones whose pools cannot open a booster
+        // (the single card is flagged out of the booster pool).
+        val gen = SealedDeckGenerator(
+            BoosterGenerator(
+                mapOf(
+                    "FULL" to config("FULL", viablePool("FULL"), sealedSupported = true),
+                    "PART1" to config("PART1", listOf(card("Token", Rarity.COMMON, inBooster = false)), sealedSupported = false),
+                    "PART2" to config("PART2", listOf(card("Token", Rarity.COMMON, inBooster = false)), sealedSupported = false, incomplete = true),
+                    "PART3" to config("PART3", viablePool("PART3"), sealedSupported = true, incomplete = true),
+                )
+            )
+        )
+
+        val drawn = (1..500).map { gen.randomSetCode() }.toSet()
+        drawn.toList() shouldContainExactly listOf("FULL")
+    }
+
+    test("generate(randomSetCode()) never throws even when partial sets are unviable") {
+        val gen = SealedDeckGenerator(
+            BoosterGenerator(
+                mapOf(
+                    "FULL" to config("FULL", viablePool("FULL"), sealedSupported = true),
+                    "PART" to config("PART", listOf(card("Token", Rarity.COMMON, inBooster = false)), sealedSupported = false),
+                )
+            )
+        )
+
+        shouldNotThrowAny {
+            repeat(200) { gen.generate(gen.randomSetCode()) }
+        }
+    }
+
+    test("falls back to all sets when none are fully implemented") {
+        val gen = SealedDeckGenerator(
+            BoosterGenerator(
+                mapOf("PART" to config("PART", viablePool("PART"), sealedSupported = false))
+            )
+        )
+
+        gen.randomSetCode() shouldBe "PART"
+    }
+})

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameConnectionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/GameConnectionTest.kt
@@ -49,10 +49,12 @@ class GameConnectionTest : GameServerTestBase() {
                 client.connectAs("Alice")
                 client.send(ClientMessage.CreateGame(emptyMap()))
 
-                // Empty deck => the server generates and shuffles a random deck before
-                // replying, which is the slowest CreateGame path. Allow a generous budget
-                // so this stays green under CI load (it was an intermittent 5s timeout).
-                eventually(15.seconds) {
+                // Empty deck => the server picks a random set and opens a sealed pool before
+                // replying. The earlier intermittent failure here was NOT slowness: randomSetCode()
+                // could land on a partial set whose pool can't open a booster, so the server threw
+                // and never sent GameCreated (see SealedDeckGeneratorTest). That's fixed at the
+                // source; this budget only needs to cover the real generation cost under CI load.
+                eventually(10.seconds) {
                     client.messages.any { it is ServerMessage.GameCreated } shouldBe true
                 }
                 val gameCreated = client.messages.filterIsInstance<ServerMessage.GameCreated>().first()


### PR DESCRIPTION
## Problem

`GameConnectionTest > creating game with empty deck generates random deck` is flaky ([failing CI run](https://github.com/wingedsheep/argentum-engine/actions/runs/27090490737/job/79953106047?pr=533)).

A [previous fix](https://github.com/wingedsheep/argentum-engine/commit/e90326235) bumped the `eventually()` budget 5s → 15s assuming the empty-deck path was just slow. It still flaked — because **timing was never the cause**.

## Root cause

`CreateGame` with an empty deck picks a random set via `SealedDeckGenerator.randomSetCode()` and opens an 8-booster sealed pool **synchronously** before replying with `GameCreated`. `randomSetCode()` drew from *every* available set — but ~23 of the 90 active sets are **partial** (incomplete, or not sealed-curated) with a card pool too thin for the single-set booster strategy, which throws `No cards available for booster generation`. That exception is caught upstream and turned into an `INTERNAL_ERROR`; `GameCreated` is never sent, so the test waits out the whole budget and fails (~25% of the time).

A stress run over all 90 active sets confirmed it: **all 23 failing sets are non-`fullyImplemented`; zero `fullyImplemented` sets ever fail.**

```
FULLY IMPLEMENTED (10): [BLB, DOM, ECL, INV, KTK, LGN, ONS, POR, SCG, TDM]
FAILED & fullyImplemented (should be empty!): []
FAILED & partial: [ALA, ALL, ATQ, BIG, C15, CMD, EXO, GPT, HML, ICE, JUD, LEG, M14, M21, MRD, NEM, PZ2, RNA, ROE, STH, TOR, TSP, WTH]
```

## Fix

Restrict `randomSetCode()` to `fullyImplemented` sets (`sealedSupported && !incomplete`) — the same gate clients already use to show sets by default — with a fallback to all sets if none qualify. A host **explicitly** choosing a partial set still works; only the random path is constrained, which is exactly what a random quick/AI game wants: a playable set. This fixes all `randomSetCode()` callers (empty-deck CreateGame, quick-game lobby, AI opponent).

After the fix, 500 random `generate(randomSetCode())` draws produce **0 failures**.

## Tests

- New `SealedDeckGeneratorTest` (ai module) pins the contract: `randomSetCode` only returns fully-implemented sets, `generate(randomSetCode())` never throws even with unviable partial sets present, and it falls back when none are fully implemented.
- Corrected the now-stale `GameConnectionTest` comment and trimmed the budget back to 10s.
- `GameConnectionTest` and `SealedDeckGeneratorTest` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)