### PR TITLE
Add Moonlit Meditation; generalize Mirrormind Crown's token-copy replacement to Auras

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2703,6 +2703,16 @@ replacementEffect {
   "Devour land N" wording. **Scope today:** only the stack-spell entry path is wired; reanimation and
   token entries skip Devour (which is fine for printed cards — Devour creatures all cost real mana to
   cast).
+- `ReplaceTokenCreationWithAttachedCopy(optional, oncePerTurn, attachmentVerb, appliesTo)` —
+  "the first time you would create one or more tokens each turn, you may instead create that
+  many tokens that are copies of [attached] permanent." Works for both Equipment and Auras —
+  the engine reads the source's `AttachedToComponent` to find the permanent to copy.
+  `optional = true` surfaces a yes/no during resolution; `oncePerTurn = true` adds
+  `TokenReplacementOfferedThisTurnComponent` after the first offer (cleared at end of turn).
+  `attachmentVerb` is a display-only label ("equipped", "enchanted", "fortified") — the
+  attachment-type validation already happens at cast/attach time via `equipmentTarget` /
+  `auraTarget`. Token copies are summoning-sick only when the copy is a creature (CR 302.1).
+  Mirrormind Crown: `attachmentVerb = "equipped"`; Moonlit Meditation: `attachmentVerb = "enchanted"`.
 - `EntersAsCopy(optional, copyFilter, copyFromZone, filterByTotalManaSpent, additionalSubtypes, additionalKeywords, nameOverride, powerOverride, toughnessOverride, exileCopiedCard)` —
   "enter as a copy of …". As the permanent resolves, the controller picks an object matching
   `copyFilter` and the permanent enters as a copy (Rule 707 copiable values), with any overrides

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2711,7 +2711,7 @@ replacementEffect {
   `TokenReplacementOfferedThisTurnComponent` after the first offer (cleared at end of turn).
   `attachmentVerb` is a display-only label ("equipped", "enchanted", "fortified") — the
   attachment-type validation already happens at cast/attach time via `equipmentTarget` /
-  `auraTarget`. Token copies are summoning-sick only when the copy is a creature (CR 302.1).
+  `auraTarget`. Token copies are summoning-sick only when the copy is a creature (CR 302.6).
   Mirrormind Crown: `attachmentVerb = "equipped"`; Moonlit Meditation: `attachmentVerb = "enchanted"`.
 - `EntersAsCopy(optional, copyFilter, copyFromZone, filterByTotalManaSpent, additionalSubtypes, additionalKeywords, nameOverride, powerOverride, toughnessOverride, exileCopiedCard)` —
   "enter as a copy of …". As the permanent resolves, the controller picks an object matching

--- a/manual-scenarios/cards/m/moonlit-meditation.json
+++ b/manual-scenarios/cards/m/moonlit-meditation.json
@@ -1,0 +1,40 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Clachan Festival"],
+    "battlefield": [
+      {"name": "Serra Angel", "summoningSickness": false},
+      {"name": "Moonlit Meditation", "attachedTo": "Serra Angel"},
+      {"name": "Centaur Glade"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -1217,30 +1217,49 @@ data class RedirectZoneChangeWithEffect(
 // =============================================================================
 
 /**
- * Replace token creation with creating token copies of the equipped creature.
- * Example: Mirrormind Crown — "As long as this Equipment is attached to a creature,
- * the first time you would create one or more tokens each turn, you may instead
- * create that many tokens that are copies of equipped creature."
+ * Replace token creation with creating token copies of the permanent this source is attached to.
+ *
+ * Works for both Equipment (attached creature) and Auras (enchanted artifact / creature / etc.).
+ * The source must have an [com.wingedsheep.engine.state.components.battlefield.AttachedToComponent]
+ * — the engine looks at that to find the permanent to copy.
+ *
+ * Examples:
+ * - Mirrormind Crown — "As long as this Equipment is attached to a creature, the first time
+ *   you would create one or more tokens each turn, you may instead create that many tokens
+ *   that are copies of equipped creature."
+ *     `ReplaceTokenCreationWithAttachedCopy(attachmentVerb = "equipped",
+ *                                           validAttachedFilter = GameObjectFilter.Creature)`
+ * - Moonlit Meditation — "Enchant artifact or creature you control. The first time you would
+ *   create one or more tokens each turn, you may instead create that many tokens that are
+ *   copies of enchanted permanent."
+ *     `ReplaceTokenCreationWithAttachedCopy(attachmentVerb = "enchanted")`
  *
  * @param optional If true, the player may choose whether to apply the replacement ("you may")
  * @param oncePerTurn If true, only applies to the first token creation each turn
+ * @param attachmentVerb Word used in the description for the attached permanent
+ *        (e.g. "equipped", "enchanted", "fortified"). Display-only — behavior is driven
+ *        entirely by the source's [com.wingedsheep.engine.state.components.battlefield.AttachedToComponent]
+ *        and validated at cast / attach time by auraTarget / equipmentTarget.
  */
-@SerialName("ReplaceTokenCreationWithEquippedCopy")
+@SerialName("ReplaceTokenCreationWithAttachedCopy")
 @Serializable
-data class ReplaceTokenCreationWithEquippedCopy(
+data class ReplaceTokenCreationWithAttachedCopy(
     val optional: Boolean = true,
     val oncePerTurn: Boolean = true,
+    val attachmentVerb: String = "attached",
     override val appliesTo: EventPattern = EventPattern.TokenCreationEvent()
 ) : ReplacementEffect {
     override val description: String = buildString {
-        append("As long as this Equipment is attached to a creature, ")
-        if (oncePerTurn) append("the first time ")
+        if (oncePerTurn) append("The first time ")
+        else append("If ")
         append("you would create one or more tokens")
         if (oncePerTurn) append(" each turn")
         append(", ")
         if (optional) append("you may instead ")
         else append("instead ")
-        append("create that many tokens that are copies of equipped creature")
+        append("create that many tokens that are copies of ")
+        append(attachmentVerb)
+        append(" permanent")
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -1227,8 +1227,7 @@ data class RedirectZoneChangeWithEffect(
  * - Mirrormind Crown — "As long as this Equipment is attached to a creature, the first time
  *   you would create one or more tokens each turn, you may instead create that many tokens
  *   that are copies of equipped creature."
- *     `ReplaceTokenCreationWithAttachedCopy(attachmentVerb = "equipped",
- *                                           validAttachedFilter = GameObjectFilter.Creature)`
+ *     `ReplaceTokenCreationWithAttachedCopy(attachmentVerb = "equipped")`
  * - Moonlit Meditation — "Enchant artifact or creature you control. The first time you would
  *   create one or more tokens each turn, you may instead create that many tokens that are
  *   copies of enchanted permanent."

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/MirrormindCrown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/MirrormindCrown.kt
@@ -2,7 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.ecl.cards
 
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithEquippedCopy
+import com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithAttachedCopy
 
 /**
  * Mirrormind Crown
@@ -20,9 +20,10 @@ val MirrormindCrown = card("Mirrormind Crown") {
     oracleText = "As long as this Equipment is attached to a creature, the first time you would create one or more tokens each turn, you may instead create that many tokens that are copies of equipped creature.\nEquip {2}"
 
     replacementEffect(
-        ReplaceTokenCreationWithEquippedCopy(
+        ReplaceTokenCreationWithAttachedCopy(
             optional = true,
-            oncePerTurn = true
+            oncePerTurn = true,
+            attachmentVerb = "equipped"
         )
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MoonlitMeditation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MoonlitMeditation.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithAttachedCopy
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Moonlit Meditation
+ * {2}{U}
+ * Enchantment — Aura
+ * Enchant artifact or creature you control
+ * The first time you would create one or more tokens each turn, you may instead
+ * create that many tokens that are copies of enchanted permanent.
+ */
+val MoonlitMeditation = card("Moonlit Meditation") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant artifact or creature you control\n" +
+        "The first time you would create one or more tokens each turn, you may instead " +
+        "create that many tokens that are copies of enchanted permanent."
+
+    auraTarget = TargetPermanent(filter = TargetFilter.CreatureOrArtifact.youControl())
+
+    replacementEffect(
+        ReplaceTokenCreationWithAttachedCopy(
+            optional = true,
+            oncePerTurn = true,
+            attachmentVerb = "enchanted"
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "69"
+        artist = "Liiga Smilshkalne"
+        flavorText = "\"All is the hand that weaves the Fabric of Being. The Fabric of Being is All.\"\n" +
+            "—Drix Codex, line 1"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2a56007-5bca-4edf-9cc4-5f77a273636c.jpg?1752946830"
+        ruling("2025-07-25", "The effect of Moonlit Meditation's last ability applies before anything that modifies how those tokens enter the battlefield.")
+        ruling("2025-07-25", "The effect of Moonlit Meditation's last ability can apply to any token, not just artifact or creature tokens. For example, you could replace creating a Shard token (a predefined enchantment token) with creating a copy of the enchanted permanent.")
+        ruling("2025-07-25", "If the enchanted permanent is legendary, the copies will also be legendary. If this results in you controlling more than one legendary permanent with the same name, you'll put all but one of them into their owner's graveyard.")
+        ruling("2025-07-25", "If you choose not to apply the replacement effect, you will not get the choice to apply it again until the next turn.")
+        ruling("2025-07-25", "If you create one or more tokens, and then Moonlit Meditation comes under your control that same turn, the replacement effect won't apply to any tokens you create for the rest of the turn.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -12174,7 +12174,10 @@
             }
         ],
         "replacementEffects": [
-            "ReplaceTokenCreationWithEquippedCopy"
+            {
+                "type": "ReplaceTokenCreationWithAttachedCopy",
+                "attachmentVerb": "equipped"
+            }
         ]
     },
     "equipCost": "{2}",

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -10322,6 +10322,60 @@
     ]
 }
 
+// Moonlit Meditation
+{
+    "name": "Moonlit Meditation",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant artifact or creature you control\nThe first time you would create one or more tokens each turn, you may instead create that many tokens that are copies of enchanted permanent.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "ReplaceTokenCreationWithAttachedCopy",
+                "attachmentVerb": "enchanted"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature|artifact ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "RARE",
+        "artist": "Liiga Smilshkalne",
+        "flavorText": "\"All is the hand that weaves the Fabric of Being. The Fabric of Being is All.\"\n—Drix Codex, line 1",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2a56007-5bca-4edf-9cc4-5f77a273636c.jpg?1752946830",
+        "rulings": [
+            {
+                "date": "2025-07-25",
+                "text": "The effect of Moonlit Meditation's last ability applies before anything that modifies how those tokens enter the battlefield."
+            },
+            {
+                "date": "2025-07-25",
+                "text": "The effect of Moonlit Meditation's last ability can apply to any token, not just artifact or creature tokens. For example, you could replace creating a Shard token (a predefined enchantment token) with creating a copy of the enchanted permanent."
+            },
+            {
+                "date": "2025-07-25",
+                "text": "If the enchanted permanent is legendary, the copies will also be legendary. If this results in you controlling more than one legendary permanent with the same name, you'll put all but one of them into their owner's graveyard."
+            },
+            {
+                "date": "2025-07-25",
+                "text": "If you choose not to apply the replacement effect, you will not get the choice to apply it again until the next turn."
+            },
+            {
+                "date": "2025-07-25",
+                "text": "If you create one or more tokens, and then Moonlit Meditation comes under your control that same turn, the replacement effect won't apply to any tokens you create for the rest of the turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Mouth of the Storm
 {
     "name": "Mouth of the Storm",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -29,6 +29,10 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     // restriction — a universal capability (the engine supports auras). `PermanentLayerEffect` wraps
     // the host's static continuous effect, whose real capability is the nested _StaticLayerEffect.
     supported("EnchantPermanent", "aura: enchant restriction (engine supports auras)")
+    // "The first time you would create one or more tokens each turn, you may instead create that many
+    // copies of [attached] permanent" (Mirrormind Crown, Moonlit Meditation) — the engine's
+    // ReplaceTokenCreationWithAttachedCopy replacement effect, driven by the source's AttachedToComponent.
+    supported("ReplaceAPlayerWouldCreateTokens", "replace token creation with copies of attached permanent (ReplaceTokenCreationWithAttachedCopy)")
     envelope("PermanentLayerEffect", "envelope: host continuous effect (capability is the _StaticLayerEffect)")
     // A static "each/other matching permanent gets …" lord (Crusade, Goblin King) — the capability is
     // the nested _StaticLayerEffect; the emitter's staticLordBlock renders it.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -139,6 +139,7 @@ object Emitter {
                 rname == "EnchantPermanent" -> block = ctx.auraTargetBlock(rule)
                 rname == "PermanentLayerEffect" -> block = ctx.staticHostBlock(rule)
                 rname == "AsPermanentEnters" -> block = ctx.asEntersBlock(rule)
+                rname == "ReplaceAPlayerWouldCreateTokens" -> block = ctx.replaceTokenCreationBlock(card, rule)
                 rname == "EachPermanentLayerEffect" -> block = ctx.staticLordBlock(rule)
                 rname == "FromAnyZone" -> block = ctx.fromAnyZoneBlock(rule)
                 rname == "FromGraveyard" -> block = ctx.fromGraveyardBlock(rule)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -101,16 +101,41 @@ private fun EmitCtx.scaffoldLord(): List<Stmt>? { reasons.add("EachPermanentLaye
  * bare cardtype (e.g. "enchant tapped creature") scaffolds rather than emit an inexact restriction.
  */
 internal fun EmitCtx.auraTargetBlock(rule: JsonObject): List<Stmt>? {
-    val filter = rule["args"] as? JsonObject
-    if (filter?.strField("_Permanents") != "IsCardtype") { reasons.add("EnchantPermanent"); return null }
-    val target = when (filter["args"].asStr()) {
-        "Creature" -> "Targets.Creature"
-        "Land" -> "Targets.Land"
-        "Artifact" -> "Targets.Artifact"
-        "Enchantment" -> "Targets.Enchantment"
-        else -> { reasons.add("EnchantPermanent"); return null }
+    val filter = rule["args"] as? JsonObject ?: run { reasons.add("EnchantPermanent"); return null }
+    // "Enchant creature / land / artifact / enchantment": a single card-type restriction.
+    if (filter.strField("_Permanents") == "IsCardtype") {
+        val target = when (filter["args"].asStr()) {
+            "Creature" -> "Targets.Creature"
+            "Land" -> "Targets.Land"
+            "Artifact" -> "Targets.Artifact"
+            "Enchantment" -> "Targets.Enchantment"
+            else -> { reasons.add("EnchantPermanent"); return null }
+        }
+        return listOf(Assign("auraTarget", Lit(target)))
     }
-    return listOf(Assign("auraTarget", Lit(target)))
+    // "Enchant artifact or creature you control" (Moonlit Meditation): a card-type Or AND-ed with a
+    // you-control restriction. Only shapes with an exact SDK TargetFilter render; any other combination
+    // declines to a scaffold.
+    auraYouControlTarget(filter)?.let { return listOf(Assign("auraTarget", Lit(it))) }
+    reasons.add("EnchantPermanent")
+    return null
+}
+
+/** `And(Or(<types>), ControlledBy You)` -> a you-control `TargetPermanent(...)` expr, or null
+ *  (-> SCAFFOLD). Currently only "artifact or creature you control" maps to an exact SDK filter. */
+private fun auraYouControlTarget(filter: JsonObject): String? {
+    if (filter.strField("_Permanents") != "And") return null
+    val args = (filter["args"] as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    if (args.size != 2) return null
+    if (args.none { jsonContains(it, "_Permanents", "ControlledByAPlayer") && jsonContains(it, "_Player", "You") }) return null
+    val typeNode = args.firstOrNull { it.strField("_Permanents") == "Or" } ?: return null
+    val types = (typeNode["args"] as? JsonArray)
+        ?.mapNotNull { (it as? JsonObject)?.takeIf { o -> o.strField("_Permanents") == "IsCardtype" }?.get("args").asStr() }
+        ?.toSet() ?: return null
+    return when (types) {
+        setOf("Artifact", "Creature") -> "TargetPermanent(TargetFilter.CreatureOrArtifact.youControl())"
+        else -> null
+    }
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
@@ -2,12 +2,17 @@ package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.Call
 import com.wingedsheep.tooling.coverage.Dsl
+import com.wingedsheep.tooling.coverage.Eval
+import com.wingedsheep.tooling.coverage.Stmt
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
+import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
+import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
@@ -77,4 +82,42 @@ internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1): Dsl? {
         }
     }
     return null
+}
+
+/**
+ * `ReplaceAPlayerWouldCreateTokens` -> `replacementEffect(ReplaceTokenCreationWithAttachedCopy(...))`.
+ *
+ * We render exactly the printed shape this primitive models: "the first time you would create one or
+ * more tokens each turn, you may instead create that many tokens that are copies of [attached]
+ * permanent" (Mirrormind Crown, Moonlit Meditation). Any other token-creation replacement (mandatory,
+ * not-first-time-each-turn, doubling, additional tokens, or copying something other than the source's
+ * host permanent) declines to a scaffold rather than misrender, since the SDK type's optional /
+ * oncePerTurn defaults would no longer be faithful. The display-only `attachmentVerb` follows the
+ * source's attachment subtype (Aura -> "enchanted", Equipment -> "equipped", Fortification ->
+ * "fortified"); a host with none of those declines.
+ */
+internal fun EmitCtx.replaceTokenCreationBlock(card: JsonObject, rule: JsonObject): List<Stmt>? {
+    val blob = compact(rule)
+    val faithful = jsonContains(rule, "_ReplacableEventAPlayerWouldCreateTokens",
+        "APlayerWouldCreateTokensForTheFirstTimeEachTurn") &&          // once per turn
+        jsonContains(rule, "_Player", "You") &&                        // "you would create"
+        jsonContains(rule, "_ReplacementActionAPlayerWouldCreateTokens", "ChooseAnAction") && // "you may"
+        "TokenCopyOfPermanent" in blob &&                              // copy a permanent
+        jsonContains(rule, "_Permanent", "HostPermanent") &&           // the attached permanent
+        "NoTokenCopyEffects" in blob                                   // plain copy, no riders
+    if (!faithful) { reasons.add("ReplaceAPlayerWouldCreateTokens"); return null }
+    val verb = attachmentVerb(card) ?: run { reasons.add("ReplaceAPlayerWouldCreateTokens"); return null }
+    val effect = call("ReplaceTokenCreationWithAttachedCopy", arg("attachmentVerb", "\"$verb\""))
+    return listOf(Eval(call("replacementEffect", arg(effect))))
+}
+
+/** The display verb for a token-copy replacement's attached permanent, from the source's subtype. */
+private fun attachmentVerb(card: JsonObject): String? {
+    val subs = card.field("Typeline").field("Subtypes").asArr?.mapNotNull { it.asStr() } ?: emptyList()
+    return when {
+        "Aura" in subs -> "enchanted"
+        "Equipment" in subs -> "equipped"
+        "Fortification" in subs -> "fortified"
+        else -> null
+    }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TokenContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TokenContinuations.kt
@@ -7,14 +7,14 @@ import kotlinx.serialization.Serializable
 
 /**
  * Resume token creation after the player answers a "may" question for
- * ReplaceTokenCreationWithEquippedCopy (Mirrormind Crown).
+ * ReplaceTokenCreationWithAttachedCopy (Mirrormind Crown, Moonlit Meditation).
  *
- * If yes: create [tokenCount] token copies of the equipped creature.
+ * If yes: create [tokenCount] token copies of the attached permanent.
  * If no: execute the original [originalEffect] normally — this can be any
  * token-creating effect (e.g. CreateTokenEffect, CreateTokenCopyOfTargetEffect).
  *
- * @property equipmentId The equipment with the replacement effect
- * @property equippedCreatureId The creature equipped at the time the decision was posed
+ * @property sourceId The Equipment / Aura / other permanent with the replacement effect
+ * @property attachedPermanentId The permanent attached at the time the decision was posed
  * @property originalEffect The original token creation effect (used if player declines)
  * @property tokenCount The evaluated number of tokens to create
  * @property effectContext The execution context from the original effect
@@ -22,8 +22,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TokenCreationReplacementContinuation(
     override val decisionId: String,
-    val equipmentId: EntityId,
-    val equippedCreatureId: EntityId,
+    val sourceId: EntityId,
+    val attachedPermanentId: EntityId,
     val originalEffect: Effect,
     val tokenCount: Int,
     val effectContext: EffectContext

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/TokenContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/TokenContinuationResumer.kt
@@ -34,12 +34,12 @@ class TokenContinuationResumer(
         val context = continuation.effectContext
 
         if (response.choice) {
-            // Player chose to replace: create copies of equipped creature.
-            // Pass cardRegistry so the token applies the equipped creature's printed
+            // Player chose to replace: create copies of the attached permanent.
+            // Pass cardRegistry so the token applies the attached permanent's printed
             // "enters with N counters" replacement effects (per Mirrormind Crown rulings).
-            val result = TokenCreationReplacementHelper.createEquippedCreatureCopies(
+            val result = TokenCreationReplacementHelper.createAttachedPermanentCopies(
                 state,
-                continuation.equippedCreatureId,
+                continuation.attachedPermanentId,
                 context.controllerId,
                 continuation.tokenCount,
                 cardRegistry = services.cardRegistry,
@@ -49,7 +49,7 @@ class TokenContinuationResumer(
             return checkForMore(result.state, result.events)
         } else {
             // Player declined: execute original token creation effect
-            // The equipment is already marked as "offered this turn" so the replacement
+            // The source is already marked as "offered this turn" so the replacement
             // won't fire again when we re-execute the original effect.
             val effectResult = services.effectExecutorRegistry.execute(
                 state,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -27,7 +27,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.DoubleTokenCreation
 import com.wingedsheep.sdk.scripting.EventPattern as SdkGameEvent
 import com.wingedsheep.sdk.scripting.ModifyTokenCount
-import com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithEquippedCopy
+import com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithAttachedCopy
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.events.ControllerFilter
 import java.util.UUID
@@ -102,8 +102,9 @@ object TokenCreationReplacementHelper {
     }
 
     /**
-     * Check if any equipment controlled by the token creator has a
-     * ReplaceTokenCreationWithEquippedCopy replacement effect that applies.
+     * Check if any permanent controlled by the token creator has a
+     * ReplaceTokenCreationWithAttachedCopy replacement effect that applies
+     * (e.g., Mirrormind Crown, Moonlit Meditation).
      *
      * @return A paused EffectResult if a replacement decision is needed, or null
      */
@@ -128,25 +129,26 @@ object TokenCreationReplacementHelper {
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
 
             for (re in replacementComponent.replacementEffects) {
-                if (re !is ReplaceTokenCreationWithEquippedCopy) continue
+                if (re !is ReplaceTokenCreationWithAttachedCopy) continue
 
                 // Check once-per-turn
                 if (re.oncePerTurn && container.has<TokenReplacementOfferedThisTurnComponent>()) continue
 
-                // Check attached to creature
+                // Check the source is attached to something (Aura/Equipment that fell off
+                // or never attached can't fire). Attachment-type validation is enforced at
+                // cast/attach time by auraTarget / equipmentTarget — no re-check here.
                 val attachedTo = container.get<AttachedToComponent>() ?: continue
-                val equippedContainer = state.getEntity(attachedTo.targetId) ?: continue
-                val equippedCard = equippedContainer.get<CardComponent>() ?: continue
-                if (!equippedCard.typeLine.isCreature) continue
+                val attachedContainer = state.getEntity(attachedTo.targetId) ?: continue
+                val attachedCard = attachedContainer.get<CardComponent>() ?: continue
 
-                val cardName = container.get<CardComponent>()?.name ?: "Equipment"
+                val cardName = container.get<CardComponent>()?.name ?: "Source"
 
                 // Mark as offered this turn (prevents re-offering on decline)
                 var newState = state.withEntity(entityId, container.with(TokenReplacementOfferedThisTurnComponent))
 
                 if (re.optional) {
                     val decisionId = UUID.randomUUID().toString()
-                    val prompt = "Use $cardName? Create ${if (tokenCount == 1) "a token that's a copy" else "$tokenCount tokens that are copies"} of ${equippedCard.name} instead?"
+                    val prompt = "Use $cardName? Create ${if (tokenCount == 1) "a token that's a copy" else "$tokenCount tokens that are copies"} of ${attachedCard.name} instead?"
 
                     val decision = YesNoDecision(
                         id = decisionId,
@@ -161,8 +163,8 @@ object TokenCreationReplacementHelper {
 
                     val continuation = TokenCreationReplacementContinuation(
                         decisionId = decisionId,
-                        equipmentId = entityId,
-                        equippedCreatureId = attachedTo.targetId,
+                        sourceId = entityId,
+                        attachedPermanentId = attachedTo.targetId,
                         originalEffect = effect,
                         tokenCount = tokenCount,
                         effectContext = context
@@ -185,7 +187,7 @@ object TokenCreationReplacementHelper {
                     )
                 } else {
                     // Mandatory replacement — create copies directly
-                    return createEquippedCreatureCopies(
+                    return createAttachedPermanentCopies(
                         newState, attachedTo.targetId, controllerId, tokenCount,
                         cardRegistry, staticAbilityHandler
                     )
@@ -196,25 +198,28 @@ object TokenCreationReplacementHelper {
     }
 
     /**
-     * Create N token copies of the equipped creature.
+     * Create N token copies of the attached permanent (equipped creature, enchanted
+     * permanent, etc.).
      *
-     * Per the printed rulings, Mirrormind Crown's tokens copy exactly what was printed
-     * on the equipped creature. That includes printed "enters with N counters" replacement
-     * effects (e.g., Burdened Stoneback's "this creature enters with two -1/-1 counters"),
-     * which apply to the token via [EntersWithCountersHelper.applyEntersWithCounters].
+     * Per the printed rulings (Mirrormind Crown, Moonlit Meditation), the tokens copy
+     * exactly what was printed on the attached permanent. That includes printed
+     * "enters with N counters" replacement effects (e.g., Burdened Stoneback's "this
+     * creature enters with two -1/-1 counters"), applied via
+     * [EntersWithCountersHelper.applyEntersWithCounters]. Summoning sickness is added
+     * only when the copy is itself a creature (CR 302.1).
      */
-    fun createEquippedCreatureCopies(
+    fun createAttachedPermanentCopies(
         state: GameState,
-        equippedCreatureId: EntityId,
+        attachedPermanentId: EntityId,
         controllerId: EntityId,
         count: Int,
         cardRegistry: CardRegistry? = null,
         staticAbilityHandler: StaticAbilityHandler? = null
     ): EffectResult {
-        val equippedContainer = state.getEntity(equippedCreatureId)
+        val attachedContainer = state.getEntity(attachedPermanentId)
             ?: return EffectResult.success(state)
 
-        val equippedCard = equippedContainer.get<CardComponent>()
+        val attachedCard = attachedContainer.get<CardComponent>()
             ?: return EffectResult.success(state)
 
         var newState = state
@@ -223,15 +228,20 @@ object TokenCreationReplacementHelper {
         repeat(count) {
             val (tokenId, stateWithId) = newState.newEntity()
             newState = stateWithId
-            val tokenCard = equippedCard.copy(ownerId = controllerId)
+            val tokenCard = attachedCard.copy(ownerId = controllerId)
 
             val components = mutableListOf<Component>(
                 tokenCard,
                 TokenComponent,
                 ControllerComponent(controllerId),
-                SummoningSicknessComponent,
                 EnteredThisTurnComponent
             )
+            // Summoning sickness only applies to creatures (CR 302.1). An artifact or
+            // enchantment token copy doesn't get it; a creature (or artifact-creature)
+            // copy does.
+            if (tokenCard.typeLine.isCreature) {
+                components.add(SummoningSicknessComponent)
+            }
 
             var container = ComponentContainer.of(*components.toTypedArray())
             if (staticAbilityHandler != null) {
@@ -242,8 +252,8 @@ object TokenCreationReplacementHelper {
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
 
-            // Apply the equipped creature's printed enters-with-counters replacement effects
-            // (and any global ones from other permanents).
+            // Apply the attached permanent's printed enters-with-counters replacement
+            // effects (and any global ones from other permanents).
             if (cardRegistry != null) {
                 val (afterCounters, counterEvents) = EntersWithCountersHelper.applyEntersWithCounters(
                     newState, tokenId, controllerId, cardRegistry

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -236,7 +236,7 @@ object TokenCreationReplacementHelper {
                 ControllerComponent(controllerId),
                 EnteredThisTurnComponent
             )
-            // Summoning sickness only applies to creatures (CR 302.1). An artifact or
+            // Summoning sickness only applies to creatures (CR 302.6). An artifact or
             // enchantment token copy doesn't get it; a creature (or artifact-creature)
             // copy does.
             if (tokenCard.typeLine.isCreature) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -206,7 +206,7 @@ object TokenCreationReplacementHelper {
      * "enters with N counters" replacement effects (e.g., Burdened Stoneback's "this
      * creature enters with two -1/-1 counters"), applied via
      * [EntersWithCountersHelper.applyEntersWithCounters]. Summoning sickness is added
-     * only when the copy is itself a creature (CR 302.1).
+     * only when the copy is itself a creature (CR 302.6).
      */
     fun createAttachedPermanentCopies(
         state: GameState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -622,7 +622,7 @@ class StaticAbilityHandler(
         it is com.wingedsheep.sdk.scripting.RedirectZoneChange || it is com.wingedsheep.sdk.scripting.PreventExtraTurns ||
         it is com.wingedsheep.sdk.scripting.RedirectZoneChangeWithEffect || it is com.wingedsheep.sdk.scripting.EntersWithCounters ||
         it is com.wingedsheep.sdk.scripting.EntersWithDynamicCounters || it is com.wingedsheep.sdk.scripting.DoubleCounterPlacement ||
-        it is com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithEquippedCopy ||
+        it is com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithAttachedCopy ||
         it is com.wingedsheep.sdk.scripting.DoubleTokenCreation || it is com.wingedsheep.sdk.scripting.ModifyTokenCount
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -393,8 +393,9 @@ data class AbilityResolutionCountThisTurnComponent(
 }
 
 /**
- * Marks an equipment that has already offered its token creation replacement this turn.
- * Used by ReplaceTokenCreationWithEquippedCopy (Mirrormind Crown) to enforce "first time each turn".
+ * Marks an attachment source that has already offered its token creation replacement
+ * this turn. Used by ReplaceTokenCreationWithAttachedCopy (Mirrormind Crown,
+ * Moonlit Meditation) to enforce "first time each turn".
  * Cleared at end of turn by CleanupPhaseManager.
  */
 @Serializable

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MirrormindCrownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MirrormindCrownScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Mirrormind Crown (ECL #258, {4}, Artifact — Equipment).
+ *
+ *   As long as this Equipment is attached to a creature, the first time you would
+ *   create one or more tokens each turn, you may instead create that many tokens
+ *   that are copies of equipped creature.
+ *   Equip {2}
+ *
+ * Regression guard for the original consumer of
+ * [com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithAttachedCopy] — Moonlit Meditation
+ * shares the same primitive, but Mirrormind Crown was the first card to use it and the
+ * `attachmentVerb = "equipped"` path is exercised nowhere else.
+ */
+class MirrormindCrownScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Mirrormind Crown") {
+
+            test("yes — replaces the Centaur token with a copy of the equipped creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mirrormind Crown")
+                    .withCardOnBattlefield(1, "Centaur Glade")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Mirrormind Crown")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val crownDef = cardRegistry.getCard("Mirrormind Crown")!!
+                val equipAbility = crownDef.script.activatedAbilities.first()
+
+                val equipResult = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = equipAbility.id,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("Activating equip should succeed: ${equipResult.error}") {
+                    equipResult.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Mirrormind Crown should be attached to Grizzly Bears") {
+                    game.state.getEntity(crown)?.get<AttachedToComponent>()?.targetId shouldBe bears
+                }
+
+                val glade = game.findPermanent("Centaur Glade")!!
+                val gladeAbility = cardRegistry.getCard("Centaur Glade")!!.script.activatedAbilities.first()
+                val activate = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = glade, abilityId = gladeAbility.id)
+                )
+                withClue("Activating Centaur Glade should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("Token creation should pause for a YesNo decision; got $decision") {
+                    decision.shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("No Centaur token should be created when replacement is taken") {
+                    game.findPermanents("Centaur Token").size shouldBe 0
+                }
+                withClue("A token copy of Grizzly Bears should join the original (1 + 1 copy)") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 2
+                }
+            }
+
+            test("no — declining leaves the original Centaur token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mirrormind Crown")
+                    .withCardOnBattlefield(1, "Centaur Glade")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Mirrormind Crown")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val equipAbility = cardRegistry.getCard("Mirrormind Crown")!!.script.activatedAbilities.first()
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = equipAbility.id,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val glade = game.findPermanent("Centaur Glade")!!
+                val gladeAbility = cardRegistry.getCard("Centaur Glade")!!.script.activatedAbilities.first()
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = glade, abilityId = gladeAbility.id)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("A normal Centaur token should be created when replacement is declined") {
+                    game.findPermanents("Centaur Token").size shouldBe 1
+                }
+                withClue("Grizzly Bears count is unchanged") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoonlitMeditationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoonlitMeditationScenarioTest.kt
@@ -1,0 +1,224 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Moonlit Meditation (EOE #69, {2}{U}, Enchantment — Aura).
+ *
+ *   Enchant artifact or creature you control
+ *   The first time you would create one or more tokens each turn, you may instead
+ *   create that many tokens that are copies of enchanted permanent.
+ *
+ * Driven by Centaur Glade ({2}{G}{G}: create a 3/3 Centaur token) — a clean,
+ * activatable single-token source with no token-count interactions of its own.
+ */
+class MoonlitMeditationScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Moonlit Meditation") {
+
+            test("yes — first token creation each turn becomes a copy of the enchanted creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Moonlit Meditation")
+                    .withCardOnBattlefield(1, "Centaur Glade")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Moonlit Meditation", bears)
+                withClue("Casting Moonlit Meditation should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val aura = game.findPermanent("Moonlit Meditation")
+                withClue("Moonlit Meditation should be on the battlefield") {
+                    aura.shouldNotBeNull()
+                }
+                withClue("Moonlit Meditation should be attached to Grizzly Bears") {
+                    game.state.getEntity(aura!!)?.get<AttachedToComponent>()?.targetId shouldBe bears
+                }
+
+                // Activate Centaur Glade's {2}{G}{G} token ability.
+                val glade = game.findPermanent("Centaur Glade")!!
+                val gladeAbility = cardRegistry.getCard("Centaur Glade")!!.script.activatedAbilities.first()
+                val activate = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = glade, abilityId = gladeAbility.id)
+                )
+                withClue("Activating Centaur Glade should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                // The token creation should pause for the Moonlit Meditation yes/no.
+                val decision = game.getPendingDecision()
+                withClue("Token creation should pause for a YesNo decision; got $decision") {
+                    decision.shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("No Centaur token should be created when replacement is taken") {
+                    game.findPermanents("Centaur Token").size shouldBe 0
+                }
+                withClue("A token copy of Grizzly Bears should be on the battlefield (original + 1 copy)") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 2
+                }
+            }
+
+            test("no — declining leaves the original Centaur token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Moonlit Meditation")
+                    .withCardOnBattlefield(1, "Centaur Glade")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Moonlit Meditation", bears).error shouldBe null
+                game.resolveStack()
+
+                val glade = game.findPermanent("Centaur Glade")!!
+                val gladeAbility = cardRegistry.getCard("Centaur Glade")!!.script.activatedAbilities.first()
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = glade, abilityId = gladeAbility.id)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("A normal Centaur token should be created when replacement is declined") {
+                    game.findPermanents("Centaur Token").size shouldBe 1
+                }
+                withClue("Grizzly Bears count is unchanged") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 1
+                }
+            }
+
+            test("once per turn — declining locks the replacement out for the rest of the turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Moonlit Meditation")
+                    .withCardOnBattlefield(1, "Centaur Glade")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Moonlit Meditation", bears).error shouldBe null
+                game.resolveStack()
+
+                val glade = game.findPermanent("Centaur Glade")!!
+                val gladeAbility = cardRegistry.getCard("Centaur Glade")!!.script.activatedAbilities.first()
+
+                // First activation: decline the replacement.
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = glade, abilityId = gladeAbility.id)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                // Second activation: no yes/no should be offered — the Aura already had
+                // its one shot this turn (ruling: "If you choose not to apply the
+                // replacement effect, you will not get the choice to apply it again
+                // until the next turn.").
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = glade, abilityId = gladeAbility.id)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Second activation must NOT offer the replacement again this turn") {
+                    val pending = game.getPendingDecision()
+                    if (pending is YesNoDecision) {
+                        withClue("Unexpected YesNoDecision prompt: ${pending.prompt}") {
+                            pending.prompt.contains("Moonlit Meditation") shouldBe false
+                        }
+                    }
+                }
+
+                withClue("Two Centaur tokens should now exist (both activations resolved normally)") {
+                    game.findPermanents("Centaur Token").size shouldBe 2
+                }
+                withClue("No extra Grizzly Bears copies should exist") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 1
+                }
+            }
+
+            test("non-creature token replaced too: an Aura on an artifact creates copies of the artifact") {
+                // Per Scryfall ruling: "The effect of Moonlit Meditation's last ability can
+                // apply to any token, not just artifact or creature tokens." Here we cover
+                // the inverse axis — the replacement can fire when the enchanted permanent
+                // is an artifact (the Aura's "Enchant artifact or creature" half).
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Moonlit Meditation")
+                    .withCardOnBattlefield(1, "Centaur Glade")
+                    .withCardOnBattlefield(1, "Sol Ring")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val solRing = game.findPermanent("Sol Ring")!!
+                game.castSpell(1, "Moonlit Meditation", solRing).error shouldBe null
+                game.resolveStack()
+
+                val glade = game.findPermanent("Centaur Glade")!!
+                val gladeAbility = cardRegistry.getCard("Centaur Glade")!!.script.activatedAbilities.first()
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = glade, abilityId = gladeAbility.id)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("No Centaur token should be created when replacement is taken") {
+                    game.findPermanents("Centaur Token").size shouldBe 0
+                }
+                // One original Sol Ring + 1 token copy = 2.
+                withClue("A token copy of Sol Ring should be on the battlefield (original + 1 copy)") {
+                    val ringIds = game.state.getBattlefield().filter { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Sol Ring"
+                    }
+                    ringIds.size shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds Moonlit Meditation (EOE #69, {2}{U} Enchantment — Aura): the first time you'd create one or more
tokens each turn, you may instead create that many copies of the enchanted permanent.

Rather than introducing a parallel SDK type, this generalizes the existing Mirrormind Crown primitive:

- SDK rename: ReplaceTokenCreationWithEquippedCopy → ReplaceTokenCreationWithAttachedCopy, with a new
attachmentVerb ("equipped" / "enchanted" / …) for display. The handler reads AttachedToComponent, so
both Equipment and Auras (and any future Fortification, etc.) share one code path. Attachment-type
validation stays at cast/attach time on equipmentTarget / auraTarget.
- Engine fix: token copies only receive SummoningSicknessComponent when the copy itself is a creature
(CR 302.6). Previously harmless for Mirrormind Crown (always equipping a creature), but matters now
that an Aura can copy an artifact.

Tests

- MoonlitMeditationScenarioTest — yes-replace, no-decline, once-per-turn-after-decline, and the
non-creature (Sol Ring) copy path.
- MirrormindCrownScenarioTest — regression coverage for the equip path of the renamed primitive.
- CardDefinitionSnapshotTest reblessed for ECL and EOE.

Docs

- card-sdk-language-reference.md updated alongside the SDK rename per repo convention.