### PR TITLE
feat(tmp): implement Mogg Fanatic, Goblin Bombardment, Flowstone Giant, Canyon Drake + mtgish autogen

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/CanyonDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/CanyonDrake.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Canyon Drake
+ * {2}{R}{R}
+ * Creature — Drake (1/2)
+ *
+ * Flying
+ * {1}, Discard a card at random: This creature gets +2/+0 until end of turn.
+ */
+val CanyonDrake = card("Canyon Drake") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Drake"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n" +
+        "{1}, Discard a card at random: This creature gets +2/+0 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.DiscardAtRandom(1))
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+        description = "{1}, Discard a card at random: This creature gets +2/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "166"
+        artist = "Quinton Hoover"
+        flavorText = "\"These runes are tough enough without the distraction,\" Ertai muttered, one eye on the drake."
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/22f84143-5912-43ca-a274-f26ed0dbadd0.jpg?1562052811"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/FlowstoneGiant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/FlowstoneGiant.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Flowstone Giant
+ * {2}{R}{R}
+ * Creature — Giant (3/3)
+ *
+ * {R}: This creature gets +2/-2 until end of turn.
+ */
+val FlowstoneGiant = card("Flowstone Giant") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    power = 3
+    toughness = 3
+    oracleText = "{R}: This creature gets +2/-2 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(2, -2, EffectTarget.Self)
+        description = "{R}: This creature gets +2/-2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Joel Biske"
+        flavorText = "When the first of these giants woke from the bedrock, he was still sleepy. " +
+            "He yawned and stretched until his legs grew so thin that they snapped like icicles in the sun.\n—Vec lore"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46e8240a-d882-4f60-8960-1856284e04a0.jpg?1562053769"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/GoblinBombardment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/GoblinBombardment.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Goblin Bombardment
+ * {1}{R}
+ * Enchantment
+ *
+ * Sacrifice a creature: This enchantment deals 1 damage to any target.
+ */
+val GoblinBombardment = card("Goblin Bombardment") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Sacrifice a creature: This enchantment deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+        description = "Sacrifice a creature: This enchantment deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "179"
+        artist = "Brian Snõddy"
+        flavorText = "One mogg to aim the catapult, one mogg to steer the rock."
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/179e954f-1d90-4ef4-b800-25845cc338e2.jpg?1562052788"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MoggFanatic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MoggFanatic.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mogg Fanatic
+ * {R}
+ * Creature — Goblin (1/1)
+ *
+ * Sacrifice this creature: It deals 1 damage to any target.
+ */
+val MoggFanatic = card("Mogg Fanatic") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice this creature: It deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+        description = "Sacrifice this creature: It deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "190"
+        artist = "Brom"
+        flavorText = "\"I got it! I got it! I—\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca2ecfd4-c874-4468-8601-87aa110d5a00.jpg?1562056411"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -54,6 +54,64 @@
     ]
 }
 
+// Canyon Drake
+{
+    "name": "Canyon Drake",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\n{1}, Discard a card at random: This creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{1}"
+                        },
+                        {
+                            "type": "CostDiscard",
+                            "atRandom": true
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}, Discard a card at random: This creature gets +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "rarity": "RARE",
+        "artist": "Quinton Hoover",
+        "flavorText": "\"These runes are tough enough without the distraction,\" Ertai muttered, one eye on the drake.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/22f84143-5912-43ca-a274-f26ed0dbadd0.jpg?1562052811"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Canyon Wildcat
 {
     "name": "Canyon Wildcat",
@@ -186,6 +244,51 @@
     ]
 }
 
+// Flowstone Giant
+{
+    "name": "Flowstone Giant",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "{R}: This creature gets +2/-2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{R}"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{R}: This creature gets +2/-2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Joel Biske",
+        "flavorText": "When the first of these giants woke from the bedrock, he was still sleepy. He yawned and stretched until his legs grew so thin that they snapped like icicles in the sun.\n—Vec lore",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46e8240a-d882-4f60-8960-1856284e04a0.jpg?1562053769"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Fylamarid
 {
     "name": "Fylamarid",
@@ -252,6 +355,53 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Goblin Bombardment
+{
+    "name": "Goblin Bombardment",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Sacrifice a creature: This enchantment deals 1 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostSacrifice",
+                    "filter": "creature"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice a creature: This enchantment deals 1 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Snõddy",
+        "flavorText": "One mogg to aim the catapult, one mogg to steer the rock.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/179e954f-1d90-4ef4-b800-25845cc338e2.jpg?1562052788"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -426,6 +576,53 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Mogg Fanatic
+{
+    "name": "Mogg Fanatic",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "Sacrifice this creature: It deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice this creature: It deals 1 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "artist": "Brom",
+        "flavorText": "\"I got it! I got it! I—\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca2ecfd4-c874-4468-8601-87aa110d5a00.jpg?1562056411"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -446,6 +446,9 @@ internal fun EmitCtx.abilityCostDsl(node: JsonElement?): String? {
         // (ManaCostX -> "{X}") as the mana cost (Silklash Spider).
         "PayManaX" -> renderMana((obj["args"].asArr)?.getOrNull(0)).ifEmpty { null }?.let { "Costs.Mana(\"$it\")" }
         "DiscardHand" -> "Costs.DiscardHand"  // "Discard your hand" (Slate of Ancestry)
+        // "Discard a card at random" — a fixed, no-choice cost (the engine picks): Costs.DiscardAtRandom(1).
+        // It carries no value selection / X / inherited choice, so it is safe to render exactly (Canyon Drake).
+        "DiscardACardAtRandom" -> "Costs.DiscardAtRandom(1)"
         "TapPermanent" ->
             if (obj.field("args").strField("_Permanent") == "ThisPermanent") "Costs.Tap" else null
         "SacrificePermanent" ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TmpRedActivatedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TmpRedActivatedScenarioTest.kt
@@ -1,0 +1,201 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for four Tempest (TMP) red cards, all built from existing SDK primitives:
+ *
+ * - Mogg Fanatic — "Sacrifice this creature: It deals 1 damage to any target."
+ *   ([com.wingedsheep.sdk.dsl.Costs.SacrificeSelf] + [com.wingedsheep.sdk.dsl.Effects.DealDamage]).
+ * - Goblin Bombardment — "Sacrifice a creature: This enchantment deals 1 damage to any target."
+ *   ([com.wingedsheep.sdk.dsl.Costs.Sacrifice] of a creature filter + DealDamage).
+ * - Flowstone Giant — "{R}: This creature gets +2/-2 until end of turn." (ModifyStats on Self).
+ * - Canyon Drake — "Flying; {1}, Discard a card at random: gets +2/+0 until end of turn."
+ *   ([com.wingedsheep.sdk.dsl.Costs.DiscardAtRandom] + ModifyStats on Self).
+ */
+class TmpRedActivatedScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Mogg Fanatic — Sacrifice this creature: 1 damage to any target") {
+            test("sacrifices itself and deals 1 damage to a player") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mogg Fanatic", summoningSickness = false)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fanatic = game.findPermanent("Mogg Fanatic")!!
+                val abilityId = cardRegistry.getCard("Mogg Fanatic")!!.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = fanatic,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                    )
+                )
+                withClue("Activating Mogg Fanatic should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Mogg Fanatic is sacrificed as a cost") {
+                    game.isOnBattlefield("Mogg Fanatic") shouldBe false
+                }
+                game.resolveStack()
+
+                withClue("Player 2 takes 1 damage (20 -> 19)") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+            }
+
+            test("kills a 1-toughness creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mogg Fanatic", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Goblin Bombardment") // unrelated enchantment, just board context
+                    .withCardOnBattlefield(2, "Grizzly Bears") // a 2/2; 1 damage won't kill it
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myFanatic = game.findPermanents("Mogg Fanatic")
+                    .first { game.state.projectedState.getController(it) == game.player1Id }
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val abilityId = cardRegistry.getCard("Mogg Fanatic")!!.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = myFanatic,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Grizzly Bears (2/2) survives 1 damage") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+        }
+
+        context("Goblin Bombardment — Sacrifice a creature: 1 damage to any target") {
+            test("sacrifices a chosen creature and deals 1 damage to a player") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Goblin Bombardment")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bombardment = game.findPermanent("Goblin Bombardment")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val abilityId = cardRegistry.getCard("Goblin Bombardment")!!.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bombardment,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(bears)),
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                    )
+                )
+                withClue("Activating Goblin Bombardment should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Grizzly Bears was sacrificed as a cost") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("Goblin Bombardment remains (it is not sacrificed)") {
+                    game.isOnBattlefield("Goblin Bombardment") shouldBe true
+                }
+                game.resolveStack()
+
+                withClue("Player 2 takes 1 damage (20 -> 19)") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+            }
+        }
+
+        context("Flowstone Giant — {R}: gets +2/-2 until end of turn") {
+            test("pumping once makes the 3/3 a 5/1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Flowstone Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Flowstone Giant")!!
+                val abilityId = cardRegistry.getCard("Flowstone Giant")!!.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = giant, abilityId = abilityId)
+                )
+                withClue("Activating Flowstone Giant should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Power becomes 3+2 = 5") {
+                    game.state.projectedState.getPower(giant) shouldBe 5
+                }
+                withClue("Toughness becomes 3-2 = 1") {
+                    game.state.projectedState.getToughness(giant) shouldBe 1
+                }
+            }
+        }
+
+        context("Canyon Drake — Flying; {1}, Discard a card at random: gets +2/+0") {
+            test("has flying and pumping discards a card at random while making it a 3/2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Canyon Drake", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Grizzly Bears") // the only random-discard candidate
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val drake = game.findPermanent("Canyon Drake")!!
+                withClue("Canyon Drake has flying") {
+                    game.state.projectedState.hasKeyword(drake, Keyword.FLYING) shouldBe true
+                }
+
+                val abilityId = cardRegistry.getCard("Canyon Drake")!!.activatedAbilities.first().id
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = drake, abilityId = abilityId)
+                )
+                withClue("Activating Canyon Drake should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("The single hand card was discarded as the at-random cost") {
+                    game.state.getHand(game.player1Id).size shouldBe 0
+                }
+                game.resolveStack()
+
+                withClue("Power becomes 1+2 = 3") {
+                    game.state.projectedState.getPower(drake) shouldBe 3
+                }
+                withClue("Toughness stays 2") {
+                    game.state.projectedState.getToughness(drake) shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards (Tempest / TMP — all canonical-in-TMP, verified via `check-card-printing`)

| Card | Cost | Type | Implementation |
|------|------|------|----------------|
| **Mogg Fanatic** | `{R}` | 1/1 Goblin | `Costs.SacrificeSelf` + `Effects.DealDamage(1, Targets.Any)` |
| **Goblin Bombardment** | `{1}{R}` | Enchantment | `Costs.Sacrifice(GameObjectFilter.Creature)` + `Effects.DealDamage(1, Targets.Any)` |
| **Flowstone Giant** | `{2}{R}{R}` | 3/3 Giant | `{R}`: `Effects.ModifyStats(2, -2, EffectTarget.Self)` (until EOT) |
| **Canyon Drake** | `{2}{R}{R}` | 1/2 Drake | Flying; `{1}`, discard a card at random: `Effects.ModifyStats(2, 0, EffectTarget.Self)` (until EOT) |

All four compose existing SDK primitives — no new engine/SDK building blocks were needed.

## Tests
- New `TmpRedActivatedScenarioTest` (rules-engine) — 5 tests, all passing:
  - Mogg Fanatic sacrifices itself and deals 1 to a player; and aimed at a creature.
  - Goblin Bombardment sacrifices a chosen creature (itself survives) and deals 1 to a player.
  - Flowstone Giant `{R}` makes the 3/3 a 5/1 (projected stats).
  - Canyon Drake has Flying and its activated cost discards the single hand card at random, making it a 3/2.
- Re-blessed `mtg-sets` `CardDefinitionSnapshotTest` golden for TMP — diff adds only these four cards.

## mtgish autogen tooling
Three of the four already emitted **AUTO** (whole-card render) with no changes. **Canyon Drake** was the only `SCAFFOLD`, blocked on the `activated-cost` recovery for its "Discard a card at random" cost.

Added one cost-atom handler in the emitter (`CardStructure.kt` `abilityCostDsl`):

```kotlin
"DiscardACardAtRandom" -> "Costs.DiscardAtRandom(1)"
```

This is a fixed, no-choice cost (no value selection / X / inherited choice), so it renders exactly — consistent with the fidelity policy (decline → SCAFFOLD only when a constraint *can't* be rendered faithfully). After the change, **all four cards emit & compile-verify as AUTO**, keywords in printed order (Flying before the activated ability).

### Verification
- `coverage-verify POR` → **GATE PASS, 158/158, 0 mismatch** (unaffected — no Portal card uses this cost).
- `EmitterGoldenTest` → PASS (no golden drift).
- Full `:mtgish-tooling:test` → PASS.

No SCAFFOLD card remains among the four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)