### PR TITLE
feat(tmp): implement Dismiss, Manta Riders, Soltari Priest, Time Warp + mtgish autogen

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/Dismiss.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/Dismiss.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dismiss
+ * {2}{U}{U}
+ * Instant
+ * Counter target spell.
+ * Draw a card.
+ */
+val Dismiss = card("Dismiss") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell.\nDraw a card."
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpell() then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e55d6be-7682-4786-9872-e847afd710b0.jpg?1562052798"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MantaRiders.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MantaRiders.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Manta Riders
+ * {U}
+ * Creature — Merfolk
+ * 1/1
+ * {U}: This creature gains flying until end of turn.
+ */
+val MantaRiders = card("Manta Riders") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk"
+    power = 1
+    toughness = 1
+    oracleText = "{U}: This creature gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Kaja Foglio"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdff306c-1c7e-49ae-b10f-99e1927bbef1.jpg?1562056858"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/SoltariPriest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/SoltariPriest.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Soltari Priest
+ * {W}{W}
+ * Creature — Soltari Cleric
+ * 2/1
+ * Protection from red
+ * Shadow (This creature can block or be blocked by only creatures with shadow.)
+ */
+val SoltariPriest = card("Soltari Priest") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Soltari Cleric"
+    power = 2
+    toughness = 1
+    oracleText = "Protection from red\n" +
+        "Shadow (This creature can block or be blocked by only creatures with shadow.)"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.RED)))
+    keywords(Keyword.SHADOW)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "46"
+        artist = "Janet Aulisio"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35a71390-3fa8-43eb-ad86-67de2a7aeab8.jpg?1562053297"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/TimeWarp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/TimeWarp.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.TakeExtraTurnEffect
+
+/**
+ * Time Warp
+ * {3}{U}{U}
+ * Sorcery
+ * Target player takes an extra turn after this one.
+ */
+val TimeWarp = card("Time Warp") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Target player takes an extra turn after this one."
+
+    spell {
+        val player = target("player", Targets.Player)
+        effect = TakeExtraTurnEffect(target = player)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "97"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/3447aeaf-3b26-442a-99d4-0a7ee76c8e76.jpg?1562053291"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -107,6 +107,47 @@
     ]
 }
 
+// Dismiss
+{
+    "name": "Dismiss",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "UNCOMMON",
+        "artist": "Donato Giancola",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e55d6be-7682-4786-9872-e847afd710b0.jpg?1562052798"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Fighting Drake
 {
     "name": "Fighting Drake",
@@ -375,6 +416,42 @@
     ]
 }
 
+// Manta Riders
+{
+    "name": "Manta Riders",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Merfolk",
+    "oracleText": "{U}: This creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{U}"
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "artist": "Kaja Foglio",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cdff306c-1c7e-49ae-b10f-99e1927bbef1.jpg?1562056858"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Master Decoy
 {
     "name": "Master Decoy",
@@ -593,6 +670,39 @@
     ]
 }
 
+// Soltari Priest
+{
+    "name": "Soltari Priest",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Soltari Cleric",
+    "oracleText": "Protection from red\nShadow (This creature can block or be blocked by only creatures with shadow.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "SHADOW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "RED"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "UNCOMMON",
+        "artist": "Janet Aulisio",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35a71390-3fa8-43eb-ad86-67de2a7aeab8.jpg?1562053297"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Staunch Defenders
 {
     "name": "Staunch Defenders",
@@ -677,6 +787,38 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Time Warp
+{
+    "name": "Time Warp",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player takes an extra turn after this one.",
+    "script": {
+        "spellEffect": {
+            "type": "TakeExtraTurn",
+            "target": {
+                "type": "BoundVariable",
+                "name": "player"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "RARE",
+        "artist": "Pete Venters",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/3447aeaf-3b26-442a-99d4-0a7ee76c8e76.jpg?1562053291"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -132,6 +132,13 @@ internal fun EmitCtx.renderPlayerAction(node: JsonObject, tvar: String?): Dsl? {
             // bound-target-player form renders; an untargeted/you form scaffolds rather than guess.
             return if (ptv != null) call("Patterns.Library.shuffleGraveyardIntoLibrary", arg(Lit(ptv))) else null
         }
+        "TakeAnExtraTurn" -> {
+            // "Target player takes an extra turn after this one" (Time Warp). Only the
+            // bound-target-player form renders here — the untargeted "take an extra turn"
+            // (Time Walk) is the standalone `simple("TakeAnExtraTurn", …)` handler, and the
+            // "lose at end step" variant (Last Chance) is the `extraTurnEffect` spell shortcut.
+            return if (ptv != null) call("TakeExtraTurnEffect", arg("target", Lit(ptv))) else null
+        }
     }
     return null
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DismissScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DismissScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Dismiss (TMP).
+ *
+ * Oracle: "Counter target spell. Draw a card."
+ *
+ * Reuses existing primitives ([com.wingedsheep.sdk.dsl.Effects.CounterSpell] +
+ * [com.wingedsheep.sdk.dsl.Effects.DrawCards]); the test confirms the composed behaviour
+ * resolves — the targeted spell is countered and the caster draws a card.
+ */
+class DismissScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dismiss — counter target spell, draw a card") {
+            test("counters the targeted spell and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dismiss")
+                    .withLandsOnBattlefield(1, "Island", 4) // {2}{U}{U}
+                    .withCardInLibrary(1, "Island") // something to draw
+                    // Player 2 (active player) has a sorcery-speed spell to counter
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1) // player 1 holds only Dismiss
+
+                // Player 2 puts Grizzly Bears on the stack during their main phase
+                val castResult = game.castSpell(2, "Grizzly Bears")
+                withClue("Casting Grizzly Bears should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                // Player 2 passes priority so Player 1 can respond
+                game.passPriority()
+
+                // Player 1 responds with Dismiss (instant) targeting Grizzly Bears on the stack
+                val dismissResult = game.castSpellTargetingStackSpell(1, "Dismiss", "Grizzly Bears")
+                withClue("Casting Dismiss should succeed: ${dismissResult.error}") {
+                    dismissResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be countered (in player 2's graveyard, not on battlefield)") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("Dismiss leaves hand (-1) and draws a card (+1) -> net 0 vs before-cast hand") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MantaRidersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MantaRidersScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Manta Riders (TMP).
+ *
+ * Oracle: "{U}: This creature gains flying until end of turn."
+ *
+ * Reuses [com.wingedsheep.sdk.dsl.Effects.GrantKeyword] targeting [EffectTarget.Self]; the
+ * test confirms activating the ability grants flying via projected state.
+ */
+class MantaRidersScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Manta Riders — {U}: gains flying until end of turn") {
+            test("does not have flying before activation") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Manta Riders", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val riders = game.findPermanent("Manta Riders")!!
+                withClue("Manta Riders has no flying by default") {
+                    game.state.projectedState.hasKeyword(riders, Keyword.FLYING) shouldBe false
+                }
+            }
+
+            test("gains flying after activating the ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Manta Riders", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 1) // pays {U}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val riders = game.findPermanent("Manta Riders")!!
+                val abilityId = cardRegistry.getCard("Manta Riders")!!.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = riders, abilityId = abilityId)
+                )
+                withClue("Activating Manta Riders should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Manta Riders should have flying after activation") {
+                    game.state.projectedState.hasKeyword(riders, Keyword.FLYING) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoltariPriestScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoltariPriestScenarioTest.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Soltari Priest (TMP).
+ *
+ * Oracle: "Protection from red" + "Shadow".
+ *
+ * Reuses [com.wingedsheep.sdk.scripting.KeywordAbility.Protection] and the [Keyword.SHADOW]
+ * keyword (combat handled by the engine's ShadowRule). The test confirms both keywords are
+ * present in projected state.
+ */
+class SoltariPriestScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Soltari Priest — Protection from red + Shadow") {
+            test("has shadow and protection from red, but not other protections") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Soltari Priest", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val priest = game.findPermanent("Soltari Priest")!!
+                val projected = game.state.projectedState
+
+                withClue("Soltari Priest should have shadow") {
+                    projected.hasKeyword(priest, Keyword.SHADOW) shouldBe true
+                }
+                withClue("Soltari Priest should have protection from red") {
+                    projected.hasKeyword(priest, "PROTECTION_FROM_RED") shouldBe true
+                }
+                withClue("Soltari Priest should not have protection from other colors") {
+                    projected.hasKeyword(priest, "PROTECTION_FROM_WHITE") shouldBe false
+                    projected.hasKeyword(priest, "PROTECTION_FROM_BLUE") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TimeWarpScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TimeWarpScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Time Warp (TMP).
+ *
+ * Oracle: "Target player takes an extra turn after this one."
+ *
+ * Reuses [com.wingedsheep.sdk.scripting.effects.TakeExtraTurnEffect] with a player target.
+ * In a 2-player game an extra turn is modeled by the other player skipping their next turn
+ * ([SkipNextTurnComponent]). The test confirms the targeted player's opponent is set to skip.
+ */
+class TimeWarpScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Time Warp — target player takes an extra turn") {
+            test("self-target: caster's opponent skips their next turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Time Warp")
+                    .withLandsOnBattlefield(1, "Island", 5) // {3}{U}{U}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val result = game.castSpellTargetingPlayer(1, "Time Warp", targetPlayerNumber = 1)
+                withClue("Casting Time Warp should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Player 1 takes the extra turn, so Player 2 (its opponent) skips a turn") {
+                    game.state.getEntity(game.player2Id)?.has<SkipNextTurnComponent>() shouldBe true
+                    game.state.getEntity(game.player1Id)?.has<SkipNextTurnComponent>() shouldBe false
+                }
+            }
+
+            test("targeting the opponent: opponent takes the extra turn, caster skips") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Time Warp")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val result = game.castSpellTargetingPlayer(1, "Time Warp", targetPlayerNumber = 2)
+                withClue("Casting Time Warp should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Player 2 takes the extra turn, so Player 1 (its opponent) skips a turn") {
+                    game.state.getEntity(game.player1Id)?.has<SkipNextTurnComponent>() shouldBe true
+                    game.state.getEntity(game.player2Id)?.has<SkipNextTurnComponent>() shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards (all Tempest-canonical, previously unimplemented)

| Card | Cost / Type | Oracle | Implementation |
|------|-------------|--------|----------------|
| **Dismiss** | {2}{U}{U} Instant | Counter target spell. Draw a card. | `Effects.CounterSpell() then Effects.DrawCards(1)` |
| **Manta Riders** | {U} 1/1 Merfolk | {U}: This creature gains flying until end of turn. | `Effects.GrantKeyword(FLYING, EffectTarget.Self)` activated ability |
| **Soltari Priest** | {W}{W} 2/1 Soltari Cleric | Protection from red; Shadow | `KeywordAbility.Protection(Color.RED)` + `Keyword.SHADOW` |
| **Time Warp** | {3}{U}{U} Sorcery | Target player takes an extra turn after this one. | `TakeExtraTurnEffect(target = player)` |

All four reuse existing SDK primitives — no new engine effects/triggers/conditions. Each has a passing Kotest scenario test in `rules-engine`:
- `DismissScenarioTest` — counters the targeted stack spell and nets a card.
- `MantaRidersScenarioTest` — has no flying by default; gains flying (projected state) after activation.
- `SoltariPriestScenarioTest` — has Shadow + protection-from-red in projected state, no other protections.
- `TimeWarpScenarioTest` — targeted player takes the extra turn (its opponent gets `SkipNextTurnComponent`), both self-target and opponent-target.

## mtgish tooling changes

Three of the four already emitted as **complete renders** out of the box. **Time Warp** was `SCAFFOLD` because the `PlayerAction` envelope handler had no `TakeAnExtraTurn` case (`STRUCTURE needs human wiring: PlayerAction`).

Added a `TakeAnExtraTurn` case to `renderPlayerAction` (`PlayerContinuousHandlers.kt`): "target player takes an extra turn" now renders `TakeExtraTurnEffect(target = <bound player>)`. Per the fidelity policy it only renders the **bound-target-player** form and declines (`-> SCAFFOLD`) otherwise — the untargeted form (Time Walk) keeps its standalone `simple("TakeAnExtraTurn", …)` handler, and the lose-at-end-step form (Last Chance / Final Fortune) keeps its `extraTurnEffect` spell shortcut. One handler entry, benefits every set with a targeted extra-turn spell. The capability bridge already mapped `TakeAnExtraTurn` + the `PlayerAction` envelope, so no bridge change was needed.

Removed a redundant explicit `description` from Manta Riders' activated ability so the engine's auto-derived description (which the emitter relies on) matches — this is the established convention for generated cards (e.g. POR `CapriciousSorcerer`).

### Final fidelity tiers
All four cards: **Complete render / AUTO**, gameplay-tree match the golden under `coverage-verify --set TMP`.

## Verification
- All four scenario tests pass.
- `coverage-verify POR` — **158/158 GATE PASS, 0 mismatch** (kept calibrated).
- `coverage-verify TMP` — all four cards gameplay-tree match the golden. The sole remaining TMP gate mismatch is **Reckless Spite**, a pre-existing, untouched card (`byDestruction` golden vs emitter) — not part of this change.
- `EmitterGoldenTest` (POR fixture) unchanged and passing.
- TMP card snapshot golden re-blessed (only the four new cards added).
- `mtg-sets` + `mtgish-tooling` test suites pass; all touched modules compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)