### PR TITLE
feat(tmp): implement Diabolic Edict, Dauthi Slayer, Pit Imp, Dread of Night + mtgish autogen

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/DauthiSlayer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/DauthiSlayer.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.MustAttack
+
+/**
+ * Dauthi Slayer
+ * {B}{B}
+ * Creature — Dauthi Soldier
+ * 2/2
+ * Shadow (This creature can block or be blocked by only creatures with shadow.)
+ * This creature attacks each combat if able.
+ */
+val DauthiSlayer = card("Dauthi Slayer") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Dauthi Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Shadow (This creature can block or be blocked by only creatures with shadow.)\n" +
+        "This creature attacks each combat if able."
+
+    keywords(Keyword.SHADOW)
+
+    staticAbility {
+        ability = MustAttack()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Dermot Power"
+        flavorText = "\"They have knives for every soul.\"\n—Lyna, Soltari emissary"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/652ccd79-aefd-4b45-b747-75190da0cfc6.jpg?1562054258"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/DiabolicEdict.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/DiabolicEdict.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect
+
+/**
+ * Diabolic Edict
+ * {1}{B}
+ * Instant
+ * Target player sacrifices a creature of their choice.
+ */
+val DiabolicEdict = card("Diabolic Edict") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target player sacrifices a creature of their choice."
+
+    spell {
+        val player = target("target player", Targets.Player)
+        effect = ForceSacrificeEffect(GameObjectFilter.Creature, 1, player)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Ron Spencer"
+        flavorText = "Greven il-Vec lifted Vhati off his feet. \"The fall will give you time to think on your failure.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2ecf2ee-1e2d-4ab2-8b2c-717c794b09b2.jpg?1562055897"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/DreadOfNight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/DreadOfNight.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Dread of Night
+ * {B}
+ * Enchantment
+ * White creatures get -1/-1.
+ */
+val DreadOfNight = card("Dread of Night") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "White creatures get -1/-1."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = -1,
+            toughnessBonus = -1,
+            filter = GroupFilter(GameObjectFilter.Creature.withColor(Color.WHITE))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "130"
+        artist = "Richard Thomas"
+        flavorText = "\"These moonless, foreign skies keep me in thrall. Dark whispers echo in the night, and I cannot resist.\"\n—Selenia, dark angel"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d08586d4-8163-454c-b8d8-c5034c4aee6c.jpg?1562056862"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/PitImp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/PitImp.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pit Imp
+ * {B}
+ * Creature — Imp
+ * 0/1
+ * Flying
+ * {B}: This creature gets +1/+0 until end of turn. Activate no more than twice each turn.
+ */
+val PitImp = card("Pit Imp") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Imp"
+    power = 0
+    toughness = 1
+    oracleText = "Flying\n{B}: This creature gets +1/+0 until end of turn. Activate no more than twice each turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.MaxPerTurn(2))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Phil Foglio"
+        flavorText = "The moans of the Death Pits were underscored by the chattering of imps, for whom the ship was cause for much discussion."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24c7acfe-b5b2-426f-a5a1-1ff8ef7ebf72.jpg?1562052816"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -107,6 +107,98 @@
     ]
 }
 
+// Dauthi Slayer
+{
+    "name": "Dauthi Slayer",
+    "manaCost": "{B}{B}",
+    "typeLine": "Creature — Dauthi Soldier",
+    "oracleText": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nThis creature attacks each combat if able.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "SHADOW"
+    ],
+    "script": {
+        "staticAbilities": [
+            "MustAttack"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "artist": "Dermot Power",
+        "flavorText": "\"They have knives for every soul.\"\n—Lyna, Soltari emissary",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/652ccd79-aefd-4b45-b747-75190da0cfc6.jpg?1562054258"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Diabolic Edict
+{
+    "name": "Diabolic Edict",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target player sacrifices a creature of their choice.",
+    "script": {
+        "spellEffect": {
+            "type": "ForceSacrifice",
+            "filter": "creature",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target player"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "Ron Spencer",
+        "flavorText": "Greven il-Vec lifted Vhati off his feet. \"The fall will give you time to think on your failure.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2ecf2ee-1e2d-4ab2-8b2c-717c794b09b2.jpg?1562055897"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dread of Night
+{
+    "name": "Dread of Night",
+    "manaCost": "{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "White creatures get -1/-1.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": -1,
+                "toughnessBonus": -1,
+                "filter": {
+                    "baseFilter": "creature white"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Thomas",
+        "flavorText": "\"These moonless, foreign skies keep me in thrall. Dark whispers echo in the night, and I cannot resist.\"\n—Selenia, dark angel",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d08586d4-8163-454c-b8d8-c5034c4aee6c.jpg?1562056862"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Fighting Drake
 {
     "name": "Fighting Drake",
@@ -487,6 +579,59 @@
         "imageUri": "https://cards.scryfall.io/normal/front/3/0/307f5d5e-3a4b-430e-8769-fb553216befa.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Pit Imp
+{
+    "name": "Pit Imp",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Imp",
+    "oracleText": "Flying\n{B}: This creature gets +1/+0 until end of turn. Activate no more than twice each turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{B}"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    {
+                        "type": "MaxPerTurn",
+                        "count": 2
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Phil Foglio",
+        "flavorText": "The moans of the Death Pits were underscored by the chattering of imps, for whom the ship was cause for much discussion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/24c7acfe-b5b2-426f-a5a1-1ff8ef7ebf72.jpg?1562052816"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
 }
 
 // Reckless Spite

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -507,6 +507,18 @@ private fun EmitCtx.activationRestrictionLines(rule: JsonObject): List<String>? 
             "        )",
         )
     }
+    // "Activate no more than N times each turn" (Pit Imp / Phyrexian Battleflies) -> MaxPerTurn(N).
+    // The modifier list is the rule's args after the cost + action list; render only when EVERY
+    // modifier present is this exact shape, so an unrecognised modifier still scaffolds.
+    val modifiers = (rule["args"].asArr ?: emptyList()).filterIsInstance<JsonObject>()
+        .filter { it.strField("_ActivateModifier") != null }
+    if (modifiers.isNotEmpty() && modifiers.all { it.strField("_ActivateModifier") == "ActivateNoMoreThanNumberTimesEachTurn" }) {
+        val lines = modifiers.map { mod ->
+            val n = findInteger(mod.field("args")) as? Int ?: return run { reasons.add("activated-modifiers"); null }
+            "ActivationRestriction.MaxPerTurn($n)"
+        }
+        return listOf("        restrictions = listOf(${lines.joinToString(", ")})")
+    }
     reasons.add("activated-modifiers")
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -132,6 +132,14 @@ internal fun EmitCtx.renderPlayerAction(node: JsonObject, tvar: String?): Dsl? {
             // bound-target-player form renders; an untargeted/you form scaffolds rather than guess.
             return if (ptv != null) call("Patterns.Library.shuffleGraveyardIntoLibrary", arg(Lit(ptv))) else null
         }
+        "SacrificeAPermanent" -> {
+            // "target player sacrifices a <filter> of their choice" — the edict (Diabolic Edict,
+            // Gatekeeper of Malakir). The sacrificing player (who chooses) is the bound target player;
+            // render ForceSacrificeEffect(filter, 1, targetPlayer). Only the bound-target-player form
+            // renders — an untargeted/each-player form scaffolds rather than guess the actor.
+            val filter = gameObjectFilterExpr(inner["args"]) ?: return null
+            return if (ptv != null) call("ForceSacrificeEffect", arg(filter), arg("1"), arg(Lit(ptv))) else null
+        }
     }
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -224,6 +224,9 @@ private fun EmitCtx.staticAbilityExpr(ruleName: String, ruleNode: JsonObject): D
         }
         "MustBlockAttacker" -> return call("MustBlock")
         "MustAttackPlayer" -> return call("MustAttack")
+        // "This creature attacks each combat if able" (Dauthi Slayer, Juggernaut) — the unfiltered
+        // self MustAttack, distinct from MustAttackPlayer which carries a forced defender.
+        "MustAttack" -> return call("MustAttack")
         "CanBlockAnyNumberOfCreatures" -> return call("CanBlockAnyNumber")
     }
     return null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauthiSlayerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauthiSlayerScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Dauthi Slayer ({B}{B} Creature — Dauthi Soldier 2/2):
+ * Shadow. This creature attacks each combat if able.
+ */
+class DauthiSlayerScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    test("Dauthi Slayer has shadow") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val slayer = driver.putCreatureOnBattlefield(you, "Dauthi Slayer")
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(slayer, Keyword.SHADOW) shouldBe true
+    }
+
+    test("Dauthi Slayer must attack each combat if able") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val slayer = driver.putCreatureOnBattlefield(you, "Dauthi Slayer")
+        driver.removeSummoningSickness(slayer)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        // Declaring no attackers must fail — Dauthi Slayer is forced to attack.
+        val noAttack = driver.submit(DeclareAttackers(playerId = you, attackers = emptyMap()))
+        noAttack.isSuccess shouldBe false
+        noAttack.error shouldContain "must attack"
+
+        // Declaring it as an attacker succeeds.
+        val attack = driver.submit(DeclareAttackers(playerId = you, attackers = mapOf(slayer to opponent)))
+        attack.isSuccess shouldBe true
+    }
+
+    test("Dauthi Slayer is not forced to attack when it cannot attack (tapped)") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val slayer = driver.putCreatureOnBattlefield(you, "Dauthi Slayer")
+        driver.removeSummoningSickness(slayer)
+        // A tapped creature is unable to attack, so "attacks if able" does not force it.
+        driver.tapPermanent(slayer)
+
+        // A second, ready attacker keeps combat in this turn so we evaluate the forced-attack
+        // check against the still-tapped Dauthi Slayer (otherwise the driver advances a turn).
+        val bear = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        driver.removeSummoningSickness(bear)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        // Declaring only the bear succeeds — the tapped Dauthi Slayer is not forced to attack.
+        val attack = driver.submit(DeclareAttackers(playerId = you, attackers = mapOf(bear to opponent)))
+        attack.isSuccess shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiabolicEdictScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiabolicEdictScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Diabolic Edict ({1}{B} Instant): Target player sacrifices a creature of their choice.
+ *
+ * The card is an edict, modelled with [com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect]
+ * targeting a player. When the targeted player controls exactly one creature, it is
+ * auto-sacrificed at resolution.
+ */
+class DiabolicEdictScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    test("Diabolic Edict forces the targeted player to sacrifice their only creature") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent has a single creature -> auto-sacrificed.
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val edict = driver.putCardInHand(you, "Diabolic Edict")
+        driver.giveMana(you, Color.BLACK, 2)
+        driver.castSpell(you, edict, listOf(opponent))
+        driver.bothPass()
+
+        driver.getCreatures(opponent).size shouldBe 0
+    }
+
+    test("Diabolic Edict can target its own caster") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        val edict = driver.putCardInHand(you, "Diabolic Edict")
+        driver.giveMana(you, Color.BLACK, 2)
+        driver.castSpell(you, edict, listOf(you))
+        driver.bothPass()
+
+        driver.getCreatures(you).size shouldBe 0
+    }
+
+    test("Diabolic Edict resolves harmlessly when the targeted player has no creatures") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val edict = driver.putCardInHand(you, "Diabolic Edict")
+        driver.giveMana(you, Color.BLACK, 2)
+        val result = driver.castSpell(you, edict, listOf(opponent))
+        result.error shouldBe null
+        driver.bothPass()
+
+        driver.getCreatures(opponent).size shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadOfNightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadOfNightScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dread of Night ({B} Enchantment): White creatures get -1/-1.
+ *
+ * A color-filtered lord modelled with [com.wingedsheep.sdk.scripting.ModifyStats] over a
+ * white-creature group filter, affecting every player's white creatures.
+ */
+class DreadOfNightScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 20, "Swamp" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    test("Dread of Night gives white creatures -1/-1") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // White Knight is a 2/2 white creature.
+        val knight = driver.putCreatureOnBattlefield(you, "White Knight")
+        projector.getProjectedPower(driver.state, knight) shouldBe 2
+        projector.getProjectedToughness(driver.state, knight) shouldBe 2
+
+        driver.putPermanentOnBattlefield(you, "Dread of Night")
+
+        projector.getProjectedPower(driver.state, knight) shouldBe 1
+        projector.getProjectedToughness(driver.state, knight) shouldBe 1
+    }
+
+    test("Dread of Night affects white creatures regardless of controller and ignores non-white") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val theirWhite = driver.putCreatureOnBattlefield(opponent, "White Knight")
+        // Grizzly Bears is a green 2/2 — unaffected.
+        val green = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        driver.putPermanentOnBattlefield(you, "Dread of Night")
+
+        projector.getProjectedPower(driver.state, theirWhite) shouldBe 1
+        projector.getProjectedToughness(driver.state, theirWhite) shouldBe 1
+        projector.getProjectedPower(driver.state, green) shouldBe 2
+        projector.getProjectedToughness(driver.state, green) shouldBe 2
+    }
+
+    test("Two Dread of Night stack to -2/-2") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val knight = driver.putCreatureOnBattlefield(you, "White Knight")
+
+        driver.putPermanentOnBattlefield(you, "Dread of Night")
+        driver.putPermanentOnBattlefield(you, "Dread of Night")
+
+        projector.getProjectedPower(driver.state, knight) shouldBe 0
+        projector.getProjectedToughness(driver.state, knight) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PitImpScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PitImpScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pit Imp ({B} Creature — Imp 0/1):
+ * Flying. {B}: This creature gets +1/+0 until end of turn. Activate no more than twice each turn.
+ */
+class PitImpScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    fun pumpAbilityId(driver: GameTestDriver) =
+        driver.cardRegistry.getCard("Pit Imp")!!.script.activatedAbilities[0].id
+
+    test("Pit Imp has flying") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val imp = driver.putCreatureOnBattlefield(you, "Pit Imp")
+        projector.project(driver.state).hasKeyword(imp, Keyword.FLYING) shouldBe true
+    }
+
+    test("Pit Imp pump gives +1/+0 and can be activated twice but not a third time") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val imp = driver.putCreatureOnBattlefield(you, "Pit Imp")
+        projector.getProjectedPower(driver.state, imp) shouldBe 0
+
+        driver.giveMana(you, Color.BLACK, 3)
+
+        val first = driver.submit(ActivateAbility(playerId = you, sourceId = imp, abilityId = pumpAbilityId(driver)))
+        first.isSuccess shouldBe true
+        driver.bothPass()
+        projector.getProjectedPower(driver.state, imp) shouldBe 1
+        projector.getProjectedToughness(driver.state, imp) shouldBe 1
+
+        val second = driver.submit(ActivateAbility(playerId = you, sourceId = imp, abilityId = pumpAbilityId(driver)))
+        second.isSuccess shouldBe true
+        driver.bothPass()
+        projector.getProjectedPower(driver.state, imp) shouldBe 2
+
+        // Third activation in the same turn is illegal (MaxPerTurn(2)).
+        val third = driver.submit(ActivateAbility(playerId = you, sourceId = imp, abilityId = pumpAbilityId(driver)))
+        third.isSuccess shouldBe false
+    }
+})


### PR DESCRIPTION
## Cards

Four TMP-original commons/uncommon (canonical home is Tempest — confirmed by `check-card-printing`), all composed from existing SDK primitives (no new effects/keywords/conditions):

| Card | Cost | Implementation |
|------|------|----------------|
| **Diabolic Edict** | `{1}{B}` Instant | `ForceSacrificeEffect(Creature, 1, targetPlayer)` — target player sacrifices a creature of their choice |
| **Dauthi Slayer** | `{B}{B}` 2/2 | `Keyword.SHADOW` + `MustAttack()` static ("attacks each combat if able") |
| **Pit Imp** | `{B}` 0/1 | `Flying` + `{B}` activated `ModifyStats(+1/+0, Self)` with `ActivationRestriction.MaxPerTurn(2)` |
| **Dread of Night** | `{B}` Enchantment | `ModifyStats(-1/-1)` over `GroupFilter(Creature.withColor(WHITE))` — affects all players' white creatures |

Each card has a passing `rules-engine` scenario test (11 tests total): edict auto-sac / self-target / no-creatures; shadow keyword / forced-attack / not-forced-when-tapped; flying / +1/+0 twice-then-blocked; -1/-1 / controller-agnostic + ignores non-white / two stack to -2/-2.

## mtgish tooling

Three of the four previously tiered **SCAFFOLD**; taught the emitter to render their shapes so all four now emit at **AUTO** (complete render), reusable across every set:

- **`StaticAbilities.kt`** — `_PermanentRule` `"MustAttack"` → `MustAttack()` (the unfiltered self must-attack, distinct from `MustAttackPlayer`).
- **`CardStructure.kt`** — `ActivatedWithModifiers` modifier `ActivateNoMoreThanNumberTimesEachTurn(N)` → `ActivationRestriction.MaxPerTurn(N)`, rendered only when **every** modifier present is this exact shape (else scaffolds).
- **`PlayerContinuousHandlers.kt`** — `PlayerAction` wrapping `SacrificeAPermanent` → the edict `ForceSacrificeEffect(filter, 1, targetPlayer)`, only for the bound-target-player form (untargeted/each-player still scaffolds).

Dread of Night was already AUTO (existing `EachPermanentLayerEffect` → lord path).

## Verification

- `coverage-verify POR` → **158/158 GATE PASS** (0-mismatch preserved).
- `EmitterGoldenTest` (in-suite) unchanged/green — only POR is fixtured; my changes don't alter POR output.
- `CardDefinitionSnapshotTest` re-blessed for TMP — diff adds only the four new card trees.

No SCAFFOLD cards remain among the four. Note: `coverage-verify TMP` reports one pre-existing mismatch on **Reckless Spite** (a `byDestruction` emitter gap in a card committed earlier); it is unrelated to these changes, and TMP is not a calibrated gate set (`coverage-verify-all` gates only POR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)