### PR TITLE
Map mtgish CreateFutureReplaceWouldDealDamage (prevent next N damage)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/ClergyEnVec.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/ClergyEnVec.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Clergy en-Vec
+ * {1}{W}
+ * Creature — Human Cleric
+ * 1/1
+ * {T}: Prevent the next 1 damage that would be dealt to any target this turn.
+ */
+val ClergyEnVec = card("Clergy en-Vec") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Prevent the next 1 damage that would be dealt to any target this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", AnyTarget())
+        effect = Effects.PreventNextDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Heather Hudson"
+        flavorText = "\"Faith's shield is hammered out by the blows of unbelievers.\"\n—Oracle en-Vec"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fcb0e068-16d0-4e1c-acad-0a6d34148c5a.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/OrimSamiteHealer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/OrimSamiteHealer.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Orim, Samite Healer
+ * {1}{W}{W}
+ * Legendary Creature — Human Cleric
+ * 1/3
+ * {T}: Prevent the next 3 damage that would be dealt to any target this turn.
+ */
+val OrimSamiteHealer = card("Orim, Samite Healer") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 1
+    toughness = 3
+    oracleText = "{T}: Prevent the next 3 damage that would be dealt to any target this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", AnyTarget())
+        effect = Effects.PreventNextDamage(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "33"
+        artist = "Kaja Foglio"
+        flavorText = "\"The silkworm spins itself a new existence. So the healer weaves the threads of life.\"\n—Orim, Samite healer"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/7086d077-f083-4870-8b0b-2d34aca49df1.jpg"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -107,6 +107,52 @@
     ]
 }
 
+// Clergy en-Vec
+{
+    "name": "Clergy en-Vec",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{T}: Prevent the next 1 damage that would be dealt to any target this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "artist": "Heather Hudson",
+        "flavorText": "\"Faith's shield is hammered out by the blows of unbelievers.\"\n—Oracle en-Vec",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fcb0e068-16d0-4e1c-acad-0a6d34148c5a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Fighting Drake
 {
     "name": "Fighting Drake",
@@ -464,6 +510,53 @@
                 "text": "The ability only triggers when one or more creatures attack you. It will not trigger on creatures attacking a planeswalker you control."
             }
         ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Orim, Samite Healer
+{
+    "name": "Orim, Samite Healer",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "{T}: Prevent the next 3 damage that would be dealt to any target this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "RARE",
+        "artist": "Kaja Foglio",
+        "flavorText": "\"The silkworm spins itself a new existence. So the healer weaves the threads of life.\"\n—Orim, Samite healer",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/7086d077-f083-4870-8b0b-2d34aca49df1.jpg"
     },
     "colorIdentityOverride": [
         "WHITE"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -17,6 +17,12 @@ internal fun BridgeBuilder.damageLifeAndCards() {
     // "The next time you would draw a card this turn, [do X] instead" (the Onslaught Words cycle); the
     // replacement action's own capability is surfaced via the `_ReplacementActionWouldDraw` discriminator.
     effect("CreateFutureReplaceWouldDraw", "ReplaceNextDrawWith")
+    // "Prevent the next N damage that would be dealt to <recipient> this turn" — the damage twin of the
+    // draw replacement above (Daru Healer, Samite Healer, the Circles' "to you" mode, Healing Salve, …).
+    // The common prevent shape is one PreventDamageEffect; redirect / gain-life / distributed replacement
+    // variants compose further primitives, so this is `composed` (mirrors `CreateReplaceWouldDealDamageUntil`).
+    composed("CreateFutureReplaceWouldDealDamage", "PreventDamageShield (prevent next N damage to recipient)",
+        composes = listOf("PreventDamageShield"))
     composed("GainLifeForEach", "GainLife + DynamicAmount", composes = listOf("GainLife"))
     effect("GainLife", "GainLife")
     effect("LoseLife", "LoseLife")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
+import com.wingedsheep.tooling.coverage.objects
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -136,6 +137,51 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         val inner = asReplacementActions(a.getOrNull(1)) ?: return@on null
         val edsl = renderEffectList(inner, tvar) ?: return@on null
         call("Effects.ReplaceNextDraw", arg(edsl))
+    }
+
+    // "{cost}: Prevent the next N damage that would be dealt to <recipient> this turn." (Daru Healer,
+    // Samite Healer, the Circles' "to you" mode, Healing Salve, …) — the damage twin of the draw
+    // replacement above. Only the fixed-amount "prevent that damage" shape maps to PreventNextDamage:
+    //  - the event is the next-AMOUNT-to-recipient form (the next-TIME / by-source / distributed events
+    //    are different prevention shapes we don't render here),
+    //  - the amount is a literal (a cast-time `X` prevention can't be threaded — see the creator's note),
+    //  - the single replacement is PreventThatDamage (redirect / gain-life / instead variants scaffold),
+    //  - the recipient resolves to a target we render exactly.
+    on("CreateFutureReplaceWouldDealDamage") { _, args, tvar ->
+        val a = args.asArr ?: return@on null
+        val event = a.getOrNull(0) as? JsonObject ?: return@on null
+        if (!jsonContains(event, "_FutureReplacableEventWouldDealDamage",
+                "NextAmountOfDamageThatWouldBeDealtThisTurnToRecipient")) return@on null
+        val repl = a.getOrNull(1) as? JsonArray ?: return@on null
+        if (repl.size != 1 ||
+            (repl[0] as? JsonObject)?.strField("_ReplacementActionWouldDealDamage") != "PreventThatDamage")
+            return@on null
+        val amount = findInteger(event) as? Int ?: return@on null  // X / "all" -> SCAFFOLD
+        val target = damagePreventionRecipient(event, tvar) ?: return@on null
+        call("Effects.PreventNextDamage", arg("$amount"), arg(Lit(target)))
+    }
+}
+
+/** Resolve the damage recipient of a `NextAmountOfDamage…ToRecipient` event to an EffectTarget DSL:
+ *  a bound target ref -> the ability's target local [tvar]; "you" -> the controller; this permanent ->
+ *  self. Returns null for recipients we can't render exactly (distributed, host permanent, or a bound
+ *  target ref with no target rendered), so the card scaffolds rather than prevent damage to the wrong
+ *  thing. */
+private fun damagePreventionRecipient(event: JsonObject, tvar: String?): String? {
+    val recip = event.objects().firstOrNull { it.containsKey("_SingleDamageRecipient") } ?: return null
+    return when (recip.strField("_SingleDamageRecipient")) {
+        "Ref_AnyTarget", "Ref_TargetPlayerOrPermanent" -> tvar
+        "Permanent" -> when (recip["args"].strField("_Permanent")) {
+            "Ref_TargetPermanent" -> tvar
+            "ThisPermanent" -> "EffectTarget.Self"
+            else -> null
+        }
+        "Player" -> when (recip["args"].strField("_Player")) {
+            "You" -> "EffectTarget.Controller"
+            "Ref_TargetPlayer" -> tvar
+            else -> null
+        }
+        else -> null  // DistributedAnyTarget, host permanent, …
     }
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClergyEnVecTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClergyEnVecTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmp.cards.ClergyEnVec
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Clergy en-Vec — auto-generated from the mtgish IR by mtgish-tooling
+ * (the `CreateFutureReplaceWouldDealDamage` mapping) and promoted with this scenario test.
+ *
+ * Clergy en-Vec: {1}{W}
+ * Creature — Human Cleric
+ * 1/1
+ * {T}: Prevent the next 1 damage that would be dealt to any target this turn.
+ */
+class ClergyEnVecTest : FunSpec({
+
+    val abilityId = ClergyEnVec.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("prevents the next 1 damage to target creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 20, "Mountain" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val clergy = driver.putCreatureOnBattlefield(activePlayer, "Clergy en-Vec")
+        val target = driver.putCreatureOnBattlefield(activePlayer, "Hill Giant")
+        driver.removeSummoningSickness(clergy)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = clergy,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Lightning Bolt deals 3 — the shield prevents 1, so 2 lands.
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(target)))
+        driver.bothPass()
+
+        val damage = driver.state.getEntity(target)?.get<DamageComponent>()?.amount ?: 0
+        damage shouldBe 2
+    }
+
+    test("prevents the next 1 damage to target player") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 20, "Mountain" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val clergy = driver.putCreatureOnBattlefield(activePlayer, "Clergy en-Vec")
+        driver.removeSummoningSickness(clergy)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = clergy,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Player(opponent)))
+        driver.bothPass()
+
+        driver.getLifeTotal(opponent) shouldBe 18
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrimSamiteHealerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrimSamiteHealerTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmp.cards.OrimSamiteHealer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Orim, Samite Healer — auto-generated from the mtgish IR by mtgish-tooling
+ * (the `CreateFutureReplaceWouldDealDamage` mapping) and promoted with this scenario test.
+ *
+ * Orim, Samite Healer: {1}{W}{W}
+ * Legendary Creature — Human Cleric
+ * 1/3
+ * {T}: Prevent the next 3 damage that would be dealt to any target this turn.
+ */
+class OrimSamiteHealerTest : FunSpec({
+
+    val abilityId = OrimSamiteHealer.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("prevents the next 3 damage to target player, the rest lands") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 20, "Mountain" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val orim = driver.putCreatureOnBattlefield(activePlayer, "Orim, Samite Healer")
+        driver.removeSummoningSickness(orim)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = orim,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // First Lightning Bolt (3): the 3-damage shield prevents all of it.
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt1 = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt1, listOf(ChosenTarget.Player(opponent)))
+        driver.bothPass()
+        driver.getLifeTotal(opponent) shouldBe 20
+
+        // Second Lightning Bolt (3): the shield is spent, so all 3 lands.
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt2 = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt2, listOf(ChosenTarget.Player(opponent)))
+        driver.bothPass()
+        driver.getLifeTotal(opponent) shouldBe 17
+    }
+})


### PR DESCRIPTION
## What

Maps the mtgish `_Action` **`CreateFutureReplaceWouldDealDamage`** in `:mtgish-tooling` — the damage twin of the existing `CreateFutureReplaceWouldDraw` mapping. **201 cards** in the mtgish corpus carry this action; it was previously UNMAPPED, so every one probed `BLOCKED`.

### Bridge (capability dictionary — `bridge/DamageLifeAndCards.kt`)
A `composed` entry to `PreventDamageShield`, mirroring the sibling `CreateReplaceWouldDealDamageUntil`. The prevent shape is one `PreventDamageEffect`; redirect / gain-life / distributed replacement variants compose further primitives, so `composed` (not `effect`) is the honest kind.

### Emitter (rendering dictionary — `emitter/DamageDrawLifeHandlers.kt`)
An `on("CreateFutureReplaceWouldDealDamage")` handler that renders `Effects.PreventNextDamage(n, target)` for the canonical *"prevent the next N damage that would be dealt to &lt;recipient&gt; this turn"* shape only:

- event is the next-**amount**-to-recipient form,
- amount is a **literal** (a cast-time `X` prevention can't be threaded — see the creator's note),
- the single replacement is `PreventThatDamage`,
- the recipient resolves **exactly** (bound target → the ability's target local; `You` → `EffectTarget.Controller`; this permanent → `EffectTarget.Self`).

Everything else — cast-time X, next-**time**/by-source/distributed events, redirect/gain-life/instead replacements, host permanent — returns `null` and scaffolds, per the conservative fidelity policy. The emitter output matches the already-implemented Daru Healer's authoring byte-for-byte (`Effects.PreventNextDamage(1, t)`).

## Demonstration cards

Two TMP cards the emitter now renders **whole**, promoted with scenario tests:

| Card | Ability |
|------|---------|
| **Clergy en-Vec** | `{T}`: Prevent the next 1 damage that would be dealt to any target this turn. |
| **Orim, Samite Healer** | `{T}`: Prevent the next 3 damage that would be dealt to any target this turn. |

Both oracle texts verified against Scryfall; both are canonically TMP (earliest printing). The TMP card snapshot golden is re-blessed (+2 cards, additions only).

## Tests

- ✅ `EmitterGoldenTest` (POR fixture — hermetic emitter net)
- ✅ `:mtgish-tooling` unit tests
- ✅ `ClergyEnVecTest`, `OrimSamiteHealerTest` (new)
- ✅ `CardDefinitionSnapshotTest` (re-blessed TMP)
- ✅ `coverage-verify POR` — 195 cards emitted, compiled, gameplay-tree matched, **0 mismatch**

POR carries none of these cards, so the calibration gate is unaffected by the new handler (it can only newly-render previously-blocked cards, never alter an existing AUTO render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)