### PR TITLE
mtgish: map _Rule = Cycling + auto-gen Disciple of Law

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/DiscipleOfLaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/DiscipleOfLaw.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.usg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Disciple of Law
+ * {1}{W}
+ * Creature — Human Cleric
+ * 1/2
+ * Protection from red
+ * Cycling {2}
+ */
+val DiscipleOfLaw = card("Disciple of Law") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 2
+    oracleText = "Protection from red\nCycling {2}"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.RED)))
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Matthew D. Wilson"
+        flavorText = "A religious order for religious order."
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a5c8701-a294-4474-9747-129f972cfb18.jpg?1562920710"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/USG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/USG.json
@@ -225,6 +225,40 @@
     ]
 }
 
+// Disciple of Law
+{
+    "name": "Disciple of Law",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Protection from red\nCycling {2}",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "RED"
+            }
+        },
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Matthew D. Wilson",
+        "flavorText": "A religious order for religious order.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a5c8701-a294-4474-9747-129f972cfb18.jpg?1562920710"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Duress
 {
     "name": "Duress",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -15,4 +15,9 @@ internal fun BridgeBuilder.keywords() {
     // resolution is `AttachEquipment`. So it's composed, not a bare keyword (which would emit a
     // non-existent enum). The emitter renders only the canonical unrestricted shape (see Emitter.equipAbilityLine).
     composed("Equip", "equip: equipAbility(cost) -> sorcery-speed AttachEquipment activated ability", composes = listOf("AttachEquipment"))
+    // Cycling (CR 702.29) is a keyword ability with no `Keyword.CYCLING` enum member — `KeywordAbility.cycling(cost)`
+    // synthesises the activated "Discard this card: Draw a card" ability. Like Equip it's composed, not a bare
+    // keyword (PascalCase auto-resolve would look for a non-existent CYCLING enum and block it). The emitter renders
+    // the canonical pure-mana shape (see Emitter.kt `rname == "Cycling"`).
+    composed("Cycling", "cycling: KeywordAbility.cycling(cost) -> 'Discard this card: Draw a card' activated ability", composes = listOf("DrawCards"))
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscipleOfLawTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscipleOfLawTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Disciple of Law (USG) — {1}{W} Creature — Human Cleric, 1/2.
+ *
+ * "Protection from red
+ *  Cycling {2} ({2}, Discard this card: Draw a card.)"
+ *
+ * Exercises the Cycling keyword ability (CR 702.29) mapped through the mtgish
+ * `_Rule = Cycling` bridge entry: `KeywordAbility.cycling("{2}")` synthesises the
+ * "Discard this card: Draw a card" activated ability that can be played from hand.
+ */
+class DiscipleOfLawTest : ScenarioTestBase() {
+
+    init {
+        context("Disciple of Law's cycling ability") {
+
+            test("cycling pays {2}, discards the card, and draws a replacement") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Disciple of Law")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.isInHand(1, "Disciple of Law") shouldBe true
+
+                val cycle = game.cycleCard(1, "Disciple of Law")
+                withClue("Cycling should succeed: ${cycle.error}") { cycle.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Cycled card is discarded to the graveyard") {
+                    game.isInGraveyard(1, "Disciple of Law") shouldBe true
+                    game.isInHand(1, "Disciple of Law") shouldBe false
+                }
+                withClue("Cycling draws the next card off the library") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("cycling fails without the mana to pay its cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Disciple of Law")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.cycleCard(1, "Disciple of Law")
+
+                // With no mana available the cost can't be paid, so the card is neither
+                // discarded nor cycled — it stays in hand and the graveyard stays empty.
+                withClue("Cycling does not resolve without the mana to pay {2}") {
+                    game.isInHand(1, "Disciple of Law") shouldBe true
+                    game.isInGraveyard(1, "Disciple of Law") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds the mtgish→Argentum capability mapping for **`_Rule = Cycling`** (CR 702.29) in `:mtgish-tooling`, then auto-generates and finalizes a card that uses it.

## Why the mapping was missing

Cycling is a keyword ability with **no `Keyword.CYCLING` enum member** — `KeywordAbility.cycling(cost)` synthesises the "Discard this card: Draw a card" activated ability. The **emitter** already rendered it (`Emitter.kt`, `rname == "Cycling"`), but the **capability bridge** had no entry, so the probe's PascalCase→enum auto-resolve looked for a non-existent `CYCLING` enum and classified every Cycling card as `UNMAPPED`/blocked.

The fix mirrors **Equip** (also a keyword ability with no enum member): a one-line `composed("Cycling", …)` bridge entry.

```
composed("Cycling", "cycling: KeywordAbility.cycling(cost) -> 'Discard this card: Draw a card' activated ability", composes = listOf("DrawCards"))
```

## Impact

- In **USG**, `_Rule = Cycling` was the **#2 blocker (32 cards)**. After the mapping, FREE-to-implement jumps **+19** and Cycling leaves the blocked leaderboard.
- **POR calibration stays 100%** (`probe --calibrate POR` → 200/200).
- `EmitterGoldenTest` unaffected — the bridge change alters classification only, not emitted DSL.

## The card

Auto-generated via `coverage-generate --set USG`, then finalized:

**Disciple of Law** (USG · {1}{W} · 1/2 Human Cleric · Protection from red · Cycling {2}) — the red-hate twin of the already-implemented Disciple of Grace. Auto-discovered by `CardDiscovery` (no manual registration).

- Added `DiscipleOfLawTest` scenario test exercising the new mapping: cycling pays {2}, discards to the graveyard, and draws a replacement; and fails with no mana available.
- Re-blessed the USG card snapshot (only addition is Disciple of Law).

## Tests
- `:rules-engine:test --tests DiscipleOfLawTest` ✅ (both cases)
- `:mtgish-tooling:test` ✅ (incl. `EmitterGoldenTest`)
- `:mtg-sets *CardDefinitionSnapshotTest` ✅ (re-blessed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)