### PR TITLE
Map mtgish AtTheBeginningOfAPlayersUpkeep trigger in coverage tooling

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -10,6 +10,7 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("WhenACreatureBlocks", "trigger: blocks (Ydwen Efreet)")
     supported("WhenACreatureDealsCombatDamageToAPlayer", "trigger: combat damage to player")
     supported("WhenAPlayerCastsASpell", "trigger: a player casts a spell (Triggers.YouCastSpell / AnyPlayerCastsSpell / OpponentCastsSpell + type filters)")
+    supported("AtTheBeginningOfAPlayersUpkeep", "trigger: upkeep (Triggers.YourUpkeep / EachUpkeep / EachOpponentUpkeep)")
     supported("AtTheBeginningOfAPlayersEndStep", "trigger: end step (Triggers.YourEndStep / EachEndStep)")
 
     // Costs.


### PR DESCRIPTION
## What & why

Follow-up to #548 (which mapped the end-step phase-begin trigger). The **upkeep** phase-begin trigger is the single highest-volume bridge gap — ~595 leaderboard hits across 71 sets.

The merged upkeep work added the **emitter** rendering (`You`/`AnyPlayer`/`Opponent` → `Triggers.YourUpkeep` / `EachUpkeep` / `EachOpponentUpkeep`) but no **bridge** entry. Because `Autogen.classify` returns `BLOCKED` unless `Probe.analyze().coverable` — which needs a bridge mapping for the trigger — every upkeep card still classified `BLOCKED`. An emitter that renders a trigger is *dead for autogen* until the bridge `supported(...)` entry exists (the `WhenAPlayerCastsASpell` PR did both; upkeep had only the emitter).

## Change

- **bridge** (`TriggersCostsAndContinuous.kt`): one line — `supported("AtTheBeginningOfAPlayersUpkeep", …)`. No emitter change needed (all three scopes already render).

## Verification

- POR calibration **100%**.
- `EmitterGoldenTest` unchanged (emitter output is identical — this is a bridge-coverability change only).
- `coverage-verify POR` **GATE PASS (158/158)**.

Per-trigger immediate AUTOGEN delta is modest (most upkeep cards carry co-blockers), but the trigger is removed as a wall corpus-wide, compounding as effect-level emitter mappings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)