### PR TITLE
Add Ali from Cairo with LifeLossFloor replacement effect

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 60 / 78
+**Implemented:** 61 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -50,7 +50,7 @@
 - [x] Stone-Throwing Devils
 - [x] Aladdin
 - [x] Ali Baba
-- [ ] Ali from Cairo
+- [x] Ali from Cairo
 - [x] Bird Maiden
 - [x] Desert Nomads
 - [x] Hurr Jackal

--- a/backlog/sets/lord-of-the-rings/cards.md
+++ b/backlog/sets/lord-of-the-rings/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards (261 Draft / 30 Extra)
 **Release Date:** June 23, 2023
-**Implemented:** 197 / 291
+**Implemented:** 198 / 291
 Run `scripts/card-status --set LTR` (and `--list --set LTR`) to verify status at any time.
 The split below mirrors that script: **Draft** = Scryfall `booster: true`; **Extra** =
 starter-deck/special cards and basic lands.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2744,6 +2744,16 @@ replacementEffect {
   instances stack (×s multiply, +s sum) — two Leylines of Hope add 2 to every life-gain event.
 - `ModifyLifeLoss(multiplier, modifier, restrictions, appliesTo)` — same shape as `ModifyLifeGain` for life loss
   events (`LifeLossEvent`), plus a `restrictions: List<Condition>` list that further gates the replacement.
+- `LifeLossFloor(floor, restrictions, appliesTo)` — cap damage-induced life loss so the resulting life total
+  is ≥ `floor`. `appliesTo` is a `LifeLossEvent` whose `player` filter gates who is protected (default
+  `Player.Each`); `restrictions: List<Condition>` (evaluated against the source's controller) further
+  gates the floor — same shape as `ModifyLifeLoss.restrictions`. **Scope:** damage-as-life-loss only
+  (CR 120.3a); `LoseLifeExecutor` deliberately skips this step so pay-life costs and direct life-loss
+  effects bypass the floor (matching the Ali from Cairo ruling "does not apply to effects which reduce
+  your life without doing damage"). The damage event still fires at the original amount, so lifelink
+  and damage-dealt triggers see the full damage. Multiple instances pick the strictest floor. Used by
+  Ali from Cairo (`LifeLossFloor(floor = 1, appliesTo = LifeLossEvent(Player.You))`); Worship adds a
+  `restrictions = listOf(YouControlACreature)` gate.
 - `PreventLifeGain(appliesTo)` — life gain matching the event is fully prevented (Sulfuric Vortex, Erebos).
 - Custom — implement the `ReplacementEffect` interface directly.
 

--- a/manual-scenarios/cards/a/ali-from-cairo.json
+++ b/manual-scenarios/cards/a/ali-from-cairo.json
@@ -1,0 +1,33 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 1,
+  "player1": {
+    "lifeTotal": 3,
+    "hand": [],
+    "battlefield": [
+      {"name": "Ali from Cairo"},
+      {"name": "Mountain", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Lightning Bolt", "Lightning Bolt"],
+    "battlefield": [
+      {"name": "Mountain", "tapped": false},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Grizzly Bears" }
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -799,6 +799,73 @@ data class ModifyLifeLoss(
     }
 }
 
+/**
+ * Floor the resulting life total when a player would lose life from damage.
+ *
+ * If a damage event would reduce the [appliesTo]-matching player's life total below
+ * [floor], the life-loss amount is capped so the resulting life total equals [floor].
+ * Damage that would not breach the floor is unchanged. The damage event itself still
+ * fires at the original amount — only the life-total reduction is capped — so
+ * lifelink, damage-dealt triggers, and abilities that key off the dealt damage still
+ * see the full amount, matching the printed ruling on Ali from Cairo: "the full
+ * damage is dealt (and abilities that trigger on damage being dealt still trigger),
+ * but the full loss of life is not applied."
+ *
+ * Scope: damage-as-life-loss (CR 120.3a) only. Direct life-loss effects (pay-life
+ * costs, Drain Life, Greed) are deliberately unaffected — the engine wires this
+ * replacement only at the damage-pipeline call sites; `LoseLifeExecutor` skips it,
+ * matching the ruling "This effect does not apply to effects which reduce your life
+ * without doing damage."
+ *
+ * Multiple instances pick the strictest floor (highest resulting life total).
+ *
+ * Examples:
+ * - Ali from Cairo ("Damage that would reduce your life total to less than 1
+ *   reduces it to 1 instead"):
+ *     `LifeLossFloor(floor = 1, appliesTo = LifeLossEvent(Player.You))`
+ * - Worship ("If you control a creature, damage that would reduce your life total
+ *   to less than 1 reduces it to 1 instead"):
+ *     `LifeLossFloor(floor = 1, restrictions = listOf(YouControlACreature),
+ *                    appliesTo = LifeLossEvent(Player.You))`
+ *
+ * @param floor Minimum resulting life total (default 1).
+ * @param restrictions Additional [Condition]s gating when this floor applies.
+ *        Evaluated against the source permanent's controller; ALL must hold.
+ * @param appliesTo Life-loss event filter (which player is protected).
+ */
+@SerialName("LifeLossFloor")
+@Serializable
+data class LifeLossFloor(
+    val floor: Int = 1,
+    val restrictions: List<Condition> = emptyList(),
+    override val appliesTo: EventPattern = EventPattern.LifeLossEvent()
+) : ReplacementEffect {
+    override val description: String = buildString {
+        val restrictionDesc = restrictions.joinToString(" and ") { it.description.removePrefix("if ") }
+        if (restrictionDesc.isNotEmpty()) {
+            append(restrictionDesc.replaceFirstChar { it.uppercase() })
+            append(", damage")
+        } else {
+            append("Damage")
+        }
+        append(" that would reduce ")
+        when ((appliesTo as? EventPattern.LifeLossEvent)?.player) {
+            Player.You -> append("your")
+            Player.Opponent, Player.EachOpponent -> append("an opponent's")
+            else -> append("a player's")
+        }
+        append(" life total to less than $floor reduces it to $floor instead")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        val newRestrictions = restrictions.map { it.applyTextReplacement(replacer) }
+        val anyChanged = newAppliesTo !== appliesTo ||
+            newRestrictions.zip(restrictions).any { (n, o) -> n !== o }
+        return if (anyChanged) copy(appliesTo = newAppliesTo, restrictions = newRestrictions) else this
+    }
+}
+
 // =============================================================================
 // Copy Replacement Effects
 // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/AliFromCairo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/AliFromCairo.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.LifeLossFloor
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Ali from Cairo
+ * {2}{R}{R}
+ * Creature — Human
+ * 0/1
+ *
+ * Damage that would reduce your life total to less than 1 reduces it to 1 instead.
+ *
+ * Implementation note: this is a life-loss floor replacement on the damage-as-life-loss
+ * pipeline (CR 120.3a). The damage event itself still fires at the full amount — only
+ * the life-total reduction is capped at 1 — so lifelink, damage-dealt triggers, and
+ * abilities keying off the dealt damage still see the original amount. Direct
+ * life-loss effects (pay-life costs, Drain Life, Greed) are unaffected.
+ */
+val AliFromCairo = card("Ali from Cairo") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human"
+    power = 0
+    toughness = 1
+    oracleText = "Damage that would reduce your life total to less than 1 reduces it to 1 instead."
+
+    replacementEffect(
+        LifeLossFloor(
+            floor = 1,
+            appliesTo = EventPattern.LifeLossEvent(player = Player.You),
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "36"
+        artist = "Mark Poole"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42027613-d261-4ce2-8ba1-7a2480c660f8.jpg?1562907105"
+
+        ruling("2004-10-04", "This effect does not apply to effects which reduce your life without doing damage.")
+        ruling("2004-10-04", "The ability works up until Ali enters the graveyard, so if he takes lethal damage or is destroyed at the same time you take damage, the ability helps you. If the damage occurs after it goes to the graveyard, however, it is not affected by the Ali which is no longer on the battlefield.")
+        ruling("2004-10-04", "This effect does not prevent damage, it prevents the damage from turning into loss of life. So the full damage is dealt (and abilities that trigger on damage being dealt still trigger), but the full loss of life is not applied.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BloodletterOfAclazotz.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BloodletterOfAclazotz.kt
@@ -19,7 +19,7 @@ import com.wingedsheep.sdk.scripting.references.Player
  *
  * Implementation note: the doubling is applied at the life-total reduction step in
  * `DamageUtils` (both for direct life loss and for damage that causes life loss per
- * CR 119.3). Lifelink and other damage-based effects continue to see the original
+ * CR 120.3a). Lifelink and other damage-based effects continue to see the original
  * damage amount, matching the printed ruling.
  */
 val BloodletterOfAclazotz = card("Bloodletter of Aclazotz") {

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -151,6 +151,46 @@
     ]
 }
 
+// Ali from Cairo
+{
+    "name": "Ali from Cairo",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Human",
+    "oracleText": "Damage that would reduce your life total to less than 1 reduces it to 1 instead.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "replacementEffects": [
+            "LifeLossFloor"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "RARE",
+        "artist": "Mark Poole",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42027613-d261-4ce2-8ba1-7a2480c660f8.jpg?1562907105",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "This effect does not apply to effects which reduce your life without doing damage."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "The ability works up until Ali enters the graveyard, so if he takes lethal damage or is destroyed at the same time you take damage, the ability helps you. If the damage occurs after it goes to the graveyard, however, it is not affected by the Ali which is no longer on the battlefield."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "This effect does not prevent damage, it prevents the damage from turning into loss of life. So the full damage is dealt (and abilities that trigger on damage being dealt still trigger), but the full loss of life is not applied."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Army of Allah
 {
     "name": "Army of Allah",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -41,12 +41,16 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.CapDamage
 import com.wingedsheep.sdk.scripting.DamageCantBePrevented
 import com.wingedsheep.sdk.scripting.DoubleDamage
+import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.ModifyDamageAmount
+import com.wingedsheep.sdk.scripting.LifeLossFloor
 import com.wingedsheep.sdk.scripting.ModifyLifeLoss
 import com.wingedsheep.sdk.scripting.PreventDamage
 import com.wingedsheep.sdk.scripting.PreventLifeGain
 import com.wingedsheep.sdk.scripting.RedirectDamage
 import com.wingedsheep.sdk.scripting.ReplaceDamageWithCounters
+import com.wingedsheep.sdk.scripting.ReplacementEffect
+import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.events.DamageType
 import com.wingedsheep.sdk.scripting.events.RecipientFilter
 import com.wingedsheep.sdk.scripting.events.SourceFilter
@@ -189,11 +193,12 @@ object DamageUtils {
         val lifeComponent = newState.getEntity(targetId)?.get<LifeTotalComponent>()
         val projected = newState.projectedState
         if (lifeComponent != null) {
-            // CR 119.3: damage to a player causes that player to lose life, so life-loss
-            // replacements (Bloodletter of Aclazotz) modify the life total reduction here.
-            // Lifelink and other damage-based effects below still see the unmodified
-            // `effectiveAmount`, matching the official ruling.
-            val lifeLossAmount = applyStaticLifeLossModification(newState, targetId, effectiveAmount)
+            // CR 120.3a: damage to a player by a source without infect causes that player
+            // to lose that much life, so life-loss replacements (Bloodletter of Aclazotz)
+            // modify the life total reduction here. Lifelink and other damage-based effects
+            // below still see the unmodified `effectiveAmount`, matching the official ruling.
+            var lifeLossAmount = applyStaticLifeLossModification(newState, targetId, effectiveAmount)
+            lifeLossAmount = applyLifeLossFloors(newState, targetId, lifeComponent.life, lifeLossAmount)
             val newLife = lifeComponent.life - lifeLossAmount
             newState = newState.updateEntity(targetId) { container ->
                 container.with(LifeTotalComponent(newLife))
@@ -274,8 +279,8 @@ object DamageUtils {
         val targetWasCreature = projected.isCreature(targetId)
         events.add(DamageDealtEvent(sourceId, targetId, effectiveAmount, false, sourceName = sourceName, targetName = targetName, targetIsPlayer = targetIsPlayer, targetWasFaceDown = targetIsFaceDown, targetControllerId = targetControllerId, targetWasCreature = targetWasCreature, excessAmount = creatureExcessDamage))
 
-        // Lifelink: if the source has lifelink, its controller gains life equal to the damage dealt (Rule 702.15).
-        // Per CR 119.3 / 702.15b the lifelink damage causes a life-gain event; ModifyLifeGain
+        // Lifelink: if the source has lifelink, its controller gains life equal to the damage dealt
+        // (CR 120.3f / 702.15b). The lifelink damage causes a life-gain event, so ModifyLifeGain
         // (Alhammarret's Archive, Leyline of Hope) replaces the actual amount gained.
         if (sourceId != null) {
             val projected = newState.projectedState
@@ -1267,7 +1272,7 @@ object DamageUtils {
      *
      * Multiple matching effects are applied in iteration order. Used both by direct
      * life-loss effects (LoseLifeExecutor) and by damage that reduces a player's life
-     * total (CR 119.3).
+     * total (CR 120.3a).
      */
     fun applyStaticLifeLossModification(
         state: GameState,
@@ -1277,19 +1282,67 @@ object DamageUtils {
         if (amount <= 0) return 0
 
         var modifiedAmount = amount
+        forEachLifeLossReplacement<ModifyLifeLoss>(state, losingPlayerId, { it.restrictions }) { effect ->
+            modifiedAmount = (modifiedAmount * effect.multiplier) + effect.modifier
+            if (modifiedAmount < 0) modifiedAmount = 0
+        }
+        return modifiedAmount
+    }
 
+    /**
+     * Apply life-loss floor replacement effects ([LifeLossFloor]) so the resulting
+     * life total does not fall below each effect's floor.
+     *
+     * Called only from the damage → life-loss pipeline (CR 120.3a); direct life-loss
+     * effects ([com.wingedsheep.engine.handlers.effects.life.LoseLifeExecutor]) skip
+     * this step, matching the printed ruling on Ali from Cairo: "This effect does
+     * not apply to effects which reduce your life without doing damage."
+     *
+     * Multiple matching floors pick the strictest (highest resulting life total).
+     */
+    fun applyLifeLossFloors(
+        state: GameState,
+        losingPlayerId: EntityId,
+        currentLife: Int,
+        amount: Int
+    ): Int {
+        if (amount <= 0) return amount
+
+        var modifiedAmount = amount
+        forEachLifeLossReplacement<LifeLossFloor>(state, losingPlayerId, { it.restrictions }) { effect ->
+            val maxLossAllowed = (currentLife - effect.floor).coerceAtLeast(0)
+            if (modifiedAmount > maxLossAllowed) modifiedAmount = maxLossAllowed
+        }
+        return modifiedAmount
+    }
+
+    /**
+     * Visit every battlefield replacement effect of type [T] whose `appliesTo`
+     * is a [EventPattern.LifeLossEvent] matching [losingPlayerId] and whose
+     * [restrictionsOf]-extracted conditions all hold against the source's controller.
+     *
+     * Shared scaffold for [applyStaticLifeLossModification] (`ModifyLifeLoss`)
+     * and [applyLifeLossFloors] (`LifeLossFloor`); each function keeps the actual
+     * arithmetic in its callback.
+     */
+    private inline fun <reified T : ReplacementEffect> forEachLifeLossReplacement(
+        state: GameState,
+        losingPlayerId: EntityId,
+        restrictionsOf: (T) -> List<Condition>,
+        action: (T) -> Unit
+    ) {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
             val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
-                if (effect !is ModifyLifeLoss) continue
+                if (effect !is T) continue
 
-                val lifeLossEvent = effect.appliesTo
-                if (lifeLossEvent !is com.wingedsheep.sdk.scripting.EventPattern.LifeLossEvent) continue
+                val pattern = effect.appliesTo
+                if (pattern !is EventPattern.LifeLossEvent) continue
 
-                val playerMatches = when (lifeLossEvent.player) {
+                val playerMatches = when (pattern.player) {
                     Player.Each, Player.Any -> true
                     Player.You -> losingPlayerId == sourceControllerId
                     Player.Opponent, Player.EachOpponent -> losingPlayerId != sourceControllerId
@@ -1297,22 +1350,20 @@ object DamageUtils {
                 }
                 if (!playerMatches) continue
 
-                if (effect.restrictions.isNotEmpty()) {
+                val restrictions = restrictionsOf(effect)
+                if (restrictions.isNotEmpty()) {
                     val opponentId = state.turnOrder.firstOrNull { it != sourceControllerId }
                     val context = EffectContext(
                         sourceId = entityId,
                         controllerId = sourceControllerId,
                         opponentId = opponentId,
                     )
-                    if (effect.restrictions.any { !conditionEvaluator.evaluate(state, it, context) }) continue
+                    if (restrictions.any { !conditionEvaluator.evaluate(state, it, context) }) continue
                 }
 
-                modifiedAmount = (modifiedAmount * effect.multiplier) + effect.modifier
-                if (modifiedAmount < 0) modifiedAmount = 0
+                action(effect)
             }
         }
-
-        return modifiedAmount
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -853,11 +853,13 @@ internal class CombatDamageManager(
             return newState
         }
 
-        // Reduce life. Per CR 119.3, damage causes life loss, so life-loss
-        // replacements (Bloodletter of Aclazotz) modify the life total reduction here.
-        // Lifelink and tracking still see the unmodified `effectiveAmount`.
+        // Reduce life. Per CR 120.3a, damage to a player without infect causes that
+        // player to lose that much life, so life-loss replacements (Bloodletter of
+        // Aclazotz) modify the life total reduction here. Lifelink and tracking still
+        // see the unmodified `effectiveAmount`.
         val currentLife = newState.getEntity(targetId)?.get<LifeTotalComponent>()?.life ?: return newState
-        val lifeLossAmount = DamageUtils.applyStaticLifeLossModification(newState, targetId, effectiveAmount)
+        var lifeLossAmount = DamageUtils.applyStaticLifeLossModification(newState, targetId, effectiveAmount)
+        lifeLossAmount = DamageUtils.applyLifeLossFloors(newState, targetId, currentLife, lifeLossAmount)
         val newLife = currentLife - lifeLossAmount
         newState = newState.updateEntity(targetId) { container ->
             container.with(LifeTotalComponent(newLife))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -614,6 +614,7 @@ class StaticAbilityHandler(
         it is PreventDamage || it is DoubleDamage || it is ModifyDamageAmount || it is PreventLifeGain ||
         it is com.wingedsheep.sdk.scripting.CapDamage || it is com.wingedsheep.sdk.scripting.RedirectDamage ||
         it is com.wingedsheep.sdk.scripting.ModifyLifeLoss ||
+        it is com.wingedsheep.sdk.scripting.LifeLossFloor ||
         it is com.wingedsheep.sdk.scripting.ModifyLifeGain ||
         it is com.wingedsheep.sdk.scripting.PreventDraw ||
         it is com.wingedsheep.sdk.scripting.DamageCantBePrevented || it is ReplaceDamageWithCounters ||

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AliFromCairoTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AliFromCairoTest.kt
@@ -1,0 +1,213 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lea.cards.Earthquake
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Ali from Cairo (Arabian Nights, {2}{R}{R}, 0/1 Human).
+ *
+ * Oracle: "Damage that would reduce your life total to less than 1 reduces it to 1
+ * instead."
+ *
+ * Mechanically a damage-only life-loss floor (`LifeLossFloor`): damage is dealt at
+ * full amount, lifelink and damage-dealt triggers still see the full amount, but
+ * the life-total reduction is capped so Ali's controller stays at ≥ 1. Non-damage
+ * life loss is unaffected.
+ */
+class AliFromCairoTest : FunSpec({
+
+    val LoseFiveLifeSpell = CardDefinition.sorcery(
+        name = "Drain Five",
+        manaCost = ManaCost.parse("{B}"),
+        oracleText = "Target player loses 5 life.",
+        script = CardScript.spell(
+            effect = LoseLifeEffect(5, EffectTarget.BoundVariable("target")),
+            TargetPlayer(id = "target"),
+        ),
+    )
+
+    // 5/5 lifelink vanilla — used to assert the damage event still fires at the
+    // unmodified amount even when Ali's floor caps the life loss to zero.
+    val LifelinkBrute = CardDefinition.creature(
+        name = "Lifelink Brute",
+        manaCost = ManaCost.parse("{4}{W}"),
+        subtypes = setOf(Subtype("Ox")),
+        power = 5,
+        toughness = 5,
+        oracleText = "Lifelink",
+        keywords = setOf(Keyword.LIFELINK),
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LoseFiveLifeSpell, LifelinkBrute, Earthquake))
+        return driver
+    }
+
+    test("lethal damage to controller is floored to 1 life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Swamp" to 20), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Ali from Cairo")
+        driver.setLifeTotal(you, 3)
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(you))).error shouldBe null
+        driver.bothPass()
+
+        driver.assertLifeTotal(you, 1)
+    }
+
+    test("non-lethal damage is unchanged") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Swamp" to 20), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Ali from Cairo")
+        driver.setLifeTotal(you, 10)
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(you))).error shouldBe null
+        driver.bothPass()
+
+        driver.assertLifeTotal(you, 7)
+    }
+
+    test("opponent is not protected — Ali only floors his controller's life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Swamp" to 20), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Ali from Cairo")
+        driver.setLifeTotal(opponent, 2)
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+        driver.bothPass()
+
+        // Opponent took the full 3 — Ali's floor did not apply to them.
+        driver.assertGameOver(expectedWinner = you)
+    }
+
+    test("direct life loss (not from damage) bypasses Ali's floor") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Swamp" to 20), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Ali from Cairo")
+        driver.setLifeTotal(you, 3)
+
+        // Drain Five is sorcery-speed life loss with no damage involved — Ali's floor
+        // must NOT engage, so 3 - 5 = -2 and you lose.
+        driver.giveMana(you, Color.BLACK, 1)
+        val drain = driver.putCardInHand(you, "Drain Five")
+        driver.castSpellWithTargets(you, drain, listOf(ChosenTarget.Player(you))).error shouldBe null
+        driver.bothPass()
+
+        driver.assertGameOver(expectedWinner = opponent)
+    }
+
+    test("once Ali leaves the battlefield, his floor stops protecting his controller") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Swamp" to 20), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ali = driver.putCreatureOnBattlefield(you, "Ali from Cairo")
+        driver.moveToGraveyard(ali)
+
+        driver.setLifeTotal(you, 3)
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(you))).error shouldBe null
+        driver.bothPass()
+
+        // No Ali on the battlefield → 3 damage is taken in full → you lose.
+        driver.assertGameOver(expectedWinner = opponent)
+    }
+
+    // Per the printed ruling: "This effect does not prevent damage, it prevents the damage
+    // from turning into loss of life. So the full damage is dealt (and abilities that trigger
+    // on damage being dealt still trigger), but the full loss of life is not applied."
+    test("damage event still fires at full amount — lifelink sees unfloored damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val ali = driver.getOpponent(attacker)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(ali, "Ali from Cairo")
+        val brute = driver.putCreatureOnBattlefield(attacker, "Lifelink Brute")
+        driver.removeSummoningSickness(brute)
+        driver.setLifeTotal(ali, 1)
+        driver.setLifeTotal(attacker, 20)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(brute), ali)
+        driver.bothPass()  // declare blockers (none)
+        driver.bothPass()  // first strike step (no first strikers)
+        driver.bothPass()  // combat damage step
+
+        // Floor caps life loss to 0 (currentLife - floor = 1 - 1 = 0) → Ali still at 1.
+        driver.assertLifeTotal(ali, 1)
+        // Lifelink reads the unmodified 5 damage from the DamageDealtEvent → attacker gains 5.
+        // If the engine had instead routed Ali through "prevent damage", this would be 20.
+        driver.assertLifeTotal(attacker, 25)
+    }
+
+    // Per the printed ruling: "The ability works up until Ali enters the graveyard, so if he
+    // takes lethal damage or is destroyed at the same time you take damage, the ability
+    // helps you." Ali is still on the battlefield throughout the damage event (SBAs don't
+    // fire until the whole effect resolves), so the floor applies even when the same effect
+    // would kill him.
+    test("Ali still protects when he and his controller take lethal damage in the same event") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Swamp" to 20), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Ali from Cairo")
+        driver.setLifeTotal(you, 5)
+        driver.setLifeTotal(opponent, 20)
+
+        // Earthquake deals X damage to each creature without flying and each player.
+        // X = 5 → 5 to Ali (lethal for the 0/1), 5 to you (would be lethal), 5 to opponent.
+        driver.giveMana(you, Color.RED, 6)
+        val eq = driver.putCardInHand(you, "Earthquake")
+        driver.castXSpell(you, eq, xValue = 5).error shouldBe null
+        driver.bothPass()
+
+        // Ali was on the battlefield throughout the damage event → floor applied to "you".
+        // SBAs then put Ali in the graveyard for lethal marked damage.
+        driver.assertLifeTotal(you, 1)
+        driver.assertInGraveyard(you, "Ali from Cairo")
+        driver.assertLifeTotal(opponent, 15)
+    }
+})


### PR DESCRIPTION
Adds the new `LifeLossFloor` replacement (mtg-sdk) for "damage that would reduce your life total to less than 1 reduces it to 1 instead" — a damage-only life-loss cap parameterized by floor amount, restrictions, and the protected player. Wired into the damage→life-loss pipeline (CR 120.3a) in DamageUtils and CombatDamageManager; LoseLifeExecutor deliberately skips it so non-damage life loss bypasses the floor (per the printed ruling). The damage event still fires at full amount, so lifelink and damage-dealt triggers see the unchanged amount. Same primitive will later power Worship with a `YouControlACreature` restriction.

DamageUtils' `applyStaticLifeLossModification` (ModifyLifeLoss / Bloodletter) and the new `applyLifeLossFloors` share a private inline reified `forEachLifeLossReplacement<T>` scaffold for the battlefield scan, player-match, and restriction-gate boilerplate.

Drive-by: corrected CR 119.3 → CR 120.3a in pre-existing damage→life-loss comments in DamageUtils.kt, CombatDamageManager.kt, and BloodletterOfAclazotz.kt; updated the lifelink comment in DamageUtils.kt to cite CR 120.3f / 702.15b.

Scenario tests cover: lethal damage floored to 1, non-lethal unchanged, opponent unprotected, direct life-loss (LoseLifeEffect) bypasses the floor, post-leaves-battlefield no-op, lifelink sees the unfloored damage amount, and Ali still protecting his controller when both take lethal damage in the same event.