### PR TITLE
Add Byrke, Long Ear of the Law to Bloomburrow

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ByrkeLongEarOfTheLaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ByrkeLongEarOfTheLaw.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.blb.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Byrke, Long Ear of the Law
+ * {4}{G}{W}
+ * Legendary Creature — Rabbit Soldier
+ * 4/4
+ *
+ * Vigilance
+ * When Byrke enters, put a +1/+1 counter on each of up to two target creatures.
+ * Whenever a creature you control with a +1/+1 counter on it attacks, double the
+ * number of +1/+1 counters on it.
+ *
+ * The ETB mirrors Weftblade Enhancer's "each of up to two target creatures" shape —
+ * an optional `count = 2` [TargetCreature] fanned out with [ForEachTargetEffect] so
+ * each chosen creature gets one counter. The attack trigger fires for ANY creature
+ * you control that already carries a +1/+1 counter (the `withCounter` filter), then
+ * doubles that creature's +1/+1 counters via [Effects.DoubleCounters] on the
+ * triggering attacker ("it"). Doubling reads the post-declaration count, so multiple
+ * counters from earlier doublings/anthems compound, and Branching Evolution-style
+ * placement replacements still apply to the freshly placed counters (per ruling).
+ */
+val ByrkeLongEarOfTheLaw = card("Byrke, Long Ear of the Law") {
+    manaCost = "{4}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Rabbit Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "When Byrke enters, put a +1/+1 counter on each of up to two target creatures.\n" +
+        "Whenever a creature you control with a +1/+1 counter on it attacks, double the " +
+        "number of +1/+1 counters on it."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("up to two target creatures", TargetCreature(count = 2, optional = true))
+        effect = ForEachTargetEffect(
+            listOf(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)))
+        )
+        description = "When Byrke enters, put a +1/+1 counter on each of up to two target creatures."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.attacks(
+            filter = GameObjectFilter.Creature.youControl().withCounter(Counters.PLUS_ONE_PLUS_ONE),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.DoubleCounters(Counters.PLUS_ONE_PLUS_ONE, EffectTarget.TriggeringEntity)
+        description = "Whenever a creature you control with a +1/+1 counter on it attacks, " +
+            "double the number of +1/+1 counters on it."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "380"
+        artist = "Manuel Castañón"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/6441abd3-320b-424a-9753-61e3581fe1a9.jpg?1726396879"
+        ruling(
+            "2024-07-26",
+            "To double the number of +1/+1 counters on a creature, put a number of +1/+1 counters " +
+                "on it equal to the number it already has. Replacement effects that modify the number " +
+                "of counters being placed on creatures you control, such as the effect of Branching " +
+                "Evolution, apply to this ability as normal.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -2197,6 +2197,96 @@
     ]
 }
 
+// Byrke, Long Ear of the Law
+{
+    "name": "Byrke, Long Ear of the Law",
+    "manaCost": "{4}{G}{W}",
+    "typeLine": "Legendary Creature — Rabbit Soldier",
+    "oracleText": "Vigilance\nWhen Byrke enters, put a +1/+1 counter on each of up to two target creatures.\nWhenever a creature you control with a +1/+1 counter on it attacks, double the number of +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEachTarget",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to two target creatures"
+                },
+                "descriptionOverride": "When Byrke enters, put a +1/+1 counter on each of up to two target creatures."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "+1/+1"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DoubleCounters",
+                    "target": "TriggeringEntity"
+                },
+                "descriptionOverride": "Whenever a creature you control with a +1/+1 counter on it attacks, double the number of +1/+1 counters on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "380",
+        "rarity": "MYTHIC",
+        "artist": "Manuel Castañón",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/6441abd3-320b-424a-9753-61e3581fe1a9.jpg?1726396879",
+        "rulings": [
+            {
+                "date": "2024-07-26",
+                "text": "To double the number of +1/+1 counters on a creature, put a number of +1/+1 counters on it equal to the number it already has. Replacement effects that modify the number of counters being placed on creatures you control, such as the effect of Branching Evolution, apply to this ability as normal."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Byway Barterer
 {
     "name": "Byway Barterer",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ByrkeLongEarOfTheLawScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ByrkeLongEarOfTheLawScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Byrke, Long Ear of the Law (Bloomburrow #380) —
+ * {4}{G}{W} Legendary Creature — Rabbit Soldier, 4/4.
+ *
+ *   Vigilance
+ *   When Byrke enters, put a +1/+1 counter on each of up to two target creatures.
+ *   Whenever a creature you control with a +1/+1 counter on it attacks, double the
+ *   number of +1/+1 counters on it.
+ *
+ * Covers the ETB fan-out (one counter on each of two targets) and the attack-doubling
+ * trigger (fires only for an attacker you control that already carries a +1/+1 counter,
+ * and reads the post-declaration count, so the total is doubled).
+ */
+class ByrkeLongEarOfTheLawScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun seedCounters(game: TestGame, id: EntityId, amount: Int) {
+        game.state = game.state.updateEntity(id) { c ->
+            c.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, amount))
+        }
+    }
+
+    init {
+        context("Byrke, Long Ear of the Law") {
+
+            test("ETB puts a +1/+1 counter on each of up to two target creatures") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardInHand(1, "Byrke, Long Ear of the Law")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val cast = game.castSpell(1, "Byrke, Long Ear of the Law")
+                withClue("Casting Byrke should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+                // ETB trigger asks for up to two target creatures — choose both.
+                game.selectTargets(listOf(bears, giant))
+                game.resolveStack()
+
+                withClue("Grizzly Bears gets one +1/+1 counter") {
+                    plusOneCounters(game, bears) shouldBe 1
+                }
+                withClue("Hill Giant gets one +1/+1 counter") {
+                    plusOneCounters(game, giant) shouldBe 1
+                }
+            }
+
+            test("attacking with a counter-bearing creature you control doubles its +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Byrke, Long Ear of the Law", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                seedCounters(game, bears, 3)
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                // The doubling trigger goes on the stack; resolve it.
+                game.resolveStack()
+
+                withClue("Grizzly Bears' 3 +1/+1 counters are doubled to 6") {
+                    plusOneCounters(game, bears) shouldBe 6
+                }
+            }
+
+            test("attacking with a creature that has no +1/+1 counter does not trigger doubling") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Byrke, Long Ear of the Law", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // Attack with both Byrke (no counter) and a counterless Bears — neither qualifies.
+                game.declareAttackers(mapOf("Grizzly Bears" to 2, "Byrke, Long Ear of the Law" to 2))
+                game.resolveStack()
+
+                withClue("A counterless attacker is untouched — no counters appear") {
+                    plusOneCounters(game, bears) shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements **Byrke, Long Ear of the Law** (Bloomburrow #380) — {4}{G}{W} Legendary Creature — Rabbit Soldier, 4/4.

- **Vigilance**
- **ETB:** put a +1/+1 counter on each of up to two target creatures.
- **Attack trigger:** whenever a creature you control with a +1/+1 counter on it attacks, double the number of +1/+1 counters on it.

## Implementation
Reuses existing SDK facades — **no new engine/SDK code**:

- **ETB** mirrors Weftblade Enhancer's "each of up to two target creatures" shape: `TargetCreature(count = 2, optional = true)` fanned out with `ForEachTargetEffect` + `Effects.AddCounters(+1/+1)`.
- **Attack trigger:** `Triggers.attacks(filter = GameObjectFilter.Creature.youControl().withCounter(PLUS_ONE_PLUS_ONE), binding = ANY)` with `Effects.DoubleCounters(+1/+1, EffectTarget.TriggeringEntity)`. Doubling reads the post-declaration count, so earlier doublings/anthems compound and Branching-Evolution-style placement replacements still apply to the freshly placed counters (per the 2024-07-26 ruling, captured in `metadata`).

## Tests
New `ByrkeLongEarOfTheLawScenarioTest` (rules-engine), all passing:
1. ETB puts one +1/+1 counter on each of two distinct targets.
2. Attacking with a counter-bearing creature you control doubles its counters (3 → 6).
3. Attacking with a counterless creature (incl. Byrke itself) does **not** trigger doubling.

`CardDefinitionSnapshotTest` golden (`BLB.json`) re-blessed — diff adds only Byrke, no other card changed. Full `just build` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)