### PR TITLE
Tempest Sliver cycle + mtgish emitter: grant ability to all Slivers

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/ArmorSliver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/ArmorSliver.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Armor Sliver
+ * {2}{W}
+ * Creature — Sliver
+ * 2/2
+ * All Sliver creatures have "{2}: This creature gets +0/+1 until end of turn."
+ */
+val ArmorSliver = card("Armor Sliver") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Sliver creatures have \"{2}: This creature gets +0/+1 until end of turn.\""
+
+    val sliverFilter = GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Mana("{2}"),
+                effect = Effects.ModifyStats(0, 1, EffectTarget.Self)
+            ),
+            filter = sliverFilter
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "4"
+        artist = "Scott Kirschner"
+        flavorText = "Hanna: \"We must learn how they protect each other.\"\nMirri: \"After they're done trying to kill us, all right?\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c275aba7-cac6-48e8-b12c-6bd77a5c38fe.jpg?1708088318"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/BarbedSliver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/BarbedSliver.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Barbed Sliver
+ * {2}{R}
+ * Creature — Sliver
+ * 2/2
+ * All Sliver creatures have "{2}: This creature gets +1/+0 until end of turn."
+ */
+val BarbedSliver = card("Barbed Sliver") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Sliver creatures have \"{2}: This creature gets +1/+0 until end of turn.\""
+
+    val sliverFilter = GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Mana("{2}"),
+                effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+            ),
+            filter = sliverFilter
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "163"
+        artist = "Scott Kirschner"
+        flavorText = "Spans of spines leapt from one sliver to the next, forming a deadly hedge around the *Weatherlight*."
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19bddea7-daa7-4bdb-9b91-f7fcbc0d7a57.jpg?1562052790"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/ClotSliver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/ClotSliver.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Clot Sliver
+ * {1}{B}
+ * Creature — Sliver
+ * 1/1
+ * All Slivers have "{2}: Regenerate this permanent."
+ */
+val ClotSliver = card("Clot Sliver") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "All Slivers have \"{2}: Regenerate this permanent.\""
+
+    val sliverFilter = GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Mana("{2}"),
+                effect = RegenerateEffect(EffectTarget.Self)
+            ),
+            filter = sliverFilter
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "112"
+        artist = "Jeff Laubenstein"
+        flavorText = "\"One would think I would be accustomed to unexpected returns.\"\n—Hanna, *Weatherlight* navigator"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fdead1f4-a6e4-4370-80ae-811881a90d01.jpg?1562057819"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MindwhipSliver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MindwhipSliver.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Mindwhip Sliver
+ * {2}{B}
+ * Creature — Sliver
+ * 2/2
+ * All Slivers have "{2}, Sacrifice this permanent: Target player discards a card at
+ * random. Activate only as a sorcery."
+ */
+val MindwhipSliver = card("Mindwhip Sliver") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Slivers have \"{2}, Sacrifice this permanent: Target player discards a card at random. " +
+        "Activate only as a sorcery.\""
+
+    val sliverFilter = GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf),
+                timing = TimingRule.SorcerySpeed,
+                effect = Patterns.Hand.discardRandom(1, EffectTarget.ContextTarget(0)),
+                targetRequirement = TargetPlayer()
+            ),
+            filter = sliverFilter
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Jeff Miracola"
+        flavorText = "\"They share more than their thoughts. We must shatter their link quickly!\"\n—Hanna, to Orim"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa966fbb-140d-4057-a4fc-998ebe07c307.jpg?1562057377"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MnemonicSliver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MnemonicSliver.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mnemonic Sliver
+ * {2}{U}
+ * Creature — Sliver
+ * 2/2
+ * All Slivers have "{2}, Sacrifice this permanent: Draw a card."
+ */
+val MnemonicSliver = card("Mnemonic Sliver") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Slivers have \"{2}, Sacrifice this permanent: Draw a card.\""
+
+    val sliverFilter = GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf),
+                effect = Effects.DrawCards(1)
+            ),
+            filter = sliverFilter
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "77"
+        artist = "Randy Gallegos"
+        flavorText = "\"A jigsaw puzzle that lives, breeds, and thinks.\"\n—Hanna, *Weatherlight* navigator"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b167347-2f8f-4338-a651-c7543d812597.jpg?1562053268"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -1,3 +1,105 @@
+// Armor Sliver
+{
+    "name": "Armor Sliver",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures have \"{2}: This creature gets +0/+1 until end of turn.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostMana",
+                        "cost": "{2}"
+                    },
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                },
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Kirschner",
+        "flavorText": "Hanna: \"We must learn how they protect each other.\"\nMirri: \"After they're done trying to kill us, all right?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c275aba7-cac6-48e8-b12c-6bd77a5c38fe.jpg?1708088318"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Barbed Sliver
+{
+    "name": "Barbed Sliver",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures have \"{2}: This creature gets +1/+0 until end of turn.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostMana",
+                        "cost": "{2}"
+                    },
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                },
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Kirschner",
+        "flavorText": "Spans of spines leapt from one sliver to the next, forming a deadly hedge around the *Weatherlight*.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19bddea7-daa7-4bdb-9b91-f7fcbc0d7a57.jpg?1562052790"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Boil
 {
     "name": "Boil",
@@ -208,6 +310,48 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Clot Sliver
+{
+    "name": "Clot Sliver",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Slivers have \"{2}: Regenerate this permanent.\"",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostMana",
+                        "cost": "{2}"
+                    },
+                    "effect": {
+                        "type": "Regenerate",
+                        "target": "Self"
+                    }
+                },
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "artist": "Jeff Laubenstein",
+        "flavorText": "\"One would think I would be accustomed to unexpected returns.\"\n—Hanna, *Weatherlight* navigator",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fdead1f4-a6e4-4370-80ae-811881a90d01.jpg?1562057819"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -791,6 +935,149 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Mindwhip Sliver
+{
+    "name": "Mindwhip Sliver",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Slivers have \"{2}, Sacrifice this permanent: Target player discards a card at random. Activate only as a sorcery.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostMana",
+                                "cost": "{2}"
+                            },
+                            "CostSacrificeSelf"
+                        ]
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "Random",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        "TargetPlayer"
+                    ],
+                    "timing": "SorcerySpeed"
+                },
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Miracola",
+        "flavorText": "\"They share more than their thoughts. We must shatter their link quickly!\"\n—Hanna, to Orim",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa966fbb-140d-4057-a4fc-998ebe07c307.jpg?1562057377"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Mnemonic Sliver
+{
+    "name": "Mnemonic Sliver",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Slivers have \"{2}, Sacrifice this permanent: Draw a card.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostMana",
+                                "cost": "{2}"
+                            },
+                            "CostSacrificeSelf"
+                        ]
+                    },
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"A jigsaw puzzle that lives, breeds, and thinks.\"\n—Hanna, *Weatherlight* navigator",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b167347-2f8f-4338-a651-c7543d812597.jpg?1562053268"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -88,9 +88,20 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         val arr = node["args"] as? JsonArray ?: return@on null
         val playerRef = arr.firstOrNull() as? JsonObject
         val action = arr.firstOrNull { it is JsonObject && it.containsKey("_Action") } as? JsonObject ?: return@on null
-        if (action.strField("_Action") != "RevealHand") return@on null
-        val target = if (jsonContains(playerRef, "_Player", "Ref_TargetPlayer")) tvar else null
-        if (target != null) call("RevealHandEffect", arg(Lit(target))) else call("RevealHandEffect")
+        val targetsRef = jsonContains(playerRef, "_Player", "Ref_TargetPlayer")
+        when (action.strField("_Action")) {
+            "RevealHand" -> {
+                val target = if (targetsRef) tvar else null
+                if (target != null) call("RevealHandEffect", arg(Lit(target))) else call("RevealHandEffect")
+            }
+            // "Target player discards a card at random" (Mindwhip Sliver). discardRandom is a fixed,
+            // no-choice discard (the engine picks), so it renders exactly against the target player.
+            "DiscardACardAtRandom" -> {
+                if (!targetsRef || tvar == null) return@on null
+                call("Patterns.Hand.discardRandom", arg("1"), arg(Lit(tvar)))
+            }
+            else -> null
+        }
     }
 
     simple("CounterSpell", dsl = "CounterEffect()")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.tooling.coverage.emitter
 
 import com.wingedsheep.tooling.coverage.Assign
 import com.wingedsheep.tooling.coverage.Block
+import com.wingedsheep.tooling.coverage.Call
 import com.wingedsheep.tooling.coverage.Dsl
 import com.wingedsheep.tooling.coverage.Eval
 import com.wingedsheep.tooling.coverage.Lit
@@ -74,17 +75,25 @@ internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<Stmt>? {
                 call("ModifyStats", arg("powerBonus", "${pt[0].asInt()}"), arg("toughnessBonus", "${pt[1].asInt()}"), arg("filter", group))
             }
             "AddAbility" -> {
-                // "Other Merfolk have islandwalk" (Lord of Atlantis / Goblin King): the granted ability is a
-                // Landwalk rule carrying a land subtype, not a plain keyword — recover the *WALK keyword.
                 val granted = (le["args"] as? JsonArray)?.getOrNull(0) as? JsonObject
-                val kw = if (granted?.strField("_Rule") == "Landwalk") {
-                    val lw = mutableSetOf<String>()
-                    findLandwalkKeywords(granted, keywords, lw)
-                    lw.singleOrNull() ?: return scaffoldLord()
+                // "All Slivers have '{cost}: …'" (the Tempest sliver cycle, Crypt/Magma/Spectral Sliver):
+                // the granted ability is a full activated ability, rendered as GrantActivatedAbility over
+                // the affected group. Anything the inner ability can't render exactly scaffolds.
+                if (granted?.strField("_Rule") in setOf("Activated", "ActivatedWithModifiers")) {
+                    val inner = grantedActivatedAbilityExpr(granted!!) ?: return scaffoldLord()
+                    call("GrantActivatedAbility", arg("ability", inner), arg("filter", group))
                 } else {
-                    keywordOf(le) ?: return scaffoldLord()
+                    // "Other Merfolk have islandwalk" (Lord of Atlantis / Goblin King): the granted ability is a
+                    // Landwalk rule carrying a land subtype, not a plain keyword — recover the *WALK keyword.
+                    val kw = if (granted?.strField("_Rule") == "Landwalk") {
+                        val lw = mutableSetOf<String>()
+                        findLandwalkKeywords(granted, keywords, lw)
+                        lw.singleOrNull() ?: return scaffoldLord()
+                    } else {
+                        keywordOf(le) ?: return scaffoldLord()
+                    }
+                    call("GrantKeyword", arg("Keyword.$kw"), arg(group))
                 }
-                call("GrantKeyword", arg("Keyword.$kw"), arg(group))
             }
             else -> return scaffoldLord()
         }
@@ -94,6 +103,50 @@ internal fun EmitCtx.staticLordBlock(rule: JsonObject): List<Stmt>? {
 }
 
 private fun EmitCtx.scaffoldLord(): List<Stmt>? { reasons.add("EachPermanentLayerEffect"); return null }
+
+/**
+ * An `Activated` / `ActivatedWithModifiers` rule granted to a group ("All Slivers have '{cost}: …'") ->
+ * an `ActivatedAbility(id = AbilityId.generate(), cost = …, [timing = …], effect = …, [targetRequirement
+ * = …])` constructor expression for wrapping in `GrantActivatedAbility`. Reuses the same cost / target /
+ * effect recovery as the card-body [activatedBlock], but in expression form: a chosen target becomes
+ * `targetRequirement = <node>` and the effect references `EffectTarget.ContextTarget(0)` (the granted
+ * ability has no card-body `target(...)` local to bind). The only activation modifier rendered is
+ * `ActivateOnlyAsASorcery` -> `timing = TimingRule.SorcerySpeed`; any other modifier scaffolds.
+ */
+internal fun EmitCtx.grantedActivatedAbilityExpr(rule: JsonObject): Dsl? {
+    val costNode = (rule["args"] as? JsonArray)?.firstOrNull() as? JsonObject
+    val cost = costNode?.let { abilityCostDsl(it) } ?: return null
+    val (targets, actions) = extractEnvelope(rule)
+    if (actions == null) return null
+    if (targets != null && targets.size > 1) return null
+    // A chosen target becomes the ability's targetRequirement; the effect then refers to it via
+    // ContextTarget(0) (the granted ability has no bound `t` local).
+    val targetNode = targets?.firstOrNull()?.let { targetExpr(it, actions) ?: return null }
+    val tvar = if (targetNode != null) "EffectTarget.ContextTarget(0)" else null
+    val effect = renderEffectList(actions, tvar) ?: return null
+    val timing = grantedActivationTiming(rule) ?: return null
+
+    val args = mutableListOf(
+        arg("id", "AbilityId.generate()"),
+        arg("cost", cost),
+    )
+    if (timing.isNotEmpty()) args.add(arg("timing", timing))
+    args.add(arg("effect", effect))
+    if (targetNode != null) args.add(arg("targetRequirement", targetNode))
+    return Call("ActivatedAbility", args)
+}
+
+/** The `timing = …` value for a granted activated ability: "" (omit, default instant speed) for a plain
+ *  `Activated` rule, `TimingRule.SorcerySpeed` for an `ActivatedWithModifiers` carrying ONLY the
+ *  `ActivateOnlyAsASorcery` modifier (Mindwhip Sliver); null (-> SCAFFOLD) for any other modifier. */
+private fun EmitCtx.grantedActivationTiming(rule: JsonObject): String? {
+    if (rule.strField("_Rule") != "ActivatedWithModifiers") return ""
+    val modifiers = (rule["args"] as? JsonArray).orEmpty()
+        .filterIsInstance<JsonObject>().filter { it.strField("_ActivateModifier") != null }
+    if (modifiers.isEmpty()) return ""
+    if (modifiers.all { it.strField("_ActivateModifier") == "ActivateOnlyAsASorcery" }) return "TimingRule.SorcerySpeed"
+    return null
+}
 
 /**
  * `EnchantPermanent` -> the card-level `auraTarget = Targets.X` line. The enchant restriction is a

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArmorSliverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArmorSliverScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Armor Sliver.
+ *
+ * Armor Sliver ({2}{W}): Creature — Sliver, 2/2
+ * "All Sliver creatures have '{2}: This creature gets +0/+1 until end of turn.'"
+ */
+class ArmorSliverScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Armor Sliver grants the toughness-pump ability to Slivers") {
+
+            test("another Sliver gains the granted activated ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Armor Sliver")
+                    .withCardOnBattlefield(1, "Blade Sliver")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bladeSliver = game.findPermanent("Blade Sliver")!!
+                val pumpAction = game.getLegalActions(1).find {
+                    it.actionType == "ActivateAbility" &&
+                        (it.action as? ActivateAbility)?.sourceId == bladeSliver &&
+                        it.description.contains("+0/+1")
+                }
+                withClue("Blade Sliver should have the +0/+1 ability from Armor Sliver") {
+                    pumpAction shouldNotBe null
+                }
+            }
+
+            test("granted ability pumps toughness") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Armor Sliver")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val def = cardRegistry.getCard("Armor Sliver")!!
+                val abilityId = def.staticAbilities
+                    .filterIsInstance<GrantActivatedAbility>().first().ability.id
+                val armor = game.findPermanent("Armor Sliver")!!
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = armor, abilityId = abilityId)
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val card = game.getClientState(1).cards.values.first { it.name == "Armor Sliver" }
+                withClue("Armor Sliver should be 2/3 after +0/+1") {
+                    card.power shouldBe 2
+                    card.toughness shouldBe 3
+                }
+            }
+
+            test("non-Sliver creatures do not get the ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Armor Sliver")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val grizzly = game.findPermanent("Grizzly Bears")!!
+                val pumpAction = game.getLegalActions(1).find {
+                    it.actionType == "ActivateAbility" &&
+                        (it.action as? ActivateAbility)?.sourceId == grizzly &&
+                        it.description.contains("+0/+1")
+                }
+                withClue("Grizzly Bears should NOT have the ability") { pumpAction shouldBe null }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarbedSliverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarbedSliverScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Barbed Sliver.
+ *
+ * Barbed Sliver ({2}{R}): Creature — Sliver, 2/2
+ * "All Sliver creatures have '{2}: This creature gets +1/+0 until end of turn.'"
+ */
+class BarbedSliverScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Barbed Sliver grants the power-pump ability to Slivers") {
+
+            test("another Sliver gains the granted activated ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Barbed Sliver")
+                    .withCardOnBattlefield(1, "Blade Sliver")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bladeSliver = game.findPermanent("Blade Sliver")!!
+                val pumpAction = game.getLegalActions(1).find {
+                    it.actionType == "ActivateAbility" &&
+                        (it.action as? ActivateAbility)?.sourceId == bladeSliver &&
+                        it.description.contains("+1/+0")
+                }
+                withClue("Blade Sliver should have the +1/+0 ability from Barbed Sliver") {
+                    pumpAction shouldNotBe null
+                }
+            }
+
+            test("granted ability pumps power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Barbed Sliver")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val def = cardRegistry.getCard("Barbed Sliver")!!
+                val abilityId = def.staticAbilities
+                    .filterIsInstance<GrantActivatedAbility>().first().ability.id
+                val barbed = game.findPermanent("Barbed Sliver")!!
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = barbed, abilityId = abilityId)
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val card = game.getClientState(1).cards.values.first { it.name == "Barbed Sliver" }
+                withClue("Barbed Sliver should be 3/2 after +1/+0") {
+                    card.power shouldBe 3
+                    card.toughness shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClotSliverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClotSliverScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Clot Sliver.
+ *
+ * Clot Sliver ({1}{B}): Creature — Sliver, 1/1
+ * "All Slivers have '{2}: Regenerate this permanent.'"
+ */
+class ClotSliverScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Clot Sliver grants the regenerate ability to Slivers") {
+
+            test("another Sliver gains the granted regenerate ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Clot Sliver")
+                    .withCardOnBattlefield(1, "Blade Sliver")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bladeSliver = game.findPermanent("Blade Sliver")!!
+                val regenAction = game.getLegalActions(1).find {
+                    it.actionType == "ActivateAbility" &&
+                        (it.action as? ActivateAbility)?.sourceId == bladeSliver &&
+                        it.description.contains("Regenerate", ignoreCase = true)
+                }
+                withClue("Blade Sliver should have the regenerate ability from Clot Sliver") {
+                    regenAction shouldNotBe null
+                }
+            }
+
+            test("activating the granted ability creates a regeneration shield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Clot Sliver")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val def = cardRegistry.getCard("Clot Sliver")!!
+                val abilityId = def.staticAbilities
+                    .filterIsInstance<GrantActivatedAbility>().first().ability.id
+                val clot = game.findPermanent("Clot Sliver")!!
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = clot, abilityId = abilityId)
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val card = game.getClientState(1).cards.values.first { it.name == "Clot Sliver" }
+                withClue("Clot Sliver should have a regeneration shield") {
+                    card.activeEffects.any { it.name.startsWith("Regen") } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MindwhipSliverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MindwhipSliverScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Mindwhip Sliver.
+ *
+ * Mindwhip Sliver ({2}{B}): Creature — Sliver, 2/2
+ * "All Slivers have '{2}, Sacrifice this permanent: Target player discards a card at
+ *  random. Activate only as a sorcery.'"
+ */
+class MindwhipSliverScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Mindwhip Sliver grants the sacrifice-to-discard ability to Slivers") {
+
+            test("another Sliver gains the granted ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mindwhip Sliver")
+                    .withCardOnBattlefield(1, "Blade Sliver")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bladeSliver = game.findPermanent("Blade Sliver")!!
+                val action = game.getLegalActions(1).find {
+                    it.actionType == "ActivateAbility" &&
+                        (it.action as? ActivateAbility)?.sourceId == bladeSliver
+                }
+                withClue("Blade Sliver should have the sacrifice-to-discard ability from Mindwhip Sliver") {
+                    action shouldNotBe null
+                }
+            }
+
+            test("activating sacrifices the Sliver and the target player discards a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mindwhip Sliver")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val def = cardRegistry.getCard("Mindwhip Sliver")!!
+                val abilityId = def.staticAbilities
+                    .filterIsInstance<GrantActivatedAbility>().first().ability.id
+                val mindwhip = game.findPermanent("Mindwhip Sliver")!!
+                val opponentHandBefore = game.handSize(2)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = mindwhip,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Mindwhip Sliver should have been sacrificed") {
+                    game.findPermanent("Mindwhip Sliver") shouldBe null
+                }
+                withClue("Target player should have discarded a card at random") {
+                    game.handSize(2) shouldBe opponentHandBefore - 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MnemonicSliverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MnemonicSliverScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Mnemonic Sliver.
+ *
+ * Mnemonic Sliver ({2}{U}): Creature — Sliver, 2/2
+ * "All Slivers have '{2}, Sacrifice this permanent: Draw a card.'"
+ */
+class MnemonicSliverScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Mnemonic Sliver grants the sacrifice-to-draw ability to Slivers") {
+
+            test("another Sliver gains the granted draw ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mnemonic Sliver")
+                    .withCardOnBattlefield(1, "Blade Sliver")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bladeSliver = game.findPermanent("Blade Sliver")!!
+                val drawAction = game.getLegalActions(1).find {
+                    it.actionType == "ActivateAbility" &&
+                        (it.action as? ActivateAbility)?.sourceId == bladeSliver
+                }
+                withClue("Blade Sliver should have the sacrifice-to-draw ability from Mnemonic Sliver") {
+                    drawAction shouldNotBe null
+                }
+            }
+
+            test("activating sacrifices the Sliver and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Mnemonic Sliver")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val def = cardRegistry.getCard("Mnemonic Sliver")!!
+                val abilityId = def.staticAbilities
+                    .filterIsInstance<GrantActivatedAbility>().first().ability.id
+                val mnemonic = game.findPermanent("Mnemonic Sliver")!!
+                val handBefore = game.handSize(1)
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = mnemonic, abilityId = abilityId)
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Mnemonic Sliver should have been sacrificed") {
+                    game.findPermanent("Mnemonic Sliver") shouldBe null
+                }
+                withClue("Controller should have drawn a card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards (Tempest, canonical home TMP — all verified earliest-printing)

| Card | Cost | Oracle |
|------|------|--------|
| Armor Sliver | {2}{W} | All Sliver creatures have "{2}: This creature gets +0/+1 until end of turn." |
| Barbed Sliver | {2}{R} | All Sliver creatures have "{2}: This creature gets +1/+0 until end of turn." |
| Clot Sliver | {1}{B} | All Slivers have "{2}: Regenerate this permanent." |
| Mindwhip Sliver | {2}{B} | All Slivers have "{2}, Sacrifice this permanent: Target player discards a card at random. Activate only as a sorcery." |
| Mnemonic Sliver | {2}{U} | All Slivers have "{2}, Sacrifice this permanent: Draw a card." |

Each is a lord composed from existing primitives — `GrantActivatedAbility` over a Sliver `GroupFilter` wrapping an `ActivatedAbility`. No new SDK surface. Scenario tests in `rules-engine` cover the ability grant, activation behaviour (toughness/power pump, regeneration shield, sacrifice + draw, sacrifice + targeted random discard), and the non-Sliver exclusion. All 11 tests pass.

## Tooling change

The mtgish emitter previously scaffolded every "All Slivers have '{cost}: …'" card under the `EachPermanentLayerEffect` gap, because `staticLordBlock`'s `AddAbility` branch only rendered keyword grants. Now an `AddAbility` wrapping an `Activated` / `ActivatedWithModifiers` rule renders `GrantActivatedAbility(ability = ActivatedAbility(...), filter = group)`, reusing the existing cost/target/effect recovery in expression form (a chosen target becomes `targetRequirement` + the effect's `EffectTarget.ContextTarget(0)`; `ActivateOnlyAsASorcery` becomes `timing = TimingRule.SorcerySpeed`). The `PlayerAction` handler also learned to render "target player discards a card at random".

**Coverage-gaps for the 5 cards: SCAFFOLD → AUTOGEN** (all five now tier AUTO; TMP AUTOGEN total 99). The change is generic — it promotes the whole lord-grants-an-activated-ability shape across every set (e.g. the Legions sliver lords).

## Gates
- `coverage-verify --set POR`: **GATE PASS 158/158, 0 mismatch** (calibration anchor not regressed).
- `EmitterGoldenTest`: **PASS** (no calibrated-set drift; no re-bless needed).
- TMP card snapshot golden re-blessed — diff scoped to exactly the 5 new cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)