### PR TITLE
Add 5 Tempest utility lands + auto-gen them in mtgish tooling

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/AncientTomb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/AncientTomb.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ancient Tomb
+ * Land
+ *
+ * {T}: Add {C}{C}. This land deals 2 damage to you.
+ */
+val AncientTomb = card("Ancient Tomb") {
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}{C}. This land deals 2 damage to you."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(2)
+            .then(Effects.DealDamage(2, EffectTarget.PlayerRef(Player.You)))
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "315"
+        artist = "Colin MacNeil"
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/30e401e3-282b-4524-87e1-c6cd50cd6d00.jpg?1562053283"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/CalderaLake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/CalderaLake.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Caldera Lake
+ * Land
+ *
+ * This land enters tapped.
+ * {T}: Add {C}.
+ * {T}: Add {U} or {R}. This land deals 1 damage to you.
+ */
+val CalderaLake = card("Caldera Lake") {
+    typeLine = "Land"
+    colorIdentity = "UR"
+    oracleText = "This land enters tapped.\n{T}: Add {C}.\n{T}: Add {U} or {R}. This land deals 1 damage to you."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+            .then(Effects.DealDamage(1, EffectTarget.PlayerRef(Player.You)))
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+            .then(Effects.DealDamage(1, EffectTarget.PlayerRef(Player.You)))
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "316"
+        artist = "Allen Williams"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f01fe22-e8ff-4106-8ac5-693ef920b2c9.jpg?1562054963"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/GhostTown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/GhostTown.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.IsNotYourTurn
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ghost Town
+ * Land
+ *
+ * {T}: Add {C}.
+ * {0}: Return this land to its owner's hand. Activate only if it's not your turn.
+ */
+val GhostTown = card("Ghost Town") {
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{0}: Return this land to its owner's hand. Activate only if it's not your turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{0}")
+        effect = Effects.ReturnToHand(EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OnlyIfCondition(IsNotYourTurn))
+        description = "{0}: Return this land to its owner's hand. Activate only if it's not your turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "318"
+        artist = "Tom Wänerstrand"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/4218cdda-3a62-43fb-aaf7-7ac836392796.jpg?1562053761"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MazeOfShadows.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MazeOfShadows.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Maze of Shadows
+ * Land
+ *
+ * {T}: Add {C}.
+ * {T}: Untap target attacking creature with shadow. Prevent all combat damage
+ * that would be dealt to and dealt by that creature this turn.
+ */
+val MazeOfShadows = card("Maze of Shadows") {
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{T}: Untap target attacking creature with shadow. Prevent all combat damage " +
+        "that would be dealt to and dealt by that creature this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        val shadowAttacker = target(
+            "target attacking creature with shadow",
+            TargetCreature(filter = TargetFilter.AttackingCreature.withKeyword(Keyword.SHADOW)),
+        )
+        effect = Effects.Untap(shadowAttacker)
+            .then(Effects.PreventCombatDamageToAndBy(shadowAttacker))
+        description = "{T}: Untap target attacking creature with shadow. Prevent all combat damage " +
+            "that would be dealt to and dealt by that creature this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "319"
+        artist = "D. Alexander Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba69c3d3-6fb5-478d-93ba-341dd3ace97d.jpg?1562056379"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/PineBarrens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/PineBarrens.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pine Barrens
+ * Land
+ *
+ * This land enters tapped.
+ * {T}: Add {C}.
+ * {T}: Add {B} or {G}. This land deals 1 damage to you.
+ */
+val PineBarrens = card("Pine Barrens") {
+    typeLine = "Land"
+    colorIdentity = "BG"
+    oracleText = "This land enters tapped.\n{T}: Add {C}.\n{T}: Add {B} or {G}. This land deals 1 damage to you."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+            .then(Effects.DealDamage(1, EffectTarget.PlayerRef(Player.You)))
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+            .then(Effects.DealDamage(1, EffectTarget.PlayerRef(Player.You)))
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "321"
+        artist = "Rebecca Guay"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5ac39e8-bd0e-4fa3-bc1e-a93944d013f3.jpg?1562056869"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -1,3 +1,50 @@
+// Ancient Tomb
+{
+    "name": "Ancient Tomb",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}{C}. This land deals 2 damage to you.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddColorlessMana",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "315",
+        "rarity": "UNCOMMON",
+        "artist": "Colin MacNeil",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/30e401e3-282b-4524-87e1-c6cd50cd6d00.jpg?1562053283"
+    }
+}
+
 // Boil
 {
     "name": "Boil",
@@ -26,6 +73,96 @@
         "imageUri": "https://cards.scryfall.io/normal/front/2/f/2fa1c529-44e5-41b6-9704-ae2319f31f13.jpg"
     },
     "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Caldera Lake
+{
+    "name": "Caldera Lake",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {C}.\n{T}: Add {U} or {R}. This land deals 1 damage to you.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "BLUE"
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "RED"
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "316",
+        "rarity": "RARE",
+        "artist": "Allen Williams",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f01fe22-e8ff-4106-8ac5-693ef920b2c9.jpg?1562054963"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
         "RED"
     ]
 }
@@ -537,6 +674,56 @@
     ]
 }
 
+// Ghost Town
+{
+    "name": "Ghost Town",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{0}: Return this land to its owner's hand. Activate only if it's not your turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{0}"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": "IsNotYourTurn"
+                    }
+                ],
+                "descriptionOverride": "{0}: Return this land to its owner's hand. Activate only if it's not your turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "318",
+        "rarity": "UNCOMMON",
+        "artist": "Tom Wänerstrand",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/4218cdda-3a62-43fb-aaf7-7ac836392796.jpg?1562053761"
+    }
+}
+
 // Goblin Bombardment
 {
     "name": "Goblin Bombardment",
@@ -794,6 +981,73 @@
     ]
 }
 
+// Maze of Shadows
+{
+    "name": "Maze of Shadows",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{T}: Untap target attacking creature with shadow. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target attacking creature with shadow"
+                            },
+                            "tap": false
+                        },
+                        {
+                            "type": "PreventDamageShield",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target attacking creature with shadow"
+                            },
+                            "scope": "CombatOnly",
+                            "direction": "Both"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature kw:shadow attacking"
+                        },
+                        "id": "target attacking creature with shadow"
+                    }
+                ],
+                "descriptionOverride": "{T}: Untap target attacking creature with shadow. Prevent all combat damage that would be dealt to and dealt by that creature this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "319",
+        "rarity": "UNCOMMON",
+        "artist": "D. Alexander Gregory",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba69c3d3-6fb5-478d-93ba-341dd3ace97d.jpg?1562056379"
+    }
+}
+
 // Mogg Fanatic
 {
     "name": "Mogg Fanatic",
@@ -946,6 +1200,96 @@
         "imageUri": "https://cards.scryfall.io/normal/front/3/0/307f5d5e-3a4b-430e-8769-fb553216befa.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Pine Barrens
+{
+    "name": "Pine Barrens",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {C}.\n{T}: Add {B} or {G}. This land deals 1 damage to you.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "BLACK"
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "GREEN"
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "321",
+        "rarity": "RARE",
+        "artist": "Rebecca Guay",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5ac39e8-bd0e-4fa3-bc1e-a93944d013f3.jpg?1562056869"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
 }
 
 // Pit Imp

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -23,6 +23,9 @@ import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 /** (targets|null, actions|null) from the first Targeted / ActionList envelope in a subtree.
  *  Shared by spells (SpellActions) and triggered abilities (TriggerA). */
@@ -500,6 +503,26 @@ internal fun EmitCtx.activatedBlock(rule: JsonObject, activateFromZone: String? 
     if (cost == null) { reasons.add("activated-cost"); return null }
     val (targets, actions) = extractEnvelope(rule)
     if (actions == null) { reasons.add("activated-actions"); return null }
+
+    // "Add {U} or {R}." (Caldera Lake, Pine Barrens) is a single mtgish ability whose AddMana produces a
+    // *choice* of color. Argentum (and Adarkar Wastes / Brushland) model this as one activatedAbility per
+    // color, each carrying the same trailing actions (e.g. "This land deals 1 damage to you"). Expand the
+    // Or into N abilities, each with that color's single-produce AddMana spliced in for the Or node. Only a
+    // targetless mana ability whose Or is a flat list of single-color produces expands; anything else falls
+    // through to the single-ability path (and scaffolds there if the Or can't render).
+    manaChoiceExpansion(rule, cost, targets, actions, activateFromZone)?.let { return it }
+
+    return activatedAbilityStmts(rule, cost, targets, actions, activateFromZone)
+}
+
+/** Build one `activatedAbility { … }` block from already-recovered cost / target / action pieces. */
+private fun EmitCtx.activatedAbilityStmts(
+    rule: JsonObject,
+    cost: String,
+    targets: List<JsonObject>?,
+    actions: List<JsonObject>,
+    activateFromZone: String?,
+): List<Stmt>? {
     val (tnode, tvar) = spellTargetExpr(targets, actions) ?: return null
     val edsl = renderEffectList(actions, tvar) ?: return null
     val stmts = mutableListOf<Stmt>(Assign("cost", Lit(cost)))
@@ -515,6 +538,48 @@ internal fun EmitCtx.activatedBlock(rule: JsonObject, activateFromZone: String? 
         stmts.add(Assign("timing", Lit("TimingRule.ManaAbility")))
     }
     return listOf(Sub(Block("activatedAbility", stmts)))
+}
+
+/**
+ * `{T}: Add {U} or {R}. …` -> one `activatedAbility { }` per color. Returns null (fall through to the
+ * single-ability path) unless the actions contain exactly one `AddMana` whose produce is an `Or` of
+ * flat single-color/colorless symbols, the ability is targetless, and it carries no modifiers/zone — the
+ * conservative shape the pain-/filter-land idiom uses. Each emitted ability reuses the same trailing
+ * actions verbatim, so a damage rider ("This land deals 1 damage to you") is preserved per color.
+ */
+private fun EmitCtx.manaChoiceExpansion(
+    rule: JsonObject,
+    cost: String,
+    targets: List<JsonObject>?,
+    actions: List<JsonObject>,
+    activateFromZone: String?,
+): List<Stmt>? {
+    if (targets != null) return null
+    if (rule.strField("_Rule") == "ActivatedWithModifiers") return null
+    val orAction = actions.singleOrNull { act ->
+        act.strField("_Action") == "AddMana" &&
+            (act["args"] as? JsonObject)?.strField("_ManaProduce") == "Or"
+    } ?: return null
+    val orProduce = orAction["args"] as? JsonObject ?: return null
+    val choices = orProduce["args"].asArr ?: return null
+    if (choices.size < 2) return null
+    // Every Or child must itself be a single-color / colorless produce (no nested And/Or/choice).
+    val singles = choices.map { it as? JsonObject ?: return null }
+    if (singles.any { manaProduceDsl(it) == null }) return null
+
+    val blocks = mutableListOf<Stmt>()
+    for (single in singles) {
+        // Rewrite the actions list: replace the Or AddMana with one whose produce is this single color.
+        val rewritten = actions.map { act ->
+            if (act === orAction) buildJsonObject {
+                put("_Action", JsonPrimitive("AddMana"))
+                put("args", single)
+            } else act
+        }
+        val one = activatedAbilityStmts(rule, cost, null, rewritten, activateFromZone) ?: return null
+        blocks.addAll(one)
+    }
+    return blocks
 }
 
 /**
@@ -598,6 +663,22 @@ private fun EmitCtx.activationRestrictionLines(rule: JsonObject): List<String>? 
             "            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)",
             "        )",
         )
+    }
+    // "Activate only if it's not your turn" (Ghost Town): the sole modifier is an ActivateOnlyIf whose
+    // condition is IsAPlayersTurn over a player Other than you -> ActivationRestriction.OnlyIfCondition(
+    // IsNotYourTurn). Match the exact shape so any other ActivateOnlyIf condition still scaffolds.
+    run {
+        val mods = (rule["args"].asArr ?: emptyList()).filterIsInstance<JsonObject>()
+            .filter { it.strField("_ActivateModifier") != null }
+        val only = mods.singleOrNull()
+        if (only != null && only.strField("_ActivateModifier") == "ActivateOnlyIf") {
+            val cond = only["args"] as? JsonObject
+            if (cond?.strField("_Condition") == "IsAPlayersTurn" &&
+                jsonContains(cond, "_Players", "Other") && jsonContains(cond, "_Player", "You")
+            ) {
+                return listOf("        restrictions = listOf(ActivationRestriction.OnlyIfCondition(IsNotYourTurn))")
+            }
+        }
     }
     // "Activate no more than N times each turn" (Pit Imp / Phyrexian Battleflies) -> MaxPerTurn(N).
     // The modifier list is the rule's args after the cost + action list; render only when EVERY

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -239,6 +239,11 @@ private fun EmitCtx.refTargetFromRef(ref: String?, tvar: String?): String? {
     if (ref in SELF_REFS) return "EffectTarget.Self"
     // "that player" in a trigger ("the player ~ dealt combat damage to") -> the triggering player.
     if (ref == "Trigger_ThatPlayer") return "EffectTarget.PlayerRef(Player.TriggeringPlayer)"
+    // A plain player reference (no target) — the controller / "you" or an opponent. The pain-land idiom
+    // "{T}: Add {C}. This land deals N damage to you" carries a `_DamageRecipient: Player{You}` recipient
+    // that is the controller, not a chosen target (Adarkar Wastes, Caldera Lake, Ancient Tomb).
+    if (ref == "You") return "EffectTarget.PlayerRef(Player.You)"
+    if (ref == "Opponent") return "EffectTarget.PlayerRef(Player.Opponent)"
     return tvar
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -42,9 +42,19 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
     on("EachPlayerAction") { node, _, _ -> renderEachPlayer(node) }
     on("PlayerAction", "HavePlayerTakeAction") { node, _, tvar -> renderPlayerAction(node, tvar) }
 
-    on("CreateReplaceWouldDealDamageUntil") { node, _, _ ->
+    on("CreateReplaceWouldDealDamageUntil") { node, _, tvar ->
         val blob = compact(node)
         when {
+            // "Prevent all combat damage that would be dealt to and dealt by that creature this turn"
+            // (Maze of Shadows): an Or of the to-recipient + by-creature combat-damage events, both over
+            // the bound target permanent, + PreventThatDamage until EOT -> PreventCombatDamageToAndBy.
+            // Require the bound target so a self/untargeted variant doesn't slip through.
+            tvar != null &&
+                "CombatDamageWouldBeDealtToRecipient" in blob &&
+                "CombatDamageWouldBeDealtByCreature" in blob &&
+                jsonContains(node, "_Permanent", "Ref_TargetPermanent") &&
+                "PreventThatDamage" in blob && jsonContains(node, "_Expiration", "UntilEndOfTurn") ->
+                call("Effects.PreventCombatDamageToAndBy", arg(Lit(tvar)))
             // "prevent all damage attacking creatures would deal to you this turn" (Deep Wood)
             "IsAttacking" in blob && "PreventThatDamage" in blob && jsonContains(node, "_Player", "You") ->
                 call("Effects.PreventDamageFromAttackingCreatures")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.tooling.coverage.hasStringValue
 import com.wingedsheep.tooling.coverage.hasTag
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.nodesTagged
+import com.wingedsheep.tooling.coverage.pascalToUpperSnake
 import com.wingedsheep.tooling.coverage.render
 import com.wingedsheep.tooling.coverage.strField
 import com.wingedsheep.tooling.coverage.subtypes
@@ -201,8 +202,35 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
     }
     FilterPredicates.manaValueAtMost(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.manaValueAtLeast(filterNode)?.let { node = node.dot(it) }
+    // Keyword-ability restrictions ("attacking creature with shadow", Maze of Shadows): a
+    // HasAbility / DoesntHaveAbility clause carrying a `_CheckHasable` keyword -> .withKeyword /
+    // .withoutKeyword. Flying is already composed above (string match), so skip it here. If any
+    // HasAbility clause names an ability we can't map to a known SDK Keyword, decline (-> SCAFFOLD)
+    // rather than silently dropping the restriction and widening the target.
+    val keywordLinks = abilityKeywordLinks(filterNode) ?: return null
+    keywordLinks.forEach { node = node.dot(it) }
     controller?.let { node = node.dot(it) }
     return node
+}
+
+/**
+ * `.withKeyword(Keyword.X)` / `.withoutKeyword(Keyword.X)` links for every HasAbility / DoesntHaveAbility
+ * clause in [filterNode], or null if any such clause names an ability the SDK has no Keyword for (so the
+ * caller declines rather than dropping it). Flying is handled by the caller's string-based path, so it is
+ * skipped here to avoid a duplicate link.
+ */
+private fun EmitCtx.abilityKeywordLinks(filterNode: JsonElement?): List<Link>? {
+    val links = mutableListOf<Link>()
+    for ((tag, method) in listOf("HasAbility" to "withKeyword", "DoesntHaveAbility" to "withoutKeyword")) {
+        for (node in filterNode.nodesTagged(tag)) {
+            val kwName = node.firstWordAtKey("_CheckHasable") ?: return null  // non-keyword hasable -> decline
+            if (kwName == "Flying") continue  // composed by the caller's "Flying" string match
+            val kw = pascalToUpperSnake(kwName)
+            if (kw !in keywords) return null  // unknown ability -> decline (don't widen the filter)
+            links.add(Link(method, listOf(arg("Keyword.$kw"))))
+        }
+    }
+    return links
 }
 
 private fun targetTypes(args: JsonElement?): Set<String> = args.argWordsTagged("IsCardtype").toSet()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncientTombScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncientTombScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmp.cards.AncientTomb
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ancient Tomb (TMP #315)
+ * Land
+ * {T}: Add {C}{C}. This land deals 2 damage to you.
+ */
+class AncientTombScenarioTest : FunSpec({
+
+    val manaAbilityId = AncientTomb.activatedAbilities[0].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AncientTomb)
+        return driver
+    }
+
+    test("tapping Ancient Tomb adds {C}{C} and deals 2 damage to its controller") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val tomb = driver.putPermanentOnBattlefield(activePlayer, "Ancient Tomb")
+        val before = driver.getLifeTotal(activePlayer)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = tomb, abilityId = manaAbilityId)
+        )
+        result.isSuccess shouldBe true
+
+        driver.isTapped(tomb) shouldBe true
+
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool?.colorless shouldBe 2
+
+        driver.getLifeTotal(activePlayer) shouldBe (before - 2)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CalderaLakeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CalderaLakeScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmp.cards.CalderaLake
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Caldera Lake (TMP #316)
+ * Land — enters tapped
+ * {T}: Add {C}.
+ * {T}: Add {U} or {R}. This land deals 1 damage to you.
+ */
+class CalderaLakeScenarioTest : FunSpec({
+
+    val colorlessAbilityId = CalderaLake.activatedAbilities[0].id
+    val blueAbilityId = CalderaLake.activatedAbilities[1].id
+    val redAbilityId = CalderaLake.activatedAbilities[2].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CalderaLake)
+        return driver
+    }
+
+    test("the {U} ability adds blue mana and deals 1 damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val lake = driver.putPermanentOnBattlefield(activePlayer, "Caldera Lake")
+        driver.untapPermanent(lake) // ensure available regardless of ETB-tapped placement
+        val before = driver.getLifeTotal(activePlayer)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = lake, abilityId = blueAbilityId)
+        )
+        result.isSuccess shouldBe true
+
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool?.blue shouldBe 1
+        driver.getLifeTotal(activePlayer) shouldBe (before - 1)
+    }
+
+    test("the {R} ability adds red mana and deals 1 damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val lake = driver.putPermanentOnBattlefield(activePlayer, "Caldera Lake")
+        driver.untapPermanent(lake)
+        val before = driver.getLifeTotal(activePlayer)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = lake, abilityId = redAbilityId)
+        )
+        result.isSuccess shouldBe true
+
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool?.red shouldBe 1
+        driver.getLifeTotal(activePlayer) shouldBe (before - 1)
+    }
+
+    test("the {C} ability adds colorless mana and deals NO damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val lake = driver.putPermanentOnBattlefield(activePlayer, "Caldera Lake")
+        driver.untapPermanent(lake)
+        val before = driver.getLifeTotal(activePlayer)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = lake, abilityId = colorlessAbilityId)
+        )
+        result.isSuccess shouldBe true
+
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool?.colorless shouldBe 1
+        driver.getLifeTotal(activePlayer) shouldBe before
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostTownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostTownScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmp.cards.GhostTown
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.nulls.shouldBeNull
+
+/**
+ * Ghost Town (TMP #318)
+ * Land
+ * {T}: Add {C}.
+ * {0}: Return this land to its owner's hand. Activate only if it's not your turn.
+ */
+class GhostTownScenarioTest : FunSpec({
+
+    val manaAbilityId = GhostTown.activatedAbilities[0].id
+    val bounceAbilityId = GhostTown.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GhostTown)
+        return driver
+    }
+
+    test("the mana ability adds {C}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val town = driver.putPermanentOnBattlefield(activePlayer, "Ghost Town")
+
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = town, abilityId = manaAbilityId)
+        )
+        result.isSuccess shouldBe true
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool?.colorless shouldBe 1
+    }
+
+    test("the {0} bounce CANNOT be activated on its controller's own turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val town = driver.putPermanentOnBattlefield(activePlayer, "Ghost Town")
+
+        driver.submitExpectFailure(
+            ActivateAbility(playerId = activePlayer, sourceId = town, abilityId = bounceAbilityId)
+        )
+
+        // Still on the battlefield.
+        driver.findPermanent(activePlayer, "Ghost Town") shouldNotBe null
+    }
+
+    test("the {0} bounce CAN be activated when it's not the controller's turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        // Opponent controls the Ghost Town; it is the active player's turn, not the opponent's.
+        val town = driver.putPermanentOnBattlefield(opponent, "Ghost Town")
+
+        // Advance so the opponent gets priority during the active player's turn.
+        driver.passPriority(activePlayer)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = opponent, sourceId = town, abilityId = bounceAbilityId)
+        )
+        result.isSuccess shouldBe true
+        // Let the ability resolve.
+        driver.bothPass()
+
+        // Ghost Town left the battlefield and is back in the opponent's hand.
+        driver.findPermanent(opponent, "Ghost Town").shouldBeNull()
+        driver.findCardInHand(opponent, "Ghost Town") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MazeOfShadowsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MazeOfShadowsScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmp.cards.DauthiSlayer
+import com.wingedsheep.mtg.sets.definitions.tmp.cards.MazeOfShadows
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Maze of Shadows (TMP #319)
+ * Land
+ * {T}: Add {C}.
+ * {T}: Untap target attacking creature with shadow. Prevent all combat damage
+ *      that would be dealt to and dealt by that creature this turn.
+ */
+class MazeOfShadowsScenarioTest : FunSpec({
+
+    val manaAbilityId = MazeOfShadows.activatedAbilities[0].id
+    val untapAbilityId = MazeOfShadows.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(MazeOfShadows)
+        driver.registerCard(DauthiSlayer)
+        return driver
+    }
+
+    test("the mana ability adds {C}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val maze = driver.putPermanentOnBattlefield(activePlayer, "Maze of Shadows")
+
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = maze, abilityId = manaAbilityId)
+        )
+        result.isSuccess shouldBe true
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool?.colorless shouldBe 1
+    }
+
+    test("untaps a tapped attacking creature with shadow") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        val maze = driver.putPermanentOnBattlefield(activePlayer, "Maze of Shadows")
+        val slayer = driver.putPermanentOnBattlefield(activePlayer, "Dauthi Slayer")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(activePlayer, listOf(slayer), opponent).isSuccess shouldBe true
+
+        // Attacking taps the creature (no vigilance).
+        driver.isTapped(slayer) shouldBe true
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = maze,
+                abilityId = untapAbilityId,
+                targets = listOf(ChosenTarget.Permanent(slayer)),
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass() // resolve the ability
+
+        // The shadow attacker is now untapped.
+        driver.isTapped(slayer) shouldBe false
+    }
+
+    test("cannot target a non-shadow attacking creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        val maze = driver.putPermanentOnBattlefield(activePlayer, "Maze of Shadows")
+        val courser = driver.putPermanentOnBattlefield(activePlayer, "Centaur Courser")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(activePlayer, listOf(courser), opponent).isSuccess shouldBe true
+
+        // Centaur Courser has no shadow, so it is not a legal target.
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = maze,
+                abilityId = untapAbilityId,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+            )
+        )
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PineBarrensScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PineBarrensScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmp.cards.PineBarrens
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pine Barrens (TMP #321)
+ * Land — enters tapped
+ * {T}: Add {C}.
+ * {T}: Add {B} or {G}. This land deals 1 damage to you.
+ */
+class PineBarrensScenarioTest : FunSpec({
+
+    val colorlessAbilityId = PineBarrens.activatedAbilities[0].id
+    val blackAbilityId = PineBarrens.activatedAbilities[1].id
+    val greenAbilityId = PineBarrens.activatedAbilities[2].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(PineBarrens)
+        return driver
+    }
+
+    test("the {B} ability adds black mana and deals 1 damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val barrens = driver.putPermanentOnBattlefield(activePlayer, "Pine Barrens")
+        driver.untapPermanent(barrens)
+        val before = driver.getLifeTotal(activePlayer)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = barrens, abilityId = blackAbilityId)
+        )
+        result.isSuccess shouldBe true
+
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool?.black shouldBe 1
+        driver.getLifeTotal(activePlayer) shouldBe (before - 1)
+    }
+
+    test("the {G} ability adds green mana and deals 1 damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val barrens = driver.putPermanentOnBattlefield(activePlayer, "Pine Barrens")
+        driver.untapPermanent(barrens)
+        val before = driver.getLifeTotal(activePlayer)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = barrens, abilityId = greenAbilityId)
+        )
+        result.isSuccess shouldBe true
+
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool?.green shouldBe 1
+        driver.getLifeTotal(activePlayer) shouldBe (before - 1)
+    }
+
+    test("the {C} ability adds colorless mana and deals NO damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val barrens = driver.putPermanentOnBattlefield(activePlayer, "Pine Barrens")
+        driver.untapPermanent(barrens)
+        val before = driver.getLifeTotal(activePlayer)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = barrens, abilityId = colorlessAbilityId)
+        )
+        result.isSuccess shouldBe true
+
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool?.colorless shouldBe 1
+        driver.getLifeTotal(activePlayer) shouldBe before
+    }
+})


### PR DESCRIPTION
## Cards (all first-printed in Tempest, canonical home = TMP)

- **Ancient Tomb** — `{T}: Add {C}{C}. This land deals 2 damage to you.`
- **Caldera Lake** — enters tapped; `{T}: Add {C}`; `{T}: Add {U} or {R}. This land deals 1 damage to you.`
- **Pine Barrens** — enters tapped; `{T}: Add {C}`; `{T}: Add {B} or {G}. This land deals 1 damage to you.`
- **Ghost Town** — `{T}: Add {C}`; `{0}: Return this land to its owner's hand. Activate only if it's not your turn.`
- **Maze of Shadows** — `{T}: Add {C}`; `{T}: Untap target attacking creature with shadow. Prevent all combat damage that would be dealt to and dealt by that creature this turn.`

All five reuse existing SDK primitives — no new engine/SDK building blocks. Each ships with a passing Kotest scenario test (13 tests total, all green).

## Tooling change (SCAFFOLD → AUTOGEN for all 5)

Extended the `:mtgish-tooling` emitter so these land shapes render a whole compiling card:

1. **`refTargetFromRef`** — map a bare `You` / `Opponent` damage recipient to `EffectTarget.PlayerRef(...)`, unblocking the pain-land "deals N damage to you" rider (`PermanentDealsDamage` gap).
2. **`activatedBlock`** — expand an `AddMana { Or[colorA, colorB] }` mana ability into one `activatedAbility` per color (the Adarkar Wastes / Brushland idiom), carrying any trailing actions (the damage rider) verbatim (`AddMana` gap).
3. **`activationRestrictionLines`** — recognise `ActivateOnlyIf(IsAPlayersTurn Other(You))` → `ActivationRestriction.OnlyIfCondition(IsNotYourTurn)` (`activated-modifiers` gap, Ghost Town).
4. **`CreateReplaceWouldDealDamageUntil`** — recognise the to-recipient + by-creature combat-damage `Or` over the bound target → `Effects.PreventCombatDamageToAndBy(target)` (Maze of Shadows).
5. **`creatureFilterExpr`** — faithfully render `HasAbility`/`DoesntHaveAbility` keyword clauses (e.g. shadow) as `.withKeyword`/`.withoutKeyword`, and **DECLINE** (→ SCAFFOLD) on any unmapped ability rather than silently dropping the constraint (this also fixed a fidelity false-positive: the Maze target was previously widening to *any* attacking creature).

## Verification gates

- `just coverage-gaps --set TMP`: AUTOGEN **99 → 103**; the `AddMana` / `PermanentDealsDamage` / `CreateReplaceWouldDealDamageUntil` / Ghost-Town `activated-modifiers` SCAFFOLD entries are gone. All 5 cards emit `fidelity tier: AUTO`.
- `coverage-verify --set POR`: **GATE PASS, 0 mismatch (158/158)** — POR calibration anchor not regressed.
- `EmitterGoldenTest`: passes unchanged (no re-bless needed — POR emitter output is byte-identical).
- Full `:mtgish-tooling` test suite green.
- TMP card snapshot golden re-blessed (only the 5 new cards added; no other card moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)