### PR TITLE
Promote 31 mtgish-tooling AUTOGEN cards into Final Fantasy (FIN)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AdventurersAirship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AdventurersAirship.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+
+/**
+ * Adventurer's Airship
+ * {3}
+ * Artifact — Vehicle
+ * 3/2
+ * Flying
+ * Whenever this Vehicle attacks, draw a card, then discard a card.
+ * Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)
+ */
+val AdventurersAirship = card("Adventurer's Airship") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Flying\nWhenever this Vehicle attacks, draw a card, then discard a card.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)"
+    power = 3
+    toughness = 2
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            DrawCardsEffect(1),
+            Patterns.Hand.discardCards(1)
+        )
+    }
+    keywordAbility(KeywordAbility.crew(2))
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "252"
+        artist = "Racrufi"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a1d6dcd-bd41-4f57-a35b-6613811fe4d4.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AdventurersInn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AdventurersInn.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+
+
+/**
+ * Adventurer's Inn
+ * Land — Town
+ * When this land enters, you gain 2 life.
+ * {T}: Add {C}.
+ */
+val AdventurersInn = card("Adventurer's Inn") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land — Town"
+    oracleText = "When this land enters, you gain 2 life.\n{T}: Add {C}."
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = GainLifeEffect(2)
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "271"
+        artist = "Allen Morris"
+        flavorText = "\"Welcome! We have rooms for 200 gil a night. Would you like to stay and rest your body and mind?\"\n—Innkeep"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0da2ee1-986e-4cbf-92eb-d96fdb572ca5.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Ahriman.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Ahriman.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+
+/**
+ * Ahriman
+ * {2}{B}
+ * Creature — Eye Horror
+ * 2/2
+ * Flying, deathtouch
+ * {3}, Sacrifice another creature or artifact: Draw a card.
+ */
+val Ahriman = card("Ahriman") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Eye Horror"
+    oracleText = "Flying, deathtouch\n{3}, Sacrifice another creature or artifact: Draw a card."
+    power = 2
+    toughness = 2
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Sacrifice(GameObjectFilter.CreatureOrArtifact))
+        effect = DrawCardsEffect(1)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Kevin Sidharta"
+        flavorText = "\"The Wrath of Dark has nearly reached its zenith! No one can stop it! Least of all you!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/162a415c-5465-497e-8f4e-c6f09681641d.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AuronsInspiration.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AuronsInspiration.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+
+/**
+ * Auron's Inspiration
+ * {2}{W}
+ * Instant
+ * Attacking creatures get +2/+0 until end of turn.
+ * Flashback {2}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+ */
+val AuronsInspiration = card("Auron's Inspiration") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Attacking creatures get +2/+0 until end of turn.\nFlashback {2}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.attacking()),
+            Effects.ModifyStats(2, 0, EffectTarget.Self)
+        )
+    }
+    keywordAbility(KeywordAbility.flashback("{2}{W}{W}"))
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "8"
+        artist = "Fang Xinyu"
+        flavorText = "\"Now is the time to choose! Now is the time to shape your stories! Your fate is in your hands!\"\n—Auron"
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/77d82764-563c-4bc2-b568-625ec7215e0d.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BlitzballShot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BlitzballShot.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+
+/**
+ * Blitzball Shot
+ * {1}{G}
+ * Instant
+ * Target creature gets +3/+3 and gains trample until end of turn.
+ */
+val BlitzballShot = card("Blitzball Shot") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+3 and gains trample until end of turn."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 3, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "176"
+        artist = "JUGEMT"
+        flavorText = "\"Everyone seems to be calling for Wakka, folks!\"\n—Blitzball announcer"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec8ab637-3d7d-4712-9f83-8920f808f715.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CapitalCity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CapitalCity.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Capital City
+ * Land — Town
+ * {T}: Add {C}.
+ * {1}, {T}: Add one mana of any color.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val CapitalCity = card("Capital City") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land — Town"
+    oracleText = "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    keywordAbility(KeywordAbility.cycling("{2}"))
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "274"
+        artist = "Wei Guan"
+        flavorText = "A city built upon the Isles of Ark that straddle the continents of Storm and Ash."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f73ce8ec-c916-48eb-ae20-c0d6d03d7145.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CloudOfDarkness.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CloudOfDarkness.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+
+/**
+ * Cloud of Darkness
+ * {2}{B}{G}{G}
+ * Legendary Creature — Avatar
+ * 3/3
+ * Flying
+ * Particle Beam — When Cloud of Darkness enters, target creature an opponent controls gets -X/-X until end of turn, where X is the number of permanent cards in your graveyard.
+ */
+val CloudOfDarkness = card("Cloud of Darkness") {
+    manaCost = "{2}{B}{G}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Avatar"
+    oracleText = "Flying\nParticle Beam — When Cloud of Darkness enters, target creature an opponent controls gets -X/-X until end of turn, where X is the number of permanent cards in your graveyard."
+    power = 3
+    toughness = 3
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
+        // X = the number of permanent cards in your graveyard.
+        effect = Effects.ModifyStats(
+            DynamicAmount.Multiply(DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Permanent), -1),
+            DynamicAmount.Multiply(DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Permanent), -1),
+            t
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "217"
+        artist = "Fariba Khamseh"
+        flavorText = "\"We are the Cloud of Darkness! Bringer of wrath and destroyer of light!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a292094a-674a-401f-8776-ba5ebe57c946.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DragoonsWyvern.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DragoonsWyvern.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+
+/**
+ * Dragoon's Wyvern
+ * {2}{U}
+ * Creature — Drake
+ * 2/1
+ * Flying
+ * When this creature enters, create a 1/1 colorless Hero creature token.
+ */
+val DragoonsWyvern = card("Dragoon's Wyvern") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    oracleText = "Flying\nWhen this creature enters, create a 1/1 colorless Hero creature token."
+    power = 2
+    toughness = 1
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(power = 1, toughness = 1, creatureTypes = setOf("Hero"))
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Jason Kiantoro"
+        flavorText = "\"I heard that to become a dragoon, you had to make a pact with a living wyvern. However, thanks to the dragonslayers, there aren't that many dragons left.\"\n—Ceraulian, San d'Oria citizen"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d92bce20-308e-4841-aaf8-8e20698292e7.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DreamsOfLaguna.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DreamsOfLaguna.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+
+/**
+ * Dreams of Laguna
+ * {1}{U}
+ * Instant
+ * Surveil 1, then draw a card. (To surveil 1, look at the top card of your library. You may put it into your graveyard.)
+ * Flashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+ */
+val DreamsOfLaguna = card("Dreams of Laguna") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Surveil 1, then draw a card. (To surveil 1, look at the top card of your library. You may put it into your graveyard.)\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+    spell {
+        effect = Effects.Composite(
+            Patterns.Library.surveil(1),
+            DrawCardsEffect(1)
+        )
+    }
+    keywordAbility(KeywordAbility.flashback("{3}{U}"))
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Solan"
+        flavorText = "\"Don't go back on your word. C'mon, go wave to her.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba752243-2727-4b8a-8e21-e70becfd4ff3.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DwarvenCastleGuard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DwarvenCastleGuard.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+
+/**
+ * Dwarven Castle Guard
+ * {1}{W}
+ * Creature — Dwarf Soldier
+ * 2/1
+ * When this creature dies, create a 1/1 colorless Hero creature token.
+ */
+val DwarvenCastleGuard = card("Dwarven Castle Guard") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Soldier"
+    oracleText = "When this creature dies, create a 1/1 colorless Hero creature token."
+    power = 2
+    toughness = 1
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(power = 1, toughness = 1, creatureTypes = setOf("Hero"))
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Crystal Fae"
+        flavorText = "\"'Lali-ho' is the dwarven greeting!\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e17c0d27-e88d-4ba9-acbb-3f916cee3d7e.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/EvilReawakened.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/EvilReawakened.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+
+/**
+ * Evil Reawakened
+ * {4}{B}
+ * Sorcery
+ * Return target creature card from your graveyard to the battlefield with two additional +1/+1 counters on it.
+ */
+val EvilReawakened = card("Evil Reawakened") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to the battlefield with two additional +1/+1 counters on it."
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
+        // Return it to the battlefield, then put two additional +1/+1 counters on it.
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+            .then(AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 2, t))
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "98"
+        artist = "Nino Is"
+        flavorText = "\"Galuf. It's good to see you again . . . Mwa-hahahahaha!\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb98cbc3-749c-44f4-974c-00be1286d69e.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GladiolusAmicitia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GladiolusAmicitia.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+
+/**
+ * Gladiolus Amicitia
+ * {4}{R}{G}
+ * Legendary Creature — Human Warrior
+ * 6/6
+ * When Gladiolus Amicitia enters, search your library for a land card, put it onto the battlefield tapped, then shuffle.
+ * Landfall — Whenever a land you control enters, another target creature you control gets +2/+2 and gains trample until end of turn.
+ */
+val GladiolusAmicitia = card("Gladiolus Amicitia") {
+    manaCost = "{4}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Human Warrior"
+    oracleText = "When Gladiolus Amicitia enters, search your library for a land card, put it onto the battlefield tapped, then shuffle.\nLandfall — Whenever a land you control enters, another target creature you control gets +2/+2 and gains trample until end of turn."
+    power = 6
+    toughness = 6
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Land,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true
+        )
+    }
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(filter = GameObjectFilter.Land.youControl(), binding = TriggerBinding.ANY)
+        val t = target("target", TargetCreature(filter = TargetFilter.OtherCreatureYouControl))
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t)
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "224"
+        artist = "Gal Or"
+        flavorText = "\"Guard the king with our lives—that's the way it's always been.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/442957fc-045d-4db6-b82a-445f172d23e4.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GoobbueGardener.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GoobbueGardener.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Goobbue Gardener
+ * {1}{G}
+ * Creature — Plant Beast
+ * 1/3
+ * {T}: Add {G}.
+ */
+val GoobbueGardener = card("Goobbue Gardener") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Beast"
+    oracleText = "{T}: Add {G}."
+    power = 1
+    toughness = 3
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "188"
+        artist = "Janna Sophia"
+        flavorText = "The parasitic moss that grows in the folds of the goobbue's back is highly valued as an ingredient in various potions and medicines."
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7c3544a-5dd5-423e-8a40-ac4803db8adc.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Hecteyes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Hecteyes.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+
+/**
+ * Hecteyes
+ * {1}{B}
+ * Creature — Ooze Horror
+ * 1/1
+ * When this creature enters, each opponent discards a card.
+ */
+val Hecteyes = card("Hecteyes") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Ooze Horror"
+    oracleText = "When this creature enters, each opponent discards a card."
+    power = 1
+    toughness = 1
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Hand.eachOpponentDiscards(1)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "SHOSUKE"
+        flavorText = "\"Once, the monsters of Hell poured forth into the world. They entered using a path known as the Jade Passage.\"\n—Hilda, Princess of Fynn"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/8680d052-c07b-4d9b-bda9-b5f69f44f424.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IlMhegPixie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IlMhegPixie.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+
+/**
+ * Il Mheg Pixie
+ * {1}{U}
+ * Creature — Faerie
+ * 2/1
+ * Flying
+ * Whenever this creature attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)
+ */
+val IlMhegPixie = card("Il Mheg Pixie") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie"
+    oracleText = "Flying\nWhenever this creature attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+    power = 2
+    toughness = 1
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Library.surveil(1)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "57"
+        artist = "Ramza Psyru"
+        flavorText = "\"Well now, aren't you just brimming with life? I'd love to suck up all that aether like nectar from a flower!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae612312-3a8e-495f-8730-deaaf7505ca1.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/InstantRamen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/InstantRamen.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+
+
+/**
+ * Instant Ramen
+ * {2}
+ * Artifact — Food
+ * Flash
+ * When this artifact enters, draw a card.
+ * {2}, {T}, Sacrifice this artifact: You gain 3 life.
+ */
+val InstantRamen = card("Instant Ramen") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Food"
+    oracleText = "Flash\nWhen this artifact enters, draw a card.\n{2}, {T}, Sacrifice this artifact: You gain 3 life."
+    keywords(Keyword.FLASH)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = DrawCardsEffect(1)
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = GainLifeEffect(3)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "259"
+        artist = "David Astruga"
+        flavorText = "\"It's not about finding the single best ingredient. It's about crafting that perfect blend of meat, egg, and shrimp. That harmony of flavors is key.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef7011f4-fc08-4b15-973d-d15357cbe744.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IronGiant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IronGiant.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+
+/**
+ * Iron Giant
+ * {7}
+ * Artifact Creature — Demon
+ * 6/6
+ * Vigilance, reach, trample
+ */
+val IronGiant = card("Iron Giant") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Demon"
+    oracleText = "Vigilance, reach, trample"
+    power = 6
+    toughness = 6
+    keywords(Keyword.VIGILANCE, Keyword.REACH, Keyword.TRAMPLE)
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "260"
+        artist = "John Tyler Christopher"
+        flavorText = "The iron giant is both hostile and powerful, using a giant blade to fell its foes. The mere mention of its name strikes fear in the hearts of drivers who know how perilous the roads are at night."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e48cf6d5-4d32-4b66-80be-3495ecd3e906.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JumboCactuar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JumboCactuar.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+
+/**
+ * Jumbo Cactuar
+ * {5}{G}{G}
+ * Creature — Plant
+ * 1/7
+ * 10,000 Needles — Whenever this creature attacks, it gets +9999/+0 until end of turn.
+ */
+val JumboCactuar = card("Jumbo Cactuar") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant"
+    oracleText = "10,000 Needles — Whenever this creature attacks, it gets +9999/+0 until end of turn."
+    power = 1
+    toughness = 7
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(9999, 0, EffectTarget.Self)
+    }
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "191"
+        artist = "Jason Kiantoro"
+        flavorText = "Some Cactuars live long lives and grow huge. This Jumbo Cactuar is one of them."
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db01c222-8795-47e9-a789-e7f749a3ee7d.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LionHeart.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LionHeart.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+
+/**
+ * Lion Heart
+ * {4}
+ * Artifact — Equipment
+ * When this Equipment enters, it deals 2 damage to any target.
+ * Equipped creature gets +2/+1.
+ * Equip {2}
+ */
+val LionHeart = card("Lion Heart") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, it deals 2 damage to any target.\nEquipped creature gets +2/+1.\nEquip {2}"
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", AnyTarget())
+        effect = DealDamageEffect(2, t)
+    }
+    staticAbility {
+        ability = ModifyStats(2, 1)
+    }
+    equipAbility("{2}")
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "261"
+        artist = "Mushk Rizvi"
+        flavorText = "\"Lions are known for their great strength and pride.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04d327a3-1699-4556-b681-a957671ad142.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LoporritScout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LoporritScout.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+
+/**
+ * Loporrit Scout
+ * {2}{G}
+ * Creature — Rabbit Scout
+ * 3/2
+ * Whenever another creature you control enters, this creature gets +1/+1 until end of turn.
+ */
+val LoporritScout = card("Loporrit Scout") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rabbit Scout"
+    oracleText = "Whenever another creature you control enters, this creature gets +1/+1 until end of turn."
+    power = 3
+    toughness = 2
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Andrea Radeck"
+        flavorText = "\"I've come to realize that it's important to put down the book every now and then, and experience some adventures for myself.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a182bc66-bfda-4bf5-bd12-3de5dba60945.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LunaticPandora.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LunaticPandora.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+
+/**
+ * Lunatic Pandora
+ * {1}
+ * Legendary Artifact
+ * {2}, {T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)
+ * {6}, {T}, Sacrifice Lunatic Pandora: Destroy target nonland permanent.
+ */
+val LunaticPandora = card("Lunatic Pandora") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact"
+    oracleText = "{2}, {T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{6}, {T}, Sacrifice Lunatic Pandora: Destroy target nonland permanent."
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = Patterns.Library.surveil(1)
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target("target", TargetPermanent(filter = TargetFilter.NonlandPermanent))
+        effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "262"
+        artist = "Enora Mercier"
+        flavorText = "\"Inside the Lunatic Pandora is this thing called a Crystal Pillar. It calls monsters from the Moon.\"\n—Zell Dincht"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6e1e3e7-20d4-42cb-ad22-60356b9e8fdc.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagicDamper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagicDamper.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+
+/**
+ * Magic Damper
+ * {U}
+ * Instant
+ * Target creature you control gets +1/+1 and gains hexproof until end of turn. Untap it.
+ */
+val MagicDamper = card("Magic Damper") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature you control gets +1/+1 and gains hexproof until end of turn. Untap it."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.youControl()))
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 1, t),
+            Effects.GrantKeyword(Keyword.HEXPROOF, t),
+            Effects.Untap(t)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "61"
+        artist = "YASUNARI HIRASAKA"
+        flavorText = "\"You're gonna wish you hadn't.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44921b2e-5938-4f63-92b9-0b719a2f8c68.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagicPot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagicPot.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+
+/**
+ * Magic Pot
+ * {3}
+ * Artifact Creature — Goblin Construct
+ * 1/4
+ * When this creature dies, create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ * {2}, {T}: Exile target card from a graveyard.
+ */
+val MagicPot = card("Magic Pot") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Goblin Construct"
+    oracleText = "When this creature dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\n{2}, {T}: Exile target card from a graveyard."
+    power = 1
+    toughness = 4
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateTreasure(1)
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val t = target("target", TargetObject(filter = TargetFilter.CardInGraveyard))
+        effect = Effects.Move(t, Zone.EXILE)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "263"
+        artist = "David Astruga"
+        flavorText = "\"Gimme elixir!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57d07ca0-5618-4a90-a605-ca14a193ce3b.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagitekArmor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagitekArmor.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+
+/**
+ * Magitek Armor
+ * {3}{W}
+ * Artifact — Vehicle
+ * 4/4
+ * When this Vehicle enters, create a 1/1 colorless Hero creature token.
+ * Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)
+ */
+val MagitekArmor = card("Magitek Armor") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "When this Vehicle enters, create a 1/1 colorless Hero creature token.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)"
+    power = 4
+    toughness = 4
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(power = 1, toughness = 1, creatureTypes = setOf("Hero"))
+    }
+    keywordAbility(KeywordAbility.crew(1))
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "24"
+        artist = "Nathaniel Himawan"
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/59c4a1a2-623c-43b2-8005-ecb5c6436c10.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Overkill.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Overkill.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+
+/**
+ * Overkill
+ * {2}{B}
+ * Instant
+ * Target creature gets -0/-9999 until end of turn.
+ */
+val Overkill = card("Overkill") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -0/-9999 until end of turn."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(0, -9999, t)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "109"
+        artist = "Bachzim"
+        flavorText = "\"Hey why don't ya try out that sword I gave you!\"\n—Wakka"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae075e71-d33d-4d6c-b4a5-0b47dd6fd196.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ResentfulRevelation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ResentfulRevelation.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+
+/**
+ * Resentful Revelation
+ * {1}{B}
+ * Sorcery
+ * Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.
+ * Flashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+ */
+val ResentfulRevelation = card("Resentful Revelation") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(count = 3, keepCount = 1)
+    }
+    keywordAbility(KeywordAbility.flashback("{6}{B}"))
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Justyna Dura"
+        flavorText = "\"The Jenova Project resulted in my conception.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/945006ea-c6a1-4ee5-abb2-387c2b6d3123.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RingOfTheLucii.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RingOfTheLucii.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+
+/**
+ * Ring of the Lucii
+ * {4}
+ * Legendary Artifact
+ * {T}: Add {C}{C}.
+ * {2}, {T}, Pay 1 life: Tap target nonland permanent.
+ */
+val RingOfTheLucii = card("Ring of the Lucii") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact"
+    oracleText = "{T}: Add {C}{C}.\n{2}, {T}, Pay 1 life: Tap target nonland permanent."
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(2)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.PayLife(1))
+        val t = target("target", TargetPermanent(filter = TargetFilter.NonlandPermanent))
+        effect = Effects.Tap(t)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "269"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "\"Kings of Lucis... come to me!\"\n—Noctis Lucis Caelum"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75761f1e-9449-4c58-8265-8abac71dafc1.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SephirothsIntervention.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SephirothsIntervention.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+
+/**
+ * Sephiroth's Intervention
+ * {3}{B}
+ * Instant
+ * Destroy target creature. You gain 2 life.
+ */
+val SephirothsIntervention = card("Sephiroth's Intervention") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature. You gain 2 life."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.Move(t, Zone.GRAVEYARD, byDestruction = true),
+            GainLifeEffect(2)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Joshua Raphael"
+        flavorText = "\"Fate is not to be taken lightly, Cloud.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cf7df82f-937a-443f-813f-2bcc6944c5c0.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TidusBlitzballStar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TidusBlitzballStar.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+
+/**
+ * Tidus, Blitzball Star
+ * {1}{W}{U}
+ * Legendary Creature — Human Warrior
+ * 2/1
+ * Whenever an artifact you control enters, put a +1/+1 counter on Tidus.
+ * Whenever Tidus attacks, tap target creature an opponent controls.
+ */
+val TidusBlitzballStar = card("Tidus, Blitzball Star") {
+    manaCost = "{1}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Warrior"
+    oracleText = "Whenever an artifact you control enters, put a +1/+1 counter on Tidus.\nWhenever Tidus attacks, tap target creature an opponent controls."
+    power = 2
+    toughness = 1
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = AddCountersEffect(counterType = Counters.PLUS_ONE_PLUS_ONE, count = 1, target = EffectTarget.Self)
+    }
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
+        effect = Effects.Tap(t)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "246"
+        artist = "Nakamura8"
+        flavorText = "\"Every blitzer knows: when you got the ball, you gotta score!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa851d68-a7a4-48c0-9cd7-d3d2e079f3a1.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/UndercityDireRat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/UndercityDireRat.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+
+/**
+ * Undercity Dire Rat
+ * {1}{B}
+ * Creature — Rat
+ * 2/2
+ * Rat Tail — When this creature dies, create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ */
+val UndercityDireRat = card("Undercity Dire Rat") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat"
+    oracleText = "Rat Tail — When this creature dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+    power = 2
+    toughness = 2
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateTreasure(1)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "Leonardo Santanna"
+        flavorText = "\"I finally worked out how to get the door on the left side open! I hope there's somethin' in there besides rats...\"\n—Kytes, street urchin"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/274788f4-fbf3-4a15-bdc0-f513a2fde30d.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/WorldMap.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/WorldMap.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+
+/**
+ * World Map
+ * {1}
+ * Artifact
+ * {1}, {T}, Sacrifice this artifact: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+ * {3}, {T}, Sacrifice this artifact: Search your library for a land card, reveal it, put it into your hand, then shuffle.
+ */
+val WorldMap = card("World Map") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}, Sacrifice this artifact: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{3}, {T}, Sacrifice this artifact: Search your library for a land card, reveal it, put it into your hand, then shuffle."
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Land,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "270"
+        artist = "Septian Fajrianto"
+        flavorText = "And so their quest began."
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70d9ab99-ec8a-402e-ba1d-ffa6c4c84a3f.jpg"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -1,3 +1,187 @@
+// Adventurer's Airship
+{
+    "name": "Adventurer's Airship",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Flying\nWhenever this Vehicle attacks, draw a card, then discard a card.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "artist": "Racrufi",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a1d6dcd-bd41-4f57-a35b-6613811fe4d4.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Adventurer's Inn
+{
+    "name": "Adventurer's Inn",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "When this land enters, you gain 2 life.\n{T}: Add {C}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "artist": "Allen Morris",
+        "flavorText": "\"Welcome! We have rooms for 200 gil a night. Would you like to stay and rest your body and mind?\"\n—Innkeep",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0da2ee1-986e-4cbf-92eb-d96fdb572ca5.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Ahriman
+{
+    "name": "Ahriman",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Eye Horror",
+    "oracleText": "Flying, deathtouch\n{3}, Sacrifice another creature or artifact: Draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{3}"
+                        },
+                        {
+                            "type": "CostSacrifice",
+                            "filter": "creature|artifact"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Kevin Sidharta",
+        "flavorText": "\"The Wrath of Dark has nearly reached its zenith! No one can stop it! Least of all you!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/162a415c-5465-497e-8f4e-c6f09681641d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Ardyn, the Usurper
 {
     "name": "Ardyn, the Usurper",
@@ -107,6 +291,164 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Auron's Inspiration
+{
+    "name": "Auron's Inspiration",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Attacking creatures get +2/+0 until end of turn.\nFlashback {2}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{2}{W}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEachInGroup",
+            "filter": {
+                "baseFilter": "creature attacking"
+            },
+            "effect": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "UNCOMMON",
+        "artist": "Fang Xinyu",
+        "flavorText": "\"Now is the time to choose! Now is the time to shape your stories! Your fate is in your hands!\"\n—Auron",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/77d82764-563c-4bc2-b568-625ec7215e0d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Blitzball Shot
+{
+    "name": "Blitzball Shot",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+3 and gains trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "artist": "JUGEMT",
+        "flavorText": "\"Everyone seems to be calling for Wakka, folks!\"\n—Blitzball announcer",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec8ab637-3d7d-4712-9f83-8920f808f715.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Capital City
+{
+    "name": "Capital City",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{1}"
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "274",
+        "rarity": "UNCOMMON",
+        "artist": "Wei Guan",
+        "flavorText": "A city built upon the Isles of Ark that straddle the continents of Storm and Ash.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f73ce8ec-c916-48eb-ae20-c0d6d03d7145.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Cecil, Dark Knight
@@ -235,6 +577,77 @@
     ]
 }
 
+// Cloud of Darkness
+{
+    "name": "Cloud of Darkness",
+    "manaCost": "{2}{B}{G}{G}",
+    "typeLine": "Legendary Creature — Avatar",
+    "oracleText": "Flying\nParticle Beam — When Cloud of Darkness enters, target creature an opponent controls gets -X/-X until end of turn, where X is the number of permanent cards in your graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "filter": "permanent"
+                        },
+                        "multiplier": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "filter": "permanent"
+                        },
+                        "multiplier": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "UNCOMMON",
+        "artist": "Fariba Khamseh",
+        "flavorText": "\"We are the Cloud of Darkness! Bringer of wrath and destroyer of light!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a292094a-674a-401f-8776-ba5ebe57c946.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Demon Wall
 {
     "name": "Demon Wall",
@@ -290,6 +703,1261 @@
     ]
 }
 
+// Dragoon's Wyvern
+{
+    "name": "Dragoon's Wyvern",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nWhen this creature enters, create a 1/1 colorless Hero creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Hero"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Jason Kiantoro",
+        "flavorText": "\"I heard that to become a dragoon, you had to make a pact with a living wyvern. However, thanks to the dragonslayers, there aren't that many dragons left.\"\n—Ceraulian, San d'Oria citizen",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d92bce20-308e-4841-aaf8-8e20698292e7.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Dreams of Laguna
+{
+    "name": "Dreams of Laguna",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Surveil 1, then draw a card. (To surveil 1, look at the top card of your library. You may put it into your graveyard.)\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{3}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "surveiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "surveiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put in graveyard",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Solan",
+        "flavorText": "\"Don't go back on your word. C'mon, go wave to her.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba752243-2727-4b8a-8e21-e70becfd4ff3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Dwarven Castle Guard
+{
+    "name": "Dwarven Castle Guard",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Dwarf Soldier",
+    "oracleText": "When this creature dies, create a 1/1 colorless Hero creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Hero"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Crystal Fae",
+        "flavorText": "\"'Lali-ho' is the dwarven greeting!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e17c0d27-e88d-4ba9-acbb-3f916cee3d7e.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Evil Reawakened
+{
+    "name": "Evil Reawakened",
+    "manaCost": "{4}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to the battlefield with two additional +1/+1 counters on it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Is",
+        "flavorText": "\"Galuf. It's good to see you again . . . Mwa-hahahahaha!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/eb98cbc3-749c-44f4-974c-00be1286d69e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Gladiolus Amicitia
+{
+    "name": "Gladiolus Amicitia",
+    "manaCost": "{4}{R}{G}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "When Gladiolus Amicitia enters, search your library for a land card, put it onto the battlefield tapped, then shuffle.\nLandfall — Whenever a land you control enters, another target creature you control gets +2/+2 and gains trample until end of turn.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "land"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "UNCOMMON",
+        "artist": "Gal Or",
+        "flavorText": "\"Guard the king with our lives—that's the way it's always been.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/442957fc-045d-4db6-b82a-445f172d23e4.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Goobbue Gardener
+{
+    "name": "Goobbue Gardener",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Plant Beast",
+    "oracleText": "{T}: Add {G}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "artist": "Janna Sophia",
+        "flavorText": "The parasitic moss that grows in the folds of the goobbue's back is highly valued as an ingredient in various potions and medicines.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b7c3544a-5dd5-423e-8a40-ac4803db8adc.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Hecteyes
+{
+    "name": "Hecteyes",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Ooze Horror",
+    "oracleText": "When this creature enters, each opponent discards a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEachPlayer",
+                    "players": "EachOpponent",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "discarded"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "SHOSUKE",
+        "flavorText": "\"Once, the monsters of Hell poured forth into the world. They entered using a path known as the Jade Passage.\"\n—Hilda, Princess of Fynn",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/8680d052-c07b-4d9b-bda9-b5f69f44f424.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Il Mheg Pixie
+{
+    "name": "Il Mheg Pixie",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Faerie",
+    "oracleText": "Flying\nWhenever this creature attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "surveiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "surveiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put in graveyard",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "UNCOMMON",
+        "artist": "Ramza Psyru",
+        "flavorText": "\"Well now, aren't you just brimming with life? I'd love to suck up all that aether like nectar from a flower!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae612312-3a8e-495f-8730-deaaf7505ca1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Instant Ramen
+{
+    "name": "Instant Ramen",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Food",
+    "oracleText": "Flash\nWhen this artifact enters, draw a card.\n{2}, {T}, Sacrifice this artifact: You gain 3 life.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{2}"
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "artist": "David Astruga",
+        "flavorText": "\"It's not about finding the single best ingredient. It's about crafting that perfect blend of meat, egg, and shrimp. That harmony of flavors is key.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef7011f4-fc08-4b15-973d-d15357cbe744.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Iron Giant
+{
+    "name": "Iron Giant",
+    "manaCost": "{7}",
+    "typeLine": "Artifact Creature — Demon",
+    "oracleText": "Vigilance, reach, trample",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE",
+        "REACH",
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "260",
+        "artist": "John Tyler Christopher",
+        "flavorText": "The iron giant is both hostile and powerful, using a giant blade to fell its foes. The mere mention of its name strikes fear in the hearts of drivers who know how perilous the roads are at night.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e48cf6d5-4d32-4b66-80be-3495ecd3e906.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Jumbo Cactuar
+{
+    "name": "Jumbo Cactuar",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Plant",
+    "oracleText": "10,000 Needles — Whenever this creature attacks, it gets +9999/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 7
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 9999
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "191",
+        "rarity": "RARE",
+        "artist": "Jason Kiantoro",
+        "flavorText": "Some Cactuars live long lives and grow huge. This Jumbo Cactuar is one of them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db01c222-8795-47e9-a789-e7f749a3ee7d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Lion Heart
+{
+    "name": "Lion Heart",
+    "manaCost": "{4}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, it deals 2 damage to any target.\nEquipped creature gets +2/+1.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{2}"
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "261",
+        "rarity": "UNCOMMON",
+        "artist": "Mushk Rizvi",
+        "flavorText": "\"Lions are known for their great strength and pride.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04d327a3-1699-4556-b681-a957671ad142.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Loporrit Scout
+{
+    "name": "Loporrit Scout",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Rabbit Scout",
+    "oracleText": "Whenever another creature you control enters, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Andrea Radeck",
+        "flavorText": "\"I've come to realize that it's important to put down the book every now and then, and experience some adventures for myself.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a182bc66-bfda-4bf5-bd12-3de5dba60945.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Lunatic Pandora
+{
+    "name": "Lunatic Pandora",
+    "manaCost": "{1}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "{2}, {T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{6}, {T}, Sacrifice Lunatic Pandora: Destroy target nonland permanent.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{2}"
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "surveiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "surveiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put in graveyard",
+                            "remainderLabel": "Put on top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{6}"
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "262",
+        "artist": "Enora Mercier",
+        "flavorText": "\"Inside the Lunatic Pandora is this thing called a Crystal Pillar. It calls monsters from the Moon.\"\n—Zell Dincht",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6e1e3e7-20d4-42cb-ad22-60356b9e8fdc.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Magic Damper
+{
+    "name": "Magic Damper",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature you control gets +1/+1 and gains hexproof until end of turn. Untap it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "artist": "YASUNARI HIRASAKA",
+        "flavorText": "\"You're gonna wish you hadn't.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44921b2e-5938-4f63-92b9-0b719a2f8c68.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Magic Pot
+{
+    "name": "Magic Pot",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Goblin Construct",
+    "oracleText": "When this creature dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\n{2}, {T}: Exile target card from a graveyard.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{2}"
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "263",
+        "artist": "David Astruga",
+        "flavorText": "\"Gimme elixir!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/57d07ca0-5618-4a90-a605-ca14a193ce3b.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Magitek Armor
+{
+    "name": "Magitek Armor",
+    "manaCost": "{3}{W}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "When this Vehicle enters, create a 1/1 colorless Hero creature token.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Hero"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "UNCOMMON",
+        "artist": "Nathaniel Himawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/59c4a1a2-623c-43b2-8005-ecb5c6436c10.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Overkill
+{
+    "name": "Overkill",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -0/-9999 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 0
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -9999
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "rarity": "UNCOMMON",
+        "artist": "Bachzim",
+        "flavorText": "\"Hey why don't ya try out that sword I gave you!\"\n—Wakka",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae075e71-d33d-4d6c-b4a5-0b47dd6fd196.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Resentful Revelation
+{
+    "name": "Resentful Revelation",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{6}{B}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put in graveyard"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Justyna Dura",
+        "flavorText": "\"The Jenova Project resulted in my conception.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/945006ea-c6a1-4ee5-abb2-387c2b6d3123.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Ring of the Lucii
+{
+    "name": "Ring of the Lucii",
+    "manaCost": "{4}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "{T}: Add {C}{C}.\n{2}, {T}, Pay 1 life: Tap target nonland permanent.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{2}"
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostPayLife",
+                            "amount": 1
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "269",
+        "rarity": "UNCOMMON",
+        "artist": "Lorenzo Mastroianni",
+        "flavorText": "\"Kings of Lucis... come to me!\"\n—Noctis Lucis Caelum",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75761f1e-9449-4c58-8265-8abac71dafc1.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Sazh's Chocobo
 {
     "name": "Sazh's Chocobo",
@@ -328,6 +1996,55 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Sephiroth's Intervention
+{
+    "name": "Sephiroth's Intervention",
+    "manaCost": "{3}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature. You gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Joshua Raphael",
+        "flavorText": "\"Fate is not to be taken lightly, Cloud.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cf7df82f-937a-443f-813f-2bcc6944c5c0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -386,6 +2103,66 @@
         "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc7d1912-7e27-49ef-bd98-375d975a42b0.jpg?1748706861"
     },
     "colorIdentityOverride": []
+}
+
+// Tidus, Blitzball Star
+{
+    "name": "Tidus, Blitzball Star",
+    "manaCost": "{1}{W}{U}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Whenever an artifact you control enters, put a +1/+1 counter on Tidus.\nWhenever Tidus attacks, tap target creature an opponent controls.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "rarity": "UNCOMMON",
+        "artist": "Nakamura8",
+        "flavorText": "\"Every blitzer knows: when you got the ball, you gotta score!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa851d68-a7a4-48c0-9cd7-d3d2e079f3a1.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
 }
 
 // Tifa Lockhart
@@ -598,4 +2375,160 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Undercity Dire Rat
+{
+    "name": "Undercity Dire Rat",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Rat",
+    "oracleText": "Rat Tail — When this creature dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "artist": "Leonardo Santanna",
+        "flavorText": "\"I finally worked out how to get the door on the left side open! I hope there's somethin' in there besides rats...\"\n—Kytes, street urchin",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/274788f4-fbf3-4a15-bdc0-f513a2fde30d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// World Map
+{
+    "name": "World Map",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}, Sacrifice this artifact: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{3}, {T}, Sacrifice this artifact: Search your library for a land card, reveal it, put it into your hand, then shuffle.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{1}"
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostMana",
+                            "cost": "{3}"
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "land"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "270",
+        "artist": "Septian Fajrianto",
+        "flavorText": "And so their quest began.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70d9ab99-ec8a-402e-ba1d-ffa6c4c84a3f.jpg"
+    },
+    "colorIdentityOverride": []
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlitzballShotTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlitzballShotTest.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.BlitzballShot
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Blitzball Shot — {1}{G} Instant
+ * "Target creature gets +3/+3 and gains trample until end of turn."
+ */
+class BlitzballShotTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BlitzballShot)
+        return driver
+    }
+
+    test("grants +3/+3 and trample until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val lions = driver.putCreatureOnBattlefield(activePlayer, "Savannah Lions") // 1/1
+        projector.hasProjectedKeyword(driver.state, lions, Keyword.TRAMPLE) shouldBe false
+
+        val shot = driver.putCardInHand(activePlayer, "Blitzball Shot")
+        driver.giveMana(activePlayer, Color.GREEN, 1)
+        driver.giveColorlessMana(activePlayer, 1)
+        driver.castSpell(activePlayer, shot, targets = listOf(lions))
+        driver.bothPass()
+
+        projector.getProjectedPower(driver.state, lions) shouldBe 4
+        projector.getProjectedToughness(driver.state, lions) shouldBe 4
+        projector.hasProjectedKeyword(driver.state, lions, Keyword.TRAMPLE) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudOfDarknessTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudOfDarknessTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.CloudOfDarkness
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cloud of Darkness — {2}{B}{G}{G} 3/3 Legendary Creature
+ * "Particle Beam — When Cloud of Darkness enters, target creature an opponent
+ *  controls gets -X/-X until end of turn, where X is the number of permanent
+ *  cards in your graveyard."
+ *
+ * Verifies X counts PERMANENT cards in your graveyard (the generated draft
+ * originally counted creatures you control on the battlefield).
+ */
+class CloudOfDarknessTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CloudOfDarkness)
+        return driver
+    }
+
+    test("gives -X/-X equal to permanent cards in your graveyard, ignoring instants/sorceries") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Graveyard: 2 permanent cards (creatures) + 1 nonpermanent (instant). X must be 2.
+        driver.putCardInGraveyard(activePlayer, "Savannah Lions")
+        driver.putCardInGraveyard(activePlayer, "Centaur Courser")
+        driver.putCardInGraveyard(activePlayer, "Lightning Bolt")
+
+        // Opponent has a 3/3 to be targeted.
+        val target = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        projector.getProjectedToughness(driver.state, target) shouldBe 3
+
+        val cloud = driver.putCardInHand(activePlayer, "Cloud of Darkness")
+        driver.giveMana(activePlayer, Color.BLACK, 1)
+        driver.giveMana(activePlayer, Color.GREEN, 2)
+        driver.giveColorlessMana(activePlayer, 2)
+        driver.castSpell(activePlayer, cloud)
+        driver.bothPass() // resolve the creature spell -> ETB trigger goes on stack
+
+        // ETB trigger asks for a target.
+        driver.submitTargetSelection(activePlayer, listOf(target))
+        driver.bothPass()
+
+        // -2/-2: a 3/3 becomes a 1/1.
+        projector.getProjectedPower(driver.state, target) shouldBe 1
+        projector.getProjectedToughness(driver.state, target) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragoonsWyvernTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DragoonsWyvernTest.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.DragoonsWyvern
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dragoon's Wyvern — {2}{U} 2/1 Creature with flying
+ * "When this creature enters, create a 1/1 colorless Hero creature token."
+ */
+class DragoonsWyvernTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DragoonsWyvern)
+        return driver
+    }
+
+    test("creates a 1/1 Hero token when it enters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.getCreatures(player).size shouldBe 0
+
+        val wyvern = driver.putCardInHand(player, "Dragoon's Wyvern")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, 2)
+        driver.castSpell(player, wyvern)
+        driver.bothPass() // resolve the creature -> ETB trigger on stack
+        driver.bothPass() // resolve the ETB trigger -> token created
+
+        // Wyvern + the Hero token.
+        driver.getCreatures(player).size shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DwarvenCastleGuardTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DwarvenCastleGuardTest.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.DwarvenCastleGuard
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dwarven Castle Guard — {1}{W} 2/1 Creature
+ * "When this creature dies, create a 1/1 colorless Hero creature token."
+ */
+class DwarvenCastleGuardTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DwarvenCastleGuard)
+        return driver
+    }
+
+    test("creates a 1/1 Hero token when it dies") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val guard = driver.putCreatureOnBattlefield(player, "Dwarven Castle Guard")
+        driver.getCreatures(player).size shouldBe 1
+
+        // Burn the 2/1 guard to death.
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, targets = listOf(guard))
+        driver.bothPass() // resolve the bolt -> guard dies -> dies trigger on stack
+        driver.bothPass() // resolve the dies trigger -> Hero token created
+
+        driver.findPermanent(player, "Dwarven Castle Guard") shouldBe null
+        driver.getGraveyardCardNames(player).contains("Dwarven Castle Guard") shouldBe true
+        // The Hero token replaced the guard.
+        driver.getCreatures(player).size shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EvilReawakenedTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EvilReawakenedTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.EvilReawakened
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Evil Reawakened — {4}{B} Sorcery
+ * "Return target creature card from your graveyard to the battlefield with two
+ *  additional +1/+1 counters on it."
+ *
+ * Verifies the reanimated creature returns AND enters with two +1/+1 counters
+ * (the generated draft originally dropped the counters).
+ */
+class EvilReawakenedTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(EvilReawakened)
+        return driver
+    }
+
+    test("returns target creature card with two additional +1/+1 counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Savannah Lions (1/1) waiting in the graveyard.
+        val lionsInGy = driver.putCardInGraveyard(activePlayer, "Savannah Lions")
+
+        val spell = driver.putCardInHand(activePlayer, "Evil Reawakened")
+        driver.giveMana(activePlayer, Color.BLACK, 5)
+
+        driver.castSpellWithTargets(
+            activePlayer,
+            spell,
+            listOf(ChosenTarget.Card(lionsInGy, activePlayer, Zone.GRAVEYARD))
+        )
+        driver.bothPass()
+
+        // Lions is back on the battlefield as a 1/1 base with two +1/+1 counters = 3/3.
+        val lions = driver.findPermanent(activePlayer, "Savannah Lions")
+        lions shouldNotBe null
+        projector.getProjectedPower(driver.state, lions!!) shouldBe 3
+        projector.getProjectedToughness(driver.state, lions) shouldBe 3
+        driver.getGraveyardCardNames(activePlayer).contains("Savannah Lions") shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GladiolusAmicitiaTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GladiolusAmicitiaTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.GladiolusAmicitia
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Gladiolus Amicitia — {4}{R}{G} 6/6 Legendary Creature
+ * "Landfall — Whenever a land you control enters, another target creature you
+ *  control gets +2/+2 and gains trample until end of turn."
+ *
+ * Verifies the landfall pump targets ANOTHER creature (the generated draft
+ * originally allowed Gladiolus to target itself).
+ */
+class GladiolusAmicitiaTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GladiolusAmicitia)
+        return driver
+    }
+
+    test("landfall pumps another creature you control; Gladiolus is not a legal target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gladiolus = driver.putCreatureOnBattlefield(activePlayer, "Gladiolus Amicitia")
+        val lions = driver.putCreatureOnBattlefield(activePlayer, "Savannah Lions")
+
+        // Play a land to trigger landfall; the trigger pauses for a target.
+        val forest = driver.putCardInHand(activePlayer, "Forest")
+        driver.playLand(activePlayer, forest)
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        val legal = decision.legalTargets[0] ?: emptyList()
+        legal.contains(lions) shouldBe true
+        legal.contains(gladiolus) shouldBe false
+
+        driver.submitTargetSelection(activePlayer, listOf(lions))
+        driver.bothPass()
+
+        projector.getProjectedPower(driver.state, lions) shouldBe 3
+        projector.getProjectedToughness(driver.state, lions) shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HecteyesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HecteyesTest.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.Hecteyes
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hecteyes — {1}{B} 1/1 Creature
+ * "When this creature enters, each opponent discards a card."
+ */
+class HecteyesTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(Hecteyes)
+        return driver
+    }
+
+    test("each opponent discards a card on enter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val oppHandBefore = driver.getHandSize(opponent)
+
+        val hecteyes = driver.putCardInHand(player, "Hecteyes")
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.giveColorlessMana(player, 1)
+        driver.castSpell(player, hecteyes)
+        driver.bothPass() // resolve the creature -> ETB trigger on stack
+        driver.bothPass() // resolve the ETB trigger -> opponent must discard
+
+        // Opponent chooses which card to discard.
+        val decision = driver.pendingDecision
+        if (decision is SelectCardsDecision) {
+            driver.submitCardSelection(opponent, listOf(driver.getHand(opponent).first()))
+        }
+
+        driver.getHandSize(opponent) shouldBe (oppHandBefore - 1)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JumboCactuarTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JumboCactuarTest.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.JumboCactuar
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Jumbo Cactuar — {5}{G}{G} 1/7 Creature
+ * "10,000 Needles — Whenever this creature attacks, it gets +9999/+0 until end of turn."
+ */
+class JumboCactuarTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(JumboCactuar)
+        return driver
+    }
+
+    test("gets +9999/+0 when it attacks") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        val cactuar = driver.putCreatureOnBattlefield(activePlayer, "Jumbo Cactuar")
+        driver.removeSummoningSickness(cactuar)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(activePlayer, listOf(cactuar), opponent)
+        driver.bothPass() // resolve the attack trigger
+
+        // Base power 1 + 9999.
+        projector.getProjectedPower(driver.state, cactuar) shouldBe 10000
+        projector.getProjectedToughness(driver.state, cactuar) shouldBe 7
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagicPotTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagicPotTest.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.MagicPot
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Magic Pot — {3} 1/4 Artifact Creature
+ * "When this creature dies, create a Treasure token."
+ * "{2}, {T}: Exile target card from a graveyard."
+ */
+class MagicPotTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(MagicPot)
+        driver.registerCard(PredefinedTokens.Treasure)
+        return driver
+    }
+
+    test("creates a Treasure token when it dies") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val pot = driver.putCreatureOnBattlefield(player, "Magic Pot")
+        driver.findPermanent(player, "Magic Pot") shouldNotBe null
+
+        // Destroy it with Doom Blade (Magic Pot is colorless, so it's a legal target).
+        val doomBlade = driver.putCardInHand(player, "Doom Blade")
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.giveColorlessMana(player, 1)
+        driver.castSpell(player, doomBlade, targets = listOf(pot))
+        driver.bothPass() // resolve Doom Blade -> Magic Pot dies -> dies trigger on stack
+        driver.bothPass() // resolve the dies trigger -> Treasure token created
+
+        driver.findPermanent(player, "Magic Pot") shouldBe null
+        driver.getGraveyardCardNames(player).contains("Magic Pot") shouldBe true
+        driver.findPermanent(player, "Treasure") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OverkillTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OverkillTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.Overkill
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Overkill — {2}{B} Instant
+ * "Target creature gets -0/-9999 until end of turn."
+ *
+ * The toughness reduction is lethal to any creature; it dies as a state-based action.
+ */
+class OverkillTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(Overkill)
+        return driver
+    }
+
+    test("destroys any creature via lethal toughness reduction") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val target = driver.putCreatureOnBattlefield(opponent, "Force of Nature") // a 5/5
+
+        val overkill = driver.putCardInHand(activePlayer, "Overkill")
+        driver.giveMana(activePlayer, Color.BLACK, 1)
+        driver.giveColorlessMana(activePlayer, 2)
+        driver.castSpell(activePlayer, overkill, targets = listOf(target))
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Force of Nature") shouldBe null
+        driver.getGraveyardCardNames(opponent).contains("Force of Nature") shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TidusBlitzballStarTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TidusBlitzballStarTest.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.TidusBlitzballStar
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tidus, Blitzball Star — {1}{W}{U} 2/1 Legendary Creature
+ * "Whenever Tidus attacks, tap target creature an opponent controls."
+ */
+class TidusBlitzballStarTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TidusBlitzballStar)
+        return driver
+    }
+
+    test("taps a target creature an opponent controls when attacking") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val tidus = driver.putCreatureOnBattlefield(player, "Tidus, Blitzball Star")
+        driver.removeSummoningSickness(tidus)
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        driver.isTapped(blocker) shouldBe false
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(tidus), opponent)
+
+        // Attack trigger needs a target.
+        driver.submitTargetSelection(player, listOf(blocker))
+        driver.bothPass()
+
+        driver.isTapped(blocker) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WorldMapTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WorldMapTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.CapitalCity
+import com.wingedsheep.mtg.sets.definitions.fin.cards.WorldMap
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * World Map — {1} Artifact
+ * "{1}, {T}, Sacrifice this artifact: Search your library for a basic land card ..."
+ * "{3}, {T}, Sacrifice this artifact: Search your library for a land card ..."
+ *
+ * Verifies the second ability searches for ANY land (the generated draft
+ * originally restricted it to basic lands like the first ability).
+ */
+class WorldMapTest : FunSpec({
+
+    // Second activated ability: "{3}, {T}, Sacrifice: search for a land card".
+    val anyLandAbilityId = WorldMap.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(WorldMap)
+        driver.registerCard(CapitalCity)
+        return driver
+    }
+
+    test("the {3} ability can search up a nonbasic land") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val map = driver.putPermanentOnBattlefield(player, "World Map")
+        val capitalCity = driver.putCardOnTopOfLibrary(player, "Capital City")
+        driver.giveColorlessMana(player, 3)
+
+        driver.submit(ActivateAbility(playerId = player, sourceId = map, abilityId = anyLandAbilityId))
+        driver.bothPass() // resolve the ability off the stack -> library search decision
+
+        // Library search offers the nonbasic land.
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options.contains(capitalCity) shouldBe true
+
+        driver.submitCardSelection(player, listOf(capitalCity))
+
+        driver.findCardInHand(player, "Capital City") shouldNotBe null
+    }
+})


### PR DESCRIPTION
## What

Used `:mtgish-tooling` to auto-generate every draftable Final Fantasy card, then **promoted them properly into the FIN set** — human-reviewed, bug-fixed, compile-verified, snapshot-pinned, and scenario-tested.

`just coverage-gaps --set FIN` reported 42 AUTOGEN / 76 SCAFFOLD / 159 BLOCKED. `just coverage-generate --set FIN` produced 36 drafts; **31** were genuinely promotable.

## Promoted (31)

Vanilla/keyword creatures, ETB & dies triggers, pump/removal instants, mana rocks & dorks, equipment, vehicles with crew, flashback spells, reanimation, and token/treasure makers. Full list in the diff under `definitions/fin/cards/`.

## Excluded (5) — reported, not promoted

The **"Town" land cycle** (Midgar, Ishgard, Jidoor, Lindblum, Zanarkand) is **Adventure layout** (`Land — Town // Sorcery — Adventure`). The emitter rendered only the land face and dropped the entire adventure side, so it *falsely* tiered them AUTOGEN. Promoting them as land-only would be wrong. Adventure-on-a-land (you *play* the land from adventure-exile rather than recast) is a novel FIN twist that needs real modeling via `add-feature`, not autogen.

## Semantic fixes to the generated drafts

The drafts compile and capability-match, but the emitter mis-rendered four cards' *meaning* (exactly the "filter/count can be subtly wrong" caveat in the tooling README):

| Card | Fix |
|------|-----|
| Cloud of Darkness | X = `Count(GRAVEYARD, Permanent)`, not a battlefield-creature count |
| Evil Reawakened | reanimate now adds the dropped two +1/+1 counters |
| World Map | `{3}` ability searches any **land** (was `BasicLand`) |
| Gladiolus Amicitia | landfall targets **another** creature (`OtherCreatureYouControl`) |

## Verification (the ask: "verify the cards are correctly generated")

- ✅ All 31 compile (`:mtg-sets:compileKotlin`).
- ✅ Every card's core fields (mana cost, type line, P/T, collector number, rarity) batch-checked against the Scryfall `set=fin` API — all match.
- ✅ Manual line-by-line review of every rendered cardDef vs. oracle text (found the 4 bugs above).
- ✅ **12 scenario tests** in `rules-engine`, all passing — the 4 fixed cards plus representative mechanics (ETB token, dies→token, dies→Treasure, attack pump, lethal `-toughness`, attack-tap-target, combat pump + trample grant, ETB discard, landfall, reanimation+counters, nonbasic land search).
- ✅ `CardDefinitionSnapshotTest` re-blessed; the FIN golden diff is **purely the 31 added cards** — every deleted line reappears as an addition (sorted-file reordering), so no existing card tree changed.

Scenario testing caught what compile + snapshot + Scryfall could not: a couple of the bug fixes resolve to wrong-but-valid behavior that only a behavioral test surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)