### PR TITLE
Use projected controller in damage/life-loss replacement scans

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -64,6 +64,18 @@ object DamageUtils {
     lateinit var cardRegistry: CardRegistry
 
     /**
+     * Controller of a battlefield permanent that hosts a replacement effect, honoring
+     * control-changing effects (CR 613.1b, Layer 2). The "you" / "an opponent" filters on
+     * damage and life-loss replacements are resolved relative to this controller, so they
+     * must follow the *current* controller, not the printed one — a stolen Bloodletter of
+     * Aclazotz or Ali from Cairo retargets to the thief. Falls back to the base
+     * [ControllerComponent] only for entities with no projected entry.
+     */
+    private fun replacementHostController(state: GameState, entityId: EntityId): EntityId? =
+        state.projectedState.getController(entityId)
+            ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
+
+    /**
      * Deal damage to a target (player or creature).
      *
      * @param state The current game state
@@ -539,16 +551,11 @@ object DamageUtils {
                 val lifeGainEvent = effect.appliesTo
                 if (lifeGainEvent !is com.wingedsheep.sdk.scripting.EventPattern.LifeGainEvent) continue
 
+                val sourceControllerId = replacementHostController(state, entityId)
                 when (lifeGainEvent.player) {
                     Player.Each -> return true
-                    Player.You -> {
-                        val sourceControllerId = container.get<ControllerComponent>()?.playerId
-                        if (playerId == sourceControllerId) return true
-                    }
-                    Player.Opponent -> {
-                        val sourceControllerId = container.get<ControllerComponent>()?.playerId
-                        if (playerId != sourceControllerId) return true
-                    }
+                    Player.You -> if (playerId == sourceControllerId) return true
+                    Player.Opponent -> if (playerId != sourceControllerId) return true
                     else -> {}
                 }
             }
@@ -740,7 +747,7 @@ object DamageUtils {
             if (entityId in appliedRedirects) continue
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
-            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is RedirectDamage) continue
@@ -938,7 +945,7 @@ object DamageUtils {
             if (remainingDamage <= 0) break
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
-            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
                 if (remainingDamage <= 0) break
@@ -1054,7 +1061,7 @@ object DamageUtils {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
-            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is DoubleDamage) continue
@@ -1100,7 +1107,7 @@ object DamageUtils {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
-            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is ModifyDamageAmount) continue
@@ -1205,7 +1212,7 @@ object DamageUtils {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
-            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is CapDamage) continue
@@ -1281,7 +1288,7 @@ object DamageUtils {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
-            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is ModifyLifeLoss) continue
@@ -1355,7 +1362,7 @@ object DamageUtils {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
-            val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is ReplaceDamageWithCounters) continue

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReplacementControllerProjectionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReplacementControllerProjectionTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.BloodletterOfAclazotz
+import com.wingedsheep.mtg.sets.definitions.ons.cards.BlatantThievery
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * Damage/life-loss replacement effects are hosted on battlefield permanents, and their
+ * "you" / "an opponent" filters are resolved relative to the *host permanent's controller*.
+ * When a control-changing effect steals such a permanent, those filters must follow the new
+ * controller (the projected controller, post Layer-2), not the printed one.
+ *
+ * `DamageUtils` resolves the host's controller for every replacement scan; these tests steal
+ * a replacement-effect permanent and assert the filter retargets to the thief. They cover the
+ * two distinct comparison shapes:
+ *  - `Player.You` / `Player.Opponent` against the losing player (`ModifyLifeLoss` — Bloodletter)
+ *  - `RecipientFilter.You` against the damaged player (`PreventDamage`)
+ */
+class ReplacementControllerProjectionTest : FunSpec({
+
+    // 0/4 wall whose only ability is "prevent all damage that would be dealt to you" —
+    // a `PreventDamage` keyed to `RecipientFilter.You`, i.e. to the host's controller.
+    val aegisSentinel = CardDefinition.creature(
+        name = "Aegis Sentinel",
+        manaCost = ManaCost.parse("{2}{W}"),
+        subtypes = setOf(Subtype("Wall")),
+        power = 0,
+        toughness = 4,
+        oracleText = "Prevent all damage that would be dealt to you.",
+        script = CardScript.withReplacementEffects(
+            PreventDamage(appliesTo = EventPattern.DamageEvent(recipient = RecipientFilter.You)),
+        ),
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BloodletterOfAclazotz, BlatantThievery, aegisSentinel))
+        return driver
+    }
+
+    test("stealing Bloodletter of Aclazotz doubles the THIEF's opponent's life loss, not the original owner's") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Island" to 20), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent owns Bloodletter (its "if an opponent would lose life during your turn"
+        // currently points at YOU). Steal it onto your side.
+        val bloodletter = driver.putCreatureOnBattlefield(opponent, "Bloodletter of Aclazotz")
+
+        driver.giveMana(you, Color.BLUE, 7)
+        val thievery = driver.putCardInHand(you, "Blatant Thievery")
+        driver.castSpellWithTargets(you, thievery, listOf(ChosenTarget.Permanent(bloodletter)))
+        driver.bothPass()
+
+        // Now YOU control Bloodletter, it's your turn, and `opponent` is your opponent.
+        // 3 damage to them must be doubled to 6 (20 -> 14). Under the projection bug the
+        // host's printed controller (opponent) is used, so the filter never matches and they
+        // would take only 3 (20 -> 17).
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent)))
+        driver.bothPass()
+
+        driver.assertLifeTotal(opponent, 14)
+    }
+
+    test("stealing a 'prevent damage to you' permanent protects the THIEF, not the original owner") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Island" to 20), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sentinel = driver.putCreatureOnBattlefield(opponent, "Aegis Sentinel")
+
+        driver.giveMana(you, Color.BLUE, 7)
+        val thievery = driver.putCardInHand(you, "Blatant Thievery")
+        driver.castSpellWithTargets(you, thievery, listOf(ChosenTarget.Permanent(sentinel)))
+        driver.bothPass()
+
+        // Now YOU control the Sentinel, so "prevent all damage to you" protects YOU.
+        // 3 damage to yourself is prevented (life stays 20). Under the projection bug it would
+        // still protect the original owner, so your 3 would resolve (20 -> 17).
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(you)))
+        driver.bothPass()
+
+        driver.assertLifeTotal(you, 20)
+    }
+})


### PR DESCRIPTION
## Problem

Every battlefield replacement-effect scan in `DamageUtils.kt` resolved the **host permanent's** controller via base `container.get<ControllerComponent>()?.playerId`. Control-changing effects are applied in Layer 2 (CR 613.1b), so under a stolen permanent the `Player.You` / `Player.Opponent` / `RecipientFilter.You` filters kept pointing at the *printed* controller instead of the current one.

Concretely: steal an opponent's **Bloodletter of Aclazotz** and it would still double *your* life loss rather than your new opponent's; steal **Ali from Cairo** (PR #553's `LifeLossFloor`) and it would protect the original owner. Pre-existing bug — surfaced while reviewing #553, which added the `ModifyLifeLoss`/`LifeLossFloor` scan to this same family.

## Fix

One shared private helper, applied uniformly to all **8** scans:

```kotlin
private fun replacementHostController(state: GameState, entityId: EntityId): EntityId? =
    state.projectedState.getController(entityId)
        ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
```

Routed through: `PreventLifeGain`, `RedirectDamage`, `PreventDamage`, `DoubleDamage`, `ModifyDamageAmount`, `CapDamage`, `ModifyLifeLoss`, `ReplaceDamageWithCounters`. `CombatDamageManager` needed no change — it delegates to these helpers.

## Tests

`ReplacementControllerProjectionTest` steals a replacement-effect permanent (Blatant Thievery) and asserts the filter retargets to the thief, covering both comparison shapes:
- **`Player.Opponent`** via the real Bloodletter of Aclazotz — stealing it doubles *your* opponent's life loss (20 → 14).
- **`RecipientFilter.You`** via an inline "prevent all damage to you" wall — stealing it protects *you* (self-damage prevented).

Both were confirmed failing on the unfixed code (took/dealt the un-retargeted amount) and pass after the fix. Full `:rules-engine:test` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)