### PR TITLE
Add four OTJ cards (Geyser Drake, Harrier Strix, Bristlepack Sentry, Cactarantula) + mtgish auto-gen support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1402,6 +1402,9 @@ Triggers.youCastSpell(
 - `CreatureYouControlBecomesTargetByOpponent(filter?, includeSpellTargets = false)` — your creature
   gets targeted by an opponent's spell or ability. Permanent-only unless `includeSpellTargets = true`
   (Surrak), which also fires when an opponent targets a matching creature spell you control.
+- `BecomesTargetByOpponent` — the self-bound counterpart of the above: source becomes the target of a
+  spell or ability **an opponent controls** (Cactarantula's "Whenever this creature becomes the target
+  of a spell or ability an opponent controls, you may draw a card").
 - `Transforms` — source transforms (either direction).
 - `TransformsToFront` — to front face.
 - `TransformsToBack` — to back face.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1162,6 +1162,16 @@ object Triggers {
     )
 
     /**
+     * Whenever this permanent becomes the target of a spell or ability an opponent
+     * controls (Cactarantula). Self-bound counterpart of
+     * [CreatureYouControlBecomesTargetByOpponent].
+     */
+    val BecomesTargetByOpponent: TriggerSpec = TriggerSpec(
+        event = BecomesTargetEvent(byOpponent = true),
+        binding = TriggerBinding.SELF
+    )
+
+    /**
      * Whenever a creature you control with a specific filter becomes the target
      * of a spell or ability.
      */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BristlepackSentry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BristlepackSentry.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Bristlepack Sentry
+ * {1}{G}
+ * Creature — Plant Wolf
+ * 3/3
+ * Defender
+ * As long as you control a creature with power 4 or greater, this creature can attack
+ * as though it didn't have defender.
+ */
+val BristlepackSentry = card("Bristlepack Sentry") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Wolf"
+    power = 3
+    toughness = 3
+    oracleText = "Defender\nAs long as you control a creature with power 4 or greater, this creature can attack as though it didn't have defender."
+
+    keywords(Keyword.DEFENDER)
+
+    staticAbility {
+        ability = CanAttackDespiteDefender(
+            condition = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "156"
+        artist = "Josiah \"Jo\" Cameron"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6aea6702-16a8-4073-9c83-fbea20a5fd32.jpg?1712355891"
+
+        ruling("2024-04-12", "Once Bristlepack Sentry has legally attacked, causing its last ability to not apply by removing other creatures from the battlefield or reducing the power of one or more creatures won't cause Bristlepack Sentry to stop attacking.")
+        ruling("2024-04-12", "If you raise Bristlepack Sentry's power to 4 or greater, it fulfills its own condition and it can attack as though it didn't have defender.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/Cactarantula.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/Cactarantula.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Cactarantula
+ * {4}{G}{G}
+ * Creature — Plant Spider
+ * 6/5
+ * This spell costs {1} less to cast if you control a Desert.
+ * Reach
+ * Whenever this creature becomes the target of a spell or ability an opponent controls,
+ * you may draw a card.
+ */
+val Cactarantula = card("Cactarantula") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Spider"
+    power = 6
+    toughness = 5
+    oracleText = "This spell costs {1} less to cast if you control a Desert.\nReach\nWhenever this creature becomes the target of a spell or ability an opponent controls, you may draw a card."
+
+    keywords(Keyword.REACH)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfControlFilter(
+                    amount = 1,
+                    filter = GameObjectFilter.Land.withSubtype(Subtype.DESERT),
+                ),
+            ),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BecomesTargetByOpponent
+        optional = true
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Filip Burburan"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e0e27f9-dc2c-4366-b810-3e8d0bdff8c3.jpg?1712355900"
+
+        ruling("2024-04-12", "Cactarantula still costs only {1} less to cast if you control multiple Deserts.")
+        ruling("2024-04-12", "Cactarantula's last ability resolves before the spell or ability that caused it to trigger. It resolves even if that spell is countered.")
+        ruling("2024-04-12", "If a spell or ability targets Cactarantula more than once, its last ability still triggers only once.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GeyserDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GeyserDrake.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Geyser Drake
+ * {2}{U}
+ * Creature — Drake
+ * 2/3
+ * Flying
+ * During turns other than yours, spells you cast cost {1} less to cast.
+ *
+ * The reduction touches only the generic mana component (CostModification.ReduceGeneric),
+ * matching the ruling that it can't reduce colored mana. The OnlyIf(IsNotYourTurn) gate
+ * scopes it to opponents' turns.
+ */
+val GeyserDrake = card("Geyser Drake") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\nDuring turns other than yours, spells you cast cost {1} less to cast."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.OnlyIf(Conditions.IsNotYourTurn),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Daniel Romanovsky"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b270377b-33eb-4e5e-9d14-0da2876da74f.jpg?1712355434"
+
+        ruling("2024-04-12", "Geyser Drake's last ability doesn't change the mana cost or mana value of any spell. It changes only the total cost you pay to cast spells.")
+        ruling("2024-04-12", "Geyser Drake's last ability can't reduce the amount of colored mana you pay for a spell. It reduces only the generic mana component of that spell's cost.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HarrierStrix.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HarrierStrix.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Harrier Strix
+ * {U}
+ * Creature — Bird
+ * 1/1
+ * Flying
+ * When this creature enters, tap target permanent.
+ * {2}{U}: Draw a card, then discard a card.
+ */
+val HarrierStrix = card("Harrier Strix") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\nWhen this creature enters, tap target permanent.\n{2}{U}: Draw a card, then discard a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target("permanent to tap", Targets.Permanent)
+        effect = Effects.Tap(permanent)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        effect = Patterns.Hand.loot(1, 1)
+        description = "{2}{U}: Draw a card, then discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70ca61a9-8938-41bf-bd14-5759f4de6521.jpg?1712355435"
+
+        ruling("2024-04-12", "You may target a permanent that is already tapped with Harrier Strix's second ability.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -192,6 +192,52 @@
     ]
 }
 
+// Bristlepack Sentry
+{
+    "name": "Bristlepack Sentry",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Plant Wolf",
+    "oracleText": "Defender\nAs long as you control a creature with power 4 or greater, this creature can attack as though it didn't have defender.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CanAttackDespiteDefender",
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=4"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "artist": "Josiah \"Jo\" Cameron",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6aea6702-16a8-4073-9c83-fbea20a5fd32.jpg?1712355891",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Once Bristlepack Sentry has legally attacked, causing its last ability to not apply by removing other creatures from the battlefield or reducing the power of one or more creatures won't cause Bristlepack Sentry to stop attacking."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If you raise Bristlepack Sentry's power to 4 or greater, it fulfills its own condition and it can attack as though it didn't have defender."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Bristly Bill, Spine Sower
 {
     "name": "Bristly Bill, Spine Sower",
@@ -265,6 +311,76 @@
         "artist": "Daniel Zrom",
         "flavorText": "\"Wake up, little ones. There's a new day ahead.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/5/2/52eef0d6-24b7-40b7-8403-e8e863d0cd55.jpg?1712355894"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Cactarantula
+{
+    "name": "Cactarantula",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Plant Spider",
+    "oracleText": "This spell costs {1} less to cast if you control a Desert.\nReach\nWhenever this creature becomes the target of a spell or ability an opponent controls, you may draw a card.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesTargetEvent",
+                    "byOpponent": true
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "optional": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfControlFilter",
+                        "amount": 1,
+                        "filter": "land Desert"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "artist": "Filip Burburan",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e0e27f9-dc2c-4366-b810-3e8d0bdff8c3.jpg?1712355900",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Cactarantula still costs only {1} less to cast if you control multiple Deserts."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Cactarantula's last ability resolves before the spell or ability that caused it to trigger. It resolves even if that spell is countered."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If a spell or ability targets Cactarantula more than once, its last ability still triggers only once."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -571,6 +687,169 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Geyser Drake
+{
+    "name": "Geyser Drake",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nDuring turns other than yours, spells you cast cost {1} less to cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": {}
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": "IsNotYourTurn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Daniel Romanovsky",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b270377b-33eb-4e5e-9d14-0da2876da74f.jpg?1712355434",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Geyser Drake's last ability doesn't change the mana cost or mana value of any spell. It changes only the total cost you pay to cast spells."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Geyser Drake's last ability can't reduce the amount of colored mana you pay for a spell. It reduces only the generic mana component of that spell's cost."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Harrier Strix
+{
+    "name": "Harrier Strix",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhen this creature enters, tap target permanent.\n{2}{U}: Draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "permanent to tap"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "permanent to tap"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{2}{U}"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "{2}{U}: Draw a card, then discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70ca61a9-8938-41bf-bd14-5759f4de6521.jpg?1712355435",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You may target a permanent that is already tapped with Harrier Strix's second ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -19,6 +19,12 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     envelope("MayCost", "gate envelope: 'you may pay' (Lesson 1 cluster)")
     envelope("Unless", "gate envelope: 'unless ...' (Lesson 1 cluster)", composes = listOf("PayOrSuffer"))
 
+    // A controller-scoped continuous static ("spells you cast cost less", "you have shroud"); the real
+    // capability is the nested _PlayerEffect (e.g. DecreaseSpellCost -> ModifySpellCost). The emitter
+    // renders only the exact shapes it can express (Geyser Drake's turn-gated cost reduction) and
+    // scaffolds the rest, so this is a structural envelope, never a blanket capability claim.
+    envelope("PlayerEffect", "envelope: controller-scoped static (cost reduction, shroud, ...)")
+
     // Player-delegation envelopes.
     envelope("PlayerAction", "envelope: 'target player does X'")
     envelope("EachPlayerAction", "envelope: APNAP each-player")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -12,6 +12,7 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("WhenAPlayerCastsASpell", "trigger: a player casts a spell (Triggers.YouCastSpell / AnyPlayerCastsSpell / OpponentCastsSpell + type filters)")
     supported("AtTheBeginningOfAPlayersUpkeep", "trigger: upkeep (Triggers.YourUpkeep / EachUpkeep / EachOpponentUpkeep)")
     supported("AtTheBeginningOfAPlayersEndStep", "trigger: end step (Triggers.YourEndStep / EachEndStep)")
+    supported("WhenAPermanentBecomesTheTargetOfASpellOrAbility", "trigger: becomes target (Triggers.BecomesTargetByOpponent / BecomesTarget / CreatureYouControlBecomesTargetByOpponent)")
 
     // Costs.
     supported("PayMana", "cost: pay mana (universal)")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -19,6 +19,9 @@ import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
+import com.wingedsheep.tooling.coverage.nodesTagged
+import com.wingedsheep.tooling.coverage.render
+import com.wingedsheep.tooling.coverage.renderBlock
 import com.wingedsheep.tooling.coverage.strField
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -78,6 +81,7 @@ internal fun EmitCtx.castEffectHandled(rule: JsonObject): Boolean {
     return when (node.strField("_CastEffect")) {
         "CantBeCastUnless" -> castRestrictionLines(listOf(rule)) != null
         "AdditionalCastingCost" -> additionalCostLine(rule) != null
+        "ReduceCastingCostIf" -> costReductionStaticLines(rule) != null
         else -> false
     }
 }
@@ -87,10 +91,46 @@ internal fun EmitCtx.cardLevelCastEffectLines(card: JsonObject): List<String>? {
     for (rule in (card["Rules"].asArr ?: JsonArray(emptyList())).filterIsInstance<JsonObject>()) {
         if (rule.strField("_Rule") != "CastEffect") continue
         val line = additionalCostLine(rule)
-        if (line != null) lines.add(line)
-        else if (!castEffectHandled(rule)) return null
+        if (line != null) { lines.add(line); continue }
+        val reduction = costReductionStaticLines(rule)
+        if (reduction != null) { lines.addAll(reduction); continue }
+        if (!castEffectHandled(rule)) return null
     }
     return lines
+}
+
+/**
+ * `CastEffect(ReduceCastingCostIf([CostReduceGeneric N], PlayerPassesFilter(You, ControlsA(filter))))`
+ * -> a `staticAbility { ability = ModifySpellCost(SelfCast, ReduceGenericBy(FixedIfControlFilter(N,
+ * <filter>))) }` block (Cactarantula: "This spell costs {1} less to cast if you control a Desert").
+ *
+ * Renders only the "if you control a [filter]" conditional generic reduction; any other condition or a
+ * colored/dynamic reduction declines -> SCAFFOLD rather than widening.
+ */
+private fun EmitCtx.costReductionStaticLines(rule: JsonObject): List<String>? {
+    val node = rule["args"] as? JsonObject ?: return null
+    if (node.strField("_CastEffect") != "ReduceCastingCostIf") return null
+    val args = node["args"].asArr ?: return null
+    val symbols = (args.getOrNull(0) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return null
+    // Only a single bare generic reduction renders.
+    if (symbols.size != 1 || symbols[0].strField("_CostReductionSymbol") != "CostReduceGeneric") return null
+    val amount = symbols[0]["args"].asInt() ?: return null
+    val cond = args.getOrNull(1) as? JsonObject ?: return null
+    if (cond.strField("_Condition") != "PlayerPassesFilter") return null
+    val condArgs = cond["args"].asArr ?: return null
+    if ((condArgs.getOrNull(0) as? JsonObject)?.strField("_Player") != "You") return null
+    val controls = condArgs.getOrNull(1) as? JsonObject ?: return null
+    if (controls.strField("_Players") != "ControlsA") return null
+    val filter = gameObjectFilterDsl(controls["args"]) ?: return null
+    val ability = call(
+        "ModifySpellCost",
+        arg("target", Lit("SpellCostTarget.SelfCast")),
+        arg("modification", call(
+            "CostModification.ReduceGenericBy",
+            arg(call("CostReductionSource.FixedIfControlFilter", arg("amount", "$amount"), arg("filter", Lit(filter)))),
+        )),
+    )
+    return renderBlock(Block("staticAbility", listOf(Assign("ability", ability))), "    ")
 }
 
 private fun EmitCtx.additionalCostLine(rule: JsonObject): String? {
@@ -129,6 +169,82 @@ private fun EmitCtx.conditionalSpell(card: JsonObject): List<Stmt>? {
     if (inner == null) return null
     val edsl = renderEffectList(inner, null) ?: return null
     return listOf(Sub(Block("spell", listOf(Assign("condition", Lit(cond)), Assign("effect", edsl)))))
+}
+
+/**
+ * "you control a [filter]" condition (`PlayerPassesFilter(You, ControlsA(filter))`) -> the
+ * `Conditions.YouControl(<filter>)` DSL string, or null when the player isn't You / the filter isn't
+ * a single `ControlsA` we can render. Used by the [ifRuleBlock] static gates (Bristlepack Sentry's
+ * "as long as you control a creature with power 4 or greater").
+ */
+private fun EmitCtx.youControlConditionDsl(condNode: JsonElement?): String? {
+    val cond = condNode as? JsonObject ?: return null
+    if (cond.strField("_Condition") != "PlayerPassesFilter") return null
+    val args = cond["args"].asArr ?: return null
+    if ((args.getOrNull(0) as? JsonObject)?.strField("_Player") != "You") return null
+    val controls = args.getOrNull(1) as? JsonObject ?: return null
+    if (controls.strField("_Players") != "ControlsA") return null
+    val filter = gameObjectFilterDsl(controls["args"]) ?: return null
+    return render(call("Conditions.YouControl", arg(Lit(filter))))
+}
+
+/**
+ * `If{cond}[rules]` permanent rule -> one or more `staticAbility { ability = ... }` blocks gating a
+ * continuous effect on a condition. Renders only the exact shapes we can express faithfully:
+ *
+ *  - `If(IsAPlayersTurn(Other You))[PlayerEffect(You, DecreaseSpellCost(AnySpell, CostReduceGeneric N))]`
+ *    -> `ModifySpellCost(YouCast(Any), ReduceGeneric(N), gating = OnlyIf(IsNotYourTurn))` (Geyser Drake).
+ *  - `If(PlayerPassesFilter(You, ControlsA(filter)))[PermanentRuleEffect(ThisPermanent,
+ *    CanAttackAsThoughItDidntHaveDefender)]`
+ *    -> `CanAttackDespiteDefender(condition = YouControl(filter))` (Bristlepack Sentry).
+ *
+ * Any other condition/inner-effect combination declines -> SCAFFOLD rather than widening.
+ */
+internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
+    val args = rule["args"].asArr ?: run { reasons.add("If"); return null }
+    val cond = args.getOrNull(0) as? JsonObject ?: run { reasons.add("If"); return null }
+    val inner = (args.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
+        ?: run { reasons.add("If"); return null }
+    if (inner.size != 1) { reasons.add("If"); return null }
+    val innerRule = inner[0]
+
+    // Geyser Drake: "During turns other than yours, spells you cast cost {1} less to cast."
+    if (innerRule.strField("_Rule") == "PlayerEffect" &&
+        cond.strField("_Condition") == "IsAPlayersTurn" &&
+        jsonContains(cond, "_Players", "Other") && jsonContains(cond, "_Player", "You")
+    ) {
+        val pe = (innerRule["args"].asArr?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()?.singleOrNull()
+        if (pe != null && pe.strField("_PlayerEffect") == "DecreaseSpellCost" &&
+            jsonContains(pe, "_Spells", "AnySpell")
+        ) {
+            val amount = (pe as JsonElement?).nodesTagged("CostReduceGeneric").firstOrNull()?.get("args").asInt()
+            // Only a single bare generic reduction (no colored symbols) renders; otherwise decline.
+            val blob = compact(pe)
+            val onlyGeneric = (pe as JsonElement?).nodesTagged("CostReduceGeneric").size == 1 &&
+                !Regex("CostReduce(?!Generic)").containsMatchIn(blob)
+            if (amount != null && onlyGeneric) {
+                return listOf(staticAbilityStmt(call(
+                    "ModifySpellCost",
+                    arg("target", call("SpellCostTarget.YouCast", arg("GameObjectFilter.Any"))),
+                    arg("modification", call("CostModification.ReduceGeneric", arg("$amount"))),
+                    arg("gating", call("CostGating.OnlyIf", arg("Conditions.IsNotYourTurn"))),
+                )))
+            }
+        }
+        reasons.add("If"); return null
+    }
+
+    // Bristlepack Sentry: "As long as you control a creature with power 4 or greater, this creature
+    // can attack as though it didn't have defender."
+    if (innerRule.strField("_Rule") == "PermanentRuleEffect" &&
+        jsonContains(innerRule, "_PermanentRule", "CanAttackAsThoughItDidntHaveDefender") &&
+        jsonContains(innerRule, "_Permanent", "ThisPermanent")
+    ) {
+        val condDsl = youControlConditionDsl(cond) ?: run { reasons.add("If"); return null }
+        return listOf(staticAbilityStmt(call("CanAttackDespiteDefender", arg("condition", Lit(condDsl)))))
+    }
+
+    reasons.add("If"); return null
 }
 
 internal fun EmitCtx.spellBlock(card: JsonObject): List<Stmt>? {
@@ -252,6 +368,23 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     // "Whenever a player cycles a card" (any player) — Fleeting Aven, Invigorating Boon.
     if (jsonContains(trig, "_Trigger", "WhenAPlayerCyclesACard") && jsonContains(trig, "_Players", "AnyPlayer"))
         return "Triggers.AnyPlayerCycles"
+
+    // "Whenever this creature becomes the target of a spell or ability an opponent controls"
+    // (Cactarantula). The trigger's args is a 2-tuple [subject, spell/ability-filter]; the subject must
+    // be SinglePermanent(ThisPermanent) and the filter an opponent-controlled spell/ability. Only that
+    // exact self + opponent shape maps to Triggers.BecomesTargetByOpponent; anything else (a filtered
+    // permanent group, your own spells, a count clause) declines -> SCAFFOLD.
+    if (jsonContains(trig, "_Trigger", "WhenAPermanentBecomesTheTargetOfASpellOrAbility")) {
+        val targs = trig["args"].asArr ?: return null
+        val subject = targs.getOrNull(0) as? JsonObject
+        val selfSubject = subject?.strField("_Permanents") == "SinglePermanent" &&
+            subject.field("args").strField("_Permanent") == "ThisPermanent"
+        val filter = targs.getOrNull(1) as? JsonObject
+        val opponentControlled = filter?.strField("_SpellsAndAbilities") == "ControlledByAPlayer" &&
+            filter.field("args").strField("_Players") == "Opponent"
+        if (selfSubject && opponentControlled) return "Triggers.BecomesTargetByOpponent"
+        return null
+    }
 
     // "Whenever a creature attacks" — only the unrestricted any-creature shape (no subtype / controller /
     // count clause), which maps to a filterless ANY-binding attacks trigger (Righteous Cause).

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -140,6 +140,7 @@ object Emitter {
                 rname == "TriggerA" -> block = ctx.triggerBlock(rule)
                 rname == "TriggerOnceEachTurn" -> block = ctx.triggerBlock(rule, oncePerTurn = true)
                 rname == "PermanentRuleEffect" -> block = ctx.staticBlock(rule)
+                rname == "If" -> block = ctx.ifRuleBlock(rule)
                 rname == "PlayerEffect" -> block = ctx.playerEffectBlock(rule)
                 rname == "EnchantPermanent" -> block = ctx.auraTargetBlock(rule)
                 rname == "PermanentLayerEffect" -> block = ctx.staticHostBlock(rule)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BristlepackSentryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BristlepackSentryScenarioTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Bristlepack Sentry (OTJ) — {1}{G} Plant Wolf 3/3, Defender.
+ *
+ * "As long as you control a creature with power 4 or greater, this creature can attack
+ *  as though it didn't have defender."
+ *
+ * Exercises [com.wingedsheep.sdk.scripting.CanAttackDespiteDefender] gated by a
+ * YouControl(Creature.powerAtLeast(4)) condition.
+ */
+class BristlepackSentryScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bristlepack Sentry conditional defender attack") {
+
+            test("cannot attack while you control no creature with power 4 or greater") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bristlepack Sentry", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val result = game.declareAttackers(mapOf("Bristlepack Sentry" to 2))
+                withClue("Defender blocks the attack with no big creature in play") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("can attack while you control a creature with power 4 or greater") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bristlepack Sentry", tapped = false, summoningSickness = false)
+                    // Force of Nature is 8/8 — satisfies the power-4-or-greater condition.
+                    .withCardOnBattlefield(1, "Force of Nature", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val sentry = game.findPermanent("Bristlepack Sentry")!!
+                val result = game.declareAttackers(mapOf("Bristlepack Sentry" to 2))
+                withClue("Sentry can attack despite Defender: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Sentry is now an attacker") {
+                    game.state.getEntity(sentry)?.get<AttackingComponent>().shouldNotBeNull()
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CactarantulaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CactarantulaScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.Cactarantula
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ConduitPylons
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Cactarantula's cost reduction (this spell costs {1} less to cast if you
+ * control a Desert) via [com.wingedsheep.engine.mechanics.mana.CostCalculator].
+ *
+ * Cactarantula: {4}{G}{G}, Plant Spider 6/5, Reach.
+ */
+class CactarantulaCostScenarioTest : FunSpec({
+
+    fun createDriver(): Pair<GameTestDriver, CardRegistry> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Cactarantula, ConduitPylons))
+
+        val registry = CardRegistry()
+        registry.register(TestCards.all)
+        registry.register(Cactarantula)
+        registry.register(ConduitPylons)
+        return driver to registry
+    }
+
+    test("no Desert - full {4}{G}{G} cost") {
+        val (driver, registry) = createDriver()
+        val calculator = CostCalculator(registry)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val cost = calculator.calculateEffectiveCost(driver.state, registry.requireCard("Cactarantula"), active)
+        cost.genericAmount shouldBe 4
+    }
+
+    test("control a Desert - costs {1} less") {
+        val (driver, registry) = createDriver()
+        val calculator = CostCalculator(registry)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putPermanentOnBattlefield(active, "Conduit Pylons")
+
+        val cost = calculator.calculateEffectiveCost(driver.state, registry.requireCard("Cactarantula"), active)
+        cost.genericAmount shouldBe 3
+    }
+})
+
+/**
+ * Scenario test for Cactarantula's targeting trigger:
+ * "Whenever this creature becomes the target of a spell or ability an opponent controls,
+ *  you may draw a card."
+ *
+ * Exercises the new self-bound [com.wingedsheep.sdk.dsl.Triggers.BecomesTargetByOpponent] facade.
+ */
+class CactarantulaTriggerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cactarantula targeting trigger") {
+
+            test("opponent targeting it with a spell lets you may-draw a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    // Player 2 controls Cactarantula; Player 1 (active) targets it.
+                    .withCardOnBattlefield(2, "Cactarantula", tapped = false, summoningSickness = false)
+                    .withCardInHand(1, "Doom Blade")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .build()
+
+                val cactarantula = game.findPermanent("Cactarantula")!!
+                val libBefore = game.librarySize(2)
+
+                val cast = game.castSpell(1, "Doom Blade", targetId = cactarantula)
+                withClue("Doom Blade should cast targeting Cactarantula: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                // The targeting trigger goes on the stack above Doom Blade and resolves first.
+                game.resolveStack()
+
+                // Cactarantula's controller (Player 2) may draw — accept.
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(true)
+                }
+                game.resolveStack()
+
+                withClue("Player 2 drew a card from the may-draw trigger") {
+                    game.librarySize(2) shouldBe (libBefore - 1)
+                }
+            }
+
+            test("your own spell targeting it does not trigger") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cactarantula", tapped = false, summoningSickness = false)
+                    .withCardInHand(1, "Giant Growth")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .build()
+
+                val cactarantula = game.findPermanent("Cactarantula")!!
+                val libBefore = game.librarySize(1)
+
+                val cast = game.castSpell(1, "Giant Growth", targetId = cactarantula)
+                withClue("Giant Growth should cast: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("no may-draw decision should be pending (own spell)") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("library unchanged - the trigger did not fire") {
+                    game.librarySize(1) shouldBe libBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeyserDrakeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeyserDrakeScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.GeyserDrake
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Geyser Drake — {2}{U} Drake 2/3.
+ * "During turns other than yours, spells you cast cost {1} less to cast."
+ *
+ * Verifies that the [com.wingedsheep.sdk.scripting.ModifySpellCost] static ability gated by
+ * OnlyIf(IsNotYourTurn) reduces the generic component of the controller's spells only on
+ * opponents' turns, and never reduces colored mana.
+ */
+class GeyserDrakeScenarioTest : FunSpec({
+
+    fun createDriver(): Pair<GameTestDriver, CardRegistry> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GeyserDrake))
+
+        val registry = CardRegistry()
+        registry.register(TestCards.all)
+        registry.register(GeyserDrake)
+
+        return driver to registry
+    }
+
+    test("no reduction on your own turn") {
+        val (driver, registry) = createDriver()
+        val calculator = CostCalculator(registry)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(active, "Geyser Drake")
+
+        // It is the active player's own turn, so no reduction applies.
+        val bearsDef = registry.requireCard("Centaur Courser") // {2}{G}
+        val cost = calculator.calculateEffectiveCost(driver.state, bearsDef, active)
+        cost.genericAmount shouldBe 2
+    }
+
+    test("reduces generic by 1 during an opponent's turn") {
+        val (driver, registry) = createDriver()
+        val calculator = CostCalculator(registry)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(opponent, "Geyser Drake")
+
+        // From the opponent's perspective it is NOT their turn, so their spells cost {1} less.
+        val bearsDef = registry.requireCard("Centaur Courser") // {2}{G}
+        val cost = calculator.calculateEffectiveCost(driver.state, bearsDef, opponent)
+        cost.genericAmount shouldBe 1
+    }
+
+    test("does not reduce colored mana") {
+        val (driver, registry) = createDriver()
+        val calculator = CostCalculator(registry)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(opponent, "Geyser Drake")
+
+        // Counterspell is {U}{U} — all colored, no generic. Reduction can't touch it.
+        val counterspell = registry.requireCard("Counterspell")
+        val cost = calculator.calculateEffectiveCost(driver.state, counterspell, opponent)
+        cost.genericAmount shouldBe 0
+        cost.cmc shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarrierStrixScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarrierStrixScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Harrier Strix (OTJ) — {U} Bird 1/1, Flying.
+ *
+ * "When this creature enters, tap target permanent."
+ * "{2}{U}: Draw a card, then discard a card."
+ */
+class HarrierStrixScenarioTest : ScenarioTestBase() {
+
+    private val lootAbilityId =
+        cardRegistry.getCard("Harrier Strix")!!.activatedAbilities.first().id
+
+    init {
+        context("Harrier Strix abilities") {
+
+            test("ETB taps target permanent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Harrier Strix")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Centaur Courser")!!
+                val cast = game.castSpell(1, "Harrier Strix")
+                withClue("casting Harrier Strix should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // ETB trigger asks for a target permanent.
+                game.selectTargets(listOf(target))
+                game.resolveStack()
+
+                withClue("the targeted permanent is tapped") {
+                    game.state.getEntity(target)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("loot ability draws then discards (net hand size unchanged)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Harrier Strix", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInHand(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val strix = game.findPermanent("Harrier Strix")!!
+                val handBefore = game.handSize(1)
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = strix,
+                        abilityId = lootAbilityId
+                    )
+                )
+                withClue("activating loot should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Draw a card (hand +1), then a discard decision is pending.
+                val toDiscard = game.findCardsInHand(1, "Forest").first()
+                game.selectCards(listOf(toDiscard))
+                game.resolveStack()
+
+                withClue("draw a card, then discard a card -> net hand size unchanged") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("the discarded card is in the graveyard") {
+                    game.isInGraveyard(1, "Forest") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards

Four Outlaws of Thunder Junction commons, each with a passing rules-engine scenario test:

| Card | Cost | P/T | Text |
|------|------|-----|------|
| **Geyser Drake** | {2}{U} | 2/3 Drake | Flying. During turns other than yours, spells you cast cost {1} less to cast. |
| **Harrier Strix** | {U} | 1/1 Bird | Flying. When this enters, tap target permanent. {2}{U}: Draw a card, then discard a card. |
| **Bristlepack Sentry** | {1}{G} | 3/3 Plant Wolf | Defender. As long as you control a creature with power 4+, this can attack as though it didn't have defender. |
| **Cactarantula** | {4}{G}{G} | 6/5 Plant Spider | Costs {1} less if you control a Desert. Reach. Whenever it becomes the target of a spell/ability an opponent controls, you may draw a card. |

Implementation notes:
- Geyser Drake → `ModifySpellCost(YouCast(Any), ReduceGeneric(1), gating = OnlyIf(IsNotYourTurn))` (generic-only, per the rulings).
- Harrier Strix → ETB `Effects.Tap(target permanent)` + `Patterns.Hand.loot(1, 1)` activated ability.
- Bristlepack Sentry → `CanAttackDespiteDefender(condition = YouControl(Creature.powerAtLeast(4)))`.
- Cactarantula → self-cast `ReduceGenericBy(FixedIfControlFilter(1, Land.withSubtype(DESERT)))` + Reach + an optional may-draw on the new becomes-target-by-opponent trigger.

## SDK

Adds `Triggers.BecomesTargetByOpponent` — the self-bound counterpart of
`CreatureYouControlBecomesTargetByOpponent` (Cactarantula's targeting trigger).
Documented in `docs/card-sdk-language-reference.md`.

## mtgish auto-gen tooling

All four cards now tier **AUTO** (emitter renders the whole card) and classify **AUTOGEN** (probe coverable):

- **emitter** (`coverage/emitter/CardStructure.kt`, `Emitter.kt`):
  - new `If`-rule handler renders the turn-gated cost reduction (Geyser Drake) and the conditional `CanAttackDespiteDefender` (Bristlepack Sentry);
  - `CastEffect/ReduceCastingCostIf` renders the control-a-Desert self-cost reduction (Cactarantula);
  - the `WhenAPermanentBecomesTheTargetOfASpellOrAbility` trigger (self + opponent-controlled) renders `Triggers.BecomesTargetByOpponent`;
  - every new shape declines to **SCAFFOLD** rather than widening when it can't render exactly.
- **bridge** (`coverage/bridge/`): `PlayerEffect` envelope + the becomes-target trigger marked `supported`.

## Verification

- POR `coverage-verify` **GATE PASS — 158/158, 0 gameplay-tree mismatch, 0 capability mismatch** (Portal stays 0-mismatch).
- POR bridge calibration **100% (200/200)**.
- `EmitterGoldenTest` (POR regression) passes; full `:mtgish-tooling` test suite passes.
- OTJ generated cards compile with 0 capability mismatch (the two pre-existing OTJ gate fails — Shoot the Sheriff, Spring Splasher — are unrelated emitter filter-recovery limitations that touch none of the new code paths).
- All four card scenario tests pass; OTJ card snapshot re-blessed (additive only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)