### PR TITLE
feat(otj): Canyon Crab, Drover Grizzly, Giant Beaver, Holy Cow + mtgish Mount/intervening-if support

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/CanyonCrab.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/CanyonCrab.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Canyon Crab
+ * {1}{U}
+ * Creature — Crab
+ * 0/5
+ *
+ * {1}{U}: This creature gets +2/-2 until end of turn.
+ * At the beginning of your end step, if you haven't cast a spell from your hand this turn,
+ * draw a card, then discard a card.
+ *
+ * Intervening-if (CR 603.4 / Scryfall ruling 2024-04-12): the end-step ability checks
+ * "haven't cast a spell from your hand this turn" both when it would trigger and again as it
+ * resolves, so casting a spell after the trigger but before resolution still fizzles it.
+ */
+val CanyonCrab = card("Canyon Crab") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab"
+    power = 0
+    toughness = 5
+    oracleText = "{1}{U}: This creature gets +2/-2 until end of turn.\n" +
+        "At the beginning of your end step, if you haven't cast a spell from your hand this turn, " +
+        "draw a card, then discard a card."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}")
+        effect = Effects.ModifyStats(power = 2, toughness = -2, target = EffectTarget.Self)
+        description = "{1}{U}: This creature gets +2/-2 until end of turn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.Not(Conditions.YouCastSpellsThisTurn(1, fromZone = Zone.HAND))
+        effect = Patterns.Hand.loot(draw = 1, discard = 1)
+        description = "At the beginning of your end step, if you haven't cast a spell from your hand " +
+            "this turn, draw a card, then discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "40"
+        artist = "Ignatius Budi"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b740a8a8-e1d3-4642-a214-03731c9b5553.jpg?1712355388"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DroverGrizzly.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DroverGrizzly.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Drover Grizzly
+ * {2}{G}
+ * Creature — Bear Mount
+ * 4/2
+ *
+ * Whenever this creature attacks while saddled, creatures you control gain trample until end of turn.
+ * Saddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount
+ * becomes saddled until end of turn. Saddle only as a sorcery.)
+ *
+ * "While saddled" is an intervening-if (CR 603.4) on the attack trigger: it checks the source's
+ * SaddledComponent both when the trigger would fire and again as it resolves.
+ */
+val DroverGrizzly = card("Drover Grizzly") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear Mount"
+    power = 4
+    toughness = 2
+    oracleText = "Whenever this creature attacks while saddled, creatures you control gain trample " +
+        "until end of turn.\n" +
+        "Saddle 1 (Tap any number of other creatures you control with total power 1 or more: This " +
+        "Mount becomes saddled until end of turn. Saddle only as a sorcery.)"
+
+    keywordAbility(KeywordAbility.saddle(1))
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.SourceIsSaddled
+        effect = Patterns.Group.grantKeywordToAll(Keyword.TRAMPLE, Filters.Group.creaturesYouControl)
+        description = "creatures you control gain trample until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "161"
+        artist = "Adrián Rodríguez Pérez"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/560062cd-34f8-4d30-9e25-099b03961724.jpg?1712355911"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GiantBeaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GiantBeaver.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Giant Beaver
+ * {3}{G}
+ * Creature — Beaver Mount
+ * 4/4
+ *
+ * Vigilance
+ * Whenever this creature attacks while saddled, put a +1/+1 counter on target creature that
+ * saddled it this turn.
+ * Saddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount
+ * becomes saddled until end of turn. Saddle only as a sorcery.)
+ *
+ * "While saddled" is an intervening-if (CR 603.4) on the attack trigger. The target is restricted
+ * to creatures that saddled this Mount this turn via the source-relative
+ * `crewedOrSaddledSourceThisTurn` filter (backed by the engine's CrewSaddleContributorsComponent).
+ */
+val GiantBeaver = card("Giant Beaver") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beaver Mount"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "Whenever this creature attacks while saddled, put a +1/+1 counter on target creature that " +
+        "saddled it this turn.\n" +
+        "Saddle 3 (Tap any number of other creatures you control with total power 3 or more: This " +
+        "Mount becomes saddled until end of turn. Saddle only as a sorcery.)"
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.saddle(3))
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.SourceIsSaddled
+        val saddler = target(
+            "target creature that saddled it this turn",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.crewedOrSaddledSourceThisTurn()))
+        )
+        effect = Effects.AddCounters("+1/+1", 1, saddler)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Lars Grant-West"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/919826a9-c427-42c6-8885-a87f0b6d2192.jpg?1712355929"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HolyCow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HolyCow.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Holy Cow
+ * {2}{W}
+ * Creature — Ox Angel
+ * 2/2
+ *
+ * Flash
+ * Flying
+ * When this creature enters, you gain 2 life and scry 1.
+ */
+val HolyCow = card("Holy Cow") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Ox Angel"
+    power = 2
+    toughness = 2
+    oracleText = "Flash\nFlying\nWhen this creature enters, you gain 2 life and scry 1."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2).then(Patterns.Library.scry(1))
+        description = "you gain 2 life and scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "16"
+        artist = "Justyna Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90de84c9-941b-4056-8501-ce8a948b9643.jpg?1712355286"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -387,6 +387,117 @@
     ]
 }
 
+// Canyon Crab
+{
+    "name": "Canyon Crab",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Crab",
+    "oracleText": "{1}{U}: This creature gets +2/-2 until end of turn.\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "PlayerCastSpellsThisTurn",
+                        "atLeast": 1,
+                        "fromZone": "Hand"
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, if you haven't cast a spell from your hand this turn, draw a card, then discard a card."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{1}{U}"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}{U}: This creature gets +2/-2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "UNCOMMON",
+        "artist": "Ignatius Budi",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b740a8a8-e1d3-4642-a214-03731c9b5553.jpg?1712355388"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Concealed Courtyard
 {
     "name": "Concealed Courtyard",
@@ -556,6 +667,64 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/f/5ffa48cc-b991-4d47-b7ec-cf678915c758.jpg?1712356314"
     },
     "colorIdentityOverride": []
+}
+
+// Drover Grizzly
+{
+    "name": "Drover Grizzly",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Bear Mount",
+    "oracleText": "Whenever this creature attacks while saddled, creatures you control gain trample until end of turn.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "SADDLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "SADDLE",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEachInGroup",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "SourceMatches",
+                    "filter": {
+                        "statePredicates": [
+                            "IsSaddled"
+                        ]
+                    }
+                },
+                "descriptionOverride": "creatures you control gain trample until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "artist": "Adrián Rodríguez Pérez",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/560062cd-34f8-4d30-9e25-099b03961724.jpg?1712355911"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Forsaken Miner
@@ -742,6 +911,76 @@
     ]
 }
 
+// Giant Beaver
+{
+    "name": "Giant Beaver",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Beaver Mount",
+    "oracleText": "Vigilance\nWhenever this creature attacks while saddled, put a +1/+1 counter on target creature that saddled it this turn.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE",
+        "SADDLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "SADDLE",
+            "n": 3
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature that saddled it this turn"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "CrewedOrSaddledSourceThisTurn"
+                            ]
+                        }
+                    },
+                    "id": "target creature that saddled it this turn"
+                },
+                "triggerCondition": {
+                    "type": "SourceMatches",
+                    "filter": {
+                        "statePredicates": [
+                            "IsSaddled"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Lars Grant-West",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/919826a9-c427-42c6-8885-a87f0b6d2192.jpg?1712355929"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Harrier Strix
 {
     "name": "Harrier Strix",
@@ -850,6 +1089,105 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Holy Cow
+{
+    "name": "Holy Cow",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Ox Angel",
+    "oracleText": "Flash\nFlying\nWhen this creature enters, you gain 2 life and scry 1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeAs": "scried"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "scried",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "toBottom",
+                                    "storeRemainder": "toTop",
+                                    "selectedLabel": "Put on bottom",
+                                    "remainderLabel": "Put on top"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "toBottom",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Bottom"
+                                    }
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "toTop",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Top"
+                                    },
+                                    "order": "ControllerChooses"
+                                },
+                                "EmitScriedEvent"
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "you gain 2 life and scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "artist": "Justyna Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90de84c9-941b-4056-8501-ce8a948b9643.jpg?1712355286"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -271,6 +271,117 @@
     ]
 }
 
+// Canyon Crab
+{
+    "name": "Canyon Crab",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Crab",
+    "oracleText": "{1}{U}: This creature gets +2/-2 until end of turn.\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "PlayerCastSpellsThisTurn",
+                        "atLeast": 1,
+                        "fromZone": "Hand"
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, if you haven't cast a spell from your hand this turn, draw a card, then discard a card."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{1}{U}"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}{U}: This creature gets +2/-2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "UNCOMMON",
+        "artist": "Ignatius Budi",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b740a8a8-e1d3-4642-a214-03731c9b5553.jpg?1712355388"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Concealed Courtyard
 {
     "name": "Concealed Courtyard",
@@ -442,6 +553,64 @@
     "colorIdentityOverride": []
 }
 
+// Drover Grizzly
+{
+    "name": "Drover Grizzly",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Bear Mount",
+    "oracleText": "Whenever this creature attacks while saddled, creatures you control gain trample until end of turn.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "SADDLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "SADDLE",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEachInGroup",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "SourceMatches",
+                    "filter": {
+                        "statePredicates": [
+                            "IsSaddled"
+                        ]
+                    }
+                },
+                "descriptionOverride": "creatures you control gain trample until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "artist": "Adrián Rodríguez Pérez",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/560062cd-34f8-4d30-9e25-099b03961724.jpg?1712355911"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Forsaken Miner
 {
     "name": "Forsaken Miner",
@@ -571,6 +740,175 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Giant Beaver
+{
+    "name": "Giant Beaver",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Beaver Mount",
+    "oracleText": "Vigilance\nWhenever this creature attacks while saddled, put a +1/+1 counter on target creature that saddled it this turn.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE",
+        "SADDLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "SADDLE",
+            "n": 3
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature that saddled it this turn"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "CrewedOrSaddledSourceThisTurn"
+                            ]
+                        }
+                    },
+                    "id": "target creature that saddled it this turn"
+                },
+                "triggerCondition": {
+                    "type": "SourceMatches",
+                    "filter": {
+                        "statePredicates": [
+                            "IsSaddled"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Lars Grant-West",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/919826a9-c427-42c6-8885-a87f0b6d2192.jpg?1712355929"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Holy Cow
+{
+    "name": "Holy Cow",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Ox Angel",
+    "oracleText": "Flash\nFlying\nWhen this creature enters, you gain 2 life and scry 1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeAs": "scried"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "scried",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "toBottom",
+                                    "storeRemainder": "toTop",
+                                    "selectedLabel": "Put on bottom",
+                                    "remainderLabel": "Put on top"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "toBottom",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Bottom"
+                                    }
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "toTop",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Top"
+                                    },
+                                    "order": "ControllerChooses"
+                                },
+                                "EmitScriedEvent"
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "you gain 2 life and scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "artist": "Justyna Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90de84c9-941b-4056-8501-ce8a948b9643.jpg?1712355286"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -7,6 +7,11 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     envelope("CastEffect", "envelope: on-cast actions")
     envelope("PermanentRuleEffect", "envelope: static ability")
     envelope("TriggerA", "envelope: triggered ability (cond in _Trigger)")
+    // TriggerI — a triggered ability with an intervening-if condition (CR 603.4): args are
+    // [trigger, condition, actions]. The condition is rendered as a `triggerCondition = …` line; an
+    // unrenderable condition declines to a scaffold (Canyon Crab's "if you haven't cast a spell from
+    // your hand this turn").
+    envelope("TriggerI", "envelope: triggered ability with intervening-if condition")
     envelope("TriggerOnceEachTurn", "envelope: triggered ability that triggers only once each turn")
     envelope("Activated", "envelope: activated ability")
     envelope("ActivatedWithModifiers", "envelope: activated ability")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -8,6 +8,14 @@ internal fun BridgeBuilder.keywords() {
     keyword("Vigilance", "VIGILANCE")
     keyword("Reach", "REACH")
     keyword("Defender", "DEFENDER")
+    // Saddle N (CR 702.171) — a PARAMETERIZED keyword ability (the N count rides in the rule's args),
+    // NOT a bare card keyword. It must be `supported`, not `keyword`: a `keyword` entry would make
+    // `keywordLines` stamp a bare `keywords(Keyword.SADDLE)` on the card and drop the N, exactly the
+    // parameterized-keyword trap the `keywordLines` guard warns about (and why Crew carries no bridge
+    // entry at all). The emitter's explicit `rname == "Saddle"` branch renders
+    // `keywordAbility(KeywordAbility.saddle(N))`; this `supported` entry only marks the capability as
+    // covered (never blocking) so the probe doesn't report Saddle as a gap.
+    supported("Saddle", "keyword ability: Saddle N -> keywordAbility(KeywordAbility.saddle(N)) (CR 702.171)")
 
     composed("Landwalk", "specific *WALK keywords (SWAMPWALK, FORESTWALK, ...)")
     // Equip is a keyword ability, but the engine has no `Keyword.EQUIP` enum member: `equipAbility(cost)`

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -13,6 +13,19 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("AtTheBeginningOfAPlayersUpkeep", "trigger: upkeep (Triggers.YourUpkeep / EachUpkeep / EachOpponentUpkeep)")
     supported("AtTheBeginningOfAPlayersEndStep", "trigger: end step (Triggers.YourEndStep / EachEndStep)")
 
+    // Intervening-if conditions (CR 603.4) gating a TriggerI, plus the Mount "while saddled" gate. The
+    // emitter renders the recognised shapes to `triggerCondition = Conditions.*`; an unrenderable
+    // condition still scaffolds, so these are accepted as supported vocabulary (the emitter is the gate).
+    supported("PermanentPassesFilter", "condition: a permanent matches a filter (e.g. ThisPermanent IsSaddled -> Conditions.SourceIsSaddled)")
+    supported("PlayerPassesFilter", "condition: a player matches a filter (e.g. You HasntCastASpellThisTurn)")
+    supported("IsSaddled", "predicate: this permanent is saddled (CR 702.171b)")
+    supported("HasntCastASpellThisTurn", "predicate: player hasn't cast a (filtered) spell this turn")
+    supported("WasCastFromTheirHand", "predicate: spell cast from the player's hand (fromZone = HAND)")
+    // Source-relative Mount/Vehicle payoff filter: "a creature that crewed/saddled it this turn"
+    // (Giant Beaver) -> GameObjectFilter.Creature.crewedOrSaddledSourceThisTurn().
+    supported("SaddledPermanentThisTurn", "filter: a creature that saddled this permanent this turn (crewedOrSaddledSourceThisTurn)")
+    supported("CrewedPermanentThisTurn", "filter: a creature that crewed this permanent this turn (crewedOrSaddledSourceThisTurn)")
+
     // Costs.
     supported("PayMana", "cost: pay mana (universal)")
     supported("SacrificeAPermanent", "cost: sacrifice")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -172,15 +172,25 @@ private val TRIGGER_SPEC = mapOf(
     "WhenACreatureBecomesBlocked" to "Triggers.BecomesBlocked",
 )
 
-/** A TriggerA rule (self-triggered) -> triggeredAbility { trigger; [target]; effect }.
+/** A TriggerA rule (self-triggered) -> triggeredAbility { trigger; [triggerCondition]; [target]; effect }.
  *  [oncePerTurn] is set by the `TriggerOnceEachTurn` rule envelope, whose body is otherwise shaped
- *  identically to a TriggerA. */
-internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false): List<Stmt>? {
+ *  identically to a TriggerA. [triggerCondition] is an optional intervening-if condition DSL (CR 603.4)
+ *  supplied by an enclosing gate (e.g. the "while saddled" `If` wrapper passes
+ *  `Conditions.SourceIsSaddled`); it renders as a `triggerCondition = …` line. */
+internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false, triggerCondition: String? = null): List<Stmt>? {
     // A modal triggered ability ("When this enters, choose one — …") carries a `Modal_*` envelope; the
     // generic action path would render only the first mode and silently drop the rest, so decline the
     // whole ability rather than emit one arm (mirrors the spell-side modal guard).
     if ("\"Modal_" in compact(rule)) { reasons.add("modal-trigger"); return null }
-    val spec = triggerSpecFor(rule) ?: run { reasons.add("trigger-shape"); return null }
+
+    // A Mount's "while saddled" attack trigger nests the intervening-if (CR 603.4) *inside* the
+    // TriggerA's trigger slot: `args[0]` is an `If { <gate> } <realTrigger>` node rather than a bare
+    // `_Trigger`. Recognise the exact "this permanent is saddled" gate, unwrap it to the inner real
+    // trigger, and thread `Conditions.SourceIsSaddled` as the triggerCondition (Drover Grizzly, Giant
+    // Beaver). Any other `If` gate leaves the rule untouched so triggerSpecFor declines -> SCAFFOLD; we
+    // never silently drop or widen the gate.
+    val (effRule, effTriggerCondition) = unwrapSaddledIfTrigger(rule, triggerCondition)
+    val spec = triggerSpecFor(effRule) ?: run { reasons.add("trigger-shape"); return null }
     val (targets, actions) = extractEnvelope(rule)
     if (actions == null) { reasons.add("trigger-actions"); return null }
     val (tnode, tvar) = spellTargetExpr(targets, actions) ?: return null
@@ -198,11 +208,79 @@ internal fun EmitCtx.triggerBlock(rule: JsonObject, oncePerTurn: Boolean = false
     val edsl = renderEffectList(effectActions, tvar) ?: return null
 
     val stmts = mutableListOf<Stmt>(Assign("trigger", Lit(spec)))
+    if (effTriggerCondition != null) stmts.add(Assign("triggerCondition", Lit(effTriggerCondition)))
     if (oncePerTurn) stmts.add(Assign("oncePerTurn", Lit("true")))
     if (mayWrapped && !selfOptional) stmts.add(Assign("optional", Lit("true")))
     if (tvar != null) stmts.add(targetLocal(tnode!!))
     stmts.add(Assign("effect", edsl))
     return listOf(Sub(Block("triggeredAbility", stmts)))
+}
+
+/**
+ * The Mount "while saddled" attack trigger nests the intervening-if (CR 603.4) inside the TriggerA's
+ * trigger slot: `args[0]` is an `If` node whose `args` are `[<gate condition>, <real _Trigger>]`. If
+ * that gate is exactly "this permanent is saddled" (`PermanentPassesFilter(ThisPermanent, IsSaddled)`),
+ * return a rule with `args[0]` replaced by the inner real trigger plus `Conditions.SourceIsSaddled` as
+ * the triggerCondition; the actions in `args[1]` are untouched (Drover Grizzly, Giant Beaver). Any
+ * other gate (or no `If`) returns the rule unchanged with the caller's existing condition, so
+ * `triggerSpecFor` then declines an unrecognised `If` -> SCAFFOLD. Never widens the gate.
+ */
+private fun unwrapSaddledIfTrigger(rule: JsonObject, existing: String?): Pair<JsonObject, String?> {
+    val args = rule["args"].asArr ?: return rule to existing
+    val trig = args.getOrNull(0) as? JsonObject ?: return rule to existing
+    if (trig.strField("_Trigger") != "If") return rule to existing
+    val ifArgs = trig["args"].asArr ?: return rule to existing
+    val gate = ifArgs.getOrNull(0) as? JsonObject
+    val innerTrigger = ifArgs.getOrNull(1) as? JsonObject ?: return rule to existing
+    val isSaddledGate = gate?.strField("_Condition") == "PermanentPassesFilter" &&
+        jsonContains(gate, "_Permanent", "ThisPermanent") &&
+        jsonContains(gate, "_Permanents", "IsSaddled")
+    if (!isSaddledGate) return rule to existing
+    val rewritten = buildJsonObject {
+        rule.forEach { (k, v) -> if (k != "args") put(k, v) }
+        put("args", JsonArray(listOf<JsonElement>(innerTrigger) + args.drop(1)))
+    }
+    return rewritten to (existing ?: "Conditions.SourceIsSaddled")
+}
+
+/**
+ * A `TriggerI` rule (triggered ability with an intervening-if) -> triggeredAbility { trigger;
+ * triggerCondition; [target]; effect }. The rule's args are [trigger, condition, actions]: the
+ * trigger reuses [triggerSpecFor], the condition is rendered by [interveningIfDsl] (only the exact
+ * shapes we can express render; anything else declines to a scaffold), and the actions reuse the
+ * normal trigger-body path. Canyon Crab: "At the beginning of your end step, if you haven't cast a
+ * spell from your hand this turn, draw a card, then discard a card."
+ */
+internal fun EmitCtx.triggerIBlock(rule: JsonObject): List<Stmt>? {
+    val args = rule["args"].asArr ?: run { reasons.add("TriggerI"); return null }
+    val cond = args.getOrNull(1) as? JsonObject
+    val condDsl = interveningIfDsl(cond) ?: run { reasons.add("TriggerI"); return null }
+    // Re-key the TriggerI rule's [trigger, condition, actions] into a TriggerA-shaped [trigger, actions]
+    // so the shared triggerBlock recovers the spec + body; the condition is threaded separately.
+    val triggerA = buildJsonObject {
+        put("_Rule", JsonPrimitive("TriggerA"))
+        put("args", JsonArray(listOfNotNull(args.getOrNull(0)) + listOfNotNull(args.getOrNull(2))))
+    }
+    return triggerBlock(triggerA, triggerCondition = condDsl)
+}
+
+/**
+ * An intervening-if condition node -> a `Conditions.*` DSL string, or null (-> SCAFFOLD) for any
+ * condition shape we can't express exactly. Only the shapes the Mount/cast-from-hand cards need are
+ * recognised; declining beats widening. Currently:
+ *  - `PlayerPassesFilter(You, HasntCastASpellThisTurn(WasCastFromTheirHand))` ("you haven't cast a
+ *    spell from your hand this turn") -> `Conditions.Not(Conditions.YouCastSpellsThisTurn(1, fromZone = Zone.HAND))`.
+ */
+private fun EmitCtx.interveningIfDsl(cond: JsonObject?): String? {
+    if (cond == null) return null
+    if (cond.strField("_Condition") == "PlayerPassesFilter" &&
+        jsonContains(cond, "_Player", "You") &&
+        jsonContains(cond, "_Players", "HasntCastASpellThisTurn") &&
+        jsonContains(cond, "_Spells", "WasCastFromTheirHand")
+    ) {
+        return "Conditions.Not(Conditions.YouCastSpellsThisTurn(1, fromZone = Zone.HAND))"
+    }
+    return null
 }
 
 /** The triggered-ability trigger spec for a TriggerA / TriggerOnceEachTurn rule, or null (-> SCAFFOLD)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.tooling.coverage.asObj
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.field
+import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.asciiIdentifier
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
@@ -138,6 +139,7 @@ object Emitter {
                 }
                 rname == "SpellActions" -> block = ctx.spellBlock(card)
                 rname == "TriggerA" -> block = ctx.triggerBlock(rule)
+                rname == "TriggerI" -> block = ctx.triggerIBlock(rule)
                 rname == "TriggerOnceEachTurn" -> block = ctx.triggerBlock(rule, oncePerTurn = true)
                 rname == "PermanentRuleEffect" -> block = ctx.staticBlock(rule)
                 rname == "PlayerEffect" -> block = ctx.playerEffectBlock(rule)
@@ -157,6 +159,11 @@ object Emitter {
                 rname == "Morph" -> block = manaKeywordCost(rule)?.let { listOf(Assign("morph", Lit("\"$it\""))) }
                 rname == "Flashback" -> block = manaKeywordCost(rule)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.flashback", arg("\"$it\"")))))) }
                 rname == "Crew" -> block = rule["args"].asInt()?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.crew", arg("$it")))))) }
+                // Saddle N (CR 702.171) — a numeric keyword ability. mtgish shapes the count as a nested
+                // `_GameNumber: Integer` game number, so dig the integer out of the args (findInteger) rather
+                // than reading args directly as an Int. Renders `keywordAbility(KeywordAbility.saddle(N))`,
+                // exactly like Crew above; the engine synthesises the Saddle special action from the keyword.
+                rname == "Saddle" -> block = (findInteger(rule["args"]) as? Int)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.saddle", arg("$it")))))) }
                 rname == "Equip" -> block = equipAbilityLine(rule)
                 rname == "Protection" -> block = protectionScopeDsl(rule)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.Protection", arg(Lit(it))))))) }
                 rname != null && (rname in handledRules || Bridge[rname]?.kind == "keyword") -> continue

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -131,6 +131,15 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
     // the generic "blocking creature" constant, silently dropping the source relation. Decline so it
     // scaffolds (Cromat's {W}{B} ability).
     if ("IsBlockingAttacker" in blob || "IsBlockedByDefender" in blob) return null
+    // "creature that crewed/saddled it this turn" (CrewedOrSaddledSourceThisTurn) — a source-relative
+    // Mount/Vehicle payoff filter (Giant Beaver: "put a +1/+1 counter on target creature that saddled it
+    // this turn"). mtgish tags it `SaddledPermanentThisTurn` bound to the trigger's permanent. It composes
+    // onto the plain creature filter via .crewedOrSaddledSourceThisTurn(); a controller restriction on top
+    // of it isn't a shape we render, so decline rather than widen.
+    if ("SaddledPermanentThisTurn" in blob || "CrewedPermanentThisTurn" in blob) {
+        if ("ControlledByAPlayer" in blob) return null
+        return Call("TargetFilter", listOf(arg(Lit("GameObjectFilter.Creature").dot("crewedOrSaddledSourceThisTurn"))))
+    }
     // "nonartifact creature" (the Terror template) renders via .nonartifact(); any OTHER non-cardtype
     // restriction has no faithful filter rendering yet, so drop to SCAFFOLD rather than omit it.
     val nonCardtypes = filterNode.argWordsTagged("IsNonCardtype")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CanyonCrabScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CanyonCrabScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.CastSpellRecord
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Canyon Crab's end-step loot trigger.
+ *
+ * Oracle: "At the beginning of your end step, if you haven't cast a spell from your hand this
+ * turn, draw a card, then discard a card."
+ *
+ * The trigger is an intervening-if (CR 603.4) gated on
+ * `Not(YouCastSpellsThisTurn(1, fromZone = HAND))`, so:
+ *  1. No spell cast from hand this turn → loots (library -1, graveyard +1).
+ *  2. A spell cast from hand this turn → doesn't trigger at all.
+ */
+class CanyonCrabScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Canyon Crab end-step loot") {
+
+            test("loots when no spell was cast from hand this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Canyon Crab")
+                    .withCardInHand(1, "Grizzly Bears") // a card to discard
+                    .withCardInLibrary(1, "Grizzly Bears") // a card to draw
+                    .withActivePlayer(1)
+                    .build()
+
+                val libBefore = game.state.getLibrary(game.player1Id).size
+                val gyBefore = game.state.getGraveyard(game.player1Id).size
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Canyon Crab should draw a card (library -1)") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libBefore - 1
+                }
+
+                // The loot's discard step presents a card-selection decision; choose one to discard.
+                val discard = game.getPendingDecision()
+                withClue("loot presents a discard selection over the hand") {
+                    (discard is SelectCardsDecision) shouldBe true
+                }
+                game.selectCards(listOf((discard as SelectCardsDecision).options.first())).error shouldBe null
+                game.resolveStack()
+
+                withClue("Canyon Crab should discard a card (graveyard +1)") {
+                    game.state.getGraveyard(game.player1Id).size shouldBe gyBefore + 1
+                }
+            }
+
+            test("does not trigger when a spell was cast from hand this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Canyon Crab")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .build()
+
+                // Record that a spell was cast from hand this turn — satisfies
+                // YouCastSpellsThisTurn(1, fromZone = HAND), so the intervening-if is false.
+                game.state = game.state.copy(
+                    spellsCastThisTurnByPlayer = mapOf(
+                        game.player1Id to listOf(
+                            CastSpellRecord(
+                                typeLine = TypeLine.parse("Instant"),
+                                manaValue = 1,
+                                colors = emptySet(),
+                                isFaceDown = false,
+                                castFromZone = Zone.HAND,
+                            )
+                        )
+                    )
+                )
+
+                val libBefore = game.state.getLibrary(game.player1Id).size
+                val gyBefore = game.state.getGraveyard(game.player1Id).size
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("library unchanged — no draw because a spell was cast from hand") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libBefore
+                }
+                withClue("graveyard unchanged — no discard from the loot trigger") {
+                    game.state.getGraveyard(game.player1Id).size shouldBe gyBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DroverGrizzlyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DroverGrizzlyScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SaddleMount
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Drover Grizzly (OTJ).
+ *
+ * Oracle: "Whenever this creature attacks while saddled, creatures you control gain trample
+ * until end of turn. Saddle 1"
+ *
+ * The "while saddled" gate is an intervening-if (CR 603.4) on the attack trigger, so the
+ * trample grant only happens if the Grizzly was saddled before it attacked.
+ */
+class DroverGrizzlyScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("attacking while saddled grants trample to creatures you control") {
+        val driver = newDriver()
+        val grizzly = driver.putCreatureOnBattlefield(driver.player1, "Drover Grizzly")
+        val saddler = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") // power 2 >= 1
+        driver.removeSummoningSickness(grizzly)
+
+        driver.submitSuccess(SaddleMount(driver.player1, grizzly, listOf(saddler)))
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(grizzly), driver.player2)
+        driver.bothPass() // resolve the attack-while-saddled trigger
+
+        projector.hasProjectedKeyword(driver.state, grizzly, Keyword.TRAMPLE) shouldBe true
+        projector.hasProjectedKeyword(driver.state, saddler, Keyword.TRAMPLE) shouldBe true
+    }
+
+    test("attacking while NOT saddled does not grant trample") {
+        val driver = newDriver()
+        val grizzly = driver.putCreatureOnBattlefield(driver.player1, "Drover Grizzly")
+        val other = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.removeSummoningSickness(grizzly)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(grizzly), driver.player2)
+        driver.bothPass()
+
+        projector.hasProjectedKeyword(driver.state, grizzly, Keyword.TRAMPLE) shouldBe false
+        projector.hasProjectedKeyword(driver.state, other, Keyword.TRAMPLE) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiantBeaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiantBeaverScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SaddleMount
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Giant Beaver (OTJ).
+ *
+ * Oracle: "Vigilance. Whenever this creature attacks while saddled, put a +1/+1 counter on
+ * target creature that saddled it this turn. Saddle 3"
+ *
+ * The "while saddled" gate is an intervening-if; the target is restricted to creatures that
+ * saddled this Mount this turn (source-relative CrewSaddleContributorsComponent).
+ */
+class GiantBeaverScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("attacking while saddled puts a +1/+1 counter on a creature that saddled it") {
+        val driver = newDriver()
+        val beaver = driver.putCreatureOnBattlefield(driver.player1, "Giant Beaver")
+        // Saddle 3 needs total power >= 3; two Grizzly Bears (power 2 each) suffice.
+        val saddlerA = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val saddlerB = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.removeSummoningSickness(beaver)
+
+        driver.submitSuccess(SaddleMount(driver.player1, beaver, listOf(saddlerA, saddlerB)))
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(beaver), driver.player2)
+
+        // The attack trigger asks for a target among the creatures that saddled it.
+        driver.submitTargetSelection(driver.player1, listOf(saddlerA))
+        driver.bothPass()
+
+        driver.plusOneCounters(saddlerA) shouldBe 1
+        driver.plusOneCounters(saddlerB) shouldBe 0
+    }
+
+    test("attacking while not saddled does not trigger the counter") {
+        val driver = newDriver()
+        val beaver = driver.putCreatureOnBattlefield(driver.player1, "Giant Beaver")
+        val bystander = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.removeSummoningSickness(beaver)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(beaver), driver.player2)
+        driver.bothPass()
+
+        driver.plusOneCounters(bystander) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HolyCowScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HolyCowScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Holy Cow (OTJ #16).
+ *
+ * Holy Cow — {2}{W} Creature — Ox Angel, 2/2.
+ *   "Flash. Flying. When this creature enters, you gain 2 life and scry 1."
+ */
+class HolyCowScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Holy Cow ETB") {
+
+            fun buildGame() = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Holy Cow")
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            test("gains 2 life and scrys 1 on enter") {
+                val game = buildGame()
+                val startLife = game.getLifeTotal(1)
+
+                game.castSpell(1, "Holy Cow").error shouldBe null
+                game.resolveStack() // ETB: gain 2 life, then scry 1 (SelectCardsDecision)
+
+                withClue("controller gained 2 life") {
+                    game.getLifeTotal(1) shouldBe startLife + 2
+                }
+                val decision = game.getPendingDecision()
+                withClue("scry 1 presents a single-card selection over the top card") {
+                    (decision is SelectCardsDecision) shouldBe true
+                    (decision as SelectCardsDecision).options.size shouldBe 1
+                }
+                // Bottom the looked-at card.
+                game.selectCards((decision as SelectCardsDecision).options).error shouldBe null
+                game.resolveStack()
+
+                withClue("library still has both cards (scry bottoms, doesn't remove)") {
+                    game.librarySize(1) shouldBe 2
+                }
+                withClue("Holy Cow resolved onto the battlefield") {
+                    game.isOnBattlefield("Holy Cow") shouldBe true
+                }
+            }
+
+            test("Holy Cow has flying once it resolves") {
+                val game = buildGame()
+                game.castSpell(1, "Holy Cow").error shouldBe null
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.skipSelection() // keep card on top
+                game.resolveStack()
+
+                val cow = game.findPermanent("Holy Cow")!!
+                projector.hasProjectedKeyword(game.state, cow, Keyword.FLYING) shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards

Four Outlaws of Thunder Junction cards, each with a passing scenario test:

| Card | Cost | P/T | Text |
|------|------|-----|------|
| **Canyon Crab** | {1}{U} | 0/5 | {1}{U}: +2/-2 until EOT. At your end step, *if you haven't cast a spell from your hand this turn*, draw then discard. |
| **Drover Grizzly** | {2}{G} | 4/2 | Saddle 1. Attacks while saddled → your creatures gain trample EOT. |
| **Giant Beaver** | {3}{G} | 4/4 | Vigilance, Saddle 3. Attacks while saddled → +1/+1 counter on target creature that saddled it. |
| **Holy Cow** | {2}{W} | 2/2 | Flash, Flying. ETB: gain 2 life and scry 1. |

Implementation notes:
- The end-step / "while saddled" abilities are modelled as intervening-if conditions (CR 603.4) via `triggerCondition` — `Conditions.Not(YouCastSpellsThisTurn(1, fromZone = HAND))` and `Conditions.SourceIsSaddled`.
- Giant Beaver's target is restricted to the saddlers via `GameObjectFilter.Creature.crewedOrSaddledSourceThisTurn()` (engine `CrewSaddleContributorsComponent`).

## mtgish-tooling

Taught the predictive bridge + emitter the shapes these cards need so **all four now emit as AUTO**, without regressing Portal:

- **`TriggerI` envelope + `interveningIfDsl`** — render a triggered ability's intervening-if to a `triggerCondition = Conditions.*` line (Canyon Crab). Unrenderable conditions decline to SCAFFOLD.
- **Mount "while saddled" gate** — the IR nests the intervening-if *inside* the `TriggerA` trigger slot (`args[0]._Trigger == "If"`). `unwrapSaddledIfTrigger` recognises the exact `PermanentPassesFilter(ThisPermanent, IsSaddled)` gate, unwraps to the inner real trigger, and threads `Conditions.SourceIsSaddled`. Any other gate declines rather than widens. (The previous draft's top-level `rname == "If"` handler was dead code — the `If` is never a top-level rule — and is replaced.)
- **Saddle N** — registered as a `supported` capability, **not** a `keyword`. A `keyword` entry made `keywordLines` stamp a bare `keywords(Keyword.SADDLE)` and drop the N (the parameterized-keyword trap); the explicit emitter branch now renders `keywordAbility(KeywordAbility.saddle(N))`, mirroring Crew.
- **`crewedOrSaddledSourceThisTurn`** target-filter recovery for the Mount saddler-payoff shape; declines (no widen) when a controller restriction is layered on top.

## Verification

- `:rules-engine:test` — all 8 new scenario tests pass.
- `just coverage-verify POR` — **158/158, GATE PASS, 0 mismatch** (no Portal regression).
- `coverage-fidelity --emit` for all four cards → **AUTO** (complete render).
- `:mtgish-tooling:test` (incl. `EmitterGoldenTest`) — green; POR golden byte-identical. No committed ONS fixture exists, so the golden net is unaffected.
- `just build` — green (re-blessed the OTJ card snapshot golden; additive, only the four new cards).

### Pre-existing, not introduced here
`coverage-verify OTJ` reports 2 gameplay-tree mismatches on **Shoot the Sheriff** ("non-outlaw creature") and **Spring Splasher** ("defending player controls") — both pre-existing emitter target/filter limitations on already-committed OTJ cards, in filter-recovery paths this PR does not touch. OTJ is not a gated 0-mismatch set (only POR has a committed fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)