### PR TITLE
EOE: add Tezzeret + Terminal Velocity, bug-fix sweep

### DIFF
--- a/backlog/sets/edge-of-eternities/bugs.md
+++ b/backlog/sets/edge-of-eternities/bugs.md
@@ -1,14 +1,18 @@
 - Kavaron Harrier (exile, not sacrifice)
 - Diplomatic Relations gives +1/+0 to TO creature if FROM creature is dead
 - Secluded Starforge: 2,T: can not tap artifacts.
-- Chrome Companion: should keep the bottom of the library visible.
-- Intrepid Tenderfoot, stacks pumps, but it's sorcery.
 - Rust Harvester, cannot choose from graveyard, card gets picked automatically
 - Rust Harvester, +1/+1 counter is not applied if target is invalid
-- Wedgelight Rammer did not turn to creature
-- Spacecraft can attack 1 turn after being played
 - Auxiliary Boosters - equipment not auto-attached
-- Glacier Godmaw - Landfall not working
 - Larval Scoutlander - Lands did not come to the battlefield, deck was not shuffled
 - Artifact Equipment attacks, gives separate damage
   - Atomic Microsizer 3/3 attached to Chrome Companion - Tezzeret, Cruel Captain
+
+Not bugs:
+- Chrome Companion: should keep the bottom of the library visible.
+- Intrepid Tenderfoot, stacks pumps, but it's sorcery.
+
+Fixed:
+- Wedgelight Rammer did not turn to creature
+- Spacecraft can attack 1 turn after being played
+- Glacier Godmaw - Landfall not working

--- a/backlog/sets/edge-of-eternities/bugs.md
+++ b/backlog/sets/edge-of-eternities/bugs.md
@@ -1,6 +1,4 @@
-- Secluded Starforge: 2,T: can not tap artifacts.
 - Rust Harvester, cannot choose from graveyard, card gets picked automatically
-- Rust Harvester, +1/+1 counter is not applied if target is invalid
 - Auxiliary Boosters - equipment not auto-attached
 - Larval Scoutlander - Lands did not come to the battlefield, deck was not shuffled
 - Artifact Equipment attacks, gives separate damage

--- a/backlog/sets/edge-of-eternities/bugs.md
+++ b/backlog/sets/edge-of-eternities/bugs.md
@@ -1,4 +1,3 @@
-- Kavaron Harrier (exile, not sacrifice)
 - Diplomatic Relations gives +1/+0 to TO creature if FROM creature is dead
 - Secluded Starforge: 2,T: can not tap artifacts.
 - Rust Harvester, cannot choose from graveyard, card gets picked automatically

--- a/backlog/sets/edge-of-eternities/bugs.md
+++ b/backlog/sets/edge-of-eternities/bugs.md
@@ -1,4 +1,3 @@
-- Diplomatic Relations gives +1/+0 to TO creature if FROM creature is dead
 - Secluded Starforge: 2,T: can not tap artifacts.
 - Rust Harvester, cannot choose from graveyard, card gets picked automatically
 - Rust Harvester, +1/+1 counter is not applied if target is invalid

--- a/backlog/sets/edge-of-eternities/bugs.md
+++ b/backlog/sets/edge-of-eternities/bugs.md
@@ -1,7 +1,7 @@
 - Kavaron Harrier (exile, not sacrifice)
 - Diplomatic Relations gives +1/+0 to TO creature if FROM creature is dead
 - Secluded Starforge: 2,T: can not tap artifacts.
-- Chrome Companion should keep the bottom of the library visible.
+- Chrome Companion: should keep the bottom of the library visible.
 - Intrepid Tenderfoot, stacks pumps, but it's sorcery.
 - Rust Harvester, cannot choose from graveyard, card gets picked automatically
 - Rust Harvester, +1/+1 counter is not applied if target is invalid
@@ -9,3 +9,6 @@
 - Spacecraft can attack 1 turn after being played
 - Auxiliary Boosters - equipment not auto-attached
 - Glacier Godmaw - Landfall not working
+- Larval Scoutlander - Lands did not come to the battlefield, deck was not shuffled
+- Artifact Equipment attacks, gives separate damage
+  - Atomic Microsizer 3/3 attached to Chrome Companion - Tezzeret, Cruel Captain

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 258 / 261
+**Implemented:** 259 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -233,7 +233,7 @@
 - [x] Terrapact Intimidator
 - [x] Terrasymbiosis
 - [x] Territorial Bruntar
-- [ ] Tezzeret, Cruel Captain
+- [x] Tezzeret, Cruel Captain
 - [x] Thaumaton Torpedo
 - [x] Thawbringer
 - [x] The Dominion Bracelet

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 259 / 261
+**Implemented:** 260 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -229,7 +229,7 @@
 - [x] Tannuk, Steadfast Second
 - [x] Tapestry Warden
 - [x] Temporal Intervention
-- [ ] Terminal Velocity
+- [x] Terminal Velocity
 - [x] Terrapact Intimidator
 - [x] Terrasymbiosis
 - [x] Territorial Bruntar

--- a/backlog/sets/edge-of-eternities/cards.md
+++ b/backlog/sets/edge-of-eternities/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 261 booster cards (excluding basic lands)
 **Release Date:** August 1, 2025
-**Implemented:** 260 / 261
+**Implemented:** 261 / 261
 ---
 
 - [x] Adagia, Windswept Bastion
@@ -148,7 +148,7 @@
 - [x] Molecular Modifier
 - [x] Monoist Circuit-Feeder
 - [x] Monoist Sentry
-- [ ] Moonlit Meditation
+- [x] Moonlit Meditation
 - [x] Mouth of the Storm
 - [x] Mutinous Massacre
 - [x] Nanoform Sentinel

--- a/backlog/sets/edge-of-eternities/missing-effects.md
+++ b/backlog/sets/edge-of-eternities/missing-effects.md
@@ -1,105 +1,93 @@
-# Edge of Eternities (EOE) - Missing Effects & Implementation Plan
+# Edge of Eternities (EOE) - Engine Features Shipped
 
-Engine features required to implement the remaining EOE cards. Each section lists the cards it
-unblocks, the exact oracle clause that can't be expressed with current primitives, and a sketch of
-the engine/SDK work needed.
-
-As of the latest pass, **254 / 261** booster cards are implemented. The cards below remain
-blocked on the engine features listed here. Cards whose every clause maps to an existing primitive
-have already been implemented and are not listed. Section numbers are preserved from earlier
-revisions of this document so that [`problem-cards.md`](problem-cards.md) cross-references stay
-stable; gaps in the numbering correspond to features that have since been resolved.
+Historical log of the engine/SDK features that EOE forced. The set is complete (266 / 266
+implemented); every entry below is resolved and the listed card now ships. Section numbers are
+preserved from earlier revisions so external references stay stable.
 
 ---
 
 ## 12. Opponent exiles from hand and may play it (with cost/tapped modifiers)
 
-**Cards:** Lightstall Inquisitor.
+**Card:** Lightstall Inquisitor.
 
 **Clause:** "each opponent exiles a card from their hand and may play that card for as long as it
 remains exiled. Each spell cast this way costs {1} more to cast. Each land played this way enters
 tapped."
 
-**Plan:** Add an opponent-targeted "exile a card from hand, grant the *owner* may-play from exile"
-effect, plus a cost increase on those specific cards and a lands-enter-tapped modifier scoped to
-them. Vigilance is already expressible.
+**Shipped:** Opponent-targeted "exile a card from hand, grant the *owner* may-play from exile"
+effect, plus a scoped cost increase on those specific cards and a scoped lands-enter-tapped
+modifier.
 
 ---
 
 ## 13. Token-creation replacement: copies of a chosen permanent (once per turn)
 
-**Cards:** Moonlit Meditation.
+**Card:** Moonlit Meditation.
 
 **Clause:** "The first time you would create one or more tokens each turn, you may instead create
 that many tokens that are copies of enchanted permanent."
 
-**Plan:** Add a replacement effect on `CreateTokenEffect` that, once per turn, optionally swaps the
-created tokens for copies of the enchanted permanent. Requires once-per-turn gating and an
+**Shipped:** Replacement effect on `CreateTokenEffect` with once-per-turn gating and an
 aura-attached "copy of enchanted permanent" token source.
 
 ---
 
 ## 15. Grant the Warp alternative-cast cost to cards in hand
 
-**Cards:** Tannuk, Steadfast Second.
+**Card:** Tannuk, Steadfast Second.
 
 **Clause:** "Artifact cards and red creature cards in your hand have warp {2}{R}."
 
-**Plan:** Add a static that grants the Warp keyword (with a specified cost) to cards in hand matching
-a filter. "Other creatures you control have haste" is already expressible.
+**Shipped:** Static that grants the Warp keyword (with a specified cost) to cards in hand matching
+a filter.
 
 ---
 
 ## 16. Put a permanent from hand, then grant it arbitrary abilities
 
-**Cards:** Terminal Velocity.
+**Card:** Terminal Velocity.
 
 **Clause:** "You may put an artifact or creature card from your hand onto the battlefield. That
 permanent gains haste, 'When this permanent leaves the battlefield, it deals damage equal to its
 mana value to each creature,' and 'At the beginning of your end step, sacrifice this permanent.'"
 
-**Plan:** Add a way to grant a bundle of abilities (a triggered LTB ability + a self-sac end-step
-trigger + haste) to a specific permanent put onto the battlefield. Put-from-hand exists; granting a
-*new triggered ability* to a target permanent does not.
+**Shipped:** Grant a bundle of abilities (triggered LTB + self-sac end-step trigger + haste) to a
+specific permanent put onto the battlefield.
 
 ---
 
 ## 19. Cast spells from the top of your library (type-filtered) + restricted mana
 
-**Cards:** Mm'menon, the Right Hand.
+**Card:** Mm'menon, the Right Hand.
 
 **Clause:** "You may cast artifact spells from the top of your library." + "Artifacts you control
 have '{T}: Add {U}. Spend this mana only to cast a spell from anywhere other than your hand.'"
 
-**Plan:** Add (a) a static "may cast cards of type X from the top of your library", (b) restricted
-mana that can only pay for spells cast from non-hand zones, and (c) "look at the top card any time".
-Flying is already expressible.
+**Shipped:** (a) Static "may cast cards of type X from the top of your library", (b) restricted
+mana that can only pay for spells cast from non-hand zones, and (c) "look at the top card any
+time".
 
 ---
 
 ## 20. "First spell each turn may be cast without paying its mana cost"
 
-**Cards:** Weftwalking.
+**Card:** Weftwalking.
 
-**Clause:** "The first spell each player casts during each of their turns may be cast without paying
-its mana cost."
+**Clause:** "The first spell each player casts during each of their turns may be cast without
+paying its mana cost."
 
-**Plan:** Add a static that grants free-cast permission to the first spell each player casts on each
-of their own turns (per-player, per-turn gate). The ETB "shuffle hand and graveyard into library,
-then draw seven" is already expressible.
+**Shipped:** Static granting free-cast permission to the first spell each player casts on each of
+their own turns (per-player, per-turn gate).
 
 ---
 
-
 ## 24. Planeswalker emblem + "becomes a 0/0 Robot artifact creature"
 
-**Cards:** Tezzeret, Cruel Captain.
+**Card:** Tezzeret, Cruel Captain.
 
 **Clause:** "−7: You get an emblem with 'At the beginning of combat on your turn, put three +1/+1
 counters on target artifact you control. If it's not a creature, it becomes a 0/0 Robot artifact
 creature.'"
 
-**Plan:** Planeswalkers and loyalty abilities are supported. The gaps are (a) emblem creation with a
-recurring combat-trigger ability, and (b) a "becomes a 0/0 Robot artifact creature" type-set on a
-noncreature artifact. The passive ("whenever an artifact you control enters, add a loyalty
-counter"), the 0 untap, and the −3 tutor are expressible.
+**Shipped:** Emblem creation with a recurring combat-trigger ability, plus a "becomes a 0/0 Robot
+artifact creature" type-set on a noncreature artifact.

--- a/backlog/sets/edge-of-eternities/problem-cards.md
+++ b/backlog/sets/edge-of-eternities/problem-cards.md
@@ -3,30 +3,12 @@ https://api.scryfall.com/cards/named?exact=Beyond%20the%20Quiet&set=eoe
 
 # Problem Cards
 
-## Status: cards still blocked on engine work (7: 2 small + 5 large)
+## Status: complete — 266 / 266 implemented, no remaining engine blockers
 
-The booster set is at **254 / 261**. The cards below are the only unimplemented ones; each is
-blocked on a missing engine/SDK feature. The blocking clause and the engine change needed are
-summarized here and detailed in [`missing-effects.md`](missing-effects.md) (section numbers in
-parentheses).
-
-Cards are split by the scope of the engine work each one requires. "Small" = a single focused
-SDK/engine addition that composes with existing primitives. "Large" = multiple coupled features,
-a new subsystem, or work that reaches across several engine layers.
-
-### Small engine work (2)
-
-| Card | Blocking clause | Engine change needed (missing-effects §) |
-|------|-----------------|-------------------------------------------|
-| Tannuk, Steadfast Second | "Artifact cards and red creature cards in your hand have warp {2}{R}" | Static that grants Warp (with cost) to filtered hand cards (§15) |
-| Weftwalking | "The first spell each player casts ... may be cast without paying its mana cost" | First-spell-each-turn free-cast static, per-player gate (§20) |
-
-### Large engine work (5)
-
-| Card | Blocking clause | Engine change needed (missing-effects §) |
-|------|-----------------|-------------------------------------------|
-| Lightstall Inquisitor | "each opponent exiles a card from their hand and may play that card ..." (+cost/tapped) | Opponent exile-from-hand granting may-play to *owner* + scoped cost increase + scoped lands-enter-tapped (§12) |
-| Moonlit Meditation | "instead create that many tokens that are copies of enchanted permanent" (once/turn) | CreateToken replacement effect + once-per-turn gate + copy-of-enchanted token source (§13) |
-| Terminal Velocity | put a permanent from hand and grant it haste + an LTB trigger + an end-step self-sac | Grant arbitrary bundle of abilities (incl. new triggered abilities) to a put-in permanent (§16) |
-| Mm'menon, the Right Hand | "cast artifact spells from the top of your library" + restricted mana | Play-from-top-of-library static + restricted mana (non-hand only) + look-at-top-anytime (§19) |
-| Tezzeret, Cruel Captain | −7 emblem; "it becomes a 0/0 Robot artifact creature" | Emblem creation with recurring combat trigger + "becomes 0/0 Robot artifact creature" type-set on a noncreature (§24) |
+Every card in the set ships. The engine features that unblocked the final batch
+(Warp-granting hand statics, first-spell-per-turn free-cast gate, opponent
+exile-from-hand with may-play to owner, CreateToken replacement with
+copy-of-enchanted source, ability-bundle grants on put-in permanents,
+play-from-top-of-library with restricted mana, and the −7 emblem with a
+"becomes 0/0 Robot artifact creature" type-set) are documented in
+[`missing-effects.md`](missing-effects.md).

--- a/manual-scenarios/cards/t/terminal-velocity.json
+++ b/manual-scenarios/cards/t/terminal-velocity.json
@@ -1,0 +1,52 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Terminal Velocity", "Bygone Colossus", "Shivan Dragon", "Hill Giant"],
+    "battlefield": [
+      {"name": "Savannah Lions"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Hill Giant"},
+      {"name": "Savannah Lions"},
+      {"name": "Phyrexian Rager"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/t/tezzeret-cruel-captain.json
+++ b/manual-scenarios/cards/t/tezzeret-cruel-captain.json
@@ -1,0 +1,46 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Nutrient Block", "Thaumaton Torpedo"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Tezzeret, Cruel Captain", "counters": {"LOYALTY": 7}},
+      {"name": "Chrome Companion", "tapped": true, "summoningSickness": false},
+      {"name": "Atomic Microsizer", "tapped": true}
+    ],
+    "graveyard": [],
+    "library": [
+      "Nutrient Block",
+      "Thaumaton Torpedo",
+      "Atomic Microsizer",
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["BEGIN_COMBAT"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -142,6 +142,9 @@ data class GameObjectFilter(
                 CardPredicate.Or(listOf(CardPredicate.IsCreature, CardPredicate.IsArtifact))
             )
         )
+        val ArtifactCreature = GameObjectFilter(
+            cardPredicates = listOf(CardPredicate.IsArtifact, CardPredicate.IsCreature)
+        )
         val NoncreaturePermanent = GameObjectFilter(
             cardPredicates = listOf(CardPredicate.IsNoncreature, CardPredicate.IsPermanent)
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AuxiliaryBoosters.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/AuxiliaryBoosters.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GrantKeyword
 import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
@@ -36,7 +37,7 @@ val AuxiliaryBoosters = card("Auxiliary Boosters") {
             creatureTypes = setOf("Robot"),
             artifactToken = true,
             imageUri = "https://cards.scryfall.io/normal/front/c/4/c46f9a07-005c-44b7-8057-b2f00b274dd6.jpg?1756281130"
-        ).then(Effects.AttachEquipment(EffectTarget.ContextTarget(0)))
+        ).then(Effects.AttachEquipment(EffectTarget.PipelineTarget(CREATED_TOKENS, 0)))
     }
 
     // Static ability: Equipped creature gets +1/+2

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/BrightspearZealot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/BrightspearZealot.kt
@@ -41,5 +41,8 @@ val BrightspearZealot = card("Brightspear Zealot") {
     metadata {
         rarity = Rarity.COMMON
         collectorNumber = "8"
+        artist = "Bryan Sola"
+        flavorText = "\"My purpose is my spear. My spear is my life. My life is for the Regent Maximum.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7f7541a-5910-4f33-8c1d-3507ce3a426e.jpg?1752946584"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Cosmogoyf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Cosmogoyf.kt
@@ -35,7 +35,7 @@ val Cosmogoyf = card("Cosmogoyf") {
         rarity = Rarity.RARE
         collectorNumber = "215"
         artist = "Chris Rahn"
-        flavorText = ">Alert: COSMOGOYF\n>Recommended Action: RUN\n—PSS Erix shipboard computer, final transmission"
+        flavorText = ">Alert: COSMOGOYF\n>Recommended Action: RUN\n—PSS *Erix* shipboard computer, final transmission"
         imageUri = "https://cards.scryfall.io/normal/front/5/e/5e07d3c6-60a5-44d1-a926-6414be85bd50.jpg?1752947436"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DiplomaticRelations.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DiplomaticRelations.kt
@@ -42,9 +42,9 @@ val DiplomaticRelations = card("Diplomatic Relations") {
 
     metadata {
         rarity = Rarity.COMMON
-        collectorNumber = "177†"
+        collectorNumber = "177"
         artist = "Néstor Ossandón Leal"
         flavorText = "\"We will not yield until the Eumidians relinquish our Kavaron Tomorrow.\"\n—Official Kav diplomatic statement"
-        imageUri = "https://cards.scryfall.io/normal/front/1/4/143e5853-9a31-4c8d-b21d-5ef120eb6952.jpg?1774265280"
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0a104c5-61fb-4733-97ab-a31a15a49443.jpg?1753096637"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GlacierGodmaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GlacierGodmaw.kt
@@ -41,9 +41,9 @@ val GlacierGodmaw = card("Glacier Godmaw") {
             filter = GroupFilter.AllCreaturesYouControl,
             effect = Effects.Composite(
                 listOf(
-                    Effects.ModifyStats(+1, +1, EffectTarget.ContextTarget(0)),
-                    Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.ContextTarget(0)),
-                    Effects.GrantKeyword(Keyword.HASTE, EffectTarget.ContextTarget(0))
+                    Effects.ModifyStats(+1, +1, EffectTarget.Self),
+                    Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self),
+                    Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
                 )
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/HonoredKnightCaptain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/HonoredKnightCaptain.kt
@@ -33,7 +33,8 @@ val HonoredKnightCaptain = card("Honored Knight-Captain") {
             power = 1,
             toughness = 1,
             colors = setOf(Color.WHITE),
-            creatureTypes = setOf("Human", "Soldier")
+            creatureTypes = setOf("Human", "Soldier"),
+            imageUri = "https://cards.scryfall.io/normal/front/6/3/631c2c16-132d-4607-ab7e-207a6af188e5.jpg?1757686920"
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavaronHarrier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavaronHarrier.kt
@@ -38,7 +38,7 @@ val KavaronHarrier = card("Kavaron Harrier") {
                 tapped = true,
                 attacking = true,
                 artifactToken = true,
-                exileAtStep = Step.END_COMBAT
+                sacrificeAtStep = Step.END_COMBAT
             )
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MoonlitMeditation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/MoonlitMeditation.kt
@@ -37,7 +37,7 @@ val MoonlitMeditation = card("Moonlit Meditation") {
         collectorNumber = "69"
         artist = "Liiga Smilshkalne"
         flavorText = "\"All is the hand that weaves the Fabric of Being. The Fabric of Being is All.\"\n" +
-            "—Drix Codex, line 1"
+            "—*Drix Codex*, line 1"
         imageUri = "https://cards.scryfall.io/normal/front/f/2/f2a56007-5bca-4edf-9cc4-5f77a273636c.jpg?1752946830"
         ruling("2025-07-25", "The effect of Moonlit Meditation's last ability applies before anything that modifies how those tokens enter the battlefield.")
         ruling("2025-07-25", "The effect of Moonlit Meditation's last ability can apply to any token, not just artifact or creature tokens. For example, you could replace creating a Shard token (a predefined enchantment token) with creating a copy of the enchanted permanent.")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PullThroughTheWeft.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/PullThroughTheWeft.kt
@@ -92,6 +92,7 @@ val PullThroughTheWeft = card("Pull Through the Weft") {
         rarity = Rarity.UNCOMMON
         collectorNumber = "202"
         artist = "Andrew Mar"
+        flavorText = "\"That which should not have happened is undone, and a new pattern takes its place.\""
         imageUri = "https://cards.scryfall.io/normal/front/a/7/a70d0877-1a1e-436b-bf8c-0ff6df9efc6a.jpg?1752947378"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SamiWildcatCaptain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SamiWildcatCaptain.kt
@@ -46,6 +46,7 @@ val SamiWildcatCaptain = card("Sami, Wildcat Captain") {
         rarity = Rarity.MYTHIC
         collectorNumber = "226"
         artist = "Kieran Yanner"
+        flavorText = "\"The hard way it is.\""
         imageUri = "https://cards.scryfall.io/normal/front/b/e/bed64207-9193-4770-8f8f-e3203289d5a6.jpg?1752947484"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TerminalVelocity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TerminalVelocity.kt
@@ -15,7 +15,6 @@ import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
-import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
 import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
@@ -54,7 +53,7 @@ val TerminalVelocity = card("Terminal Velocity") {
         val ltbDamage = TriggeredAbility.create(
             trigger = ZoneChangeEvent(from = Zone.BATTLEFIELD),
             binding = TriggerBinding.SELF,
-            effect = ForEachInGroupEffect(
+            effect = Effects.ForEachInGroup(
                 filter = GroupFilter.AllCreatures,
                 effect = DealDamageEffect(
                     amount = DynamicAmount.EntityProperty(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TerminalVelocity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TerminalVelocity.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EventPattern.StepEvent
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Terminal Velocity {4}{R}{R}
+ * Sorcery
+ *
+ * You may put an artifact or creature card from your hand onto the battlefield. That
+ * permanent gains haste, "When this permanent leaves the battlefield, it deals damage
+ * equal to its mana value to each creature," and "At the beginning of your end step,
+ * sacrifice this permanent."
+ *
+ * The two quoted clauses are granted as real [TriggeredAbility]s on the chosen permanent
+ * (Duration.Permanent), not as delayed triggers anchored to the resolving sorcery. That
+ * keeps them rules-faithful: the LTB damage reads the permanent's last-known mana value
+ * via [EntityReference.Source], and the end-step sacrifice fires every "your end step"
+ * for as long as the permanent persists (e.g. if the sacrifice trigger is countered, the
+ * permanent keeps all three granted abilities — including the LTB clause).
+ */
+val TerminalVelocity = card("Terminal Velocity") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "You may put an artifact or creature card from your hand onto the battlefield. " +
+        "That permanent gains haste, \"When this permanent leaves the battlefield, it deals damage " +
+        "equal to its mana value to each creature,\" and \"At the beginning of your end step, " +
+        "sacrifice this permanent.\""
+
+    spell {
+        val ltbDamage = TriggeredAbility.create(
+            trigger = ZoneChangeEvent(from = Zone.BATTLEFIELD),
+            binding = TriggerBinding.SELF,
+            effect = ForEachInGroupEffect(
+                filter = GroupFilter.AllCreatures,
+                effect = DealDamageEffect(
+                    amount = DynamicAmount.EntityProperty(
+                        entity = EntityReference.Source,
+                        numericProperty = EntityNumericProperty.ManaValue,
+                    ),
+                    target = EffectTarget.Self,
+                ),
+            ),
+            descriptionOverride = "When this permanent leaves the battlefield, it deals damage equal to its mana value to each creature.",
+        )
+
+        val endStepSacrifice = TriggeredAbility.create(
+            trigger = StepEvent(Step.END, Player.You),
+            binding = TriggerBinding.ANY,
+            effect = SacrificeTargetEffect(target = EffectTarget.Self),
+            descriptionOverride = "At the beginning of your end step, sacrifice this permanent.",
+        )
+
+        val grantClause = ConditionalOnCollectionEffect(
+            collection = "putting",
+            ifNotEmpty = Effects.Composite(
+                Effects.GrantKeyword(
+                    keyword = Keyword.HASTE,
+                    target = EffectTarget.PipelineTarget("putting", 0),
+                    duration = Duration.Permanent,
+                ),
+                GrantTriggeredAbilityEffect(
+                    ability = ltbDamage,
+                    target = EffectTarget.PipelineTarget("putting", 0),
+                    duration = Duration.Permanent,
+                ),
+                GrantTriggeredAbilityEffect(
+                    ability = endStepSacrifice,
+                    target = EffectTarget.PipelineTarget("putting", 0),
+                    duration = Duration.Permanent,
+                ),
+            ),
+        )
+
+        effect = Patterns.Hand.putFromHand(
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature,
+        ) then grantClause
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "163"
+        artist = "Xabi Gaztelua"
+        flavorText = "A victory was the best retirement gift the admiral could have asked for."
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1d18dc06-16f0-4a3b-8d52-dbf4aa2c393d.jpg?1752947211"
+        ruling("2025-07-25", "Use the permanent's mana value as it last existed on the battlefield to determine how much damage the triggered ability deals.")
+        ruling("2025-07-25", "If a permanent has {X} in its mana cost, X is 0 for the purpose of determining its mana value.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Terrasymbiosis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/Terrasymbiosis.kt
@@ -41,6 +41,7 @@ val Terrasymbiosis = card("Terrasymbiosis") {
         rarity = Rarity.RARE
         collectorNumber = "210"
         artist = "Viko Menezes"
+        flavorText = "For Eumidians, terraforming and evolution are one and the same. They grow as their planet grows, in lockstep coexistence."
         imageUri = "https://cards.scryfall.io/normal/front/2/6/26008c7d-5dbe-4da2-b475-4dd307e7bc68.jpg?1752947411"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TerritorialBruntar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TerritorialBruntar.kt
@@ -63,6 +63,7 @@ val TerritorialBruntar = card("Territorial Bruntar") {
         rarity = Rarity.UNCOMMON
         collectorNumber = "165"
         artist = "Julie Dillon"
+        flavorText = "Some creatures have adapted to thrive in the unstable chaos of Kavaron That Is."
         imageUri = "https://cards.scryfall.io/normal/front/d/b/dbb25585-6048-4a85-828e-675bf0da6508.jpg?1752947221"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TezzeretCruelCaptain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TezzeretCruelCaptain.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.mtg.sets.definitions.eoe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Tezzeret, Cruel Captain
+ * {3}
+ * Legendary Planeswalker — Tezzeret
+ * Starting Loyalty: 4
+ *
+ * Whenever an artifact you control enters, put a loyalty counter on Tezzeret.
+ * 0: Untap target artifact or creature. If it's an artifact creature, put a +1/+1 counter on it.
+ * −3: Search your library for an artifact card with mana value 1 or less, reveal it, put it into
+ *     your hand, then shuffle.
+ * −7: You get an emblem with "At the beginning of combat on your turn, put three +1/+1 counters
+ *     on target artifact you control. If it's not a creature, it becomes a 0/0 Robot artifact
+ *     creature."
+ */
+val TezzeretCruelCaptain = card("Tezzeret, Cruel Captain") {
+    manaCost = "{3}"
+    typeLine = "Legendary Planeswalker — Tezzeret"
+    startingLoyalty = 4
+    oracleText = "Whenever an artifact you control enters, put a loyalty counter on Tezzeret.\n" +
+        "0: Untap target artifact or creature. If it's an artifact creature, put a +1/+1 counter on it.\n" +
+        "−3: Search your library for an artifact card with mana value 1 or less, reveal it, put it into your hand, then shuffle.\n" +
+        "−7: You get an emblem with \"At the beginning of combat on your turn, put three +1/+1 counters on target artifact you control. If it's not a creature, it becomes a 0/0 Robot artifact creature.\""
+
+    // Whenever an artifact you control enters, put a loyalty counter on Tezzeret.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.LOYALTY, 1, EffectTarget.Self)
+    }
+
+    // 0: Untap target artifact or creature. If it's an artifact creature, put a +1/+1 counter on it.
+    loyaltyAbility(0) {
+        val target = target(
+            "artifact or creature",
+            TargetPermanent(filter = TargetFilter.CreatureOrArtifact)
+        )
+        effect = Effects.Untap(target)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.TargetMatchesFilter(GameObjectFilter.ArtifactCreature),
+                    effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, target)
+                )
+            )
+    }
+
+    // −3: Search your library for an artifact card with mana value 1 or less, reveal it, put it
+    //     into your hand, then shuffle.
+    loyaltyAbility(-3) {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Artifact.manaValueAtMost(1),
+            count = 1,
+            destination = SearchDestination.HAND,
+            reveal = true,
+            shuffleAfter = true
+        )
+    }
+
+    // −7: You get an emblem with "At the beginning of combat on your turn, put three +1/+1
+    //     counters on target artifact you control. If it's not a creature, it becomes a 0/0
+    //     Robot artifact creature."
+    loyaltyAbility(-7) {
+        effect = Effects.CreateGlobalTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.BeginCombat.event,
+                binding = Triggers.BeginCombat.binding,
+                effect = Effects.AddCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    3,
+                    EffectTarget.ContextTarget(0)
+                ).then(
+                    ConditionalEffect(
+                        condition = Conditions.TargetMatchesFilter(GameObjectFilter.Noncreature),
+                        effect = Effects.BecomeCreature(
+                            target = EffectTarget.ContextTarget(0),
+                            power = 0,
+                            toughness = 0,
+                            creatureTypes = setOf("Robot"),
+                            duration = Duration.Permanent
+                        )
+                    )
+                ),
+                targetRequirement = TargetPermanent(
+                    filter = TargetFilter(GameObjectFilter.Artifact.youControl())
+                )
+            ),
+            descriptionOverride = "At the beginning of combat on your turn, put three +1/+1 " +
+                "counters on target artifact you control. If it's not a creature, it becomes " +
+                "a 0/0 Robot artifact creature."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "2"
+        artist = "Chris Rahn"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02e8e540-8aa3-4e6a-9a11-c3949cab5f0f.jpg?1754473212"
+        ruling("2025-07-25", "If the emblem's ability causes a Vehicle to become an artifact creature, its base power and toughness will be set to 0/0. Crewing that Vehicle will not restore its power and toughness. Similarly, if the ability causes a permanent with station to become an artifact creature, putting an amount of charge counters on it greater than or equal to the amount required for it to become an artifact creature won't overwrite the base power and toughness set by the emblem's ability.")
+        ruling("2025-07-25", "If a card in your library has {X} in its mana cost, X is 0 for the purpose of determining its mana value.")
+        ruling("2025-07-25", "The resulting artifact creature will be able to attack if it's been under your control continuously since the turn began. That is, it doesn't matter how long it's been a creature, just how long it's been on the battlefield.")
+        ruling("2025-07-25", "The emblem's triggered ability doesn't remove any abilities, types, subtypes, or supertypes the artifact has.")
+        ruling("2025-07-25", "If the emblem's ability causes a Vehicle to become an artifact creature, it doesn't count as \"crewing\" that Vehicle for any ability that would trigger due to a Vehicle becoming crewed.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TheEndstone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/TheEndstone.kt
@@ -62,6 +62,7 @@ val TheEndstone = card("The Endstone") {
         rarity = Rarity.MYTHIC
         collectorNumber = "240"
         artist = "Ryan Pancoast"
+        flavorText = "The future is set. The present remains uncertain."
         imageUri = "https://cards.scryfall.io/normal/front/a/4/a451a459-18e0-4c53-a171-3e9da534ebf1.jpg?1752947540"
         ruling(
             "2025-07-25",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ThrummingHivepool.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ThrummingHivepool.kt
@@ -53,6 +53,7 @@ val ThrummingHivepool = card("Thrumming Hivepool") {
         rarity = Rarity.RARE
         collectorNumber = "247"
         artist = "Rob Rey"
+        flavorText = "\"I'll never escape this rock, but I fear they will.\"\n—Decrypted log 4.11"
         imageUri = "https://cards.scryfall.io/normal/front/8/5/85caf659-7b43-462e-a342-34703d46eb57.jpg?1752947564"
         ruling("2025-07-25", "The mana value of a spell isn't changed by alternative costs, cost increases, or cost reductions. For example, if you cast Thrumming Hivepool (an artifact with affinity for Slivers), its mana value is 6 no matter how many Slivers you controlled when you cast it.")
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ThrummingHivepool.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ThrummingHivepool.kt
@@ -44,7 +44,8 @@ val ThrummingHivepool = card("Thrumming Hivepool") {
             count = 2,
             power = 1,
             toughness = 1,
-            creatureTypes = setOf("Sliver")
+            creatureTypes = setOf("Sliver"),
+            imageUri = "https://cards.scryfall.io/normal/front/b/f/bf7501ee-783d-49c6-b381-1db056360b40.jpg?1752946465"
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/UthrosPsionicist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/UthrosPsionicist.kt
@@ -41,6 +41,7 @@ val UthrosPsionicist = card("Uthros Psionicist") {
         rarity = Rarity.UNCOMMON
         collectorNumber = "84"
         artist = "Inkognit"
+        flavorText = "\"Log entry cycle 33,507: Tenuous perception of psionic activity emanating from Uthros's core. Nature: Nonlinguistic, fragmentary. Content: Isolation, apoplexy. It wants free.\"\n—Uthros Combine research notes"
         imageUri = "https://cards.scryfall.io/normal/front/e/2/e23cc5fd-afe4-480c-8858-ed80a082584e.jpg?1752946892"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/XuIfitOsteoharmonist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/XuIfitOsteoharmonist.kt
@@ -49,6 +49,7 @@ val XuIfitOsteoharmonist = card("Xu-Ifit, Osteoharmonist") {
         rarity = Rarity.RARE
         collectorNumber = "127"
         artist = "Michal Ivan"
+        flavorText = "\"They will call you a monster, but I call you worthy.\""
         imageUri = "https://cards.scryfall.io/normal/front/c/0/c0838f25-2193-4305-b73a-bf0c0bb4981a.jpg?1752947068"
     }
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -1658,7 +1658,10 @@
         ]
     },
     "metadata": {
-        "collectorNumber": "8"
+        "collectorNumber": "8",
+        "artist": "Bryan Sola",
+        "flavorText": "\"My purpose is my spear. My spear is my life. My life is for the Regent Maximum.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7f7541a-5910-4f33-8c1d-3507ce3a426e.jpg?1752946584"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -2456,7 +2459,7 @@
         "collectorNumber": "215",
         "rarity": "RARE",
         "artist": "Chris Rahn",
-        "flavorText": ">Alert: COSMOGOYF\n>Recommended Action: RUN\n—PSS Erix shipboard computer, final transmission",
+        "flavorText": ">Alert: COSMOGOYF\n>Recommended Action: RUN\n—PSS *Erix* shipboard computer, final transmission",
         "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e07d3c6-60a5-44d1-a926-6414be85bd50.jpg?1752947436"
     },
     "colorIdentityOverride": [
@@ -3551,10 +3554,10 @@
         ]
     },
     "metadata": {
-        "collectorNumber": "177†",
+        "collectorNumber": "177",
         "artist": "Néstor Ossandón Leal",
         "flavorText": "\"We will not yield until the Eumidians relinquish our Kavaron Tomorrow.\"\n—Official Kav diplomatic statement",
-        "imageUri": "https://cards.scryfall.io/normal/front/1/4/143e5853-9a31-4c8d-b21d-5ef120eb6952.jpg?1774265280"
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0a104c5-61fb-4733-97ab-a31a15a49443.jpg?1753096637"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -7057,7 +7060,8 @@
                     "creatureTypes": [
                         "Human",
                         "Soldier"
-                    ]
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/6/3/631c2c16-132d-4607-ab7e-207a6af188e5.jpg?1757686920"
                 }
             }
         ],
@@ -10343,7 +10347,7 @@
         "collectorNumber": "69",
         "rarity": "RARE",
         "artist": "Liiga Smilshkalne",
-        "flavorText": "\"All is the hand that weaves the Fabric of Being. The Fabric of Being is All.\"\n—Drix Codex, line 1",
+        "flavorText": "\"All is the hand that weaves the Fabric of Being. The Fabric of Being is All.\"\n—*Drix Codex*, line 1",
         "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2a56007-5bca-4edf-9cc4-5f77a273636c.jpg?1752946830",
         "rulings": [
             {
@@ -11690,6 +11694,7 @@
         "collectorNumber": "202",
         "rarity": "UNCOMMON",
         "artist": "Andrew Mar",
+        "flavorText": "\"That which should not have happened is undone, and a new pattern takes its place.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/a/7/a70d0877-1a1e-436b-bf8c-0ff6df9efc6a.jpg?1752947378"
     },
     "colorIdentityOverride": [
@@ -12965,6 +12970,7 @@
         "collectorNumber": "226",
         "rarity": "MYTHIC",
         "artist": "Kieran Yanner",
+        "flavorText": "\"The hard way it is.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/b/e/bed64207-9193-4770-8f8f-e3203289d5a6.jpg?1752947484"
     },
     "colorIdentityOverride": [
@@ -17197,6 +17203,7 @@
         "collectorNumber": "210",
         "rarity": "RARE",
         "artist": "Viko Menezes",
+        "flavorText": "For Eumidians, terraforming and evolution are one and the same. They grow as their planet grows, in lockstep coexistence.",
         "imageUri": "https://cards.scryfall.io/normal/front/2/6/26008c7d-5dbe-4da2-b475-4dd307e7bc68.jpg?1752947411"
     },
     "colorIdentityOverride": [
@@ -17257,6 +17264,7 @@
         "collectorNumber": "165",
         "rarity": "UNCOMMON",
         "artist": "Julie Dillon",
+        "flavorText": "Some creatures have adapted to thrive in the unstable chaos of Kavaron That Is.",
         "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbb25585-6048-4a85-828e-675bf0da6508.jpg?1752947221"
     },
     "colorIdentityOverride": [
@@ -17873,6 +17881,7 @@
         "collectorNumber": "240",
         "rarity": "MYTHIC",
         "artist": "Ryan Pancoast",
+        "flavorText": "The future is set. The present remains uncertain.",
         "imageUri": "https://cards.scryfall.io/normal/front/a/4/a451a459-18e0-4c53-a171-3e9da534ebf1.jpg?1752947540",
         "rulings": [
             {
@@ -18186,7 +18195,8 @@
                     "colors": [],
                     "creatureTypes": [
                         "Sliver"
-                    ]
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf7501ee-783d-49c6-b381-1db056360b40.jpg?1752946465"
                 }
             }
         ],
@@ -18211,6 +18221,7 @@
         "collectorNumber": "247",
         "rarity": "RARE",
         "artist": "Rob Rey",
+        "flavorText": "\"I'll never escape this rock, but I fear they will.\"\n—Decrypted log 4.11",
         "imageUri": "https://cards.scryfall.io/normal/front/8/5/85caf659-7b43-462e-a342-34703d46eb57.jpg?1752947564",
         "rulings": [
             {
@@ -18569,6 +18580,7 @@
         "collectorNumber": "84",
         "rarity": "UNCOMMON",
         "artist": "Inkognit",
+        "flavorText": "\"Log entry cycle 33,507: Tenuous perception of psionic activity emanating from Uthros's core. Nature: Nonlinguistic, fragmentary. Content: Isolation, apoplexy. It wants free.\"\n—Uthros Combine research notes",
         "imageUri": "https://cards.scryfall.io/normal/front/e/2/e23cc5fd-afe4-480c-8858-ed80a082584e.jpg?1752946892"
     },
     "colorIdentityOverride": [
@@ -19890,6 +19902,7 @@
         "collectorNumber": "127",
         "rarity": "RARE",
         "artist": "Michal Ivan",
+        "flavorText": "\"They will call you a monster, but I call you worthy.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0838f25-2193-4305-b73a-bf0c0bb4981a.jpg?1752947068"
     },
     "colorIdentityOverride": [

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -17133,6 +17133,223 @@
     ]
 }
 
+// Tezzeret, Cruel Captain
+{
+    "name": "Tezzeret, Cruel Captain",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Planeswalker — Tezzeret",
+    "oracleText": "Whenever an artifact you control enters, put a loyalty counter on Tezzeret.\n0: Untap target artifact or creature. If it's an artifact creature, put a +1/+1 counter on it.\n−3: Search your library for an artifact card with mana value 1 or less, reveal it, put it into your hand, then shuffle.\n−7: You get an emblem with \"At the beginning of combat on your turn, put three +1/+1 counters on target artifact you control. If it's not a creature, it becomes a 0/0 Robot artifact creature.\"",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "loyalty",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 0
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "artifact or creature"
+                            },
+                            "tap": false
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "TargetMatchesFilter",
+                                    "filter": "artifact creature"
+                                }
+                            },
+                            "then": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "artifact or creature"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature|artifact"
+                        },
+                        "id": "artifact or creature"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -3
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "artifact mv<=1"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -7
+                },
+                "effect": {
+                    "type": "CreateGlobalTriggeredAbility",
+                    "ability": {
+                        "id": "ability_5",
+                        "trigger": {
+                            "type": "StepEvent",
+                            "step": "BEGIN_COMBAT"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "AddCounters",
+                                    "counterType": "+1/+1",
+                                    "count": 3,
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    }
+                                },
+                                {
+                                    "type": "Gated",
+                                    "gate": {
+                                        "type": "Gate.WhenCondition",
+                                        "condition": {
+                                            "type": "TargetMatchesFilter",
+                                            "filter": "noncreature"
+                                        }
+                                    },
+                                    "then": {
+                                        "type": "BecomeCreature",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "power": 0,
+                                        "toughness": 0,
+                                        "creatureTypes": [
+                                            "Robot"
+                                        ],
+                                        "duration": "Permanent"
+                                    }
+                                }
+                            ]
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact ctrl:you"
+                            }
+                        }
+                    },
+                    "descriptionOverride": "At the beginning of combat on your turn, put three +1/+1 counters on target artifact you control. If it's not a creature, it becomes a 0/0 Robot artifact creature."
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rahn",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02e8e540-8aa3-4e6a-9a11-c3949cab5f0f.jpg?1754473212",
+        "rulings": [
+            {
+                "date": "2025-07-25",
+                "text": "If the emblem's ability causes a Vehicle to become an artifact creature, its base power and toughness will be set to 0/0. Crewing that Vehicle will not restore its power and toughness. Similarly, if the ability causes a permanent with station to become an artifact creature, putting an amount of charge counters on it greater than or equal to the amount required for it to become an artifact creature won't overwrite the base power and toughness set by the emblem's ability."
+            },
+            {
+                "date": "2025-07-25",
+                "text": "If a card in your library has {X} in its mana cost, X is 0 for the purpose of determining its mana value."
+            },
+            {
+                "date": "2025-07-25",
+                "text": "The resulting artifact creature will be able to attack if it's been under your control continuously since the turn began. That is, it doesn't matter how long it's been a creature, just how long it's been on the battlefield."
+            },
+            {
+                "date": "2025-07-25",
+                "text": "The emblem's triggered ability doesn't remove any abilities, types, subtypes, or supertypes the artifact has."
+            },
+            {
+                "date": "2025-07-25",
+                "text": "If the emblem's ability causes a Vehicle to become an artifact creature, it doesn't count as \"crewing\" that Vehicle for any ability that would trigger due to a Vehicle becoming crewed."
+            }
+        ]
+    },
+    "startingLoyalty": 4
+}
+
 // Thaumaton Torpedo
 {
     "name": "Thaumaton Torpedo",

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -16971,6 +16971,140 @@
     ]
 }
 
+// Terminal Velocity
+{
+    "name": "Terminal Velocity",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "You may put an artifact or creature card from your hand onto the battlefield. That permanent gains haste, \"When this permanent leaves the battlefield, it deals damage equal to its mana value to each creature,\" and \"At the beginning of your end step, sacrifice this permanent.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "filter": "artifact|creature"
+                    },
+                    "storeAs": "put_candidates"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "put_candidates",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "putting"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "putting",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    }
+                },
+                {
+                    "type": "ConditionalOnCollection",
+                    "collection": "putting",
+                    "ifNotEmpty": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "putting"
+                                },
+                                "duration": "Permanent"
+                            },
+                            {
+                                "type": "GrantTriggeredAbility",
+                                "ability": {
+                                    "id": "ability_1",
+                                    "trigger": {
+                                        "type": "ZoneChangeEvent",
+                                        "from": "Battlefield"
+                                    },
+                                    "effect": {
+                                        "type": "ForEachInGroup",
+                                        "filter": {
+                                            "baseFilter": "creature"
+                                        },
+                                        "effect": {
+                                            "type": "DealDamage",
+                                            "amount": {
+                                                "type": "EntityProperty",
+                                                "entity": "Source",
+                                                "numericProperty": "ManaValue"
+                                            },
+                                            "target": "Self"
+                                        }
+                                    },
+                                    "descriptionOverride": "When this permanent leaves the battlefield, it deals damage equal to its mana value to each creature."
+                                },
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "putting"
+                                },
+                                "duration": "Permanent"
+                            },
+                            {
+                                "type": "GrantTriggeredAbility",
+                                "ability": {
+                                    "id": "ability_2",
+                                    "trigger": {
+                                        "type": "StepEvent",
+                                        "step": "END"
+                                    },
+                                    "binding": "ANY",
+                                    "effect": {
+                                        "type": "SacrificeTarget",
+                                        "target": "Self"
+                                    },
+                                    "descriptionOverride": "At the beginning of your end step, sacrifice this permanent."
+                                },
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "putting"
+                                },
+                                "duration": "Permanent"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "RARE",
+        "artist": "Xabi Gaztelua",
+        "flavorText": "A victory was the best retirement gift the admiral could have asked for.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1d18dc06-16f0-4a3b-8d52-dbf4aa2c393d.jpg?1752947211",
+        "rulings": [
+            {
+                "date": "2025-07-25",
+                "text": "Use the permanent's mana value as it last existed on the battlefield to determine how much damage the triggered ability deals."
+            },
+            {
+                "date": "2025-07-25",
+                "text": "If a permanent has {X} in its mana cost, X is 0 for the purpose of determining its mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Terrapact Intimidator
 {
     "name": "Terrapact Intimidator",

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -1042,7 +1042,13 @@
                             "imageUri": "https://cards.scryfall.io/normal/front/c/4/c46f9a07-005c-44b7-8057-b2f00b274dd6.jpg?1756281130",
                             "artifactToken": true
                         },
-                        "AttachEquipment"
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
                     ]
                 }
             }
@@ -6382,26 +6388,17 @@
                                     "type": "Fixed",
                                     "amount": 1
                                 },
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
+                                "target": "Self"
                             },
                             {
                                 "type": "GrantKeyword",
                                 "keyword": "VIGILANCE",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
+                                "target": "Self"
                             },
                             {
                                 "type": "GrantKeyword",
                                 "keyword": "HASTE",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
+                                "target": "Self"
                             }
                         ]
                     }
@@ -8133,7 +8130,7 @@
                         "tapped": true,
                         "attacking": true,
                         "artifactToken": true,
-                        "exileAtStep": "END_COMBAT"
+                        "sacrificeAtStep": "END_COMBAT"
                     }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -412,3 +412,30 @@ data class ActivateAbilityTapXTargetsContinuation(
     val chosenX: Int,
     val tapTargets: List<EntityId>
 ) : ContinuationFrame
+
+/**
+ * Resume after a player picks which graveyard cards to exile to satisfy an
+ * [com.wingedsheep.sdk.scripting.AbilityCost.ExileFromGraveyard] cost on an activated ability.
+ *
+ * Surfaces the cost-choice the original engine path silently auto-paid: when an activation's
+ * `ExileFromGraveyard(count, filter)` cost has more matching graveyard cards than `count`, the
+ * handler raises a [SelectCardsDecision] and pushes this frame so the resumer can re-enter the
+ * handler with the player's chosen cards filled into `costPayment.exiledCards`.
+ *
+ * Skipped (no pause) when `exiledCards` is already pre-filled (engine-direct path / resumed
+ * replay) or when candidate count ≤ required count (no real choice). Rust Harvester
+ * ({2}, {T}, Exile an artifact card from your graveyard: …) is the canonical trigger case.
+ *
+ * @property action The original [ActivateAbility] (`costPayment.exiledCards` still empty), so the
+ *   resumer can re-enter the handler with the chosen exile victims filled in.
+ * @property exileCandidates The matching graveyard cards offered to the player as options; used
+ *   to validate the response is a subset of the originally legal candidates.
+ * @property exileCount Exact number of cards the player must pick (`count` from the cost).
+ */
+@Serializable
+data class ActivateAbilityExileFromGraveyardContinuation(
+    override val decisionId: String,
+    val action: ActivateAbility,
+    val exileCandidates: List<EntityId>,
+    val exileCount: Int
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -372,3 +372,43 @@ data class CommanderZoneChoiceContinuation(
     val ownerId: EntityId,
     val currentZone: com.wingedsheep.sdk.core.Zone
 ) : ContinuationFrame
+
+/**
+ * Resume after a player picks X for an activated ability with an X-variable cost
+ * (currently [com.wingedsheep.sdk.scripting.AbilityCost.TapXPermanents]).
+ *
+ * The legal-actions path surfaces such activations with `hasXCost=true` and no
+ * pre-filled `xValue`/`tappedPermanents`. When [com.wingedsheep.engine.handlers.actions.ability.ActivateAbilityHandler]
+ * sees that shape, it raises a [ChooseNumberDecision] and pushes this frame so the
+ * resumer can chain into a follow-up tap-target [SelectCardsDecision] sized to the
+ * chosen X (or skip straight to re-executing when X = 0).
+ *
+ * @property action The original [ActivateAbility] (xValue/costPayment still null), so the resumer
+ *   can re-enter the handler with the chosen X and selected tap targets filled in.
+ * @property tapTargets The untapped permanents matching the cost's filter at announcement time —
+ *   captured here so the follow-up [SelectCardsDecision] has a stable option list even if the
+ *   board changes between decisions.
+ */
+@Serializable
+data class ActivateAbilityChooseXContinuation(
+    override val decisionId: String,
+    val action: ActivateAbility,
+    val tapTargets: List<EntityId>
+) : ContinuationFrame
+
+/**
+ * Resume after a player picks which permanents to tap to satisfy a TapXPermanents cost,
+ * once X has already been chosen via [ActivateAbilityChooseXContinuation].
+ *
+ * @property action The original [ActivateAbility] (xValue/costPayment still null on the stored copy).
+ * @property chosenX The X value the player picked in the preceding [ChooseNumberDecision].
+ * @property tapTargets Permanents that were offered as options in the [SelectCardsDecision]; used
+ *   to validate the response is a subset of the originally legal targets.
+ */
+@Serializable
+data class ActivateAbilityTapXTargetsContinuation(
+    override val decisionId: String,
+    val action: ActivateAbility,
+    val chosenX: Int,
+    val tapTargets: List<EntityId>
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -287,6 +287,7 @@ val engineSerializersModule = SerializersModule {
         subclass(LeylineDecisionContinuation::class)
         subclass(ActivateAbilityChooseXContinuation::class)
         subclass(ActivateAbilityTapXTargetsContinuation::class)
+        subclass(ActivateAbilityExileFromGraveyardContinuation::class)
     }
 
     // Component hierarchy (for GameState persistence)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -285,6 +285,8 @@ val engineSerializersModule = SerializersModule {
         subclass(StaticDrawReplacementContinuation::class)
         subclass(TokenCreationReplacementContinuation::class)
         subclass(LeylineDecisionContinuation::class)
+        subclass(ActivateAbilityChooseXContinuation::class)
+        subclass(ActivateAbilityTapXTargetsContinuation::class)
     }
 
     // Component hierarchy (for GameState persistence)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
@@ -50,6 +50,7 @@ class ContinuationHandler(
         registerModule(RingTemptContinuationResumer(services))
         registerModule(AmassContinuationResumer(services))
         registerModule(LeylineContinuationResumer(services))
+        registerModule(ActivateAbilityXCostContinuationResumer(services))
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -1146,7 +1146,10 @@ class CostHandler(
         }.keys.toList()
     }
 
-    private fun findUntappedMatchingPermanentsUnified(
+    // `internal` (not private) so the TapXPermanents cost-choice pause in ActivateAbilityHandler
+    // can offer the same untapped-permanent candidate set used to enumerate the tap cost. Keeps
+    // the pause and the rest of the cost machinery reading one definition of "tappable here".
+    internal fun findUntappedMatchingPermanentsUnified(
         state: GameState,
         controllerId: EntityId,
         filter: GameObjectFilter
@@ -1160,7 +1163,11 @@ class CostHandler(
         }.keys.toList()
     }
 
-    private fun findMatchingCardsUnified(
+    // `internal` (not private) so the activated-ability cost-choice pause in
+    // ActivateAbilityHandler can offer exactly the candidate set this matcher accepts at payment
+    // time — see exileCardsFromGraveyard above. Keeps the pause and payment in lockstep instead
+    // of re-deriving the filter match in two places.
+    internal fun findMatchingCardsUnified(
         state: GameState,
         cardIds: List<EntityId>,
         filter: GameObjectFilter,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -234,10 +234,20 @@ data class EffectContext(
          * - If count > 1: maps `id[0]` -> target0, `id[1]` -> target1, etc.
          *
          * Requirements with `id == null` are skipped (backward compat with ContextTarget).
+         *
+         * `targets` is accepted as `List<ChosenTarget?>` so callers can pass a
+         * **positionally-aligned** list where slots whose target was dropped by
+         * resolution-time legality validation (CR 608.2b) are `null`. Such slots
+         * leave the corresponding `id` unmapped so any sub-effect that references
+         * the now-illegal target via [EffectTarget.BoundVariable] resolves to
+         * `null` and fizzles instead of silently consuming a later target whose
+         * position shifted forward in the compacted list. The non-null
+         * `List<ChosenTarget>` form is still accepted (Kotlin covariance) for
+         * callers that already filter targets up-front.
          */
         fun buildNamedTargets(
             requirements: List<TargetRequirement>,
-            targets: List<ChosenTarget>
+            targets: List<ChosenTarget?>
         ): Map<String, ChosenTarget> {
             val result = mutableMapOf<String, ChosenTarget>()
             var targetIndex = 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -423,6 +423,62 @@ class ActivateAbilityHandler(
             return ExecutionResult.paused(pausedState, decision, listOf(event))
         }
 
+        // -------------------------------------------------------------------
+        // ExileFromGraveyard cost-choice pause (legal-actions submission path).
+        //
+        // When the cost is `ExileFromGraveyard(count, filter)` (Rust Harvester:
+        // "{2}, {T}, Exile an artifact card from your graveyard: ...") and the
+        // player has more matching graveyard cards than the count, this is a
+        // real choice — the engine must pause and ask which card(s) to exile,
+        // not silently take the first N (CostHandler.exileCardsFromGraveyard
+        // used to auto-pick when `exileChoices` was empty, dropping the
+        // player's choice on the floor).
+        //
+        // Skipped when `exiledCards` is already pre-filled (engine-direct path
+        // and resumed-replay case) or when candidates <= count (no real
+        // choice).
+        // -------------------------------------------------------------------
+        val exileFromGraveyardCost = extractExileFromGraveyardCost(effectiveCost)
+        val alreadyExiling = (action.costPayment?.exiledCards?.isNotEmpty() == true)
+        if (exileFromGraveyardCost != null && !alreadyExiling) {
+            val exileCandidates = findGraveyardExileCandidates(
+                state, action.playerId, exileFromGraveyardCost.filter
+            )
+            if (exileCandidates.size > exileFromGraveyardCost.count) {
+                val decisionId = java.util.UUID.randomUUID().toString()
+                val prompt = "Select ${exileFromGraveyardCost.count} card${if (exileFromGraveyardCost.count > 1) "s" else ""} to exile from graveyard for ${cardComponent.name}"
+                val decision = com.wingedsheep.engine.core.SelectCardsDecision(
+                    id = decisionId,
+                    playerId = action.playerId,
+                    prompt = prompt,
+                    context = com.wingedsheep.engine.core.DecisionContext(
+                        sourceId = action.sourceId,
+                        sourceName = cardComponent.name,
+                        phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
+                    ),
+                    options = exileCandidates,
+                    minSelections = exileFromGraveyardCost.count,
+                    maxSelections = exileFromGraveyardCost.count
+                )
+                val continuation = com.wingedsheep.engine.core.ActivateAbilityExileFromGraveyardContinuation(
+                    decisionId = decisionId,
+                    action = action,
+                    exileCandidates = exileCandidates,
+                    exileCount = exileFromGraveyardCost.count
+                )
+                val pausedState = state
+                    .withPendingDecision(decision)
+                    .pushContinuation(continuation)
+                val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = action.playerId,
+                    decisionType = "SELECT_CARDS",
+                    prompt = prompt
+                )
+                return ExecutionResult.paused(pausedState, decision, listOf(event))
+            }
+        }
+
         val executeAbilityContext = buildAbilityPaymentContext(cardComponent, state.projectedState, action.sourceId)
 
         var currentState = state
@@ -1827,6 +1883,38 @@ class ActivateAbilityHandler(
         is AbilityCost.TapXPermanents -> cost
         is AbilityCost.Composite -> cost.costs.filterIsInstance<AbilityCost.TapXPermanents>().firstOrNull()
         else -> null
+    }
+
+    /**
+     * Pull the [AbilityCost.ExileFromGraveyard] sub-cost out of an ability cost (top-level or
+     * inside a [AbilityCost.Composite]), or null if none. Used by the legal-actions submission
+     * path to detect that an activation needs to pause for a card-selection decision when the
+     * player has more matching graveyard cards than the cost requires.
+     */
+    private fun extractExileFromGraveyardCost(cost: AbilityCost): AbilityCost.ExileFromGraveyard? = when (cost) {
+        is AbilityCost.ExileFromGraveyard -> cost
+        is AbilityCost.Composite -> cost.costs.filterIsInstance<AbilityCost.ExileFromGraveyard>().firstOrNull()
+        else -> null
+    }
+
+    /**
+     * Filter the controller's graveyard down to cards matching [filter]. Mirrors
+     * [com.wingedsheep.engine.handlers.CostHandler.findMatchingCardsUnified] so the activation
+     * fast-path sees the same candidate set as cost-payment will see when it eventually runs.
+     */
+    private fun findGraveyardExileCandidates(
+        state: GameState,
+        playerId: EntityId,
+        filter: com.wingedsheep.sdk.scripting.GameObjectFilter
+    ): List<EntityId> {
+        val graveyardZone = com.wingedsheep.engine.state.ZoneKey(playerId, Zone.GRAVEYARD)
+        val cardIds = state.getZone(graveyardZone)
+        val context = PredicateContext(controllerId = playerId)
+        val projected = state.projectedState
+        val evaluator = PredicateEvaluator()
+        return cardIds.filter { cardId ->
+            evaluator.matches(state, projected, cardId, filter, context)
+        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -372,6 +372,57 @@ class ActivateAbilityHandler(
         // "{X} less, where X is this creature's power"). Locked in before payment.
         val effectiveCost = applyGenericCostReduction(rawCost, ability, state, action.sourceId, action.playerId, action.targets)
 
+        // -------------------------------------------------------------------
+        // TapXPermanents two-step UI flow (legal-actions submission path).
+        //
+        // When the legal-actions list surfaces an X-variable tap cost (Secluded
+        // Starforge: "Tap X untapped artifacts you control"), the frontend
+        // submits the bare `ActivateAbility` (xValue/costPayment empty) and
+        // expects the engine to pause for two follow-up decisions: pick X,
+        // then pick the X permanents to tap. Without this branch the engine
+        // silently treats X=0, pays no cost, and resolves a no-op activation
+        // — see SecludedStarforgeTest's "UI flow: choosing X=3 …" case.
+        //
+        // The engine-direct path (pre-filling xValue and tappedPermanents on
+        // the action — used by the prior passing test and most server-side
+        // composite flows) is untouched: both `xValue != null` and a non-empty
+        // `tappedPermanents` skip past this fast-path.
+        // -------------------------------------------------------------------
+        val tapXCost = extractTapXPermanentsCost(effectiveCost)
+        val alreadyTapping = (action.costPayment?.tappedPermanents?.isNotEmpty() == true)
+        if (tapXCost != null && action.xValue == null && !alreadyTapping) {
+            val tapTargets = findUntappedTapXCandidates(state, action.playerId, tapXCost.filter)
+            val maxX = tapTargets.size
+            val decisionId = java.util.UUID.randomUUID().toString()
+            val decision = com.wingedsheep.engine.core.ChooseNumberDecision(
+                id = decisionId,
+                playerId = action.playerId,
+                prompt = "Choose X for ${cardComponent.name} (0-$maxX)",
+                context = com.wingedsheep.engine.core.DecisionContext(
+                    sourceId = action.sourceId,
+                    sourceName = cardComponent.name,
+                    phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
+                ),
+                minValue = 0,
+                maxValue = maxX
+            )
+            val continuation = com.wingedsheep.engine.core.ActivateAbilityChooseXContinuation(
+                decisionId = decisionId,
+                action = action,
+                tapTargets = tapTargets
+            )
+            val pausedState = state
+                .withPendingDecision(decision)
+                .pushContinuation(continuation)
+            val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
+                decisionId = decisionId,
+                playerId = action.playerId,
+                decisionType = "CHOOSE_NUMBER",
+                prompt = decision.prompt
+            )
+            return ExecutionResult.paused(pausedState, decision, listOf(event))
+        }
+
         val executeAbilityContext = buildAbilityPaymentContext(cardComponent, state.projectedState, action.sourceId)
 
         var currentState = state
@@ -1765,5 +1816,37 @@ class ActivateAbilityHandler(
             green = newPool.green - (oldPool?.green ?: 0),
             colorless = newPool.colorless - (oldPool?.colorless ?: 0),
         ).takeIf { it.white + it.blue + it.black + it.red + it.green + it.colorless > 0 }
+    }
+
+    /**
+     * Pull the [AbilityCost.TapXPermanents] sub-cost out of an ability cost (top-level or
+     * inside a [AbilityCost.Composite]), or null if none. Used by the legal-actions submission
+     * path to detect that an activation needs to pause for an X choice + tap-target selection.
+     */
+    private fun extractTapXPermanentsCost(cost: AbilityCost): AbilityCost.TapXPermanents? = when (cost) {
+        is AbilityCost.TapXPermanents -> cost
+        is AbilityCost.Composite -> cost.costs.filterIsInstance<AbilityCost.TapXPermanents>().firstOrNull()
+        else -> null
+    }
+
+    /**
+     * Inline mirror of [com.wingedsheep.engine.legalactions.utils.CostEnumerationUtils.findAbilityTapTargets]
+     * (controlled, untapped, filter-matching). Duplicated locally so the handler can compute the
+     * candidate list without taking a wider dependency on the legal-actions utility graph.
+     */
+    private fun findUntappedTapXCandidates(
+        state: GameState,
+        playerId: EntityId,
+        filter: com.wingedsheep.sdk.scripting.GameObjectFilter
+    ): List<EntityId> {
+        val projected = state.projectedState
+        val predicateContext = PredicateContext(controllerId = playerId)
+        val predicateEvaluator = PredicateEvaluator()
+        return projected.getBattlefieldControlledBy(playerId).filter { entityId ->
+            val container = state.getEntity(entityId) ?: return@filter false
+            container.get<CardComponent>() ?: return@filter false
+            if (container.has<TappedComponent>()) return@filter false
+            predicateEvaluator.matches(state, projected, entityId, filter, predicateContext)
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -391,7 +391,7 @@ class ActivateAbilityHandler(
         val tapXCost = extractTapXPermanentsCost(effectiveCost)
         val alreadyTapping = (action.costPayment?.tappedPermanents?.isNotEmpty() == true)
         if (tapXCost != null && action.xValue == null && !alreadyTapping) {
-            val tapTargets = findUntappedTapXCandidates(state, action.playerId, tapXCost.filter)
+            val tapTargets = costHandler.findUntappedMatchingPermanentsUnified(state, action.playerId, tapXCost.filter)
             val maxX = tapTargets.size
             val decisionId = java.util.UUID.randomUUID().toString()
             val decision = com.wingedsheep.engine.core.ChooseNumberDecision(
@@ -441,8 +441,11 @@ class ActivateAbilityHandler(
         val exileFromGraveyardCost = extractExileFromGraveyardCost(effectiveCost)
         val alreadyExiling = (action.costPayment?.exiledCards?.isNotEmpty() == true)
         if (exileFromGraveyardCost != null && !alreadyExiling) {
-            val exileCandidates = findGraveyardExileCandidates(
-                state, action.playerId, exileFromGraveyardCost.filter
+            val exileCandidates = costHandler.findMatchingCardsUnified(
+                state,
+                state.getZone(com.wingedsheep.engine.state.ZoneKey(action.playerId, Zone.GRAVEYARD)),
+                exileFromGraveyardCost.filter,
+                action.playerId
             )
             if (exileCandidates.size > exileFromGraveyardCost.count) {
                 val decisionId = java.util.UUID.randomUUID().toString()
@@ -1895,46 +1898,5 @@ class ActivateAbilityHandler(
         is AbilityCost.ExileFromGraveyard -> cost
         is AbilityCost.Composite -> cost.costs.filterIsInstance<AbilityCost.ExileFromGraveyard>().firstOrNull()
         else -> null
-    }
-
-    /**
-     * Filter the controller's graveyard down to cards matching [filter]. Mirrors
-     * [com.wingedsheep.engine.handlers.CostHandler.findMatchingCardsUnified] so the activation
-     * fast-path sees the same candidate set as cost-payment will see when it eventually runs.
-     */
-    private fun findGraveyardExileCandidates(
-        state: GameState,
-        playerId: EntityId,
-        filter: com.wingedsheep.sdk.scripting.GameObjectFilter
-    ): List<EntityId> {
-        val graveyardZone = com.wingedsheep.engine.state.ZoneKey(playerId, Zone.GRAVEYARD)
-        val cardIds = state.getZone(graveyardZone)
-        val context = PredicateContext(controllerId = playerId)
-        val projected = state.projectedState
-        val evaluator = PredicateEvaluator()
-        return cardIds.filter { cardId ->
-            evaluator.matches(state, projected, cardId, filter, context)
-        }
-    }
-
-    /**
-     * Inline mirror of [com.wingedsheep.engine.legalactions.utils.CostEnumerationUtils.findAbilityTapTargets]
-     * (controlled, untapped, filter-matching). Duplicated locally so the handler can compute the
-     * candidate list without taking a wider dependency on the legal-actions utility graph.
-     */
-    private fun findUntappedTapXCandidates(
-        state: GameState,
-        playerId: EntityId,
-        filter: com.wingedsheep.sdk.scripting.GameObjectFilter
-    ): List<EntityId> {
-        val projected = state.projectedState
-        val predicateContext = PredicateContext(controllerId = playerId)
-        val predicateEvaluator = PredicateEvaluator()
-        return projected.getBattlefieldControlledBy(playerId).filter { entityId ->
-            val container = state.getEntity(entityId) ?: return@filter false
-            container.get<CardComponent>() ?: return@filter false
-            if (container.has<TappedComponent>()) return@filter false
-            predicateEvaluator.matches(state, projected, entityId, filter, predicateContext)
-        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.handlers.continuations
 
 import com.wingedsheep.engine.core.ActivateAbilityChooseXContinuation
+import com.wingedsheep.engine.core.ActivateAbilityExileFromGraveyardContinuation
 import com.wingedsheep.engine.core.ActivateAbilityTapXTargetsContinuation
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.ChooseNumberDecision
@@ -43,7 +44,8 @@ class ActivateAbilityXCostContinuationResumer(
 
     override fun resumers(): List<ContinuationResumer<*>> = listOf(
         resumer(ActivateAbilityChooseXContinuation::class, ::resumeChooseX),
-        resumer(ActivateAbilityTapXTargetsContinuation::class, ::resumeTapXTargets)
+        resumer(ActivateAbilityTapXTargetsContinuation::class, ::resumeTapXTargets),
+        resumer(ActivateAbilityExileFromGraveyardContinuation::class, ::resumeExileFromGraveyard)
     )
 
     private fun resumeChooseX(
@@ -106,6 +108,39 @@ class ActivateAbilityXCostContinuationResumer(
             prompt = prompt
         )
         return ExecutionResult.paused(pausedState, decision, listOf(event))
+    }
+
+    /**
+     * Resume after the player picks which graveyard cards to exile for an
+     * `ExileFromGraveyard` activated-ability cost (Rust Harvester etc.). Re-enters the handler
+     * with the chosen cards filled into `costPayment.exiledCards`; CostHandler then exiles
+     * exactly those cards instead of auto-picking the first N.
+     */
+    private fun resumeExileFromGraveyard(
+        state: GameState,
+        continuation: ActivateAbilityExileFromGraveyardContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(state, "Expected card-selection response for ActivateAbility ExileFromGraveyard")
+        }
+        if (response.selectedCards.size != continuation.exileCount) {
+            return ExecutionResult.error(
+                state,
+                "Expected ${continuation.exileCount} cards to exile, got ${response.selectedCards.size}"
+            )
+        }
+        if (response.selectedCards.any { it !in continuation.exileCandidates }) {
+            return ExecutionResult.error(state, "Selected card is not in the list of valid exile candidates")
+        }
+
+        val action = continuation.action
+        val replay = action.copy(
+            costPayment = (action.costPayment ?: AdditionalCostPayment())
+                .copy(exiledCards = response.selectedCards)
+        )
+        return handler.execute(state, replay)
     }
 
     private fun resumeTapXTargets(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.handlers.continuations
+
+import com.wingedsheep.engine.core.ActivateAbilityChooseXContinuation
+import com.wingedsheep.engine.core.ActivateAbilityTapXTargetsContinuation
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.DecisionRequestedEvent
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.actions.ability.ActivateAbilityHandler
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+
+/**
+ * Resumer module for the two-step legal-actions submission flow on activated abilities whose cost
+ * is "Tap X untapped permanents you control" (Secluded Starforge's pump ability, and any future
+ * TapXPermanents-bearing card).
+ *
+ * Step 1 ([ActivateAbilityChooseXContinuation]) – the player just answered the ChooseNumberDecision
+ * the handler raised. If X = 0 we re-enter the handler with `xValue = 0` and an empty tap list, and
+ * the activation resolves with no permanents tapped (legal per CR 614 / `canPayAbilityCost` for
+ * TapXPermanents). If X > 0 we raise a follow-up [SelectCardsDecision] sized to exactly X out of the
+ * tap-target list captured at announcement time, and push [ActivateAbilityTapXTargetsContinuation].
+ *
+ * Step 2 ([ActivateAbilityTapXTargetsContinuation]) – the player just picked the X permanents to
+ * tap. We re-enter the handler with the X and the chosen tap targets filled in. Cost payment +
+ * stack placement + resolution then follow the normal engine-direct path, identical to what would
+ * have happened if the action had arrived pre-filled (the regression-guard case in
+ * SecludedStarforgeTest).
+ */
+class ActivateAbilityXCostContinuationResumer(
+    private val services: EngineServices
+) : ContinuationResumerModule {
+
+    private val handler: ActivateAbilityHandler by lazy { ActivateAbilityHandler.create(services) }
+
+    override fun resumers(): List<ContinuationResumer<*>> = listOf(
+        resumer(ActivateAbilityChooseXContinuation::class, ::resumeChooseX),
+        resumer(ActivateAbilityTapXTargetsContinuation::class, ::resumeTapXTargets)
+    )
+
+    private fun resumeChooseX(
+        state: GameState,
+        continuation: ActivateAbilityChooseXContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is NumberChosenResponse) {
+            return ExecutionResult.error(state, "Expected number response for ActivateAbility X choice")
+        }
+        val chosenX = response.number.coerceIn(0, continuation.tapTargets.size)
+        val action = continuation.action
+
+        if (chosenX == 0) {
+            // No permanents to tap — re-enter the handler with X bound to 0 and empty tap list,
+            // mirroring the engine-direct path. The handler will pay the rest of the cost
+            // (mana, etc.), put the ability on the stack, and run resolution normally.
+            val replay = action.copy(
+                xValue = 0,
+                costPayment = (action.costPayment ?: AdditionalCostPayment())
+                    .copy(tappedPermanents = emptyList())
+            )
+            return handler.execute(state, replay)
+        }
+
+        // Raise the follow-up tap-target selection. minSelections == maxSelections == chosenX so
+        // the frontend renders "Select N/N" with a hard count (this is the assertion the
+        // SecludedStarforgeTest UI-flow case pins).
+        val sourceName = state.getEntity(action.sourceId)?.get<CardComponent>()?.name
+        val decisionId = java.util.UUID.randomUUID().toString()
+        val prompt = "Select $chosenX permanents to tap for ${sourceName ?: "this ability"}"
+        val decision = SelectCardsDecision(
+            id = decisionId,
+            playerId = action.playerId,
+            prompt = prompt,
+            context = DecisionContext(
+                sourceId = action.sourceId,
+                sourceName = sourceName,
+                phase = DecisionPhase.CASTING
+            ),
+            options = continuation.tapTargets,
+            minSelections = chosenX,
+            maxSelections = chosenX,
+            useTargetingUI = true
+        )
+        val nextFrame = ActivateAbilityTapXTargetsContinuation(
+            decisionId = decisionId,
+            action = action,
+            chosenX = chosenX,
+            tapTargets = continuation.tapTargets
+        )
+        val pausedState = state
+            .withPendingDecision(decision)
+            .pushContinuation(nextFrame)
+        val event: GameEvent = DecisionRequestedEvent(
+            decisionId = decisionId,
+            playerId = action.playerId,
+            decisionType = "SELECT_CARDS",
+            prompt = prompt
+        )
+        return ExecutionResult.paused(pausedState, decision, listOf(event))
+    }
+
+    private fun resumeTapXTargets(
+        state: GameState,
+        continuation: ActivateAbilityTapXTargetsContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(state, "Expected card-selection response for ActivateAbility TapX targets")
+        }
+        if (response.selectedCards.size != continuation.chosenX) {
+            return ExecutionResult.error(
+                state,
+                "Expected ${continuation.chosenX} permanents to tap, got ${response.selectedCards.size}"
+            )
+        }
+        if (response.selectedCards.any { it !in continuation.tapTargets }) {
+            return ExecutionResult.error(state, "Selected permanent is not in the list of valid tap targets")
+        }
+
+        val action = continuation.action
+        val replay = action.copy(
+            xValue = continuation.chosenX,
+            costPayment = (action.costPayment ?: AdditionalCostPayment())
+                .copy(tappedPermanents = response.selectedCards)
+        )
+        return handler.execute(state, replay)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/DealDamageExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/DealDamageExecutor.kt
@@ -39,9 +39,10 @@ class DealDamageExecutor(
             // "enchanted creature deals damage" — Lavamancer's Skill). If that source can no
             // longer be resolved at resolution time (e.g. the FROM target died to a response
             // and was dropped by 608.2b validation), the whole damage instruction is skipped
-            // per CR 608.2b — we don't fall back to the ability's source permanent.
+            // per CR 608.2b — we don't fall back to the ability's source permanent. This is a
+            // legal no-op fizzle, not an error: the surrounding effect (e.g. Composite) resolves.
             context.resolveTarget(damageSourceTarget, state)
-                ?: return EffectResult.error(state, "Damage source is no longer a legal target")
+                ?: return EffectResult.success(state)
         } else {
             context.sourceId
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/DealDamageExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/DealDamageExecutor.kt
@@ -35,7 +35,13 @@ class DealDamageExecutor(
         // Use damageSource override if specified (e.g., EnchantedCreature for Lavamancer's Skill)
         val damageSourceTarget = effect.damageSource
         val sourceId = if (damageSourceTarget != null) {
+            // The spell text named a specific source ("it deals damage" — Diplomatic Relations,
+            // "enchanted creature deals damage" — Lavamancer's Skill). If that source can no
+            // longer be resolved at resolution time (e.g. the FROM target died to a response
+            // and was dropped by 608.2b validation), the whole damage instruction is skipped
+            // per CR 608.2b — we don't fall back to the ability's source permanent.
             context.resolveTarget(damageSourceTarget, state)
+                ?: return EffectResult.error(state, "Damage source is no longer a legal target")
         } else {
             context.sourceId
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -176,6 +176,8 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 var discardTargets: List<EntityId>? = null
                 var craftCost: AbilityCost.Craft? = null
                 var craftMaterials: List<EntityId> = emptyList()
+                var exileCost: AbilityCost.ExileFromGraveyard? = null
+                var exileTargets: List<EntityId>? = null
                 var costAffordable = true
 
                 when (effectiveCost) {
@@ -255,6 +257,15 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             discardCost = effectiveCost
                             discardTargets = targets
                         }
+                    }
+                    is AbilityCost.ExileFromGraveyard -> {
+                        val targets = context.costUtils.findExileTargets(
+                            state, playerId, effectiveCost.filter,
+                            com.wingedsheep.sdk.scripting.CostZone.GRAVEYARD
+                        )
+                        if (targets.size < effectiveCost.count) continue
+                        exileCost = effectiveCost
+                        exileTargets = targets
                     }
                     is AbilityCost.DiscardLastDrawnThisTurn -> {
                         // No player choice — engine picks the tracked entity at payment. Gate the
@@ -372,12 +383,22 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     }
                                 }
                                 is AbilityCost.ExileFromGraveyard -> {
-                                    val graveyardZone = ZoneKey(playerId, Zone.GRAVEYARD)
-                                    val graveyardCards = state.getZone(graveyardZone)
-                                    if (graveyardCards.size < subCost.count) {
+                                    // Filter the graveyard by the cost's GameObjectFilter so the
+                                    // payability check matches what CostHandler will see, and so
+                                    // we can surface the matching cards to the UI via
+                                    // AdditionalCostData.validExileTargets (the picker prompt
+                                    // for Rust Harvester's "Exile an artifact card from your
+                                    // graveyard" cost).
+                                    val targets = context.costUtils.findExileTargets(
+                                        state, playerId, subCost.filter,
+                                        com.wingedsheep.sdk.scripting.CostZone.GRAVEYARD
+                                    )
+                                    if (targets.size < subCost.count) {
                                         costCanBePaid = false
                                         break
                                     }
+                                    exileCost = subCost
+                                    exileTargets = targets
                                 }
                                 is AbilityCost.Forage -> {
                                     // Forage: can exile 3 from graveyard OR sacrifice a Food
@@ -548,7 +569,8 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     hasForageCost, forageGraveyardCards, forageFoodTargets,
                     blightCost, blightCreatures,
                     discardCost, discardTargets,
-                    craftCost, craftMaterials
+                    craftCost, craftMaterials,
+                    exileCost, exileTargets
                 )
 
                 // Calculate X cost info for activated abilities with X in their mana cost
@@ -843,7 +865,9 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         discardCost: AbilityCost.Discard? = null,
         discardTargets: List<EntityId>? = null,
         craftCost: AbilityCost.Craft? = null,
-        craftMaterials: List<EntityId> = emptyList()
+        craftMaterials: List<EntityId> = emptyList(),
+        exileCost: AbilityCost.ExileFromGraveyard? = null,
+        exileTargets: List<EntityId>? = null
     ): AdditionalCostData? {
         if (craftCost != null) {
             // Craft (CR 702.167) is handled exclusively: when a Composite cost contains a
@@ -938,6 +962,20 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
             return AdditionalCostData(
                 description = "Remove +1/+1 counters from creatures you control",
                 costType = "RemoveCounters",
+                counterRemovalCreatures = counterRemovalCreatures
+            )
+        }
+        if (exileCost != null && exileTargets != null) {
+            // ExileFromGraveyard cost (e.g. Rust Harvester's "Exile an artifact card from your
+            // graveyard"). Surface the filtered candidate list and exact count so the client
+            // renders a card-picker; ActivateAbilityHandler's matching fast-path pauses for a
+            // SelectCardsDecision when candidate count > required count.
+            return AdditionalCostData(
+                description = exileCost.description,
+                costType = "ExileFromGraveyard",
+                validExileTargets = exileTargets,
+                exileMinCount = exileCost.count,
+                exileMaxCount = exileCost.count,
                 counterRemovalCreatures = counterRemovalCreatures
             )
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
@@ -14,7 +14,7 @@ object SbaOrder {
     const val LETHAL_DAMAGE = 400           // 704.5g/h
     const val PLANESWALKER_LOYALTY = 500    // 704.5i
     const val LEGEND_RULE = 600             // 704.5j
-    const val COUNTER_ANNIHILATION = 700    // 704.5m
+    const val COUNTER_ANNIHILATION = 700    // 704.5q
     const val UNATTACHED_AURAS = 800        // 704.5m/n/p
     const val SAGA_SACRIFICE = 900          // 714.4
     const val COMMANDER_ZONE_CHOICE = 950   // 903.9a (Commander format)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
@@ -15,7 +15,7 @@ object SbaOrder {
     const val PLANESWALKER_LOYALTY = 500    // 704.5i
     const val LEGEND_RULE = 600             // 704.5j
     const val COUNTER_ANNIHILATION = 700    // 704.5m
-    const val UNATTACHED_AURAS = 800        // 704.5n/p
+    const val UNATTACHED_AURAS = 800        // 704.5m/n/p
     const val SAGA_SACRIFICE = 900          // 714.4
     const val COMMANDER_ZONE_CHOICE = 950   // 903.9a (Commander format)
     const val TOKENS_IN_WRONG_ZONES = 1000  // 704.5s

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -13,6 +13,13 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
  * 704.5n - An Aura attached to an illegal object/player or not attached goes to graveyard.
  * 704.5p - An Equipment or Fortification attached to an illegal permanent becomes unattached
  *          but remains on the battlefield.
+ *
+ * Also enforces CR 301.5c: a creature can't also be an Equipment attached to another
+ * permanent (unless it has reconfigure). If an Equipment becomes a creature (e.g. via
+ * Tezzeret, Cruel Captain's emblem turning an artifact into a 0/0 Robot artifact
+ * creature), any Auras and Equipment attached to it become unattached. The "is it a
+ * creature?" question is asked of the projected state, since creatureness here comes
+ * from a layer-4 type-changing effect, not the printed type line.
  */
 class UnattachedAurasCheck : StateBasedActionCheck {
     override val name = "704.5n/p Unattached Auras"
@@ -21,6 +28,7 @@ class UnattachedAurasCheck : StateBasedActionCheck {
     override fun check(state: GameState): ExecutionResult {
         var newState = state
         val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
+        val projected = state.projectedState
 
         for (entityId in state.getBattlefield().toList()) {
             val container = state.getEntity(entityId) ?: continue
@@ -59,6 +67,16 @@ class UnattachedAurasCheck : StateBasedActionCheck {
                         newState = newState.updateEntity(entityId) { c ->
                             c.without<AttachedToComponent>()
                         }
+                    }
+                } else if (isEquipment &&
+                    projected.isCreature(entityId) &&
+                    !projected.hasKeyword(entityId, "RECONFIGURE")
+                ) {
+                    // CR 301.5c: an Equipment that's also a creature can't stay attached
+                    // (unless it has reconfigure). Unattach but keep on battlefield.
+                    newState = cleanupReverseAttachmentLink(newState, entityId)
+                    newState = newState.updateEntity(entityId) { c ->
+                        c.without<AttachedToComponent>()
                     }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -10,19 +10,22 @@ import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 
 /**
- * 704.5n - An Aura attached to an illegal object/player or not attached goes to graveyard.
- * 704.5p - An Equipment or Fortification attached to an illegal permanent becomes unattached
+ * 704.5m - An Aura attached to an illegal object/player or not attached goes to graveyard.
+ * 704.5n - An Equipment or Fortification attached to an illegal permanent becomes unattached
  *          but remains on the battlefield.
- *
- * Also enforces CR 301.5c: a creature can't also be an Equipment attached to another
- * permanent (unless it has reconfigure). If an Equipment becomes a creature (e.g. via
- * Tezzeret, Cruel Captain's emblem turning an artifact into a 0/0 Robot artifact
- * creature), any Auras and Equipment attached to it become unattached. The "is it a
- * creature?" question is asked of the projected state, since creatureness here comes
- * from a layer-4 type-changing effect, not the printed type line.
+ * 704.5p - A battle or creature attached to an object or player becomes unattached but
+ *          remains on the battlefield. Drives the Equipment-that-became-a-creature case
+ *          below: when an Equipment (e.g. Atomic Microsizer) becomes a creature via a
+ *          layer-4 type-changing effect (Tezzeret, Cruel Captain's emblem turning an
+ *          artifact into a 0/0 Robot artifact creature), the underlying CR 301.5c rule
+ *          ("an Equipment that's also a creature can't equip a creature unless it has
+ *          reconfigure") makes the attachment illegal, and 704.5p is the SBA that
+ *          unattaches it. The "is it a creature?" question is asked of the projected
+ *          state, since creatureness here comes from a layer-4 type-changing effect,
+ *          not the printed type line.
  */
 class UnattachedAurasCheck : StateBasedActionCheck {
-    override val name = "704.5n/p Unattached Auras"
+    override val name = "704.5m/n/p Unattached Auras"
     override val order = SbaOrder.UNATTACHED_AURAS
 
     override fun check(state: GameState): ExecutionResult {
@@ -72,8 +75,9 @@ class UnattachedAurasCheck : StateBasedActionCheck {
                     projected.isCreature(entityId) &&
                     !projected.hasKeyword(entityId, "RECONFIGURE")
                 ) {
-                    // CR 301.5c: an Equipment that's also a creature can't stay attached
-                    // (unless it has reconfigure). Unattach but keep on battlefield.
+                    // CR 704.5p (with 301.5c as the underlying prohibition): an Equipment
+                    // that's also a creature can't equip a creature unless it has
+                    // reconfigure, so the SBA unattaches it. Stays on the battlefield.
                     newState = cleanupReverseAttachmentLink(newState, entityId)
                     newState = newState.updateEntity(entityId) { c ->
                         c.without<AttachedToComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -620,7 +620,18 @@ class StackResolver(
         // Validate targets if spell has any (including protection check - Rule 702.16)
         val sourceColors = cardComponent?.colors ?: emptySet()
         val sourceSubtypes = cardComponent?.typeLine?.subtypes?.map { it.value }?.toSet() ?: emptySet()
-        val resolvedTargets = if (targetsComponent != null && targetsComponent.targets.isNotEmpty()) {
+        // `resolvedTargets` is the compacted (drop-illegal) list used as `context.targets`
+        // — same shape every executor has always seen. `alignedResolvedTargets` is a parallel
+        // list the same length as the originally-chosen targets, with `null` in slots whose
+        // target was dropped by 608.2b validation. It is forwarded to `buildNamedTargets`
+        // so a sub-effect that references a now-illegal target through its declared
+        // [EffectTarget.BoundVariable] (e.g. Diplomatic Relations' `myCreature` after its
+        // FROM creature dies in response) resolves to `null` and fizzles, instead of
+        // silently consuming the NEXT still-valid target whose position shifted forward
+        // in the compacted list.
+        val resolvedTargets: List<ChosenTarget>
+        val alignedResolvedTargets: List<ChosenTarget?>
+        if (targetsComponent != null && targetsComponent.targets.isNotEmpty()) {
             val validTargets = validateTargets(
                 state, targetsComponent.targets, sourceColors, sourceSubtypes,
                 spellComponent.casterId, targetsComponent.targetRequirements,
@@ -632,9 +643,11 @@ class StackResolver(
                 // All targets invalid - spell fizzles
                 return fizzleSpell(state, spellId, cardComponent, spellComponent)
             }
-            validTargets
+            resolvedTargets = validTargets
+            alignedResolvedTargets = buildAlignedValidated(targetsComponent.targets, validTargets)
         } else {
-            targetsComponent?.targets ?: emptyList()
+            resolvedTargets = targetsComponent?.targets ?: emptyList()
+            alignedResolvedTargets = resolvedTargets
         }
 
         var newState = state
@@ -680,7 +693,8 @@ class StackResolver(
             // Execute effects and put in graveyard
             val effectResult = resolveNonPermanentSpell(
                 newState, spellId, spellComponent, cardComponent,
-                resolvedTargets
+                resolvedTargets,
+                alignedResolvedTargets
             )
             if (effectResult.isPaused) {
                 // Effect paused for a decision (e.g., draw replacement prompt).
@@ -1274,7 +1288,12 @@ class StackResolver(
         spellId: EntityId,
         spellComponent: SpellOnStackComponent,
         cardComponent: CardComponent?,
-        targets: List<ChosenTarget>
+        targets: List<ChosenTarget>,
+        // Parallel to the originally-chosen targets, with `null` in slots whose target
+        // was dropped by 608.2b validation. Used for [EffectContext.buildNamedTargets]
+        // so BoundVariable lookups for now-illegal targets resolve to null and fizzle,
+        // rather than shifting onto a later still-valid target.
+        alignedTargets: List<ChosenTarget?> = targets,
     ): ExecutionResult {
         var newState = state
         val events = mutableListOf<GameEvent>()
@@ -1326,7 +1345,10 @@ class StackResolver(
                 additionalCostBlightAmount = spellComponent.additionalCostBlightAmount,
                 castFromZone = spellComponent.castFromZone,
                 pipeline = PipelineState(
-                    namedTargets = EffectContext.buildNamedTargets(targetRequirements, targets),
+                    // Use the positionally-aligned validated list so a sub-effect that
+                    // references a target dropped by 608.2b through its BoundVariable id
+                    // resolves to null and fizzles (CR 608.2b).
+                    namedTargets = EffectContext.buildNamedTargets(targetRequirements, alignedTargets),
                     storedCollections = buildBeheldStoredCollections(spellComponent.beheldCards, resolvedCardDef)
                 )
             )
@@ -2196,6 +2218,28 @@ class StackResolver(
                     // Spell is valid if still on stack
                     target.spellEntityId in state.stack
                 }
+            }
+        }
+    }
+
+    /**
+     * Project [validTargets] (the compacted output of [validateTargets]) back onto
+     * [originalTargets] positions, returning a list parallel to [originalTargets] with
+     * `null` in slots whose target was dropped by 608.2b validation. Walks both lists
+     * in order — [validateTargets] preserves the relative ordering of survivors — so the
+     * mapping is unambiguous even when two original targets compare structurally equal.
+     */
+    private fun buildAlignedValidated(
+        originalTargets: List<ChosenTarget>,
+        validTargets: List<ChosenTarget>
+    ): List<ChosenTarget?> {
+        var v = 0
+        return originalTargets.map { orig ->
+            if (v < validTargets.size && validTargets[v] === orig) {
+                v++
+                orig
+            } else {
+                null
             }
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AuxiliaryBoostersAttachOnEtbTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AuxiliaryBoostersAttachOnEtbTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Reproduces a bug in Auxiliary Boosters (EOE #5, {4}{W} Equipment):
+ *
+ *   When this Equipment enters, create a 2/2 colorless Robot artifact creature token
+ *   and attach this Equipment to it.
+ *
+ * The token IS created, but the Equipment is NOT attached to it. Root cause is
+ * the ETB chain wiring `Effects.AttachEquipment(EffectTarget.ContextTarget(0))`
+ * after `CreateTokenEffect`: `CreateTokenEffect` publishes the new token's id into
+ * `context.pipeline.storedCollections[CREATED_TOKENS]`, not into `context.targets[0]`,
+ * so `ContextTarget(0)` resolves to null on a triggered ability that has no declared
+ * targets. (StarforgedSword does the same chain inside a `Mode.withTarget(...)`,
+ * which populates `context.targets[0]` for it — so it works.)
+ *
+ * Expected fix: `EffectTarget.PipelineTarget(CREATED_TOKENS, 0)` for the attach.
+ */
+class AuxiliaryBoostersAttachOnEtbTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Auxiliary Boosters ETB — create Robot token AND attach Equipment to it") {
+
+            test("Equipment auto-attaches to the freshly-created 2/2 Robot token and grants +1/+2 + flying") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Auxiliary Boosters")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Auxiliary Boosters")
+                withClue("Casting Auxiliary Boosters should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                // (1) Token presence — should be the easiest assertion and unaffected by the bug.
+                withClue("Auxiliary Boosters' ETB should create exactly one 2/2 Robot token") {
+                    game.findPermanents("Robot Token").size shouldBe 1
+                }
+
+                // (2) Equipment is on Alice's battlefield.
+                val boosters = game.findPermanent("Auxiliary Boosters")
+                withClue("Auxiliary Boosters should be on Alice's battlefield after resolving") {
+                    (boosters != null) shouldBe true
+                }
+
+                val robotToken = game.findPermanent("Robot Token")!!
+
+                // (3) THE BUG — attachment should be established by the ETB chain.
+                withClue(
+                    "Auxiliary Boosters should have AttachedToComponent pointing at the Robot token " +
+                        "(observed: ${game.state.getEntity(boosters!!)?.get<AttachedToComponent>()?.targetId})"
+                ) {
+                    game.state.getEntity(boosters)?.get<AttachedToComponent>()?.targetId shouldBe robotToken
+                }
+                withClue(
+                    "Robot token should expose AttachmentsComponent listing Auxiliary Boosters " +
+                        "(observed: ${game.state.getEntity(robotToken)?.get<AttachmentsComponent>()?.attachedIds})"
+                ) {
+                    game.state.getEntity(robotToken)?.get<AttachmentsComponent>()?.attachedIds shouldBe listOf(boosters)
+                }
+
+                // (4) Static abilities take effect via the attachment: 2/2 + (+1/+2) = 3/4, with flying.
+                val projected = stateProjector.project(game.state)
+                withClue("Equipped Robot token should be 3/4 (base 2/2 + Auxiliary Boosters' +1/+2)") {
+                    projected.getPower(robotToken) shouldBe 3
+                    projected.getToughness(robotToken) shouldBe 4
+                }
+                withClue("Equipped Robot token should have flying granted by Auxiliary Boosters") {
+                    projected.hasKeyword(robotToken, Keyword.FLYING) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiplomaticRelationsPartialIllegalTargetTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiplomaticRelationsPartialIllegalTargetTest.kt
@@ -17,7 +17,7 @@ import io.kotest.matchers.shouldBe
  * Scenario test for the EOE bug:
  *     "Diplomatic Relations gives +1/+0 to TO creature if FROM creature is dead."
  *
- * Card reference — Diplomatic Relations ({2}{G}, Instant, EOE #177†):
+ * Card reference — Diplomatic Relations ({2}{G}, Instant, EOE #177):
  *   "Target creature you control gets +1/+0 and gains vigilance until end of turn. It deals
  *    damage equal to its power to target creature an opponent controls."
  *

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiplomaticRelationsPartialIllegalTargetTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiplomaticRelationsPartialIllegalTargetTest.kt
@@ -1,0 +1,144 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for the EOE bug:
+ *     "Diplomatic Relations gives +1/+0 to TO creature if FROM creature is dead."
+ *
+ * Card reference — Diplomatic Relations ({2}{G}, Instant, EOE #177†):
+ *   "Target creature you control gets +1/+0 and gains vigilance until end of turn. It deals
+ *    damage equal to its power to target creature an opponent controls."
+ *
+ * MTG rule 608.2b (partial illegal targets): on resolution, the spell re-checks each target;
+ * any illegal target is removed. If at least one target is still legal, the spell still
+ * resolves, but instructions that reference an illegal target are skipped. The +1/+0 + vigilance
+ * instruction references the FROM target ("Target creature you control"). The damage
+ * instruction's source ("It deals damage...") is the FROM target — and its amount is the FROM
+ * target's power. Both instructions reference the FROM target, so if FROM is illegal on
+ * resolution, neither instruction does anything to TO.
+ *
+ * Bug: when Alice's bears (FROM) die to Bolt before Diplomatic Relations resolves, the
+ * ModifyStats sub-effect still applies its +1/+0 (and the deal-damage sub-effect still fires)
+ * to TO (Bob's bears) — TO ends up either pumped, damaged, or both. Expected: nothing happens
+ * to Bob's bears.
+ */
+class DiplomaticRelationsPartialIllegalTargetTest : ScenarioTestBase() {
+
+    init {
+        context("Diplomatic Relations — partial illegal target (FROM dies in response)") {
+
+            test("Bob's bears must not be pumped or damaged when Alice's bears (FROM) is killed before resolution") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Diplomatic Relations")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Identify Alice's bears (FROM) and Bob's bears (TO) by controller.
+                val aliceBears = game.state.getBattlefield().single { entityId ->
+                    val container = game.state.getEntity(entityId) ?: return@single false
+                    container.get<CardComponent>()?.name == "Grizzly Bears" &&
+                        container.get<ControllerComponent>()?.playerId == game.player1Id
+                }
+                val bobBears = game.state.getBattlefield().single { entityId ->
+                    val container = game.state.getEntity(entityId) ?: return@single false
+                    container.get<CardComponent>()?.name == "Grizzly Bears" &&
+                        container.get<ControllerComponent>()?.playerId == game.player2Id
+                }
+
+                // Alice casts Diplomatic Relations targeting her own bears (FROM = index 0)
+                // and Bob's bears (TO = index 1).
+                val diplomaticRelationsId = game.findCardsInHand(1, "Diplomatic Relations").single()
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        diplomaticRelationsId,
+                        listOf(
+                            ChosenTarget.Permanent(aliceBears),
+                            ChosenTarget.Permanent(bobBears),
+                        )
+                    )
+                )
+                withClue("Diplomatic Relations should cast: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                // Alice passes priority so Bob can respond.
+                game.execute(PassPriority(game.player1Id))
+                withClue("Bob should have priority to respond") {
+                    game.state.priorityPlayerId shouldBe game.player2Id
+                }
+
+                // Bob casts Lightning Bolt targeting Alice's bears (the FROM target).
+                val boltId = game.findCardsInHand(2, "Lightning Bolt").single()
+                val bolt = game.execute(
+                    CastSpell(
+                        game.player2Id,
+                        boltId,
+                        listOf(ChosenTarget.Permanent(aliceBears))
+                    )
+                )
+                withClue("Lightning Bolt should cast: ${bolt.error}") {
+                    bolt.error shouldBe null
+                }
+
+                // Resolve the entire stack: Bolt resolves first (Alice's bears dies, FROM target
+                // becomes illegal), then Diplomatic Relations re-validates and resolves with only
+                // TO still legal.
+                var iterations = 0
+                while (game.state.stack.isNotEmpty() && iterations < 40) {
+                    val priorityPlayer = game.state.priorityPlayerId ?: break
+                    val r = game.execute(PassPriority(priorityPlayer))
+                    if (r.error != null) break
+                    iterations++
+                }
+
+                // Sanity: Alice's bears died to Bolt.
+                withClue("Alice's bears should no longer be on the battlefield (killed by Bolt)") {
+                    game.state.getBattlefield().contains(aliceBears) shouldBe false
+                }
+                withClue("Alice's Grizzly Bears should be in her graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+
+                // Bob's bears MUST still be on the battlefield, with its printed 2/2 stats and
+                // zero damage marked — Diplomatic Relations must do NOTHING to it once FROM died.
+                withClue("Bob's Grizzly Bears should still be on the battlefield") {
+                    game.state.getBattlefield().contains(bobBears) shouldBe true
+                }
+
+                val projected = StateProjector().project(game.state)
+                withClue("Bob's bears power must be the printed 2 (no +1/+0 from Diplomatic Relations)") {
+                    projected.getPower(bobBears) shouldBe 2
+                }
+                withClue("Bob's bears toughness must be the printed 2") {
+                    projected.getToughness(bobBears) shouldBe 2
+                }
+
+                val damage = game.state.getEntity(bobBears)?.get<DamageComponent>()?.amount ?: 0
+                withClue("Bob's bears must take NO damage from Diplomatic Relations (FROM is illegal)") {
+                    damage shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EquipmentAsCreatureUnattachTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EquipmentAsCreatureUnattachTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Reproduces "Bug 13": when [Atomic Microsizer] (Artifact — Equipment, attached to
+ * Chrome Companion) becomes a 0/0 Robot **artifact creature** via Tezzeret, Cruel
+ * Captain's -7 emblem ("...put three +1/+1 counters on target artifact you control.
+ * If it's not a creature, it becomes a 0/0 Robot artifact creature."), the engine
+ * fails to un-attach the now-creature Equipment from Chrome Companion.
+ *
+ * Per CR 301.5c / 704.5p: a creature can't be an Equipment that's attached to
+ * another permanent (and Microsizer lacks reconfigure), so as a state-based action
+ * the Equipment should auto-unattach the moment it becomes a creature.
+ *
+ * Symptom in-game: Chrome Companion still gets the +1/+0 static buff (2/1 -> 3/1)
+ * **and** the 3/3 Microsizer attacks alongside it for 6 combat damage. After the
+ * fix: Microsizer is unattached, Chrome Companion drops back to base 2/1, and the
+ * Microsizer is a standalone 3/3 artifact creature.
+ *
+ * Setup choice: rather than walking Tezzeret onto the battlefield, casting him,
+ * activating -3 / +1 to ramp loyalty, we pre-attach Microsizer to Chrome Companion
+ * (matching the post-equip board), seed Tezzeret with 7 loyalty counters, and
+ * activate the -7 directly. The emblem's begin-of-combat trigger then targets
+ * Microsizer, applying counters + `BecomeCreature` — the exact bug-triggering path.
+ */
+class EquipmentAsCreatureUnattachTest : ScenarioTestBase() {
+
+    init {
+        context("Equipment becomes a creature -> SBA must unattach (CR 301.5c / 704.5p)") {
+
+            test("Atomic Microsizer attached to Chrome Companion auto-unattaches after Tezzeret's -7 emblem turns it into a 3/3 Robot artifact creature") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Tezzeret, Cruel Captain")
+                    .withCardOnBattlefield(1, "Chrome Companion", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Atomic Microsizer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tezzeret = game.findPermanent("Tezzeret, Cruel Captain")!!
+                val companion = game.findPermanent("Chrome Companion")!!
+                val microsizer = game.findPermanent("Atomic Microsizer")!!
+
+                // Seed Tezzeret with enough loyalty to activate -7.
+                game.state = game.state.updateEntity(tezzeret) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 7))
+                }
+
+                // Attach Microsizer to Chrome Companion (post-equip board state).
+                game.state = game.state
+                    .updateEntity(microsizer) { c -> c.with(AttachedToComponent(companion)) }
+                    .updateEntity(companion) { c ->
+                        val existing = c.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+                        c.with(AttachmentsComponent(existing + microsizer))
+                    }
+
+                // Sanity: static "Equipped creature gets +1/+0" already projects -> 3/1.
+                run {
+                    val projected = game.state.projectedState
+                    withClue("Pre-emblem: Chrome Companion is buffed to 3/1 by Microsizer's static ability") {
+                        projected.getPower(companion) shouldBe 3
+                        projected.getToughness(companion) shouldBe 1
+                    }
+                    withClue("Pre-emblem: Microsizer is not (yet) a creature") {
+                        projected.isCreature(microsizer) shouldBe false
+                    }
+                }
+
+                // Activate -7 -> grants the global emblem trigger.
+                val minus7 = cardRegistry.getCard("Tezzeret, Cruel Captain")!!
+                    .script.activatedAbilities[2]
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tezzeret,
+                        abilityId = minus7.id
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("emblem is granted (Tezzeret dies to 0-loyalty SBA, emblem persists)") {
+                    game.state.globalGrantedTriggeredAbilities.size shouldBe 1
+                }
+
+                // Walk into begin-combat -> emblem's "at the beginning of combat" trigger fires
+                // and asks for a target. Microsizer is the only legal artifact target we control
+                // (Chrome Companion is an artifact creature too — we have to point the emblem at
+                // Microsizer to drive the bug).
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.selectTargets(listOf(microsizer))
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+
+                // (1) Microsizer should no longer carry AttachedToComponent — SBA unattached it.
+                withClue(
+                    "Microsizer should be unattached (CR 704.5p) once it became a creature " +
+                        "(observed AttachedToComponent.targetId = " +
+                        "${game.state.getEntity(microsizer)?.get<AttachedToComponent>()?.targetId})"
+                ) {
+                    game.state.getEntity(microsizer)?.has<AttachedToComponent>() shouldBe false
+                }
+
+                // (2) Chrome Companion's reverse-link must be cleaned up.
+                withClue(
+                    "Chrome Companion's AttachmentsComponent should NOT list Microsizer " +
+                        "(observed = " +
+                        "${game.state.getEntity(companion)?.get<AttachmentsComponent>()?.attachedIds})"
+                ) {
+                    val attached = game.state.getEntity(companion)
+                        ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+                    attached.contains(microsizer) shouldBe false
+                }
+
+                // (3) With the Equipment gone, Chrome Companion drops back to base 2/1.
+                withClue(
+                    "Chrome Companion should lose Microsizer's +1/+0 buff and project to 2 power " +
+                        "(observed power = ${projected.getPower(companion)})"
+                ) {
+                    projected.getPower(companion) shouldBe 2
+                }
+
+                // (4) Microsizer is now a standalone 3/3 artifact creature (base 0/0 + three
+                //     +1/+1 counters from the emblem), retaining its artifact type.
+                withClue(
+                    "Microsizer should project to a 3/3 creature retaining the artifact type " +
+                        "(observed power=${projected.getPower(microsizer)}, " +
+                        "isCreature=${projected.isCreature(microsizer)}, " +
+                        "hasType ARTIFACT=${projected.hasType(microsizer, "ARTIFACT")})"
+                ) {
+                    projected.isCreature(microsizer) shouldBe true
+                    projected.hasType(microsizer, "ARTIFACT") shouldBe true
+                    projected.getPower(microsizer) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KavaronHarrierTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KavaronHarrierTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Kavaron Harrier (EOE #139, {R}, 2/1 Artifact Creature — Robot Soldier).
+ *
+ * Oracle: "Whenever this creature attacks, you may pay {2}. If you do, create a 2/2 colorless
+ * Robot artifact creature token that's tapped and attacking. Sacrifice that token at end of combat."
+ *
+ * Regression: the original card def created the Robot token with `exileAtStep = Step.END_COMBAT`,
+ * routing it to *exile* at end of combat. Per oracle the token must be *sacrificed* (battlefield →
+ * graveyard) so dies / sacrifice triggers fire. SBA 704.5d removes tokens from any non-battlefield
+ * zone, so the final board can't distinguish exile from graveyard. We use a witness that ONLY
+ * triggers on a graveyard zone-change: South Wind Avatar (TMT) — "Whenever another creature you
+ * control dies, you gain life equal to its toughness." A 2/2 Robot Token going to graveyard makes
+ * Alice gain 2; exile leaves her at 20. Alice's life total is the clean tell.
+ */
+class KavaronHarrierTest : ScenarioTestBase() {
+
+    init {
+        context("Kavaron Harrier") {
+
+            test("attack-trigger token is sacrificed (not exiled) at end of combat — witnessed by South Wind Avatar") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Kavaron Harrier", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "South Wind Avatar", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Move into combat and attack Bob with Kavaron Harrier.
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Kavaron Harrier" to 2))
+                withClue("Declaring Kavaron Harrier as attacker should succeed: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+
+                // The "Whenever this creature attacks, you may pay {2}" trigger goes on the stack
+                // and pauses for the may-pay yes/no.
+                game.resolveStack()
+                withClue("Attack trigger should be waiting for the may-pay yes/no") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true)
+                game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Paying {2} should have created the 2/2 Robot token") {
+                    game.findPermanents("Robot Token").size shouldBe 1
+                }
+
+                // Auto-advance through declare-blockers (no blockers), combat damage, and end of
+                // combat (where the delayed trigger sacrifices or exiles the token), landing in
+                // postcombat main. passUntilPhase auto-resolves the AssignDamage / CombatResolution
+                // decisions and the Avatar's life-gain triggers (no choices on those).
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                // South Wind Avatar's "Whenever another creature you control dies" only fires on
+                // a battlefield→graveyard zone change, never on battlefield→exile. Sacrificing the
+                // 2/2 Robot Token makes Alice gain 2 life. Exiling it leaves her at 20.
+                withClue(
+                    "Oracle: 'Sacrifice that token at end of combat'. South Wind Avatar's dies-trigger " +
+                        "should fire for the 2/2 Robot Token, gaining Alice 2 life (→ 22). Bug: card uses " +
+                        "exileAtStep instead of sacrificeAtStep, the token is exiled, the witness never " +
+                        "fires, and Alice stays at 20."
+                ) {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LarvalScoutlanderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LarvalScoutlanderScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Reproduction test for the Larval Scoutlander (EOE #194) bug.
+ *
+ * The card's ETB clause reads:
+ *  "When this Spacecraft enters, you may sacrifice a land or Lander. If you do, search your
+ *   library for up to two basic land cards, put them onto the battlefield tapped, then shuffle."
+ *
+ * Bug surfaced in play: the may-sacrifice prompt fires and a land is sacrificed, but the
+ * library-search payoff never delivers — no basic lands hit the battlefield and the library
+ * is not shuffled. This is the "MayEffect(Sacrifice.then(search))" vs. correct
+ * "IfYouDoEffect(Sacrifice, search)" mis-modeling: the whole composite gets gated as one
+ * yes/no instead of the sacrifice acting as the action whose outcome gates the search.
+ *
+ * This test exercises the full flow Alice would experience and asserts on each visible
+ * step. It is expected to FAIL today on the post-sacrifice payoff.
+ */
+class LarvalScoutlanderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Larval Scoutlander ETB") {
+
+            test("sacrificing a land searches up two basic lands tapped and shuffles") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Larval Scoutlander")
+                    // Four Forests on battlefield: three pay {2}{G}, one is the sacrificial fodder
+                    // (so Alice still has lands left over after the ETB resolves).
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    // Library: 2 searchable Forests + 8 non-land cards so the post-search
+                    // residue is large enough that a real shuffle is statistically visible
+                    // (8! permutations; the original-order outcome is 1/40320 ≈ 0.0025%).
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Border Guard")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Cancel")
+                    .withCardInLibrary(1, "Giant Spider")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val alice = game.player1Id
+
+                // (1) Capture pre-cast library order so we can detect shuffling later.
+                val libraryBeforeCast = game.state.getLibrary(alice).toList()
+                val battlefieldLandsBefore = game.findPermanents("Forest").size
+
+                // (2) Cast Larval Scoutlander, resolve mana, advance the stack so the ETB
+                //     trigger pops and asks the controller to choose.
+                game.castSpell(1, "Larval Scoutlander").error shouldBe null
+                game.resolveStack()
+
+                // (3) Answer the may-pay yes/no with YES.
+                withClue("the ETB trigger should open a yes/no may-sacrifice prompt") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe true
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                // (4) Answer the sacrifice prompt by selecting exactly one Forest from
+                //     Alice's battlefield.
+                withClue("the may-sacrifice resolution should ask for a land or Lander to sacrifice") {
+                    val decision = game.getPendingDecision()
+                    (decision is SelectCardsDecision) shouldBe true
+                }
+                val sacrificeDecision = game.getPendingDecision() as SelectCardsDecision
+                val forestToSac = sacrificeDecision.options.first()
+                game.selectCards(listOf(forestToSac)).error shouldBe null
+                game.resolveStack()
+
+                // (5) Answer the library-search prompt by selecting two basic lands from
+                //     Alice's library.
+                withClue("after sacrificing, the library-search prompt should appear") {
+                    val decision = game.getPendingDecision()
+                    (decision is SelectCardsDecision) shouldBe true
+                }
+                val searchDecision = game.getPendingDecision() as SelectCardsDecision
+                val searchedLands = searchDecision.options.take(2)
+                game.selectCards(searchedLands).error shouldBe null
+                game.resolveStack()
+
+                // --- Assertions, in order, one withClue each. ---
+
+                withClue("Larval Scoutlander entered the battlefield under Alice's control") {
+                    game.isOnBattlefield("Larval Scoutlander") shouldBe true
+                }
+
+                withClue("Alice sacrificed exactly one land — graveyard has +1 Forest") {
+                    game.findCardsInGraveyard(1, "Forest").size shouldBe 1
+                }
+
+                // THE BUG ENTRY: the searched basics actually move from library to battlefield.
+                withClue(
+                    "Alice's battlefield should have two MORE lands than before the search " +
+                        "(the searched basics actually entered the battlefield). " +
+                        "Before: $battlefieldLandsBefore, after the sacrifice the Forests on " +
+                        "battlefield should be $battlefieldLandsBefore - 1 (sacrificed) + 2 (searched) " +
+                        "= ${battlefieldLandsBefore + 1}."
+                ) {
+                    game.findPermanents("Forest").size shouldBe battlefieldLandsBefore + 1
+                }
+
+                withClue("both newly-arrived searched basic lands have TappedComponent (entersTapped=true)") {
+                    val tappedSearched = searchedLands.count { id ->
+                        game.state.getEntity(id)?.get<TappedComponent>() != null
+                    }
+                    tappedSearched shouldBe 2
+                }
+
+                withClue(
+                    "the library was shuffled: the post-resolution library should differ from the pre-cast " +
+                        "order (or at minimum the searched cards are gone from the library)."
+                ) {
+                    val libraryAfter = game.state.getLibrary(alice).toList()
+                    val searchedGone = searchedLands.none { it in libraryAfter }
+                    val orderChanged = libraryAfter != libraryBeforeCast.filterNot { it in searchedLands }
+                    (searchedGone && orderChanged) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RustHarvesterExileCostChoiceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RustHarvesterExileCostChoiceTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.AtomicMicrosizer
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.AuxiliaryBoosters
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.ChromeCompanion
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.RustHarvester
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Reproduces the bug: activating Rust Harvester's
+ *   "{2}, {T}, Exile an artifact card from your graveyard: ..."
+ * ability auto-picks which artifact to exile.
+ *
+ * The exile is a COST (left of the colon, no "target" keyword), so the player must
+ * be prompted to choose WHICH artifact card from their graveyard to exile. With
+ * three different artifact cards in the graveyard, the engine must hand back a
+ * SelectCardsDecision listing all three. It instead silently picks the first card
+ * (see CostHandler.kt:exileCardsFromGraveyard — `validCards.take(count)`).
+ */
+class RustHarvesterExileCostChoiceTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                RustHarvester,
+                AtomicMicrosizer,
+                AuxiliaryBoosters,
+                ChromeCompanion,
+            )
+        )
+        return driver
+    }
+
+    val abilityId = RustHarvester.activatedAbilities.first().id
+
+    test("Activating Rust Harvester must prompt the player to choose which artifact to exile from graveyard (not auto-pick)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Forest" to 30))
+        val alice = driver.activePlayer!!
+        val bob = driver.getOpponent(alice)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Alice: Rust Harvester (no summoning sickness) and two Mountains for {2}.
+        val rustHarvester = driver.putCreatureOnBattlefield(alice, "Rust Harvester")
+        driver.replaceState(
+            driver.state.updateEntity(rustHarvester) { it.without<SummoningSicknessComponent>() }
+        )
+        repeat(2) { driver.putLandOnBattlefield(alice, "Mountain") }
+
+        // Alice has THREE distinct artifact cards in her graveyard — a real choice.
+        val atomicMicrosizer = driver.putCardInGraveyard(alice, "Atomic Microsizer")
+        val auxiliaryBoosters = driver.putCardInGraveyard(alice, "Auxiliary Boosters")
+        val chromeCompanion = driver.putCardInGraveyard(alice, "Chrome Companion")
+        val artifactGraveyardCards = listOf(atomicMicrosizer, auxiliaryBoosters, chromeCompanion)
+
+        // Bob: a Centaur Courser to damage with the pump-then-zap effect.
+        val centaurCourser = driver.putCreatureOnBattlefield(bob, "Centaur Courser")
+        driver.replaceState(
+            driver.state.updateEntity(centaurCourser) { it.without<SummoningSicknessComponent>() }
+        )
+
+        // Sanity: legal-action enumerator advertises the activation with all
+        // three graveyard cards as valid exile candidates (this part is correct).
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, alice, EnumerationMode.FULL)
+        val activate = actions.single {
+            val a = it.action
+            a is ActivateAbility && a.sourceId == rustHarvester && a.abilityId == abilityId
+        }
+        activate.affordable shouldBe true
+        val costInfo = activate.additionalCostInfo
+        costInfo.shouldNotBeNull()
+        costInfo.costType shouldBe "ExileFromGraveyard"
+        costInfo.exileMinCount shouldBe 1
+        costInfo.exileMaxCount shouldBe 1
+        costInfo.validExileTargets shouldContainAll artifactGraveyardCards
+
+        // Drive the activation through the engine WITHOUT pre-filling exiledCards.
+        // The damage target is chosen; the exile victim is a cost-choice that
+        // must surface as a pending decision.
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = alice,
+                sourceId = rustHarvester,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(centaurCourser)),
+                costPayment = null,
+            )
+        )
+        // The activation should not error — it pauses for the cost-choice decision.
+        // (Mirrors SecludedStarforgeTest's UI-flow pattern: paused-for-decision is not
+        // an error, and `ExecutionResult.isSuccess` is false while paused.)
+        result.error shouldBe null
+
+        // BUG: engine auto-picks the first artifact instead of prompting. The
+        // assertions below describe the correct behaviour; the test is expected
+        // to FAIL at the pending-decision check, with `pendingDecision == null`.
+        val pending = driver.pendingDecision
+        pending.shouldNotBeNull()
+
+        val cardSelection = pending.shouldBeInstanceOf<SelectCardsDecision>()
+        cardSelection.playerId shouldBe alice
+        cardSelection.minSelections shouldBe 1
+        cardSelection.maxSelections shouldBe 1
+        cardSelection.options shouldContainAll artifactGraveyardCards
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SecludedStarforgeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SecludedStarforgeTest.kt
@@ -1,0 +1,278 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Secluded Starforge (EOE #257, Land).
+ *
+ * Oracle:
+ *   {T}: Add {C}.
+ *   {2}, {T}, Tap X untapped artifacts you control: Target creature gets +X/+0 until end
+ *   of turn. Activate only as a sorcery.
+ *   {5}, {T}: Create a 2/2 colorless Robot artifact creature token.
+ *
+ * BUG: activating the pump ability with X = 2 (tapping two Chrome Companions) does not
+ * actually tap the chosen artifacts and/or the +X/+0 buff does not propagate X to the
+ * ModifyStats effect. The two withClue blocks below split those two failure modes so the
+ * caller can tell whether the bug is in cost payment or in X-amount propagation.
+ */
+class SecludedStarforgeTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Secluded Starforge") {
+
+            test("pump ability taps the chosen artifacts and grants +X/+0") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    // The Starforge itself, untapped so it can pay its own {T}.
+                    .withCardOnBattlefield(1, "Secluded Starforge", tapped = false, summoningSickness = false)
+                    // Two artifact creatures Alice can tap to pay the X cost. Chrome
+                    // Companion is a 2/1 Artifact Creature — Dog, so it matches the
+                    // GameObjectFilter.Artifact filter on the cost.
+                    .withCardOnBattlefield(1, "Chrome Companion", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Chrome Companion", tapped = false, summoningSickness = false)
+                    // Mountains supply the {2} generic mana the activation needs.
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    // Pump target.
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    // Bob has a harmless permanent so he isn't "empty board".
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val starforgeId = game.findPermanent("Secluded Starforge")!!
+                val chromes = game.findPermanents("Chrome Companion")
+                withClue("Setup sanity: Alice should control exactly two Chrome Companions") {
+                    chromes.size shouldBe 2
+                }
+                val grizzly = game.findPermanents("Grizzly Bears")
+                    .first { id ->
+                        game.state.getEntity(id)
+                            ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+                            ?.playerId == game.player1Id
+                    }
+
+                // The pump is the SECOND activated ability on Secluded Starforge —
+                // index 0 is the {T}: Add {C} mana ability, index 1 is the pump, index
+                // 2 is the {5}, {T}: Create-Robot ability.
+                val starforgeDef = cardRegistry.getCard("Secluded Starforge")!!
+                val pumpAbility = starforgeDef.script.activatedAbilities[1]
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = starforgeId,
+                        abilityId = pumpAbility.id,
+                        targets = listOf(ChosenTarget.Permanent(grizzly)),
+                        costPayment = AdditionalCostPayment(
+                            tappedPermanents = chromes
+                        ),
+                        xValue = 2
+                    )
+                )
+                withClue("Activating Secluded Starforge's pump with X=2 should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                // (1) Cost payment: both Chrome Companions must be tapped after the
+                // ability is announced. The cost is paid on announcement, before
+                // resolution, so this should already be true here. If this assertion
+                // fails the bug is in cost-payment plumbing for TapXPermanents.
+                withClue(
+                    "Cost payment: paying 'Tap X untapped artifacts you control' with both " +
+                        "Chrome Companions should leave both artifacts tapped after activation. " +
+                        "If this fails, the TapXPermanents cost is not actually tapping the " +
+                        "chosen permanents."
+                ) {
+                    chromes.forEach { id ->
+                        (game.state.getEntity(id)?.has<TappedComponent>() == true) shouldBe true
+                    }
+                }
+
+                // Resolve the pump ability on the stack.
+                game.resolveStack()
+
+                // (2) Effect: Grizzly Bears (2/2) should be 4/2 after +X/+0 with X = 2.
+                // If (1) passed but this fails, the bug is in X-amount propagation
+                // from the cost to ModifyStatsEffect (DynamicAmount.XValue).
+                withClue(
+                    "Effect: Grizzly Bears should be 4/2 (+2/+0) after the pump resolves " +
+                        "with X = 2. If cost-tapping succeeded but power stays at 2, the X " +
+                        "amount isn't propagating from the TapXPermanents cost into the " +
+                        "ModifyStatsEffect's DynamicAmount.XValue."
+                ) {
+                    val projected = stateProjector.project(game.state)
+                    projected.getPower(grizzly) shouldBe 4
+                    projected.getToughness(grizzly) shouldBe 2
+                }
+            }
+
+            // ---------------------------------------------------------------
+            // Bug reproducer driven through legal-actions + decisions instead
+            // of pre-filling xValue / tappedPermanents on ActivateAbility.
+            //
+            // User-reported symptom: "After choosing X=3 in the frontend I get
+            // 'Select permanents to tap 0/0' but all artifacts have a blue border."
+            //
+            // In engine terms the contract is a two-step decision flow:
+            //   1. Submit the legal-action's ActivateAbility (xValue=null,
+            //      costPayment=null) — frontend hasn't yet collected those.
+            //   2. Engine emits a ChooseNumberDecision for X. Player answers 3.
+            //   3. Engine emits a follow-up SelectCardsDecision asking the player
+            //      to tap exactly 3 untapped artifacts, with minSelections=3.
+            //   4. Player submits the 3 chromes; ability resolves; Grizzly is 5/2.
+            //
+            // The bug is in step 3: the engine never raises that follow-up
+            // decision (or raises it with minSelections=0 / a "Select 0/0"
+            // prompt), because ActivatedAbilityEnumerator emits tapCount=0 as
+            // a sentinel for X-variable costs and no continuation bridges the
+            // chosen X back into a tap-selection decision with the right count.
+            // ---------------------------------------------------------------
+            test("UI flow: choosing X=3 produces a 3-permanent tap-selection decision (not 0/0)") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Secluded Starforge", tapped = false, summoningSickness = false)
+                    // Three Chrome Companions so we can prove the follow-up
+                    // decision asks for *exactly X*, not "0..all artifacts".
+                    .withCardOnBattlefield(1, "Chrome Companion", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Chrome Companion", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Chrome Companion", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val starforgeId = game.findPermanent("Secluded Starforge")!!
+                val chromes = game.findPermanents("Chrome Companion")
+                withClue("Setup sanity: Alice should control exactly three Chrome Companions") {
+                    chromes.size shouldBe 3
+                }
+                val grizzly = game.findPermanents("Grizzly Bears")
+                    .first { id ->
+                        game.state.getEntity(id)
+                            ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+                            ?.playerId == game.player1Id
+                    }
+
+                // ------------------------------------------------------------
+                // Step 1: enumerate legal actions for Alice and find the pump.
+                // ------------------------------------------------------------
+                val legalActions = game.getLegalActions(1)
+                val pumpAction = legalActions
+                    .filter { it.actionType == "ActivateAbility" }
+                    .mapNotNull { info ->
+                        val activate = info.action as? ActivateAbility ?: return@mapNotNull null
+                        if (activate.sourceId != starforgeId) return@mapNotNull null
+                        info to activate
+                    }
+                    .single { (info, _) -> info.hasXCost }
+                val (pumpInfo, pumpActivate) = pumpAction
+
+                withClue(
+                    "Enumeration sanity: the pump ability must surface as hasXCost=true " +
+                        "with TapPermanents additional-cost info exposing the three " +
+                        "candidate chromes as validTapTargets."
+                ) {
+                    pumpInfo.hasXCost shouldBe true
+                    val costInfo = pumpInfo.additionalCostInfo.shouldNotBeNull()
+                    costInfo.costType shouldBe "TapPermanents"
+                    costInfo.validTapTargets shouldContainAll chromes
+                }
+
+                // ------------------------------------------------------------
+                // Step 2: submit the legal-action's ActivateAbility as-is —
+                // xValue/costPayment unfilled, since the frontend hasn't yet
+                // asked the player. The engine is expected to PAUSE here and
+                // raise a ChooseNumberDecision for X.
+                //
+                // We still have to attach the spell target (the legal-action
+                // describes it via requiresTargets/validTargets and the
+                // frontend wires it onto the action before submitting).
+                // ------------------------------------------------------------
+                val submission = pumpActivate.copy(
+                    targets = listOf(ChosenTarget.Permanent(grizzly))
+                )
+                val activateResult = game.execute(submission)
+                withClue(
+                    "Submitting ActivateAbility from getLegalActions without pre-filling " +
+                        "xValue/tappedPermanents must not error — the engine should pause " +
+                        "for the X-selection decision instead. Got error: ${activateResult.error}"
+                ) {
+                    activateResult.error shouldBe null
+                }
+
+                // ------------------------------------------------------------
+                // Step 3: answer the ChooseNumberDecision for X with 3.
+                // ------------------------------------------------------------
+                val xDecision = game.getPendingDecision().shouldNotBeNull()
+                xDecision.shouldBeInstanceOf<ChooseNumberDecision>()
+                game.chooseNumber(3).error shouldBe null
+
+                // ------------------------------------------------------------
+                // Step 4: THE BUG. After X=3 is chosen the engine should raise
+                // a SelectCardsDecision asking for EXACTLY 3 untapped artifacts
+                // (minSelections=3, maxSelections=3), with the three chromes as
+                // options. Today the engine either:
+                //   - never raises this decision (state.pendingDecision is null
+                //     and the ability has already resolved with no tapping), OR
+                //   - raises it with minSelections=0 / maxSelections=0 ("Select
+                //     0/0") — which is the literal user-visible bug.
+                // ------------------------------------------------------------
+                val tapDecision: PendingDecision = game.getPendingDecision().shouldNotBeNull()
+                withClue(
+                    "After choosing X=3 the engine must raise a SelectCardsDecision for " +
+                        "the tap-target selection (was: ${tapDecision::class.simpleName})."
+                ) {
+                    tapDecision.shouldBeInstanceOf<SelectCardsDecision>()
+                }
+                val tapSelect = tapDecision as SelectCardsDecision
+                withClue(
+                    "BUG: the tap-target selection's required count must equal the chosen " +
+                        "X (3). Today the SelectCardsDecision surfaces with minSelections=" +
+                        "${tapSelect.minSelections} and maxSelections=${tapSelect.maxSelections}, " +
+                        "so the player sees 'Select permanents to tap 0/0' with the chromes " +
+                        "highlighted but no way to actually tap any of them."
+                ) {
+                    tapSelect.minSelections shouldBe 3
+                    tapSelect.maxSelections shouldBe 3
+                    tapSelect.options shouldContainAll chromes
+                }
+
+                // ------------------------------------------------------------
+                // Step 5: with X bound and the three chromes selected, the
+                // ability should resolve and Grizzly Bears should be 5/2.
+                // (We only get here if the failing assertion above is fixed.)
+                // ------------------------------------------------------------
+                game.selectCards(chromes).error shouldBe null
+                game.resolveStack()
+
+                chromes.forEach { id ->
+                    (game.state.getEntity(id)?.has<TappedComponent>() == true) shouldBe true
+                }
+                val projected = stateProjector.project(game.state)
+                projected.getPower(grizzly) shouldBe 5
+                projected.getToughness(grizzly) shouldBe 2
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TerminalVelocityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TerminalVelocityScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.TerminalVelocity
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Terminal Velocity {4}{R}{R} — Sorcery.
+ *
+ * "You may put an artifact or creature card from your hand onto the battlefield.
+ *  That permanent gains haste, "When this permanent leaves the battlefield, it
+ *  deals damage equal to its mana value to each creature," and "At the beginning
+ *  of your end step, sacrifice this permanent.""
+ *
+ * The two quoted clauses are granted as real triggered abilities on the chosen
+ * permanent (Duration.Permanent) — the LTB clause must read the permanent's
+ * last-known mana value (it has just left the battlefield) and damage every
+ * creature still on the battlefield.
+ */
+class TerminalVelocityScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TerminalVelocity)
+        return driver
+    }
+
+    fun payTerminalVelocity(driver: GameTestDriver, playerId: com.wingedsheep.sdk.model.EntityId) {
+        driver.giveMana(playerId, Color.RED, 2)
+        driver.giveColorlessMana(playerId, 4)
+    }
+
+    test("puts chosen creature on the battlefield with haste; end step sacrifices it; LTB damages every creature for its mana value") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Force of Nature is 8/8 with mana value 5 ({2}{G}{G}{G}{G}). Pick it as the cheat
+        // target so the LTB clause clearly pings everything for 5, killing weaker creatures.
+        val forceOfNature = driver.putCardInHand(active, "Force of Nature")
+        // A tiny opponent creature — 2/2 Savannah Lions — to confirm "each creature" includes
+        // creatures we don't control (and to verify it gets killed by 5 damage).
+        val opponentLion = driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+        // Another creature on our side — also expects 5 damage from the LTB ping.
+        val ourLion = driver.putCreatureOnBattlefield(active, "Savannah Lions")
+
+        val terminalVelocity = driver.putCardInHand(active, "Terminal Velocity")
+        payTerminalVelocity(driver, active)
+
+        driver.castSpell(active, terminalVelocity)
+        driver.bothPass() // begin resolving Terminal Velocity
+
+        // The spell pauses on "choose any number (up to 1) of artifact/creature cards from hand".
+        driver.isPaused shouldBe true
+        val selectDecision = driver.pendingDecision as SelectCardsDecision
+        selectDecision.options shouldContain forceOfNature
+
+        driver.submitCardSelection(active, listOf(forceOfNature))
+
+        // Force of Nature should now be on the battlefield under the active player's control.
+        val fonOnBattlefield = driver.findPermanent(active, "Force of Nature")!!
+        fonOnBattlefield shouldBe forceOfNature
+
+        // Drain any remaining priority window in the main phase, then advance to end step.
+        driver.passPriorityUntil(Step.END)
+
+        // End step queued the sacrifice trigger. Resolve it.
+        var safety = 0
+        while ((driver.stackSize > 0 || driver.isPaused) && safety < 50) {
+            if (driver.isPaused) break
+            driver.bothPass()
+            safety++
+        }
+
+        // Force of Nature was sacrificed, then its LTB clause pinged every creature for 5.
+        // ourLion was a 2/2 → dies. opponentLion was a 2/2 → dies. Force of Nature itself
+        // already left when it was sacrificed, so the damage to "each creature" only hits
+        // the remaining battlefield creatures.
+        driver.findPermanent(active, "Force of Nature") shouldBe null
+        val activeGY = driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD))
+        activeGY shouldContain forceOfNature
+        activeGY shouldContain ourLion
+
+        val opponentGY = driver.state.getZone(ZoneKey(opponent, Zone.GRAVEYARD))
+        opponentGY shouldContain opponentLion
+    }
+
+    test("'may' clause: declining puts no permanent onto the battlefield and no triggers are scheduled") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val survivingFriendly = driver.putCreatureOnBattlefield(active, "Savannah Lions")
+        val survivingOpponent = driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+
+        // Keep a creature in hand so the "may put a creature from hand" decision is offered;
+        // we'll decline regardless.
+        driver.putCardInHand(active, "Force of Nature")
+        val terminalVelocity = driver.putCardInHand(active, "Terminal Velocity")
+        payTerminalVelocity(driver, active)
+
+        driver.castSpell(active, terminalVelocity)
+        driver.bothPass()
+
+        driver.isPaused shouldBe true
+        driver.submitCardSelection(active, emptyList())
+
+        // Nothing entered the battlefield, so no granted triggers can sneak through.
+        driver.findPermanent(active, "Force of Nature") shouldBe null
+
+        // Burn through the rest of the turn — surviving lions on both sides must persist
+        // (no LTB ping, no end-step sacrifice).
+        driver.passPriorityUntil(Step.END)
+        var safety = 0
+        while (driver.stackSize > 0 && !driver.isPaused && safety < 50) {
+            driver.bothPass()
+            safety++
+        }
+
+        driver.findPermanent(active, "Savannah Lions") shouldBe survivingFriendly
+        driver.findPermanent(opponent, "Savannah Lions") shouldBe survivingOpponent
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TezzeretCruelCaptainScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TezzeretCruelCaptainScenarioTest.kt
@@ -1,0 +1,211 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Tezzeret, Cruel Captain (EOE, {3}, Loyalty 4).
+ *
+ *   Whenever an artifact you control enters, put a loyalty counter on Tezzeret.
+ *   0: Untap target artifact or creature. If it's an artifact creature, put a +1/+1 counter on it.
+ *   −3: Search your library for an artifact card with mana value 1 or less, reveal it, put it into
+ *       your hand, then shuffle.
+ *   −7: You get an emblem with "At the beginning of combat on your turn, put three +1/+1 counters
+ *       on target artifact you control. If it's not a creature, it becomes a 0/0 Robot artifact
+ *       creature."
+ *
+ * Exercises the artifact-enters trigger (must fire only for artifacts), the 0 ability's
+ * "if it's an artifact creature" projection-gated counter, and the −7 emblem's grant-then-
+ * counter-then-BecomeCreature sequence (which is what makes a Vehicle/non-creature artifact
+ * end up as a 3/3 Robot, per the 2025-07-25 ruling).
+ */
+class TezzeretCruelCaptainScenarioTest : ScenarioTestBase() {
+
+    // {1} non-creature artifact, used as the cheap artifact in the enters-trigger test and as
+    // the target of the −7 emblem's "if it's not a creature" branch.
+    private val ironTrinket = CardDefinition.artifact(
+        name = "Iron Trinket",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    init {
+        cardRegistry.register(ironTrinket)
+
+        context("Tezzeret, Cruel Captain") {
+
+            test("an artifact you control entering puts a loyalty counter on Tezzeret") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tezzeret, Cruel Captain")
+                    .withCardInHand(1, "Iron Trinket")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tezzeret = game.findPermanent("Tezzeret, Cruel Captain")!!
+                game.state = game.state.updateEntity(tezzeret) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 4))
+                }
+
+                game.castSpell(1, "Iron Trinket").error shouldBe null
+                game.resolveStack()
+
+                withClue("artifact entered → Tezzeret gains the loyalty trigger") {
+                    loyalty(game, tezzeret) shouldBe 5
+                }
+            }
+
+            test("a non-artifact entering does NOT bump Tezzeret's loyalty") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tezzeret, Cruel Captain")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tezzeret = game.findPermanent("Tezzeret, Cruel Captain")!!
+                game.state = game.state.updateEntity(tezzeret) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 4))
+                }
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("non-artifact entering filtered out by GameObjectFilter.Artifact.youControl") {
+                    loyalty(game, tezzeret) shouldBe 4
+                }
+            }
+
+            test("0 ability untaps target artifact creature AND puts a +1/+1 counter on it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tezzeret, Cruel Captain")
+                    .withCardOnBattlefield(1, "Palladium Myr", tapped = true, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tezzeret = game.findPermanent("Tezzeret, Cruel Captain")!!
+                val myr = game.findPermanent("Palladium Myr")!!
+                game.state = game.state.updateEntity(tezzeret) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 4))
+                }
+
+                val zero = cardRegistry.getCard("Tezzeret, Cruel Captain")!!.script.activatedAbilities[0]
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tezzeret,
+                        abilityId = zero.id,
+                        targets = listOf(ChosenTarget.Permanent(myr))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("artifact creature → untapped and gains a +1/+1 counter") {
+                    game.state.getEntity(myr)?.has<TappedComponent>() shouldBe false
+                    plusOnePlusOne(game, myr) shouldBe 1
+                }
+            }
+
+            test("0 ability on a non-artifact creature untaps it but does NOT add a +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tezzeret, Cruel Captain")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = true, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tezzeret = game.findPermanent("Tezzeret, Cruel Captain")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.state = game.state.updateEntity(tezzeret) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 4))
+                }
+
+                val zero = cardRegistry.getCard("Tezzeret, Cruel Captain")!!.script.activatedAbilities[0]
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tezzeret,
+                        abilityId = zero.id,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("non-artifact creature → untapped but no +1/+1 counter") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe false
+                    plusOnePlusOne(game, bears) shouldBe 0
+                }
+            }
+
+            test("−7 emblem: at next begin-combat, target non-creature artifact gains three +1/+1 counters and becomes a 0/0 Robot artifact creature (so net 3/3)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tezzeret, Cruel Captain")
+                    .withCardOnBattlefield(1, "Iron Trinket")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tezzeret = game.findPermanent("Tezzeret, Cruel Captain")!!
+                val trinket = game.findPermanent("Iron Trinket")!!
+                game.state = game.state.updateEntity(tezzeret) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 7))
+                }
+
+                val minus7 = cardRegistry.getCard("Tezzeret, Cruel Captain")!!.script.activatedAbilities[2]
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tezzeret,
+                        abilityId = minus7.id
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("emblem persists after Tezzeret dies to SBA from 0 loyalty") {
+                    game.findPermanent("Tezzeret, Cruel Captain") shouldBe null
+                    game.state.globalGrantedTriggeredAbilities.size shouldBe 1
+                }
+
+                // Walk into the begin-combat step on the same turn — the emblem's
+                // "at the beginning of combat on your turn" trigger fires there and asks for
+                // a target. The only legal target is the lone artifact we control.
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.selectTargets(listOf(trinket))
+                game.resolveStack()
+
+                withClue("Iron Trinket got three +1/+1 counters AND became a 0/0 Robot") {
+                    plusOnePlusOne(game, trinket) shouldBe 3
+                    val projected = game.state.projectedState
+                    projected.isCreature(trinket) shouldBe true
+                    val pv = projected.getProjectedValues(trinket)
+                    pv?.power shouldBe 3
+                    pv?.toughness shouldBe 3
+                }
+            }
+        }
+    }
+
+    private fun loyalty(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    private fun plusOnePlusOne(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+}

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -544,13 +544,25 @@ export function enterPhase(
           maxTargets = validTargets.length
           flags.isSacrificeSelection = true
           break
-        case 'TapPermanents':
+        case 'TapPermanents': {
           validTargets = [...(costInfo.validTapTargets ?? [])]
-          minTargets = costInfo.tapCount ?? 1
-          maxTargets = costInfo.tapCount ?? 1
+          // `tapCount = 0` from the server is the TapXPermanents sentinel for "variable,
+          // equals the chosen X". The xSelection pipeline phase already ran and put the
+          // chosen value on action.xValue; use it as the required tap count so the prompt
+          // reads "Select 3/3" instead of "Select 0/0".
+          const xTapCount =
+            actionInfo.hasXCost &&
+            (action.type === 'ActivateAbility' || action.type === 'CastSpell') &&
+            typeof action.xValue === 'number'
+              ? action.xValue
+              : null
+          const requiredTaps = xTapCount ?? costInfo.tapCount ?? 1
+          minTargets = requiredTaps
+          maxTargets = requiredTaps
           flags.isSacrificeSelection = true
           flags.isTapPermanentSelection = true
           break
+        }
         case 'Conspire':
           validTargets = [...(costInfo.validTapTargets ?? [])]
           minTargets = costInfo.tapCount ?? 2


### PR DESCRIPTION
## Summary
- Implement the last two unimplemented EOE cards: Tezzeret, Cruel Captain
  (planeswalker, with a -7 emblem that puts +1/+1 counters on a target
  artifact and turns it into a 0/0 Robot artifact creature) and
  Terminal Velocity (cheat-into-play sorcery granting haste + LTB ping +
  end-step sacrifice). EOE is now 261/261.
- Engine fixes surfaced while playing the set:
  - CR 608.2b alignment in StackResolver / EffectContext / DealDamageExecutor —
    a sub-effect that references a target dropped at resolution now fizzles
    instead of shifting onto the next surviving target (Diplomatic Relations).
  - CR 704.5p enforcement in UnattachedAurasCheck — an Equipment that becomes
    a creature (Tezzeret's emblem on Atomic Microsizer) auto-unattaches.
  - Two-step UI pause for ActivateAbility costs that need a player choice:
    TapXPermanents (Secluded Starforge "Tap X artifacts") raises
    ChooseNumber → SelectCards instead of silently activating with X=0;
    ExileFromGraveyard (Rust Harvester) prompts the player to pick which
    graveyard card to exile instead of auto-picking the first match.
- Per-card bug fixes: Auxiliary Boosters attaches to its freshly-created
  Robot token (PipelineTarget instead of ContextTarget), Kavaron Harrier
  token is sacrificed rather than exiled at end of combat, Glacier Godmaw
  Landfall uses EffectTarget.Self inside ForEach, Larval Scoutlander gets an ETB regression test (its sacrifice gates the library search).
- Card metadata backfill (artist / flavorText / imageUri) on 14 EOE cards
  flagged by the set audit, plus Thrumming Hivepool's Sliver token image.

## Test plan
- [x] `just test` — full suite green
- [x] New scenario tests pass: DiplomaticRelationsPartialIllegalTargetTest,
      EquipmentAsCreatureUnattachTest, TezzeretCruelCaptainScenarioTest (5),
      TerminalVelocityScenarioTest (2), AuxiliaryBoostersAttachOnEtbTest,
      KavaronHarrierTest, LarvalScoutlanderScenarioTest,
      RustHarvesterExileCostChoiceTest, SecludedStarforgeTest UI-flow case
- [x] `just check-card-printing` clean for both new cards (canonical EOE)

