### PR TITLE
Add Jihad to Arabian Nights with opponent-choice SDK primitive

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 61 / 78
+**Implemented:** 62 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -19,7 +19,7 @@
 - [x] Army of Allah
 - [x] Camel
 - [ ] Eye for an Eye
-- [ ] Jihad
+- [x] Jihad
 - [x] King Suleiman
 - [x] Moorish Cavalry
 - [x] Piety

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2620,9 +2620,12 @@ EntersWithChoice(
 
 **Other `ChoiceType`s** — `ChoiceType.COLOR` writes `ChosenColorComponent` (read by
 `GrantChosenColor`), `ChoiceType.CREATURE_TYPE` writes `ChosenCreatureTypeComponent`,
-`ChoiceType.CREATURE_ON_BATTLEFIELD` writes `ChosenCreatureComponent`, and
+`ChoiceType.CREATURE_ON_BATTLEFIELD` writes `ChosenCreatureComponent`,
 `ChoiceType.BASIC_LAND_TYPE` writes `ChosenLandTypeComponent` (read by
-`SetEnchantedLandTypeFromChosen` and `GrantLandwalkOfChosenType`). Example — Phantasmal Terrain
+`SetEnchantedLandTypeFromChosen` and `GrantLandwalkOfChosenType`), and
+`ChoiceType.OPPONENT` writes an entity-id choice into the `CastChoicesComponent` under
+`ChoiceSlot.OPPONENT` — read back via the `Player.ChosenOpponent` reference (e.g. Jihad's
+anthem + state-trigger condition: `Exists(Player.ChosenOpponent, Zone.BATTLEFIELD, …)`). Example — Phantasmal Terrain
 ("As this Aura enters, choose a basic land type. Enchanted land is the chosen type."):
 
 ```kotlin

--- a/manual-scenarios/cards/j/jihad.json
+++ b/manual-scenarios/cards/j/jihad.json
@@ -1,0 +1,41 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Jihad", "Lightning Bolt"],
+    "battlefield": [
+      {"name": "Savannah Lions"},
+      {"name": "Mountain", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false},
+      {"name": "Plains", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": [
+      "Plains", "Plains", "Plains", "Plains", "Plains",
+      "Plains", "Plains", "Plains", "Plains", "Plains"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Mons's Goblin Raiders"},
+      {"name": "Mountain", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain", "Mountain", "Mountain", "Mountain", "Mountain",
+      "Mountain", "Mountain", "Mountain", "Mountain", "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
@@ -39,4 +39,12 @@ enum class ChoiceSlot {
 
     /** The X declared for a `blight X` additional cost when cast (e.g. Soul Immolation). */
     BLIGHT_AMOUNT,
+
+    /**
+     * An opponent chosen as the object entered, stored as a [ChoiceValue.EntityChoice]
+     * carrying the player entity id (e.g. Jihad "as this enchantment enters, choose
+     * a color and an opponent"). Read back through the
+     * [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent] reference.
+     */
+    OPPONENT,
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -979,7 +979,17 @@ enum class ChoiceType {
      * [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent]
      * and read by [com.wingedsheep.sdk.scripting.SetEnchantedLandTypeFromChosen].
      */
-    BASIC_LAND_TYPE
+    BASIC_LAND_TYPE,
+    /**
+     * Choose an opponent (e.g., Jihad: "As this enchantment enters, choose a color
+     * and an opponent"). Stored on the permanent in a
+     * [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent]
+     * under [com.wingedsheep.sdk.scripting.ChoiceSlot.OPPONENT] as a
+     * [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.EntityChoice]
+     * holding the chosen player's entity id, and read back through
+     * [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent].
+     */
+    OPPONENT
 }
 
 /**
@@ -1064,6 +1074,11 @@ data class EntersWithChoice(
             "As this permanent enters, an opponent chooses a basic land type"
         } else {
             "As this permanent enters, choose a basic land type"
+        }
+        ChoiceType.OPPONENT -> if (chooser == Player.Opponent) {
+            "As this permanent enters, an opponent chooses an opponent"
+        } else {
+            "As this permanent enters, choose an opponent"
         }
     }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
@@ -112,6 +112,23 @@ sealed interface Player {
     // Relational Player References
     // =============================================================================
 
+    /**
+     * The opponent locked into the source's [com.wingedsheep.sdk.scripting.ChoiceSlot.OPPONENT]
+     * slot (set by an `EntersWithChoice(ChoiceType.OPPONENT, …)` replacement effect).
+     * Resolves to that stored player entity id; null if no opponent has been chosen on
+     * the source.
+     *
+     * Used by cards like Jihad ("White creatures get +2/+1 as long as the chosen player
+     * controls a nontoken permanent of the chosen color") — `Exists(Player.ChosenOpponent,
+     * Zone.BATTLEFIELD, …)` reads the chosen opponent from the source's
+     * [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent].
+     */
+    @SerialName("ChosenOpponent")
+    @Serializable
+    data object ChosenOpponent : Player {
+        override val description: String = "the chosen player"
+    }
+
     /** Controller of a permanent (used with EffectTarget) */
     @SerialName("ControllerOf")
     @Serializable
@@ -144,6 +161,7 @@ sealed interface Player {
             is ContextPlayer -> "that player's"
             Candidate -> "that player's"
             TriggeringPlayer -> "that player's"
+            ChosenOpponent -> "the chosen player's"
             is ControllerOf -> "its controller's"
             is OwnerOf -> "its owner's"
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Jihad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Jihad.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Jihad
+ * {W}{W}{W}
+ * Enchantment
+ *
+ * As this enchantment enters, choose a color and an opponent.
+ * White creatures get +2/+1 as long as the chosen player controls a nontoken
+ * permanent of the chosen color.
+ * When the chosen player controls no nontoken permanents of the chosen color,
+ * sacrifice this enchantment.
+ */
+val Jihad = card("Jihad") {
+    manaCost = "{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "As this enchantment enters, choose a color and an opponent.\n" +
+        "White creatures get +2/+1 as long as the chosen player controls a nontoken " +
+        "permanent of the chosen color.\n" +
+        "When the chosen player controls no nontoken permanents of the chosen color, " +
+        "sacrifice this enchantment."
+
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+    replacementEffect(EntersWithChoice(ChoiceType.OPPONENT))
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.withColor(Color.WHITE))
+        )
+        condition = Exists(
+            player = Player.ChosenOpponent,
+            zone = Zone.BATTLEFIELD,
+            filter = GameObjectFilter.Permanent.sharingChosenColorWithSource().nontoken()
+        )
+    }
+
+    stateTriggeredAbility {
+        condition = Exists(
+            player = Player.ChosenOpponent,
+            zone = Zone.BATTLEFIELD,
+            filter = GameObjectFilter.Permanent.sharingChosenColorWithSource().nontoken(),
+            negate = true
+        )
+        effect = Effects.SacrificeTarget(EffectTarget.Self)
+        description = "When the chosen player controls no nontoken permanents of " +
+            "the chosen color, sacrifice this enchantment"
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "5"
+        artist = "Brian Snõddy"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6c7705a-2987-4ef1-92b1-2c55d989ec6f.jpg?1740685879"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -1594,6 +1594,83 @@
     }
 }
 
+// Jihad
+{
+    "name": "Jihad",
+    "manaCost": "{W}{W}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "As this enchantment enters, choose a color and an opponent.\nWhite creatures get +2/+1 as long as the chosen player controls a nontoken permanent of the chosen color.\nWhen the chosen player controls no nontoken permanents of the chosen color, sacrifice this enchantment.",
+    "script": {
+        "stateTriggeredAbilities": [
+            {
+                "id": "ability_1",
+                "condition": {
+                    "type": "Exists",
+                    "player": "ChosenOpponent",
+                    "zone": "Battlefield",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsPermanent",
+                            "SharesChosenColorWithSource",
+                            "IsNontoken"
+                        ]
+                    },
+                    "negate": true
+                },
+                "effect": {
+                    "type": "SacrificeTarget",
+                    "target": "Self"
+                },
+                "descriptionOverride": "When the chosen player controls no nontoken permanents of the chosen color, sacrifice this enchantment"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "creature white"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "ChosenOpponent",
+                    "zone": "Battlefield",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsPermanent",
+                            "SharesChosenColorWithSource",
+                            "IsNontoken"
+                        ]
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "COLOR"
+            },
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "OPPONENT"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "RARE",
+        "artist": "Brian Snõddy",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6c7705a-2987-4ef1-92b1-2c55d989ec6f.jpg?1740685879"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Junún Efreet
 {
     "name": "Junún Efreet",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -205,7 +205,15 @@ data class EntersWithChoiceSpellContinuation(
      * positionally aligned list of basic land type options presented. The response's
      * chosen index indexes into this list.
      */
-    val landTypes: List<String> = emptyList()
+    val landTypes: List<String> = emptyList(),
+    /**
+     * For [com.wingedsheep.sdk.scripting.ChoiceType.OPPONENT] choices, the positionally
+     * aligned list of candidate opponent player entity ids presented in the decision.
+     * The response's chosen index indexes into this list to recover the player id
+     * stored on the resulting `CastChoicesComponent` under
+     * [com.wingedsheep.sdk.scripting.ChoiceSlot.OPPONENT].
+     */
+    val opponentIds: List<EntityId> = emptyList()
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.state.components.battlefield.CastFromHandComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.EnteredViaAbilityComponent
+import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
 import com.wingedsheep.engine.state.components.battlefield.HasDealtCombatDamageToPlayerComponent
 import com.wingedsheep.engine.state.components.battlefield.HasDealtDamageComponent
 import com.wingedsheep.engine.state.components.battlefield.CastRecordComponent
@@ -393,7 +394,12 @@ class ConditionEvaluator(
         val projected = ctx.projectedStateFor(state)
         val predicateContext = when (ctx) {
             is Resolution -> PredicateContext.fromEffectContext(ctx.effectContext)
-            is Projection -> controllerId?.let { PredicateContext(controllerId = it) } ?: return condition.negate
+            is Projection -> controllerId?.let {
+                // Pass `sourceId` through so source-reading predicates (e.g.
+                // `sharingChosenColorWithSource`) can find the source's
+                // `CastChoicesComponent` during static-ability gating.
+                PredicateContext(controllerId = it, sourceId = ctx.sourceId)
+            } ?: return condition.negate
         }
 
         val playerIds: List<EntityId> = when (condition.player) {
@@ -403,6 +409,9 @@ class ConditionEvaluator(
             is Player.Each -> state.turnOrder
             is Player.Any -> state.turnOrder
             is Player.Candidate -> listOfNotNull((ctx as? Resolution)?.effectContext?.candidatePlayerId)
+            is Player.ChosenOpponent -> listOfNotNull(
+                ctx.sourceId?.let { state.getEntity(it)?.chosenOpponent() }
+            )
             else -> controllerId?.let { listOf(it) } ?: emptyList()
         }
 
@@ -529,6 +538,9 @@ class ConditionEvaluator(
             }
             is Player.TriggeringPlayer -> (ctx as? Resolution)?.effectContext?.triggeringPlayerId
             is Player.Candidate -> (ctx as? Resolution)?.effectContext?.candidatePlayerId
+            is Player.ChosenOpponent -> ctx.sourceId?.let { sourceId ->
+                state.getEntity(sourceId)?.chosenOpponent()
+            }
             else -> null
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
 import com.wingedsheep.engine.state.components.battlefield.blightAmountChoice
+import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsStationUsingToughnessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -696,6 +697,9 @@ class DynamicAmountEvaluator(
                 listOf(activePlayer) + state.turnOrder.filter { it != activePlayer }
             }
             is Player.Candidate -> listOfNotNull(context.candidatePlayerId)
+            is Player.ChosenOpponent -> listOfNotNull(
+                context.sourceId?.let { state.getEntity(it)?.chosenOpponent() }
+            )
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -455,6 +455,14 @@ class PlayLandHandler(
                             ExecutionResult.paused(pausedState, decision, events)
                         }
                     }
+
+                    ChoiceType.OPPONENT -> {
+                        // Lands don't currently use the OPPONENT choice type, but the branch is
+                        // present so [ChoiceType]'s exhaustive `when` compiles. If a future
+                        // land needs "choose an opponent" on entry, wire the prompt + opponent-id
+                        // continuation here, matching the spell path in [StackResolver].
+                        null
+                    }
                 }
                 if (result != null) return result
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -571,6 +571,16 @@ class ModalAndCloneContinuationResumer(
                     c.withCastChoice(ChoiceSlot.LAND_TYPE, ChoiceValue.TextChoice(chosenType))
                 }
             }
+            com.wingedsheep.sdk.scripting.ChoiceType.OPPONENT -> {
+                if (response !is OptionChosenResponse) {
+                    return ExecutionResult.error(state, "Expected option chosen response for opponent choice")
+                }
+                val chosenOpponent = continuation.opponentIds.getOrNull(response.optionIndex)
+                    ?: return ExecutionResult.error(state, "Invalid opponent index: ${response.optionIndex}")
+                state.updateEntity(spellId) { c ->
+                    c.withCastChoice(ChoiceSlot.OPPONENT, ChoiceValue.EntityChoice(chosenOpponent))
+                }
+            }
         }
 
         // Check if the card has remaining choices to chain to
@@ -670,6 +680,11 @@ class ModalAndCloneContinuationResumer(
                 state.updateEntity(continuation.landId) { c ->
                     c.withCastChoice(ChoiceSlot.LAND_TYPE, ChoiceValue.TextChoice(chosenType))
                 }
+            }
+            com.wingedsheep.sdk.scripting.ChoiceType.OPPONENT -> {
+                // Lands don't currently surface an opponent choice (no land card uses it),
+                // but the branch is here for exhaustiveness over [ChoiceType].
+                return checkForMore(state, emptyList())
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2572,6 +2572,44 @@ class StackResolver(
                     .withPendingDecision(decision)
                 ExecutionResult.paused(pausedState, decision)
             }
+
+            ChoiceType.OPPONENT -> {
+                // CR 614.12a — replacement-effect choices that modify how a permanent enters
+                // are made before the permanent enters. We surface the opponent prompt now so
+                // the chosen opponent is durably recorded in [CastChoicesComponent]. In a 1v1
+                // game this collapses to a forced choice but the prompt is still surfaced.
+                val opponentIds = state.turnOrder.filter { it != chooserId }
+                if (opponentIds.isEmpty()) return null
+                val opponentNames = opponentIds.map { pid ->
+                    state.getEntity(pid)
+                        ?.get<com.wingedsheep.engine.state.components.identity.PlayerComponent>()?.name
+                        ?: "Player ${pid.value}"
+                }
+                val decisionId = "choose-opponent-enters-${spellId.value}"
+                val decision = ChooseOptionDecision(
+                    id = decisionId,
+                    playerId = chooserId,
+                    prompt = "Choose an opponent",
+                    context = DecisionContext(
+                        sourceId = spellId,
+                        sourceName = cardComponent.name,
+                        phase = DecisionPhase.RESOLUTION
+                    ),
+                    options = opponentNames
+                )
+                val continuation = EntersWithChoiceSpellContinuation(
+                    decisionId = decisionId,
+                    spellId = spellId,
+                    controllerId = controllerId,
+                    ownerId = ownerId,
+                    choiceType = ChoiceType.OPPONENT,
+                    opponentIds = opponentIds
+                )
+                val pausedState = state
+                    .pushContinuation(continuation)
+                    .withPendingDecision(decision)
+                ExecutionResult.paused(pausedState, decision)
+            }
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
@@ -106,6 +106,10 @@ fun ComponentContainer.chosenModeId(): String? =
 fun ComponentContainer.chosenCreatureRef(): EntityId? =
     (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CREATURE) as? ChoiceValue.EntityChoice)?.entityId
 
+/** The opponent chosen as this object entered (a player entity id), or null. */
+fun ComponentContainer.chosenOpponent(): EntityId? =
+    (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.OPPONENT) as? ChoiceValue.EntityChoice)?.entityId
+
 /** Whether this object was cast kicked. */
 fun ComponentContainer.wasKickedChoice(): Boolean =
     get<CastChoicesComponent>()?.chosen?.containsKey(ChoiceSlot.KICKED) == true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JihadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JihadScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Jihad (ARN) — exercises two pieces that didn't exist before this card:
+ *  - the [ChoiceSlot.OPPONENT] cast-choice slot + [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent]
+ *    reference (read by the static anthem's condition and the state-trigger condition);
+ *  - the `nontoken()` × `sharingChosenColorWithSource()` filter composition pinning the buff to
+ *    *nontoken* permanents of the *chosen* color on the *chosen* player.
+ *
+ * The ETB cast-choice flow itself (color + opponent prompt → resumer writes the bag) is covered
+ * by Riptide Replicator / Callous Oppressor style tests for [ChoiceSlot.COLOR]; here we set the
+ * bag directly to isolate the *reading* paths and avoid duplicating decision-loop plumbing.
+ */
+class JihadScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Jihad — static anthem + state-trigger sacrifice gated on chosen player + color") {
+
+            test("anthem applies while the chosen opponent controls a nontoken permanent of the chosen color") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Jihad")
+                    .withCardOnBattlefield(1, "Glory Seeker")          // white creature on owner's side
+                    .withCardOnBattlefield(2, "Mons's Goblin Raiders")            // chosen player controls a red permanent
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val jihad = game.findPermanent("Jihad")!!
+                val whiteCreature = game.findPermanent("Glory Seeker")!!
+                game.state = game.state.updateEntity(jihad) { c ->
+                    c.with(
+                        CastChoicesComponent(
+                            chosen = mapOf(
+                                ChoiceSlot.COLOR to ChoiceValue.ColorChoice(Color.RED),
+                                ChoiceSlot.OPPONENT to ChoiceValue.EntityChoice(game.player2Id)
+                            )
+                        )
+                    )
+                }
+
+                game.resolveStack()
+
+                withClue("Glory Seeker (2/2) should be +2/+1 while chosen opponent controls a red nontoken permanent") {
+                    projector.getProjectedPower(game.state, whiteCreature) shouldBe (2 + 2)
+                    projector.getProjectedToughness(game.state, whiteCreature) shouldBe (2 + 1)
+                }
+                withClue("Jihad should remain on the battlefield while the condition holds") {
+                    game.isOnBattlefield("Jihad") shouldBe true
+                }
+            }
+
+            test("tokens do not count — chosen opponent only has a red token, so Jihad is sacrificed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Jihad")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    // Only thing the chosen opponent controls of the chosen color is a TOKEN —
+                    // `nontoken()` excludes it, so the condition is false from the start.
+                    .withCardOnBattlefield(2, "Mons's Goblin Raiders", isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val jihad = game.findPermanent("Jihad")!!
+                val whiteCreature = game.findPermanent("Glory Seeker")!!
+                game.state = game.state.updateEntity(jihad) { c ->
+                    c.with(
+                        CastChoicesComponent(
+                            chosen = mapOf(
+                                ChoiceSlot.COLOR to ChoiceValue.ColorChoice(Color.RED),
+                                ChoiceSlot.OPPONENT to ChoiceValue.EntityChoice(game.player2Id)
+                            )
+                        )
+                    )
+                }
+
+                // Sanity check: the token *exists* on the battlefield as a permanent...
+                val tokenId = game.findPermanent("Mons's Goblin Raiders")!!
+                game.state.getEntity(tokenId)?.has<TokenComponent>() shouldBe true
+
+                // ...but the anthem is OFF (filter rejects tokens).
+                projector.getProjectedPower(game.state, whiteCreature) shouldBe 2
+                projector.getProjectedToughness(game.state, whiteCreature) shouldBe 2
+
+                // Run the state-trigger poller: with no *nontoken* red permanent on the chosen
+                // opponent's side, Jihad's state trigger fires and sacrifices it.
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("Jihad's state-triggered ability should sacrifice it") {
+                    game.isOnBattlefield("Jihad") shouldBe false
+                }
+            }
+
+            test("untargeted opponent's permanents are ignored — Jihad is sacrificed even if a non-chosen player controls the color") {
+                // 3 players' worth of state isn't supported by the 2-player scenario harness;
+                // we model the "ignored player" angle by having the controller themselves hold
+                // the chosen color while the chosen opponent holds nothing of it.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Jihad")
+                    .withCardOnBattlefield(1, "Mountain")    // controller owns the red permanent, NOT the chosen opponent
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val jihad = game.findPermanent("Jihad")!!
+                game.state = game.state.updateEntity(jihad) { c ->
+                    c.with(
+                        CastChoicesComponent(
+                            chosen = mapOf(
+                                ChoiceSlot.COLOR to ChoiceValue.ColorChoice(Color.RED),
+                                ChoiceSlot.OPPONENT to ChoiceValue.EntityChoice(game.player2Id)
+                            )
+                        )
+                    )
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("Only the chosen opponent's permanents satisfy the condition") {
+                    game.isOnBattlefield("Jihad") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JihadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JihadScenarioTest.kt
@@ -1,8 +1,14 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.OptionChosenResponse
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
 import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.battlefield.chosenColor
+import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Color
@@ -136,6 +142,69 @@ class JihadScenarioTest : ScenarioTestBase() {
 
                 withClue("Only the chosen opponent's permanents satisfy the condition") {
                     game.isOnBattlefield("Jihad") shouldBe false
+                }
+            }
+
+            test("casting Jihad walks the color → opponent choice chain and records both on the cast-choices bag") {
+                // Unlike the cases above (which seed the bag directly to isolate the reading
+                // paths), this one casts Jihad from hand and answers the prompts, exercising the
+                // OPPONENT pause/resume plumbing: StackResolver.pauseForEntersWithChoice +
+                // ModalAndCloneContinuationResumer writing ChoiceSlot.OPPONENT from opponentIds.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Jihad")
+                    .withLandsOnBattlefield(1, "Plains", 3)             // pay {W}{W}{W}
+                    .withCardOnBattlefield(1, "Glory Seeker")           // white creature to observe the anthem
+                    .withCardOnBattlefield(2, "Mons's Goblin Raiders")  // chosen opponent's red nontoken permanent
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val whiteCreature = game.findPermanent("Glory Seeker")!!
+
+                val cast = game.castSpell(1, "Jihad")
+                withClue("Casting Jihad ({W}{W}{W}) should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                // CR 614.12a — the as-it-enters choices are made before Jihad enters. The engine
+                // surfaces them in ChoiceType ordinal order: COLOR first, then OPPONENT.
+                game.resolveStack()
+                val colorDecision = game.state.pendingDecision
+                withClue("Jihad should pause for the color choice first") {
+                    (colorDecision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(colorDecision!!.id, Color.RED))
+
+                // Resolving the color choice chains straight into the opponent choice.
+                val opponentDecision = game.state.pendingDecision
+                withClue("Jihad should then pause for the opponent choice") {
+                    (opponentDecision is ChooseOptionDecision) shouldBe true
+                }
+                val options = (opponentDecision as ChooseOptionDecision).options
+                val player2Index = options.indexOf("Player2")
+                withClue("The lone opponent should be offered as a choice, options were $options") {
+                    (player2Index >= 0) shouldBe true
+                }
+                game.submitDecision(OptionChosenResponse(opponentDecision.id, player2Index))
+
+                game.resolveStack()
+
+                val jihadEntity = game.state.getEntity(game.findPermanent("Jihad")!!)!!
+                withClue("Jihad should have resolved onto the battlefield") {
+                    game.isOnBattlefield("Jihad") shouldBe true
+                }
+                withClue("The chosen-color slot should hold the picked color (RED)") {
+                    jihadEntity.chosenColor() shouldBe Color.RED
+                }
+                withClue("The chosen-opponent slot should hold the picked player's entity id") {
+                    jihadEntity.chosenOpponent() shouldBe game.player2Id
+                }
+
+                // End-to-end: the recorded color + opponent actually drive the anthem.
+                withClue("Glory Seeker (2/2) should be +2/+1 from Jihad's anthem") {
+                    projector.getProjectedPower(game.state, whiteCreature) shouldBe (2 + 2)
+                    projector.getProjectedToughness(game.state, whiteCreature) shouldBe (2 + 1)
                 }
             }
         }


### PR DESCRIPTION
Jihad's "as it enters, choose a color and an opponent" needed a new ETB choice slot that stores a player entity. The card's anthem and state- trigger sacrifice both read this slot via a new `Player.ChosenOpponent` reference, composed with existing `Exists` + `sharingChosenColorWithSource`
+ `nontoken` filter pieces — no card-specific code in the engine.

Engine side:
- `ChoiceSlot.OPPONENT` + `ChoiceType.OPPONENT` + `chosenOpponent()` accessor on `CastChoicesComponent`, reusing the existing `ChoiceValue.EntityChoice` carrier.
- `Player.ChosenOpponent` resolver wired into `ConditionEvaluator` (both per-player conditions and `Exists`) and `DynamicAmountEvaluator`.
- `EntersWithChoice` pause/resume path: `StackResolver.pauseForEntersWithChoice` emits a `ChooseOptionDecision` listing opponent names; the resumer writes the picked player id back into the cast-choices bag. Exhaustiveness branch added to the land path for symmetry.
- Fix: `ConditionEvaluator.evaluateExistsCtx` was dropping `sourceId` when building the `PredicateContext` in projection mode, breaking source-reading predicates like `sharingChosenColorWithSource` inside any static-ability gating condition. Jihad's anthem is the first card to hit this path; the fix is generic.