### PR TITLE
Implement OTJ batch 1: Aloe Alchemist, Ankle Biter, Armored Armadillo, Bridled Bighorn

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1417,6 +1417,10 @@ Triggers.youCastSpell(
   of Spring); the inline-static cards (Overabundance, Pulse) use the mana statics in §9 instead.
 - `YouCommitCrime` — MKM crime mechanic.
 - `YouGiveAGift` — Gift mechanic.
+- `BecomesPlotted` — OTJ Plot (CR 718) — "when this card becomes plotted". SELF binding; fires for the
+  very card that was plotted while it sits face up in exile (Aloe Alchemist). Detected by
+  `TriggerDetector.detectPlottedCardTriggers` off the plot special action's `CardPlottedEvent`, since
+  the card is never on the battlefield for the index loop to see.
 - `Valiant` — Bloomburrow Valiant trigger.
 - `RoomFullyUnlocked` — Rooms — both doors unlocked.
 - `OnDoorUnlocked` — single Room door unlocked.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1109,6 +1109,20 @@ object Triggers {
     )
 
     // =========================================================================
+    // Plot Triggers (Outlaws of Thunder Junction)
+    // =========================================================================
+
+    /**
+     * When this card becomes plotted (CR 718). SELF binding — fires for the very card that
+     * was plotted, while it sits face up in exile. Used by Aloe Alchemist: "When this card
+     * becomes plotted, target creature gets +3/+2 and gains trample until end of turn."
+     */
+    val BecomesPlotted: TriggerSpec = TriggerSpec(
+        event = BecomesPlottedEvent,
+        binding = TriggerBinding.SELF
+    )
+
+    // =========================================================================
     // Gift Triggers
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -843,6 +843,21 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
+     * When this card becomes plotted (Outlaws of Thunder Junction). A Plot card's controller
+     * pays the plot cost and exiles it from hand face up as a special action — the card is then
+     * marked plotted (CR 718). This is a SELF-scoped trigger: it fires only for the very card
+     * that became plotted, while it sits in exile.
+     *
+     * Used by cards like Aloe Alchemist: "When this card becomes plotted, target creature gets
+     * +3/+2 and gains trample until end of turn."
+     */
+    @SerialName("BecomesPlottedEvent")
+    @Serializable
+    data object BecomesPlottedEvent : EventPattern {
+        override val description: String = "this card becomes plotted"
+    }
+
+    /**
      * When a player chooses one or more targets.
      *
      * Fires when [player] casts a spell, activates an ability, or puts a triggered ability

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AloeAlchemist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AloeAlchemist.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Aloe Alchemist
+ * {1}{G}
+ * Creature — Plant Warlock
+ * 3/2
+ * Trample
+ * When this card becomes plotted, target creature gets +3/+2 and gains trample until end of turn.
+ * Plot {1}{G}
+ */
+val AloeAlchemist = card("Aloe Alchemist") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Warlock"
+    power = 3
+    toughness = 2
+    oracleText = "Trample\n" +
+        "When this card becomes plotted, target creature gets +3/+2 and gains trample until end of turn.\n" +
+        "Plot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    keywords(Keyword.TRAMPLE)
+    keywordAbility(KeywordAbility.plot("{1}{G}"))
+
+    triggeredAbility {
+        trigger = Triggers.BecomesPlotted
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(power = 3, toughness = 2, target = t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, target = t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "152"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/69f2f632-b6cc-4092-acd5-a6b152e90488.jpg?1712355875"
+
+        ruling("2024-04-12", "Plot abilities are written \"Plot [cost],\" which means \"Any time you have priority during your main phase while the stack is empty, you may pay [cost] and exile this card from your hand. It becomes plotted.\"")
+        ruling("2024-04-12", "Aloe Alchemist's triggered ability triggers when it becomes plotted, not when you cast it from exile. You choose the target as the ability is put onto the stack.")
+        ruling("2024-04-12", "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AnkleBiter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/AnkleBiter.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ankle Biter
+ * {G}
+ * Creature — Snake
+ * 1/1
+ * Deathtouch
+ */
+val AnkleBiter = card("Ankle Biter") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Snake"
+    power = 1
+    toughness = 1
+    oracleText = "Deathtouch"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Monztre"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/424972d6-3b2c-449b-b786-749a77020fa1.jpg?1712355878"
+        flavorText = "\"Little tip, newcomer. Give your boots a shake in the morning before you put them on.\"\n—Annie Flash, to Kellan"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ArmoredArmadillo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ArmoredArmadillo.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Armored Armadillo
+ * {W}
+ * Creature — Armadillo
+ * 0/4
+ * Ward {1}
+ * {3}{W}: This creature gets +X/+0 until end of turn, where X is its toughness.
+ */
+val ArmoredArmadillo = card("Armored Armadillo") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Armadillo"
+    power = 0
+    toughness = 4
+    oracleText = "Ward {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\n" +
+        "{3}{W}: This creature gets +X/+0 until end of turn, where X is its toughness."
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{1}")))
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{W}")
+        effect = Effects.ModifyStats(
+            power = DynamicAmounts.sourceToughness(),
+            toughness = DynamicAmount.Fixed(0),
+            target = EffectTarget.Self
+        )
+        description = "{3}{W}: This creature gets +X/+0 until end of turn, where X is its toughness."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Leon Tukker"
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/263232df-69b8-4205-93ad-c724fe57ec11.jpg?1712355235"
+        flavorText = "\"I always wanted to ride a slow cannonball with legs!\"\n—Kellan"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BridledBighorn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BridledBighorn.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Bridled Bighorn
+ * {3}{W}
+ * Creature — Sheep Mount
+ * 3/4
+ * Vigilance
+ * Whenever this creature attacks while saddled, create a 1/1 white Sheep creature token.
+ * Saddle 2 (Tap any number of other creatures you control with total power 2 or more:
+ * This Mount becomes saddled until end of turn. Saddle only as a sorcery.)
+ */
+val BridledBighorn = card("Bridled Bighorn") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Sheep Mount"
+    power = 3
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "Whenever this creature attacks while saddled, create a 1/1 white Sheep creature token.\n" +
+        "Saddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)"
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.saddle(2))
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.SourceIsSaddled
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Sheep"),
+            imageUri = "https://cards.scryfall.io/normal/front/d/c/dccb30d0-b491-43be-8aa0-2ee7da86343e.jpg?1712469939"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Edgar Sánchez Hidalgo"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa7bf089-fa9b-4ffc-bf84-45cd51c76463.jpg?1712355251"
+
+        ruling("2024-04-12", "A Mount's saddled status lasts until end of turn, but its abilities that care about it being saddled work only while it remains saddled.")
+        ruling("2024-04-12", "Saddle doesn't change whether the Mount can attack. It's saddled the same way whether or not it attacks.")
+        ruling("2024-04-12", "You can saddle a Mount even if it's already saddled, but doing so has no additional effect.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -1,3 +1,173 @@
+// Aloe Alchemist
+{
+    "name": "Aloe Alchemist",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Plant Warlock",
+    "oracleText": "Trample\nWhen this card becomes plotted, target creature gets +3/+2 and gains trample until end of turn.\nPlot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{1}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesPlottedEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "UNCOMMON",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/69f2f632-b6cc-4092-acd5-a6b152e90488.jpg?1712355875",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "Plot abilities are written \"Plot [cost],\" which means \"Any time you have priority during your main phase while the stack is empty, you may pay [cost] and exile this card from your hand. It becomes plotted.\""
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Aloe Alchemist's triggered ability triggers when it becomes plotted, not when you cast it from exile. You choose the target as the ability is put onto the stack."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can't cast a plotted card on the same turn it became plotted. On any future turn, you may cast that card from exile without paying its mana cost during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Ankle Biter
+{
+    "name": "Ankle Biter",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Snake",
+    "oracleText": "Deathtouch",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Monztre",
+        "flavorText": "\"Little tip, newcomer. Give your boots a shake in the morning before you put them on.\"\n—Annie Flash, to Kellan",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/424972d6-3b2c-449b-b786-749a77020fa1.jpg?1712355878"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Armored Armadillo
+{
+    "name": "Armored Armadillo",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Armadillo",
+    "oracleText": "Ward {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\n{3}{W}: This creature gets +X/+0 until end of turn, where X is its toughness.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{1}"
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{3}{W}"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Toughness"
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{3}{W}: This creature gets +X/+0 until end of turn, where X is its toughness."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Leon Tukker",
+        "flavorText": "\"I always wanted to ride a slow cannonball with legs!\"\n—Kellan",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/263232df-69b8-4205-93ad-c724fe57ec11.jpg?1712355235"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Blacksnag Buzzard
 {
     "name": "Blacksnag Buzzard",
@@ -189,6 +359,79 @@
     "colorIdentityOverride": [
         "GREEN",
         "BLUE"
+    ]
+}
+
+// Bridled Bighorn
+{
+    "name": "Bridled Bighorn",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Sheep Mount",
+    "oracleText": "Vigilance\nWhenever this creature attacks while saddled, create a 1/1 white Sheep creature token.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE",
+        "SADDLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "SADDLE",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Sheep"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/c/dccb30d0-b491-43be-8aa0-2ee7da86343e.jpg?1712469939"
+                },
+                "triggerCondition": {
+                    "type": "SourceMatches",
+                    "filter": {
+                        "statePredicates": [
+                            "IsSaddled"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Edgar Sánchez Hidalgo",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa7bf089-fa9b-4ffc-bf84-45cd51c76463.jpg?1712355251",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A Mount's saddled status lasts until end of turn, but its abilities that care about it being saddled work only while it remains saddled."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Saddle doesn't change whether the Mount can attack. It's saddled the same way whether or not it attacks."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can saddle a Mount even if it's already saddled, but doing so has no additional effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -12,6 +12,8 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("WhenAPlayerCastsASpell", "trigger: a player casts a spell (Triggers.YouCastSpell / AnyPlayerCastsSpell / OpponentCastsSpell + type filters)")
     supported("AtTheBeginningOfAPlayersUpkeep", "trigger: upkeep (Triggers.YourUpkeep / EachUpkeep / EachOpponentUpkeep)")
     supported("AtTheBeginningOfAPlayersEndStep", "trigger: end step (Triggers.YourEndStep / EachEndStep)")
+    // OTJ Plot (CR 718) — "When this card becomes plotted, …" (Triggers.BecomesPlotted, Aloe Alchemist).
+    supported("WhenACardBecomesPlotted", "trigger: this card becomes plotted (Triggers.BecomesPlotted)")
     supported("WhenAPermanentBecomesTheTargetOfASpellOrAbility", "trigger: becomes target (Triggers.BecomesTargetByOpponent / BecomesTarget / CreatureYouControlBecomesTargetByOpponent)")
 
     // Intervening-if conditions (CR 603.4) gating a TriggerI, plus the Mount "while saddled" gate. The

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -670,22 +670,30 @@ internal fun EmitCtx.asEntersBlock(rule: JsonObject): List<Stmt>? {
 }
 
 /**
- * A `FromAnyZone { TriggerA { WhenAPlayerCyclesACard(You, this) ... } }` rule -> a triggered ability
- * with `trigger = Triggers.YouCycleThis` ("When you cycle this card, [bonus]"). A lone `you may` bonus
- * becomes `optional = true`, mirroring [triggerBlock].
+ * A `FromAnyZone { TriggerA { <trigger>(this) ... } }` rule -> a triggered ability. The two
+ * self-on-this-card shapes recognised:
+ *   - `WhenAPlayerCyclesACard(You, ThisCardInHand)` -> `Triggers.YouCycleThis` ("When you cycle this
+ *     card, [bonus]").
+ *   - `WhenACardBecomesPlotted(ThisCardInHand)` -> `Triggers.BecomesPlotted` ("When this card becomes
+ *     plotted, [bonus]", OTJ Plot / CR 718 — Aloe Alchemist).
+ * A lone `you may` bonus becomes `optional = true`, mirroring [triggerBlock].
  */
 internal fun EmitCtx.fromAnyZoneBlock(rule: JsonObject): List<Stmt>? {
     val inner = rule["args"] as? JsonObject
     if (inner?.strField("_Rule") != "TriggerA" ||
-        !jsonContains(inner, "_Trigger", "WhenAPlayerCyclesACard") ||
         !jsonContains(inner, "_CardInHand", "ThisCardInHand")) { reasons.add("FromAnyZone"); return null }
+    val triggerSpec = when {
+        jsonContains(inner, "_Trigger", "WhenAPlayerCyclesACard") -> "Triggers.YouCycleThis"
+        jsonContains(inner, "_Trigger", "WhenACardBecomesPlotted") -> "Triggers.BecomesPlotted"
+        else -> { reasons.add("FromAnyZone"); return null }
+    }
     val (targets, actions) = extractEnvelope(inner)
     if (actions == null) { reasons.add("FromAnyZone"); return null }
     val (tnode, tvar) = spellTargetExpr(targets, actions) ?: return null
     val mayWrapped = actions.singleOrNull()?.strField("_Action") == "MayAction"
     val effectActions = if (mayWrapped) listOf(innerAction(actions.single()) ?: return null) else actions
     val edsl = renderEffectList(effectActions, tvar) ?: return null
-    val stmts = mutableListOf<Stmt>(Assign("trigger", Lit("Triggers.YouCycleThis")))
+    val stmts = mutableListOf<Stmt>(Assign("trigger", Lit(triggerSpec)))
     if (mayWrapped) stmts.add(Assign("optional", Lit("true")))
     if (tvar != null) stmts.add(targetLocal(tnode!!))
     stmts.add(Assign("effect", edsl))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/EmitCtx.kt
@@ -166,6 +166,13 @@ internal fun EmitCtx.dynamicAmountExpr(node: JsonElement?): Dsl? {
         "Trigger_AmountOfDamageDealt" ->
             return call("DynamicAmount.ContextProperty", arg("ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT"))
         "PowerOfTheSacrificedCreature" -> return call("DynamicAmounts.sacrificedPower")
+        // "X is its toughness" / "its power" on THIS permanent (Armored Armadillo's "+X/+0 where X is its
+        // toughness"). Only the ThisPermanent subject maps to the source-relative facade; any other
+        // permanent subject declines (-> scaffold) rather than misattribute the stat.
+        "ToughnessOfPermanent" ->
+            return if (jsonContains(node["args"], "_Permanent", "ThisPermanent")) call("DynamicAmounts.sourceToughness") else null
+        "PowerOfPermanent" ->
+            return if (jsonContains(node["args"], "_Permanent", "ThisPermanent")) call("DynamicAmounts.sourcePower") else null
         "LifeTotalOfPlayer" -> {
             val player = if (jsonContains(node, "_Player", "Opponent")) "Player.Opponent" else "Player.You"
             return call("DynamicAmount.LifeTotal", arg(player))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -165,6 +165,18 @@ object Emitter {
                 // than reading args directly as an Int. Renders `keywordAbility(KeywordAbility.saddle(N))`,
                 // exactly like Crew above; the engine synthesises the Saddle special action from the keyword.
                 rname == "Saddle" -> block = (findInteger(rule["args"]) as? Int)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.saddle", arg("$it")))))) }
+                // Ward {cost} (CR 702.21) carries a `_Cost` arg. Only the pure-mana shape renders as
+                // `KeywordAbility.Ward(WardCost.Mana("{x}"))`; Ward—Pay life / Ward—Discard / other
+                // costs return null -> scaffold rather than drop the cost. A bare WARD enum keyword
+                // would lose the cost entirely, so this must never fall through to the keyword case.
+                rname == "Ward" -> block = manaKeywordCost(rule)?.let {
+                    listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.Ward", arg(call("WardCost.Mana", arg("\"$it\""))))))))
+                }
+                // Plot {cost} (CR 718, OTJ) carries a `_Cost: PayMana` arg -> KeywordAbility.plot("{cost}").
+                // Pure-mana only; a non-mana plot cost (none printed) declines -> scaffold.
+                rname == "Plot" -> block = manaKeywordCost(rule)?.let {
+                    listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.plot", arg("\"$it\""))))))
+                }
                 rname == "Equip" -> block = equipAbilityLine(rule)
                 rname == "Protection" -> block = protectionScopeDsl(rule)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.Protection", arg(Lit(it))))))) }
                 rname != null && (rname in handledRules || Bridge[rname]?.kind == "keyword") -> continue

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -198,12 +198,14 @@ internal fun EmitCtx.renderLayerEffect(node: JsonObject, action: String, tvar: S
     return effect
 }
 
-/** A ±X modifier (`PlusX` / `MinusX`) applied to a dynamic amount: PlusX keeps it; MinusX negates it via
- *  `Multiply(amt, -1)` (the golden's negated-count idiom — Feeding Frenzy's "-X/-X"). */
+/** A ±X modifier (`PlusX` / `MinusX` / `Zero`) applied to a dynamic amount: PlusX keeps it; MinusX
+ *  negates it via `Multiply(amt, -1)` (the golden's negated-count idiom — Feeding Frenzy's "-X/-X");
+ *  Zero is the constant `Fixed(0)` arm of an asymmetric "+X/+0" (Armored Armadillo). */
 internal fun EmitCtx.adjustModX(modNode: JsonElement?, amt: Dsl): Dsl? =
     when ((modNode as? JsonObject)?.strField("_ModX")) {
         "PlusX" -> amt
         "MinusX" -> call("DynamicAmount.Multiply", arg(amt), arg("-1"))
+        "Zero" -> call("DynamicAmount.Fixed", arg("0"))
         else -> null
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.ClassLevelChangedEvent
 import com.wingedsheep.engine.core.CountersAddedEvent
 import com.wingedsheep.engine.core.AttackersDeclaredEvent
 import com.wingedsheep.engine.core.CardCycledEvent
+import com.wingedsheep.engine.core.CardPlottedEvent
 import com.wingedsheep.engine.core.CardsDiscardedEvent
 import com.wingedsheep.engine.core.CardsDrawnEvent
 import com.wingedsheep.engine.core.ControlChangedEvent
@@ -1044,6 +1045,12 @@ class TriggerDetector(
             detectCyclingCardTriggers(state, event, triggers)
         }
 
+        // Handle "when this card becomes plotted" triggers on the plotted card itself, which
+        // now sits face up in exile rather than on the battlefield (e.g., Aloe Alchemist).
+        if (event is CardPlottedEvent) {
+            detectPlottedCardTriggers(state, event, triggers)
+        }
+
         // Handle damage-received triggers for creatures no longer on the battlefield
         // (e.g., Broodhatch Nantuko dies from combat damage but trigger still fires)
         if (event is DamageDealtEvent && event.targetId !in state.getBattlefield()) {
@@ -1187,6 +1194,39 @@ class TriggerDetector(
 
         for (ability in abilities) {
             if (ability.trigger is EventPattern.CycleEvent) {
+                triggers.add(
+                    PendingTrigger(
+                        ability = ability,
+                        sourceId = entityId,
+                        sourceName = cardComponent.name,
+                        controllerId = event.playerId,
+                        triggerContext = TriggerContext(triggeringPlayerId = event.playerId)
+                    )
+                )
+            }
+        }
+    }
+
+    /**
+     * Detect "when this card becomes plotted" triggers on the plotted card itself (e.g.,
+     * Aloe Alchemist). After the plot special action resolves the card sits face up in exile,
+     * not on the battlefield, so the main index scan never sees it. This mirrors
+     * [detectCyclingCardTriggers]: read the plotted card's own triggered abilities and fire any
+     * that key off [EventPattern.BecomesPlottedEvent].
+     */
+    private fun detectPlottedCardTriggers(
+        state: GameState,
+        event: CardPlottedEvent,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        val entityId = event.cardId
+        val container = state.getEntity(entityId) ?: return
+        val cardComponent = container.get<CardComponent>() ?: return
+
+        val abilities = abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state)
+
+        for (ability in abilities) {
+            if (ability.trigger is EventPattern.BecomesPlottedEvent) {
                 triggers.add(
                     PendingTrigger(
                         ability = ability,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -253,6 +253,13 @@ class TriggerMatcher(
                 event is CommitCrimeEvent &&
                     matchesPlayer(trigger.player, event.playerId, controllerId)
             }
+            is EventPattern.BecomesPlottedEvent -> {
+                // "When this card becomes plotted" triggers fire on a card that is now in exile,
+                // not on the battlefield, so the index-driven main loop never reaches them.
+                // TriggerDetector.detectPlottedCardTriggers handles them directly; returning false
+                // here keeps the regular loop from double-firing or mis-binding them.
+                false
+            }
             is EventPattern.TargetsChosenEvent -> {
                 event is com.wingedsheep.engine.core.TargetsChosenEvent &&
                     matchesPlayer(trigger.player, event.chooserId, controllerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/PlotCardHandler.kt
@@ -9,6 +9,8 @@ import com.wingedsheep.engine.core.PlotCard
 import com.wingedsheep.engine.core.TappedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.event.TriggerDetector
+import com.wingedsheep.engine.event.TriggerProcessor
 import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
@@ -46,7 +48,9 @@ import kotlin.reflect.KClass
 class PlotCardHandler(
     private val cardRegistry: CardRegistry,
     private val manaSolver: ManaSolver,
-    private val manaAbilitySideEffectExecutor: com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor
+    private val manaAbilitySideEffectExecutor: com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor,
+    private val triggerDetector: TriggerDetector,
+    private val triggerProcessor: TriggerProcessor
 ) : ActionHandler<PlotCard> {
     override val actionType: KClass<PlotCard> = PlotCard::class
 
@@ -216,6 +220,25 @@ class PlotCardHandler(
         events.add(CardPlottedEvent(action.playerId, action.cardId, cardComponent.name))
 
         currentState = currentState.tick()
+
+        // Fire any "when this card becomes plotted" triggers (CR 718, e.g. Aloe Alchemist). The
+        // ActionProcessor does not run trigger detection centrally — each handler detects and
+        // processes its own triggers, like CycleCardHandler does for cycling triggers. The plotted
+        // card now sits in exile, so TriggerDetector.detectPlottedCardTriggers picks these up.
+        val triggers = triggerDetector.detectTriggers(currentState, events)
+        if (triggers.isNotEmpty()) {
+            val triggerResult = triggerProcessor.processTriggers(currentState, triggers)
+            if (triggerResult.isPaused) {
+                return ExecutionResult.paused(
+                    triggerResult.state,
+                    triggerResult.pendingDecision!!,
+                    events + triggerResult.events
+                )
+            }
+            currentState = triggerResult.newState
+            events.addAll(triggerResult.events)
+        }
+
         // Plot is a special action — does not change priority and does not use the stack.
         return ExecutionResult.success(currentState, events)
     }
@@ -225,7 +248,9 @@ class PlotCardHandler(
             return PlotCardHandler(
                 services.cardRegistry,
                 services.manaSolver,
-                services.manaAbilitySideEffectExecutor
+                services.manaAbilitySideEffectExecutor,
+                services.triggerDetector,
+                services.triggerProcessor
             )
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AloeAlchemistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AloeAlchemistScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlotCard
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Aloe Alchemist (OTJ #152) — {1}{G} Plant Warlock, 3/2, Trample, Plot {1}{G}.
+ *
+ *   "When this card becomes plotted, target creature gets +3/+2 and gains trample until end
+ *    of turn."
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.EventPattern.BecomesPlottedEvent] trigger
+ * ([com.wingedsheep.sdk.dsl.Triggers.BecomesPlotted]) end-to-end: paying the plot cost exiles
+ * the card face up (CR 718) and fires the SELF-bound trigger while the card sits in exile, even
+ * though the card is never on the battlefield.
+ */
+class AloeAlchemistScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("plotting Aloe Alchemist fires its trigger and pumps the chosen creature") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val target = driver.putCreatureOnBattlefield(player, "Grizzly Bears") // 2/2
+        val aloe = driver.putCardInHand(player, "Aloe Alchemist")
+        driver.giveMana(player, Color.GREEN, 2) // plot cost {1}{G}
+
+        driver.state.projectedState.getPower(target) shouldBe 2
+        driver.state.projectedState.getToughness(target) shouldBe 2
+
+        // Plotting pauses for the "becomes plotted" trigger's target choice (CR 603.3d).
+        driver.submit(PlotCard(player, aloe)).isPaused shouldBe true
+        driver.submitTargetSelection(player, listOf(target))
+        driver.bothPass() // resolve the trigger
+
+        // Aloe is now plotted in exile, not on the battlefield.
+        driver.getExile(player).contains(aloe) shouldBe true
+        driver.getCreatures(player).contains(aloe) shouldBe false
+
+        // Target got +3/+2 and trample until end of turn.
+        driver.state.projectedState.getPower(target) shouldBe 5
+        driver.state.projectedState.getToughness(target) shouldBe 4
+        driver.state.projectedState.hasKeyword(target, Keyword.TRAMPLE) shouldBe true
+    }
+
+    test("the pump and trample wear off at end of turn") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val target = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val aloe = driver.putCardInHand(player, "Aloe Alchemist")
+        driver.giveMana(player, Color.GREEN, 2)
+
+        driver.submit(PlotCard(player, aloe)).isPaused shouldBe true
+        driver.submitTargetSelection(player, listOf(target))
+        driver.bothPass()
+
+        driver.state.projectedState.getPower(target) shouldBe 5
+
+        // Advance to the next turn — the until-end-of-turn buff is cleaned up.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.state.projectedState.getPower(target) shouldBe 2
+        driver.state.projectedState.getToughness(target) shouldBe 2
+        driver.state.projectedState.hasKeyword(target, Keyword.TRAMPLE) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnkleBiterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnkleBiterScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ankle Biter (OTJ #153) — {G} Snake, 1/1, Deathtouch.
+ *
+ *   "Deathtouch"
+ *
+ * Verifies the vanilla-with-deathtouch creature: it carries the keyword in projected state, and
+ * its single point of combat damage is lethal to anything it fights (CR 702.2), trading up into a
+ * larger creature.
+ */
+class AnkleBiterScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("Ankle Biter has deathtouch in projected state") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val biter = driver.putCreatureOnBattlefield(player, "Ankle Biter")
+
+        driver.state.projectedState.getPower(biter) shouldBe 1
+        driver.state.projectedState.getToughness(biter) shouldBe 1
+        driver.state.projectedState.hasKeyword(biter, Keyword.DEATHTOUCH) shouldBe true
+    }
+
+    test("blocking with Ankle Biter kills a larger attacker via deathtouch") {
+        val driver = createDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        // A 2/2 attacker — would normally survive 1 damage, but deathtouch makes it lethal.
+        val bears = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        val biter = driver.putCreatureOnBattlefield(defender, "Ankle Biter")
+        driver.removeSummoningSickness(bears)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(bears), defender).isSuccess shouldBe true
+
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(defender, mapOf(biter to listOf(bears))).isSuccess shouldBe true
+
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // Deathtouch: 1 damage from the Biter is lethal to the 2/2 attacker.
+        driver.findPermanent(attacker, "Grizzly Bears") shouldBe null
+        driver.getGraveyardCardNames(attacker) shouldContain "Grizzly Bears"
+
+        // The 1/1 Biter also dies to the 2 damage it took.
+        driver.findPermanent(defender, "Ankle Biter") shouldBe null
+        driver.getGraveyardCardNames(defender) shouldContain "Ankle Biter"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArmoredArmadilloScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArmoredArmadilloScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ArmoredArmadillo
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Armored Armadillo (OTJ #3) — {W} Armadillo, 0/4, Ward {1}.
+ *
+ *   "{3}{W}: This creature gets +X/+0 until end of turn, where X is its toughness."
+ *
+ * Verifies the toughness-scaled self-pump activated ability resolves with X equal to the
+ * Armadillo's current toughness (4), making it a 4/4 until end of turn.
+ */
+class ArmoredArmadilloScenarioTest : FunSpec({
+
+    val pumpAbility = ArmoredArmadillo.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ArmoredArmadillo)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("the activated ability adds the Armadillo's toughness to its power") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val armadillo = driver.putCreatureOnBattlefield(player, "Armored Armadillo")
+        driver.giveMana(player, Color.WHITE, 4) // {3}{W}
+
+        driver.state.projectedState.getPower(armadillo) shouldBe 0
+        driver.state.projectedState.getToughness(armadillo) shouldBe 4
+
+        driver.submitSuccess(ActivateAbility(player, armadillo, pumpAbility))
+        driver.bothPass() // resolve the ability
+
+        // X = its toughness = 4, so +4/+0 → 4/4.
+        driver.state.projectedState.getPower(armadillo) shouldBe 4
+        driver.state.projectedState.getToughness(armadillo) shouldBe 4
+    }
+
+    test("the pump wears off at end of turn") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val armadillo = driver.putCreatureOnBattlefield(player, "Armored Armadillo")
+        driver.giveMana(player, Color.WHITE, 4)
+
+        driver.submitSuccess(ActivateAbility(player, armadillo, pumpAbility))
+        driver.bothPass()
+        driver.state.projectedState.getPower(armadillo) shouldBe 4
+
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.state.projectedState.getPower(armadillo) shouldBe 0
+        driver.state.projectedState.getToughness(armadillo) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BridledBighornScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BridledBighornScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SaddleMount
+import com.wingedsheep.engine.state.components.battlefield.SaddledComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bridled Bighorn (OTJ #7) — {3}{W} Sheep Mount, 3/4, Vigilance, Saddle 2.
+ *
+ *   "Whenever this creature attacks while saddled, create a 1/1 white Sheep creature token."
+ *
+ * Verifies the Mount's saddle-gated attack trigger: saddling (CR 702.171) then attacking spawns a
+ * Sheep token, while attacking unsaddled produces none.
+ */
+class BridledBighornScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.isSaddled(id: EntityId): Boolean =
+        state.getEntity(id)?.has<SaddledComponent>() == true
+
+    test("attacking while saddled creates a 1/1 white Sheep token") {
+        val driver = createDriver()
+        val player = driver.player1
+
+        val bighorn = driver.putCreatureOnBattlefield(player, "Bridled Bighorn")
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears") // power 2 → pays Saddle 2
+        driver.removeSummoningSickness(bighorn)
+
+        val creaturesBefore = driver.getCreatures(player).size
+
+        driver.submitSuccess(SaddleMount(player, bighorn, listOf(bear)))
+        driver.bothPass()
+        driver.isSaddled(bighorn) shouldBe true
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(bighorn), driver.player2)
+        driver.bothPass() // resolve the attack trigger
+
+        // One new Sheep token (Grizzly Bears + Bighorn + Sheep = creaturesBefore + 1).
+        driver.getCreatures(player).size shouldBe creaturesBefore + 1
+    }
+
+    test("attacking while NOT saddled creates no token") {
+        val driver = createDriver()
+        val player = driver.player1
+
+        val bighorn = driver.putCreatureOnBattlefield(player, "Bridled Bighorn")
+        driver.removeSummoningSickness(bighorn)
+
+        val creaturesBefore = driver.getCreatures(player).size
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(bighorn), driver.player2)
+        driver.bothPass()
+
+        driver.getCreatures(player).size shouldBe creaturesBefore
+    }
+})


### PR DESCRIPTION
Adds four Outlaws of Thunder Junction cards, with the SDK/engine and mtgish-tooling support needed to render their new mechanics, plus a client "Plotted" badge so plotted cards are visible in exile.

## Cards
- **Aloe Alchemist** ({1}{G} 3/2 Trample, **Plot {1}{G}**) — "When this card becomes plotted, target creature gets +3/+2 and gains trample until end of turn." The payoff fires off a new `BecomesPlotted` trigger (CR 718): paying the plot cost exiles the card face-up and fires the SELF-bound trigger **while the card sits in exile**, never on the battlefield. This extends the plot infrastructure that already lived in the engine (`PlotCardHandler`).
- **Ankle Biter** ({G} 1/1 Deathtouch) — vanilla-with-keyword.
- **Armored Armadillo** ({W} 0/4 Ward {1}) — "{3}{W}: This creature gets +X/+0 until end of turn, where X is its toughness" via `DynamicAmounts.sourceToughness()`.
- **Bridled Bighorn** ({3}{W} 3/4 Vigilance, Saddle 2) — saddle-gated attack trigger (`Conditions.SourceIsSaddled`) that creates a 1/1 white Sheep token.

All four oracle texts verified against Scryfall.

## SDK / engine
- New `Triggers.BecomesPlotted` + `EventPattern.BecomesPlottedEvent`.
- `TriggerDetector` / `TriggerMatcher` / `PlotCardHandler` fire the SELF-bound becomes-plotted trigger.
- `docs/card-sdk-language-reference.md` documents the new trigger.

## Client — "Plotted" badge
- A plotted card sits face-up in exile carrying a `PlottedComponent`, but it was indistinguishable from any other exiled card in the UI. New `ClientCard.isPlotted` flag (read from `PlottedComponent` in `ClientStateTransformer`, exile only) drives a gold **"Plotted"** corner badge on the card, mirroring the existing `isSuspected` display-flag pattern.
- Plot exiles the card face-up (public info), so the flag is shown to both players. Covered by a `ClientStateTransformer` view test (`PlottedCardVisibilityTest`).
- A manual scenario (`manual-scenarios/cards/a/aloe-alchemist-plot.json`, vs the engine AI) drives the flow in the running client: plot Aloe Alchemist, target your Grizzly Bears (becomes 5/4 trample), and the exiled card shows the badge.

## mtgish-tooling
- **Bridge:** `WhenACardBecomesPlotted` added to the supported trigger vocabulary.
- **Emitter:** renders `Plot {cost}` and `Ward {cost}` keyword abilities and the becomes-plotted trigger spec. All four cards now emit **AUTO** (faithful whole render — no silently dropped constraints). Saddle/intervening-if handling was reconciled with the batch-3 (#563) and end-step/upkeep tooling work already on main, keeping both additions.

## Tests / verification
- Scenario tests for all four cards (rules-engine), all passing.
- `PlottedCardVisibilityTest` (rules-engine view test) for the badge flag, passing.
- OTJ snapshot golden re-blessed (regenerated as the true union of all OTJ cards after the merge).
- `:mtgish-tooling:test` (incl. EmitterGoldenTest) green.
- `just coverage-verify POR` → **GATE PASS, 158/158, 0 mismatch** (unchanged).
- web-client `typecheck` + `build` green; `just build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
