### PR TITLE
Add a "Plotted" badge so plotted cards are visible in exile (CR 718)

### DIFF
--- a/manual-scenarios/cards/a/aloe-alchemist-plot.json
+++ b/manual-scenarios/cards/a/aloe-alchemist-plot.json
@@ -1,0 +1,33 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Aloe Alchemist"],
+    "battlefield": [
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Forest", "tapped": false},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "aiPlayer": 2,
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -199,6 +199,9 @@ data class ClientCard(
     /** Whether this permanent is suspected (CR 701.60 — has menace and can't block). Battlefield only. */
     val isSuspected: Boolean = false,
 
+    /** Whether this card is plotted in exile (CR 718 — Plot keyword, castable for free on a later turn). Exile only. */
+    val isPlotted: Boolean = false,
+
     /** Morph cost for face-down creatures (only visible to controller) */
     val morphCost: String? = null,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -992,6 +992,10 @@ class ClientStateTransformer(
             mayPlayFromExile || isCastableFromLinkedExile(state, viewingPlayerId, entityId, container)
         )
 
+        // Plotted cards (CR 718) sit face-up in exile with a PlottedComponent; surface a flag so the
+        // client can badge them as plotted (otherwise indistinguishable from any other exiled card).
+        val isPlotted = zoneKey.zoneType == Zone.EXILE && container.has<PlottedComponent>()
+
         // Threshold-style progress badge: detect static abilities gated on
         // "controller's graveyard has at least N cards".
         val thresholdInfo = cardDef?.let { def ->
@@ -1049,6 +1053,7 @@ class ClientStateTransformer(
             linkedExile = linkedExile,
             isFaceDown = isFaceDown,
             isSuspected = projectedValues?.isSuspected == true,
+            isPlotted = isPlotted,
             morphCost = if (isFaceDown && morphData != null) morphData.morphCost.description else null,
             targets = targets,
             imageUri = cardComponent.imageUri ?: cardDef?.metadata?.imageUri,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/PlottedCardVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/PlottedCardVisibilityTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.core.PlotCard
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * A plotted card (CR 718, Outlaws of Thunder Junction) sits face-up in exile carrying a
+ * [com.wingedsheep.engine.state.components.identity.PlottedComponent]. [ClientStateTransformer]
+ * surfaces that as [ClientCard.isPlotted] so the client can badge it — otherwise a plotted card is
+ * indistinguishable from any other exiled card. Plot exiles the card face-up (public information),
+ * so the flag is visible to both players.
+ */
+class PlottedCardVisibilityTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun transformer(d: GameTestDriver): ClientStateTransformer =
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+
+    test("a card in hand (not yet plotted) is not flagged isPlotted") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val aloe = d.putCardInHand(player, "Aloe Alchemist")
+
+        val view = transformer(d).transform(d.state, viewingPlayerId = player)
+        view.cards[aloe]?.isPlotted shouldBe false
+    }
+
+    test("plotting Aloe Alchemist flags it isPlotted in exile for both players") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val opponent = d.getOpponent(player)
+
+        val target = d.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val aloe = d.putCardInHand(player, "Aloe Alchemist")
+        d.giveMana(player, Color.GREEN, 2) // plot cost {1}{G}
+
+        d.submit(PlotCard(player, aloe)).isPaused shouldBe true
+        d.submitTargetSelection(player, listOf(target))
+        d.bothPass()
+
+        // The card is now plotted in exile.
+        d.getExile(player).contains(aloe) shouldBe true
+
+        // Plot is face-up / public, so both the controller and the opponent see the flag.
+        val ownerView = transformer(d).transform(d.state, viewingPlayerId = player)
+        val opponentView = transformer(d).transform(d.state, viewingPlayerId = opponent)
+
+        ownerView.cards[aloe].shouldNotBeNull().isPlotted shouldBe true
+        opponentView.cards[aloe].shouldNotBeNull().isPlotted shouldBe true
+    }
+})

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1540,6 +1540,26 @@ export const styles: Record<string, React.CSSProperties> = {
     pointerEvents: 'none',
     zIndex: 6,
   } as React.CSSProperties,
+  // Plotted status (CR 718) — a card sitting face-up in exile, castable for free on a later turn.
+  plottedBadge: {
+    position: 'absolute',
+    top: 4,
+    left: 4,
+    borderRadius: 4,
+    padding: '1px 5px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 3,
+    fontWeight: 700,
+    fontSize: 10,
+    color: '#1a1200',
+    background: 'linear-gradient(135deg, #c9a227, #f5d76e)',
+    border: '1px solid #fff3b0',
+    boxShadow: '0 0 6px rgba(245, 215, 110, 0.85)',
+    textShadow: 'none',
+    pointerEvents: 'none',
+    zIndex: 6,
+  } as React.CSSProperties,
 }
 
 /**

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1338,6 +1338,13 @@ function GameCardImpl({
         </div>
       )}
 
+      {/* Plot (CR 718): card sitting face-up in exile, castable for free on a later turn */}
+      {card.isPlotted && (
+        <div style={styles.plottedBadge} title="Plotted (CR 718) — cast it for free on a later turn">
+          Plotted
+        </div>
+      )}
+
       {/* Counter badge for creatures with +1/+1 or -1/-1 counters */}
       {battlefield && hasStatCounters(card) && (
         <div style={{

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -190,6 +190,9 @@ export interface ClientCard {
   /** Whether this permanent is suspected (CR 701.60 — has menace and can't block). Battlefield only. */
   readonly isSuspected?: boolean
 
+  /** Whether this card is plotted in exile (CR 718 — Plot keyword, castable for free on a later turn). Exile only. */
+  readonly isPlotted?: boolean
+
   /** Morph cost for face-down creatures (only visible to controller) */
   readonly morphCost?: string | null
 


### PR DESCRIPTION
## Summary

Surfaces plot status to the client as a display-only flag, mirroring the existing `isSuspected` pattern. A plotted card sits face-up in exile with a `PlottedComponent`, but the client previously had no way to tell it apart from any other exiled card — this adds a gold "Plotted" corner badge (CR 718 tooltip).

**Stacked on #567** (`feat/otj-cards-batch1`): the badge reads `PlottedComponent` / the plot handler, which only exist in that branch. GitHub will auto-retarget this PR's base to `main` once #567 merges.

| Layer | Change | File |
|---|---|---|
| DTO | new `isPlotted: Boolean = false` field | `rules-engine/.../view/ClientDTO.kt` |
| Transformer | reads `PlottedComponent` (exile only) → sets `isPlotted` | `rules-engine/.../view/ClientStateTransformer.kt` |
| Client type | `isPlotted?: boolean` on `ClientCard` | `web-client/src/types/gameState.ts` |
| Client style | gold `plottedBadge` corner style | `web-client/src/components/game/board/styles.ts` |
| Client render | "Plotted" corner badge w/ CR-718 tooltip | `web-client/src/components/game/card/GameCard.tsx` |

No new SDK type, no engine logic — purely a display flag.

## Notes
- **Masking:** Plot exiles the card *face-up* (public info), so the flag is intentionally shown to both players. No `StateMasker` change needed.
- **Battlefield vs exile:** `isSuspected` renders only on the battlefield; plotted is exile-only, so this is a standalone corner badge gated on `card.isPlotted` rather than threaded through the battlefield-only `KeywordIcons`.
- Includes a manual dev scenario (`manual-scenarios/cards/a/aloe-alchemist-plot.json`) to exercise the badge by hand.

## Verification
- New `PlottedCardVisibilityTest` — in-hand card is not flagged; after plotting, both controller and opponent see `isPlotted = true`.
- `:rules-engine:compileKotlin`, web-client `typecheck` and `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)