### PR TITLE
OTJ: blue cards (Discerning Peddler, Seize the Secrets, Stoic Sphinx, Slick Sequence) + mtgish gen

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2239,6 +2239,15 @@ default to "you" so card authors don't need to pass it explicitly.
   `TriggeringSpellMatches` half is load-bearing — it stops a later non-matching cast from satisfying
   the count once one matching spell exists. Used by Alania, Divergent Storm (first instant / first
   sorcery / first Otter).
+- `YouCommittedCrimeThisTurn` — Outlaws of Thunder Junction crime gate: true once you've cast a
+  spell, activated an ability, or put a triggered ability on the stack this turn that targets an
+  opponent, anything an opponent controls, and/or a card in an opponent's graveyard. Backed by
+  `PlayerCommittedCrimeThisTurn(Player.You)`, which reads `GameState.playersWhoCommittedCrimeThisTurn`
+  — a turn-scoped set populated at every `CommitCrimeEvent` emit site (crime detection is the engine's
+  `CrimeDetector`) and cleared at each turn boundary. Stays true for the rest of the turn even if the
+  crime-committing spell/ability is countered. Resolves identically in resolution and projection (e.g.
+  cost-reduction) contexts. Pairs with `CostGating.OnlyIf(...)` for "costs {N} less if you've committed
+  a crime this turn" (Seize the Secrets).
 - `YouHaveCitysBlessing` — Ascend gate. Backed by `PlayerHasCitysBlessing(Player.You)`.
 - `IsFirstSpellPaidWithTreasureManaCastThisTurn` — gates a triggered ability to fire only
   on the first spell each turn that mana from a Treasure was spent to cast (Rain of

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -31,6 +31,7 @@ import com.wingedsheep.sdk.scripting.conditions.IsNotYourTurn as IsNotYourTurnCo
 import com.wingedsheep.sdk.scripting.conditions.IsInPhase as IsInPhaseCondition
 import com.wingedsheep.sdk.scripting.conditions.PlayerAttackedWithCreaturesThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PlayerCastSpellsThisTurn
+import com.wingedsheep.sdk.scripting.conditions.PlayerCommittedCrimeThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PlayerHasCitysBlessing
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.values.Aggregation
@@ -691,6 +692,17 @@ object Conditions {
         fromZone: com.wingedsheep.sdk.core.Zone? = null
     ): ConditionInterface =
         PlayerCastSpellsThisTurn(Player.You, filter, atLeast, fromZone)
+
+    /**
+     * If you've committed a crime this turn (CR Outlaws of Thunder Junction). A crime is committed
+     * when you cast a spell, activate an ability, or put a triggered ability on the stack that
+     * targets an opponent, anything an opponent controls, and/or a card in an opponent's graveyard.
+     *
+     * Turn-scoped tracker — stays true for the rest of the turn once any crime is committed. Used by
+     * Seize the Secrets ("This spell costs {1} less to cast if you've committed a crime this turn").
+     */
+    val YouCommittedCrimeThisTurn: ConditionInterface =
+        PlayerCommittedCrimeThisTurn(Player.You)
 
     /**
      * If this is the first spell you've cast this turn that mana from a Treasure was

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
@@ -159,6 +159,29 @@ data class PlayerCastSpellsThisTurn(
 }
 
 /**
+ * Condition: "If [player] has committed a crime this turn" (CR Outlaws of Thunder Junction —
+ * a player commits a crime as they cast a spell, activate an ability, or put a triggered ability
+ * on the stack that targets one or more opponents, permanents/spells/abilities an opponent controls,
+ * and/or cards in an opponent's graveyard).
+ *
+ * Pure turn-scoped tracker: once a crime is committed it stays true for the rest of the turn, even
+ * if the crime-committing spell/ability is countered or leaves the stack. Crime detection lives in
+ * the engine (`CrimeDetector` at the `CommitCrimeEvent` emit sites); this condition only reads the
+ * recorded set. The `Conditions.YouCommittedCrimeThisTurn` DSL helper passes [Player.You], resolved
+ * to the source's controller in both resolution and projection (cost-reduction) contexts.
+ *
+ * Used for cards like Seize the Secrets ("This spell costs {1} less to cast if you've committed a
+ * crime this turn").
+ */
+@SerialName("PlayerCommittedCrimeThisTurn")
+@Serializable
+data class PlayerCommittedCrimeThisTurn(
+    val player: Player = Player.You
+) : Condition {
+    override val description: String = "if ${player.description} committed a crime this turn"
+}
+
+/**
  * Condition: "if this is the first spell you've cast this turn that mana from a Treasure
  * was spent to cast." Used by Rain of Riches.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DiscerningPeddler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DiscerningPeddler.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Discerning Peddler
+ * {1}{R}
+ * Creature — Human Rogue
+ * 2/2
+ *
+ * When this creature enters, you may discard a card. If you do, draw a card.
+ */
+val DiscerningPeddler = card("Discerning Peddler") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, you may discard a card. If you do, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            IfYouDoEffect(
+                action = Effects.Discard(1),
+                ifYouDo = Effects.DrawCards(1),
+            ),
+        )
+        description = "When this creature enters, you may discard a card. If you do, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "Josu Hernaiz"
+        flavorText = "\"Can I interest you in some herbs from Naktamun? Fresh from the Omenpath! Or a " +
+            "set of Fioran cookware? Finest in the Multiverse!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73b359bf-afd8-439d-a4d2-985db1ad368c.jpg?1712355741"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SeizeTheSecrets.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SeizeTheSecrets.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Seize the Secrets
+ * {2}{U}
+ * Sorcery
+ *
+ * This spell costs {1} less to cast if you've committed a crime this turn. (Targeting opponents,
+ * anything they control, and/or cards in their graveyards is a crime.)
+ * Draw two cards.
+ *
+ * The cost reduction reads the turn-scoped crime tracker (CR Outlaws of Thunder Junction). Seize
+ * the Secrets itself doesn't target an opponent, so it never sets the flag — the crime must have
+ * been committed by an earlier spell or ability this turn.
+ */
+val SeizeTheSecrets = card("Seize the Secrets") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "This spell costs {1} less to cast if you've committed a crime this turn. " +
+        "(Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\n" +
+        "Draw two cards."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.OnlyIf(Conditions.YouCommittedCrimeThisTurn),
+        )
+    }
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "64"
+        artist = "Miranda Meeks"
+        flavorText = "Nolan refused to give up the vault's location. The strange figure simply " +
+            "smiled and reached into his mind."
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1bdbdfa8-aa28-4b3d-95e7-3d0e7e37f982.jpg?1712355485"
+
+        ruling("2024-04-12", "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard.")
+        ruling("2024-04-12", "Seize the Secrets checks whether you've committed a crime this turn as you cast it, not as it resolves. Targeting something for Seize the Secrets won't help, as it has no targets.")
+        ruling("2024-04-12", "Once you've committed a crime, you've committed a crime for the rest of the turn. It doesn't matter if the spell or ability that committed the crime is later countered or otherwise leaves the stack.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SlickSequence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SlickSequence.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Slick Sequence
+ * {U}{R}
+ * Instant
+ *
+ * Slick Sequence deals 2 damage to any target. If you've cast another spell this turn, draw a card.
+ *
+ * "Another spell" is evaluated at resolution, when this spell is already recorded in the turn's
+ * cast history, so `YouCastSpellsThisTurn(atLeast = 2)` means "this spell plus at least one other".
+ */
+val SlickSequence = card("Slick Sequence") {
+    manaCost = "{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Instant"
+    oracleText = "Slick Sequence deals 2 damage to any target. If you've cast another spell this turn, draw a card."
+
+    spell {
+        val any = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, any) then
+            ConditionalEffect(
+                condition = Conditions.YouCastSpellsThisTurn(atLeast = 2),
+                effect = Effects.DrawCards(1),
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Fajareka Setiawan"
+        flavorText = "\"Shooting first don't mean much if you ain't got proper follow-through.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/beb1c974-0d35-4e9f-a310-44eb2af64494.jpg?1712356219"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/StoicSphinx.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/StoicSphinx.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Stoic Sphinx
+ * {2}{U}{U}
+ * Creature — Sphinx
+ * 5/3
+ *
+ * Flash
+ * Flying
+ * This creature has hexproof as long as you haven't cast a spell this turn.
+ *
+ * The hexproof clause is a conditional static ability (CR 604.3): it grants hexproof while the
+ * controller's spell count for the turn is zero, dropping off the moment they cast a spell.
+ */
+val StoicSphinx = card("Stoic Sphinx") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    power = 5
+    toughness = 3
+    oracleText = "Flash\nFlying\nThis creature has hexproof as long as you haven't cast a spell this turn."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.HEXPROOF, Filters.Self),
+            condition = Conditions.Not(Conditions.YouCastSpellsThisTurn(1)),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "Andreas Zafiratos"
+        flavorText = "Lucky travelers reported a mighty winged creature among the geysers. " +
+            "Unlucky ones didn't make it back."
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f93f5055-30d8-4fc4-afa5-29212e8c7536.jpg?1712355517"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -912,6 +912,91 @@
     "colorIdentityOverride": []
 }
 
+// Discerning Peddler
+{
+    "name": "Discerning Peddler",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "When this creature enters, you may discard a card. If you do, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you may discard a card. If you do, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"Can I interest you in some herbs from Naktamun? Fresh from the Omenpath! Or a set of Fioran cookware? Finest in the Multiverse!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73b359bf-afd8-439d-a4d2-985db1ad368c.jpg?1712355741"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Drover Grizzly
 {
     "name": "Drover Grizzly",
@@ -1748,6 +1833,60 @@
     ]
 }
 
+// Seize the Secrets
+{
+    "name": "Seize the Secrets",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "This spell costs {1} less to cast if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nDraw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": "PlayerCommittedCrimeThisTurn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "artist": "Miranda Meeks",
+        "flavorText": "Nolan refused to give up the vault's location. The strange figure simply smiled and reached into his mind.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1bdbdfa8-aa28-4b3d-95e7-3d0e7e37f982.jpg?1712355485",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Seize the Secrets checks whether you've committed a crime this turn as you cast it, not as it resolves. Targeting something for Seize the Secrets won't help, as it has no targets."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Once you've committed a crime, you've committed a crime for the rest of the turn. It doesn't matter if the spell or ability that committed the crime is later countered or otherwise leaves the stack."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Shoot the Sheriff
 {
     "name": "Shoot the Sheriff",
@@ -1810,6 +1949,66 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Slick Sequence
+{
+    "name": "Slick Sequence",
+    "manaCost": "{U}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Slick Sequence deals 2 damage to any target. If you've cast another spell this turn, draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "PlayerCastSpellsThisTurn",
+                            "atLeast": 2
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "UNCOMMON",
+        "artist": "Fajareka Setiawan",
+        "flavorText": "\"Shooting first don't mean much if you ain't got proper follow-through.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/beb1c974-0d35-4e9f-a310-44eb2af64494.jpg?1712356219"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 
@@ -1924,6 +2123,54 @@
         "artist": "Loïc Canavaggia",
         "flavorText": "It once escaped a cook's pot. Now it fears neither heat nor human.",
         "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6822d12-1a25-42e7-94cc-71bd29daed93.jpg?1712355509"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Stoic Sphinx
+{
+    "name": "Stoic Sphinx",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "Flash\nFlying\nThis creature has hexproof as long as you haven't cast a spell this turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "PlayerCastSpellsThisTurn",
+                        "atLeast": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "RARE",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "Lucky travelers reported a mighty winged creature among the geysers. Unlucky ones didn't make it back.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f93f5055-30d8-4fc4-afa5-29212e8c7536.jpg?1712355517"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -23,6 +23,16 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("PlayerPassesFilter", "condition: a player matches a filter (e.g. You HasntCastASpellThisTurn)")
     supported("IsSaddled", "predicate: this permanent is saddled (CR 702.171b)")
     supported("HasntCastASpellThisTurn", "predicate: player hasn't cast a (filtered) spell this turn")
+    // "you've cast another spell this turn" -> Conditions.YouCastSpellsThisTurn(atLeast = 2) at
+    // resolution (the resolving spell is already recorded). The emitter renders the "Other ThisSpell"
+    // shape; a non-You / unfiltered-other mismatch declines -> SCAFFOLD.
+    supported("CastASpellThisTurn", "predicate: player has cast a (filtered) spell this turn (YouCastSpellsThisTurn)")
+    // OTJ crime (CR Outlaws of Thunder Junction) — "you've committed a crime this turn" ->
+    // Conditions.YouCommittedCrimeThisTurn, gating a cost reduction or a resolution-time effect.
+    supported("CommitedACrimeThisTurn", "predicate: player has committed a crime this turn (YouCommittedCrimeThisTurn)")
+    // "if you do" / "if [the cost] was paid" — the IfYouDoEffect linkage after a MayCost(DiscardACard)
+    // loot, rendered by the emitter as MayEffect(IfYouDoEffect(...)). Universal condition vocabulary.
+    supported("CostWasPaid", "condition: the optional cost was paid (IfYouDoEffect linkage)")
     supported("WasCastFromTheirHand", "predicate: spell cast from the player's hand (fromZone = HAND)")
     // Source-relative Mount/Vehicle payoff filter: "a creature that crewed/saddled it this turn"
     // (Giant Beaver) -> GameObjectFilter.Creature.crewedOrSaddledSourceThisTurn().

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -100,12 +100,18 @@ internal fun EmitCtx.cardLevelCastEffectLines(card: JsonObject): List<String>? {
 }
 
 /**
- * `CastEffect(ReduceCastingCostIf([CostReduceGeneric N], PlayerPassesFilter(You, ControlsA(filter))))`
- * -> a `staticAbility { ability = ModifySpellCost(SelfCast, ReduceGenericBy(FixedIfControlFilter(N,
- * <filter>))) }` block (Cactarantula: "This spell costs {1} less to cast if you control a Desert").
+ * `CastEffect(ReduceCastingCostIf([CostReduceGeneric N], <condition>))` -> a
+ * `staticAbility { ability = ModifySpellCost(SelfCast, …) }` block. Renders only a single bare generic
+ * reduction, and only for the exact conditions we can express faithfully:
  *
- * Renders only the "if you control a [filter]" conditional generic reduction; any other condition or a
- * colored/dynamic reduction declines -> SCAFFOLD rather than widening.
+ *  - `PlayerPassesFilter(You, ControlsA(filter))` ("if you control a [filter]") ->
+ *    `ReduceGenericBy(FixedIfControlFilter(N, <filter>))` (Cactarantula: "costs {1} less if you control
+ *    a Desert").
+ *  - `PlayerPassesFilter(You, CommitedACrimeThisTurn)` ("if you've committed a crime this turn") ->
+ *    `ReduceGeneric(N)` gated by `CostGating.OnlyIf(Conditions.YouCommittedCrimeThisTurn)` (Seize the
+ *    Secrets).
+ *
+ * Any other condition, or a colored/dynamic reduction, declines -> SCAFFOLD rather than widening.
  */
 private fun EmitCtx.costReductionStaticLines(rule: JsonObject): List<String>? {
     val node = rule["args"] as? JsonObject ?: return null
@@ -119,17 +125,28 @@ private fun EmitCtx.costReductionStaticLines(rule: JsonObject): List<String>? {
     if (cond.strField("_Condition") != "PlayerPassesFilter") return null
     val condArgs = cond["args"].asArr ?: return null
     if ((condArgs.getOrNull(0) as? JsonObject)?.strField("_Player") != "You") return null
-    val controls = condArgs.getOrNull(1) as? JsonObject ?: return null
-    if (controls.strField("_Players") != "ControlsA") return null
-    val filter = gameObjectFilterDsl(controls["args"]) ?: return null
-    val ability = call(
-        "ModifySpellCost",
-        arg("target", Lit("SpellCostTarget.SelfCast")),
-        arg("modification", call(
-            "CostModification.ReduceGenericBy",
-            arg(call("CostReductionSource.FixedIfControlFilter", arg("amount", "$amount"), arg("filter", Lit(filter)))),
-        )),
-    )
+    val predicate = condArgs.getOrNull(1) as? JsonObject ?: return null
+
+    val ability = when (predicate.strField("_Players")) {
+        "ControlsA" -> {
+            val filter = gameObjectFilterDsl(predicate["args"]) ?: return null
+            call(
+                "ModifySpellCost",
+                arg("target", Lit("SpellCostTarget.SelfCast")),
+                arg("modification", call(
+                    "CostModification.ReduceGenericBy",
+                    arg(call("CostReductionSource.FixedIfControlFilter", arg("amount", "$amount"), arg("filter", Lit(filter)))),
+                )),
+            )
+        }
+        "CommitedACrimeThisTurn" -> call(
+            "ModifySpellCost",
+            arg("target", Lit("SpellCostTarget.SelfCast")),
+            arg("modification", call("CostModification.ReduceGeneric", arg("$amount"))),
+            arg("gating", call("CostGating.OnlyIf", arg("Conditions.YouCommittedCrimeThisTurn"))),
+        )
+        else -> return null
+    }
     return renderBlock(Block("staticAbility", listOf(Assign("ability", ability))), "    ")
 }
 
@@ -244,7 +261,50 @@ internal fun EmitCtx.ifRuleBlock(rule: JsonObject): List<Stmt>? {
         return listOf(staticAbilityStmt(call("CanAttackDespiteDefender", arg("condition", Lit(condDsl)))))
     }
 
+    // Stoic Sphinx: "This creature has hexproof as long as you haven't cast a spell this turn."
+    //   If(PlayerPassesFilter(You, HasntCastASpellThisTurn(AnySpell)))
+    //     [ PermanentLayerEffect(ThisPermanent, [ AddAbility(<keyword>) ]) ]
+    // -> ConditionalStaticAbility(GrantKeyword(Keyword.X, Filters.Self), Not(YouCastSpellsThisTurn(1))).
+    // Only the SELF "grant a single keyword to this permanent" inner shape renders; any other layer
+    // effect (stat change, multi-keyword, group filter) declines -> SCAFFOLD.
+    if (innerRule.strField("_Rule") == "PermanentLayerEffect" &&
+        jsonContains(innerRule, "_Permanent", "ThisPermanent")
+    ) {
+        val condDsl = youHaventCastASpellConditionDsl(cond) ?: run { reasons.add("If"); return null }
+        val layerEffects = (innerRule["args"].asArr?.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>()
+        val le = layerEffects?.singleOrNull()
+        if (le == null || le.strField("_StaticLayerEffect") != "AddAbility") { reasons.add("If"); return null }
+        // An AddAbility whose granted rule is anything richer than a plain keyword (an activated ability,
+        // landwalk, protection-from-color) isn't a bare keyword grant — decline rather than mis-render.
+        val granted = (le["args"] as? JsonArray)?.singleOrNull() as? JsonObject
+        if (granted?.strField("_Rule") != null && granted.size > 1) { reasons.add("If"); return null }
+        val kw = keywordOf(le) ?: run { reasons.add("If"); return null }
+        return listOf(staticAbilityStmt(call(
+            "ConditionalStaticAbility",
+            arg("ability", call("GrantKeyword", arg("Keyword.$kw"), arg("Filters.Self"))),
+            arg("condition", Lit(condDsl)),
+        )))
+    }
+
     reasons.add("If"); return null
+}
+
+/**
+ * "you haven't cast a spell this turn" (`PlayerPassesFilter(You, HasntCastASpellThisTurn(AnySpell))`)
+ * -> the `Conditions.Not(Conditions.YouCastSpellsThisTurn(1))` DSL string. Only the unfiltered
+ * any-spell, You-scoped shape renders here (the from-hand variant is handled by [interveningIfDsl]);
+ * anything else declines.
+ */
+private fun EmitCtx.youHaventCastASpellConditionDsl(cond: JsonObject?): String? {
+    if (cond == null) return null
+    if (cond.strField("_Condition") == "PlayerPassesFilter" &&
+        jsonContains(cond, "_Player", "You") &&
+        jsonContains(cond, "_Players", "HasntCastASpellThisTurn") &&
+        jsonContains(cond, "_Spells", "AnySpell")
+    ) {
+        return "Conditions.Not(Conditions.YouCastSpellsThisTurn(1))"
+    }
+    return null
 }
 
 internal fun EmitCtx.spellBlock(card: JsonObject): List<Stmt>? {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -102,6 +102,7 @@ class TurnManager(
             pendingUncounterableSpells = emptyList(),
             spellWarpedThisTurn = false,
             nonlandPermanentLeftBattlefieldThisTurn = false,
+            playersWhoCommittedCrimeThisTurn = emptySet(),
             lastCastSpellColors = null,
             lastCardDrawnThisTurnByPlayer = emptyMap()
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -102,6 +102,7 @@ import com.wingedsheep.sdk.scripting.conditions.YouControlSource
 import com.wingedsheep.sdk.scripting.conditions.PlayerAttackedWithCreaturesThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PermanentTypeEnteredBattlefieldThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PlayerCastSpellsThisTurn
+import com.wingedsheep.sdk.scripting.conditions.PlayerCommittedCrimeThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PlayerHasCitysBlessing
 import com.wingedsheep.sdk.scripting.conditions.CreatureDiedThisTurnCondition
 import com.wingedsheep.sdk.scripting.conditions.ControlledCreatureDiedThisTurnCondition
@@ -241,6 +242,10 @@ class ConditionEvaluator(
             // Player-relative trackers (resolve [Player] against the current context).
             is PlayerAttackedWithCreaturesThisTurn -> evaluateAttackedWithCreaturesCtx(state, condition, ctx)
             is PlayerCastSpellsThisTurn -> evaluateCastSpellsThisTurnCtx(state, condition, ctx)
+            is PlayerCommittedCrimeThisTurn -> {
+                val playerId = resolvePlayer(state, condition.player, ctx)
+                playerId != null && playerId in state.playersWhoCommittedCrimeThisTurn
+            }
             is PlayerHasCitysBlessing -> evaluateHasCitysBlessingCtx(state, condition, ctx)
             is PermanentTypeEnteredBattlefieldThisTurn ->
                 evaluatePermanentTypeEnteredBattlefieldThisTurnCtx(state, condition, ctx)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -309,6 +309,7 @@ class StackResolver(
         // regardless of how many opponent-controlled targets the spell chose.
         if (CrimeDetector.isCrime(newState, casterId, effectiveTargets)) {
             events.add(CommitCrimeEvent(casterId, cardId, eventName))
+            newState = recordCrime(newState, casterId)
         }
 
         // "Whenever a player chooses one or more targets" (Psychic Battle). Emit once per cast
@@ -328,6 +329,15 @@ class StackResolver(
             events
         )
     }
+
+    /**
+     * Record that [playerId] committed a crime this turn (CR Outlaws of Thunder Junction). Folded
+     * in at every [CommitCrimeEvent] emit site so the `PlayerCommittedCrimeThisTurn` condition (e.g.
+     * Seize the Secrets' cost reduction) can read it. Cleared at each turn boundary by `TurnManager`.
+     */
+    private fun recordCrime(state: GameState, playerId: EntityId): GameState =
+        if (playerId in state.playersWhoCommittedCrimeThisTurn) state
+        else state.copy(playersWhoCommittedCrimeThisTurn = state.playersWhoCommittedCrimeThisTurn + playerId)
 
     /**
      * Emit a [BecomesTargetEvent] for a permanent or spell target. Players and other target kinds
@@ -399,6 +409,7 @@ class StackResolver(
 
         if (CrimeDetector.isCrime(newState, ability.controllerId, targets)) {
             events.add(CommitCrimeEvent(ability.controllerId, abilityId, ability.sourceName))
+            newState = recordCrime(newState, ability.controllerId)
         }
 
         if (targets.isNotEmpty()) {
@@ -554,6 +565,7 @@ class StackResolver(
 
         if (CrimeDetector.isCrime(newState, ability.controllerId, targets)) {
             events.add(CommitCrimeEvent(ability.controllerId, abilityId, ability.sourceName))
+            newState = recordCrime(newState, ability.controllerId)
         }
 
         if (targets.isNotEmpty()) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -115,6 +115,14 @@ data class GameState(
     val nonlandPermanentLeftBattlefieldThisTurn: Boolean = false,
 
     /**
+     * Players (by entity id) who have committed a crime this turn (CR 700-level Outlaws of Thunder
+     * Junction rule). Populated wherever a [com.wingedsheep.engine.core.CommitCrimeEvent] is emitted
+     * (spell cast, activated ability, triggered ability), and cleared at every turn boundary. Read by
+     * the `PlayerCommittedCrimeThisTurn` condition (e.g. Seize the Secrets' cost reduction).
+     */
+    val playersWhoCommittedCrimeThisTurn: Set<EntityId> = emptySet(),
+
+    /**
      * Colors of the spell most recently cast this turn (by any player), or null if no spell has
      * been cast yet this turn. Used by Mana Maze's "can't cast a spell that shares a color with
      * the spell most recently cast this turn" restriction. Cleared at the start of each turn.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscerningPeddlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscerningPeddlerScenarioTest.kt
@@ -37,14 +37,20 @@ class DiscerningPeddlerScenarioTest : ScenarioTestBase() {
                 }
                 game.resolveStack()
 
-                // ETB MayEffect: accept, then choose the card to discard.
-                game.answerYesNo(true)
-                game.resolveStack()
-                val grizzly = game.state.getHand(game.player1Id).first { id ->
-                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                // ETB MayEffect: accept, then choose the card to discard. With a single
+                // discardable card the engine auto-selects it (no second decision), so guard
+                // the explicit selection like the Rescue Leopard loot test.
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(true)
+                    game.resolveStack()
                 }
-                game.selectCards(listOf(grizzly))
-                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    val grizzly = game.state.getHand(game.player1Id).first { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    }
+                    game.selectCards(listOf(grizzly))
+                    game.resolveStack()
+                }
 
                 withClue("Grizzly Bears should have been discarded to the graveyard") {
                     game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 1

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscerningPeddlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscerningPeddlerScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Discerning Peddler (OTJ #121) — {1}{R} Human Rogue 2/2.
+ *
+ * "When this creature enters, you may discard a card. If you do, draw a card."
+ *
+ * The ETB is a MayEffect → IfYouDoEffect(Discard, DrawCards). Verifies the accept path (a card is
+ * discarded and a card drawn) and the decline path (hand and graveyard unchanged).
+ */
+class DiscerningPeddlerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Discerning Peddler ETB loot") {
+
+            test("entering loots: discard a card then draw a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Discerning Peddler")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Discerning Peddler")
+                withClue("casting Discerning Peddler should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // ETB MayEffect: accept, then choose the card to discard.
+                game.answerYesNo(true)
+                game.resolveStack()
+                val grizzly = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                game.selectCards(listOf(grizzly))
+                game.resolveStack()
+
+                withClue("Grizzly Bears should have been discarded to the graveyard") {
+                    game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("the drawn Forest should be in hand") {
+                    game.state.getHand(game.player1Id).count { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                    } shouldBe 1
+                }
+            }
+
+            test("declining leaves hand and graveyard unchanged") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Discerning Peddler")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Discerning Peddler").error shouldBe null
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(false)
+                    game.resolveStack()
+                }
+
+                withClue("nothing discarded when declining") {
+                    game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 0
+                }
+                withClue("Grizzly Bears still in hand, Forest not drawn") {
+                    game.state.getHand(game.player1Id).count { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                    } shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeizeTheSecretsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeizeTheSecretsScenarioTest.kt
@@ -1,6 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
-import com.wingedsheep.engine.core.CardRegistry
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeizeTheSecretsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeizeTheSecretsScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardRegistry
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.SeizeTheSecrets
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Seize the Secrets:
+ *  - "{2}{U} Sorcery — This spell costs {1} less to cast if you've committed a crime this turn.
+ *     Draw two cards."
+ *
+ * Pins the turn-scoped crime tracker end-to-end: committing a crime (casting a spell at an
+ * opponent's permanent) flips `playersWhoCommittedCrimeThisTurn`, which the cost-reduction gate
+ * (`CostGating.OnlyIf(YouCommittedCrimeThisTurn)`) reads at cast time. Only the player who
+ * committed the crime gets the discount, and it must have happened *before* this cast (Seize the
+ * Secrets has no target of its own, so it never commits a crime).
+ */
+class SeizeTheSecretsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + SeizeTheSecrets)
+        return driver
+    }
+
+    test("full cost {2}{U} = 3 when no crime has been committed this turn") {
+        val registry = CardRegistry()
+        registry.register(TestCards.all)
+        registry.register(SeizeTheSecrets)
+        val calculator = CostCalculator(registry)
+
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val def = registry.requireCard("Seize the Secrets")
+        calculator.calculateEffectiveCost(driver.state, def, you).cmc shouldBe 3
+    }
+
+    test("costs {1} less = 2 once you've committed a crime this turn") {
+        val registry = CardRegistry()
+        registry.register(TestCards.all)
+        registry.register(SeizeTheSecrets)
+        val calculator = CostCalculator(registry)
+
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = if (you == driver.player1) driver.player2 else driver.player1
+
+        // The opponent controls a creature; targeting it with a spell is a crime.
+        val victim = driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+
+        // Cast Lightning Bolt at the opponent's creature → commits a crime.
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, listOf(victim)).isSuccess shouldBe true
+
+        driver.state.playersWhoCommittedCrimeThisTurn.contains(you) shouldBe true
+
+        val def = registry.requireCard("Seize the Secrets")
+        calculator.calculateEffectiveCost(driver.state, def, you).cmc shouldBe 2
+    }
+
+    test("opponent's crime does not discount your Seize the Secrets") {
+        val registry = CardRegistry()
+        registry.register(TestCards.all)
+        registry.register(SeizeTheSecrets)
+        val calculator = CostCalculator(registry)
+
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = if (you == driver.player1) driver.player2 else driver.player1
+
+        // Simulate the opponent (not you) having committed a crime this turn.
+        driver.replaceState(
+            driver.state.copy(
+                playersWhoCommittedCrimeThisTurn = setOf(opponent),
+            ),
+        )
+
+        val def = registry.requireCard("Seize the Secrets")
+        // You haven't committed a crime, so no discount.
+        calculator.calculateEffectiveCost(driver.state, def, you).cmc shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlickSequenceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlickSequenceScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Slick Sequence (OTJ #233) — {U}{R} Instant.
+ *
+ * "Slick Sequence deals 2 damage to any target. If you've cast another spell this turn, draw a card."
+ *
+ * The conditional draw is gated on `YouCastSpellsThisTurn(atLeast = 2)`, evaluated at resolution
+ * when Slick Sequence is itself already recorded — so "another spell" means this spell plus at least
+ * one other. Verifies: damage always lands; draw only when a prior spell was cast this turn.
+ */
+class SlickSequenceScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Slick Sequence") {
+
+            test("no draw when it's the only spell cast this turn (damage still lands)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Slick Sequence")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val cast = game.castSpellTargetingPlayer(1, "Slick Sequence", 2)
+                withClue("casting Slick Sequence should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("2 damage to the opponent (20 -> 18)") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("no card drawn — Slick Sequence is the only spell this turn") {
+                    game.handSize(1) shouldBe handBefore - 1 // only the Slick Sequence left hand
+                }
+            }
+
+            test("draws a card when another spell was cast this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInHand(1, "Slick Sequence")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // First spell this turn: Lightning Bolt at the opponent.
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+
+                val handBefore = game.handSize(1) // Slick Sequence still in hand
+
+                // Second spell: Slick Sequence. "Another spell" was cast, so it should draw.
+                game.castSpellTargetingPlayer(1, "Slick Sequence", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("opponent took 3 (bolt) + 2 (sequence) = 5 damage (20 -> 15)") {
+                    game.getLifeTotal(2) shouldBe 15
+                }
+                withClue("a card was drawn: Slick Sequence left hand (-1) but the Forest was drawn (+1) → net unchanged") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("the drawn Forest is in hand") {
+                    game.findCardsInHand(1, "Forest").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StoicSphinxScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StoicSphinxScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.StoicSphinx
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Stoic Sphinx (OTJ) — {2}{U}{U} Sphinx 5/3, Flash, Flying.
+ *
+ * "This creature has hexproof as long as you haven't cast a spell this turn."
+ *
+ * The hexproof is a `ConditionalStaticAbility(GrantKeyword(HEXPROOF, Self), Not(YouCastSpellsThisTurn(1)))`.
+ * These tests pin the toggle through the projector: hexproof while the controller's spell count is
+ * zero, gone the moment they cast a spell. Flash and Flying are always present.
+ */
+class StoicSphinxScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + StoicSphinx)
+        return driver
+    }
+
+    test("has flying and hexproof when no spell has been cast this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        // Place the Sphinx directly so casting it isn't counted toward the spell count.
+        val sphinx = driver.putCreatureOnBattlefield(you, "Stoic Sphinx")
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(sphinx, Keyword.FLYING) shouldBe true
+        projected.hasKeyword(sphinx, Keyword.HEXPROOF) shouldBe true
+    }
+
+    test("loses hexproof once you've cast a spell this turn (flying stays)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val sphinx = driver.putCreatureOnBattlefield(you, "Stoic Sphinx")
+
+        // Cast any spell this turn → controller's spell count becomes 1.
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, listOf(you)).isSuccess shouldBe true
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(sphinx, Keyword.FLYING) shouldBe true
+        projected.hasKeyword(sphinx, Keyword.HEXPROOF) shouldBe false
+    }
+})


### PR DESCRIPTION
Implements 4 Outlaws of Thunder Junction blue cards via the add-card workflow, plus a supporting engine/SDK feature (new condition; touches `StackResolver`, `GameState`, `TurnManager`, `Conditions`, `ConditionEvaluator`, `TurnConditions`) and mtgish bridge/emitter changes so they auto-generate.

Cards: Discerning Peddler · Seize the Secrets · Stoic Sphinx · Slick Sequence
Each has a scenario test.

⚠️ **DRAFT — verification pending.** A session-limit cutoff interrupted the agent before verify/PR. This branch touches **core engine files**, so review the new condition/feature carefully (add-feature scope). Run full `just test-rules` + per-card scenario tests + `just coverage-verify --set OTJ` (POR 0-mismatch) before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)