### PR TITLE
OTJ: G/W cards (Frontier Seeker, Oasis Gardener, Take Up the Shield, Spinewoods Paladin) + mtgish gen

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TakeUpTheShield.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TakeUpTheShield.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Take Up the Shield
+ * {1}{W}
+ * Instant
+ *
+ * Put a +1/+1 counter on target creature. It gains lifelink and indestructible until end of turn.
+ * (Damage and effects that say "destroy" don't destroy it.)
+ *
+ * Canonical printing lives here in Dominaria United (earliest real-expansion printing). The
+ * Outlaws of Thunder Junction reprint contributes a [com.wingedsheep.sdk.model.Printing] row only.
+ */
+val TakeUpTheShield = card("Take Up the Shield") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Put a +1/+1 counter on target creature. It gains lifelink and indestructible until end of turn. " +
+        "(Damage and effects that say \"destroy\" don't destroy it.)"
+
+    spell {
+        val t = target("target creature", TargetCreature())
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+            .then(Effects.GrantKeyword(Keyword.LIFELINK, t))
+            .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "35"
+        artist = "Manuel Castañón"
+        flavorText = "\"You are all part of my pride. As long as I live, I will protect you.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/851e842e-a497-4c36-90ee-8d64f806c378.jpg?1673306597"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FrontierSeeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/FrontierSeeker.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Frontier Seeker
+ * {1}{W}
+ * Creature — Human Scout
+ * 2/1
+ *
+ * When this creature enters, look at the top five cards of your library. You may reveal a
+ * Mount creature card or a Plains card from among them and put it into your hand. Put the
+ * rest on the bottom of your library in a random order.
+ *
+ * "Plains card" matches any card with the Plains land type (including nonbasic duals), per
+ * the standard land-type ruling.
+ */
+val FrontierSeeker = card("Frontier Seeker") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, look at the top five cards of your library. You may " +
+        "reveal a Mount creature card or a Plains card from among them and put it into your hand. " +
+        "Put the rest on the bottom of your library in a random order."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(5)),
+                    storeAs = "looked"
+                ),
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.Or(
+                                listOf(
+                                    CardPredicate.And(
+                                        listOf(
+                                            CardPredicate.HasSubtype(Subtype("Mount")),
+                                            CardPredicate.IsCreature
+                                        )
+                                    ),
+                                    CardPredicate.HasSubtype(Subtype.PLAINS)
+                                )
+                            )
+                        )
+                    ),
+                    storeSelected = "kept",
+                    storeRemainder = "rest",
+                    selectedLabel = "Put in hand",
+                    remainderLabel = "Put on bottom"
+                ),
+                MoveCollectionEffect(
+                    from = "kept",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "13"
+        artist = "Raluca Marinescu"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/9368cc76-bee5-4b46-a309-981106c3addf.jpg?1712355276"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OasisGardener.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/OasisGardener.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Oasis Gardener
+ * {3}
+ * Artifact Creature — Scarecrow
+ * 2/2
+ *
+ * When this creature enters, you gain 2 life.
+ * {T}: Add one mana of any color.
+ */
+val OasisGardener = card("Oasis Gardener") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, you gain 2 life.\n{T}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+        description = "you gain 2 life."
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "246"
+        artist = "Kristina Carroll"
+        flavorText = "\"I think the blasted thing's actually attracting more birds, but all the same, " +
+            "the garden's never looked better.\"\n—Jay Marigold, homesteader"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee0dc663-4bfb-46d4-af79-d0143c799487.jpg?1712356276"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SpinewoodsPaladin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SpinewoodsPaladin.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Spinewoods Paladin
+ * {4}{G}
+ * Creature — Human Knight
+ * 5/4
+ *
+ * Trample
+ * When this creature enters, you gain 3 life.
+ * Plot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery
+ * on a later turn without paying its mana cost. Plot only as a sorcery.)
+ */
+val SpinewoodsPaladin = card("Spinewoods Paladin") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Knight"
+    power = 5
+    toughness = 4
+    oracleText = "Trample\nWhen this creature enters, you gain 3 life.\n" +
+        "Plot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery " +
+        "on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+        description = "you gain 3 life."
+    }
+
+    keywordAbility(KeywordAbility.plot("{3}{G}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Kai Carpenter"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b2b432d-9e73-4ab2-a098-546d406df6c0.jpg?1712356003"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TakeUpTheShieldReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/TakeUpTheShieldReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Take Up the Shield reprint in OTJ.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in the
+ * Dominaria United `cards/` package (earliest real-expansion printing). This file contributes
+ * only the OTJ-specific presentation row — set, collector number, art — picked up
+ * automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val TakeUpTheShieldReprint = Printing(
+    oracleId = "e8d0eafe-540a-4b2e-a989-e98ff3c31105",
+    name = "Take Up the Shield",
+    setCode = "OTJ",
+    collectorNumber = "34",
+    scryfallId = "76a31968-ba6d-4c01-838f-4cb8c64e73fb",
+    artist = "Josiah \"Jo\" Cameron",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/76a31968-ba6d-4c01-838f-4cb8c64e73fb.jpg?1712355363",
+    releaseDate = "2024-04-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DMU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DMU.json
@@ -726,6 +726,64 @@
     ]
 }
 
+// Take Up the Shield
+{
+    "name": "Take Up the Shield",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Put a +1/+1 counter on target creature. It gains lifelink and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "artist": "Manuel Castañón",
+        "flavorText": "\"You are all part of my pride. As long as I live, I will protect you.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/851e842e-a497-4c36-90ee-8d64f806c378.jpg?1673306597"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Tolarian Terror
 {
     "name": "Tolarian Terror",

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -1102,6 +1102,111 @@
     ]
 }
 
+// Frontier Seeker
+{
+    "name": "Frontier Seeker",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "When this creature enters, look at the top five cards of your library. You may reveal a Mount creature card or a Plains card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "Or",
+                                        "predicates": [
+                                            {
+                                                "type": "And",
+                                                "predicates": [
+                                                    {
+                                                        "type": "HasSubtype",
+                                                        "subtype": "Mount"
+                                                    },
+                                                    "IsCreature"
+                                                ]
+                                            },
+                                            {
+                                                "type": "HasSubtype",
+                                                "subtype": "Plains"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put on bottom"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "UNCOMMON",
+        "artist": "Raluca Marinescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/9368cc76-bee5-4b46-a309-981106c3addf.jpg?1712355276"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Geyser Drake
 {
     "name": "Geyser Drake",
@@ -1609,6 +1714,53 @@
     ]
 }
 
+// Oasis Gardener
+{
+    "name": "Oasis Gardener",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "When this creature enters, you gain 2 life.\n{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "you gain 2 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "artist": "Kristina Carroll",
+        "flavorText": "\"I think the blasted thing's actually attracting more birds, but all the same, the garden's never looked better.\"\n—Jay Marigold, homesteader",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee0dc663-4bfb-46d4-af79-d0143c799487.jpg?1712356276"
+    },
+    "colorIdentityOverride": []
+}
+
 // Riku of Many Paths
 {
     "name": "Riku of Many Paths",
@@ -1810,6 +1962,55 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Spinewoods Paladin
+{
+    "name": "Spinewoods Paladin",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Trample\nWhen this creature enters, you gain 3 life.\nPlot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE",
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{3}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "you gain 3 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "artist": "Kai Carpenter",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b2b432d-9e73-4ab2-a098-546d406df6c0.jpg?1712356003"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -5,11 +5,14 @@ import com.wingedsheep.tooling.coverage.Composite
 import com.wingedsheep.tooling.coverage.Dsl
 import com.wingedsheep.tooling.coverage.Lit
 import com.wingedsheep.tooling.coverage.Raw
+import com.wingedsheep.tooling.coverage.Registry
 import com.wingedsheep.tooling.coverage.amountNode
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
@@ -266,6 +269,40 @@ internal fun EmitCtx.renderLook(node: JsonObject, args: JsonElement?, tvar: Stri
             ),
         ))
     }
+    // "Look at the top N. You may reveal a <type> card and put it into your hand. Put the rest on the
+    // BOTTOM of your library in a random order." (Frontier Seeker). This is the filtered-may-keep / bottom
+    // shape: a ChooseUpTo(1) over a card-type filter, kept revealed to hand, remainder bottomed at random.
+    // The flat lookAtTopAndKeep pattern can't carry a selection filter, so render the atomic pipeline.
+    // Only render when the reveal filter translates faithfully; an untranslatable predicate scaffolds.
+    if ("MayRevealACardOfTypeAndPutIntoHand" in blob &&
+        "PutTheRemainingCardsOnTheBottomOfLibraryInARandomOrder" in blob
+    ) {
+        val n = findInteger(node) ?: return null
+        val filterNode = mayRevealFilterNode(node) ?: return null
+        val pred = cardsPredicateDsl(filterNode) ?: return null
+        return Composite(listOf(
+            Lit("GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed($n)), storeAs = \"looked\")"),
+            Raw(
+                "SelectFromCollectionEffect(\n" +
+                    "                from = \"looked\",\n" +
+                    "                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),\n" +
+                    "                filter = GameObjectFilter(cardPredicates = listOf($pred)),\n" +
+                    "                storeSelected = \"kept\",\n" +
+                    "                storeRemainder = \"rest\",\n" +
+                    "                selectedLabel = \"Put in hand\",\n" +
+                    "                remainderLabel = \"Put on bottom\"\n" +
+                    "            )",
+            ),
+            Lit("MoveCollectionEffect(from = \"kept\", destination = CardDestination.ToZone(Zone.HAND), revealed = true)"),
+            Raw(
+                "MoveCollectionEffect(\n" +
+                    "                from = \"rest\",\n" +
+                    "                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),\n" +
+                    "                order = CardOrder.Random\n" +
+                    "            )",
+            ),
+        ))
+    }
     // "Look at the top N, put some into your hand" — only a fixed look/keep count renders this way.
     val look = findInteger(node)
     var keep: Int? = null
@@ -279,3 +316,58 @@ internal fun EmitCtx.renderLook(node: JsonObject, args: JsonElement?, tvar: Stri
     }
     return null
 }
+
+/**
+ * The `_Cards` filter node of the `MayRevealACardOfTypeAndPutIntoHand` sub-action inside a
+ * `LookAtTheTopNumberCardsOfLibrary` action, or null. The look action's `args` is
+ * `[Integer, [subActions…]]`; we find the reveal sub-action and return its `args` (the filter tree).
+ */
+private fun mayRevealFilterNode(node: JsonObject): JsonElement? {
+    val subActions = node.field("args").asArr?.getOrNull(1).asArr ?: return null
+    val reveal = subActions.firstOrNull {
+        it.strField("_LookAtTopOfLibraryAction") == "MayRevealACardOfTypeAndPutIntoHand"
+    } ?: return null
+    return reveal.field("args")
+}
+
+/**
+ * Translate a mtgish `_Cards` filter tree into a `CardPredicate.*` DSL string, or null when any leaf
+ * is a predicate we can't render faithfully (power/mana-value/ability/variable/colour/etc.). Declining
+ * the whole filter sends the card to SCAFFOLD rather than silently dropping a constraint.
+ *
+ * Faithfully handled: card-type (`IsCardtype`), creature subtype (`IsCreatureType`), land/artifact/
+ * enchantment subtype, supertype, and `And`/`Or` compositions of those — the shapes that map exactly
+ * onto `CardPredicate` constants.
+ */
+private fun cardsPredicateDsl(node: JsonElement?): String? {
+    val obj = node as? JsonObject ?: return null
+    return when (obj.strField("_Cards")) {
+        "And" -> obj.field("args").asArr?.let { parts ->
+            val mapped = parts.map { cardsPredicateDsl(it) ?: return null }
+            "CardPredicate.And(listOf(${mapped.joinToString(", ")}))"
+        }
+        "Or" -> obj.field("args").asArr?.let { parts ->
+            val mapped = parts.map { cardsPredicateDsl(it) ?: return null }
+            "CardPredicate.Or(listOf(${mapped.joinToString(", ")}))"
+        }
+        "IsCardtype" -> when (obj.field("args").asStr()) {
+            "Creature" -> "CardPredicate.IsCreature"
+            "Land" -> "CardPredicate.IsLand"
+            "Artifact" -> "CardPredicate.IsArtifact"
+            "Enchantment" -> "CardPredicate.IsEnchantment"
+            "Instant" -> "CardPredicate.IsInstant"
+            "Sorcery" -> "CardPredicate.IsSorcery"
+            "Planeswalker" -> "CardPredicate.IsPlaneswalker"
+            else -> null
+        }
+        // Subtype filters all route through HasSubtype(Subtype("X")); use the named SDK constant when
+        // one exists ("Plains" -> Subtype.PLAINS) so the output matches hand-authored convention.
+        "IsCreatureType", "IsLandType", "IsArtifactType", "IsEnchantmentType" ->
+            obj.field("args").asStr()?.let { "CardPredicate.HasSubtype(${subtypeRef(it)})" }
+        else -> null
+    }
+}
+
+/** `Subtype.PLAINS` when a named companion constant exists for the value, else `Subtype("Mount")`. */
+private fun subtypeRef(value: String): String =
+    Registry.subtypeConstant(value)?.let { "Subtype.$it" } ?: "Subtype(\"$value\")"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrontierSeekerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrontierSeekerScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Frontier Seeker (OTJ #13) — {1}{W} Creature — Human Scout, 2/1.
+ *
+ * "When this creature enters, look at the top five cards of your library. You may reveal a
+ *  Mount creature card or a Plains card from among them and put it into your hand. Put the
+ *  rest on the bottom of your library in a random order."
+ *
+ * Exercises the look-at-top / may-take-a-matching-card / bottom-the-rest pipeline: only a
+ * Mount creature card or a Plains card is a legal pick; everything else returns to the bottom.
+ */
+class FrontierSeekerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Frontier Seeker enters-the-battlefield trigger") {
+
+            fun buildGame() = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Frontier Seeker")
+                .withLandsOnBattlefield(1, "Plains", 2)
+                // Top of library seeded with a Mount creature, a non-matching creature, and filler.
+                .withCardInLibrary(1, "Bridled Bighorn") // Sheep Mount — a legal pick
+                .withCardInLibrary(1, "Grizzly Bears")   // not a Mount, not a Plains
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Mountain")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            test("takes the Mount creature card into hand and bottoms the rest") {
+                val game = buildGame()
+                val mount = game.findCardsInLibrary(1, "Bridled Bighorn").first()
+
+                game.castSpell(1, "Frontier Seeker").error shouldBe null
+                game.resolveStack()
+
+                // ETB look-5 pauses for a "may take a Mount/Plains card" selection.
+                game.getPendingDecision() ?: error("expected a selection decision for the look-five trigger")
+                game.selectCards(listOf(mount)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Mount creature card is now in hand") {
+                    game.isInHand(1, "Bridled Bighorn") shouldBe true
+                }
+                withClue("the other four looked-at cards went to the bottom (library back to 4)") {
+                    game.librarySize(1) shouldBe 4
+                }
+                withClue("Frontier Seeker resolved onto the battlefield") {
+                    game.isOnBattlefield("Frontier Seeker") shouldBe true
+                }
+            }
+
+            test("may decline and put all five on the bottom") {
+                val game = buildGame()
+
+                game.castSpell(1, "Frontier Seeker").error shouldBe null
+                game.resolveStack()
+
+                game.getPendingDecision() ?: error("expected a selection decision for the look-five trigger")
+                // Decline the optional reveal — nothing goes to hand.
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing added to hand") {
+                    game.isInHand(1, "Bridled Bighorn") shouldBe false
+                }
+                withClue("all five looked-at cards returned to the bottom") {
+                    game.librarySize(1) shouldBe 5
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OasisGardenerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OasisGardenerScenarioTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Oasis Gardener (OTJ #246) — {3} Artifact Creature — Scarecrow, 2/2.
+ *
+ * "When this creature enters, you gain 2 life.
+ *  {T}: Add one mana of any color."
+ *
+ * The mana ability is a generic, well-covered primitive ([Effects.AddAnyColorMana]); this test
+ * pins the novel ETB life gain and confirms the creature resolves onto the battlefield.
+ */
+class OasisGardenerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Oasis Gardener ETB") {
+
+            test("gains 2 life when it enters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Oasis Gardener")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startLife = game.getLifeTotal(1)
+
+                game.castSpell(1, "Oasis Gardener").error shouldBe null
+                game.resolveStack()
+
+                withClue("controller gained 2 life from the ETB trigger") {
+                    game.getLifeTotal(1) shouldBe startLife + 2
+                }
+                withClue("Oasis Gardener resolved onto the battlefield") {
+                    game.isOnBattlefield("Oasis Gardener") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpinewoodsPaladinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpinewoodsPaladinScenarioTest.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Spinewoods Paladin (OTJ #183) — {4}{G} Creature — Human Knight, 5/4.
+ *
+ * "Trample
+ *  When this creature enters, you gain 3 life.
+ *  Plot {3}{G}"
+ *
+ * Plot is a generic, well-covered keyword; this test pins the novel ETB life gain and the
+ * Trample keyword.
+ */
+class SpinewoodsPaladinScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Spinewoods Paladin ETB") {
+
+            test("gains 3 life on enter and has trample") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Spinewoods Paladin")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startLife = game.getLifeTotal(1)
+
+                game.castSpell(1, "Spinewoods Paladin").error shouldBe null
+                game.resolveStack()
+
+                withClue("controller gained 3 life from the ETB trigger") {
+                    game.getLifeTotal(1) shouldBe startLife + 3
+                }
+                withClue("Spinewoods Paladin resolved onto the battlefield") {
+                    game.isOnBattlefield("Spinewoods Paladin") shouldBe true
+                }
+                val paladin = game.findPermanent("Spinewoods Paladin")!!
+                withClue("Spinewoods Paladin has trample") {
+                    projector.hasProjectedKeyword(game.state, paladin, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TakeUpTheShieldScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TakeUpTheShieldScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Take Up the Shield (DMU #35, reprinted in OTJ #34) — {1}{W} Instant.
+ *
+ * "Put a +1/+1 counter on target creature. It gains lifelink and indestructible until end of
+ *  turn."
+ *
+ * Canonical definition lives in Dominaria United; the OTJ printing contributes only a Printing row.
+ */
+class TakeUpTheShieldScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Take Up the Shield") {
+
+            test("adds a +1/+1 counter and grants lifelink and indestructible") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Take Up the Shield")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+                val powerBefore = projector.getProjectedPower(game.state, bear)
+
+                game.castSpell(1, "Take Up the Shield", bear).error shouldBe null
+                game.resolveStack()
+
+                withClue("the targeted creature has a +1/+1 counter") {
+                    val counters = game.state.getEntity(bear)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 1
+                }
+                withClue("the +1/+1 counter raises projected power by 1") {
+                    projector.getProjectedPower(game.state, bear) shouldBe powerBefore + 1
+                }
+                withClue("the creature gains lifelink until end of turn") {
+                    projector.hasProjectedKeyword(game.state, bear, Keyword.LIFELINK) shouldBe true
+                }
+                withClue("the creature gains indestructible until end of turn") {
+                    projector.hasProjectedKeyword(game.state, bear, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements 4 Outlaws of Thunder Junction green/white cards via the add-card workflow, plus an mtgish emitter change (`ZoneHandlers.kt`) so they auto-generate.

Cards: Frontier Seeker · Oasis Gardener · Take Up the Shield · Spinewoods Paladin
Each has a scenario test. Take Up the Shield's canonical `card(...)` is placed in its earliest printing (DMU) with an OTJ `Printing(...)` reprint row.

⚠️ **DRAFT — verification pending.** A session-limit cutoff interrupted the agent before verify/PR. Confirm the DMU reprint placement (check-card-printing rule), run per-card scenario tests + `just coverage-verify --set OTJ` (POR 0-mismatch) before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)