### PR TITLE
Teach the mtgish generator the Earthbend keyword action

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -599,6 +599,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   duplicated on the effect. For "tap X target creatures" use `dynamicMaxCount = DynamicAmount.XValue`
   on the target (Icy Blast); for a fixed cap use `count = N` (Tidal Surge, Choking Tethers, Eddymurk
   Crab). Do **not** pass a magic `count = 20` to mean "any number" — use `unlimited`/`dynamicMaxCount`.
+- `Effects.UntapEachTarget()` — the untap twin of `TapEachTarget`: untaps every object chosen as a
+  target ("untap each of those creatures"). Composes `ForEachTargetEffect` over
+  `Effects.Untap(ContextTarget(0))`, with the count owned by the spell's target requirement.
 - `PhaseOutEffect(target = Self)` — phase the target permanent out (Rule 702.26); facade `Effects.PhaseOut(target)`. While phased out it's treated as though it doesn't exist (excluded from `getBattlefield`, so from projection, triggers, combat, targeting, and SBAs) and phases back in before its controller's next untap step. Indirect phasing (attached Auras/Equipment) is handled automatically. Used as the `suffer` branch of a pay-or-phase trigger (Vaporous Djinn: "phases out unless you pay {U}{U}" = `PayOrSufferEffect(Costs.pay.Mana(...), Effects.PhaseOut())`).
 - `MarkExileOnDeathEffect(target)` — replace next "to graveyard" with "to exile".
 - `GatedEffect(gate, then, otherwise?, decisionMaker?)` — **the unified resolution frame for the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2058,6 +2058,16 @@ object Effects {
         )
 
     /**
+     * Untap every permanent chosen as a target ("untap each of those creatures"). The untap twin of
+     * [TapEachTarget]: composes [ForEachTargetEffect] over [Effects.Untap], so the number of targets is
+     * owned entirely by the spell's `TargetCreature`/`TargetPermanent`, not duplicated on the effect.
+     */
+    fun UntapEachTarget(): Effect =
+        com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect(
+            listOf(TapUntapEffect(EffectTarget.ContextTarget(0), tap = false))
+        )
+
+    /**
      * Phase out a target permanent (Rule 702.26). It's treated as though it
      * doesn't exist until it phases back in before its controller's next untap step.
      */

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -19,6 +19,13 @@ internal fun BridgeBuilder.manaCountersAndState() {
     effect("AddCreatureTypeVariable", "BecomeCreatureType", UNIVERSAL)
     effects("PutACounterOfTypeOnPermanent", "PutNumberCountersOfTypeOnPermanent", tag = "AddCounters", note = UNIVERSAL)
 
+    // Earthbend N (TLA keyword action): target land becomes a 0/0 creature-land with haste, gets N
+    // +1/+1 counters, and gains "when it dies or is exiled, return it to the battlefield tapped".
+    // Composed wholesale by Effects.Earthbend (no Keyword.EARTHBEND) — animate + grant haste + add
+    // counters + grant the return self-trigger (whose body is two zone-gated MoveToZone moves).
+    composed("Earthbend", "Effects.Earthbend: AnimateLand + GrantKeyword(haste) + AddCounters + GrantTriggeredAbility(return)",
+        composes = listOf("AnimateLand", "GrantKeyword", "AddCounters", "GrantTriggeredAbility", "MoveToZone"))
+
     effect("RegeneratePermanent", "Regenerate", UNIVERSAL)
     effects("GainControlOfPermanent", "GainControlOfPermanentUntil", tag = "GainControl", note = UNIVERSAL)
     effect("RemoveCreatureFromCombat", "RemoveFromCombat", UNIVERSAL)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -88,6 +88,17 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         call("AddCountersEffect", arg("counterType", counter), arg("count", "1"), arg("target", tgt))
     }
 
+    on("Earthbend") { _, args, tvar ->
+        // Earthbend N (TLA keyword action): "target land becomes a 0/0 creature with haste that's still
+        // a land. Put N +1/+1 counters on it. When it dies or is exiled, return it to the battlefield
+        // tapped." The whole keyword action lowers to Effects.Earthbend(N, target). The IR args are
+        // [<target land ref>, <N>]. Only a fixed integer N renders — an "Earthbend X" carries a
+        // cast-time X the Int-typed facade can't take, so it scaffolds.
+        val n = findInteger(args) as? Int ?: return@on null
+        val tgt = refTarget(args, tvar) ?: return@on null
+        call("Effects.Earthbend", arg("$n"), arg(Lit(tgt)))
+    }
+
     on("CreatePermanentLayerEffectUntil", "CreateEachPermanentLayerEffectUntil") { node, _, tvar ->
         // "Enchanted creature and other creatures that share a creature type with it get …" (Onslaught
         // Crowns) — a group keyed to the host permanent, which the generic ForEachInGroup can't express.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -291,7 +291,19 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
         }
         val singleType = mapOf("Land" to "TargetFilter.Land", "Artifact" to "TargetFilter.Artifact", "Enchantment" to "TargetFilter.Enchantment")
         if (types.size == 1 && types.first() in singleType) {
-            val parts = mutableListOf(arg("filter", singleType.getValue(types.first())))
+            // "target land you control" / "...an opponent controls" — the controller restriction is a
+            // ControlledByAPlayer clause. Preserve it as a `.youControl()` / `.opponentControls()` suffix
+            // (mirrors the creature path); a controller clause we can't render exactly declines (-> SCAFFOLD)
+            // rather than silently widening to any land/artifact/enchantment.
+            val controller: Link? = when {
+                "ControlledByAPlayer" !in blob -> null
+                "\"You\"" in blob -> Link("youControl")
+                "\"Opponent\"" in blob -> Link("opponentControls")
+                else -> return null
+            }
+            var f: Dsl = Lit(singleType.getValue(types.first()))
+            controller?.let { f = f.dot(it) }
+            val parts = mutableListOf(arg("filter", f))
             if (ttype in setOf("NumberTargetPermanents", "UptoNumberTargetPermanents") && countInt is Int) parts.add(0, arg("count", "$countInt"))
             if (ttype == "UptoNumberTargetPermanents") parts.add(0, arg("optional", "true"))
             return Call("TargetPermanent", parts)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UntapEachTargetScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UntapEachTargetScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for `Effects.UntapEachTarget()` — the untap twin of `Effects.TapEachTarget()`
+ * ("untap each of those target creatures"). Like its tap counterpart it composes
+ * `ForEachTargetEffect` over `Effects.Untap`, so the count is owned entirely by the spell's
+ * `TargetCreature` (here "up to three") and never duplicated on the effect.
+ *
+ * No printed card uses the facade yet (it backs the mtgish auto-generator's `UntapEachPermanent`
+ * rendering), so this pins the wiring through an inline test sorcery.
+ */
+class UntapEachTargetScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.handCardId(playerNumber: Int, name: String): EntityId {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getHand(playerId).first {
+            state.getEntity(it)?.get<CardComponent>()?.name == name
+        }
+    }
+
+    private fun TestGame.isTapped(id: EntityId): Boolean =
+        state.getEntity(id)?.has<TappedComponent>() == true
+
+    init {
+        cardRegistry.register(
+            card("Test Untap Surge") {
+                manaCost = "{1}{U}"
+                typeLine = "Sorcery"
+                oracleText = "Untap up to three target creatures."
+                spell {
+                    target("target", TargetCreature(optional = true, count = 3))
+                    effect = Effects.UntapEachTarget()
+                }
+            }
+        )
+
+        context("Effects.UntapEachTarget — fixed count (up to three)") {
+            test("untaps every targeted creature, leaves untargeted ones tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Test Untap Surge")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true)
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findAllPermanents("Grizzly Bears")
+                bears.size shouldBe 3
+                withClue("all three bears start tapped") {
+                    bears.all { game.isTapped(it) } shouldBe true
+                }
+
+                val targeted = bears.take(2)
+                val untargeted = bears.drop(2)
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        game.handCardId(1, "Test Untap Surge"),
+                        targeted.map { ChosenTarget.Permanent(it) }
+                    )
+                )
+                withClue("Test Untap Surge should cast: ${cast.error}") { cast.error shouldBe null }
+
+                game.resolveStack()
+
+                withClue("both targeted creatures should be untapped") {
+                    targeted.none { game.isTapped(it) } shouldBe true
+                }
+                withClue("the untargeted creature should remain tapped") {
+                    untargeted.all { game.isTapped(it) } shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds the TLA **Earthbend** keyword action to the `:mtgish-tooling` auto-generator (the `add-feature` "Step 8b" wiring). The Earthbend *engine* feature already exists as `Effects.Earthbend` (a pure composition — no fake keyword); this PR teaches the predictive tooling to recognise and draft it.

### Generator wiring (the core of the task)
- **Capability bridge** (`bridge/ManaCountersAndState.kt`): a `composed` entry for the `Earthbend` IR `_Action` → `AnimateLand + GrantKeyword(haste) + AddCounters + GrantTriggeredAbility(return) + MoveToZone`. Earthbend cards now score **COVERABLE** instead of blocked.
- **Rendering emitter** (`emitter/TapLayerStateHandlers.kt`): a handler that renders `Effects.Earthbend(N, t)` from the IR `[<target land ref>, <N>]`. An `Earthbend X` declines → SCAFFOLD (the `Int`-typed facade can't carry a cast-time X — the creator's-note rule).

### Supporting fixes the render needed / surfaced
- **`emitter/TargetRecovery.kt`**: a single-type Land/Artifact/Enchantment target now preserves its `ControlledByAPlayer` clause as `.youControl()` / `.opponentControls()` (mirrors the existing creature path), instead of silently widening "target land **you control**" to *any* land. A controller shape we can't render exactly declines → SCAFFOLD (decline, don't widen).
- **`mtg-sdk` `Effects.UntapEachTarget()`**: the untap twin of the existing `TapEachTarget()`. The `UntapEachPermanent` emitter handler already *constructed* this facade name, but it was never added to the SDK — so the first TLA card to hit it (Fancy Footwork) emitted a non-compiling draft and blocked the whole-set verify gate. Added the 4-line composition + a scenario test.

## Why it's a composition, not a new type
Earthbend is a keyword *action*, not a keyword *ability* — no `Keyword.EARTHBEND`. The bridge entry points at the existing primitives; the emitter calls the existing `Effects.Earthbend` facade. One bridge/emitter pair unlocks every earthbend card in the corpus.

## Verification
- `coverage --card "Earthbending Lesson"` → **COVERABLE-NOW**; emits a complete **AUTO** draft with `Effects.Earthbend(4, t)` and `.youControl()` preserved.
- `coverage-verify TLA` → **exit 0** (compile + capability gate); 5 earthbend cards (Earthbending Lesson, Badgermole, The Boulder Ready to Rumble, Haru Hidden Talent, Earth Village Ruffians) now whole-card drafts.
- `EmitterGoldenTest` POR + EOE → **PASS** — the shared `TargetRecovery` change causes zero golden drift on calibrated sets.
- Scenario tests pass: new `UntapEachTargetScenarioTest` + existing `EarthbendingLessonTest` / `BadgermoleCubTest`.

Docs: `card-sdk-language-reference.md` updated for `UntapEachTarget` (Earthbend was already documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)