### PR TITLE
Tournament: wait for human ready before starting next AI game

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -127,7 +127,9 @@ class TournamentMatchHandler(
 
             val lobby = ctx.lobbyRepository.findLobbyById(lobbyId)
             if (lobby != null) {
-                autoReadyAiPlayers(lobby, tournament)
+                // Ready the AI, but not the human: they must click "Ready for Next Round" after
+                // dismissing the game-over overlay, so the next game can't start underneath it.
+                autoReadyAiPlayers(lobby, tournament, autoReadyHumansVsAi = false)
                 ctx.lobbyRepository.saveLobby(lobby)
             }
 
@@ -307,7 +309,9 @@ class TournamentMatchHandler(
         }
 
         if (!tournament.isComplete) {
-            autoReadyAiPlayers(lobby, tournament)
+            // Ready the AI for the next round, but not the human: they must click "Ready for Next
+            // Round" after dismissing the game-over overlay, so the next game can't start underneath it.
+            autoReadyAiPlayers(lobby, tournament, autoReadyHumansVsAi = false)
         }
 
         ctx.lobbyRepository.saveLobby(lobby)
@@ -748,14 +752,20 @@ class TournamentMatchHandler(
         }
     }
 
-    fun autoReadyAiPlayers(lobby: TournamentLobby, tournament: TournamentManager) {
+    /**
+     * @param autoReadyHumansVsAi when true, a human whose next opponent is AI is auto-readied (and the
+     *   match started) so a solo-vs-AI tournament doesn't require a manual ready click to begin. This is
+     *   intentionally `false` after a game/round finishes: the human must first dismiss the game-over
+     *   overlay and click "Ready for Next Round" in the lobby, so the next game can't start underneath it.
+     */
+    fun autoReadyAiPlayers(lobby: TournamentLobby, tournament: TournamentManager, autoReadyHumansVsAi: Boolean = true) {
         val lock = ctx.roundLocks.computeIfAbsent(lobby.lobbyId) { Any() }
         synchronized(lock) {
-            autoReadyAiPlayersLocked(lobby, tournament)
+            autoReadyAiPlayersLocked(lobby, tournament, autoReadyHumansVsAi)
         }
     }
 
-    private fun autoReadyAiPlayersLocked(lobby: TournamentLobby, tournament: TournamentManager) {
+    private fun autoReadyAiPlayersLocked(lobby: TournamentLobby, tournament: TournamentManager, autoReadyHumansVsAi: Boolean) {
         // Check if there are any AI players with submitted decks to ready up
         val hasAiPlayersToReady = lobby.players.any { (playerId, ps) ->
             aiGameManager.isAiPlayer(playerId) && ps.hasSubmittedDeck && playerId !in lobby.getReadyPlayerIds()
@@ -795,7 +805,10 @@ class TournamentMatchHandler(
             }
         }
 
-        // Auto-ready human players whose next opponent is AI (no reason to wait)
+        // Auto-ready human players whose next opponent is AI (no reason to wait).
+        // Skipped after a game/round ends: the human must dismiss the game-over overlay and click
+        // "Ready for Next Round" first, otherwise the next game would start under the overlay.
+        if (!autoReadyHumansVsAi) return
         for ((playerId, playerState) in lobby.players) {
             if (aiGameManager.isAiPlayer(playerId)) continue
             if (!playerState.hasSubmittedDeck) continue


### PR DESCRIPTION
## Problem

When playing a tournament against AI, ending a game immediately started the next one — while the **"Return to Menu" / "Watch Replay"** game-over overlay was still on screen. The new board rendered underneath the overlay before the player could react.

## Cause

`TournamentMatchHandler.autoReadyAiPlayers` does two things: readies AI players, and *also* auto-readies any human whose next opponent is AI and then immediately starts the match via `tryStartMatchForPlayer`. That convenience is correct for the **initial** tournament start, but wrong after a game/round finishes — it readies the human and starts the next game before they've dismissed the overlay.

The two post-game call sites are `handleMatchResult` (after each game) and `doHandleRoundComplete` (after a round).

## Fix

Add an `autoReadyHumansVsAi` flag (default `true`) to `autoReadyAiPlayers`, and pass `false` from the two post-game paths. The AI still auto-readies, but the human must dismiss the overlay and click **"Ready for Next Round"** in the lobby. `tryStartMatchForPlayer` only starts the match once *both* sides are ready (it returns early at the `opponentId !in readyPlayerIds` check while the human is still unready), so the next game can no longer begin underneath the overlay.

Initial-start and resume flows keep the default `true`, so a fresh solo-vs-AI tournament still kicks off without a redundant extra ready click.

## Testing

`./gradlew :game-server:compileKotlin` — BUILD SUCCESSFUL. (Behavioral change is in lobby orchestration; game-server has no unit tests, behavior is covered by E2E.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)