### PR TITLE
Add Firebending keyword + combat-duration mana

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -434,7 +434,11 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 ### Mana
 
-- `AddMana(color, amount, restriction?)` — add N of one color.
+- `AddMana(color, amount, restriction?, expiry?)` — add N of one color. `expiry` is a `ManaExpiry`
+  (default `END_OF_TURN`); set `END_OF_COMBAT` for firebending-style combat-duration mana that the
+  pool keeps through combat and discards when combat ends. Combat-duration mana is stored as an
+  `AnySpend` restricted entry (so it spends like any other mana) and cleared by
+  `CombatManager.endCombat`. See [ManaExpiry](#manaexpiry).
 - `AddColorlessMana(amount, restriction?)` — add colorless.
 - `AddManaOfChoice(colorSet, amount?, restriction?, riders?)` — **unified primitive.** Add N mana of one color the controller picks from a resolved [ManaColorSet](#manacolorset). All "any-color from a constrained pool" cards (any color, commander identity, among permanents, lands could produce, source-chosen color) are expressed as this effect plus a different `ManaColorSet`. `riders` is a `Set<ManaSpellRider>` consumed when the mana pays for a spell (e.g. Path of Ancestry tags its mana with `ScryOnSharedTypeWithCommander`); when riders are set without a `restriction`, the engine stores the entries under `ManaRestriction.AnySpend` to preserve the rider through the pool.
 - `AddAnyColorMana(amount?, restriction?)` — sugar for `AddManaOfChoice(ManaColorSet.AnyColor, amount)`.
@@ -1948,6 +1952,14 @@ composite abilities).
   overload: it adds a `KeywordAbility.Variable(MOBILIZE, label)` display tag (prints "Mobilize X") plus the same
   attack-triggered `CreateTokenEffect`, but with `count = amount` (any `DynamicAmount`) resolved at attack time.
   Avenger of the Fallen passes `DynamicAmounts.creatureCardsInYourGraveyard()`.
+- `Firebending(n)` — "Whenever this creature attacks, add N {R}. Until end of combat, you don't lose this mana
+  as steps and phases end." (CR 702.189, Avatar: The Last Airbender). Display-only; wire the behavior with the
+  `card { firebending(n) }` builder helper, which adds this keyword ability plus a "whenever this attacks"
+  triggered `AddManaEffect(Color.RED, n, expiry = ManaExpiry.END_OF_COMBAT)` (mirrors `mobilize()` / `rampage()`).
+  The mana is ordinary red mana spendable anywhere — it is held as an `AnySpend` restricted-pool entry tagged
+  with [ManaExpiry](#manaexpiry).`END_OF_COMBAT` and discarded by `CombatManager.endCombat`. It is a normal
+  triggered ability (not a mana ability): it uses the stack and can be responded to. `n` may be any fixed value;
+  "firebending X (X = its power)" is not yet expressible by this helper (the keyword carries only a fixed Int).
 - `Decayed` — "This creature can't block, and when it attacks, sacrifice it at end of combat" (CR 702.147,
   Innistrad: Midnight Hunt). Display-only; wire the behavior with the `card { decayed() }` builder helper, which adds
   the keyword plus a `CantBlock(GroupFilter.source())` static ability and a "whenever this attacks" triggered
@@ -2570,6 +2582,18 @@ the spell when the rider needs the stack (typically because it requires a player
 - `ManaSpellRider.ScryOnSharedTypeWithCommander(amount)` — Path of Ancestry: if the spell is
   a creature spell that shares a creature type with any of the controller's commanders,
   queues a `scry amount` triggered ability above the spell.
+
+### `ManaExpiry`<a id="manaexpiry"></a>
+
+The *duration* axis of mana — when it leaves the pool — orthogonal to `ManaRestriction` (where it
+may be spent) and `ManaSpellRider` (what happens to the spell). Passed via the `expiry` parameter
+of `AddMana`. The engine empties pools at end of turn, so:
+
+- `ManaExpiry.END_OF_TURN` — the default; ordinary mana cleared by the end-of-turn pool emptying.
+- `ManaExpiry.END_OF_COMBAT` — firebending-style mana (CR 702.189): kept through combat, discarded
+  by `CombatManager.endCombat` when the combat phase ends ("Any of this mana you still have as combat
+  ends will be lost"). Stored as an `AnySpend` restricted-pool entry tagged with the expiry, so it
+  spends like any other mana and the tag survives partial spends.
 
 ### `TurnTracker` keys (used with `TurnTracking`)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -244,6 +244,20 @@ enum class Keyword(val displayName: String) {
      */
     MOBILIZE("Mobilize"),
 
+    /**
+     * Firebending N (Avatar: The Last Airbender). A numeric keyword ability:
+     * "Whenever this creature attacks, add N {R}. Until end of combat, you don't
+     * lose this mana as steps and phases end."
+     *
+     * Display-only on the keyword; the behavior is the attack-triggered ability
+     * wired by the `firebending(n)` DSL helper on
+     * [com.wingedsheep.sdk.dsl.CardBuilder] — an
+     * [com.wingedsheep.sdk.scripting.effects.AddManaEffect] producing red mana with
+     * [com.wingedsheep.sdk.scripting.effects.ManaExpiry.END_OF_COMBAT] so the pool
+     * keeps it through combat and discards it once combat ends.
+     */
+    FIREBENDING("Firebending"),
+
     // ── Ability words (display prefix, no uniform mechanic) ──
     /**
      * Eerie (Duskmourn: House of Horror).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ManaExpiry
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
@@ -473,6 +474,31 @@ class CardBuilder(private val name: String) {
                 descriptionOverride = "Whenever this creature attacks, create $article tapped " +
                     "and attacking 1/1 red Warrior creature $tokenWord. Sacrifice $pronoun at the " +
                     "beginning of the next end step."
+            )
+        )
+    }
+
+    /**
+     * Add Firebending N (Avatar: The Last Airbender, CR 702.189) — keyword ability +
+     * triggered ability.
+     *
+     * "Whenever this creature attacks, add N {R}. Until end of combat, you don't lose this
+     * mana as steps and phases end." The keyword ability is display-only (no separate
+     * Firebending handler exists); the behavior lives entirely in the attack-triggered
+     * ability wired here — an [AddManaEffect] producing N red mana with
+     * [ManaExpiry.END_OF_COMBAT], which the pool keeps through combat and discards once
+     * combat ends. It is an ordinary triggered ability (not a mana ability): it uses the
+     * stack and can be responded to.
+     */
+    fun firebending(n: Int) {
+        keywordAbilityList.add(KeywordAbility.firebending(n))
+        triggeredAbilities.add(
+            TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = AddManaEffect(Color.RED, n, expiry = ManaExpiry.END_OF_COMBAT),
+                descriptionOverride = "Whenever this creature attacks, add ${"{R}".repeat(n)}. " +
+                    "Until end of combat, you don't lose this mana as steps and phases end."
             )
         )
     }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -780,6 +780,7 @@ sealed interface KeywordAbility {
         fun fabricate(n: Int): KeywordAbility = Numeric(Keyword.FABRICATE, n)
         fun tribute(n: Int): KeywordAbility = Numeric(Keyword.TRIBUTE, n)
         fun mobilize(n: Int): KeywordAbility = Numeric(Keyword.MOBILIZE, n)
+        fun firebending(n: Int): KeywordAbility = Numeric(Keyword.FIREBENDING, n)
 
         /**
          * Mobilize X — display tag for a Mobilize whose count is dynamic (e.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
@@ -34,9 +34,16 @@ data class PayManaCostEffect(val cost: ManaCost) : Effect {
 data class AddManaEffect(
     val color: Color,
     val amount: DynamicAmount = DynamicAmount.Fixed(1),
-    val restriction: ManaRestriction? = null
+    val restriction: ManaRestriction? = null,
+    /**
+     * When this mana leaves the pool. [ManaExpiry.END_OF_TURN] (the default) is ordinary
+     * mana; [ManaExpiry.END_OF_COMBAT] is firebending-style mana that the pool keeps through
+     * combat and discards when combat ends.
+     */
+    val expiry: ManaExpiry = ManaExpiry.END_OF_TURN
 ) : Effect {
-    constructor(color: Color, amount: Int, restriction: ManaRestriction? = null) : this(color, DynamicAmount.Fixed(amount), restriction)
+    constructor(color: Color, amount: Int, restriction: ManaRestriction? = null, expiry: ManaExpiry = ManaExpiry.END_OF_TURN) :
+        this(color, DynamicAmount.Fixed(amount), restriction, expiry)
 
     override val description: String = buildString {
         append(when (val a = amount) {
@@ -44,6 +51,9 @@ data class AddManaEffect(
             else -> "Add {${color.symbol}} for each ${a.description}"
         })
         if (restriction != null) append(". ${restriction.description}")
+        if (expiry == ManaExpiry.END_OF_COMBAT) {
+            append(". Until end of combat, you don't lose this mana as steps and phases end")
+        }
     }
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaExpiry.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaExpiry.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.sdk.scripting.effects
+
+import kotlinx.serialization.Serializable
+
+/**
+ * When mana produced by an effect leaves its owner's pool.
+ *
+ * This is the *duration* axis of mana, orthogonal to [ManaRestriction] (which controls
+ * *where* the mana may be spent) and [ManaSpellRider] (which controls *what happens to a
+ * spell* the mana is spent on).
+ *
+ * The engine empties mana pools at end of turn (cleanup), so [END_OF_TURN] is the default
+ * and describes every ordinary mana source. [END_OF_COMBAT] is for mana that must be gone
+ * once the combat phase ends — firebending (Avatar: The Last Airbender, CR 702.189):
+ * "Until end of combat, you don't lose this mana as steps and phases end. Any of this mana
+ * you still have as combat ends will be lost." Combat-duration mana is held as an
+ * [ManaRestriction.AnySpend] restricted entry (so it flows through the normal spend logic)
+ * tagged with this expiry, and cleared by `CombatManager.endCombat`.
+ */
+@Serializable
+enum class ManaExpiry {
+    /** Mana persists until the normal end-of-turn pool emptying (the default for all mana). */
+    END_OF_TURN,
+
+    /** Mana is discarded when the combat phase ends (firebending). */
+    END_OF_COMBAT,
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/FireSages.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/FireSages.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fire Sages — {1}{R}
+ * Creature — Human Cleric
+ * 2/2
+ * Firebending 1 (Whenever this creature attacks, add {R}. This mana lasts until end of combat.)
+ * {1}{R}{R}: Put a +1/+1 counter on this creature.
+ */
+val FireSages = card("Fire Sages") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "Firebending 1 (Whenever this creature attacks, add {R}. This mana lasts until end of combat.)\n" +
+        "{1}{R}{R}: Put a +1/+1 counter on this creature."
+
+    firebending(1)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}{R}")
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "136"
+        artist = "Yuu Fujiki"
+        flavorText = "\"Things have changed. In the past, the sages were loyal only to the Avatar.\"\n—Fire Sage Shyu"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71a9fa44-306f-417a-a9d9-991aff95025c.jpg?1764120933"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -408,6 +408,67 @@
     ]
 }
 
+// Fire Sages
+{
+    "name": "Fire Sages",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Firebending 1 (Whenever this creature attacks, add {R}. This mana lasts until end of combat.)\n{1}{R}{R}: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIREBENDING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "FIREBENDING",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "expiry": "END_OF_COMBAT"
+                },
+                "descriptionOverride": "Whenever this creature attacks, add {R}. Until end of combat, you don't lose this mana as steps and phases end."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{1}{R}{R}"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "UNCOMMON",
+        "artist": "Yuu Fujiki",
+        "flavorText": "\"Things have changed. In the past, the sages were loyal only to the Avatar.\"\n—Fire Sage Shyu",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71a9fa44-306f-417a-a9d9-991aff95025c.jpg?1764120933"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Mai, Scornful Striker
 {
     "name": "Mai, Scornful Striker",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -16,6 +16,13 @@ internal fun BridgeBuilder.keywords() {
     // `keywordAbility(KeywordAbility.saddle(N))`; this `supported` entry only marks the capability as
     // covered (never blocking) so the probe doesn't report Saddle as a gap.
     supported("Saddle", "keyword ability: Saddle N -> keywordAbility(KeywordAbility.saddle(N)) (CR 702.171)")
+    // Firebending N (CR 702.189, Avatar: The Last Airbender) — a PARAMETERIZED keyword ability (the
+    // N count rides in the rule's args as a nested _GameNumber:Integer, exactly like Saddle). Must be
+    // `supported`, not `keyword`: a bare `keywords(Keyword.FIREBENDING)` would drop the N. The
+    // emitter's `rname == "Firebending"` branch renders `keywordAbility(KeywordAbility.firebending(N))`;
+    // the integer case auto-renders, while "firebending X (X = its power)" carries an XValue node and
+    // the emitter declines it (-> SCAFFOLD). This entry only marks the capability covered.
+    supported("Firebending", "keyword ability: Firebending N -> keywordAbility(KeywordAbility.firebending(N)) (CR 702.189)")
 
     composed("Landwalk", "specific *WALK keywords (SWAMPWALK, FORESTWALK, ...)")
     // Equip is a keyword ability, but the engine has no `Keyword.EQUIP` enum member: `equipAbility(cost)`

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -165,6 +165,15 @@ object Emitter {
                 // than reading args directly as an Int. Renders `keywordAbility(KeywordAbility.saddle(N))`,
                 // exactly like Crew above; the engine synthesises the Saddle special action from the keyword.
                 rname == "Saddle" -> block = (findInteger(rule["args"]) as? Int)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.saddle", arg("$it")))))) }
+                // Firebending N (CR 702.189, Avatar: The Last Airbender) — a numeric keyword ability
+                // whose count rides in a nested `_GameNumber: Integer` (like Saddle). Unlike Saddle,
+                // the engine has no Firebending handler: the behavior (attack -> add N {R} that lasts
+                // until end of combat) lives in the `firebending(n)` CardBuilder helper's triggered
+                // ability, so render the builder call directly (like `station()`), NOT a bare
+                // keywordAbility (which would add the display keyword but drop the mana trigger).
+                // "firebending X (X = its power)" carries an XValue node -> findInteger returns "X" ->
+                // `as? Int` is null -> scaffold, rather than guessing.
+                rname == "Firebending" -> block = (findInteger(rule["args"]) as? Int)?.let { listOf(Eval(call("firebending", arg("$it")))) }
                 // Ward {cost} (CR 702.21) carries a `_Cost` arg. Only the pure-mana shape renders as
                 // `KeywordAbility.Ward(WardCost.Mana("{x}"))`; Ward—Pay life / Ward—Discard / other
                 // costs return null -> scaffold rather than drop the cost. A bare WARD enum keyword

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/AddManaExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/AddManaExecutor.kt
@@ -7,6 +7,8 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.ManaExpiry
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
 import kotlin.reflect.KClass
 
 /**
@@ -31,15 +33,22 @@ class AddManaExecutor(
 
         var newState = state.updateEntity(context.controllerId) { container ->
             val manaPool = container.get<ManaPoolComponent>() ?: ManaPoolComponent()
-            val updatedPool = if (effect.restriction != null) {
-                manaPool.addRestricted(effect.color, amount, effect.restriction!!)
-            } else {
-                manaPool.add(effect.color, amount)
+            val updatedPool = when {
+                effect.restriction != null ->
+                    manaPool.addRestricted(effect.color, amount, effect.restriction!!, expiry = effect.expiry)
+                effect.expiry != ManaExpiry.END_OF_TURN ->
+                    // Combat-duration (firebending) mana: spendable anywhere, but tagged so the
+                    // pool discards it when combat ends. Stored as an AnySpend restricted entry
+                    // so it flows through the normal spend logic (canPay / pay / solver).
+                    manaPool.addRestricted(effect.color, amount, ManaRestriction.AnySpend, expiry = effect.expiry)
+                else ->
+                    manaPool.add(effect.color, amount)
             }
             container.with(updatedPool)
         }
 
-        if (effect.restriction == null) {
+        // Treasure tagging only applies to ordinary, plain-counter mana (the `add` branch above).
+        if (effect.restriction == null && effect.expiry == ManaExpiry.END_OF_TURN) {
             newState = TreasureManaTracker.tagAddedMana(newState, context.controllerId, context.sourceId, amount)
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatManager.kt
@@ -4,7 +4,9 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.combat.*
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ManaExpiry
 import com.wingedsheep.engine.mechanics.combat.rules.AttackDefenderRule
 import com.wingedsheep.engine.mechanics.combat.rules.AttackRestrictionRule
 import com.wingedsheep.engine.mechanics.combat.rules.BlockEvasionRule
@@ -116,6 +118,17 @@ class CombatManager(
                     .without<RequiresManualDamageAssignmentComponent>()
                     .without<AttackersDeclaredThisCombatComponent>()
                     .without<BlockersDeclaredThisCombatComponent>()
+            }
+        }
+
+        // Discard combat-duration mana (firebending, CR 702.189): "Any of this mana you still
+        // have as combat ends will be lost." Ordinary (end-of-turn) mana is untouched.
+        for (playerId in newState.turnOrder) {
+            val pool = newState.getEntity(playerId)?.get<ManaPoolComponent>() ?: continue
+            if (pool.restrictedMana.any { it.expiry == ManaExpiry.END_OF_COMBAT }) {
+                newState = newState.updateEntity(playerId) { container ->
+                    container.with(pool.clearExpired(ManaExpiry.END_OF_COMBAT))
+                }
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.state.Component
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.scripting.effects.ManaExpiry
 import com.wingedsheep.sdk.scripting.effects.ManaRestriction
 import com.wingedsheep.sdk.scripting.effects.ManaSpellRider
 import com.wingedsheep.sdk.scripting.events.SourceFilter
@@ -103,11 +104,20 @@ data class ManaPoolComponent(
         color: Color?,
         amount: Int,
         restriction: ManaRestriction,
-        riders: Set<ManaSpellRider> = emptySet()
+        riders: Set<ManaSpellRider> = emptySet(),
+        expiry: ManaExpiry = ManaExpiry.END_OF_TURN
     ): ManaPoolComponent {
-        val entries = (1..amount).map { RestrictedManaEntry(color, restriction, riders) }
+        val entries = (1..amount).map { RestrictedManaEntry(color, restriction, riders, expiry) }
         return copy(restrictedMana = restrictedMana + entries)
     }
+
+    /**
+     * Remove every restricted-mana entry whose expiry matches [expiry]. Used to discard
+     * combat-duration mana ([ManaExpiry.END_OF_COMBAT], firebending) when combat ends,
+     * without disturbing ordinary mana that persists to end of turn.
+     */
+    fun clearExpired(expiry: ManaExpiry): ManaPoolComponent =
+        copy(restrictedMana = restrictedMana.filterNot { it.expiry == expiry })
 
     /**
      * Empty the mana pool.
@@ -121,12 +131,15 @@ data class ManaPoolComponent(
  * @param restriction The restriction on how this mana can be spent.
  * @param riders Side-effects applied to a spell when this mana is spent on it
  *   (e.g. [ManaSpellRider.MakesSpellUncounterable] for Cavern of Souls).
+ * @param expiry When this mana leaves the pool. [ManaExpiry.END_OF_TURN] is ordinary mana;
+ *   [ManaExpiry.END_OF_COMBAT] is firebending-style mana cleared by `CombatManager.endCombat`.
  */
 @Serializable
 data class RestrictedManaEntry(
     val color: Color?,
     val restriction: ManaRestriction,
-    val riders: Set<ManaSpellRider> = emptySet()
+    val riders: Set<ManaSpellRider> = emptySet(),
+    val expiry: ManaExpiry = ManaExpiry.END_OF_TURN
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1513,9 +1513,15 @@ class ClientStateTransformer(
                 green = manaPoolComponent.green,
                 colorless = manaPoolComponent.colorless,
                 restrictedMana = manaPoolComponent.restrictedMana.map { entry ->
+                    val expiryNote = if (entry.expiry == com.wingedsheep.sdk.scripting.effects.ManaExpiry.END_OF_COMBAT) {
+                        "This mana lasts until end of combat, then is lost."
+                    } else null
                     ClientRestrictedManaEntry(
                         color = entry.color?.symbol?.toString(),
-                        restrictionDescription = entry.restriction.description
+                        restrictionDescription = listOfNotNull(
+                            entry.restriction.description.ifBlank { null },
+                            expiryNote
+                        ).joinToString(" ")
                     )
                 }
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CombatDurationManaTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CombatDurationManaTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.ManaPool
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.player.RestrictedManaEntry
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.scripting.effects.ManaExpiry
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit coverage for combat-duration mana — the engine primitive behind firebending
+ * (CR 702.189). It is held as an [ManaRestriction.AnySpend] restricted entry tagged with
+ * [ManaExpiry.END_OF_COMBAT], so it flows through the normal spend logic but is cleared by
+ * `CombatManager.endCombat` (and, like all mana, by the end-of-turn pool emptying).
+ */
+class CombatDurationManaTest : FunSpec({
+
+    test("addRestricted tags the entry with the requested expiry") {
+        val pool = ManaPoolComponent().addRestricted(
+            color = Color.RED,
+            amount = 2,
+            restriction = ManaRestriction.AnySpend,
+            expiry = ManaExpiry.END_OF_COMBAT
+        )
+        pool.restrictedMana.size shouldBe 2
+        pool.restrictedMana.all { it.color == Color.RED && it.expiry == ManaExpiry.END_OF_COMBAT } shouldBe true
+    }
+
+    test("clearExpired(END_OF_COMBAT) removes only combat-duration mana, leaving end-of-turn mana") {
+        val pool = ManaPoolComponent(
+            restrictedMana = listOf(
+                RestrictedManaEntry(Color.RED, ManaRestriction.AnySpend, expiry = ManaExpiry.END_OF_COMBAT),
+                // An ordinary restricted entry (e.g. ritual mana spendable only on instants/sorceries)
+                // that persists to end of turn must survive end-of-combat clearing.
+                RestrictedManaEntry(Color.BLACK, ManaRestriction.InstantOrSorceryOnly, expiry = ManaExpiry.END_OF_TURN),
+            )
+        )
+        val after = pool.clearExpired(ManaExpiry.END_OF_COMBAT)
+        after.restrictedMana.size shouldBe 1
+        after.restrictedMana.single().color shouldBe Color.BLACK
+    }
+
+    test("combat-duration mana is spendable like any other mana (AnySpend)") {
+        val pool = ManaPool(
+            restrictedMana = listOf(
+                RestrictedManaEntry(Color.RED, ManaRestriction.AnySpend, expiry = ManaExpiry.END_OF_COMBAT)
+            )
+        )
+        val context = SpellPaymentContext()
+        pool.canPay(ManaCost.parse("{R}"), context) shouldBe true
+
+        val afterPaying = pool.pay(ManaCost.parse("{R}"), context)
+        afterPaying shouldBe ManaPool.EMPTY
+    }
+
+    test("end-of-turn pool emptying also discards combat-duration mana") {
+        val pool = ManaPoolComponent().addRestricted(
+            color = Color.RED, amount = 1, restriction = ManaRestriction.AnySpend, expiry = ManaExpiry.END_OF_COMBAT
+        )
+        pool.empty() shouldBe ManaPoolComponent()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FirebendingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FirebendingScenarioTest.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tla.cards.FireSages
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.ManaExpiry
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Firebending N (Avatar: The Last Airbender, CR 702.189) — "Whenever this creature attacks,
+ * add N {R}. Until end of combat, you don't lose this mana as steps and phases end."
+ *
+ * Exercised through Fire Sages (firebending 1) plus an inline firebending-2 creature. The
+ * mechanic is composed entirely from existing primitives: an attack-triggered [AddManaEffect]
+ * with [ManaExpiry.END_OF_COMBAT]. These tests pin the rules clauses: mana is added on attack,
+ * held as a spendable combat-duration entry, multiple sources trigger separately, a non-attacker
+ * adds nothing, and any leftover mana is discarded when combat ends.
+ */
+class FirebendingScenarioTest : FunSpec({
+
+    // firebending 2 to prove the N parameter, plus a vanilla creature to attack with when we
+    // want the firebending creature to stay home.
+    val firebrand = card("Test Firebrand") {
+        manaCost = "{1}{R}"
+        typeLine = "Creature — Elemental"
+        power = 1
+        toughness = 1
+        firebending(2)
+    }
+    val bear = card("Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FireSages, firebrand, bear))
+        return driver
+    }
+
+    /** Fully resolve the stack, resolving every triggered ability that lands on it. */
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            bothPass()
+            guard++
+        }
+    }
+
+    fun GameTestDriver.combatMana(playerId: com.wingedsheep.sdk.model.EntityId) =
+        (state.getEntity(playerId)?.get<ManaPoolComponent>()?.restrictedMana ?: emptyList())
+            .filter { it.expiry == ManaExpiry.END_OF_COMBAT }
+
+    test("attacking with firebending 1 adds one red, combat-duration, spendable-anywhere mana") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val sages = driver.putCreatureOnBattlefield(attacker, "Fire Sages")
+        driver.removeSummoningSickness(sages)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(sages), defender)
+        driver.resolveStack()
+
+        val combat = driver.combatMana(attacker)
+        combat.size shouldBe 1
+        combat.first().color shouldBe Color.RED
+        // Firebending mana is spendable on anything (CR 702.189), modeled as an AnySpend entry.
+        combat.first().restriction shouldBe ManaRestriction.AnySpend
+        // It rides in the restricted list, not the plain red counter.
+        driver.state.getEntity(attacker)?.get<ManaPoolComponent>()?.red shouldBe 0
+    }
+
+    test("firebending 2 adds two red mana — the N parameter is honored") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val fb = driver.putCreatureOnBattlefield(attacker, "Test Firebrand")
+        driver.removeSummoningSickness(fb)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(fb), defender)
+        driver.resolveStack()
+
+        driver.combatMana(attacker).size shouldBe 2
+    }
+
+    test("multiple firebending attackers trigger separately") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val sages = driver.putCreatureOnBattlefield(attacker, "Fire Sages")       // firebending 1
+        val fb = driver.putCreatureOnBattlefield(attacker, "Test Firebrand")      // firebending 2
+        driver.removeSummoningSickness(sages)
+        driver.removeSummoningSickness(fb)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(sages, fb), defender)
+        driver.resolveStack()
+
+        driver.combatMana(attacker).size shouldBe 3
+    }
+
+    test("a firebending creature that does not attack adds no mana") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val sages = driver.putCreatureOnBattlefield(attacker, "Fire Sages")
+        val bearId = driver.putCreatureOnBattlefield(attacker, "Test Bear")
+        driver.removeSummoningSickness(sages)
+        driver.removeSummoningSickness(bearId)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        // Only the bear attacks; Fire Sages stays home, so its firebending never triggers.
+        driver.declareAttackers(attacker, listOf(bearId), defender)
+        driver.resolveStack()
+
+        driver.combatMana(attacker).size shouldBe 0
+    }
+
+    test("combat-duration mana is discarded when combat ends (CR 702.189)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val sages = driver.putCreatureOnBattlefield(attacker, "Fire Sages")
+        driver.removeSummoningSickness(sages)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(sages), defender)
+        driver.resolveStack()
+        driver.combatMana(attacker).size shouldBe 1
+
+        // Run real game flow through end of combat into the postcombat main phase, where
+        // CombatManager.endCombat clears END_OF_COMBAT mana.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        driver.combatMana(attacker).size shouldBe 0
+        // The whole restricted list is empty — nothing leaked into end-of-turn mana.
+        driver.state.getEntity(attacker)?.get<ManaPoolComponent>()?.restrictedMana?.size shouldBe 0
+    }
+})


### PR DESCRIPTION
## What

Adds **Firebending N** (Avatar: The Last Airbender) to the engine, plus the reusable engine primitive it needs: **combat-duration mana**.

> Firebending N — *"Whenever this creature attacks, add N {R}. Until end of combat, you don't lose this mana as steps and phases end. Any of this mana you still have as combat ends will be lost."* (CR 702.189)

It's implemented by composition — no bespoke executor. Firebending is a normal attack-triggered ability (uses the stack, not a mana ability), mirroring `rampage()`/`mobilize()`.

## The reusable primitive: combat-duration mana

The engine only empties mana at end of turn, so the one thing firebending mana needs is to be **gone when combat ends**. Modeled as a new orthogonal *duration* axis on mana:

- **`ManaExpiry`** (SDK enum): `END_OF_TURN` (default, all ordinary mana) / `END_OF_COMBAT`. Sits alongside `ManaRestriction` (*where* mana may be spent) and `ManaSpellRider` (*what happens to the spell*).
- **`AddManaEffect.expiry`** carries it. `END_OF_COMBAT` mana is stored as an `AnySpend` restricted-pool entry (so it spends through **all** existing `canPay`/`pay`/solver logic unchanged) tagged with the expiry.
- **`RestrictedManaEntry.expiry`** + **`ManaPoolComponent.clearExpired(expiry)`**; cleared in **`CombatManager.endCombat`** (the real "combat ends" hook, on entry to postcombat main). Ordinary end-of-turn mana is untouched.

This serves the next card too: any "add mana, lasts until end of combat" effect.

## Firebending itself

`card { firebending(n) }` adds the `FIREBENDING` display keyword (`KeywordAbility.Numeric`) plus a "whenever this attacks" `AddManaEffect(RED, n, expiry = END_OF_COMBAT)`. Multiple instances trigger separately. `n` is a fixed Int; "firebending X (X = its power)" is noted as a future extension.

## Cross-layer trace
- **SDK**: `Keyword.FIREBENDING`, `KeywordAbility.firebending(n)`, `ManaExpiry`, `AddManaEffect.expiry`, `CardBuilder.firebending(n)`.
- **Engine**: `RestrictedManaEntry.expiry`, `ManaPoolComponent` add/clear, `AddManaExecutor` routing, `CombatManager.endCombat` clearing.
- **Server/Client**: `ClientStateTransformer` surfaces a *"lasts until end of combat"* tooltip on the restricted-mana HUD orb (existing `ManaPool.tsx` renders it).
- **Content**: **Fire Sages** (TLA #136) exercises it end to end.

## mtgish auto-generation
- Bridge: `supported("Firebending", ...)` in `coverage/bridge/Keywords.kt`.
- Emitter: a Saddle-style handler in `Emitter.kt` rendering `firebending(N)` from the IR's nested `_GameNumber`. "firebending X" carries an `XValue` node → emitter declines (→ SCAFFOLD), per the decline-don't-widen policy.
- Verified: `fidelity --emit "Fire Sages"` now renders the full `cardDef` and tiers it **AUTO**.

## Tests
- `FirebendingScenarioTest` — attack adds combat-duration mana; N honored; multiple attackers trigger separately; a non-attacker adds none; mana is discarded when combat ends (real flow through `endCombat`).
- `CombatDurationManaTest` — tag / `clearExpired` selectivity / spendability (`canPay`+`pay`) / end-of-turn emptying.
- Re-blessed `TLA.json` snapshot (Fire Sages added). Full `rules-engine` + `mtgish-tooling` + `mtg-sets` suites green.

## Notes
- Docs: `card-sdk-language-reference.md` updated (AddMana `expiry`, new `ManaExpiry` section, `Firebending` keyword entry).
- CR rule number 702.189 is from two independent secondary sources (the set's CR `.txt` wasn't fetchable here); the rule is described in full text in every comment regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)