### PR TITLE
chore(EOE): mark Edge of Eternities as complete

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/EdgeOfEternitiesSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/EdgeOfEternitiesSet.kt
@@ -18,7 +18,6 @@ object EdgeOfEternitiesSet : MtgSet {
     override val displayName = "Edge of Eternities"
     override val releaseDate = "2025-08-01"
     override val sealedSupported = true
-    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)


### PR DESCRIPTION
## Summary

Marks **Edge of Eternities (EOE)** as a fully-implemented set by removing the `incomplete = true` override from `EdgeOfEternitiesSet`.

All EOE cards are now implemented:

```
Set  Name                Released    Std   Done  Total  Missing      %  +Extra
EOE  Edge of Eternities  2025-08-01  Yes    266    266        0   100%  —
```

With the override removed, the interface default (`incomplete = false`) applies — matching the convention of other completed sets (e.g. Portal), which simply omit the line.

## Effect

`BoosterGenerator.fullyImplemented` becomes `true` for EOE (`sealedSupported && !incomplete`), so EOE no longer rides along in the "partial sets" combined booster pool and is eligible as a standalone sealed/draft set. The lobby set picker no longer hides it behind the partial-set toggle.

## Verification

- `scripts/card-status --set EOE` → 266/266, 0 missing, 100%
- `./gradlew :mtg-sets:compileKotlin` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)