### PR TITLE
Quick Game set picker: reuse the tournament lobby's searchable modal

### DIFF
--- a/web-client/src/components/ui/DeckPicker.tsx
+++ b/web-client/src/components/ui/DeckPicker.tsx
@@ -21,6 +21,7 @@
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { PrintingRef } from '@/types'
+import type { AvailableSet } from '@/types/messages'
 import {
   useDeckLibrary,
   mergeCommanderIntoCards,
@@ -37,7 +38,10 @@ import {
   type DeckValidationResult,
 } from './DeckSummary'
 import { parseArenaDeckList } from '../deckbuilder/parseArenaDeck'
+import { SetIcon } from './SetIcon'
+import { SetPickerModal } from './SetPickerModal'
 import styles from './DeckPicker.module.css'
+import lobbyStyles from './GameUI.module.css'
 
 type Tab = 'saved' | 'examples' | 'paste' | 'random'
 
@@ -59,8 +63,8 @@ export interface DeckPickerProps {
   onSetCodeChange?: (setCode: string | null) => void
   /** Initial set code for the Random tab — used to re-hydrate after a reconnect. */
   initialSetCode?: string | null
-  /** Available sets for the Random tab dropdown. Empty list hides the dropdown. */
-  availableSets?: ReadonlyArray<{ code: string; name: string }>
+  /** Available sets for the Random tab set picker. Empty list hides the picker. */
+  availableSets?: ReadonlyArray<AvailableSet>
   disabled?: boolean
   /**
    * Tabs to expose. Defaults to all four. Pass a subset to restrict the picker — e.g. the
@@ -178,6 +182,7 @@ export function DeckPicker({
   const [examples, setExamples] = useState<ExampleDeck[]>([])
   const [validation, setValidation] = useState<ValidationResult | null>(null)
   const [randomSetCode, setRandomSetCode] = useState<string | null>(initialSetCode)
+  const [showSetPicker, setShowSetPicker] = useState(false)
   const validateAbortRef = useRef<AbortController | null>(null)
 
   // Re-hydrate on initial-set-code change (e.g. server-driven on reconnect).
@@ -473,36 +478,56 @@ export function DeckPicker({
 
         {tab === 'random' && (
           <>
-            {availableSets.length > 0 && (
-              <div className={styles.actionsRow}>
-                <label className={styles.helperText} style={{ flex: 1 }}>
-                  Set
-                </label>
-                <select
-                  value={randomSetCode ?? ''}
-                  onChange={(e) => {
-                    const next = e.target.value === '' ? null : e.target.value
-                    setRandomSetCode(next)
-                    onSetCodeChange?.(next)
-                  }}
-                  disabled={disabled}
-                  className={styles.nameInput}
-                  style={{ flex: 2 }}
-                >
-                  <option value="">Random Set</option>
-                  {[...availableSets]
-                    .sort((a, b) => a.name.localeCompare(b.name))
-                    .map((set) => (
-                      <option key={set.code} value={set.code}>
-                        {set.name}
-                      </option>
-                    ))}
-                </select>
-              </div>
-            )}
+            {availableSets.length > 0 && (() => {
+              const selectedSet = randomSetCode
+                ? availableSets.find((s) => s.code === randomSetCode) ?? null
+                : null
+              return (
+                <div className={styles.actionsRow}>
+                  <label className={styles.helperText} style={{ flexShrink: 0 }}>Set</label>
+                  <span
+                    className={`${lobbyStyles.setChip} ${selectedSet?.partial ? lobbyStyles.setChipPartial : ''}`}
+                    title={selectedSet?.name ?? 'A random set is rolled when the game starts'}
+                  >
+                    {selectedSet ? (
+                      <SetIcon code={selectedSet.code} className={lobbyStyles.setChipIcon} />
+                    ) : (
+                      <span className={lobbyStyles.setChipIcon} aria-hidden>🎲</span>
+                    )}
+                    <span className={lobbyStyles.setChipName}>{selectedSet?.name ?? 'Random Set'}</span>
+                  </span>
+                  <button
+                    type="button"
+                    className={lobbyStyles.addSetsButton}
+                    onClick={() => setShowSetPicker(true)}
+                    disabled={disabled}
+                    style={{ marginLeft: 'auto' }}
+                  >
+                    Choose set
+                  </button>
+                </div>
+              )
+            })()}
             <p className={styles.helperText}>
               The server will generate a random sealed pool deck when the game starts.
             </p>
+            {showSetPicker && (
+              <SetPickerModal
+                sets={availableSets}
+                mode="single"
+                selectedCodes={randomSetCode ? [randomSetCode] : []}
+                onToggleSet={(code) => {
+                  setRandomSetCode(code)
+                  onSetCodeChange?.(code)
+                }}
+                onSelectRandom={() => {
+                  setRandomSetCode(null)
+                  onSetCodeChange?.(null)
+                }}
+                onClose={() => setShowSetPicker(false)}
+                title="Choose a set"
+              />
+            )}
           </>
         )}
       </div>

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -12,6 +12,7 @@ import { QuickGameLobbyOverlay } from './QuickGameLobbyOverlay'
 import { useDeckLibrary, buildDraftedDeckSave, type SavedDeckEntry } from '@/store/deckLibrary'
 import { DeckPicker } from './DeckPicker'
 import { BanListEditor } from './BanListEditor'
+import { SetPickerModal } from './SetPickerModal'
 import { labelForFormat } from '@/utils/deckLegality'
 import styles from './GameUI.module.css'
 
@@ -700,11 +701,6 @@ function LobbyOverlay({
   const tournamentState = useGameStore((state) => state.tournamentState)
   const [copied, setCopied] = useState(false)
   const [showSetPicker, setShowSetPicker] = useState(false)
-  const [setSearch, setSetSearch] = useState('')
-  // Partially-implemented sets are hidden by default; the host opts into them with this toggle.
-  const [showPartialSets, setShowPartialSets] = useState(false)
-  // Hide thin sets (lots of partial sets have only a handful of cards). Defaults to 50.
-  const [minCards, setMinCards] = useState(50)
 
   // Show tournament standings when tournament is active
   if (tournamentState) {
@@ -752,42 +748,15 @@ function LobbyOverlay({
     setTimeout(() => setCopied(false), 2000)
   }
 
-  // Unified set picker: every set (complete + incomplete) lives behind one searchable modal.
-  // The lobby itself only shows the *selected* sets as compact chips, so its footprint stays small
-  // and stable no matter how many sets exist in total or how many a host picks.
+  // Unified set picker: every set (complete + incomplete) lives behind one searchable modal
+  // (`SetPickerModal`, shared with the Quick Game lobby). The lobby itself only shows the
+  // *selected* sets as compact chips, so its footprint stays small and stable no matter how many
+  // sets exist in total or how many a host picks.
   type AvailableSet = typeof lobbyState.settings.availableSets[number]
   const allSets = lobbyState.settings.availableSets
   const selectedSets = lobbyState.settings.setCodes
     .map((code) => allSets.find((s) => s.code === code))
     .filter((s): s is AvailableSet => s != null)
-
-  // Picker visibility rules (an already-selected set always stays visible so it can be un-ticked):
-  //  - partial sets are hidden unless the host flips the toggle, and
-  //  - sets with fewer than `minCards` implemented cards are pruned (kills the long tail of
-  //    near-empty sets you'd otherwise see once partial sets are shown).
-  const partialSetCount = allSets.filter((s) => s.partial).length
-  const isSetSelected = (s: AvailableSet) => lobbyState.settings.setCodes.includes(s.code)
-  const pickerSets = allSets.filter((s) => {
-    if (isSetSelected(s)) return true
-    if (s.partial && !showPartialSets) return false
-    if ((s.implementedCount ?? 0) < minCards) return false
-    return true
-  })
-
-  // Searchable multi-select inside the modal — match on set name or code, like the deckbuilder picker.
-  const setSearchNeedle = setSearch.trim().toLowerCase()
-  const filteredPickerSets = setSearchNeedle
-    ? pickerSets.filter(
-        (s) =>
-          s.name.toLowerCase().includes(setSearchNeedle) ||
-          s.code.toLowerCase().includes(setSearchNeedle),
-      )
-    : pickerSets
-
-  const closeSetPicker = () => {
-    setShowSetPicker(false)
-    setSetSearch('')
-  }
 
   const toggleSet = (code: string) => {
     const isSelected = lobbyState.settings.setCodes.includes(code)
@@ -795,107 +764,6 @@ function LobbyOverlay({
       ? lobbyState.settings.setCodes.filter((c) => c !== code)
       : [...lobbyState.settings.setCodes, code]
     updateLobbySettings({ setCodes: newCodes })
-  }
-
-  // Format an ISO `YYYY-MM-DD` release date as e.g. "Oct 2002". Parsed manually to avoid timezone shifts.
-  const MONTH_ABBREVS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-  const formatReleaseDate = (releaseDate?: string): string | null => {
-    if (!releaseDate) return null
-    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(releaseDate)
-    if (!match) return null
-    const [, year, month] = match
-    if (!year) return null
-    const monthName = MONTH_ABBREVS[Number(month) - 1]
-    return monthName ? `${monthName} ${year}` : year
-  }
-
-  // Newest-first comparator on ISO `YYYY-MM-DD` keys; sets/blocks with no known release date sort last.
-  const UNKNOWN_RELEASE = ''
-  const releaseSortKey = (releaseDate?: string): string => releaseDate ?? UNKNOWN_RELEASE
-  const byNewestFirst = (a: string, b: string): number => {
-    if (a === UNKNOWN_RELEASE || b === UNKNOWN_RELEASE) {
-      if (a === b) return 0
-      return a === UNKNOWN_RELEASE ? 1 : -1 // unknowns always last
-    }
-    return b.localeCompare(a) // later date first
-  }
-
-  // One toggle row inside the picker modal. Incomplete sets get a "partial" tag so the host knows
-  // those boosters draw from a reduced pool of implemented cards.
-  const renderSetPickerRow = (set: AvailableSet) => {
-    const isSelected = lobbyState.settings.setCodes.includes(set.code)
-    const released = formatReleaseDate(set.releaseDate)
-    return (
-      <button
-        key={set.code}
-        type="button"
-        onClick={() => toggleSet(set.code)}
-        className={`${styles.setPickerRow} ${isSelected ? styles.setPickerRowActive : ''}`}
-      >
-        <span className={styles.setPickerCheck} aria-hidden>{isSelected ? '✓' : ''}</span>
-        <SetIcon code={set.code} className={styles.setPickerIcon} />
-        <span className={styles.setPickerName}>{set.name}</span>
-        {set.partial && <span className={styles.setPartialBadge}>partial</span>}
-        {released && <span className={styles.setReleaseDate}>{released}</span>}
-        {set.implementedCount != null && (
-          <span className={styles.setButtonCardCount}>{set.implementedCount} cards</span>
-        )}
-      </button>
-    )
-  }
-
-  // Order sets newest-first while keeping blocks grouped: each block is a single unit positioned by
-  // its newest set's release date, and each blockless set is its own unit. Units are sorted by date
-  // (newest on top), and sets within a block are sorted newest-first too.
-  const renderGroupedSetRows = (sets: readonly AvailableSet[]) => {
-    const blockOrder: string[] = []
-    const blockSets = new Map<string, AvailableSet[]>()
-    const ungrouped: AvailableSet[] = []
-    for (const set of sets) {
-      if (set.block) {
-        if (!blockSets.has(set.block)) {
-          blockOrder.push(set.block)
-          blockSets.set(set.block, [])
-        }
-        blockSets.get(set.block)!.push(set)
-      } else {
-        ungrouped.push(set)
-      }
-    }
-
-    type Unit =
-      | { kind: 'block'; key: string; label: string; sets: AvailableSet[]; sortKey: string }
-      | { kind: 'set'; key: string; set: AvailableSet; sortKey: string }
-
-    const units: Unit[] = []
-    for (const name of blockOrder) {
-      const blockMembers = blockSets
-        .get(name)!
-        .slice()
-        .sort((a, b) => byNewestFirst(releaseSortKey(a.releaseDate), releaseSortKey(b.releaseDate)))
-      units.push({
-        kind: 'block',
-        key: name,
-        label: `${name} Block`,
-        sets: blockMembers,
-        sortKey: releaseSortKey(blockMembers[0]?.releaseDate), // newest in block, after sort above
-      })
-    }
-    for (const set of ungrouped) {
-      units.push({ kind: 'set', key: set.code, set, sortKey: releaseSortKey(set.releaseDate) })
-    }
-    units.sort((a, b) => byNewestFirst(a.sortKey, b.sortKey))
-
-    return units.map((unit) =>
-      unit.kind === 'block' ? (
-        <div key={`block:${unit.key}`} className={styles.setPickerGroup}>
-          <div className={styles.setPickerGroupLabel}>{unit.label}</div>
-          {unit.sets.map(renderSetPickerRow)}
-        </div>
-      ) : (
-        renderSetPickerRow(unit.set)
-      ),
-    )
   }
 
   return (
@@ -1500,79 +1368,12 @@ function LobbyOverlay({
       </div>
 
       {showSetPicker && (
-        <div className={styles.deckViewerBackdrop} onClick={closeSetPicker}>
-          <div className={styles.deckViewerPanel} style={{ maxWidth: 560 }} onClick={(e) => e.stopPropagation()}>
-            <div className={styles.deckViewerHeader}>
-              <h3 className={styles.deckViewerTitle}>Choose sets</h3>
-              <span className={styles.setPickerSelectedCount}>
-                {selectedSets.length} selected
-              </span>
-              <button className={styles.deckViewerClose} onClick={closeSetPicker}>×</button>
-            </div>
-            <div className={styles.deckViewerBody}>
-              <input
-                type="text"
-                className={styles.setPickerSearch}
-                placeholder="Search sets by name or code…"
-                value={setSearch}
-                spellCheck={false}
-                autoComplete="off"
-                autoFocus
-                onChange={(e) => setSetSearch(e.target.value)}
-              />
-              <div className={styles.setPickerFilters}>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={showPartialSets}
-                  className={`${styles.setPickerSwitch} ${showPartialSets ? styles.setPickerSwitchOn : ''}`}
-                  onClick={() => setShowPartialSets((v) => !v)}
-                >
-                  <span className={styles.setPickerSwitchTrack} aria-hidden>
-                    <span className={styles.setPickerSwitchThumb} />
-                  </span>
-                  <span className={styles.setPickerSwitchLabel}>
-                    Show partial sets
-                    {partialSetCount > 0 && (
-                      <span className={styles.setPickerSwitchCount}>{partialSetCount}</span>
-                    )}
-                  </span>
-                </button>
-                <label className={styles.setPickerMinCards}>
-                  <span className={styles.setPickerMinCardsLabel}>Min cards</span>
-                  <input
-                    type="number"
-                    min={0}
-                    step={10}
-                    inputMode="numeric"
-                    className={styles.setPickerMinCardsInput}
-                    value={minCards}
-                    onChange={(e) => setMinCards(Math.max(0, Math.floor(Number(e.target.value) || 0)))}
-                  />
-                </label>
-              </div>
-              <p className={styles.setPickerNote}>
-                Sets tagged <span className={styles.setPartialBadge}>partial</span> aren't fully
-                implemented — their boosters draw from a reduced pool of the cards that exist.
-              </p>
-              <div className={styles.setPickerList}>
-                {filteredPickerSets.length > 0 ? (
-                  renderGroupedSetRows(filteredPickerSets)
-                ) : (
-                  <div className={styles.setPickerEmpty}>
-                    No sets match.{' '}
-                    {!showPartialSets && partialSetCount > 0
-                      ? 'Try enabling partial sets'
-                      : minCards > 0
-                        ? 'Try lowering the minimum card count'
-                        : 'Try a different search'}
-                    .
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
+        <SetPickerModal
+          sets={allSets}
+          selectedCodes={lobbyState.settings.setCodes}
+          onToggleSet={toggleSet}
+          onClose={() => setShowSetPicker(false)}
+        />
       )}
     </div>
   )

--- a/web-client/src/components/ui/SetPickerModal.tsx
+++ b/web-client/src/components/ui/SetPickerModal.tsx
@@ -1,0 +1,287 @@
+/**
+ * SetPickerModal — the searchable, grouped set browser shared by the tournament lobby and the
+ * Quick Game lobby's "Random" deck tab.
+ *
+ * Every set (complete + partial) lives behind this one modal. It supports two modes:
+ *   - `multi`  (default): clicking a row toggles it and the modal stays open. The host builds a
+ *               multi-set pool (tournament lobby).
+ *   - `single`: clicking a row selects it and closes the modal. With `onSelectRandom` a top
+ *               "Random Set" row clears the selection so the server rolls a random set
+ *               (Quick Game random sealed pool).
+ *
+ * Visuals come from `GameUI.module.css` (the shared lobby stylesheet — `QuickGameLobbyOverlay`
+ * already reuses it) so both lobbies look identical.
+ */
+import { useState } from 'react'
+import type { AvailableSet } from '@/types/messages'
+import { SetIcon } from './SetIcon'
+import styles from './GameUI.module.css'
+
+export interface SetPickerModalProps {
+  /** All sets the picker can browse (complete + partial). */
+  sets: readonly AvailableSet[]
+  /** Codes currently selected — drives row highlight and (multi mode) the "N selected" count. */
+  selectedCodes: readonly string[]
+  /** Toggle (multi) or select (single) a set by code. */
+  onToggleSet: (code: string) => void
+  /** Dismiss the modal. */
+  onClose: () => void
+  /**
+   * 'multi' (default) keeps the modal open after each toggle; 'single' selects one set and closes.
+   */
+  mode?: 'single' | 'multi'
+  /**
+   * Single mode only — when provided, a "Random Set" row is shown at the top that clears the
+   * selection (the server then rolls a random set). Selecting it closes the modal.
+   */
+  onSelectRandom?: () => void
+  /** Modal heading. Defaults to "Choose sets". */
+  title?: string
+}
+
+const MONTH_ABBREVS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+// Format an ISO `YYYY-MM-DD` release date as e.g. "Oct 2002". Parsed manually to avoid timezone shifts.
+function formatReleaseDate(releaseDate?: string): string | null {
+  if (!releaseDate) return null
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(releaseDate)
+  if (!match) return null
+  const [, year, month] = match
+  if (!year) return null
+  const monthName = MONTH_ABBREVS[Number(month) - 1]
+  return monthName ? `${monthName} ${year}` : year
+}
+
+// Newest-first comparator on ISO `YYYY-MM-DD` keys; sets/blocks with no known release date sort last.
+const UNKNOWN_RELEASE = ''
+const releaseSortKey = (releaseDate?: string): string => releaseDate ?? UNKNOWN_RELEASE
+function byNewestFirst(a: string, b: string): number {
+  if (a === UNKNOWN_RELEASE || b === UNKNOWN_RELEASE) {
+    if (a === b) return 0
+    return a === UNKNOWN_RELEASE ? 1 : -1 // unknowns always last
+  }
+  return b.localeCompare(a) // later date first
+}
+
+export function SetPickerModal({
+  sets,
+  selectedCodes,
+  onToggleSet,
+  onClose,
+  mode = 'multi',
+  onSelectRandom,
+  title = 'Choose sets',
+}: SetPickerModalProps) {
+  const [search, setSearch] = useState('')
+  // Partially-implemented sets are hidden by default; the user opts into them with this toggle.
+  const [showPartialSets, setShowPartialSets] = useState(false)
+  // Hide thin sets (lots of partial sets have only a handful of cards). Defaults to 50.
+  const [minCards, setMinCards] = useState(50)
+
+  const isSingle = mode === 'single'
+  const isSelected = (code: string) => selectedCodes.includes(code)
+
+  // Picker visibility rules (an already-selected set always stays visible so it can be changed):
+  //  - partial sets are hidden unless the toggle is flipped, and
+  //  - sets with fewer than `minCards` implemented cards are pruned (kills the long tail of
+  //    near-empty sets you'd otherwise see once partial sets are shown).
+  const partialSetCount = sets.filter((s) => s.partial).length
+  const pickerSets = sets.filter((s) => {
+    if (isSelected(s.code)) return true
+    if (s.partial && !showPartialSets) return false
+    if ((s.implementedCount ?? 0) < minCards) return false
+    return true
+  })
+
+  // Searchable inside the modal — match on set name or code, like the deckbuilder picker.
+  const searchNeedle = search.trim().toLowerCase()
+  const filteredPickerSets = searchNeedle
+    ? pickerSets.filter(
+        (s) =>
+          s.name.toLowerCase().includes(searchNeedle) ||
+          s.code.toLowerCase().includes(searchNeedle),
+      )
+    : pickerSets
+
+  const handlePick = (code: string) => {
+    onToggleSet(code)
+    if (isSingle) onClose()
+  }
+
+  const handleRandom = () => {
+    onSelectRandom?.()
+    onClose()
+  }
+
+  // One toggle row inside the picker modal. Incomplete sets get a "partial" tag so the user knows
+  // those boosters draw from a reduced pool of implemented cards.
+  const renderSetPickerRow = (set: AvailableSet) => {
+    const selected = isSelected(set.code)
+    const released = formatReleaseDate(set.releaseDate)
+    return (
+      <button
+        key={set.code}
+        type="button"
+        onClick={() => handlePick(set.code)}
+        className={`${styles.setPickerRow} ${selected ? styles.setPickerRowActive : ''}`}
+      >
+        <span className={styles.setPickerCheck} aria-hidden>{selected ? '✓' : ''}</span>
+        <SetIcon code={set.code} className={styles.setPickerIcon} />
+        <span className={styles.setPickerName}>{set.name}</span>
+        {set.partial && <span className={styles.setPartialBadge}>partial</span>}
+        {released && <span className={styles.setReleaseDate}>{released}</span>}
+        {set.implementedCount != null && (
+          <span className={styles.setButtonCardCount}>{set.implementedCount} cards</span>
+        )}
+      </button>
+    )
+  }
+
+  // Order sets newest-first while keeping blocks grouped: each block is a single unit positioned by
+  // its newest set's release date, and each blockless set is its own unit. Units are sorted by date
+  // (newest on top), and sets within a block are sorted newest-first too.
+  const renderGroupedSetRows = (rows: readonly AvailableSet[]) => {
+    const blockOrder: string[] = []
+    const blockSets = new Map<string, AvailableSet[]>()
+    const ungrouped: AvailableSet[] = []
+    for (const set of rows) {
+      if (set.block) {
+        if (!blockSets.has(set.block)) {
+          blockOrder.push(set.block)
+          blockSets.set(set.block, [])
+        }
+        blockSets.get(set.block)!.push(set)
+      } else {
+        ungrouped.push(set)
+      }
+    }
+
+    type Unit =
+      | { kind: 'block'; key: string; label: string; sets: AvailableSet[]; sortKey: string }
+      | { kind: 'set'; key: string; set: AvailableSet; sortKey: string }
+
+    const units: Unit[] = []
+    for (const name of blockOrder) {
+      const blockMembers = blockSets
+        .get(name)!
+        .slice()
+        .sort((a, b) => byNewestFirst(releaseSortKey(a.releaseDate), releaseSortKey(b.releaseDate)))
+      units.push({
+        kind: 'block',
+        key: name,
+        label: `${name} Block`,
+        sets: blockMembers,
+        sortKey: releaseSortKey(blockMembers[0]?.releaseDate), // newest in block, after sort above
+      })
+    }
+    for (const set of ungrouped) {
+      units.push({ kind: 'set', key: set.code, set, sortKey: releaseSortKey(set.releaseDate) })
+    }
+    units.sort((a, b) => byNewestFirst(a.sortKey, b.sortKey))
+
+    return units.map((unit) =>
+      unit.kind === 'block' ? (
+        <div key={`block:${unit.key}`} className={styles.setPickerGroup}>
+          <div className={styles.setPickerGroupLabel}>{unit.label}</div>
+          {unit.sets.map(renderSetPickerRow)}
+        </div>
+      ) : (
+        renderSetPickerRow(unit.set)
+      ),
+    )
+  }
+
+  const showRandomRow = isSingle && onSelectRandom != null
+  const randomActive = selectedCodes.length === 0
+
+  return (
+    <div className={styles.deckViewerBackdrop} onClick={onClose}>
+      <div className={styles.deckViewerPanel} style={{ maxWidth: 560 }} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.deckViewerHeader}>
+          <h3 className={styles.deckViewerTitle}>{title}</h3>
+          {!isSingle && (
+            <span className={styles.setPickerSelectedCount}>
+              {selectedCodes.length} selected
+            </span>
+          )}
+          <button className={styles.deckViewerClose} onClick={onClose}>×</button>
+        </div>
+        <div className={styles.deckViewerBody}>
+          <input
+            type="text"
+            className={styles.setPickerSearch}
+            placeholder="Search sets by name or code…"
+            value={search}
+            spellCheck={false}
+            autoComplete="off"
+            autoFocus
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <div className={styles.setPickerFilters}>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showPartialSets}
+              className={`${styles.setPickerSwitch} ${showPartialSets ? styles.setPickerSwitchOn : ''}`}
+              onClick={() => setShowPartialSets((v) => !v)}
+            >
+              <span className={styles.setPickerSwitchTrack} aria-hidden>
+                <span className={styles.setPickerSwitchThumb} />
+              </span>
+              <span className={styles.setPickerSwitchLabel}>
+                Show partial sets
+                {partialSetCount > 0 && (
+                  <span className={styles.setPickerSwitchCount}>{partialSetCount}</span>
+                )}
+              </span>
+            </button>
+            <label className={styles.setPickerMinCards}>
+              <span className={styles.setPickerMinCardsLabel}>Min cards</span>
+              <input
+                type="number"
+                min={0}
+                step={10}
+                inputMode="numeric"
+                className={styles.setPickerMinCardsInput}
+                value={minCards}
+                onChange={(e) => setMinCards(Math.max(0, Math.floor(Number(e.target.value) || 0)))}
+              />
+            </label>
+          </div>
+          <p className={styles.setPickerNote}>
+            Sets tagged <span className={styles.setPartialBadge}>partial</span> aren't fully
+            implemented — their boosters draw from a reduced pool of the cards that exist.
+          </p>
+          <div className={styles.setPickerList}>
+            {showRandomRow && (
+              <button
+                type="button"
+                onClick={handleRandom}
+                className={`${styles.setPickerRow} ${randomActive ? styles.setPickerRowActive : ''}`}
+              >
+                <span className={styles.setPickerCheck} aria-hidden>{randomActive ? '✓' : ''}</span>
+                <span className={styles.setPickerIcon} aria-hidden>🎲</span>
+                <span className={styles.setPickerName}>Random Set</span>
+              </button>
+            )}
+            {filteredPickerSets.length > 0 ? (
+              renderGroupedSetRows(filteredPickerSets)
+            ) : (
+              !showRandomRow && (
+                <div className={styles.setPickerEmpty}>
+                  No sets match.{' '}
+                  {!showPartialSets && partialSetCount > 0
+                    ? 'Try enabling partial sets'
+                    : minCards > 0
+                      ? 'Try lowering the minimum card count'
+                      : 'Try a different search'}
+                  .
+                </div>
+              )
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

The Quick Game lobby's **Random** deck tab picked a sealed-pool set with a bare native `<select>` — no search, no set icons, no partial-set filtering, no block grouping. The tournament lobby already has a far richer set browser, but it was inlined inside `GameUI.tsx`.

This extracts that browser into a shared **`SetPickerModal`** and uses it in both lobbies, so Quick Game gets the same picker the tournament lobby has.

## Changes

- **New `SetPickerModal.tsx`** — owns the search box, the *show partial sets* toggle, the *min cards* filter, and block-grouped, newest-first rows with set icons, release dates, and card counts. Two modes:
  - `multi` (default): clicking a row toggles it; modal stays open — the tournament lobby's multi-set pool.
  - `single`: clicking a row selects it and closes; an optional **Random Set** reset row clears the selection so the server rolls a random set — the Quick Game random pool.
- **`GameUI.tsx`** — dropped the inline picker state, helpers, and modal JSX in favour of `<SetPickerModal mode="multi">`. No visual or behavioural change to the tournament lobby (it renders the same markup/classes).
- **`DeckPicker.tsx`** — the Random tab's `<select>` is replaced by a set chip + **Choose set** button that opens `<SetPickerModal mode="single" allowRandom>`, styled to match the lobby's set chips. `availableSets` is widened from `{code, name}` to the full `AvailableSet` — the Quick Game store already supplied the rich metadata; only the prop type was narrowing it.

Frontend-only; no server changes (the backend already sends `availableSets` with `partial` / `block` / `implementedCount` / `releaseDate`).

## Verification

- `npm run typecheck` — clean
- `npm run build` — succeeds
- Drove the running app (vs-AI Quick Game → Random tab → Choose set) to capture the screenshots below.

## Screenshots

**Random tab — set chip + "Choose set" button (matches the lobby chips):**

![Random tab](https://raw.githubusercontent.com/wingedsheep/argentum-engine/quick-game-set-picker-screenshots/random-tab.png)

**The shared picker modal (search, partial toggle, min-cards, grouped sets, icons, dates, counts) — now in Quick Game:**

![Set picker modal](https://raw.githubusercontent.com/wingedsheep/argentum-engine/quick-game-set-picker-screenshots/modal.png)

**Single-select picks one set and closes — the chip updates:**

![Selected set](https://raw.githubusercontent.com/wingedsheep/argentum-engine/quick-game-set-picker-screenshots/selected.png)

_(The `quick-game-set-picker-screenshots` branch is a throwaway image host, not part of this PR's diff.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)