### PR TITLE
Add Nafs Asp + fireOnPlayer delayed-trigger axis + PayOrSuffer fix

### DIFF
--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 62 / 78
+**Implemented:** 63 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -66,7 +66,7 @@
 - [x] Ghazbán Ogre
 - [x] Ifh-Bíff Efreet
 - [ ] Metamorphosis
-- [ ] Nafs Asp
+- [x] Nafs Asp
 - [x] Sandstorm
 - [x] Singing Tree
 - [x] Wyluli Wolf

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1505,11 +1505,11 @@ Triggers.youCastSpell(
   the data-side facade. Three orthogonal axes control *whose / which* turn fires the trigger:
   - `fireOnlyOnControllersTurn` — gates on the controller: only matches when the active player
     equals the controller of the delayed trigger's source.
-  - `fireOnPlayer: EffectTarget?` — gates on a *specific* player resolved at scheduling time
-    (defaults to `null` = no player gate). Pass `EffectTarget.PlayerRef(Player.TriggeringPlayer)`
+  - `fireOnPlayer: EffectTarget?` — gates on a specific player resolved at scheduling time
+    (defaults to `null`, meaning no player gate). Pass `EffectTarget.PlayerRef(Player.TriggeringPlayer)`
     to lock the trigger to "the player who triggered me" — useful for "at the beginning of *their*
-    next [step]" templates where the relevant player is the damaged/triggering one, not the
-    source's controller. The resolved player id is also re-exposed to the inner `effect` as
+    next [step]" templates where the relevant player is the damaged/triggering one rather than
+    the source's controller. The resolved player id is also re-exposed to the inner `effect` as
     `triggeringPlayerId` / `triggeringEntityId` when the trigger fires, so `Player.TriggeringPlayer`
     inside the inner effect resolves to the same player. (Nafs Asp's "Whenever this creature deals
     damage to a player, that player loses 1 life at the beginning of their next draw step unless

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1501,10 +1501,19 @@ Triggers.youCastSpell(
 - `DelayedTriggeredAbility` — registered now, fires at a specific future step (Astral Slide).
 - `Effects.GrantTriggeredAbilityEffect` — grant a triggered ability for a duration; `GrantTriggeredAbilityExecutor` uses
   projected state and supports leaves-battlefield-to-zone triggers.
-- `CreateDelayedTriggerEffect(step, effect, fireOnlyOnControllersTurn, timing, …)` —
-  the data-side facade. Two orthogonal axes control *when* the trigger may first fire:
-  - `fireOnlyOnControllersTurn` — gates *whose* turn: only matches when the active player equals
-    the controller.
+- `CreateDelayedTriggerEffect(step, effect, fireOnlyOnControllersTurn, fireOnPlayer, timing, …)` —
+  the data-side facade. Three orthogonal axes control *whose / which* turn fires the trigger:
+  - `fireOnlyOnControllersTurn` — gates on the controller: only matches when the active player
+    equals the controller of the delayed trigger's source.
+  - `fireOnPlayer: EffectTarget?` — gates on a *specific* player resolved at scheduling time
+    (defaults to `null` = no player gate). Pass `EffectTarget.PlayerRef(Player.TriggeringPlayer)`
+    to lock the trigger to "the player who triggered me" — useful for "at the beginning of *their*
+    next [step]" templates where the relevant player is the damaged/triggering one, not the
+    source's controller. The resolved player id is also re-exposed to the inner `effect` as
+    `triggeringPlayerId` / `triggeringEntityId` when the trigger fires, so `Player.TriggeringPlayer`
+    inside the inner effect resolves to the same player. (Nafs Asp's "Whenever this creature deals
+    damage to a player, that player loses 1 life at the beginning of their next draw step unless
+    they pay {1}".) Composes with `fireOnlyOnControllersTurn`: if both are set, both gates apply.
   - `timing: DelayedTriggerTiming` — gates *which* turn is the earliest eligible one:
     - `CURRENT_TURN_OR_LATER` (default) — no turn floor; the next upcoming occurrence of `step`,
       which may be the current turn. (Astral Slide exile-until-end-step.)

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1501,19 +1501,19 @@ Triggers.youCastSpell(
 - `DelayedTriggeredAbility` — registered now, fires at a specific future step (Astral Slide).
 - `Effects.GrantTriggeredAbilityEffect` — grant a triggered ability for a duration; `GrantTriggeredAbilityExecutor` uses
   projected state and supports leaves-battlefield-to-zone triggers.
-- `CreateDelayedTriggerEffect(step, effect, fireOnlyOnControllersTurn, fireOnPlayer, timing, …)` —
-  the data-side facade. Three orthogonal axes control *whose / which* turn fires the trigger:
-  - `fireOnlyOnControllersTurn` — gates on the controller: only matches when the active player
-    equals the controller of the delayed trigger's source.
-  - `fireOnPlayer: EffectTarget?` — gates on a specific player resolved at scheduling time
-    (defaults to `null`, meaning no player gate). Pass `EffectTarget.PlayerRef(Player.TriggeringPlayer)`
-    to lock the trigger to "the player who triggered me" — useful for "at the beginning of *their*
-    next [step]" templates where the relevant player is the damaged/triggering one rather than
-    the source's controller. The resolved player id is also re-exposed to the inner `effect` as
-    `triggeringPlayerId` / `triggeringEntityId` when the trigger fires, so `Player.TriggeringPlayer`
-    inside the inner effect resolves to the same player. (Nafs Asp's "Whenever this creature deals
-    damage to a player, that player loses 1 life at the beginning of their next draw step unless
-    they pay {1}".) Composes with `fireOnlyOnControllersTurn`: if both are set, both gates apply.
+- `CreateDelayedTriggerEffect(step, effect, fireOnPlayer, timing, …)` —
+  the data-side facade. Two orthogonal axes control *whose / which* turn fires the trigger:
+  - `fireOnPlayer: EffectTarget?` — the single "whose turn" gate. Resolved to a concrete player
+    at scheduling time; only matches when that player is active. Defaults to `null` (no player
+    gate — fires on the next matching step of *any* turn). Two common shapes:
+    - `EffectTarget.PlayerRef(Player.You)` — only the controller's turn ("at the beginning of
+      *your* next end step"; Dragonhawk, Kav Landseeker, Meandering Towershell).
+    - `EffectTarget.PlayerRef(Player.TriggeringPlayer)` — the triggering/damaged player's turn
+      ("at the beginning of *their* next [step]"; Nafs Asp's "that player loses 1 life at the
+      beginning of their next draw step unless they pay {1}").
+    The resolved player id is also re-exposed to the inner `effect` as `triggeringPlayerId` /
+    `triggeringEntityId` when the trigger fires, so `Player.TriggeringPlayer` inside the inner
+    effect resolves to the same player.
   - `timing: DelayedTriggerTiming` — gates *which* turn is the earliest eligible one:
     - `CURRENT_TURN_OR_LATER` (default) — no turn floor; the next upcoming occurrence of `step`,
       which may be the current turn. (Astral Slide exile-until-end-step.)
@@ -1521,8 +1521,8 @@ Triggers.youCastSpell(
       controller's current-turn end step has already begun (END/CLEANUP); otherwise the current
       turn's end step qualifies. (Dragonhawk, Fate's Tempest.)
     - `NEXT_TURN` — stricter "on your next turn"-style timing: the current turn never qualifies
-      regardless of step. Pair with `fireOnlyOnControllersTurn = true` to land on the controller's
-      upcoming own turn rather than an intervening opponent turn. (Kav Landseeker.)
+      regardless of step. Pair with `fireOnPlayer = PlayerRef(Player.You)` to land on the
+      controller's upcoming own turn rather than an intervening opponent turn. (Kav Landseeker.)
 - **Event-based delayed triggers** — pass `trigger = <TriggerSpec>` (instead of `step`) and the
   delayed ability fires whenever a matching *event* occurs, staying resident until `expiry`
   (`DelayedTriggerExpiry.EndOfTurn`) removes it. Supported events include `DealsDamageEvent`,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -553,7 +553,17 @@ data class CreateDelayedTriggerEffect(
      * target is exposed to [effect] as [com.wingedsheep.sdk.scripting.targets.EffectTarget.ContextTarget].
      * Null for non-targeting delayed triggers (the common case).
      */
-    val targetRequirement: TargetRequirement? = null
+    val targetRequirement: TargetRequirement? = null,
+    /**
+     * For step-based delayed triggers: restrict firing to a specific player's matching step
+     * (rather than the controller's, or every player's, turn). Resolved to a concrete player
+     * entity id at scheduling time by [com.wingedsheep.engine.handlers.effects.composite.CreateDelayedTriggerExecutor]
+     * and also exposed as `triggeringPlayerId` / `triggeringEntityId` to [effect] when it
+     * fires, so `EffectTarget.PlayerRef(Player.TriggeringPlayer)` inside [effect] resolves
+     * back to the same player. Used for "at the beginning of their next draw step" effects
+     * (Nafs Asp). Orthogonal to [fireOnlyOnControllersTurn]: if both are set, both gates apply.
+     */
+    val fireOnPlayer: EffectTarget? = null
 ) : Effect {
     override val description: String = when {
         trigger != null -> "create a delayed trigger that fires on ${trigger.event::class.simpleName}"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -453,8 +453,8 @@ data class PayOrSufferEffect(
  * mutually-exclusive axis (replaces the former onControllerNextTurn / skipCurrentTurn
  * booleans, whose presence/absence encoded these three states).
  *
- * Orthogonal to [CreateDelayedTriggerEffect.fireOnlyOnControllersTurn], which gates
- * *whose* turn the trigger may fire on, not *which* turn is the earliest eligible one.
+ * Orthogonal to [CreateDelayedTriggerEffect.fireOnPlayer], which gates *whose* turn the
+ * trigger may fire on, not *which* turn is the earliest eligible one.
  */
 @Serializable
 enum class DelayedTriggerTiming {
@@ -469,8 +469,8 @@ enum class DelayedTriggerTiming {
      * "At the beginning of your next end step" timing: the current turn's end step
      * still qualifies if it hasn't begun yet; only once it has started (END or CLEANUP
      * on the controller's turn) does the trigger defer to the controller's following
-     * turn. Typically paired with [CreateDelayedTriggerEffect.fireOnlyOnControllersTurn]
-     * = true. (Dragonhawk, Fate's Tempest.)
+     * turn. Typically paired with `fireOnPlayer = PlayerRef(Player.You)`. (Dragonhawk,
+     * Fate's Tempest.)
      */
     @SerialName("NextEndStep")
     NEXT_END_STEP,
@@ -478,9 +478,8 @@ enum class DelayedTriggerTiming {
     /**
      * "On your next turn" timing: the current turn never qualifies, regardless of step;
      * the trigger fires no earlier than the next turn. Pair with
-     * [CreateDelayedTriggerEffect.fireOnlyOnControllersTurn] = true to land on the
-     * controller's upcoming own turn rather than an intervening opponent turn.
-     * (Kav Landseeker.)
+     * `fireOnPlayer = PlayerRef(Player.You)` to land on the controller's upcoming own turn
+     * rather than an intervening opponent turn. (Kav Landseeker.)
      */
     @SerialName("NextTurn")
     NEXT_TURN
@@ -506,14 +505,12 @@ enum class DelayedTriggerTiming {
  *
  * @param step The step at which the delayed trigger fires
  * @param effect The effect to execute when the trigger fires
- * @param fireOnlyOnControllersTurn If true, the delayed trigger only fires when the active player is the controller
  */
 @SerialName("CreateDelayedTrigger")
 @Serializable
 data class CreateDelayedTriggerEffect(
     val step: Step? = null,
     val effect: Effect,
-    val fireOnlyOnControllersTurn: Boolean = false,
     /**
      * Event-based trigger. When non-null, the delayed trigger fires whenever
      * an event matching this TriggerSpec occurs (scoped to [watchedTarget] if set),
@@ -542,8 +539,8 @@ data class CreateDelayedTriggerEffect(
     val fireOnce: Boolean = false,
     /**
      * The earliest turn this step-based delayed trigger may fire. See
-     * [DelayedTriggerTiming]. Orthogonal to [fireOnlyOnControllersTurn], which gates
-     * whose turn the trigger fires on.
+     * [DelayedTriggerTiming]. Orthogonal to [fireOnPlayer], which gates *whose* turn the
+     * trigger fires on (not *which* turn is the earliest eligible one).
      */
     val timing: DelayedTriggerTiming = DelayedTriggerTiming.CURRENT_TURN_OR_LATER,
     /**
@@ -555,13 +552,19 @@ data class CreateDelayedTriggerEffect(
      */
     val targetRequirement: TargetRequirement? = null,
     /**
-     * For step-based delayed triggers: restrict firing to a specific player's matching step
-     * (rather than the controller's, or every player's, turn). Resolved to a concrete player
-     * entity id at scheduling time by [com.wingedsheep.engine.handlers.effects.composite.CreateDelayedTriggerExecutor]
-     * and also exposed as `triggeringPlayerId` / `triggeringEntityId` to [effect] when it
-     * fires, so `EffectTarget.PlayerRef(Player.TriggeringPlayer)` inside [effect] resolves
-     * back to the same player. Used for "at the beginning of their next draw step" effects
-     * (Nafs Asp). Orthogonal to [fireOnlyOnControllersTurn]: if both are set, both gates apply.
+     * For step-based delayed triggers: restrict firing to a specific player's matching step,
+     * rather than every player's. Resolved to a concrete player entity id at scheduling time
+     * by [com.wingedsheep.engine.handlers.effects.composite.CreateDelayedTriggerExecutor] and
+     * also exposed as `triggeringPlayerId` / `triggeringEntityId` to [effect] when it fires,
+     * so `EffectTarget.PlayerRef(Player.TriggeringPlayer)` inside [effect] resolves back to
+     * the same player. Defaults to `null` (no player gate — fires on the next matching step of
+     * any turn).
+     *
+     * This is the single "whose turn" gate. Common shapes:
+     *  - `PlayerRef(Player.You)` — only on the controller's turn ("at the beginning of *your*
+     *    next end step"; Dragonhawk, Kav Landseeker, Meandering Towershell).
+     *  - `PlayerRef(Player.TriggeringPlayer)` — on the triggering/damaged player's turn ("at
+     *    the beginning of *their* next draw step"; Nafs Asp).
      */
     val fireOnPlayer: EffectTarget? = null
 ) : Effect {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/NafsAsp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/NafsAsp.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Nafs Asp
+ * {G}
+ * Creature — Snake
+ * 1/1
+ *
+ * "Whenever this creature deals damage to a player, that player loses 1 life at
+ * the beginning of their next draw step unless they pay {1} before that draw step."
+ *
+ * Modelled as: on damage, schedule a one-shot delayed trigger that fires at the
+ * start of the damaged player's NEXT draw step. The damaged player is captured
+ * via the new [CreateDelayedTriggerEffect.fireOnPlayer] axis, which both gates
+ * the firing step to that player's turn and re-exposes them as
+ * `Player.TriggeringPlayer` to the inner [PayOrSufferEffect] — so the same
+ * player chooses to pay {1} or lose 1 life when the trigger resolves.
+ *
+ * The 2004 ruling "people commonly pay during upkeep" survives: the player gets
+ * a single pay-or-suffer decision once the trigger lands on the stack at the
+ * start of their draw step, before that step's turn-based draw.
+ */
+val NafsAsp = card("Nafs Asp") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Snake"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature deals damage to a player, that player " +
+        "loses 1 life at the beginning of their next draw step unless they pay " +
+        "{1} before that draw step."
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Any,
+            recipient = RecipientFilter.AnyPlayer
+        )
+        effect = CreateDelayedTriggerEffect(
+            step = Step.DRAW,
+            fireOnPlayer = EffectTarget.PlayerRef(Player.TriggeringPlayer),
+            timing = DelayedTriggerTiming.CURRENT_TURN_OR_LATER,
+            effect = PayOrSufferEffect(
+                cost = Costs.pay.Mana(ManaCost.parse("{1}")),
+                suffer = LoseLifeEffect(1, EffectTarget.PlayerRef(Player.TriggeringPlayer)),
+                player = EffectTarget.PlayerRef(Player.TriggeringPlayer)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Christopher Rush"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/965f722c-2b18-4c22-8c30-12552def5940.jpg?1562922939"
+        ruling(
+            "2004-10-04",
+            "If its damage gets redirected to its controller, it will still trigger the ability."
+        )
+        ruling(
+            "2004-10-04",
+            "If it damages a player twice, they get to pay or take damage twice during their next draw step."
+        )
+        ruling(
+            "2004-10-04",
+            "The ability does not cause itself to trigger again. It causes loss of life, not damage."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DragonhawkFatesTempest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DragonhawkFatesTempest.kt
@@ -59,7 +59,7 @@ val DragonhawkFatesTempest = card("Dragonhawk, Fate's Tempest") {
         GrantMayPlayFromExileEffect("exiledCards"),
         CreateDelayedTriggerEffect(
             step = Step.END,
-            fireOnlyOnControllersTurn = true,
+            fireOnPlayer = EffectTarget.PlayerRef(Player.You),
             timing = DelayedTriggerTiming.NEXT_END_STEP,
             effect = DealDamagePerEntityInZoneEffect(
                 collectionName = "exiledCards",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/custom/SekshaasEarlySleeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/custom/SekshaasEarlySleeper.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
 import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -72,7 +73,7 @@ val SekshaasEarlySleeper = card("Sekshaas, Early Sleeper") {
                         Effects.Move(EffectTarget.Self, Zone.BATTLEFIELD),
                         GrantKeywordEffect(Keyword.HASTE, EffectTarget.Self)
                     )),
-                    fireOnlyOnControllersTurn = true
+                    fireOnPlayer = EffectTarget.PlayerRef(Player.You)
                 )
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavLandseeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/KavLandseeker.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
 import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
 import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -38,7 +39,7 @@ val KavLandseeker = card("Kav Landseeker") {
     // PipelineTarget(CREATED_TOKENS, 0) addresses the just-created Lander; the delayed-trigger
     // executor bakes it into a concrete entity id so the trigger still resolves after the
     // pipeline context is gone. timing = NEXT_TURN defers past this turn no matter the
-    // current step; fireOnlyOnControllersTurn = true lands the trigger on the controller's
+    // current step; fireOnPlayer = PlayerRef(You) lands the trigger on the controller's
     // upcoming turn rather than an intervening opponent turn.
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
@@ -50,7 +51,7 @@ val KavLandseeker = card("Kav Landseeker") {
                     effect = SacrificeTargetEffect(
                         target = EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
                     ),
-                    fireOnlyOnControllersTurn = true,
+                    fireOnPlayer = EffectTarget.PlayerRef(Player.You),
                     timing = DelayedTriggerTiming.NEXT_TURN
                 )
             )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ktk/cards/MeanderingTowershell.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ktk/cards/MeanderingTowershell.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -46,7 +47,7 @@ val MeanderingTowershell = card("Meandering Towershell") {
                         placement = ZonePlacement.TappedAndAttacking,
                         controllerOverride = EffectTarget.Controller
                     ),
-                    fireOnlyOnControllersTurn = true
+                    fireOnPlayer = EffectTarget.PlayerRef(Player.You)
                 )
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesVigilante.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CaseyJonesVigilante.kt
@@ -7,6 +7,8 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
  * Casey Jones, Vigilante
@@ -32,7 +34,7 @@ val CaseyJonesVigilante = card("Casey Jones, Vigilante") {
                 Effects.DrawCards(3),
                 CreateDelayedTriggerEffect(
                     step = Step.UPKEEP,
-                    fireOnlyOnControllersTurn = true,
+                    fireOnPlayer = EffectTarget.PlayerRef(Player.You),
                     effect = Patterns.Hand.discardRandom(3),
                 ),
             )

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -2142,6 +2142,81 @@
     ]
 }
 
+// Nafs Asp
+{
+    "name": "Nafs Asp",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Snake",
+    "oracleText": "Whenever this creature deals damage to a player, that player loses 1 life at the beginning of their next draw step unless they pay {1} before that draw step.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "step": "DRAW",
+                    "effect": {
+                        "type": "PayOrSuffer",
+                        "cost": {
+                            "type": "PayMana",
+                            "cost": "{1}"
+                        },
+                        "suffer": {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "TriggeringPlayer"
+                            }
+                        },
+                        "player": {
+                            "type": "PlayerRef",
+                            "player": "TriggeringPlayer"
+                        }
+                    },
+                    "fireOnPlayer": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Christopher Rush",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/965f722c-2b18-4c22-8c30-12552def5940.jpg?1562922939",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "If its damage gets redirected to its controller, it will still trigger the ability."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "If it damages a player twice, they get to pay or take damage twice during their next draw step."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "The ability does not cause itself to trigger again. It causes loss of life, not damage."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Oasis
 {
     "name": "Oasis",

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -5152,8 +5152,11 @@
                                 "damagePerEntity": 2,
                                 "damageSource": "Self"
                             },
-                            "fireOnlyOnControllersTurn": true,
-                            "timing": "NextEndStep"
+                            "timing": "NextEndStep",
+                            "fireOnPlayer": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
                         }
                     ]
                 }
@@ -5197,8 +5200,11 @@
                                 "damagePerEntity": 2,
                                 "damageSource": "Self"
                             },
-                            "fireOnlyOnControllersTurn": true,
-                            "timing": "NextEndStep"
+                            "timing": "NextEndStep",
+                            "fireOnPlayer": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
                         }
                     ]
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -8040,8 +8040,11 @@
                                     "collectionName": "createdTokens"
                                 }
                             },
-                            "fireOnlyOnControllersTurn": true,
-                            "timing": "NextTurn"
+                            "timing": "NextTurn",
+                            "fireOnPlayer": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
                         }
                     ]
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/KTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KTK.json
@@ -7365,7 +7365,10 @@
                                 "placement": "TappedAndAttacking",
                                 "controllerOverride": "Controller"
                             },
-                            "fireOnlyOnControllersTurn": true
+                            "fireOnPlayer": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
                         }
                     ]
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1005,7 +1005,10 @@
                                     }
                                 ]
                             },
-                            "fireOnlyOnControllersTurn": true
+                            "fireOnPlayer": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
                         }
                     ]
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
@@ -86,7 +86,18 @@ data class PayOrSufferContinuation(
     val targets: List<ChosenTarget> = emptyList(),
     val namedTargets: Map<String, ChosenTarget> = emptyMap(),
     val manaCost: ManaCost? = null,
-    val zone: Zone? = null
+    val zone: Zone? = null,
+    /**
+     * Trigger context from the original PayOrSufferEffect execution, preserved so the
+     * suffer effect can still resolve [com.wingedsheep.sdk.scripting.references.Player.TriggeringPlayer]
+     * after the player explicitly declined to pay (Nafs Asp's "that player loses 1 life
+     * unless they pay {1}"). The auto-suffer path runs synchronously with the original
+     * context; the via-decision path goes through this continuation, so we have to thread
+     * the triggering player through too — otherwise the suffer's target resolves to null
+     * and the effect silently fizzles.
+     */
+    val triggeringEntityId: EntityId? = null,
+    val triggeringPlayerId: EntityId? = null
 ) : ContinuationFrame
 
 /**
@@ -121,7 +132,11 @@ data class PayOrSufferChoiceContinuation(
     val options: List<PayCost>,
     val sufferEffect: Effect,
     val targets: List<ChosenTarget> = emptyList(),
-    val namedTargets: Map<String, ChosenTarget> = emptyMap()
+    val namedTargets: Map<String, ChosenTarget> = emptyMap(),
+    /** Mirror of [PayOrSufferContinuation.triggeringEntityId] for the multi-option path. */
+    val triggeringEntityId: EntityId? = null,
+    /** Mirror of [PayOrSufferContinuation.triggeringPlayerId] for the multi-option path. */
+    val triggeringPlayerId: EntityId? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
@@ -157,6 +157,10 @@ data class PayOrSufferChoiceContinuation(
  * @property filter The filter for valid selections (for sacrifice costs)
  * @property storedCollections Pipeline collections carried into whichever consequence fires, so a
  *   consequence can reference cards gathered earlier in the same resolution ("…this way").
+ * @property triggeringEntityId Trigger context from the original effect, preserved so a consequence
+ *   referencing [com.wingedsheep.sdk.scripting.references.Player.TriggeringPlayer] still resolves
+ *   after the async pay-or-decline round-trip (mirrors [PayOrSufferContinuation]).
+ * @property triggeringPlayerId See [triggeringEntityId].
  */
 @Serializable
 data class AnyPlayerMayPayContinuation(
@@ -171,7 +175,9 @@ data class AnyPlayerMayPayContinuation(
     val consequenceIfNonePaid: Effect? = null,
     val requiredCount: Int,
     val filter: GameObjectFilter,
-    val storedCollections: Map<String, List<EntityId>> = emptyMap()
+    val storedCollections: Map<String, List<EntityId>> = emptyMap(),
+    val triggeringEntityId: EntityId? = null,
+    val triggeringPlayerId: EntityId? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
@@ -58,5 +58,14 @@ data class DelayedTriggeredAbility(
      * target per firing (e.g. Rediscover the Way chapter III). Null for non-targeting
      * delayed triggers.
      */
-    val targetRequirement: com.wingedsheep.sdk.scripting.targets.TargetRequirement? = null
+    val targetRequirement: com.wingedsheep.sdk.scripting.targets.TargetRequirement? = null,
+    /**
+     * For step-based delayed triggers: if non-null, only fires when this player is the
+     * active player. Also exposed as `triggeringPlayerId` / `triggeringEntityId` on the
+     * synthesised [com.wingedsheep.sdk.scripting.TriggeredAbility]'s trigger context, so
+     * `Player.TriggeringPlayer` inside [effect] resolves back to this same player. Set by
+     * [com.wingedsheep.engine.handlers.effects.composite.CreateDelayedTriggerExecutor] from
+     * [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect.fireOnPlayer].
+     */
+    val fireOnPlayerId: EntityId? = null
 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
@@ -19,7 +19,6 @@ import kotlinx.serialization.Serializable
  * @property sourceId The entity that created this delayed trigger
  * @property sourceName Human-readable name of the source
  * @property controllerId The player who controls this delayed trigger
- * @property fireOnlyOnControllersTurn If true, only fires when the active player is the controller
  */
 @Serializable
 data class DelayedTriggeredAbility(
@@ -30,7 +29,6 @@ data class DelayedTriggeredAbility(
     val sourceId: EntityId,
     val sourceName: String,
     val controllerId: EntityId,
-    val fireOnlyOnControllersTurn: Boolean = false,
     /**
      * For event-based delayed triggers: the TriggerSpec describing what event fires this.
      * When non-null, this ability is event-based and [fireAtStep] is unused.
@@ -60,9 +58,14 @@ data class DelayedTriggeredAbility(
      */
     val targetRequirement: com.wingedsheep.sdk.scripting.targets.TargetRequirement? = null,
     /**
-     * For step-based delayed triggers: if non-null, only fires when this player is the
-     * active player. Also exposed as `triggeringPlayerId` / `triggeringEntityId` on the
-     * synthesised [com.wingedsheep.sdk.scripting.TriggeredAbility]'s trigger context, so
+     * For step-based delayed triggers: the single "whose turn" gate. If non-null, only fires
+     * when this player is the active player; null means it fires on the next matching step of
+     * any turn. Setting it to the source's [controllerId] expresses the common "only on the
+     * controller's turn" case (e.g. "at the beginning of *your* next end step"); setting it to
+     * the triggering player expresses "at the beginning of *their* next [step]" (Nafs Asp).
+     *
+     * Also exposed as `triggeringPlayerId` / `triggeringEntityId` on the synthesised
+     * [com.wingedsheep.sdk.scripting.TriggeredAbility]'s trigger context, so
      * `Player.TriggeringPlayer` inside [effect] resolves back to this same player. Set by
      * [com.wingedsheep.engine.handlers.effects.composite.CreateDelayedTriggerExecutor] from
      * [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect.fireOnPlayer].

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -298,6 +298,7 @@ class TriggerDetector(
             delayed.trigger == null &&
                 delayed.fireAtStep == step &&
                 (!delayed.fireOnlyOnControllersTurn || delayed.controllerId == activePlayer) &&
+                (delayed.fireOnPlayerId == null || delayed.fireOnPlayerId == activePlayer) &&
                 (delayed.notBeforeTurn == null || state.turnNumber >= delayed.notBeforeTurn)
         }
         if (matching.isEmpty()) return emptyList<PendingTrigger>() to emptySet()
@@ -313,7 +314,11 @@ class TriggerDetector(
                 sourceId = delayed.sourceId,
                 sourceName = delayed.sourceName,
                 controllerId = delayed.controllerId,
-                triggerContext = TriggerContext(step = step)
+                triggerContext = TriggerContext(
+                    step = step,
+                    triggeringEntityId = delayed.fireOnPlayerId,
+                    triggeringPlayerId = delayed.fireOnPlayerId
+                )
             )
         }
         val consumedIds = matching.map { it.id }.toSet()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -297,7 +297,6 @@ class TriggerDetector(
         val matching = state.delayedTriggers.filter { delayed ->
             delayed.trigger == null &&
                 delayed.fireAtStep == step &&
-                (!delayed.fireOnlyOnControllersTurn || delayed.controllerId == activePlayer) &&
                 (delayed.fireOnPlayerId == null || delayed.fireOnPlayerId == activePlayer) &&
                 (delayed.notBeforeTurn == null || state.turnNumber >= delayed.notBeforeTurn)
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -220,7 +220,9 @@ class SacrificeAndPayContinuationResumer(
                 controllerId = continuation.playerId,
                 opponentId = null,
                 targets = continuation.targets,
-                pipeline = PipelineState(namedTargets = continuation.namedTargets)
+                pipeline = PipelineState(namedTargets = continuation.namedTargets),
+                triggeringEntityId = continuation.triggeringEntityId,
+                triggeringPlayerId = continuation.triggeringPlayerId
             )
             val result = services.effectExecutorRegistry.execute(state, continuation.sufferEffect, context).toExecutionResult()
             return if (result.isPaused) result else checkForMore(result.state, result.events.toList())
@@ -237,7 +239,9 @@ class SacrificeAndPayContinuationResumer(
             controllerId = continuation.playerId,
             opponentId = null,
             targets = continuation.targets,
-            pipeline = PipelineState(namedTargets = continuation.namedTargets)
+            pipeline = PipelineState(namedTargets = continuation.namedTargets),
+            triggeringEntityId = continuation.triggeringEntityId,
+            triggeringPlayerId = continuation.triggeringPlayerId
         )
         val result = services.effectExecutorRegistry.execute(state, singleCostEffect, context).toExecutionResult()
         return if (result.isPaused) result else checkForMore(result.state, result.events.toList())
@@ -576,13 +580,17 @@ class SacrificeAndPayContinuationResumer(
         val playerId = continuation.playerId
         val sufferEffect = continuation.sufferEffect
 
-        // Create context for executing the suffer effect, preserving targets from the original trigger
+        // Create context for executing the suffer effect, preserving targets AND the original
+        // trigger context. Without the latter, effects like LoseLifeEffect(1, PlayerRef(TriggeringPlayer))
+        // (Nafs Asp's bite when the damaged player declines to pay {1}) silently fizzle.
         val context = EffectContext(
             sourceId = sourceId,
             controllerId = playerId,
             opponentId = null,
             targets = continuation.targets,
-            pipeline = PipelineState(namedTargets = continuation.namedTargets)
+            pipeline = PipelineState(namedTargets = continuation.namedTargets),
+            triggeringEntityId = continuation.triggeringEntityId,
+            triggeringPlayerId = continuation.triggeringPlayerId
         )
 
         // Execute the suffer effect using the registry

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -690,7 +690,9 @@ class SacrificeAndPayContinuationResumer(
             sourceId = continuation.sourceId,
             controllerId = continuation.controllerId,
             opponentId = null,
-            pipeline = PipelineState(storedCollections = continuation.storedCollections)
+            pipeline = PipelineState(storedCollections = continuation.storedCollections),
+            triggeringEntityId = continuation.triggeringEntityId,
+            triggeringPlayerId = continuation.triggeringPlayerId
         )
         val result = services.effectExecutorRegistry.execute(state, consequence, context).toExecutionResult()
         val allEvents = priorEvents + result.events

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -59,11 +59,21 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
         // For step-based delayed triggers that restrict to a specific player's turn (e.g.
         // Nafs Asp's "at the beginning of their next draw step"): resolve the player target
         // now, while the trigger context still knows who it is, and bake the entity id in.
-        // Use resolvePlayerTarget first (the PlayerRef-aware resolver, since fireOnPlayer is
-        // a player by definition), then fall back to the generic resolver for already-baked
-        // SpecificEntity/TriggeringEntity targets.
-        val fireOnPlayerId = effect.fireOnPlayer?.let {
-            context.resolvePlayerTarget(it) ?: context.resolveTarget(it)
+        // resolvePlayerTarget covers PlayerRef shapes; the generic resolveTarget fallback
+        // covers pre-baked SpecificEntity/TriggeringEntity ids. Either way, the resolved id
+        // must point at a player — anything else (e.g. SpecificEntity(creatureId)) would
+        // never match state.activePlayerId and the trigger would silently never fire, so we
+        // fail loudly at scheduling time instead.
+        val fireOnPlayerId = effect.fireOnPlayer?.let { target ->
+            val resolved = context.resolvePlayerTarget(target) ?: context.resolveTarget(target)
+                ?: return EffectResult.error(state, "CreateDelayedTrigger fireOnPlayer did not resolve: $target")
+            if (resolved !in state.turnOrder) {
+                return EffectResult.error(
+                    state,
+                    "CreateDelayedTrigger fireOnPlayer resolved to non-player entity $resolved (from $target)"
+                )
+            }
+            resolved
         }
 
         // The earliest turn this delayed trigger may fire, derived from effect.timing:

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -56,6 +56,16 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
         // entity id so matching later is cheap and doesn't need the original context.
         val watchedEntityId = effect.watchedTarget?.let { context.resolveTarget(it) }
 
+        // For step-based delayed triggers that restrict to a specific player's turn (e.g.
+        // Nafs Asp's "at the beginning of their next draw step"): resolve the player target
+        // now, while the trigger context still knows who it is, and bake the entity id in.
+        // Use resolvePlayerTarget first (the PlayerRef-aware resolver, since fireOnPlayer is
+        // a player by definition), then fall back to the generic resolver for already-baked
+        // SpecificEntity/TriggeringEntity targets.
+        val fireOnPlayerId = effect.fireOnPlayer?.let {
+            context.resolvePlayerTarget(it) ?: context.resolveTarget(it)
+        }
+
         // The earliest turn this delayed trigger may fire, derived from effect.timing:
         //  - NEXT_END_STEP ("at the beginning of your next end step"): fires at the next
         //    upcoming end step on the controller's turn. If we're still before the end step
@@ -89,7 +99,8 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             expiry = if (effect.trigger != null) effect.expiry else null,
             fireOnce = effect.trigger != null && effect.fireOnce,
             notBeforeTurn = notBeforeTurn,
-            targetRequirement = effect.targetRequirement
+            targetRequirement = effect.targetRequirement,
+            fireOnPlayerId = fireOnPlayerId
         )
 
         return EffectResult.success(state.addDelayedTrigger(delayedTrigger))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -83,7 +83,7 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
         //    following turn. Only bump notBeforeTurn when the current turn's end step has
         //    already begun (or passed), i.e. we're in END or CLEANUP on the controller's turn.
         //  - NEXT_TURN ("on your next turn") is stricter: the current turn never qualifies,
-        //    regardless of step. Combine with fireOnlyOnControllersTurn = true to land on the
+        //    regardless of step. Combine with fireOnPlayer = PlayerRef(You) to land on the
         //    controller's upcoming turn.
         //  - CURRENT_TURN_OR_LATER: no turn floor.
         val notBeforeTurn = when (effect.timing) {
@@ -103,7 +103,6 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             sourceId = sourceId,
             sourceName = sourceName,
             controllerId = context.controllerId,
-            fireOnlyOnControllersTurn = effect.fireOnlyOnControllersTurn,
             trigger = effect.trigger,
             watchedEntityId = watchedEntityId,
             expiry = if (effect.trigger != null) effect.expiry else null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
@@ -84,7 +84,15 @@ class AnyPlayerMayPayExecutor(
 
         // No more players can pay - run the "none paid" branch (e.g., reanimate the card).
         if (index >= playerOrder.size) {
-            return runConsequence(state, effect.consequenceIfNonePaid, context.controllerId, sourceId, context.pipeline.storedCollections)
+            return runConsequence(
+                state,
+                effect.consequenceIfNonePaid,
+                context.controllerId,
+                sourceId,
+                context.pipeline.storedCollections,
+                context.triggeringEntityId,
+                context.triggeringPlayerId
+            )
         }
 
         val playerId = playerOrder[index]
@@ -247,7 +255,9 @@ class AnyPlayerMayPayExecutor(
         consequenceIfNonePaid = effect.consequenceIfNonePaid,
         requiredCount = requiredCount,
         filter = filter,
-        storedCollections = context.pipeline.storedCollections
+        storedCollections = context.pipeline.storedCollections,
+        triggeringEntityId = context.triggeringEntityId,
+        triggeringPlayerId = context.triggeringPlayerId
     )
 
     /**
@@ -259,7 +269,9 @@ class AnyPlayerMayPayExecutor(
         consequence: Effect?,
         controllerId: EntityId,
         sourceId: EntityId,
-        storedCollections: Map<String, List<EntityId>>
+        storedCollections: Map<String, List<EntityId>>,
+        triggeringEntityId: EntityId? = null,
+        triggeringPlayerId: EntityId? = null
     ): EffectResult {
         if (consequence == null) return EffectResult.success(state)
         val executor = executeEffect ?: return EffectResult.success(state)
@@ -267,7 +279,9 @@ class AnyPlayerMayPayExecutor(
             sourceId = sourceId,
             controllerId = controllerId,
             opponentId = null,
-            pipeline = PipelineState(storedCollections = storedCollections)
+            pipeline = PipelineState(storedCollections = storedCollections),
+            triggeringEntityId = triggeringEntityId,
+            triggeringPlayerId = triggeringPlayerId
         )
         return executor(state, consequence, context)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -135,7 +135,9 @@ class PayOrSufferExecutor(
             filter = cost.filter,
             random = false,
             targets = context.targets,
-            namedTargets = context.pipeline.namedTargets
+            namedTargets = context.pipeline.namedTargets,
+            triggeringEntityId = context.triggeringEntityId,
+            triggeringPlayerId = context.triggeringPlayerId
         )
 
         val stateWithContinuation = decisionResult.state.pushContinuation(continuation)
@@ -195,7 +197,9 @@ class PayOrSufferExecutor(
             filter = cost.filter,
             random = true,
             targets = context.targets,
-            namedTargets = context.pipeline.namedTargets
+            namedTargets = context.pipeline.namedTargets,
+            triggeringEntityId = context.triggeringEntityId,
+            triggeringPlayerId = context.triggeringPlayerId
         )
 
         val stateWithDecision = state.withPendingDecision(decision)
@@ -264,7 +268,9 @@ class PayOrSufferExecutor(
             filter = cost.filter,
             random = false,
             targets = context.targets,
-            namedTargets = context.pipeline.namedTargets
+            namedTargets = context.pipeline.namedTargets,
+            triggeringEntityId = context.triggeringEntityId,
+            triggeringPlayerId = context.triggeringPlayerId
         )
 
         val stateWithContinuation = decisionResult.state.pushContinuation(continuation)
@@ -330,7 +336,9 @@ class PayOrSufferExecutor(
             filter = cost.filter,
             random = false,
             targets = context.targets,
-            namedTargets = context.pipeline.namedTargets
+            namedTargets = context.pipeline.namedTargets,
+            triggeringEntityId = context.triggeringEntityId,
+            triggeringPlayerId = context.triggeringPlayerId
         )
 
         val stateWithContinuation = decisionResult.state.pushContinuation(continuation)
@@ -391,7 +399,9 @@ class PayOrSufferExecutor(
             filter = GameObjectFilter.Any, // Not used for life payment
             random = false,
             targets = context.targets,
-            namedTargets = context.pipeline.namedTargets
+            namedTargets = context.pipeline.namedTargets,
+            triggeringEntityId = context.triggeringEntityId,
+            triggeringPlayerId = context.triggeringPlayerId
         )
 
         val stateWithDecision = state.withPendingDecision(decision)
@@ -456,6 +466,8 @@ class PayOrSufferExecutor(
             random = false,
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
+            triggeringEntityId = context.triggeringEntityId,
+            triggeringPlayerId = context.triggeringPlayerId,
             zone = cost.zone
         )
 
@@ -516,6 +528,8 @@ class PayOrSufferExecutor(
             random = false,
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
+            triggeringEntityId = context.triggeringEntityId,
+            triggeringPlayerId = context.triggeringPlayerId,
             manaCost = cost.cost
         )
 
@@ -589,7 +603,9 @@ class PayOrSufferExecutor(
             options = availableOptions.map { cost.options[it.first] },
             sufferEffect = effect.suffer,
             targets = context.targets,
-            namedTargets = context.pipeline.namedTargets
+            namedTargets = context.pipeline.namedTargets,
+            triggeringEntityId = context.triggeringEntityId,
+            triggeringPlayerId = context.triggeringPlayerId
         )
 
         val stateWithDecision = state.withPendingDecision(decision)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -177,7 +177,9 @@ class CreateTokenCopyOfTargetExecutor(
                     sourceId = sourceId,
                     sourceName = sourceName,
                     controllerId = controllerId,
-                    fireOnlyOnControllersTurn = effect.sacrificeOnlyOnControllersTurn
+                    // "sacrifice at the beginning of your next end step" → gate the firing step
+                    // to the token controller's turn (the single fireOnPlayerId gate).
+                    fireOnPlayerId = if (effect.sacrificeOnlyOnControllersTurn) controllerId else null
                 )
                 newState = newState.addDelayedTrigger(delayedTrigger)
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MeanderingTowershellTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MeanderingTowershellTest.kt
@@ -78,7 +78,8 @@ class MeanderingTowershellTest : FunSpec({
         // A delayed trigger should have been created
         driver.state.delayedTriggers.size shouldBe 1
         driver.state.delayedTriggers.first().fireAtStep shouldBe Step.BEGIN_COMBAT
-        driver.state.delayedTriggers.first().fireOnlyOnControllersTurn shouldBe true
+        // Gated to the controller's turn via fireOnPlayer = PlayerRef(You).
+        driver.state.delayedTriggers.first().fireOnPlayerId shouldBe attacker
     }
 
     test("Meandering Towershell does not return on opponent's turn") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NafsAspScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NafsAspScenarioTest.kt
@@ -109,6 +109,51 @@ class NafsAspScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("damaged player loses 1 life when they CAN pay but decline (regression: trigger context survives the YesNo continuation)") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nafs Asp")
+                    // Untapped Forest on P2 so ManaSolver.canPay({1}) returns true and the
+                    // YesNoDecision is actually presented (rather than the auto-suffer shortcut).
+                    .withCardOnBattlefield(2, "Forest")
+                    .withActivePlayer(1)
+                repeat(5) {
+                    builder.withCardInLibrary(1, "Mountain")
+                    builder.withCardInLibrary(2, "Forest")
+                }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Nafs Asp" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                val lifeAfterCombat = game.getLifeTotal(2)
+
+                // Advance into P2's draw step. The trigger resolves and presents a YesNo
+                // decision to P2 ("Pay {1} or accept consequence?"). resolveStack stops on
+                // the pending decision rather than auto-answering.
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                game.resolveStack()
+
+                withClue("Trigger resolved → P2 sees the pay-or-suffer decision") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                // P2 declines to pay {1}. The suffer (LoseLife on the triggering player)
+                // must fire — regression for the bug where the continuation rebuilt
+                // EffectContext without triggeringPlayerId, fizzling the LoseLife.
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("P2 declined to pay {1}, so the suffer's LoseLife on the triggering player resolves and drops life by 1") {
+                    game.getLifeTotal(2) shouldBe lifeAfterCombat - 1
+                }
+                withClue("Trigger fully consumed; no further bite scheduled") {
+                    game.state.delayedTriggers.size shouldBe 0
+                }
+            }
+
             test("no delayed trigger when Nafs Asp deals no damage to a player this turn") {
                 val builder = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NafsAspScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NafsAspScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Nafs Asp's deferred-bite delayed trigger.
+ *
+ * Oracle: "Whenever this creature deals damage to a player, that player loses 1 life
+ * at the beginning of their next draw step unless they pay {1} before that draw step."
+ *
+ * Covers the new [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect.fireOnPlayer]
+ * axis end-to-end: the damaged player is captured at schedule time, the delayed trigger
+ * is gated to fire only on *that* player's draw step (not Nafs Asp's controller's), and
+ * the pay-or-suffer decision is presented to the damaged player.
+ */
+class NafsAspScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Nafs Asp deferred bite") {
+
+            test("damaged player auto-loses 1 life on their next draw step when they can't pay {1}") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nafs Asp")
+                    .withActivePlayer(1)
+                // Give both players a few library cards so the turn-based draw at their draw
+                // step doesn't bottom them out into a state-based loss before the bite lands.
+                repeat(5) {
+                    builder.withCardInLibrary(1, "Mountain")
+                    builder.withCardInLibrary(2, "Forest")
+                }
+                val game = builder.build()
+
+                val startLife = game.getLifeTotal(2)
+
+                // Combat damage: Nafs Asp swings unblocked into Player2.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Nafs Asp" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                withClue("Combat damage itself drops life by 1 (and only 1)") {
+                    game.getLifeTotal(2) shouldBe startLife - 1
+                }
+
+                withClue("Damage trigger should have scheduled a delayed bite on P2's next draw step") {
+                    game.state.delayedTriggers.size shouldBe 1
+                    game.state.delayedTriggers[0].fireAtStep shouldBe Step.DRAW
+                    game.state.delayedTriggers[0].fireOnPlayerId shouldBe game.player2Id
+                }
+
+                val lifeAfterCombat = game.getLifeTotal(2)
+                val p1LifeBefore = game.getLifeTotal(1)
+
+                // End Player1's turn, advance through cleanup to Player2's draw step.
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                game.resolveStack()
+
+                withClue("Player1's life must not move — target is the damaged player, not the controller") {
+                    game.getLifeTotal(1) shouldBe p1LifeBefore
+                }
+                withClue("Player2 has no mana sources, so the delayed trigger's pay-or-suffer auto-suffers") {
+                    game.getLifeTotal(2) shouldBe lifeAfterCombat - 1
+                }
+                withClue("The delayed trigger fires only once") {
+                    game.state.delayedTriggers.size shouldBe 0
+                }
+            }
+
+            test("delayed bite waits for the damaged player's draw step, not their upkeep") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nafs Asp")
+                    .withActivePlayer(1)
+                repeat(5) {
+                    builder.withCardInLibrary(1, "Mountain")
+                    builder.withCardInLibrary(2, "Forest")
+                }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Nafs Asp" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                val lifeAfterCombat = game.getLifeTotal(2)
+
+                // Stop at P2's UPKEEP — strictly one step before DRAW. The bite must not
+                // land yet (fireAtStep is DRAW, not UPKEEP).
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("Trigger is scheduled for P2's DRAW, not their UPKEEP") {
+                    game.getLifeTotal(2) shouldBe lifeAfterCombat
+                    game.state.delayedTriggers.size shouldBe 1
+                }
+
+                // Advance one more step to DRAW — trigger fires and suffer auto-resolves.
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                game.resolveStack()
+
+                withClue("Bite lands on P2's DRAW step") {
+                    game.getLifeTotal(2) shouldBe lifeAfterCombat - 1
+                    game.state.delayedTriggers.size shouldBe 0
+                }
+            }
+
+            test("no delayed trigger when Nafs Asp deals no damage to a player this turn") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nafs Asp")
+                    .withActivePlayer(1)
+                // Give both players a few library cards so the turn-based draw at their draw
+                // step doesn't bottom them out into a state-based loss before the bite lands.
+                repeat(5) {
+                    builder.withCardInLibrary(1, "Mountain")
+                    builder.withCardInLibrary(2, "Forest")
+                }
+                val game = builder.build()
+
+                val startLifeP2 = game.getLifeTotal(2)
+
+                // Don't attack — pass straight through to P2's draw step.
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                game.resolveStack()
+
+                withClue("Nafs Asp dealt no damage to a player, so no delayed bite is scheduled") {
+                    game.getLifeTotal(2) shouldBe startLifeP2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NafsAspScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NafsAspScenarioTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.DeclareAttackers
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
@@ -150,6 +151,58 @@ class NafsAspScenarioTest : ScenarioTestBase() {
                     game.getLifeTotal(2) shouldBe lifeAfterCombat - 1
                 }
                 withClue("Trigger fully consumed; no further bite scheduled") {
+                    game.state.delayedTriggers.size shouldBe 0
+                }
+            }
+
+            test("damaging a player twice schedules two bites that both resolve on their next draw step (ruling: pay or suffer twice)") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nafs Asp")
+                    .withCardOnBattlefield(1, "Nafs Asp")
+                    .withActivePlayer(1)
+                repeat(5) {
+                    builder.withCardInLibrary(1, "Mountain")
+                    builder.withCardInLibrary(2, "Forest")
+                }
+                val game = builder.build()
+
+                val startLife = game.getLifeTotal(2)
+
+                // Two Nafs Asps swing unblocked into Player2: two independent combat-damage
+                // events, each triggering its own deferred bite. declareAttackers() keys by
+                // card name and so can't declare two same-named attackers — build the action
+                // directly from both entity ids.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val asps = game.findAllPermanents("Nafs Asp")
+                asps.size shouldBe 2
+                game.execute(
+                    DeclareAttackers(game.player1Id, asps.associateWith { game.player2Id })
+                ).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                val lifeAfterCombat = game.getLifeTotal(2)
+
+                withClue("Both attackers connect: combat itself drops P2 by 2") {
+                    game.getLifeTotal(2) shouldBe startLife - 2
+                }
+                withClue("Each damage event schedules its own deferred bite on P2's draw step") {
+                    game.state.delayedTriggers.size shouldBe 2
+                    game.state.delayedTriggers.all {
+                        it.fireAtStep == Step.DRAW && it.fireOnPlayerId == game.player2Id
+                    } shouldBe true
+                }
+
+                // Advance to P2's draw step: both bites fire and, with no mana to pay {1},
+                // both auto-suffer — P2 loses 1 life per bite.
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                game.resolveStack()
+
+                withClue("Both deferred bites resolve at the draw step → P2 loses 2 more life") {
+                    game.getLifeTotal(2) shouldBe lifeAfterCombat - 2
+                }
+                withClue("Both delayed triggers are consumed") {
                     game.state.delayedTriggers.size shouldBe 0
                 }
             }


### PR DESCRIPTION
## Summary

Implements Nafs Asp (ARN): "Whenever this creature deals damage to a
player, that player loses 1 life at the beginning of their next draw
step unless they pay {1} before that draw step."

Modelled as: on damage, schedule a one-shot delayed trigger that fires
at the start of the *damaged* player's next draw step. To express that,
adds one new SDK axis and fixes a latent PayOrSuffer bug surfaced by it.

## Changes

- **SDK**: `CreateDelayedTriggerEffect.fireOnPlayer: EffectTarget?` —
  orthogonal to `fireOnlyOnControllersTurn`; gates the firing step to a
  specific player resolved at scheduling time, and re-exposes them as
  `triggeringPlayerId` so `PlayerRef(TriggeringPlayer)` inside the inner
  effect resolves back to the same player. Validated at scheduling time
  to actually be a player (fails loudly on misuse).
- **Engine**: `PayOrSufferContinuation` / `PayOrSufferChoiceContinuation`
  now thread `triggeringEntityId` / `triggeringPlayerId` through the
  decline-to-pay path. Without this, any suffer effect referencing
  `PlayerRef(TriggeringPlayer)` silently fizzled after a "No" YesNo —
  not just Nafs Asp.
- **Card**: `mtg-sets/.../arn/cards/NafsAsp.kt` + ARN snapshot + cards.md
  (62 → 63 / 78).
- **Docs**: card SDK reference updated for the new axis.

## Test plan

- [x] `NafsAspScenarioTest` (4 cases): auto-suffer when no mana, wrong
      step (UPKEEP) doesn't fire, decline-to-pay regression, no damage
      → no schedule.
- [x] `scripts/check-card-printing "Nafs Asp"` passes (canonical in ARN).