### PR TITLE
Fix surviving target picked for both effects after a target dies (Friendly Rivalry / Diplomatic Relations)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -872,7 +872,7 @@ class ConditionEvaluator(
         condition: TargetMatchesFilter,
         context: EffectContext
     ): Boolean {
-        val target = context.targets.getOrNull(condition.targetIndex) ?: return false
+        val target = context.positionalTarget(condition.targetIndex) ?: return false
         val entityId = when (target) {
             is com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent -> target.entityId
             is com.wingedsheep.engine.state.components.stack.ChosenTarget.Player -> return false
@@ -894,7 +894,7 @@ class ConditionEvaluator(
         condition: TargetIsPlayer,
         context: EffectContext
     ): Boolean {
-        val target = context.targets.getOrNull(condition.targetIndex) ?: return false
+        val target = context.positionalTarget(condition.targetIndex) ?: return false
         return target is com.wingedsheep.engine.state.components.stack.ChosenTarget.Player
     }
 
@@ -915,7 +915,7 @@ class ConditionEvaluator(
         condition: TargetMarkedDamageExceedsToughness,
         context: EffectContext
     ): Boolean {
-        val target = context.targets.getOrNull(condition.targetIndex) ?: return false
+        val target = context.positionalTarget(condition.targetIndex) ?: return false
         val entityId = (target as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent)
             ?.entityId ?: return false
         if (entityId !in state.getBattlefield()) return false
@@ -939,7 +939,7 @@ class ConditionEvaluator(
         condition: TargetSharesMostCommonColor,
         context: EffectContext
     ): Boolean {
-        val target = context.targets.getOrNull(condition.targetIndex) ?: return false
+        val target = context.positionalTarget(condition.targetIndex) ?: return false
         val entityId = (target as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent)
             ?.entityId ?: return false
         val projected = state.projectedState
@@ -961,7 +961,7 @@ class ConditionEvaluator(
         condition: AnotherPermanentWithSameNameAsTarget,
         context: EffectContext
     ): Boolean {
-        val target = context.targets.getOrNull(condition.targetIndex) ?: return false
+        val target = context.positionalTarget(condition.targetIndex) ?: return false
         val entityId = (target as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent)
             ?.entityId ?: return false
         val targetEntity = state.getEntity(entityId) ?: return false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -689,7 +689,7 @@ class DynamicAmountEvaluator(
             is Player.Each -> state.turnOrder
             is Player.Any -> state.turnOrder
             is Player.ContextPlayer -> {
-                val target = context.targets.getOrNull(player.index) ?: return emptyList()
+                val target = context.positionalTarget(player.index) ?: return emptyList()
                 when (target) {
                     is com.wingedsheep.engine.state.components.stack.ChosenTarget.Player -> listOf(target.playerId)
                     else -> emptyList()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -34,6 +34,21 @@ data class EffectContext(
     val candidatePlayerId: EntityId? = null,
     val targets: List<ChosenTarget> = emptyList(),
     /**
+     * Positionally-aligned view of [targets]: the same length as the originally-chosen target
+     * list, with `null` in any slot whose target was dropped by resolution-time legality
+     * validation (CR 608.2b). Populated on the spell-resolution path (and copied through
+     * composite/iteration sub-effects); empty elsewhere, where it coincides with [targets].
+     *
+     * Positional target references — [EffectTarget.ContextTarget], [EntityReference.Target],
+     * [com.wingedsheep.sdk.scripting.references.Player.ContextPlayer], and indexed conditions —
+     * MUST resolve through [positionalTarget] so a now-illegal slot reads `null` (and the
+     * sub-effect fizzles, CR 608.2b) instead of silently consuming the next still-legal target
+     * whose position shifted forward in the compacted [targets] list. Diplomatic Relations is
+     * the canonical case: "creature you control" dies in response, and without this the damage
+     * amount's `Target(0)` power read would land on the surviving opponent's creature.
+     */
+    val alignedTargets: List<ChosenTarget?> = emptyList(),
+    /**
      * The X chosen for an X-cost spell/ability. Also reused by `ChooseNumberThenEffect` to
      * carry a "choose a number" value into the inner effect (read via `CardPredicate.ManaValueEqualsX`,
      * Void). These two uses share one slot, so a future card that both pays `{X}` *and* chooses a
@@ -179,6 +194,29 @@ data class EffectContext(
      * up components (e.g., [EffectTarget.EnchantedCreature], [EffectTarget.TargetController]),
      * use the overload that also takes [GameState].
      */
+    /**
+     * Resolve a chosen target by its ORIGINAL declared position, stable even when CR 608.2b
+     * validation dropped an earlier target before resolution. Every positional
+     * `targets[index]` read that uses a card-definition-supplied index goes through here so a
+     * dropped target doesn't shift later targets forward in the compacted [targets] list.
+     *
+     * [alignedTargets] is only consulted when it is genuinely the position-preserving partner
+     * of the CURRENT [targets] — i.e. dropping its `null` slots reproduces [targets] exactly.
+     * That guard matters because executors re-scope [targets] to a different list (e.g.
+     * [com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect] iterates one target at a time,
+     * continuation resumers narrow to the remaining/selected targets) via `copy()`, which
+     * carries the now-stale parent [alignedTargets]. In that case we fall back to [targets] so
+     * `ContextTarget(0)` reads the re-scoped target, not the stale slot 0. When the lists do
+     * coincide (top-level spell resolution), [alignedTargets] supplies the `null` for any
+     * dropped slot.
+     */
+    fun positionalTarget(index: Int): ChosenTarget? =
+        if (alignedTargets.isNotEmpty() && alignedTargets.filterNotNull() == targets) {
+            alignedTargets.getOrNull(index)
+        } else {
+            targets.getOrNull(index)
+        }
+
     fun resolveTarget(target: EffectTarget): EntityId? =
         TargetResolutionUtils.resolveTarget(target, this)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -29,7 +29,7 @@ object TargetResolutionUtils {
         return when (effectTarget) {
             is EffectTarget.Self -> context.pipeline.iterationTarget ?: context.sourceId
             is EffectTarget.Controller -> context.controllerId
-            is EffectTarget.ContextTarget -> context.targets.getOrNull(effectTarget.index)?.toEntityId()
+            is EffectTarget.ContextTarget -> context.positionalTarget(effectTarget.index)?.toEntityId()
             is EffectTarget.BoundVariable -> context.pipeline.namedTargets[effectTarget.name]?.toEntityId()
             is EffectTarget.SpecificEntity -> effectTarget.entityId
             is EffectTarget.TriggeringEntity -> context.triggeringEntityId
@@ -84,7 +84,7 @@ object TargetResolutionUtils {
     fun resolvePlayerTarget(effectTarget: EffectTarget, context: EffectContext): EntityId? {
         return when (effectTarget) {
             is EffectTarget.Controller -> context.controllerId
-            is EffectTarget.ContextTarget -> context.targets.getOrNull(effectTarget.index)?.toEntityId()
+            is EffectTarget.ContextTarget -> context.positionalTarget(effectTarget.index)?.toEntityId()
             is EffectTarget.BoundVariable -> context.pipeline.namedTargets[effectTarget.name]?.toEntityId()
             is EffectTarget.PipelineTarget ->
                 context.pipeline.storedCollections[effectTarget.collectionName]?.getOrNull(effectTarget.index)
@@ -206,7 +206,7 @@ object TargetResolutionUtils {
             is EntityReference.Source -> context.sourceId
             is EntityReference.EnchantedCreature ->
                 context.sourceId?.let { state.getEntity(it)?.get<AttachedToComponent>()?.targetId }
-            is EntityReference.Target -> context.targets.getOrNull(ref.index)?.toEntityId()
+            is EntityReference.Target -> context.positionalTarget(ref.index)?.toEntityId()
             is EntityReference.Sacrificed -> context.sacrificedPermanents.getOrNull(ref.index)?.entityId
             is EntityReference.TappedAsCost -> context.tappedPermanents.getOrNull(ref.index)
             is EntityReference.Triggering -> context.triggeringEntityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -447,7 +447,7 @@ class GatedEffectExecutor(
         is Player.Opponent -> context.opponentId
         is Player.TargetOpponent -> context.opponentId
         is Player.TargetPlayer -> context.targets.firstOrNull()?.let { TargetResolutionUtils.run { it.toEntityId() } }
-        is Player.ContextPlayer -> context.targets.getOrNull(player.index)?.let { TargetResolutionUtils.run { it.toEntityId() } }
+        is Player.ContextPlayer -> context.positionalTarget(player.index)?.let { TargetResolutionUtils.run { it.toEntityId() } }
         is Player.TriggeringPlayer -> context.triggeringEntityId
         else -> context.controllerId
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileLibraryUntilManaValueExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileLibraryUntilManaValueExecutor.kt
@@ -106,7 +106,7 @@ class ExileLibraryUntilManaValueExecutor : EffectExecutor<ExileLibraryUntilManaV
             Player.TargetPlayer -> context.targets.firstOrNull()?.let {
                 listOf(TargetResolutionUtils.run { it.toEntityId() })
             } ?: emptyList()
-            is Player.ContextPlayer -> context.targets.getOrNull(player.index)?.let {
+            is Player.ContextPlayer -> context.positionalTarget(player.index)?.let {
                 listOf(TargetResolutionUtils.run { it.toEntityId() })
             } ?: emptyList()
             Player.TriggeringPlayer -> listOfNotNull(context.triggeringEntityId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -265,7 +265,7 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
             is Player.Opponent -> context.opponentId
             is Player.TargetOpponent -> context.opponentId
             is Player.TargetPlayer -> context.targets.firstOrNull()?.let { TargetResolutionUtils.run { it.toEntityId() } }
-            is Player.ContextPlayer -> context.targets.getOrNull(player.index)?.let { TargetResolutionUtils.run { it.toEntityId() } }
+            is Player.ContextPlayer -> context.positionalTarget(player.index)?.let { TargetResolutionUtils.run { it.toEntityId() } }
             is Player.TriggeringPlayer -> context.triggeringEntityId
             is Player.OwnerOf -> context.targets.firstOrNull()?.let {
                 val eid = TargetResolutionUtils.run { it.toEntityId() }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherUntilMatchExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherUntilMatchExecutor.kt
@@ -95,7 +95,7 @@ class GatherUntilMatchExecutor : EffectExecutor<GatherUntilMatchEffect> {
             is Player.Opponent -> context.opponentId
             is Player.TargetOpponent -> context.opponentId
             is Player.TargetPlayer -> context.opponentId
-            is Player.ContextPlayer -> context.targets.getOrNull(player.index)?.let {
+            is Player.ContextPlayer -> context.positionalTarget(player.index)?.let {
                 TargetResolutionUtils.run { it.toEntityId() }
             }
             is Player.TriggeringPlayer -> context.triggeringEntityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
@@ -758,7 +758,7 @@ class MoveCollectionExecutor(
             is Player.Opponent -> context.opponentId
             is Player.TargetOpponent -> context.opponentId
             is Player.TargetPlayer -> context.targets.firstOrNull()?.let { TargetResolutionUtils.run { it.toEntityId() } }
-            is Player.ContextPlayer -> context.targets.getOrNull(player.index)?.let { TargetResolutionUtils.run { it.toEntityId() } }
+            is Player.ContextPlayer -> context.positionalTarget(player.index)?.let { TargetResolutionUtils.run { it.toEntityId() } }
             is Player.TriggeringPlayer -> context.triggeringEntityId
             is Player.OwnerOf -> context.targets.firstOrNull()?.let {
                 val eid = TargetResolutionUtils.run { it.toEntityId() }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1339,6 +1339,10 @@ class StackResolver(
                 controllerId = spellComponent.casterId,
                 opponentId = newState.getOpponent(spellComponent.casterId),
                 targets = targets,
+                // Position-preserving view (null in slots dropped by 608.2b) so positional
+                // references — ContextTarget(n), EntityReference.Target(n), ContextPlayer(n) —
+                // resolve by ORIGINAL slot and don't shift onto a later still-valid target.
+                alignedTargets = alignedTargets,
                 xValue = spellComponent.xValue,
                 totalManaSpent = spellComponent.manaSpentWhite + spellComponent.manaSpentBlue +
                     spellComponent.manaSpentBlack + spellComponent.manaSpentRed +

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FriendlyRivalryPartialIllegalTargetTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FriendlyRivalryPartialIllegalTargetTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression test for the target-index-collapse class of bug:
+ *     "If you kill one of the targets, the surviving target gets picked for both effects."
+ *
+ * Card reference — Friendly Rivalry ({R}{G}, Instant, LTR #204):
+ *   "Target creature you control [0] and up to one other target legendary creature you control [1]
+ *    each deal damage equal to their power to target creature you don't control [2]."
+ *
+ * Friendly Rivalry has THREE targets and two damage instructions whose *amount* is a positional
+ * `EntityReference.Target(n)` power read — Target(0) for the first creature, Target(1) for the
+ * legendary. CR 608.2b drops illegal targets at resolution and the engine compacts
+ * `context.targets`. Before the fix, the second instruction's `Target(1)` indexed the COMPACTED
+ * list: once the first target (creature you control) died in response, the legendary slid into
+ * slot 0 and the opponent's creature slid into slot 1, so `Target(1)` read the OPPONENT'S
+ * creature's power instead of the legendary's — the surviving target was picked for both the
+ * source and the amount.
+ *
+ * This case is not masked the way Diplomatic Relations is: the legendary's damageSource
+ * (Target 1) is still legal, so the instruction does NOT fizzle — it just deals the wrong
+ * amount. With the fix, positional references resolve against the position-aligned list (null
+ * in dropped slots), so `Target(1)` keeps pointing at the legendary.
+ *
+ * Setup makes the difference observable: the opponent's creature is a 0/4 Wall of Mulch.
+ *   - Correct (fixed):  amount = Blind Seer's power (3)        -> Wall takes 3 damage.
+ *   - Buggy (compacted): amount = Wall of Mulch's power (0)    -> amount <= 0, no damage.
+ */
+class FriendlyRivalryPartialIllegalTargetTest : ScenarioTestBase() {
+
+    init {
+        context("Friendly Rivalry — partial illegal target (first creature dies in response)") {
+
+            test("the legendary's damage must use the LEGENDARY's power, not the surviving opponent creature's") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Friendly Rivalry")
+                    // Target 0: "creature you control" — dies to Bolt before resolution.
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    // Target 1: "up to one other legendary creature you control" — 3/3, survives.
+                    .withCardOnBattlefield(1, "Blind Seer", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    // Target 2: "creature you don't control" — 0/4 Wall, survives 3 damage.
+                    .withCardOnBattlefield(2, "Wall of Mulch", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val grizzly = game.state.getBattlefield().single { entityId ->
+                    val container = game.state.getEntity(entityId) ?: return@single false
+                    container.get<CardComponent>()?.name == "Grizzly Bears" &&
+                        container.get<ControllerComponent>()?.playerId == game.player1Id
+                }
+                val blindSeer = game.state.getBattlefield().single { entityId ->
+                    val container = game.state.getEntity(entityId) ?: return@single false
+                    container.get<CardComponent>()?.name == "Blind Seer"
+                }
+                val wall = game.state.getBattlefield().single { entityId ->
+                    val container = game.state.getEntity(entityId) ?: return@single false
+                    container.get<CardComponent>()?.name == "Wall of Mulch"
+                }
+
+                // Alice casts Friendly Rivalry: [creature you control = Grizzly Bears (0),
+                // legendary = Blind Seer (1), creature you don't control = Wall of Mulch (2)].
+                val rivalryId = game.findCardsInHand(1, "Friendly Rivalry").single()
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        rivalryId,
+                        listOf(
+                            ChosenTarget.Permanent(grizzly),
+                            ChosenTarget.Permanent(blindSeer),
+                            ChosenTarget.Permanent(wall),
+                        )
+                    )
+                )
+                withClue("Friendly Rivalry should cast: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                game.execute(PassPriority(game.player1Id))
+                withClue("Bob should have priority to respond") {
+                    game.state.priorityPlayerId shouldBe game.player2Id
+                }
+
+                // Bob kills the FIRST target (Grizzly Bears) so it is dropped by 608.2b.
+                val boltId = game.findCardsInHand(2, "Lightning Bolt").single()
+                val bolt = game.execute(
+                    CastSpell(
+                        game.player2Id,
+                        boltId,
+                        listOf(ChosenTarget.Permanent(grizzly))
+                    )
+                )
+                withClue("Lightning Bolt should cast: ${bolt.error}") {
+                    bolt.error shouldBe null
+                }
+
+                // Resolve the whole stack: Bolt first (Grizzly dies), then Friendly Rivalry.
+                var iterations = 0
+                while (game.state.stack.isNotEmpty() && iterations < 40) {
+                    val priorityPlayer = game.state.priorityPlayerId ?: break
+                    val r = game.execute(PassPriority(priorityPlayer))
+                    if (r.error != null) break
+                    iterations++
+                }
+
+                withClue("Grizzly Bears should have died to Bolt") {
+                    game.state.getBattlefield().contains(grizzly) shouldBe false
+                }
+                withClue("Wall of Mulch should survive (0/4 takes 3)") {
+                    game.state.getBattlefield().contains(wall) shouldBe true
+                }
+
+                // The legendary's instruction must deal Blind Seer's power (3) to the Wall.
+                // Pre-fix, Target(1) indexed the compacted list onto the Wall (power 0) -> 0 damage.
+                val damage = game.state.getEntity(wall)?.get<DamageComponent>()?.amount ?: 0
+                withClue("Wall must take 3 damage (Blind Seer's power via Target(1)), not 0 (the Wall's own power)") {
+                    damage shouldBe 3
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

> Bug report: If you killed one of the targets on (for instance) Diplomatic Relations, the surviving target would get picked for both effects.

When a multi-target spell loses a target to **CR 608.2b** validation (e.g. a target creature is killed in response), the engine *compacts* `context.targets`. Positional target references then indexed that compacted list:

- `EntityReference.Target(n)` (used in dynamic amounts like "damage equal to its power")
- `EffectTarget.ContextTarget(n)`
- `Player.ContextPlayer(n)`
- indexed conditions (`targetIndex`)

So when an earlier target was dropped, every later target slid forward one slot — the surviving target got picked for both effects.

## Why the prior fix wasn't enough

Commit `f4c9cfb3` already fixed the **named** (`BoundVariable`) path for Diplomatic Relations — named targets resolve through a position-aligned list, and `DealDamage` fizzles when its named `damageSource` is gone. That fully covers Diplomatic Relations, because its damage instruction fizzles once the source creature dies.

But the **positional** `EntityReference.Target(n)` *amount* reads were still on the compacted list. That stayed masked on Diplomatic Relations, but bit cards whose source is still legal:

- **Friendly Rivalry** — "Target creature you control [0] and up to one other target legendary creature you control [1] each deal damage equal to their power to target creature you don't control [2]." Kill target 0 in response and the *second* instruction's `Target(1)` reads the **opponent's creature's** power (slid into slot 1) instead of the legendary's.
- **Spry and Mighty** — same `Target(0)` / `Target(1)` power-difference shape.

## Fix

Route every positional target read through a new `EffectContext.positionalTarget(index)`, which consults the position-aligned list (with `null` in dropped slots) — **but only when that list is genuinely the aligned partner of the current `targets`** (dropping its nulls reproduces `targets`).

That guard matters because several executors re-scope `targets` via `copy()` and carry a now-stale parent `alignedTargets`: `ForEachTargetEffect`'s per-target iteration, the continuation resumers, and reflexive/reselect-target. For those, the guard makes `positionalTarget` fall back to the re-scoped `targets`, so `ContextTarget(0)` still means "the current target." (This is what the 8 multi-target regression tests — Wicked Pact, Kaboom, Tap/UntapEachTarget, Hide on the Ceiling — caught during development; all green now.)

## Tests

- **New:** `FriendlyRivalryPartialIllegalTargetTest` — kill the first creature in response; the legendary's damage must use the **legendary's** power (3), not the surviving 0/4 Wall's. Verified it fails before the fix and passes after.
- **Kept green:** the existing `DiplomaticRelationsPartialIllegalTargetTest` and the full `:rules-engine` suite (3319 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)