### PR TITLE
mtgish-tooling: map the damage prevention/replacement split

### DIFF
--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -23,6 +23,19 @@ internal fun BridgeBuilder.damageLifeAndCards() {
     // variants compose further primitives, so this is `composed` (mirrors `CreateReplaceWouldDealDamageUntil`).
     composed("CreateFutureReplaceWouldDealDamage", "PreventDamageShield (prevent next N damage to recipient)",
         composes = listOf("PreventDamageShield"))
+    // Damage PREVENTION, split out of the would-deal-damage REPLACEMENT family by the mtgish creator:
+    // CreateFuturePreventDamage / CreatePreventDamageUntil / PreventDamage are the first-class prevention
+    // twins of CreateFutureReplaceWouldDealDamage / CreateReplaceWouldDealDamageUntil / ReplaceWouldDealDamage.
+    // Prevention no longer carries a `PreventThatDamage` replacement-action payload (the node IS the
+    // prevention), but it maps to the same PreventDamageShield engine capability, so the *verdict* is
+    // identical to the pre-split replacement entries — only the discriminator changes.
+    //   - CreateFuturePreventDamage → "Prevent the next N damage that would be dealt to <recipient> this turn"
+    //   - PreventDamage             → immediate/static "prevent [all] damage that would be dealt to <recipient>"
+    // (CreatePreventDamageUntil is registered with the other duration-scoped creators in TriggersCostsAndContinuous.)
+    composed("CreateFuturePreventDamage", "PreventDamageShield (prevent next N damage to recipient)",
+        composes = listOf("PreventDamageShield"))
+    composed("PreventDamage", "PreventDamageShield (prevent damage to recipient)",
+        composes = listOf("PreventDamageShield"))
     composed("GainLifeForEach", "GainLife + DynamicAmount", composes = listOf("GainLife"))
     effect("GainLife", "GainLife")
     effect("LoseLife", "LoseLife")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -56,6 +56,10 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
 
     // Duration-scoped continuous trigger / replacement creators.
     composed("CreateReplaceWouldDealDamageUntil", "PreventDamageShield / RedirectNextDamage", composes = listOf("PreventDamageShield"))
+    // Duration-scoped PREVENTION twin of CreateReplaceWouldDealDamageUntil (mtgish prevention/replacement
+    // split). "Prevent all (combat) damage that would be dealt … this turn" — Deep Wood, Leery Fogbeast,
+    // Maze of Shadows. Same PreventDamageShield capability, minus the `PreventThatDamage` replacement payload.
+    composed("CreatePreventDamageUntil", "PreventDamageShield (duration-scoped prevention)", composes = listOf("PreventDamageShield"))
     composed("CreateTriggerUntil", "CreateGlobalTriggeredAbility (duration)", composes = listOf("CreateGlobalTriggeredAbility"))
     composed("CreateFutureTrigger", "CreateDelayedTrigger", composes = listOf("CreateDelayedTrigger"))
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -171,6 +171,29 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         val target = damagePreventionRecipient(event, tvar) ?: return@on null
         call("Effects.PreventNextDamage", arg("$amount"), arg(Lit(target)))
     }
+
+    // PREVENTION twin of CreateFutureReplaceWouldDealDamage (mtgish prevention/replacement split). Same
+    // "Prevent the next N damage that would be dealt to <recipient> this turn" render as above. Verified
+    // against the post-split IR: the split renamed the discriminators but preserved the structure —
+    //   event field `_FutureReplacableEventWouldDealDamage` -> `_FutureEventPreventDamage` (value unchanged),
+    //   action field `_ReplacementActionWouldDealDamage`    -> `_ActionPreventDamage`        (value unchanged).
+    // The args[1] action payload was NOT dropped, so we keep the single-`PreventThatDamage` guard: a
+    // prevention-with-rider (redirect / gain-life / "if you do …") has a different/extra action and must
+    // SCAFFOLD rather than mis-render as a plain shield. Literal-amount + exactly-resolvable-recipient
+    // constraints unchanged (X / "all" / distributed / by-source events decline).
+    on("CreateFuturePreventDamage") { _, args, tvar ->
+        val a = args.asArr ?: return@on null
+        val event = a.getOrNull(0) as? JsonObject ?: return@on null
+        if (!jsonContains(event, "_FutureEventPreventDamage",
+                "NextAmountOfDamageThatWouldBeDealtThisTurnToRecipient")) return@on null
+        val repl = a.getOrNull(1) as? JsonArray ?: return@on null
+        if (repl.size != 1 ||
+            (repl[0] as? JsonObject)?.strField("_ActionPreventDamage") != "PreventThatDamage")
+            return@on null
+        val amount = findInteger(event) as? Int ?: return@on null  // X / "all" -> SCAFFOLD
+        val target = damagePreventionRecipient(event, tvar) ?: return@on null
+        call("Effects.PreventNextDamage", arg("$amount"), arg(Lit(target)))
+    }
 }
 
 /** Resolve a `_DamageRecipient` node to an EffectTarget DSL for a direct deal-damage action.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/PlayerContinuousHandlers.kt
@@ -66,6 +66,36 @@ internal val playerContinuousHandlers: Map<String, ActionHandler> = actionHandle
             else -> null
         }
     }
+
+    // PREVENTION twin of CreateReplaceWouldDealDamageUntil (mtgish prevention/replacement split). Verified
+    // against the post-split IR for all three shapes: Cephalid Illusionist (to-and-by `Or`, `_Permanent`
+    // = Ref_TargetPermanent), Deep Wood (attacking-creatures-to-you), Angelsong (all combat damage). The
+    // split renamed the event field `_ReplacableEventWouldDealDamage` -> `_EventPreventDamage` and the action
+    // field `_ReplacementActionWouldDealDamage` -> `_ActionPreventDamage`, but preserved every value string
+    // and the `_Expiration` / `_Permanent` / `_Player` discriminators — so the original matching still holds.
+    // The `_ActionPreventDamage` = PreventThatDamage payload survived, so we keep the `"PreventThatDamage"`
+    // guard (a prevention-with-rider scaffolds). The unrestricted (Angelsong) case is matched key-agnostically
+    // — `CombatDamageWouldBeDealt` present with neither narrower variant — instead of keying off the renamed
+    // event field. Anything that doesn't match an exact shape declines (→ SCAFFOLD).
+    on("CreatePreventDamageUntil") { node, _, tvar ->
+        val blob = compact(node)
+        when {
+            tvar != null &&
+                "CombatDamageWouldBeDealtToRecipient" in blob &&
+                "CombatDamageWouldBeDealtByCreature" in blob &&
+                jsonContains(node, "_Permanent", "Ref_TargetPermanent") &&
+                "PreventThatDamage" in blob && jsonContains(node, "_Expiration", "UntilEndOfTurn") ->
+                call("Effects.PreventCombatDamageToAndBy", arg(Lit(tvar)))
+            "IsAttacking" in blob && "PreventThatDamage" in blob && jsonContains(node, "_Player", "You") ->
+                call("Effects.PreventDamageFromAttackingCreatures")
+            "CombatDamageWouldBeDealt" in blob &&
+                "CombatDamageWouldBeDealtToRecipient" !in blob &&
+                "CombatDamageWouldBeDealtByCreature" !in blob &&
+                "PreventThatDamage" in blob && jsonContains(node, "_Expiration", "UntilEndOfTurn") ->
+                call("Effects.PreventAllCombatDamage")
+            else -> null
+        }
+    }
     on("CreateTriggerUntil") { node, _, _ ->
         // Harsh Justice: reflect attackers' combat damage back to their controller.
         val blob = compact(node)

--- a/mtgish-tooling/src/test/resources/fixtures/por.fixture.json
+++ b/mtgish-tooling/src/test/resources/fixtures/por.fixture.json
@@ -2927,10 +2927,10 @@
               "_Actions": "ActionList",
               "args": [
                 {
-                  "_Action": "CreateReplaceWouldDealDamageUntil",
+                  "_Action": "CreatePreventDamageUntil",
                   "args": [
                     {
-                      "_ReplacableEventWouldDealDamage": "DamageWouldBeDealtByAPermanentToRecipient",
+                      "_EventPreventDamage": "DamageWouldBeDealtByAPermanentToRecipient",
                       "args": [
                         {
                           "_Permanents": "And",
@@ -2954,7 +2954,7 @@
                     },
                     [
                       {
-                        "_ReplacementActionWouldDealDamage": "PreventThatDamage"
+                        "_ActionPreventDamage": "PreventThatDamage"
                       }
                     ],
                     {


### PR DESCRIPTION
## Why

The mtgish creator [split damage prevention out of the would-deal-damage replacement family](https://github.com/i5jb/mtgish): `CreateFuturePreventDamage` / `CreatePreventDamageUntil` / `PreventDamage` are now first-class twins of `CreateFutureReplaceWouldDealDamage` / `CreateReplaceWouldDealDamageUntil` / `ReplaceWouldDealDamage`.

Our bridge + emitter keyed **every** prevention path off the *replacement* node names. After refreshing the IR, the corpus moved ~179 future + ~197 until prevention nodes onto the new node types — so without this change those cards silently drop from AUTOGEN to BLOCKED/SCAFFOLD (a coverage regression), and the vendored regression fixture would pin dead pre-split node names.

## What the real post-split IR showed

The split renamed discriminators but **preserved structure + all value strings**, and **kept the action payload** (just renamed):

| | pre-split field | post-split field | value |
|---|---|---|---|
| future event | `_FutureReplacableEventWouldDealDamage` | `_FutureEventPreventDamage` | unchanged |
| until event | `_ReplacableEventWouldDealDamage` | `_EventPreventDamage` | unchanged |
| action | `_ReplacementActionWouldDealDamage` | `_ActionPreventDamage` | `PreventThatDamage` |

`_Permanent` / `_Player` / `_Expiration` / `_SingleDamageRecipient` all carry over unchanged.

## Changes

- **bridge** — `CreateFuturePreventDamage` / `CreatePreventDamageUntil` / `PreventDamage` → `PreventDamageShield` (same verdict as the pre-split replacement entries).
- **emitter** — `on("CreateFuturePreventDamage")` → `Effects.PreventNextDamage`; `on("CreatePreventDamageUntil")` → `PreventCombatDamageToAndBy` / `PreventDamageFromAttackingCreatures` / `PreventAllCombatDamage`. The single-`PreventThatDamage` guard is **retained** (renamed field) so a prevention-with-rider scaffolds rather than mis-rendering as a plain shield.
- **fixture** — re-vendored `por.fixture.json` from post-split data so the in-suite golden net exercises the new path. Emitted golden is **byte-identical** (only the 3 renamed input-node lines change).
- The immediate `PreventDamage` node has **0 occurrences** in the corpus, so it gets a bridge capability entry only (no emitter handler) as future-proofing.

The pre-split replacement handlers are left intact (they still serve the genuine non-prevent redirect/replace remainder: 37 future + 29 until).

## Verification (against the refreshed post-split IR)

- Emit: Deep Wood → `PreventDamageFromAttackingCreatures()`, Angelsong → `PreventAllCombatDamage()`, Samite Healer → `PreventNextDamage(1, t)` — all tier **AUTO**.
- **`fidelity --gate POR`: 158/158 auto-emitted & verified, 0 capability mismatch.**
- **`EmitterGoldenTest` (POR + EOE): PASSED.**

> [!NOTE]
> Local `data/mtgish.lines.json` is gitignored (auto-downloaded cache), so the IR refresh isn't in this diff. Anyone pulling this branch auto-downloads the post-split IR on next tooling run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)