### PR TITLE
Equipment attachment SBAs: combat regression test + close CR 704.5n gap

### DIFF
--- a/backlog/sets/edge-of-eternities/bugs.md
+++ b/backlog/sets/edge-of-eternities/bugs.md
@@ -1,14 +1,16 @@
 - Rust Harvester, cannot choose from graveyard, card gets picked automatically
 - Auxiliary Boosters - equipment not auto-attached
 - Larval Scoutlander - Lands did not come to the battlefield, deck was not shuffled
-- Artifact Equipment attacks, gives separate damage
-  - Atomic Microsizer 3/3 attached to Chrome Companion - Tezzeret, Cruel Captain
 
 Not bugs:
 - Chrome Companion: should keep the bottom of the library visible.
 - Intrepid Tenderfoot, stacks pumps, but it's sorcery.
 
 Fixed:
+- Artifact Equipment attacks, gives separate damage
+  - Atomic Microsizer 3/3 attached to Chrome Companion - Tezzeret, Cruel Captain
+  - Equipment that becomes a creature now unattaches (CR 301.5c / 704.5n), so it no longer
+    both buffs its host AND attacks. Covered by EquipmentAsCreatureUnattachTest (combat case).
 - Wedgelight Rammer did not turn to creature
 - Spacecraft can attack 1 turn after being played
 - Glacier Godmaw - Landfall not working

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -12,17 +12,16 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 /**
  * 704.5m - An Aura attached to an illegal object/player or not attached goes to graveyard.
  * 704.5n - An Equipment or Fortification attached to an illegal permanent becomes unattached
- *          but remains on the battlefield.
+ *          but remains on the battlefield. This drives two Equipment cases below, both asked
+ *          of the projected state (so layer-4 type-changing effects are seen):
+ *            - The host stops being a creature (an Equipment can only equip a creature, CR
+ *              301.5). E.g. the equipped creature is turned into a land, or an animated
+ *              artifact's "until end of turn" animation wears off while still equipped.
+ *            - The Equipment itself becomes a creature, so it can't legally equip another
+ *              creature unless it has reconfigure (CR 301.5c). E.g. Atomic Microsizer turned
+ *              into a 0/0 Robot artifact creature by Tezzeret, Cruel Captain's emblem.
  * 704.5p - A battle or creature attached to an object or player becomes unattached but
- *          remains on the battlefield. Drives the Equipment-that-became-a-creature case
- *          below: when an Equipment (e.g. Atomic Microsizer) becomes a creature via a
- *          layer-4 type-changing effect (Tezzeret, Cruel Captain's emblem turning an
- *          artifact into a 0/0 Robot artifact creature), the underlying CR 301.5c rule
- *          ("an Equipment that's also a creature can't equip a creature unless it has
- *          reconfigure") makes the attachment illegal, and 704.5p is the SBA that
- *          unattaches it. The "is it a creature?" question is asked of the projected
- *          state, since creatureness here comes from a layer-4 type-changing effect,
- *          not the printed type line.
+ *          remains on the battlefield.
  */
 class UnattachedAurasCheck : StateBasedActionCheck {
     override val name = "704.5m/n/p Unattached Auras"
@@ -71,13 +70,20 @@ class UnattachedAurasCheck : StateBasedActionCheck {
                             c.without<AttachedToComponent>()
                         }
                     }
-                } else if (isEquipment &&
-                    projected.isCreature(entityId) &&
-                    !projected.hasKeyword(entityId, "RECONFIGURE")
+                } else if (
+                    isEquipment && (
+                        // CR 704.5n: the host is no longer a legal permanent for an Equipment.
+                        // An Equipment can only be attached to a creature, so once the host
+                        // stops being a creature (turned into a land, animation wore off, etc.)
+                        // the attachment is illegal and the Equipment unattaches.
+                        !projected.isCreature(attachedTo.targetId) ||
+                        // CR 301.5c / 704.5n: the Equipment itself became a creature, so it
+                        // can't equip a creature unless it has reconfigure.
+                        (projected.isCreature(entityId) &&
+                            !projected.hasKeyword(entityId, "RECONFIGURE"))
+                    )
                 ) {
-                    // CR 704.5p (with 301.5c as the underlying prohibition): an Equipment
-                    // that's also a creature can't equip a creature unless it has
-                    // reconfigure, so the SBA unattaches it. Stays on the battlefield.
+                    // Illegal attachment: the Equipment unattaches but stays on the battlefield.
                     newState = cleanupReverseAttachmentLink(newState, entityId)
                     newState = newState.updateEntity(entityId) { c ->
                         c.without<AttachedToComponent>()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EquipmentAsCreatureUnattachTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EquipmentAsCreatureUnattachTest.kt
@@ -144,6 +144,78 @@ class EquipmentAsCreatureUnattachTest : ScenarioTestBase() {
                     projected.getPower(microsizer) shouldBe 3
                 }
             }
+
+            test("after the Equipment animates and unattaches, combat deals separate (not doubled) damage") {
+                // End-to-end version of the bug as it was reported ("Artifact Equipment
+                // attacks, gives separate damage"). The state-based check above proves the
+                // Equipment unattaches; this plays combat all the way to damage to prove the
+                // observable symptom is gone: Chrome Companion no longer carries Microsizer's
+                // +1/+0, and Microsizer attacks on its own as a 3/3. Bob should take exactly
+                // 2 (Companion) + 3 (Microsizer) = 5, NOT 3 + 3 = 6 (the bug, where the
+                // Equipment both buffed its host AND attacked).
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Tezzeret, Cruel Captain")
+                    .withCardOnBattlefield(1, "Chrome Companion", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Atomic Microsizer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tezzeret = game.findPermanent("Tezzeret, Cruel Captain")!!
+                val companion = game.findPermanent("Chrome Companion")!!
+                val microsizer = game.findPermanent("Atomic Microsizer")!!
+
+                game.state = game.state.updateEntity(tezzeret) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 7))
+                }
+                game.state = game.state
+                    .updateEntity(microsizer) { c -> c.with(AttachedToComponent(companion)) }
+                    .updateEntity(companion) { c ->
+                        val existing = c.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+                        c.with(AttachmentsComponent(existing + microsizer))
+                    }
+
+                val minus7 = cardRegistry.getCard("Tezzeret, Cruel Captain")!!
+                    .script.activatedAbilities[2]
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tezzeret,
+                        abilityId = minus7.id
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                // Begin combat: the emblem trigger animates Microsizer; the SBA unattaches it.
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.selectTargets(listOf(microsizer))
+                game.resolveStack()
+
+                withClue("precondition: Microsizer unattached before attackers are declared") {
+                    game.state.getEntity(microsizer)?.has<AttachedToComponent>() shouldBe false
+                }
+
+                // Both attack: the host (now base 2/1) and the standalone 3/3 Microsizer.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Chrome Companion" to 2, "Atomic Microsizer" to 2)
+                ).error shouldBe null
+
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.state.pendingDecision != null) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue(
+                    "Bob should take 2 (Companion, buff gone) + 3 (Microsizer) = 5, not 6 " +
+                        "(observed life = ${game.getLifeTotal(2)})"
+                ) {
+                    game.getLifeTotal(2) shouldBe 15
+                }
+            }
         }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EquipmentHostNotCreatureUnattachTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EquipmentHostNotCreatureUnattachTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.StateBasedActionChecker
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * CR 704.5n: "If an Equipment ... is attached to an illegal permanent ..., it becomes
+ * unattached from that permanent. It remains on the battlefield."
+ *
+ * An Equipment can only be attached to a creature (CR 301.5). So once the host stops being
+ * a creature while the Equipment is still attached, the attachment is illegal and the
+ * state-based action must unattach it. This arises whenever a legally-equipped creature
+ * becomes a non-creature: e.g. it's turned into a land (Song of the Dryads), or it was an
+ * animated artifact whose "until end of turn" animation wore off while equipped.
+ *
+ * Here we model the resulting board directly — Atomic Microsizer (Equipment) attached to a
+ * non-creature permanent (a Plains, standing in for the host that lost its creature type) —
+ * and assert the SBA unattaches it. The complementary case (the Equipment *itself* becoming
+ * a creature) is covered by [EquipmentAsCreatureUnattachTest].
+ */
+class EquipmentHostNotCreatureUnattachTest : ScenarioTestBase() {
+
+    init {
+        context("Equipment attached to a non-creature host -> SBA must unattach (CR 704.5n)") {
+
+            test("Atomic Microsizer attached to a land auto-unattaches as a state-based action") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Plains")
+                    .withCardOnBattlefield(1, "Atomic Microsizer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val plains = game.findPermanent("Plains")!!
+                val microsizer = game.findPermanent("Atomic Microsizer")!!
+
+                // Attach Microsizer to the (non-creature) land, simulating a host that was a
+                // legal creature at equip time but has since stopped being a creature.
+                game.state = game.state
+                    .updateEntity(microsizer) { c -> c.with(AttachedToComponent(plains)) }
+                    .updateEntity(plains) { c ->
+                        val existing = c.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+                        c.with(AttachmentsComponent(existing + microsizer))
+                    }
+
+                withClue("precondition: Microsizer is attached to the land before SBAs run") {
+                    game.state.getEntity(microsizer)?.get<AttachedToComponent>()?.targetId shouldBe plains
+                }
+
+                // Run state-based actions over the board.
+                val sbaChecker = StateBasedActionChecker(cardRegistry = cardRegistry)
+                game.state = sbaChecker.checkAndApply(game.state).newState
+
+                withClue(
+                    "Microsizer should be unattached from the non-creature host (CR 704.5n) " +
+                        "(observed AttachedToComponent.targetId = " +
+                        "${game.state.getEntity(microsizer)?.get<AttachedToComponent>()?.targetId})"
+                ) {
+                    game.state.getEntity(microsizer)?.has<AttachedToComponent>() shouldBe false
+                }
+
+                withClue(
+                    "the land's reverse AttachmentsComponent link should be cleaned up " +
+                        "(observed = " +
+                        "${game.state.getEntity(plains)?.get<AttachmentsComponent>()?.attachedIds})"
+                ) {
+                    val attached = game.state.getEntity(plains)
+                        ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+                    attached.contains(microsizer) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two related fixes around Equipment attachment state-based actions (CR 704.5).

## 1. Combat regression test for the reported double-damage bug (already fixed)

From `backlog/sets/edge-of-eternities/bugs.md`:

> Artifact Equipment attacks, gives separate damage
> — Atomic Microsizer 3/3 attached to Chrome Companion - Tezzeret, Cruel Captain

The underlying rules bug was **already fixed** in `main` (commit `398b377b4`): when an Equipment becomes a creature while attached, `UnattachedAurasCheck` unattaches it (CR 301.5c / 704.5p), so it no longer both buffs its host **and** attacks separately. I verified the fix is load-bearing — disabling the SBA branch makes Bob end at **14** (host 3 *buffed* + Microsizer 3) instead of the correct **15** (host 2 + Microsizer 3).

The existing test only asserted the SBA **state** at begin-combat; it never played combat out, so the *observable* "separate damage" symptom had no coverage. This adds an end-to-end combat case (declare both attackers, deal damage, assert Bob takes exactly 5) and moves the bug to the `Fixed` section of the EOE backlog.

## 2. Close the complementary CR 704.5n gap (host stops being a creature)

`UnattachedAurasCheck` handled the Equipment *becoming* a creature, but not the reverse: an Equipment attached to a permanent that is **no longer a legal host**. An Equipment can only be attached to a creature, so once the equipped permanent stops being a creature — turned into a land (e.g. Song of the Dryads), or an animated artifact whose "until end of turn" animation wears off while equipped — the attachment is illegal and the SBA must unattach it (CR 704.5n).

Both equipment-unattach reasons now share one branch, gated on projected state so layer-4 type changes are seen. Adds `EquipmentHostNotCreatureUnattachTest` (Equipment attached to a land must unattach); verified it fails without the new clause.

## Tests

- `EquipmentAsCreatureUnattachTest` (SBA-state + new combat-damage case) — PASSED
- `EquipmentHostNotCreatureUnattachTest` (new, CR 704.5n) — PASSED
- Full `:rules-engine:test` suite — PASSED, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)