### PR TITLE
Add draft/sealed archetypes for Edge of Eternities (EOE)

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
@@ -210,6 +210,34 @@ object SetArchetypes {
                     "Self-mill and renew to recur threats from the graveyard, then pile on +1/+1 counters with endure. A grindy value deck that goes long."),
             )
         ),
+        "EOE" to SetSynergies(
+            setCode = "EOE",
+            setName = "Edge of Eternities",
+            archetypes = listOf(
+                Archetype("Second Spell", listOf(Color.WHITE, Color.BLUE),
+                    "Cast two spells in a single turn to fire off a stream of payoffs. Cheap interaction and artifacts keep the spells flowing while flyers and tokens reward every double-spell turn. A consistent tempo-value deck."),
+                Archetype("Sacrifice", listOf(Color.WHITE, Color.BLACK),
+                    "Field a wide board of efficient creatures and feed them to sacrifice payoffs. Warp lets your threats land early and return later, fueling drain, removal, and relentless pressure."),
+                Archetype("Spacecraft", listOf(Color.WHITE, Color.RED),
+                    "Tap your creatures to station up Spacecraft into enormous artifact threats, then back the assault with aggressive bodies. Go fast on the ground while your ships charge toward liftoff.",
+                    creatureTypes = listOf("Spacecraft")),
+                Archetype("Artifact Value", listOf(Color.BLUE, Color.BLACK),
+                    "An artifact 'good stuff' value deck. Stock up on two-for-ones and removal, trigger void as permanents leave, and grind the game out before pulling ahead on cards."),
+                Archetype("Artifact Aggro", listOf(Color.BLUE, Color.RED),
+                    "Aggressively deploy artifacts to snowball +1/+1 counters and station triggers. Each artifact entering powers up your team for a fast, synergy-driven beatdown."),
+                Archetype("Lander Ramp", listOf(Color.BLUE, Color.GREEN),
+                    "Crack Lander tokens for mana and fixing, ramping into the format's biggest threats. The premier two-for-one ramp deck that out-resources the table and splashes bombs."),
+                Archetype("Void", listOf(Color.BLACK, Color.RED),
+                    "Sacrifice your own creatures to switch on void payoffs, turning every permanent that dies into value. A grindy sacrifice-aggro deck that controls the board while bleeding the opponent."),
+                Archetype("Graveyard Midrange", listOf(Color.BLACK, Color.GREEN),
+                    "Fill your graveyard and bring key creatures back, leaning on void and sacrifice for incidental value. A resilient midrange that trades all day and rebuilds from the yard."),
+                Archetype("Landfall", listOf(Color.RED, Color.GREEN),
+                    "Lands entering trigger landfall payoffs, and Landers let you set them off on demand. Ramp, sacrifice your Landers, and crash in with an ever-growing board.",
+                    creatureTypes = listOf("Lander")),
+                Archetype("Counters", listOf(Color.GREEN, Color.WHITE),
+                    "Take the board early with cheap creatures and pile on +1/+1 counters. Station synergies and counter payoffs build a sticky, go-tall-and-wide deck that's hard to climb back against."),
+            )
+        ),
     )
 
     /** Get archetypes for a specific set code, or null if not found. */

--- a/web-client/src/components/draft/SetSynergiesOverlay.tsx
+++ b/web-client/src/components/draft/SetSynergiesOverlay.tsx
@@ -512,6 +512,64 @@ const SET_SYNERGIES: Record<string, SetSynergies> = {
       },
     ],
   },
+  EOE: {
+    setCode: 'EOE',
+    setName: 'Edge of Eternities',
+    archetypes: [
+      {
+        name: 'Second Spell',
+        colors: ['W', 'U'],
+        description: 'Cast two spells in a single turn to fire off a stream of payoffs. Cheap interaction and artifacts keep the spells flowing while flyers and tokens reward every double-spell turn. A consistent tempo-value deck.',
+      },
+      {
+        name: 'Sacrifice',
+        colors: ['W', 'B'],
+        description: 'Field a wide board of efficient creatures and feed them to sacrifice payoffs. Warp lets your threats land early and return later, fueling drain, removal, and relentless pressure.',
+      },
+      {
+        name: 'Spacecraft',
+        colors: ['W', 'R'],
+        creatureTypes: ['Spacecraft'],
+        description: 'Tap your creatures to station up Spacecraft into enormous artifact threats, then back the assault with aggressive bodies. Go fast on the ground while your ships charge toward liftoff.',
+      },
+      {
+        name: 'Artifact Value',
+        colors: ['U', 'B'],
+        description: "An artifact 'good stuff' value deck. Stock up on two-for-ones and removal, trigger void as permanents leave, and grind the game out before pulling ahead on cards.",
+      },
+      {
+        name: 'Artifact Aggro',
+        colors: ['U', 'R'],
+        description: 'Aggressively deploy artifacts to snowball +1/+1 counters and station triggers. Each artifact entering powers up your team for a fast, synergy-driven beatdown.',
+      },
+      {
+        name: 'Lander Ramp',
+        colors: ['U', 'G'],
+        description: "Crack Lander tokens for mana and fixing, ramping into the format's biggest threats. The premier two-for-one ramp deck that out-resources the table and splashes bombs.",
+      },
+      {
+        name: 'Void',
+        colors: ['B', 'R'],
+        description: 'Sacrifice your own creatures to switch on void payoffs, turning every permanent that dies into value. A grindy sacrifice-aggro deck that controls the board while bleeding the opponent.',
+      },
+      {
+        name: 'Graveyard Midrange',
+        colors: ['B', 'G'],
+        description: 'Fill your graveyard and bring key creatures back, leaning on void and sacrifice for incidental value. A resilient midrange that trades all day and rebuilds from the yard.',
+      },
+      {
+        name: 'Landfall',
+        colors: ['R', 'G'],
+        creatureTypes: ['Lander'],
+        description: 'Lands entering trigger landfall payoffs, and Landers let you set them off on demand. Ramp, sacrifice your Landers, and crash in with an ever-growing board.',
+      },
+      {
+        name: 'Counters',
+        colors: ['G', 'W'],
+        description: "Take the board early with cheap creatures and pile on +1/+1 counters. Station synergies and counter payoffs build a sticky, go-tall-and-wide deck that's hard to climb back against.",
+      },
+    ],
+  },
 }
 
 /**


### PR DESCRIPTION
## What

Defines the 10 two-color limited archetypes for **Edge of Eternities (EOE)**, which previously had no archetype data. They're added in both source-of-truth locations and kept in lockstep:

- **Backend** `ai/.../deck/SetArchetypes.kt` — consumed by the AI deckbuilder and the `GET /api/sets/{code}/archetypes` endpoint.
- **Frontend** `web-client/.../draft/SetSynergiesOverlay.tsx` — the "Archetypes" overlay shown in the draft/sealed deckbuilder.

## Archetypes

Mirrors the official EOE limited color pairs and mechanics (warp, void, station, Landers, Spacecraft, landfall, artifacts):

| Pair | Name | Theme |
|------|------|-------|
| WU | Second Spell | Double-spell payoffs |
| WB | Sacrifice | Go-wide sacrifice + warp |
| WR | Spacecraft | Station up Spacecraft (tribal) |
| UB | Artifact Value | Artifact good-stuff + void |
| UR | Artifact Aggro | Artifacts → counters/station |
| UG | Lander Ramp | Lander ramp/fixing |
| BR | Void | Sacrifice-fueled void |
| BG | Graveyard Midrange | Recursion + void |
| RG | Landfall | Landers + landfall (tribal) |
| GW | Counters | +1/+1 counters + station |

`Spacecraft` and `Lander` are tagged as `creatureTypes` so the overlay shows in-pool counts for those tribal-ish payoffs.

## Verification

- `web-client` `npm run typecheck` — clean
- `:ai:compileKotlin` — BUILD SUCCESSFUL

Note: the backend file was already missing BLB/ECL (present only in the frontend) — a pre-existing divergence left untouched here; this PR only adds EOE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)