### PR TITLE
Fix Dyadrine entering with 0 +1/+1 counters

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1190,7 +1190,12 @@ class StackResolver(
         // Handle "enters with counters" replacement effects (before adding to battlefield)
         val counterEvents = mutableListOf<GameEvent>()
         if (cardDef != null && !spellComponent.castFaceDown) {
-            val (counterState, events) = applyEntersWithCounters(newState, spellId, cardDef, controllerId, spellComponent.xValue)
+            val totalManaSpent = spellComponent.manaSpentWhite + spellComponent.manaSpentBlue +
+                spellComponent.manaSpentBlack + spellComponent.manaSpentRed +
+                spellComponent.manaSpentGreen + spellComponent.manaSpentColorless
+            val (counterState, events) = applyEntersWithCounters(
+                newState, spellId, cardDef, controllerId, spellComponent.xValue, totalManaSpent
+            )
             newState = counterState
             counterEvents.addAll(events)
         }
@@ -1880,7 +1885,8 @@ class StackResolver(
         entityId: EntityId,
         cardDef: com.wingedsheep.sdk.model.CardDefinition,
         controllerId: EntityId,
-        xValue: Int? = null
+        xValue: Int? = null,
+        totalManaSpent: Int = 0
     ): Pair<GameState, List<GameEvent>> {
         var newState = state
         val events = mutableListOf<GameEvent>()
@@ -1917,7 +1923,8 @@ class StackResolver(
                         sourceId = entityId,
                         controllerId = controllerId,
                         opponentId = newState.turnOrder.firstOrNull { it != controllerId },
-                        xValue = xValue
+                        xValue = xValue,
+                        totalManaSpent = totalManaSpent
                     )
                     val count = dynamicAmountEvaluator.evaluate(newState, effect.count, context)
                     if (count > 0) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DyadrineSynthesisAmalgamTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DyadrineSynthesisAmalgamTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.DyadrineSynthesisAmalgam
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dyadrine, Synthesis Amalgam ({X}{G}{W}, Legendary Artifact Creature — Construct, 0/1):
+ *  "Dyadrine enters with a number of +1/+1 counters on it equal to the amount of mana
+ *   spent to cast it."
+ *
+ * Regression for the `EntersWithDynamicCounters` + [DynamicAmount.TotalManaSpent] plumbing:
+ * the ETB replacement effect was evaluated with an empty context, so `TotalManaSpent`
+ * resolved to its default 0 and Dyadrine entered with no counters. The fix threads the
+ * spell's mana-spent buckets into the replacement-effect context at resolution time.
+ */
+class DyadrineSynthesisAmalgamTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DyadrineSynthesisAmalgam)
+        return driver
+    }
+
+    test("enters with +1/+1 counters equal to total mana spent (X=3 → {3}{G}{W} = 5)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val spell = driver.putCardInHand(activePlayer, "Dyadrine, Synthesis Amalgam")
+        // {3}{G}{W} with X=3 → 5 total mana.
+        driver.giveMana(activePlayer, Color.GREEN, 1)
+        driver.giveMana(activePlayer, Color.WHITE, 1)
+        driver.giveColorlessMana(activePlayer, 3)
+
+        val cast = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = spell,
+                xValue = 3,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        cast.isSuccess shouldBe true
+        driver.bothPass()
+
+        // Dyadrine resolved onto the battlefield with 5 +1/+1 counters.
+        driver.state.getBattlefield().contains(spell) shouldBe true
+
+        val counters = driver.state.getEntity(spell)?.get<CountersComponent>()
+        val plusCounters = counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+        plusCounters shouldBe 5
+    }
+
+    test("X=0: enters with counters equal to the {G}{W} paid (= 2)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        val spell = driver.putCardInHand(activePlayer, "Dyadrine, Synthesis Amalgam")
+        driver.giveMana(activePlayer, Color.GREEN, 1)
+        driver.giveMana(activePlayer, Color.WHITE, 1)
+
+        val cast = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = spell,
+                xValue = 0,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        cast.isSuccess shouldBe true
+        driver.bothPass()
+
+        val counters = driver.state.getEntity(spell)?.get<CountersComponent>()
+        val plusCounters = counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+        plusCounters shouldBe 2
+    }
+})


### PR DESCRIPTION
## Problem

[Dyadrine, Synthesis Amalgam](mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/DyadrineSynthesisAmalgam.kt) (`{X}{G}{W}`) is supposed to *"enter with a number of +1/+1 counters on it equal to the amount of mana spent to cast it"* — but it always entered with **none**.

## Root cause

The card uses `replacementEffect(EntersWithDynamicCounters(count = DynamicAmount.TotalManaSpent))`.

`DynamicAmount.TotalManaSpent` resolves by reading `EffectContext.totalManaSpent`. But the ETB replacement-effect path (`StackResolver.applyEntersWithCounters`) built its `EffectContext` with only `xValue`, leaving `totalManaSpent` at its default `0`. So the counter count always evaluated to 0.

The spell-resolution path that powers Memory Deluge already computes this correctly from the `SpellOnStackComponent` mana-spent buckets — the ETB path just never threaded it through.

## Fix

Sum the resolving spell's `manaSpent{Color}` buckets and pass them into the replacement-effect `EffectContext` (new optional `totalManaSpent` param on `applyEntersWithCounters`, defaulting to 0).

The non-stack helper (`EntersWithCountersHelper`, used for reanimation/token entry) is intentionally left at 0 — those permanents were never cast, so the mana spent to cast them is genuinely zero.

## Test

New `DyadrineSynthesisAmalgamTest`:
- X=3 → `{3}{G}{W}` = 5 mana → enters with **5** counters
- X=0 → `{G}{W}` = 2 mana → enters with **2** counters

Both pass; both would assert 0 before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)