### PR TITLE
Fix Hemosymbic Mite targeting itself with its +X/+X trigger

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -840,6 +840,8 @@ Composed pipelines (`GatherCards → SelectFromCollection → MoveCollection` sh
   abilities worded "enchanted/equipped creature deals damage … to **any other target**" (e.g. Pain for All),
   where the dealer is the attached creature, not the ability's source permanent.
 - `Targets.Creature` — any creature.
+- `Targets.CreatureYouControl` / `CreatureOpponentControls` — controller-restricted.
+- `Targets.OtherCreatureYouControl` — "another target creature you control"; excludes the source.
 - `Targets.Player` — any player.
 - `Targets.Planeswalker` — any planeswalker.
 - `Targets.Permanent` — any permanent.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
@@ -66,6 +66,12 @@ object Targets {
     val CreatureYouControl: TargetRequirement = TargetCreature(filter = TargetFilter.CreatureYouControl)
 
     /**
+     * Another target creature you control (excludes the source).
+     */
+    val OtherCreatureYouControl: TargetRequirement =
+        TargetCreature(filter = TargetFilter.OtherCreatureYouControl)
+
+    /**
      * Target creature an opponent controls.
      */
     val CreatureOpponentControls: TargetRequirement = TargetCreature(filter = TargetFilter.CreatureOpponentControls)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/HemosymbicMite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/HemosymbicMite.kt
@@ -28,7 +28,7 @@ val HemosymbicMite = card("Hemosymbic Mite") {
     // Whenever this creature becomes tapped, another target creature you control gets +X/+X until end of turn, where X is this creature's power
     triggeredAbility {
         trigger = Triggers.BecomesTapped
-        val target = target("another target creature you control", Targets.CreatureYouControl)
+        val target = target("another target creature you control", Targets.OtherCreatureYouControl)
         val powerBonus = DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Power)
         effect = Effects.ModifyStats(powerBonus, powerBonus, target)
     }

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -6927,7 +6927,8 @@
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
-                        "baseFilter": "creature ctrl:you"
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
                     },
                     "id": "another target creature you control"
                 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HemosymbicMiteTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HemosymbicMiteTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.HemosymbicMite
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Hemosymbic Mite (EOE #190).
+ *
+ * Hemosymbic Mite {G}
+ * Creature — Mite 1/1
+ * Whenever this creature becomes tapped, another target creature you control gets +X/+X until
+ * end of turn, where X is this creature's power.
+ *
+ * Regression: the "another target creature" clause must exclude the Mite itself — it cannot be
+ * its own target.
+ */
+class HemosymbicMiteTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(HemosymbicMite)
+        return driver
+    }
+
+    test("Hemosymbic Mite cannot target itself with its becomes-tapped trigger") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        val mite = driver.putCreatureOnBattlefield(activePlayer, "Hemosymbic Mite")
+        driver.removeSummoningSickness(mite)
+        val bears = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        // Attacking taps the Mite, firing its "becomes tapped" trigger, which pauses for a target.
+        driver.declareAttackers(activePlayer, listOf(mite), opponent)
+
+        // The Mite must NOT be a legal target ("another"); the other creature you control must be.
+        val decision = driver.pendingDecision as? ChooseTargetsDecision
+            ?: error("Expected a ChooseTargetsDecision for the becomes-tapped trigger")
+        val legal = decision.legalTargets[0] ?: emptyList()
+        legal shouldNotContain mite
+        legal shouldContain bears
+    }
+
+    test("Hemosymbic Mite buffs another creature you control by its power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        val mite = driver.putCreatureOnBattlefield(activePlayer, "Hemosymbic Mite")
+        driver.removeSummoningSickness(mite)
+        val bears = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(activePlayer, listOf(mite), opponent)
+
+        // Target the other creature; X = Mite's power (1), so +1/+1 (Grizzly Bears 2/2 -> 3/3).
+        driver.submitTargetSelection(activePlayer, listOf(bears)).isSuccess shouldBe true
+        driver.bothPass() // resolve the trigger
+
+        projector.getProjectedPower(driver.state, bears) shouldBe 3
+        projector.getProjectedToughness(driver.state, bears) shouldBe 3
+    }
+})


### PR DESCRIPTION
## Problem

Hemosymbic Mite (EOE #190) reads *"Whenever this creature becomes tapped, **another** target creature you control gets +X/+X…"* but its triggered ability used `Targets.CreatureYouControl`, which allowed the Mite to be its own target — violating the "another" clause.

## Fix

- Switch the trigger's target to `Targets.OtherCreatureYouControl` (`excludeSelf = true`).
- Add `Targets.OtherCreatureYouControl` to the `Targets` facade — only the underlying `TargetFilter.OtherCreatureYouControl` existed; no `TargetRequirement` was exposed.

## Tests

New `HemosymbicMiteTest`:
- **cannot target itself** — after the Mite attacks (tapping it), the trigger's legal targets exclude the Mite and include another creature you control. *(Fails on the pre-fix card, passes after.)*
- **buffs another creature** — targeting another creature applies +X/+X where X = the Mite's power.

Re-blessed the EOE card snapshot (`excludeSelf: true` now serialized) and documented the new target in the SDK language reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)