### PR TITLE
Add 4 OTJ cards (Affinity for outlaws + intervening-if triggers) and teach the mtgish generator

### DIFF
--- a/backlog/otj-engine-gaps.md
+++ b/backlog/otj-engine-gaps.md
@@ -174,6 +174,29 @@ the narrower "cast, but for free" sense. Tests: `FreestriderCommandoScenarioTest
   batch "Satoru and/or one or more other nontoken creatures enter" once-per-turn trigger before it's
   buildable.
 
+### 6b. "Whenever one or more creatures you control die" batch trigger (once per batch)
+
+The engine has per-creature dies triggers (`Triggers.YourCreatureDies`, ANY/OTHER binding, fires once
+**per dying creature**) and a once-per-*turn* gate (`oncePerTurn = true`), plus batch detectors for
+*cards put into a graveyard from anywhere* (`CardsPutIntoYourGraveyardEvent`) and for
+leave-battlefield-without-dying / sacrifice / ETB. But there is **no once-per-*batch* trigger
+restricted to creatures you control that *died* (battlefield → graveyard)**. "Whenever one or more
+**other** creatures you control die, put a +1/+1 counter on this creature" must fire exactly once when
+a board wipe kills several of your creatures simultaneously — the per-creature `YourCreatureDies`
+over-counts (one counter per dead creature), and `oncePerTurn` is wrong (it should fire again on a
+*later* batch the same turn). `CardsPutIntoYourGraveyard(Creature.youControl())` is too broad (also
+fires on mill/discard, which aren't "die").
+
+**Needs:** a batch "one or more creatures you control died" trigger event + detector (group the
+battlefield→graveyard zone-change events for creatures you control by controller, fire once per batch),
+with an OTHER-binding variant for "another creature(s)." Mirrors the existing
+`detectAnyToGraveyardBatchTriggers` but scoped to from-battlefield deaths.
+
+→ **Vengeful Townsfolk** ("Whenever one or more other creatures you control die, put a +1/+1 counter
+  on this creature"). Also the right home for other "one or more … die" payoffs (cf. Scavenger's
+  Talent / Spiteful Banditry, which currently lean on the `oncePerTurn` approximation because their
+  printed text *does* say "only once each turn").
+
 ### 6. `CARDS_DRAWN` turn-tracker + characteristic-defining P/T from it
 
 `TurnTracker` has no `CARDS_DRAWN` accumulator, so "power equal to the number of cards you've drawn

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BeastbondOutcaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BeastbondOutcaster.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Beastbond Outcaster
+ * {2}{G}
+ * Creature — Human Druid
+ * 3/3
+ *
+ * When this creature enters, if you control a creature with power 4 or greater, draw a card.
+ * Plot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a
+ * later turn without paying its mana cost. Plot only as a sorcery.)
+ *
+ * Intervening-if ETB (CR 603.4, ruling 2024-04-12): the draw trigger checks "you control a
+ * creature with power 4 or greater" both when it would fire and as it resolves; if it's false at
+ * either point, no card is drawn. Power is read through projected state, so counters and lords
+ * count. Plot is the named keyword ([KeywordAbility.plot]).
+ */
+val BeastbondOutcaster = card("Beastbond Outcaster") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, if you control a creature with power 4 or greater, " +
+        "draw a card.\nPlot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it " +
+        "as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+        effect = Effects.DrawCards(1)
+        description = "When this creature enters, if you control a creature with power 4 or greater, draw a card."
+    }
+
+    keywordAbility(KeywordAbility.plot("{1}{G}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "154"
+        artist = "Viko Menezes"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/073b9ae8-8ac3-4824-aec4-84a80531aa23.jpg?1712355883"
+
+        ruling("2024-04-12", "When Beastbond Outcaster enters the battlefield, its triggered ability will check to see if you control a creature with power 4 or greater. If you don't, the ability won't trigger at all. If the ability does trigger, it will check again as it tries to resolve. If you no longer control a creature with power 4 or greater, the ability won't do anything.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HellspurBrute.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/HellspurBrute.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Hellspur Brute
+ * {4}{R}
+ * Creature — Minotaur Mercenary
+ * 5/4
+ *
+ * Affinity for outlaws (This spell costs {1} less to cast for each Assassin, Mercenary,
+ * Pirate, Rogue, and/or Warlock you control.)
+ * Trample
+ *
+ * "Affinity for outlaws" is a cost-reduction keyword: the spell costs {1} less per outlaw the
+ * caster controls. Outlaws are creatures with any of the Assassin / Mercenary / Pirate / Rogue /
+ * Warlock types ([Subtype.OUTLAW_TYPES], per the 2024-04-12 ruling). Modeled as a self-cast
+ * [ModifySpellCost] whose [CostReductionSource.PermanentsYouControlMatching] counts permanents you
+ * control matching the outlaw filter — the same general per-permanent reduction primitive Temur
+ * Battlecrier uses. The spell is still on the stack while its cost is computed, so it never counts
+ * itself.
+ */
+val HellspurBrute = card("Hellspur Brute") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Mercenary"
+    power = 5
+    toughness = 4
+    oracleText = "Affinity for outlaws (This spell costs {1} less to cast for each Assassin, " +
+        "Mercenary, Pirate, Rogue, and/or Warlock you control.)\nTrample"
+
+    keywords(Keyword.TRAMPLE)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.PermanentsYouControlMatching(
+                    GameObjectFilter.Creature.withAnyOfSubtypes(Subtype.OUTLAW_TYPES),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "127"
+        artist = "Caio Monteiro"
+        flavorText = "The last fool who called him \"cowboy\" earned a free ride to the bottom of Blacksnag Bog."
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b99db5b-cd13-4e69-98b7-753e72c781f8.jpg?1712355767"
+
+        ruling("2024-04-12", "A card, spell, or permanent is an outlaw if it has the Assassin, Mercenary, Pirate, Rogue, or Warlock creature type. It doesn't matter if it has more than one of those creature types; as long as it has at least one, it's an outlaw.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/InventiveWingsmith.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/InventiveWingsmith.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Inventive Wingsmith
+ * {2}{W}
+ * Creature — Dwarf Artificer
+ * 2/4
+ *
+ * At the beginning of your end step, if you haven't cast a spell from your hand this turn and
+ * this creature doesn't have a flying counter on it, put a flying counter on it.
+ *
+ * Intervening-if (CR 603.4, Scryfall ruling 2024-04-12): the end-step ability checks both
+ * clauses — "haven't cast a spell from your hand this turn" and "no flying counter" — when it
+ * would trigger and again as it resolves. If either is false at either check, the ability does
+ * nothing. The flying counter is the "flying" keyword counter, which grants flying via the
+ * keyword-counter projection (StateProjector.KEYWORD_COUNTER_MAP).
+ */
+val InventiveWingsmith = card("Inventive Wingsmith") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Artificer"
+    power = 2
+    toughness = 4
+    oracleText = "At the beginning of your end step, if you haven't cast a spell from your hand " +
+        "this turn and this creature doesn't have a flying counter on it, put a flying counter on it."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.All(
+            Conditions.Not(Conditions.YouCastSpellsThisTurn(1, fromZone = Zone.HAND)),
+            Conditions.Not(Conditions.SourceHasCounter(CounterTypeFilter.Named(Counters.FLYING))),
+        )
+        effect = Effects.AddCounters(Counters.FLYING, 1, EffectTarget.Self)
+        description = "At the beginning of your end step, if you haven't cast a spell from your hand " +
+            "this turn and this creature doesn't have a flying counter on it, put a flying counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "David Astruga"
+        flavorText = "\"We must forge for ourselves the gifts that nature neglected to give us.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6b36bb3-dacc-44f6-adcd-2c2d65513d8c.jpg?1712355293"
+
+        ruling("2024-04-12", "At the beginning of your end step, Inventive Wingsmith's ability will check to see if you've cast a spell from your hand this turn and if Inventive Wingsmith has a flying counter on it. If either is true, the ability won't trigger at all. If the ability does trigger, it will check again as it tries to resolve. If either is true as the ability tries to resolve, the ability won't do anything.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MineRaider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MineRaider.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Mine Raider
+ * {2}{R}
+ * Creature — Human Rogue
+ * 3/2
+ *
+ * Trample
+ * When this creature enters, if you control another outlaw, create a Treasure token. (Assassins,
+ * Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)
+ *
+ * Intervening-if ETB (CR 603.4): the Treasure trigger fires only if you control an outlaw other
+ * than Mine Raider. Mine Raider is itself a Rogue — and therefore an outlaw — and is on the
+ * battlefield as the trigger checks, so "you control another outlaw" is exactly "you control two
+ * or more outlaws" ([Conditions.YouControlAtLeast] over the [Subtype.OUTLAW_TYPES] creature
+ * filter). The condition is re-checked at resolution, so losing your other outlaws first fizzles it.
+ */
+val MineRaider = card("Mine Raider") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Rogue"
+    power = 3
+    toughness = 2
+    oracleText = "Trample\nWhen this creature enters, if you control another outlaw, create a " +
+        "Treasure token. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. A " +
+        "Treasure token is an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouControlAtLeast(
+            2,
+            GameObjectFilter.Creature.withAnyOfSubtypes(Subtype.OUTLAW_TYPES),
+        )
+        effect = Effects.CreateTreasure(1)
+        description = "When this creature enters, if you control another outlaw, create a Treasure token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19cfacff-e884-4954-aa6b-ed56ca942bf2.jpg?1712355800"
+
+        ruling("2024-04-12", "A card, spell, or permanent is an outlaw if it has the Assassin, Mercenary, Pirate, Rogue, or Warlock creature type. It doesn't matter if it has more than one of those creature types; as long as it has at least one, it's an outlaw.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -294,6 +294,67 @@
     ]
 }
 
+// Beastbond Outcaster
+{
+    "name": "Beastbond Outcaster",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "When this creature enters, if you control a creature with power 4 or greater, draw a card.\nPlot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "PLOT"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Plot",
+            "cost": "{1}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=4"
+                },
+                "descriptionOverride": "When this creature enters, if you control a creature with power 4 or greater, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "rarity": "UNCOMMON",
+        "artist": "Viko Menezes",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/073b9ae8-8ac3-4824-aec4-84a80531aa23.jpg?1712355883",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "When Beastbond Outcaster enters the battlefield, its triggered ability will check to see if you control a creature with power 4 or greater. If you don't, the ability won't trigger at all. If the ability does trigger, it will check again as it tries to resolve. If you no longer control a creature with power 4 or greater, the ability won't do anything."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Blacksnag Buzzard
 {
     "name": "Blacksnag Buzzard",
@@ -2378,6 +2439,66 @@
     ]
 }
 
+// Hellspur Brute
+{
+    "name": "Hellspur Brute",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Minotaur Mercenary",
+    "oracleText": "Affinity for outlaws (This spell costs {1} less to cast for each Assassin, Mercenary, Pirate, Rogue, and/or Warlock you control.)\nTrample",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "PermanentsYouControlMatching",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "HasAnyOfSubtypes",
+                                    "subtypes": [
+                                        "Assassin",
+                                        "Mercenary",
+                                        "Pirate",
+                                        "Rogue",
+                                        "Warlock"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "UNCOMMON",
+        "artist": "Caio Monteiro",
+        "flavorText": "The last fool who called him \"cowboy\" earned a free ride to the bottom of Blacksnag Bog.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b99db5b-cd13-4e69-98b7-753e72c781f8.jpg?1712355767",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A card, spell, or permanent is an outlaw if it has the Assassin, Mercenary, Pirate, Rogue, or Warlock creature type. It doesn't matter if it has more than one of those creature types; as long as it has at least one, it's an outlaw."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Holy Cow
 {
     "name": "Holy Cow",
@@ -2539,6 +2660,79 @@
     },
     "colorIdentityOverride": [
         "RED",
+        "WHITE"
+    ]
+}
+
+// Inventive Wingsmith
+{
+    "name": "Inventive Wingsmith",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Dwarf Artificer",
+    "oracleText": "At the beginning of your end step, if you haven't cast a spell from your hand this turn and this creature doesn't have a flying counter on it, put a flying counter on it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "flying",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "All",
+                    "conditions": [
+                        {
+                            "type": "Not",
+                            "condition": {
+                                "type": "PlayerCastSpellsThisTurn",
+                                "atLeast": 1,
+                                "fromZone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "Not",
+                            "condition": {
+                                "type": "SourceMatches",
+                                "filter": {
+                                    "statePredicates": [
+                                        {
+                                            "type": "HasCounter",
+                                            "counterType": "FLYING"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your end step, if you haven't cast a spell from your hand this turn and this creature doesn't have a flying counter on it, put a flying counter on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "David Astruga",
+        "flavorText": "\"We must forge for ourselves the gifts that nature neglected to give us.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6b36bb3-dacc-44f6-adcd-2c2d65513d8c.jpg?1712355293",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "At the beginning of your end step, Inventive Wingsmith's ability will check to see if you've cast a spell from your hand this turn and if Inventive Wingsmith has a flying counter on it. If either is true, the ability won't trigger at all. If the ability does trigger, it will check again as it tries to resolve. If either is true as the ability tries to resolve, the ability won't do anything."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
         "WHITE"
     ]
 }
@@ -3026,6 +3220,78 @@
             {
                 "date": "2024-04-12",
                 "text": "The number of noncreature spells is counted as Magebane Lizard's ability resolves, so a noncreature spell cast in response will be counted."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Mine Raider
+{
+    "name": "Mine Raider",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Trample\nWhen this creature enters, if you control another outlaw, create a Treasure token. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. A Treasure token is an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "HasAnyOfSubtypes",
+                                    "subtypes": [
+                                        "Assassin",
+                                        "Mercenary",
+                                        "Pirate",
+                                        "Rogue",
+                                        "Warlock"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When this creature enters, if you control another outlaw, create a Treasure token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19cfacff-e884-4954-aa6b-ed56ca942bf2.jpg?1712355800",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A card, spell, or permanent is an outlaw if it has the Assassin, Mercenary, Pirate, Rogue, or Warlock creature type. It doesn't matter if it has more than one of those creature types; as long as it has at least one, it's an outlaw."
             }
         ]
     },

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -150,6 +150,26 @@ private fun EmitCtx.costReductionStaticLines(rule: JsonObject): List<String>? {
     return renderBlock(Block("staticAbility", listOf(Assign("ability", ability))), "    ")
 }
 
+/**
+ * An `Affinity(<group filter>)` rule -> a self-cast `ModifySpellCost` whose generic reduction counts
+ * the permanents you control matching the group ("Affinity for outlaws", "Affinity for artifacts").
+ * The reduction reuses [CostReductionSource.PermanentsYouControlMatching], the general per-permanent
+ * primitive. Only the group filters [gameObjectFilterDsl] can render exactly produce a block; any
+ * other affinity group declines -> SCAFFOLD rather than guess (Hellspur Brute: "Affinity for outlaws").
+ */
+internal fun EmitCtx.affinityBlock(rule: JsonObject): List<Stmt>? {
+    val filter = gameObjectFilterDsl(rule["args"]) ?: run { reasons.add("Affinity"); return null }
+    val ability = call(
+        "ModifySpellCost",
+        arg("target", Lit("SpellCostTarget.SelfCast")),
+        arg("modification", call(
+            "CostModification.ReduceGenericBy",
+            arg(call("CostReductionSource.PermanentsYouControlMatching", arg(Lit(filter)))),
+        )),
+    )
+    return listOf(staticAbilityStmt(ability))
+}
+
 private fun EmitCtx.additionalCostLine(rule: JsonObject): String? {
     val node = rule["args"] as? JsonObject ?: return null
     if (node.strField("_CastEffect") != "AdditionalCastingCost") return null
@@ -442,13 +462,35 @@ internal fun EmitCtx.triggerIBlock(rule: JsonObject): List<Stmt>? {
 
 /**
  * An intervening-if condition node -> a `Conditions.*` DSL string, or null (-> SCAFFOLD) for any
- * condition shape we can't express exactly. Only the shapes the Mount/cast-from-hand cards need are
- * recognised; declining beats widening. Currently:
+ * condition shape we can't express exactly. Only the shapes our calibrated cards need are
+ * recognised; declining beats widening. A top-level `And` composes its arms with `Conditions.All`
+ * (each arm must itself render). The single-condition shapes:
  *  - `PlayerPassesFilter(You, HasntCastASpellThisTurn(WasCastFromTheirHand))` ("you haven't cast a
- *    spell from your hand this turn") -> `Conditions.Not(Conditions.YouCastSpellsThisTurn(1, fromZone = Zone.HAND))`.
+ *    spell from your hand this turn") -> `Conditions.Not(Conditions.YouCastSpellsThisTurn(1, fromZone = Zone.HAND))`
+ *    (Canyon Crab).
+ *  - `PermanentPassesFilter(ThisPermanent, HasNoCountersOfType(<counter>))` ("this creature doesn't
+ *    have a <counter> counter on it") -> `Conditions.Not(Conditions.SourceHasCounter(CounterTypeFilter.Named("<counter>")))`
+ *    (Inventive Wingsmith).
+ *  - `PlayerPassesFilter(You, ControlsA(And(Other(ThatEnteringPermanent), IsAnOutlaw)))` ("you
+ *    control another outlaw") -> `Conditions.YouControlAtLeast(2, <outlaw filter>)` — the entering
+ *    permanent is itself an outlaw, so "another outlaw" = "two or more outlaws" (Mine Raider).
+ *  - `PlayerPassesFilter(You, ControlsA(<filter>))` ("you control a <filter>") ->
+ *    `Conditions.YouControl(<filter>)` (Beastbond Outcaster's "a creature with power 4 or greater").
  */
 private fun EmitCtx.interveningIfDsl(cond: JsonObject?): String? {
     if (cond == null) return null
+    // Top-level And -> Conditions.All(arm, arm, ...); every arm must render or the whole declines.
+    if (cond.strField("_Condition") == "And") {
+        val arms = cond["args"].asArr?.filterIsInstance<JsonObject>() ?: return null
+        if (arms.size < 2) return null
+        val rendered = arms.map { interveningIfDsl(it) ?: return null }
+        return "Conditions.All(${rendered.joinToString(", ")})"
+    }
+    return singleInterveningIfDsl(cond)
+}
+
+/** One non-And intervening-if condition node -> its `Conditions.*` DSL, or null (-> SCAFFOLD). */
+private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
     if (cond.strField("_Condition") == "PlayerPassesFilter" &&
         jsonContains(cond, "_Player", "You") &&
         jsonContains(cond, "_Players", "HasntCastASpellThisTurn") &&
@@ -456,7 +498,49 @@ private fun EmitCtx.interveningIfDsl(cond: JsonObject?): String? {
     ) {
         return "Conditions.Not(Conditions.YouCastSpellsThisTurn(1, fromZone = Zone.HAND))"
     }
+    // "this creature doesn't have a <counter> counter on it" — PermanentPassesFilter(ThisPermanent,
+    // HasNoCountersOfType(<counter>)). Only the keyword/named counters we can name render; the source
+    // ref must be ThisPermanent.
+    if (cond.strField("_Condition") == "PermanentPassesFilter" &&
+        jsonContains(cond, "_Permanent", "ThisPermanent") &&
+        jsonContains(cond, "_Permanents", "HasNoCountersOfType")
+    ) {
+        val counter = counterNameForFilter(cond) ?: return null
+        return "Conditions.Not(Conditions.SourceHasCounter(CounterTypeFilter.Named(\"$counter\")))"
+    }
+    // "you control another outlaw" — ControlsA over And(Other(ThatEnteringPermanent), IsAnOutlaw). The
+    // entering permanent is itself an outlaw, so this is exactly "two or more outlaws you control".
+    youControlAnotherOutlawDsl(cond)?.let { return it }
+    // "you control a <filter>" — reuse the static-gate renderer (PlayerPassesFilter(You, ControlsA(filter))).
+    youControlConditionDsl(cond)?.let { return it }
     return null
+}
+
+/** The "<counter> counter" name for a `HasNoCountersOfType(<CounterType>)` node, mapped to the engine's
+ *  `CounterTypeFilter.Named` string, or null for a counter kind we don't name. */
+private fun counterNameForFilter(cond: JsonObject): String? {
+    val noCounters = cond.nodesTagged("HasNoCountersOfType").firstOrNull() ?: return null
+    return when ((noCounters["args"] as? JsonObject)?.strField("_CounterType")) {
+        "FlyingCounter" -> "flying"
+        else -> null
+    }
+}
+
+/** `PlayerPassesFilter(You, ControlsA(And(Other(ThatEnteringPermanent), IsAnOutlaw)))` ("you control
+ *  another outlaw") -> `Conditions.YouControlAtLeast(2, <outlaw filter>)`, else null. The
+ *  Other(ThatEnteringPermanent) self-exclusion + the entering permanent being an outlaw is what makes
+ *  "another outlaw" equivalent to "two or more outlaws you control" (Mine Raider). */
+private fun EmitCtx.youControlAnotherOutlawDsl(cond: JsonObject): String? {
+    if (cond.strField("_Condition") != "PlayerPassesFilter") return null
+    val args = cond["args"].asArr ?: return null
+    if ((args.getOrNull(0) as? JsonObject)?.strField("_Player") != "You") return null
+    val controls = args.getOrNull(1) as? JsonObject ?: return null
+    if (controls.strField("_Players") != "ControlsA") return null
+    val blob = compact(controls)
+    if ("IsAnOutlaw" !in blob) return null
+    // Must be the "another" (Other) self-exclusion shape; a plain "an outlaw" would not be "another".
+    if ("\"Other\"" !in blob) return null
+    return "Conditions.YouControlAtLeast(2, GameObjectFilter.Creature.withAnyOfSubtypes(Subtype.OUTLAW_TYPES))"
 }
 
 /** The triggered-ability trigger spec for a TriggerA / TriggerOnceEachTurn rule, or null (-> SCAFFOLD)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -186,6 +186,13 @@ object Emitter {
                 rname == "Plot" -> block = manaKeywordCost(rule)?.let {
                     listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.plot", arg("\"$it\""))))))
                 }
+                // Affinity for <group> (cost-reduction keyword, CR 702.41) — "this spell costs {1} less
+                // to cast for each <filter> you control." The engine has no Keyword.AFFINITY card-keyword
+                // path for arbitrary group affinity, so render a self-cast ModifySpellCost whose
+                // per-permanent generic reduction counts the matching permanents you control (the general
+                // PermanentsYouControlMatching primitive). Only the group filters we can render exactly
+                // produce a block; anything else declines -> scaffold.
+                rname == "Affinity" -> block = ctx.affinityBlock(rule)
                 // Station keyword ability (CR 702.184a) — fully fixed, renders the no-arg builder.
                 rname == "Station" -> block = listOf(Eval(call("station")))
                 // {N+} station symbol that animates into a creature (CR 721.2b). Non-animating

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -73,15 +73,23 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
     }
 
     on("PutACounterOfTypeOnPermanent") { _, args, tvar ->
-        // "Put a +1/+1 (or -1/-1) counter on <permanent>." Only the bare ±1/±1 PTCounter renders; any
-        // other counter kind scaffolds rather than guess. The subject ref is self or the bound target.
+        // "Put a +1/+1 (or -1/-1) counter on <permanent>." or a named keyword counter ("a flying
+        // counter"). Only the bare ±1/±1 PTCounter and the keyword counters we name render; any other
+        // counter kind scaffolds rather than guess. The subject ref is self or the bound target.
         val arr = args.asArr ?: return@on null
         val counterNode = arr.getOrNull(0) as? JsonObject ?: return@on null
-        if (counterNode.strField("_CounterType") != "PTCounter") return@on null
-        val pt = counterNode["args"].asArr ?: return@on null
-        val counter = when (Pair(pt.getOrNull(0).asInt(), pt.getOrNull(1).asInt())) {
-            Pair(1, 1) -> "Counters.PLUS_ONE_PLUS_ONE"
-            Pair(-1, -1) -> "Counters.MINUS_ONE_MINUS_ONE"
+        val counter = when (counterNode.strField("_CounterType")) {
+            "PTCounter" -> {
+                val pt = counterNode["args"].asArr ?: return@on null
+                when (Pair(pt.getOrNull(0).asInt(), pt.getOrNull(1).asInt())) {
+                    Pair(1, 1) -> "Counters.PLUS_ONE_PLUS_ONE"
+                    Pair(-1, -1) -> "Counters.MINUS_ONE_MINUS_ONE"
+                    else -> return@on null
+                }
+            }
+            // Keyword counters (CR 122.1c) that grant their keyword via the engine's keyword-counter
+            // projection. Only the ones we can name render; anything else scaffolds.
+            "FlyingCounter" -> "Counters.FLYING"
             else -> return@on null
         }
         val tgt = refTarget(arr.getOrNull(1), tvar) ?: return@on null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeastbondOutcasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeastbondOutcasterScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Beastbond Outcaster's enter-the-battlefield draw trigger.
+ *
+ * Oracle: "When this creature enters, if you control a creature with power 4 or greater, draw a
+ * card." (Plus Plot {1}{G}, which is the named keyword and not exercised here.)
+ *
+ * Intervening-if (CR 603.4): the draw only happens if you control a creature with power >= 4 when
+ * the trigger resolves. Beastbond Outcaster itself is a 3/3, so it doesn't satisfy its own gate.
+ */
+class BeastbondOutcasterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Beastbond Outcaster — ETB draw if you control a 4-power creature") {
+
+            test("draws a card when a creature with power 4 or greater is already in play") {
+                // Outcaster Trailblazer is a 4/2 (power 4) creature.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Beastbond Outcaster")
+                    .withCardOnBattlefield(1, "Outcaster Trailblazer")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .build()
+
+                val libBefore = game.state.getLibrary(game.player1Id).size
+
+                game.castSpell(1, "Beastbond Outcaster").error shouldBe null
+                game.resolveStack()
+
+                withClue("ETB sees a power-4 creature → draw one card (library -1)") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libBefore - 1
+                }
+            }
+
+            test("draws nothing when no creature has power 4 or greater") {
+                // Beastbond Outcaster is only a 3/3; no other creature in play.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Beastbond Outcaster")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .build()
+
+                val libBefore = game.state.getLibrary(game.player1Id).size
+
+                game.castSpell(1, "Beastbond Outcaster").error shouldBe null
+                game.resolveStack()
+
+                withClue("no power-4 creature → intervening-if fails, no draw") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HellspurBruteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HellspurBruteScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Hellspur Brute's "Affinity for outlaws".
+ *
+ * Oracle: "Affinity for outlaws (This spell costs {1} less to cast for each Assassin, Mercenary,
+ * Pirate, Rogue, and/or Warlock you control.)"
+ *
+ * Modeled as a self-cast ModifySpellCost whose generic reduction counts permanents you control
+ * matching the OUTLAW_TYPES creature filter. We verify the effective cost directly via the
+ * CostCalculator, scaling the reduction with the number of outlaws controlled.
+ */
+class HellspurBruteScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hellspur Brute — Affinity for outlaws") {
+
+            test("no outlaws controlled → full {4}{R} cost (4 generic)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hellspur Brute")
+                    .build()
+
+                val calculator = CostCalculator(cardRegistry)
+                val cost = calculator.calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Hellspur Brute"),
+                    game.player1Id,
+                )
+
+                withClue("with no outlaws, the generic component stays at 4") {
+                    cost.genericAmount shouldBe 4
+                }
+            }
+
+            test("two outlaws controlled → cost reduced by 2 (2 generic)") {
+                // Reckless Lackey is a Goblin Pirate (Pirate = outlaw); Outlaw Medic is a Human
+                // Rogue (Rogue = outlaw). Two outlaws → {4}{R} reduced to {2}{R}.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hellspur Brute")
+                    .withCardOnBattlefield(1, "Reckless Lackey")
+                    .withCardOnBattlefield(1, "Outlaw Medic")
+                    .build()
+
+                val calculator = CostCalculator(cardRegistry)
+                val cost = calculator.calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Hellspur Brute"),
+                    game.player1Id,
+                )
+
+                withClue("two controlled outlaws reduce the generic from 4 to 2") {
+                    cost.genericAmount shouldBe 2
+                }
+            }
+
+            test("only the caster's own outlaws count, not the opponent's") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hellspur Brute")
+                    .withCardOnBattlefield(2, "Reckless Lackey") // opponent's outlaw — must NOT count
+                    .build()
+
+                val calculator = CostCalculator(cardRegistry)
+                val cost = calculator.calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Hellspur Brute"),
+                    game.player1Id,
+                )
+
+                withClue("an opponent's outlaw provides no affinity discount") {
+                    cost.genericAmount shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InventiveWingsmithScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InventiveWingsmithScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.engine.state.CastSpellRecord
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Inventive Wingsmith's end-step flying-counter trigger.
+ *
+ * Oracle: "At the beginning of your end step, if you haven't cast a spell from your hand this turn
+ * and this creature doesn't have a flying counter on it, put a flying counter on it."
+ *
+ * The trigger is an intervening-if (CR 603.4) gated on
+ * All(Not(YouCastSpellsThisTurn(1, fromZone = HAND)), Not(SourceHasCounter("flying"))).
+ */
+class InventiveWingsmithScenarioTest : ScenarioTestBase() {
+
+    private fun flyingCounters(game: TestGame): Int {
+        val id = game.findPermanent("Inventive Wingsmith")!!
+        return game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.FLYING) ?: 0
+    }
+
+    init {
+        context("Inventive Wingsmith end-step flying counter") {
+
+            test("gains a flying counter when no spell was cast from hand and it has no flying counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Inventive Wingsmith")
+                    .withActivePlayer(1)
+                    .build()
+
+                withClue("starts with no flying counter") {
+                    flyingCounters(game) shouldBe 0
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("end-step trigger puts a flying counter on it") {
+                    flyingCounters(game) shouldBe 1
+                }
+            }
+
+            test("does not trigger when a spell was cast from hand this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Inventive Wingsmith")
+                    .withActivePlayer(1)
+                    .build()
+
+                game.state = game.state.copy(
+                    spellsCastThisTurnByPlayer = mapOf(
+                        game.player1Id to listOf(
+                            CastSpellRecord(
+                                typeLine = TypeLine.parse("Instant"),
+                                manaValue = 1,
+                                colors = emptySet(),
+                                isFaceDown = false,
+                                castFromZone = Zone.HAND,
+                            )
+                        )
+                    )
+                )
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("no flying counter added — a spell was cast from hand") {
+                    flyingCounters(game) shouldBe 0
+                }
+            }
+
+            test("does not add a second flying counter when one is already present") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Inventive Wingsmith")
+                    .withActivePlayer(1)
+                    .build()
+
+                // Pre-seed a flying counter so the "doesn't have a flying counter" clause is false.
+                val id = game.findPermanent("Inventive Wingsmith")!!
+                game.state = game.state.updateEntity(id) { container ->
+                    container.with(CountersComponent(mapOf(CounterType.FLYING to 1)))
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("still exactly one flying counter — the trigger didn't add another") {
+                    flyingCounters(game) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MineRaiderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MineRaiderScenarioTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Mine Raider's enter-the-battlefield Treasure trigger.
+ *
+ * Oracle: "When this creature enters, if you control another outlaw, create a Treasure token."
+ *
+ * Mine Raider is itself a Human Rogue (Rogue = outlaw), so "you control another outlaw" is
+ * modeled as YouControlAtLeast(2, OUTLAW_TYPES creatures): Mine Raider plus at least one other.
+ */
+class MineRaiderScenarioTest : ScenarioTestBase() {
+
+    private fun treasureCount(game: TestGame): Int = game.findPermanents("Treasure").size
+
+    init {
+        context("Mine Raider — Treasure on ETB if you control another outlaw") {
+
+            test("creates a Treasure when cast with another outlaw in play") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Mine Raider")
+                    .withCardOnBattlefield(1, "Outlaw Medic") // another outlaw (Human Rogue)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .build()
+
+                withClue("no Treasure before Mine Raider resolves") {
+                    treasureCount(game) shouldBe 0
+                }
+
+                game.castSpell(1, "Mine Raider").error shouldBe null
+                game.resolveStack()
+
+                withClue("ETB sees another outlaw (Outlaw Medic) → one Treasure created") {
+                    treasureCount(game) shouldBe 1
+                }
+            }
+
+            test("creates no Treasure when no other outlaw is in play") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Mine Raider")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .build()
+
+                game.castSpell(1, "Mine Raider").error shouldBe null
+                game.resolveStack()
+
+                withClue("Mine Raider is the only outlaw → no Treasure") {
+                    treasureCount(game) shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements four Outlaws of Thunder Junction cards using only existing SDK primitives, and extends the `:mtgish-tooling` auto-generator so all four render whole (fidelity tier **AUTO**).

### Cards added (each with a passing rules-engine scenario test)
- **Hellspur Brute** `{4}{R}` 5/4 — *Affinity for outlaws* + Trample. Modeled as a self-cast `ModifySpellCost(SelfCast, ReduceGenericBy(PermanentsYouControlMatching(OUTLAW_TYPES creatures)))` — the general per-permanent reduction primitive (Temur Battlecrier pattern), no `Keyword.AFFINITY` card-path needed.
- **Inventive Wingsmith** `{2}{W}` 2/4 — end-step intervening-if `All(haven't cast a spell from hand this turn, no flying counter)` → put a flying keyword counter on it.
- **Mine Raider** `{2}{R}` 3/2 — Trample + ETB intervening-if "you control another outlaw" → Treasure. Mine Raider is itself a Rogue/outlaw, so "another outlaw" = `YouControlAtLeast(2, outlaws)`.
- **Beastbond Outcaster** `{2}{G}` 3/3 — ETB intervening-if "you control a creature with power 4+" → draw a card; Plot `{1}{G}`.

10 scenario tests total (positive case, intervening-if fizzle, affinity cost scaling + opponent isolation). All pass.

### mtgish tooling changes (emitter only — render correctly or decline→SCAFFOLD, never hand-patch a batch)
- `interveningIfDsl`: compose a top-level `And` → `Conditions.All`; add three single-condition shapes — "no `<named>` counter on this" (`HasNoCountersOfType` → `SourceHasCounter(Named)`), "you control another outlaw" (`ControlsA(And(Other, IsAnOutlaw))` → `YouControlAtLeast(2, outlaws)`), and "you control a `<filter>`" → `YouControl`.
- `PutACounterOfTypeOnPermanent`: render the `FlyingCounter` keyword counter (`Counters.FLYING`), not just ±1/±1.
- New `Affinity` rule dispatch + `affinityBlock`: render `Affinity(<group>)` as the self-cast `ModifySpellCost` above, for any group filter we can render exactly.

### Verification
- `coverage-verify POR`: **158/158, 0 mismatch** — no regression.
- `EmitterGoldenTest` (POR + EOE fixtures): green — no emitter drift.
- The 4 cards emit **AUTO** and compile under the OTJ gate (OTJ's pre-existing, unrelated mismatches are untouched).
- Re-blessed `OTJ.json` `CardDefinitionSnapshotTest` golden — diff adds only the 4 new cards; nothing else moved.
- Full `mtgish-tooling` test suite passes.

### Not implemented: Vengeful Townsfolk (the 5th assigned card)
Its "Whenever **one or more** other creatures you control die" is a once-per-batch from-battlefield-death trigger the engine does not have. The per-creature `YourCreatureDies` over-counts on a board wipe (one counter per dead creature instead of one), `oncePerTurn` is wrong (it should fire again on a later batch the same turn), and `CardsPutIntoYourGraveyard(Creature)` is too broad (also fires on mill/discard). Rather than ship an unfaithful approximation, this is documented as a new Tier-2 engine gap (#6b) in `backlog/otj-engine-gaps.md` for a follow-up `add-feature` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)