### PR TITLE
Add four OTJ cards + Corrupted Conviction reprint; teach mtgish ExilePermanent & mana-value If

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/CorruptedConviction.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/CorruptedConviction.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Corrupted Conviction
+ * {B}
+ * Instant
+ *
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Draw two cards.
+ *
+ * Canonical definition lives in March of the Machine (earliest real printing).
+ * Reprinted in Outlaws of Thunder Junction — see OTJ `CorruptedConvictionReprint`.
+ */
+val CorruptedConviction = card("Corrupted Conviction") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Creature))
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "98"
+        artist = "Joseph Weston"
+        flavorText = "\"For the good of all, those who stand against the harmony of Phyrexia must be cut down.\"\n—Ajani Goldmane"
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce133ad5-8748-4a3d-ae8c-7b2a5938927d.jpg?1682203658"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ConsumingAshes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ConsumingAshes.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Consuming Ashes
+ * {2}{B}{B}
+ * Instant
+ *
+ * Exile target creature. If it had mana value 3 or less, surveil 2.
+ *
+ * The exile is unconditional; the surveil is gated on the targeted creature's mana value. The mana
+ * value test reads the creature's last-known characteristic, so it resolves correctly even though
+ * the creature has already been exiled when the conditional runs.
+ */
+val ConsumingAshes = card("Consuming Ashes") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target creature. If it had mana value 3 or less, surveil 2. " +
+        "(Look at the top two cards of your library, then put any number of them into your " +
+        "graveyard and the rest on top of your library in any order.)"
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.Exile(creature).then(
+            ConditionalEffect(
+                condition = Conditions.TargetSpellManaValueAtMost(DynamicAmount.Fixed(3)),
+                effect = Patterns.Library.surveil(2)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "83"
+        artist = "Campbell White"
+        flavorText = "The enforcer only got halfway through the arrest warrant before it—and he—went up in smoke."
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54f96be9-60fc-4e2f-9172-4cc53c9a095a.jpg?1712355566"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/CorruptedConvictionReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/CorruptedConvictionReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Corrupted Conviction reprint in Outlaws of Thunder Junction.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in March of the
+ * Machine's `cards/` package. This file contributes only the OTJ-specific presentation row —
+ * set, collector number, art — picked up automatically by `CardDiscovery.findPrintingsIn`.
+ */
+val CorruptedConvictionReprint = Printing(
+    oracleId = "b45e35df-9032-4482-89a6-c7c50c6d0a79",
+    name = "Corrupted Conviction",
+    setCode = "OTJ",
+    collectorNumber = "84",
+    scryfallId = "8046f892-3317-4ef7-9cf7-97b9060540c8",
+    artist = "Inkognit",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/8046f892-3317-4ef7-9cf7-97b9060540c8.jpg?1712355575",
+    releaseDate = "2024-04-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DesertsDue.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DesertsDue.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Desert's Due
+ * {1}{B}
+ * Instant
+ *
+ * Target creature gets -2/-2 until end of turn. It gets an additional -1/-1 until end of turn
+ * for each Desert you control.
+ *
+ * The base -2 and the per-Desert -1 collapse into a single -(2 + Deserts) stat modification
+ * applied to power and toughness; the Desert count is read from the battlefield at resolution.
+ */
+val DesertsDue = card("Desert's Due") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -2/-2 until end of turn. It gets an additional -1/-1 " +
+        "until end of turn for each Desert you control."
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        val deserts = DynamicAmount.Count(
+            Player.You,
+            Zone.BATTLEFIELD,
+            GameObjectFilter.Land.withSubtype(Subtype("Desert"))
+        )
+        val total = DynamicAmount.Multiply(DynamicAmount.Add(DynamicAmount.Fixed(2), deserts), -1)
+        effect = Effects.ModifyStats(total, total, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "David Palumbo"
+        flavorText = "He was glad when the mirages appeared. At least he wouldn't die alone."
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35e899e4-e2de-44cf-b6f4-cace8d3770cb.jpg?1712355575"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ThrowFromTheSaddle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ThrowFromTheSaddle.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Throw from the Saddle
+ * {1}{G}
+ * Sorcery
+ *
+ * Target creature you control gets +1/+1 until end of turn. Put a +1/+1 counter on it instead
+ * if it's a Mount. Then it deals damage equal to its power to target creature you don't control.
+ *
+ * The boost branches on the Mount test for target 0: a Mount gets a permanent +1/+1 counter,
+ * otherwise a temporary +1/+1. The boost resolves first so the subsequent damage uses the
+ * already-boosted power. Damage is sourced from target 0 (so it triggers "deals damage" effects on
+ * that creature) and dealt to target 1.
+ */
+val ThrowFromTheSaddle = card("Throw from the Saddle") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Target creature you control gets +1/+1 until end of turn. Put a +1/+1 counter " +
+        "on it instead if it's a Mount. Then it deals damage equal to its power to target " +
+        "creature you don't control."
+
+    spell {
+        val mine = target("creature you control", Targets.CreatureYouControl)
+        val theirs = target("creature you don't control", Targets.CreatureOpponentControls)
+
+        val boost = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype("Mount")), targetIndex = 0
+            ),
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, mine),
+            elseEffect = Effects.ModifyStats(1, 1, mine)
+        )
+
+        val damage = DealDamageEffect(
+            amount = DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.Power),
+            target = theirs,
+            damageSource = mine
+        )
+
+        effect = boost.then(damage)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Eilene Cherie"
+        flavorText = "\"A little kindness would've carried you a lot farther than those spurs.\"\n—Miriam, herd whisperer"
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/775874cc-4b78-4904-9c97-431c2e400c64.jpg?1712356011"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOM.json
@@ -65,3 +65,35 @@
         "BLUE"
     ]
 }
+
+// Corrupted Conviction
+{
+    "name": "Corrupted Conviction",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "SacrificePermanent",
+                "filter": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "artist": "Joseph Weston",
+        "flavorText": "\"For the good of all, those who stand against the harmony of Phyrexia must be cut down.\"\n—Ajani Goldmane",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce133ad5-8748-4a3d-ae8c-7b2a5938927d.jpg?1682203658"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -1171,6 +1171,115 @@
     ]
 }
 
+// Consuming Ashes
+{
+    "name": "Consuming Ashes",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target creature. If it had mana value 3 or less, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Target",
+                                "numericProperty": "ManaValue"
+                            },
+                            "operator": "LTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeAs": "surveiled"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "surveiled",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeSelected": "toGraveyard",
+                                "storeRemainder": "toTop",
+                                "selectedLabel": "Put in graveyard",
+                                "remainderLabel": "Put on top"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toGraveyard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toTop",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Top"
+                                },
+                                "order": "ControllerChooses"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "artist": "Campbell White",
+        "flavorText": "The enforcer only got halfway through the arrest warrant before it—and he—went up in smoke.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54f96be9-60fc-4e2f-9172-4cc53c9a095a.jpg?1712355566"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Creosote Heath
 {
     "name": "Creosote Heath",
@@ -1412,6 +1521,75 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Desert's Due
+{
+    "name": "Desert's Due",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -2/-2 until end of turn. It gets an additional -1/-1 until end of turn for each Desert you control.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Multiply",
+                "amount": {
+                    "type": "Add",
+                    "left": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "right": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "land Desert"
+                    }
+                },
+                "multiplier": -1
+            },
+            "toughnessModifier": {
+                "type": "Multiply",
+                "amount": {
+                    "type": "Add",
+                    "left": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "right": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "land Desert"
+                    }
+                },
+                "multiplier": -1
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "artist": "David Palumbo",
+        "flavorText": "He was glad when the mirages appeared. At least he wouldn't die alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35e899e4-e2de-44cf-b6f4-cace8d3770cb.jpg?1712355575"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -4461,6 +4639,96 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Throw from the Saddle
+{
+    "name": "Throw from the Saddle",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature you control gets +1/+1 until end of turn. Put a +1/+1 counter on it instead if it's a Mount. Then it deals damage equal to its power to target creature you don't control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "TargetMatchesFilter",
+                            "filter": "creature Mount"
+                        }
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        }
+                    },
+                    "otherwise": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        }
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you don't control"
+                    },
+                    "damageSource": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature you control"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "creature you don't control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Eilene Cherie",
+        "flavorText": "\"A little kindness would've carried you a lot farther than those spurs.\"\n—Miriam, herd whisperer",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/775874cc-4b78-4904-9c97-431c2e400c64.jpg?1712356011"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.tooling.coverage.Registry
 import com.wingedsheep.tooling.coverage.amountNode
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.asArr
+import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
@@ -16,6 +17,7 @@ import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.strField
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
@@ -51,6 +53,11 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
             arg(call("Effects.Move", arg("EffectTarget.Self"), arg("Zone.GRAVEYARD"), arg("byDestruction", "true"))),
             arg("noRegenerate", noregen),
         )
+    }
+
+    on("ExilePermanent") { _, args, tvar ->  // "Exile target permanent" -> the atomic Exile facade
+        val tgt = refTarget(args, tvar) ?: return@on null
+        call("Effects.Exile", arg(Lit(tgt)))
     }
 
     on("PutPermanentIntoItsOwnersHand") { _, args, tvar ->  // bounce
@@ -91,6 +98,34 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
 
     on("Surveil") { _, args, _ ->  // "Surveil N" -> the look-top / keep-or-bin pipeline
         (findInteger(args) as? Int)?.let { call("Patterns.Library.surveil", arg("$it")) }
+    }
+
+    // Inline `If{cond}[effects]` action (inside an ActionList) -> a `ConditionalEffect`. Renders only the
+    // one condition shape we can express faithfully: "if [the targeted permanent] had mana value N or
+    // less" (`PermanentPassesFilter(Ref_TargetPermanent, ManaValueIs(LessThanOrEqualTo Integer N))`),
+    // mapped to `Conditions.TargetSpellManaValueAtMost(DynamicAmount.Fixed(N))` — Consuming Ashes'
+    // "Exile target creature. If it had mana value 3 or less, surveil 2." Any other condition / target
+    // index / comparator declines (-> SCAFFOLD) rather than widening.
+    on("If") { node, args, tvar ->
+        val a = args.asArr ?: return@on null
+        val cond = a.getOrNull(0) as? JsonObject ?: return@on null
+        if (cond.strField("_Condition") != "PermanentPassesFilter") return@on null
+        val condArgs = cond["args"].asArr ?: return@on null
+        // Subject must be the first targeted permanent (Ref_TargetPermanent / Ref_TargetPermanent1).
+        val subject = (condArgs.getOrNull(0) as? JsonObject)?.strField("_Permanent")
+        if (subject != "Ref_TargetPermanent" && subject != "Ref_TargetPermanent1") return@on null
+        val filter = condArgs.getOrNull(1) as? JsonObject ?: return@on null
+        if (filter.strField("_Permanents") != "ManaValueIs") return@on null
+        val cmp = filter["args"] as? JsonObject ?: return@on null
+        if (cmp.strField("_Comparison") != "LessThanOrEqualTo") return@on null
+        val n = (cmp["args"].asInt()) ?: ((cmp["args"] as? JsonObject)?.get("args").asInt()) ?: return@on null
+        val inner = (a.getOrNull(1) as? JsonArray)?.filterIsInstance<JsonObject>() ?: return@on null
+        val edsl = renderEffectList(inner, tvar) ?: return@on null
+        call(
+            "ConditionalEffect",
+            arg("condition", call("Conditions.TargetSpellManaValueAtMost", arg(call("DynamicAmount.Fixed", arg("$n"))))),
+            arg("effect", edsl),
+        )
     }
 
     on("Scry") { _, args, _ ->  // "Scry N" -> look-top, reorder/bottom pipeline

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConsumingAshesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConsumingAshesTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ConsumingAshes
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Consuming Ashes: {2}{B}{B} Instant
+ * Exile target creature. If it had mana value 3 or less, surveil 2.
+ */
+class ConsumingAshesTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ConsumingAshes))
+        return driver
+    }
+
+    fun castAshes(driver: GameTestDriver): Pair<com.wingedsheep.sdk.model.EntityId, com.wingedsheep.sdk.model.EntityId> {
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.giveMana(me, Color.BLACK, 2)
+        driver.giveColorlessMana(me, 2)
+        return me to opp
+    }
+
+    test("exiles a mana value 3 creature and surveils 2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Island" to 30), startingLife = 20)
+        val (me, opp) = castAshes(driver)
+
+        // Centaur Courser is {2}{G} 3/3 — mana value 3, so surveil triggers.
+        val courser = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+        val ashes = driver.putCardInHand(me, "Consuming Ashes")
+
+        // Seed a known library top so surveil presents two cards.
+        val top2 = driver.putCardOnTopOfLibrary(me, "Island")
+        val top1 = driver.putCardOnTopOfLibrary(me, "Swamp")
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = ashes,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        (result.error == null) shouldBe true
+        driver.bothPass()
+
+        // Creature is exiled.
+        driver.getExile(opp).contains(courser) shouldBe true
+
+        // Surveil 2 pauses for the keep/graveyard choice.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        val select = driver.pendingDecision as SelectCardsDecision
+        select.options.size shouldBe 2
+
+        // Mill the top card to the graveyard, keep the second on top.
+        driver.submitDecision(me, CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(top1)))
+
+        driver.isPaused shouldBe true
+        val reorder = driver.pendingDecision as ReorderLibraryDecision
+        driver.submitOrderedResponse(me, reorder.cards)
+        driver.isPaused shouldBe false
+
+        driver.getGraveyard(me).contains(top1) shouldBe true
+        val lib = driver.state.getZone(ZoneKey(me, Zone.LIBRARY))
+        lib[0] shouldBe top2
+    }
+
+    test("exiles a high mana value creature without surveiling") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Island" to 30), startingLife = 20)
+        val (me, opp) = castAshes(driver)
+
+        // Force of Nature is {3}{G}{G} — mana value 5, so no surveil.
+        val beast = driver.putCreatureOnBattlefield(opp, "Force of Nature")
+        val ashes = driver.putCardInHand(me, "Consuming Ashes")
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = ashes,
+                targets = listOf(ChosenTarget.Permanent(beast)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        (result.error == null) shouldBe true
+        driver.bothPass()
+
+        // Creature is exiled, and no surveil decision is pending.
+        driver.getExile(opp).contains(beast) shouldBe true
+        driver.isPaused shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CorruptedConvictionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CorruptedConvictionTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mom.cards.CorruptedConviction
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Corrupted Conviction: {B} Instant
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Draw two cards.
+ */
+class CorruptedConvictionTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CorruptedConviction))
+        return driver
+    }
+
+    test("sacrifices a creature as an additional cost and draws two cards") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val fodder = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        val spell = driver.putCardInHand(me, "Corrupted Conviction")
+        driver.giveMana(me, Color.BLACK, 1)
+
+        val handBefore = driver.getHandSize(me)
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        // The sacrificed creature went to the graveyard.
+        driver.findPermanent(me, "Centaur Courser") shouldBe null
+        driver.assertInGraveyard(me, "Centaur Courser")
+
+        // Net hand change: -1 (the spell cast) + 2 (drawn) = +1.
+        driver.getHandSize(me) shouldBe handBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesertsDueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesertsDueTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ConduitPylons
+import com.wingedsheep.mtg.sets.definitions.otj.cards.DesertsDue
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Desert's Due: {1}{B} Instant
+ * Target creature gets -2/-2 until end of turn. It gets an additional -1/-1 until end of turn
+ * for each Desert you control.
+ */
+class DesertsDueTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DesertsDue, ConduitPylons))
+        return driver
+    }
+
+    test("with no Deserts, gives -2/-2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Centaur Courser is a 3/3.
+        val courser = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+        val due = driver.putCardInHand(me, "Desert's Due")
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 1)
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = due,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        (result.error == null) shouldBe true
+        driver.bothPass()
+
+        // 3/3 - 2/2 = 1/1.
+        val projected = projector.project(driver.state)
+        projected.getPower(courser) shouldBe 1
+        projected.getToughness(courser) shouldBe 1
+    }
+
+    test("with two Deserts, gives -4/-4 and can kill a 3/3") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val courser = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+        // Two Deserts I control: -2/-2 base plus -1/-1 each = -4/-4.
+        driver.putLandOnBattlefield(me, "Conduit Pylons")
+        driver.putLandOnBattlefield(me, "Conduit Pylons")
+        // A Desert the opponent controls must NOT count.
+        driver.putLandOnBattlefield(opp, "Conduit Pylons")
+
+        val due = driver.putCardInHand(me, "Desert's Due")
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveColorlessMana(me, 1)
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = due,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        (result.error == null) shouldBe true
+        driver.bothPass()
+
+        // 3/3 with -4/-4 dies as a state-based action.
+        driver.assertInGraveyard(opp, "Centaur Courser")
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThrowFromTheSaddleTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThrowFromTheSaddleTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.GiantBeaver
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ThrowFromTheSaddle
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Throw from the Saddle: {1}{G} Sorcery
+ * Target creature you control gets +1/+1 until end of turn. Put a +1/+1 counter on it instead
+ * if it's a Mount. Then it deals damage equal to its power to target creature you don't control.
+ */
+class ThrowFromTheSaddleTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ThrowFromTheSaddle, GiantBeaver))
+        return driver
+    }
+
+    test("non-Mount gets a temporary +1/+1 and deals its boosted power as damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // My non-Mount 3/3.
+        val mine = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        // Their 3/3 — 4 damage kills it.
+        val theirs = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        val throwCard = driver.putCardInHand(me, "Throw from the Saddle")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 1)
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = throwCard,
+                targets = listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(theirs)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        (result.error == null) shouldBe true
+        driver.bothPass()
+
+        // Non-Mount got no +1/+1 counter (the boost was the temporary modifier).
+        val counters = driver.state.getEntity(mine)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+        counters shouldBe 0
+
+        // 3/3 + 1/1 = 4 power; 4 damage kills the opposing 3/3.
+        driver.assertInGraveyard(opp, "Centaur Courser")
+    }
+
+    test("Mount gets a +1/+1 counter and deals its boosted power as damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // My Mount: Giant Beaver, a 4/4 Beaver Mount.
+        val mine = driver.putCreatureOnBattlefield(me, "Giant Beaver")
+        // Their 4/4 Mount survives 4 but not 5 damage.
+        val theirs = driver.putCreatureOnBattlefield(opp, "Giant Beaver")
+
+        val throwCard = driver.putCardInHand(me, "Throw from the Saddle")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 1)
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = throwCard,
+                targets = listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(theirs)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        (result.error == null) shouldBe true
+        driver.bothPass()
+
+        // Mount got a real +1/+1 counter instead of a temporary boost.
+        val counters = driver.state.getEntity(mine)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+        counters shouldBe 1
+
+        // It is now 5/5.
+        val projected = projector.project(driver.state)
+        projected.getPower(mine) shouldBe 5
+
+        // 5 damage kills the opposing 4/4 Mount.
+        driver.assertInGraveyard(opp, "Giant Beaver")
+    }
+})


### PR DESCRIPTION
## Summary

Implements five Outlaws of Thunder Junction (OTJ) commons. All use existing SDK primitives — no new engine/SDK work.

### Cards
- **Consuming Ashes** (OTJ) — *Exile target creature. If it had mana value 3 or less, surveil 2.* Unconditional `Effects.Exile`, then a `ConditionalEffect` gated on `Conditions.TargetSpellManaValueAtMost(Fixed(3))` reading the exiled creature's last-known mana value.
- **Desert's Due** (OTJ) — *-2/-2, and an additional -1/-1 for each Desert you control.* A single `ModifyStats(-(2 + Deserts), …)` via a `Count(Deserts you control)` dynamic amount.
- **Throw from the Saddle** (OTJ) — *+1/+1 (a +1/+1 counter instead if it's a Mount), then it deals damage equal to its power to a creature you don't control.* `ConditionalEffect` on the Mount subtype, then `DealDamageEffect` sourcing the boosted power.
- **Corrupted Conviction** — canonical `CardDefinition` placed in its **earliest printing, March of the Machine (MOM)**; OTJ gets a `Printing` reprint row. *Sacrifice a creature additional cost; draw two.*
- **Mourner's Surprise** — **SKIPPED.** Its 1/1 Mercenary token carries an *activated* ability, and `CreateTokenEffect` has no `activatedAbilities` support. Adding it is new engine/SDK work, out of scope for these FREE cards.

All four implemented cards have passing rules-engine scenario tests covering both branches (mana-value gate, Desert count, Mount vs non-Mount, sacrifice + draw).

### mtgish tooling
- New **`ExilePermanent`** emitter handler → `Effects.Exile(target)` (atomic, helps every set with "exile target permanent").
- New **narrow inline `If`** action handler: renders only the `PermanentPassesFilter(Ref_TargetPermanent, ManaValueIs(<= Integer N))` shape → `ConditionalEffect(Conditions.TargetSpellManaValueAtMost(Fixed(N)), …)`; any other condition declines → SCAFFOLD.
- **Consuming Ashes** now renders **AUTO** and verifies gameplay-tree-equivalent against its golden.
- **Desert's Due** and **Throw from the Saddle** intentionally stay **SCAFFOLD** — rendering `AdjustPTForEach` (per-Desert dynamic) and the multi-target shape would require unsafe emitter widening, against the fidelity policy.
- **POR stays 0-mismatch (158/158 GATE PASS).** EmitterGoldenTest and all mtgish-tooling tests pass.

### Verification
- `just build` — green.
- Re-blessed `CardDefinitionSnapshotTest` goldens for MOM and OTJ (only the new cards added).
- `just check-card-printing` — canonical placement OK for all cards (Corrupted Conviction canonical in MOM, reprint row in OTJ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)