### PR TITLE
Add OTJ Gold Rush, Rooftop Assassin, Servant of the Stinger + mtgish dealt-damage target rendering

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1022,6 +1022,10 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   filter pass (e.g. Zero Point Ballad's mass destruction). Layer projection / trigger matching
   / cost calculation report `false` (no X context).
 - `.tapped()` / `.untapped()` — tap state.
+- `.dealtDamageThisTurn()` — was dealt damage this turn (marked-damage *history*, not current marked
+  damage); backed by `StatePredicate.WasDealtDamageThisTurn`. Survives damage removal / leaving combat;
+  cleared at end-of-turn cleanup. For "...that was dealt damage this turn" (Rooftop Assassin, Unsparing
+  Boltcaster). Also available on `TargetFilter` (`TargetFilter.Creature.dealtDamageThisTurn()`).
 - `.saddled()` — permanent is saddled (CR 702.171b); backed by `StatePredicate.IsSaddled`.
 - `.crewedOrSaddledSourceThisTurn()` — source-relative: creature crewed (CR 702.122) or saddled
   (CR 702.171) the effect's source permanent this turn; backed by

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -439,6 +439,15 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must have been dealt damage this turn (marked-damage *history*, not current marked damage).
+     * Survives damage removal / leaving combat; cleared at end-of-turn cleanup. Used by
+     * "...that was dealt damage this turn" (Rooftop Assassin, Unsparing Boltcaster).
+     */
+    fun dealtDamageThisTurn() = copy(
+        statePredicates = statePredicates + StatePredicate.WasDealtDamageThisTurn
+    )
+
+    /**
      * Must be in the same combat band as the effect's source (the source itself, or a band-mate
      * sharing its band id — CR 702.22). Source-relative; only matches while the source attacks.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -290,6 +290,9 @@ data class TargetFilter(
     /** Must be attacking */
     fun attacking() = copy(baseFilter = baseFilter.attacking())
 
+    /** Must have been dealt damage this turn ("...that was dealt damage this turn"). */
+    fun dealtDamageThisTurn() = copy(baseFilter = baseFilter.dealtDamageThisTurn())
+
     /** Must be controlled by you */
     fun youControl() = copy(baseFilter = baseFilter.youControl())
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GoldRush.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/GoldRush.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gold Rush
+ * {1}{G}
+ * Instant
+ * Create a Treasure token. Until end of turn, up to one target creature gets +2/+2 for each
+ * Treasure you control.
+ *
+ * Ruling: count Treasures you control as Gold Rush resolves; the bonus is locked in then and
+ * won't change if your Treasure count does later this turn. The Treasure created by this spell
+ * itself is counted, so the buff is +2/+2 times (existing Treasures + 1).
+ */
+val GoldRush = card("Gold Rush") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Create a Treasure token. Until end of turn, up to one target creature gets +2/+2 for each Treasure you control."
+
+    spell {
+        target = TargetCreature(optional = true)
+        // Per-Treasure buff: 2 x (number of Treasures you control). Evaluated and locked at
+        // resolution by ModifyStatsExecutor. The Treasure created above is on the battlefield
+        // before this runs, so it is included in the count.
+        val perTreasure = DynamicAmount.Multiply(
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Artifact.withSubtype(Subtype.TREASURE)
+            ).count(),
+            2
+        )
+        effect = Effects.Composite(
+            Effects.CreateTreasure(1),
+            Effects.ModifyStats(perTreasure, perTreasure, EffectTarget.ContextTarget(0))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "166"
+        artist = "Eric Wilkerson"
+        flavorText = "\"Don't believe anyone who tells you to bite it. If it's the real thing, you'll know.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/15845be1-919d-4450-9de6-3552c52e8623.jpg?1712355933"
+
+        ruling("2024-04-12", "You don't have to choose a target for Gold Rush. However, if you do, and that creature is an illegal target at the time Gold Rush tries to resolve, it won't resolve and none of its effects will happen. You won't create a Treasure token.")
+        ruling("2024-04-12", "Count the number of Treasures you control as Gold Rush resolves to determine how big a bonus the target creature receives. That bonus won't change even if the number of Treasures you control does during the turn.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RooftopAssassin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RooftopAssassin.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Rooftop Assassin
+ * {3}{B}
+ * Creature — Vampire Assassin
+ * 2/2
+ * Flash
+ * Flying, lifelink
+ * When this creature enters, destroy target creature an opponent controls that was dealt
+ * damage this turn.
+ *
+ * The target is constrained to creatures an opponent controls that already took damage this
+ * turn via [StatePredicate.WasDealtDamageThisTurn]. If no such creature exists, the trigger
+ * has no legal target and is removed from the stack.
+ */
+val RooftopAssassin = card("Rooftop Assassin") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Assassin"
+    power = 2
+    toughness = 2
+    oracleText = "Flash\nFlying, lifelink\n" +
+        "When this creature enters, destroy target creature an opponent controls that was dealt damage this turn."
+
+    keywords(Keyword.FLASH, Keyword.FLYING, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target",
+            TargetCreature(
+                filter = TargetFilter.Creature.dealtDamageThisTurn().opponentControls()
+            )
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Josu Hernaiz"
+        flavorText = "\"Sneaking behind people? Pedestrian.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4e4311a-8583-4cf0-8126-508dbfbcddb6.jpg?1712355656"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ServantOfTheStinger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ServantOfTheStinger.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Servant of the Stinger
+ * {1}{B}
+ * Creature — Human Warlock
+ * 1/3
+ * Deathtouch
+ * Whenever this creature deals combat damage to a player, if you've committed a crime this turn,
+ * you may sacrifice this creature. If you do, search your library for a card, put it into your
+ * hand, then shuffle.
+ *
+ * The "if you've committed a crime this turn" clause is an intervening-if (CR 603.4): it's
+ * checked both when the ability would trigger and again as it resolves. Modeled via
+ * [triggerCondition]. The "you may sacrifice this creature. If you do, search..." pay-then-payoff
+ * is a [GatedEffect] with a [Gate.MayPay] sacrificing this creature.
+ */
+val ServantOfTheStinger = card("Servant of the Stinger") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warlock"
+    power = 1
+    toughness = 3
+    oracleText = "Deathtouch\n" +
+        "Whenever this creature deals combat damage to a player, if you've committed a crime this turn, " +
+        "you may sacrifice this creature. If you do, search your library for a card, put it into your hand, then shuffle."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        triggerCondition = Conditions.YouCommittedCrimeThisTurn
+        effect = GatedEffect(
+            gate = Gate.MayPay(SacrificeSelfEffect),
+            then = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any,
+                count = 1,
+                destination = SearchDestination.HAND,
+                shuffleAfter = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "105"
+        artist = "Steven Russell Black"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5c98650-b195-4071-8e02-4df35fddddc7.jpg?1712355666"
+
+        ruling("2024-04-12", "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard.")
+        ruling("2024-04-12", "Whether you've committed a crime this turn is checked as Servant of the Stinger's triggered ability would trigger and again as it resolves. If you haven't committed a crime by the time it resolves, the ability does nothing.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -2267,6 +2267,79 @@
     "colorIdentityOverride": []
 }
 
+// Gold Rush
+{
+    "name": "Gold Rush",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Create a Treasure token. Until end of turn, up to one target creature gets +2/+2 for each Treasure you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "artifact Treasure"
+                        },
+                        "multiplier": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "artifact Treasure"
+                        },
+                        "multiplier": 2
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Wilkerson",
+        "flavorText": "\"Don't believe anyone who tells you to bite it. If it's the real thing, you'll know.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/15845be1-919d-4450-9de6-3552c52e8623.jpg?1712355933",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "You don't have to choose a target for Gold Rush. However, if you do, and that creature is an illegal target at the time Gold Rush tries to resolve, it won't resolve and none of its effects will happen. You won't create a Treasure token."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Count the number of Treasures you control as Gold Rush resolves to determine how big a bonus the target creature receives. That bonus won't change even if the number of Treasures you control does during the turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Harrier Strix
 {
     "name": "Harrier Strix",
@@ -3507,6 +3580,67 @@
     ]
 }
 
+// Rooftop Assassin
+{
+    "name": "Rooftop Assassin",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Vampire Assassin",
+    "oracleText": "Flash\nFlying, lifelink\nWhen this creature enters, destroy target creature an opponent controls that was dealt damage this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "WasDealtDamageThisTurn"
+                            ],
+                            "controllerPredicate": "ControlledByOpponent"
+                        }
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"Sneaking behind people? Pedestrian.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4e4311a-8583-4cf0-8126-508dbfbcddb6.jpg?1712355656"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Scorching Shot
 {
     "name": "Scorching Shot",
@@ -3662,6 +3796,94 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Servant of the Stinger
+{
+    "name": "Servant of the Stinger",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "Deathtouch\nWhenever this creature deals combat damage to a player, if you've committed a crime this turn, you may sacrifice this creature. If you do, search your library for a card, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": "SacrificeSelf"
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                }
+                            },
+                            "ShuffleLibrary"
+                        ]
+                    }
+                },
+                "triggerCondition": "PlayerCommittedCrimeThisTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "UNCOMMON",
+        "artist": "Steven Russell Black",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5c98650-b195-4071-8e02-4df35fddddc7.jpg?1712355666",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "A player commits a crime as they cast a spell, activate an ability, or put a triggered ability on the stack that targets at least one opponent, at least one permanent, spell, or ability an opponent controls, and/or at least one card in an opponent's graveyard."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Whether you've committed a crime this turn is checked as Servant of the Stinger's triggered ability would trigger and again as it resolves. If you haven't committed a crime by the time it resolves, the ability does nothing."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -141,10 +141,17 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
         if ("ControlledByAPlayer" in blob) return null
         return Call("TargetFilter", listOf(arg(Lit("GameObjectFilter.Creature").dot("crewedOrSaddledSourceThisTurn"))))
     }
-    // "...that was dealt damage this turn" (Rooftop Assassin): the WasDealtDamageThisTurn state predicate
-    // has no TargetFilter/GameObjectFilter helper, so decline rather than drop it (which would widen the
-    // kill to any opponent's creature).
-    if ("WasDealtDamageThisTurn" in blob) return null
+    // "...that was dealt damage this turn" (Rooftop Assassin) renders via `.dealtDamageThisTurn()` on the
+    // plain-creature path below (composed alongside the controller suffix). The special-shape branches
+    // (attacking/blocking/subtype/face-down/non-cardtype) can't compose it, so if such a predicate is also
+    // present, decline rather than silently drop the dealt-damage restriction (which would widen the kill).
+    if ("WasDealtDamageThisTurn" in blob) {
+        val unrenderableAlongside = listOf(
+            "IsAttacking", "IsBlocking", "IsFaceDown", "IsCreatureType", "IsNonCreatureType",
+            "IsNonCardtype", "Other", "HasACounterOfType",
+        )
+        if (unrenderableAlongside.any { it in blob }) return null
+    }
     // "non-Mount creature" / "non-<creature-type> creature" (Sterling Keykeeper): a negated creature
     // subtype (IsNonCreatureType). TargetFilter has no `.notSubtype` passthrough, so render the
     // GameObjectFilter form wrapped in TargetFilter. Only the bare negated subtype (optionally a
@@ -243,6 +250,9 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
     }
     FilterPredicates.manaValueAtMost(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.manaValueAtLeast(filterNode)?.let { node = node.dot(it) }
+    // "...that was dealt damage this turn" (Rooftop Assassin) — composes onto the plain-creature filter
+    // via .dealtDamageThisTurn(). Special shapes that carry this predicate already declined above.
+    if ("WasDealtDamageThisTurn" in blob) node = node.dot("dealtDamageThisTurn")
     // Keyword-ability restrictions ("attacking creature with shadow", Maze of Shadows): a
     // HasAbility / DoesntHaveAbility clause carrying a `_CheckHasable` keyword -> .withKeyword /
     // .withoutKeyword. Flying is already composed above (string match), so skip it here. If any

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecoveryTest.kt
@@ -213,13 +213,28 @@ class TargetRecoveryTest : StringSpec({
         ctx.creatureFilterDsl(nonMount) shouldBe "TargetFilter(GameObjectFilter.Creature.notSubtype(Subtype(\"Mount\")))"
     }
 
-    "creatureFilterDsl declines a 'dealt damage this turn' restriction (Rooftop Assassin)" {
-        // "...that was dealt damage this turn" has no filter helper; dropping it would widen the kill.
+    "creatureFilterDsl renders a 'dealt damage this turn' restriction (Rooftop Assassin)" {
+        // "target creature an opponent controls that was dealt damage this turn" -> the
+        // .dealtDamageThisTurn() state-predicate suffix composed with the controller suffix.
         val dealtDamage = obj(
             """{"_Permanents":"And","args":[""" +
-                """{"_Permanents":"IsCardtype","args":"Creature"},{"_Permanents":"WasDealtDamageThisTurn"}]}""",
+                """{"_Permanents":"IsCardtype","args":"Creature"},""" +
+                """{"_Permanents":"ControlledByAPlayer","args":{"_Players":"Opponent"}},""" +
+                """{"_Permanents":"WasDealtDamageThisTurn"}]}""",
         )
-        ctx.creatureFilterDsl(dealtDamage).shouldBeNull()
+        ctx.creatureFilterDsl(dealtDamage) shouldBe
+            "TargetFilter.Creature.dealtDamageThisTurn().opponentControls()"
+    }
+
+    "creatureFilterDsl declines 'dealt damage this turn' combined with an unrenderable shape" {
+        // The .dealtDamageThisTurn() suffix only composes on the plain-creature path; combined with a
+        // creature-subtype clause (a branch that returns before the suffix) it would be silently dropped,
+        // so the recovery declines (-> SCAFFOLD) rather than widen the kill.
+        val dealtDamageGoblin = obj(
+            """{"_Permanents":"And","args":[""" +
+                """{"_Permanents":"IsCreatureType","args":"Goblin"},{"_Permanents":"WasDealtDamageThisTurn"}]}""",
+        )
+        ctx.creatureFilterDsl(dealtDamageGoblin).shouldBeNull()
     }
 
     "gameObjectFilterDsl renders an outlaw filter via withAnyOfSubtypes (Vial Smasher)" {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldRushScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldRushScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Gold Rush (OTJ #166).
+ *
+ * "{1}{G} Instant. Create a Treasure token. Until end of turn, up to one target creature gets
+ *  +2/+2 for each Treasure you control."
+ *
+ * Verifies: the Treasure created by the spell counts toward the buff (so with zero prior
+ * Treasures the buff is +2/+2), additional Treasures scale it, the buff is locked at resolution,
+ * and the spell still resolves (creating a Treasure) when no target is chosen.
+ */
+class GoldRushScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Gold Rush") {
+
+            test("buffs target by +2/+2 per Treasure, counting the Treasure it creates") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Gold Rush")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+                withClue("Bear starts as a 2/2") {
+                    game.state.projectedState.getPower(bear) shouldBe 2
+                    game.state.projectedState.getToughness(bear) shouldBe 2
+                }
+
+                game.castSpell(1, "Gold Rush", bear).error shouldBe null
+                game.resolveStack()
+
+                // One Treasure now exists -> +2/+2.
+                withClue("a Treasure token was created") {
+                    game.findPermanents("Treasure").size shouldBe 1
+                }
+                withClue("Bear becomes a 4/4 (+2/+2 for the single Treasure)") {
+                    game.state.projectedState.getPower(bear) shouldBe 4
+                    game.state.projectedState.getToughness(bear) shouldBe 4
+                }
+            }
+
+            test("buff scales with existing Treasures and locks at resolution") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Gold Rush")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Treasure", isToken = true)
+                    .withCardOnBattlefield(1, "Treasure", isToken = true)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Gold Rush", bear).error shouldBe null
+                game.resolveStack()
+
+                // 2 existing + 1 created = 3 Treasures -> +6/+6.
+                withClue("three Treasures now exist") {
+                    game.findPermanents("Treasure").size shouldBe 3
+                }
+                withClue("Bear becomes an 8/8 (+6/+6 for three Treasures)") {
+                    game.state.projectedState.getPower(bear) shouldBe 8
+                    game.state.projectedState.getToughness(bear) shouldBe 8
+                }
+            }
+
+            test("resolves and still creates a Treasure when no target is chosen") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Gold Rush")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Gold Rush", null).error shouldBe null
+                game.resolveStack()
+
+                withClue("a Treasure token was created even with no creature target") {
+                    game.findPermanents("Treasure").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RooftopAssassinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RooftopAssassinScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rooftop Assassin (OTJ #103).
+ *
+ * "{3}{B} Creature — Vampire Assassin 2/2. Flash. Flying, lifelink.
+ *  When this creature enters, destroy target creature an opponent controls that was dealt
+ *  damage this turn."
+ *
+ * Verifies the ETB destroys a damaged opponent creature, and that an undamaged opponent
+ * creature is not a legal target (so the trigger has no target).
+ */
+class RooftopAssassinScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rooftop Assassin") {
+
+            test("ETB destroys an opponent creature that was dealt damage this turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Rooftop Assassin")
+                    .withCardInHand(1, "Shock")
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3, survives Shock's 2 damage
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                // Shock the Giant so it is "dealt damage this turn" but survives (3 toughness).
+                game.castSpell(1, "Shock", giant).error shouldBe null
+                game.resolveStack()
+                withClue("Hill Giant survives the Shock") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+
+                // Flash in Rooftop Assassin and destroy the damaged Giant.
+                game.castSpell(1, "Rooftop Assassin").error shouldBe null
+                game.resolveStack() // creature enters -> ETB asks for a target
+                game.selectTargets(listOf(giant)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Hill Giant is destroyed by the ETB") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("Rooftop Assassin is on the battlefield") {
+                    game.isOnBattlefield("Rooftop Assassin") shouldBe true
+                }
+            }
+
+            test("an undamaged opponent creature is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Rooftop Assassin")
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3, never damaged
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Rooftop Assassin").error shouldBe null
+                game.resolveStack()
+
+                withClue("No legal target exists, so the Giant is untouched") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+                withClue("Rooftop Assassin still enters the battlefield") {
+                    game.isOnBattlefield("Rooftop Assassin") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ServantOfTheStingerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ServantOfTheStingerScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ServantOfTheStinger
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Servant of the Stinger (OTJ #105).
+ *
+ * "{1}{B} Creature — Human Warlock 1/3. Deathtouch.
+ *  Whenever this creature deals combat damage to a player, if you've committed a crime this turn,
+ *  you may sacrifice this creature. If you do, search your library for a card, put it into your
+ *  hand, then shuffle."
+ *
+ * The crime clause is an intervening-if. Verifies: with a crime committed, the player may
+ * sacrifice on combat damage and tutor; without a crime, the ability does nothing.
+ */
+class ServantOfTheStingerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(ServantOfTheStinger))
+        return driver
+    }
+
+    test("with a crime committed, may sacrifice on combat damage and tutor a card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Forest" to 10), startingLife = 20)
+
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        val servant = driver.putCreatureOnBattlefield(attacker, "Servant of the Stinger")
+        driver.removeSummoningSickness(servant)
+
+        // Mark that the active player committed a crime this turn (intervening-if gate).
+        driver.replaceState(driver.state.copy(playersWhoCommittedCrimeThisTurn = setOf(attacker)))
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        // A specific tutor target on top of the library.
+        val target = driver.putCardOnTopOfLibrary(attacker, "Forest")
+        val handBefore = driver.getHandSize(attacker)
+
+        driver.declareAttackers(attacker, listOf(servant), defender)
+        driver.bothPass()
+        driver.declareNoBlockers(defender)
+        driver.bothPass()
+
+        // Combat damage dealt -> trigger goes on the stack; resolve it.
+        driver.bothPass()
+
+        // "You may sacrifice this creature." -> yes.
+        driver.submitYesNo(attacker, true)
+        // Search your library for a card -> pick the Forest.
+        driver.submitCardSelection(attacker, listOf(target))
+
+        // Servant was sacrificed.
+        driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(attacker, Zone.BATTLEFIELD))
+            .contains(servant) shouldBe false
+        // The tutored card is in hand.
+        driver.getHand(attacker).contains(target) shouldBe true
+        driver.getHandSize(attacker) shouldBe handBefore + 1
+        // Defender took 1 combat damage.
+        driver.assertLifeTotal(defender, 19)
+    }
+
+    test("without a crime, the ability does nothing on combat damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30, "Forest" to 10), startingLife = 20)
+
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        val servant = driver.putCreatureOnBattlefield(attacker, "Servant of the Stinger")
+        driver.removeSummoningSickness(servant)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val handBefore = driver.getHandSize(attacker)
+
+        driver.declareAttackers(attacker, listOf(servant), defender)
+        driver.bothPass()
+        driver.declareNoBlockers(defender)
+        driver.bothPass()
+
+        // Combat damage dealt; no crime committed, so the intervening-if fails — no prompt.
+        driver.bothPass()
+
+        // Servant survives; no tutor.
+        driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(attacker, Zone.BATTLEFIELD))
+            .contains(servant) shouldBe true
+        driver.getHandSize(attacker) shouldBe handBefore
+        driver.assertLifeTotal(defender, 19)
+    }
+})


### PR DESCRIPTION
## Cards added (Outlaws of Thunder Junction)

All three are canonical to OTJ (no earlier printing). Each ships with a passing scenario test.

- **Gold Rush** `{1}{G}` Instant — *Create a Treasure token. Until end of turn, up to one target creature gets +2/+2 for each Treasure you control.* Modeled as `Composite(CreateTreasure, ModifyStats(Multiply(treasureCount, 2)))` on an optional creature target. The per-Treasure amount is evaluated and **locked at resolution** (matching the ruling), and the Treasure it creates is counted. With no target chosen, the spell still resolves and creates the Treasure.
- **Rooftop Assassin** `{3}{B}` 2/2 — Flash, Flying, Lifelink; ETB *destroy target creature an opponent controls that was dealt damage this turn.*
- **Servant of the Stinger** `{1}{B}` 1/3 — Deathtouch; *Whenever this creature deals combat damage to a player, if you've committed a crime this turn, you may sacrifice this creature. If you do, search your library for a card, put it into your hand, then shuffle.* The crime clause is an intervening-if (`triggerCondition`); the may-sacrifice-then-tutor is a `GatedEffect(Gate.MayPay(SacrificeSelf), then = searchLibrary)`.

### Tests
- `GoldRushScenarioTest`, `RooftopAssassinScenarioTest` (ScenarioTestBase), `ServantOfTheStingerScenarioTest` (GameTestDriver — full combat + crime gate + may/tutor flow). All pass; `just build` is green.

## Cards skipped (2 of the 5 assigned)

Both need genuinely new engine work for a rules-faithful implementation, so per the task instruction they were left out rather than approximated:

- **Resilient Roadrunner** — its `{3}` activated ability grants *"can't be blocked this turn except by creatures with haste."* The static `CantBeBlockedExceptBy(filter)` exists, but there is no one-shot/floating **effect** to grant it for a turn (only a color-specific `GrantCantBeBlockedExceptByColorEffect`). Adding a keyword/filter grant effect + executor + `SerializableModification` is new engine work.
- **Steer Clear** — *"deals 4 damage instead if you controlled a Mount **as you cast** this spell."* Faithful behavior locks the Mount-controlled check at cast time (ruling: it doesn't matter whether you still control one at resolution). A `DynamicAmount.Conditional(YouControl(Mount), 4, 2)` evaluates at resolution, which diverges if a Mount leaves between cast and resolution. There is no cast-time condition-capture mechanism, so a faithful version is new engine work.

## mtgish tooling

Extended the emitter to render *"...that was dealt damage this turn"* targets instead of declining them:

- New general fluent helper `GameObjectFilter.dealtDamageThisTurn()` / `TargetFilter.dealtDamageThisTurn()` (backed by `StatePredicate.WasDealtDamageThisTurn`).
- `TargetRecovery` now composes `.dealtDamageThisTurn()` on the plain-creature path (with the controller suffix), declining only when combined with a shape that can't carry it (subtype / attacking / blocking / etc.) so the restriction is never silently dropped.
- Updated `TargetRecoveryTest` and the SDK reference doc.

### Coverage
- **Rooftop Assassin** now renders **AUTO** and verifies (0 capability mismatch).
- **Gold Rush** and **Servant of the Stinger** remain **SCAFFOLD** — `CreatePermanentLayerEffectUntil` with a dynamic per-Treasure amount, and the intervening-if + gated-sacrifice + tutor `TriggerI` shape respectively, both sit in the dynamic-amount / gated-cost areas the README flags as unsafe to render whole. Left to decline rather than misrender.
- **POR stays 0-mismatch** (`coverage-verify POR`: GATE PASS, 158/158).
- OTJ's 10 pre-existing gameplay-tree mismatches are unchanged (verified against the baseline); this PR added one AUTO card and introduced no new mismatches.

Snapshot goldens (`OTJ.json`) re-blessed — pure additions of the three new cards, no other card changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)