### PR TITLE
Add Vengeful Townsfolk + once-per-batch "creatures you control died" trigger

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1153,7 +1153,15 @@ for any other (filter, binding, to/excludeTo) combination.
 - `LeavesBattlefield` — SELF, any destination.
 - `Dies` — SELF, battlefield → graveyard.
 - `AnyCreatureDies` — ANY binding, filter = `Creature`.
-- `YourCreatureDies` — ANY binding, filter = `Creature.youControl()`.
+- `YourCreatureDies` — ANY binding, filter = `Creature.youControl()`. **Per-creature**: fires
+  once for *each* matching death, so a board wipe fires it once per creature. Use this for
+  "whenever another creature you control dies, …" (Unruly Mob, Rot Shambler, Pitiless Plunderer).
+- `OneOrMoreCreaturesYouControlDie(filter = Creature, excludeSelf = false)` — **batched** death
+  trigger: fires **at most once per event batch** regardless of how many matching creatures died
+  simultaneously. This is the correct shape for "whenever one or more [other] creatures you control
+  die, …" (Vengeful Townsfolk) — a per-creature `YourCreatureDies` would over-count on mass removal.
+  Set `excludeSelf = true` for the "*other* creatures" wording (the source's own death is excluded).
+  Detected specially by `TriggerDetector` (grouped by each dying creature's last-known controller).
 - `PutIntoGraveyardFromBattlefield` — SELF, same event shape as `Dies`; rename
   clarifies non-creature intent (artifact / enchantment going to yard).
 - `leavesBattlefield(filter, to?, excludeTo?, binding)` — factory. `to = GRAVEYARD`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1320,6 +1320,31 @@ object Triggers {
     )
 
     // =========================================================================
+    // Death Batch Triggers
+    // =========================================================================
+
+    /**
+     * Whenever one or more [other] creatures you control die.
+     * Batching trigger — fires at most once per event batch, regardless of how many
+     * creatures died simultaneously. This is the correct shape for "one or more
+     * creatures died" payoffs: a per-creature [YourCreatureDies] trigger over-counts
+     * on board wipes (one firing per creature), while this fires exactly once.
+     *
+     * Set [excludeSelf] for the "one or more *other* creatures you control die" wording —
+     * the source's own death is excluded from the batch.
+     *
+     * Example: "Whenever one or more other creatures you control die, put a +1/+1 counter on this creature."
+     * → OneOrMoreCreaturesYouControlDie(excludeSelf = true)   (Vengeful Townsfolk)
+     */
+    fun OneOrMoreCreaturesYouControlDie(
+        filter: GameObjectFilter = GameObjectFilter.Creature,
+        excludeSelf: Boolean = false
+    ): TriggerSpec = TriggerSpec(
+        event = CreaturesYouControlDiedEvent(filter = filter, excludeSelf = excludeSelf),
+        binding = TriggerBinding.ANY
+    )
+
+    // =========================================================================
     // Enter Battlefield Batch Triggers
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1419,6 +1419,50 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     // =========================================================================
+    // Death Batch Triggers
+    // =========================================================================
+
+    /**
+     * Whenever one or more creatures you control die.
+     *
+     * "Die" means a creature is put into a graveyard from the battlefield (CR 700.4).
+     * This is a **batching trigger** — it fires at most once per event batch, regardless
+     * of how many matching creatures died simultaneously. A board wipe that destroys
+     * several of your creatures at once fires this once, not once per creature — the key
+     * difference from the per-creature [ZoneChangeEvent] death shape (one event each),
+     * which over-counts on mass removal.
+     *
+     * [excludeSelf] models the "other" in "one or more *other* creatures you control die":
+     * the trigger's own source death does not count toward the batch.
+     *
+     * Detection is handled specially by TriggerDetector: after processing individual events,
+     * it groups battlefield→graveyard zone changes by each creature's last-known controller,
+     * checks the creature filter, and fires the trigger at most once per qualifying controller.
+     *
+     * Examples:
+     * - "Whenever one or more other creatures you control die, put a +1/+1 counter on this creature."
+     *   → CreaturesYouControlDiedEvent(excludeSelf = true)   (Vengeful Townsfolk)
+     */
+    @SerialName("CreaturesYouControlDiedEvent")
+    @Serializable
+    data class CreaturesYouControlDiedEvent(
+        val filter: GameObjectFilter = GameObjectFilter.Companion.Creature,
+        val excludeSelf: Boolean = false
+    ) : EventPattern {
+        override val description: String = buildString {
+            append("one or more ")
+            if (excludeSelf) append("other ")
+            append(describeObjectForEvent(filter))
+            append(" you control die")
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): EventPattern {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    // =========================================================================
     // Enter Battlefield Batch Triggers
     // =========================================================================
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/VengefulTownsfolk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/VengefulTownsfolk.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vengeful Townsfolk
+ * {2}{W}
+ * Creature — Human Citizen
+ * 3/3
+ *
+ * Whenever one or more other creatures you control die, put a +1/+1 counter on this creature.
+ *
+ * The trigger is a once-per-batch shape ([Triggers.OneOrMoreCreaturesYouControlDie]): a board
+ * wipe that destroys several of your creatures at once adds a single +1/+1 counter, not one per
+ * creature. `excludeSelf = true` models the "other" — Vengeful Townsfolk dying alongside them
+ * does not count toward its own trigger.
+ */
+val VengefulTownsfolk = card("Vengeful Townsfolk") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Citizen"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever one or more other creatures you control die, put a +1/+1 counter on this creature."
+
+    // Whenever one or more other creatures you control die, put a +1/+1 counter on this creature.
+    triggeredAbility {
+        trigger = Triggers.OneOrMoreCreaturesYouControlDie(excludeSelf = true)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Irina Nordsol"
+        flavorText = "\"The Sterling Company says they protect us, but where are they when the Hellspurs burn half the town? Counting their vaults!\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2df404af-571a-4867-83f5-bb4163b433ff.jpg?1712355378"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -5437,6 +5437,45 @@
     ]
 }
 
+// Vengeful Townsfolk
+{
+    "name": "Vengeful Townsfolk",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "Whenever one or more other creatures you control die, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CreaturesYouControlDiedEvent",
+                    "excludeSelf": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Irina Nordsol",
+        "flavorText": "\"The Sterling Company says they protect us, but where are they when the Hellspurs burn half the town? Counting their vaults!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2df404af-571a-4867-83f5-bb4163b433ff.jpg?1712355378"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Vial Smasher, Gleeful Grenadier
 {
     "name": "Vial Smasher, Gleeful Grenadier",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -562,6 +562,20 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         if (jsonContains(trig, "_Trigger", mtTrigger) && isSelf(trig)) return dsl
     }
 
+    // Non-self "a creature you control dies" deliberately declines -> SCAFFOLD, and the boundary is
+    // worth stating because it is tempting to "fix": the modern once-per-batch "whenever one or more
+    // other creatures you control die" (Vengeful Townsfolk) and the per-creature "whenever another
+    // creature you control dies" (Unruly Mob, Rot Shambler, Catacomb Sifter, Pitiless Plunderer, …)
+    // flatten to the *identical* mtgish node — WhenACreatureOrPlaneswalkerDies over
+    // And(Other(ThisPermanent), IsCardtype Creature, ControlledByAPlayer You). The IR carries no
+    // "one or more" quantifier, so the two can't be told apart here, yet they behave differently (a
+    // board wipe fires the batch trigger once but the per-each trigger once per creature). Rendering
+    // either way would mis-author the ~55 per-each cards that share this node, so we decline. The
+    // engine supports both shapes (Triggers.OneOrMoreCreaturesYouControlDie /
+    // Triggers.YourCreatureDies) and the bridge still scores these cards coverable — choosing between
+    // them is a human call (the add-card scenario test is the real gate).
+    if (jsonContains(trig, "_Trigger", "WhenACreatureOrPlaneswalkerDies") && !isSelf(trig)) return null
+
     // "Whenever ~ deals damage" / "Whenever ~ is dealt damage" (SELF) — paired with a "that much"
     // gain/lose-life or token effect.
     if (jsonContains(trig, "_Trigger", "WhenAPermanentDealsDamage") && isSelf(trig))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -233,6 +233,13 @@ class TriggerDetector(
         // non-graveyard zones and fires the trigger at most once per observer.
         detectLeaveBattlefieldWithoutDyingBatchTriggers(state, events, triggers, index)
 
+        // Detect "whenever one or more [other] creatures you control die" batching triggers
+        // (e.g., Vengeful Townsfolk). Groups battlefield→graveyard zone changes by each dying
+        // creature's last-known controller and fires the trigger at most once per controller —
+        // so a board wipe that kills several of a player's creatures fires the trigger once,
+        // not once per creature (the over-counting a per-creature death trigger would suffer).
+        detectCreaturesDiedBatchTriggers(state, events, triggers, index)
+
         // Detect "whenever one or more [filtered] permanents you control enter the battlefield"
         // batching triggers (e.g., Builder's Talent). Groups zone changes to battlefield
         // and fires the trigger at most once per observer.
@@ -1685,6 +1692,87 @@ class TriggerDetector(
                                 info.cardComponent.typeLine.isCreature
                             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
                                 info.cardComponent.typeLine.hasSubtype(predicate.subtype)
+                            else -> true
+                        }
+                    }
+                }
+
+                if (hasMatch) {
+                    triggers.add(
+                        PendingTrigger(
+                            ability = ability,
+                            sourceId = entry.entityId,
+                            sourceName = entry.cardComponent.name,
+                            controllerId = controllerId,
+                            triggerContext = TriggerContext()
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Detect "whenever one or more [other] creatures you control die" batching triggers
+     * (e.g., Vengeful Townsfolk).
+     *
+     * Groups battlefield→graveyard zone changes by each dying creature's last-known controller
+     * and fires the trigger at most once per qualifying controller, regardless of how many
+     * creatures died simultaneously. This is the once-per-batch shape a per-creature death
+     * trigger (one [ZoneChangeEvent] each) cannot express — a board wipe killing five of a
+     * player's creatures fires this once, not five times.
+     *
+     * Controller is read from [ZoneChangeEvent.lastKnownController] (falling back to owner),
+     * since the creature has already left the battlefield. The creature's type line comes from
+     * [ZoneChangeEvent.lastKnownTypeLine] so it survives the 704.5s token cleanup that can remove
+     * a dead token from the graveyard in the same pass.
+     */
+    private fun detectCreaturesDiedBatchTriggers(
+        state: GameState,
+        events: List<EngineGameEvent>,
+        triggers: MutableList<PendingTrigger>,
+        index: TriggerIndex
+    ) {
+        if (index.getEntitiesForCategory(TriggerCategory.CREATURES_DIED_BATCH).isEmpty()) return
+
+        // Collect creature deaths (battlefield → graveyard), grouped by last-known controller.
+        data class DeathInfo(val entityId: EntityId, val typeLine: com.wingedsheep.sdk.core.TypeLine?)
+        val deathsByController = mutableMapOf<EntityId, MutableList<DeathInfo>>()
+        for (event in events) {
+            if (event !is ZoneChangeEvent) continue
+            if (event.fromZone != Zone.BATTLEFIELD || event.toZone != Zone.GRAVEYARD) continue
+            val typeLine = event.lastKnownTypeLine
+                ?: state.getEntity(event.entityId)?.get<CardComponent>()?.typeLine
+            if (typeLine?.isCreature != true) continue
+            val controllerId = event.lastKnownController ?: event.ownerId
+            deathsByController.getOrPut(controllerId) { mutableListOf() }
+                .add(DeathInfo(event.entityId, typeLine))
+        }
+        if (deathsByController.isEmpty()) return
+
+        for (entry in index.getEntitiesForCategory(TriggerCategory.CREATURES_DIED_BATCH)) {
+            for (ability in entry.abilities) {
+                val trigger = ability.trigger
+                if (trigger !is EventPattern.CreaturesYouControlDiedEvent) continue
+
+                val controllerId = entry.controllerId
+                val controllerDeaths = deathsByController[controllerId] ?: continue
+
+                // "one or more *other* creatures you control die" excludes the source's own death.
+                val relevantDeaths = if (trigger.excludeSelf) {
+                    controllerDeaths.filter { it.entityId != entry.entityId }
+                } else {
+                    controllerDeaths
+                }
+                if (relevantDeaths.isEmpty()) continue
+
+                val hasMatch = relevantDeaths.any { info ->
+                    trigger.filter.cardPredicates.all { predicate ->
+                        when (predicate) {
+                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->
+                                info.typeLine?.isCreature == true
+                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
+                                info.typeLine?.hasSubtype(predicate.subtype) == true
                             else -> true
                         }
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -63,6 +63,7 @@ enum class TriggerCategory {
     SACRIFICE,
     COMBAT_DAMAGE_BATCH,
     LEAVE_WITHOUT_DYING,
+    CREATURES_DIED_BATCH,
     PERMANENTS_ENTERED_BATCH,
     COUNTERS_ADDED,
     GIFT_GIVEN,
@@ -193,6 +194,7 @@ class TriggerIndex(
                 is SdkGameEvent.PermanentsSacrificedEvent -> listOf(TriggerCategory.SACRIFICE)
                 is SdkGameEvent.OneOrMoreDealCombatDamageToPlayerEvent -> listOf(TriggerCategory.COMBAT_DAMAGE_BATCH)
                 is SdkGameEvent.LeaveBattlefieldWithoutDyingEvent -> listOf(TriggerCategory.LEAVE_WITHOUT_DYING)
+                is SdkGameEvent.CreaturesYouControlDiedEvent -> listOf(TriggerCategory.CREATURES_DIED_BATCH)
                 is SdkGameEvent.PermanentsEnteredEvent -> listOf(TriggerCategory.PERMANENTS_ENTERED_BATCH)
                 is SdkGameEvent.CountersPlacedEvent -> listOf(TriggerCategory.COUNTERS_ADDED)
                 is SdkGameEvent.GiftGivenEvent -> listOf(TriggerCategory.GIFT_GIVEN)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -384,6 +384,8 @@ class TriggerMatcher(
             is EventPattern.OneOrMoreDealCombatDamageToPlayerEvent -> false
             // Leave battlefield without dying batch triggers are handled by detectLeaveBattlefieldWithoutDyingBatchTriggers
             is EventPattern.LeaveBattlefieldWithoutDyingEvent -> false
+            // Creatures-you-control-die batch triggers are handled by detectCreaturesDiedBatchTriggers
+            is EventPattern.CreaturesYouControlDiedEvent -> false
             // Enter battlefield batch triggers are handled by detectPermanentsEnteredBatchTriggers
             is EventPattern.PermanentsEnteredEvent -> false
             is EventPattern.CountersPlacedEvent -> {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulTownsfolkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulTownsfolkScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vengeful Townsfolk (OTJ #37) — "Whenever one or more other creatures you control die, put a
+ * +1/+1 counter on this creature."
+ *
+ * Exercises the once-per-batch death trigger ([com.wingedsheep.sdk.dsl.Triggers.OneOrMoreCreaturesYouControlDie]).
+ * The critical case is a board wipe: several of your creatures dying simultaneously must add a
+ * single counter, not one per creature (the over-counting a per-creature death trigger suffers).
+ *
+ * Pyroclasm ("2 damage to each creature") is the simultaneous-death engine: it kills the 2/2s
+ * outright while the 3/3 Vengeful Townsfolk survives, so its counter is observable.
+ */
+class VengefulTownsfolkScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame): Int {
+        val id = game.findPermanent("Vengeful Townsfolk")!!
+        return game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Vengeful Townsfolk") {
+            test("board wipe killing two of your creatures adds exactly one +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vengeful Townsfolk")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardInHand(1, "Pyroclasm")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Pyroclasm")
+                withClue("Casting Pyroclasm should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Both 2/2 Glory Seekers should have died to 2 damage") {
+                    game.findPermanents("Glory Seeker").size shouldBe 0
+                }
+                withClue("The 3/3 Vengeful Townsfolk should survive 2 damage") {
+                    (game.findPermanent("Vengeful Townsfolk") != null) shouldBe true
+                }
+                withClue("Two simultaneous deaths form one batch → exactly one +1/+1 counter, not two") {
+                    plusOneCounters(game) shouldBe 1
+                }
+            }
+
+            test("a single other creature dying adds one +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vengeful Townsfolk")
+                    .withCardOnBattlefield(1, "Glory Seeker")
+                    .withCardInHand(1, "Pyroclasm")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Pyroclasm")
+                game.resolveStack()
+
+                withClue("The single Glory Seeker should have died") {
+                    game.findPermanents("Glory Seeker").size shouldBe 0
+                }
+                withClue("One other creature died → one +1/+1 counter") {
+                    plusOneCounters(game) shouldBe 1
+                }
+            }
+
+            test("creatures an opponent controls dying does not trigger your Vengeful Townsfolk") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vengeful Townsfolk")
+                    .withCardOnBattlefield(2, "Glory Seeker")
+                    .withCardOnBattlefield(2, "Glory Seeker")
+                    .withCardInHand(1, "Pyroclasm")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Pyroclasm")
+                game.resolveStack()
+
+                withClue("The opponent's Glory Seekers should have died") {
+                    game.findPermanents("Glory Seeker").size shouldBe 0
+                }
+                withClue("Only creatures the opponent controls died → no counter on your Vengeful Townsfolk") {
+                    plusOneCounters(game) shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Implements **Vengeful Townsfolk** (OTJ #37) — *"Whenever one or more other creatures you control die, put a +1/+1 counter on this creature."* — and the engine feature it needs: a **once-per-batch** "creatures you control die" trigger.

## Why

The engine had no batched death trigger. The only "creatures you control die" shape was the per-creature `Triggers.YourCreatureDies`, which fires **once per dying creature** — so a board wipe killing five of your creatures would add five counters instead of one. Vengeful Townsfolk (and other modern "one or more … die" payoffs) need a trigger that fires **at most once per event batch**, mirroring the existing `OneOrMoreLeaveWithoutDying` / `OneOrMorePermanentsEnter` batch triggers.

## Engine feature

- **SDK:** `EventPattern.CreaturesYouControlDiedEvent(filter, excludeSelf)` + `Triggers.OneOrMoreCreaturesYouControlDie(...)` facade.
- **Engine:** `TriggerCategory.CREATURES_DIED_BATCH` + index mapping; `TriggerDetector.detectCreaturesDiedBatchTriggers` groups battlefield→graveyard deaths by each creature's **last-known controller** and fires once per qualifying controller. `excludeSelf` models the *"other"*. `TriggerMatcher` declines the event in its per-event path (batch-handled separately, like the sibling batch events).
- Type line / controller for dead creatures read from `ZoneChangeEvent.lastKnownTypeLine` / `lastKnownController`, so dead tokens survive the 704.5s graveyard cleanup.

## mtgish tooling

The mtgish IR **flattens** *"one or more other creatures you control die"* (batch) and *"another creature you control dies"* (per-each — ~55 cards: Unruly Mob, Rot Shambler, Catacomb Sifter, Pitiless Plunderer, …) to the **byte-for-byte identical** node — there is no "one or more" quantifier in the IR. The two behave differently on a board wipe, so per the project's **decline→SCAFFOLD, don't mis-render** principle the emitter explicitly declines this shape (documented) rather than mis-author the per-each cards as batch. The bridge already scores the shape coverable and the engine now supports both shapes; choosing between them stays a human call (the scenario test is the real gate).

## Tests

`VengefulTownsfolkScenarioTest` (all passing):
- **board wipe** (Pyroclasm) kills two of your 2/2s simultaneously → exactly **one** +1/+1 counter (the over-counting fix; the 3/3 survives so the counter is observable);
- a **single** other creature dying → one counter;
- **opponent-controlled** creatures dying → **no** counter.

Also green: `:rules-engine:test`, `:mtg-sets:test` (OTJ snapshot re-blessed — only the new card added), `:mtgish-tooling:test`, `coverage-verify POR` (158/158, GATE PASS), `game-server` compile, `check-card-printing`.

## Docs

`card-sdk-language-reference.md` §8 now distinguishes the per-each `YourCreatureDies` from the batched `OneOrMoreCreaturesYouControlDie`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)