### PR TITLE
Add Resilient Roadrunner (OTJ) with floating CantBeBlockedExceptBy grant

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -554,6 +554,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `Effects.SkipNextDrawStep(target = Controller)` (`SkipNextDrawStepEffect`) — target skips their next draw step. Adds a one-shot `SkipDrawStepComponent` marker consumed by `DrawPhaseManager.performDrawStep` (Elfhame Sanctuary's "you skip your draw step this turn").
 - `HijackNextTurnEffect(target)` — you control target's next turn.
 - `GrantCantBeBlockedByChosenColorEffect(target, duration)` — unblockable except by chosen color.
+- `Effects.GrantCantBeBlockedExceptBy(target, blockerFilter, duration = EndOfTurn)` (`GrantCantBeBlockedExceptByEffect`) —
+  the floating, one-shot grant of "can't be blocked except by creatures matching `blockerFilter`". The dynamic
+  counterpart to the static `CantBeBlockedExceptBy` ability (and the filter-based sibling of the color-only
+  `GrantCantBeBlockedExceptByColorEffect`). Routes through the same projected `cantBeBlockedExceptByFilters` channel
+  the static ability uses, so the existing `CantBeBlockedExceptByRule` enforces it. Used by **Resilient Roadrunner**:
+  `{3}: This creature can't be blocked this turn except by creatures with haste` —
+  `Effects.GrantCantBeBlockedExceptBy(EffectTarget.Self, GameObjectFilter.Creature.withKeyword(Keyword.HASTE))`.
 - `CantCastSpellsEffect(target, until?)` — target can't cast spells. Facade: `Effects.CantCastSpells(target, duration)`.
 - `Effects.CantPlayLandsThisTurn(target = Controller)` (`PreventLandPlaysThisTurnEffect`) — the target player can't
   play lands for the rest of this turn (sets remaining land drops to 0). Defaults to the controller (Rock Jockey);

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -41,6 +41,7 @@ import com.wingedsheep.sdk.scripting.effects.GrantHexproofFromChosenColorEffect
 import com.wingedsheep.sdk.scripting.effects.GrantProtectionFromChosenColorEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachColorOfEffect
 import com.wingedsheep.sdk.scripting.effects.GrantCantBeBlockedByChosenColorEffect
+import com.wingedsheep.sdk.scripting.effects.GrantCantBeBlockedExceptByEffect
 import com.wingedsheep.sdk.scripting.effects.GrantHarmonizeEffect
 import com.wingedsheep.sdk.scripting.effects.GrantToxicEffect
 import com.wingedsheep.sdk.scripting.effects.CantAttackGroupEffect
@@ -1600,6 +1601,22 @@ object Effects {
         target: EffectTarget = EffectTarget.ContextTarget(0),
         duration: Duration = Duration.EndOfTurn
     ): Effect = GrantCantBeBlockedByChosenColorEffect(target, duration)
+
+    /**
+     * Grant a creature "can't be blocked except by creatures matching [blockerFilter]" for
+     * [duration]. The one-shot, floating-effect counterpart to the static
+     * [com.wingedsheep.sdk.scripting.CantBeBlockedExceptBy] ability; for the color-only sibling use
+     * [GrantCantBeBlockedExceptByColor]. Routes through the same projected evasion channel the
+     * static ability uses, so the existing block rules enforce it.
+     *
+     * Used by Resilient Roadrunner: "{3}: This creature can't be blocked this turn except by
+     * creatures with haste."
+     */
+    fun GrantCantBeBlockedExceptBy(
+        target: EffectTarget,
+        blockerFilter: GameObjectFilter,
+        duration: Duration = Duration.EndOfTurn
+    ): Effect = GrantCantBeBlockedExceptByEffect(target, blockerFilter, duration)
 
     // =========================================================================
     // Control Effects

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.sdk.scripting.effects
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.references.Player
@@ -336,6 +337,37 @@ data class CantBlockGroupEffect(
     override fun applyTextReplacement(replacer: TextReplacer): Effect {
         val newFilter = filter.applyTextReplacement(replacer)
         return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
+ * Grant a creature an evasion restriction until end of turn: it "can't be blocked except by
+ * creatures matching [blockerFilter]." The one-shot, floating-effect counterpart to the static
+ * [com.wingedsheep.sdk.scripting.CantBeBlockedExceptBy] ability (and the filter-based sibling of
+ * [GrantCantBeBlockedExceptByColorEffect], which is restricted to a single color).
+ *
+ * Resolves through the same projected `cantBeBlockedExceptByFilters` channel the static ability
+ * uses, so the existing block-evasion rule enforces it for free. Used by Resilient Roadrunner
+ * ("{3}: This creature can't be blocked this turn except by creatures with haste.") and any
+ * future activated/triggered grant that names a blocker filter.
+ *
+ * For multi-target spells, wrap in ForEachTargetEffect with EffectTarget.ContextTarget(0).
+ *
+ * @property target The creature that gains the restriction
+ * @property blockerFilter Only creatures matching this filter may block the target
+ * @property duration How long the restriction lasts
+ */
+@SerialName("GrantCantBeBlockedExceptBy")
+@Serializable
+data class GrantCantBeBlockedExceptByEffect(
+    val target: EffectTarget,
+    val blockerFilter: GameObjectFilter,
+    val duration: Duration = Duration.EndOfTurn
+) : Effect {
+    override val description: String = buildString {
+        append("${target.description} can't be blocked")
+        if (duration.description.isNotEmpty()) append(" ${duration.description}")
+        append(" except by ${blockerFilter.description}")
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ResilientRoadrunner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/ResilientRoadrunner.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Resilient Roadrunner
+ * {1}{R}
+ * Creature — Bird
+ * 2/2
+ * Haste, protection from Coyotes
+ * {3}: This creature can't be blocked this turn except by creatures with haste.
+ */
+val ResilientRoadrunner = card("Resilient Roadrunner") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 2
+    oracleText = "Haste, protection from Coyotes\n" +
+        "{3}: This creature can't be blocked this turn except by creatures with haste."
+
+    keywords(Keyword.HASTE)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Subtype("Coyote")))
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = Effects.GrantCantBeBlockedExceptBy(
+            EffectTarget.Self,
+            GameObjectFilter.Creature.withKeyword(Keyword.HASTE)
+        )
+        description = "This creature can't be blocked this turn except by creatures with haste."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "141"
+        artist = "David Auden Nash"
+        flavorText = "\"Chasing the roadrunner\"\n" +
+            "—Omenport slang for wasting energy on impossible pursuits"
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e07d3ee9-d3c4-4f07-839e-ec81c2587ae0.jpg?1712355827"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -3885,6 +3885,65 @@
     "colorIdentityOverride": []
 }
 
+// Resilient Roadrunner
+{
+    "name": "Resilient Roadrunner",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Haste, protection from Coyotes\n{3}: This creature can't be blocked this turn except by creatures with haste.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Subtype",
+                "subtype": "Coyote"
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostMana",
+                    "cost": "{3}"
+                },
+                "effect": {
+                    "type": "GrantCantBeBlockedExceptBy",
+                    "target": "Self",
+                    "blockerFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasKeyword",
+                                "keyword": "HASTE"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "This creature can't be blocked this turn except by creatures with haste."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "rarity": "UNCOMMON",
+        "artist": "David Auden Nash",
+        "flavorText": "\"Chasing the roadrunner\"\n—Omenport slang for wasting energy on impossible pursuits",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e07d3ee9-d3c4-4f07-839e-ec81c2587ae0.jpg?1712355827"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Riku of Many Paths
 {
     "name": "Riku of Many Paths",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -13,7 +13,11 @@ import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
 import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
+import com.wingedsheep.tooling.coverage.firstArgWordTagged
+import com.wingedsheep.tooling.coverage.firstWordAtKey
+import com.wingedsheep.tooling.coverage.hasTag
 import com.wingedsheep.tooling.coverage.jsonContains
+import com.wingedsheep.tooling.coverage.nodesTagged
 import com.wingedsheep.tooling.coverage.pascalToUpperSnake
 import com.wingedsheep.tooling.coverage.strField
 import com.wingedsheep.tooling.coverage.subtypes
@@ -340,16 +344,8 @@ private fun EmitCtx.staticAbilityExpr(ruleName: String, ruleNode: JsonObject): D
             return call("CantBeBlockedBy", arg("blockerFilter", filter))
         }
         "CantBeBlockedExceptByDefenders" -> {
-            if (oracleText?.contains("defender", ignoreCase = true) == true) {
-                return call("CantBeBlockedExceptBy", arg("blockerFilter", "GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER)"))
-            }
-            // "can't be blocked except by [creature subtype]" (Invisibility: except by Walls). The rule
-            // names the *only* legal blockers, so it must render CantBeBlockedExceptBy with that subtype.
-            // Scaffold if we can't recover a single creature subtype — a bare CantBeBlockedBy would
-            // invert the meaning (it removes those blockers rather than restricting to them).
-            val sub = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").find(compact(ruleNode))?.groupValues?.get(1)
-                ?: return null
-            return call("CantBeBlockedExceptBy", arg("blockerFilter", "GameObjectFilter.Creature.withSubtype(${subtypeArg(sub)})"))
+            val bf = cantBeBlockedExceptByFilter(ruleNode) ?: return null
+            return call("CantBeBlockedExceptBy", arg("blockerFilter", bf))
         }
         "CantAttackUnlessDefendingPlayer" -> {  // Deep-Sea Serpent: defender must control an Island
             val subs = subtypes(ruleNode)
@@ -362,6 +358,40 @@ private fun EmitCtx.staticAbilityExpr(ruleName: String, ruleNode: JsonObject): D
         // self MustAttack, distinct from MustAttackPlayer which carries a forced defender.
         "MustAttack" -> return call("MustAttack")
         "CanBlockAnyNumberOfCreatures" -> return call("CanBlockAnyNumber")
+    }
+    return null
+}
+
+/**
+ * The blocker filter for a `CantBeBlockedExceptByDefenders` rule — the creatures that may STILL block
+ * (the rule restricts blockers down to these). Renders the "defender" oracle idiom, a single creature
+ * subtype, or a single keyword restriction ("except by creatures with haste"); declines (null) on any
+ * compound / unrecognised shape so the card scaffolds rather than emitting a too-broad "except by any
+ * creature". Shared by the static [com.wingedsheep.sdk.scripting.CantBeBlockedExceptBy] ability and the
+ * floating one-shot `Effects.GrantCantBeBlockedExceptBy` grant (`CreatePermanentRuleEffectUntil`).
+ */
+internal fun EmitCtx.cantBeBlockedExceptByFilter(ruleNode: JsonObject): String? {
+    if (oracleText?.contains("defender", ignoreCase = true) == true)
+        return "GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER)"
+    // "except by [creature subtype]" (Invisibility: except by Walls). The rule names the *only* legal
+    // blockers, so it must render CantBeBlockedExceptBy with that subtype — a bare CantBeBlockedBy would
+    // invert the meaning (removing those blockers rather than restricting to them).
+    ruleNode.firstArgWordTagged("IsCreatureType")?.let {
+        return "GameObjectFilter.Creature.withSubtype(${subtypeArg(it)})"
+    }
+    // "except by creatures with <keyword>" (Resilient Roadrunner: haste). Render only the clean
+    // "Creature + one known keyword" shape; any extra predicate (color / power / mana value / subtype /
+    // a second or negated ability) declines so we never silently drop a restriction.
+    val hasAbilities = ruleNode.nodesTagged("HasAbility")
+    if (hasAbilities.size == 1 && ruleNode.nodesTagged("DoesntHaveAbility").isEmpty()) {
+        val foreign = listOf(
+            "IsColor", "IsNonColor", "PowerIs", "ToughnessIs", "ManaValueIs",
+            "IsTapped", "IsUntapped", "IsAttacking", "IsBlocking", "HasACounterOfType"
+        )
+        if (foreign.any { ruleNode.hasTag(it) }) return null
+        val kw = pascalToUpperSnake(hasAbilities[0].firstWordAtKey("_CheckHasable") ?: return null)
+        if (kw !in keywords) return null  // unknown ability -> decline, don't widen the filter
+        return "GameObjectFilter.Creature.withKeyword(Keyword.$kw)"
     }
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TapLayerStateHandlers.kt
@@ -119,8 +119,10 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
     }
 
     on("CreatePermanentRuleEffectUntil") { node, _, tvar ->
-        // "target <permanent> can't be blocked this turn" (Crafty Pathmage). Only the single CantBeBlocked
-        // rule at end-of-turn renders, as a CANT_BE_BLOCKED ability-flag grant; anything else scaffolds.
+        // "target <permanent> can't be blocked this turn" (Crafty Pathmage) renders as a CANT_BE_BLOCKED
+        // ability-flag grant; "<permanent> can't be blocked except by creatures with <X> this turn"
+        // (Resilient Roadrunner) renders as a floating GrantCantBeBlockedExceptBy. Only the single rule at
+        // end-of-turn renders; anything else scaffolds.
         val args = node["args"].asArr ?: return@on null
         val tgt = refTarget(args, tvar) ?: return@on null
         if (!jsonContains(node, "_Expiration", "UntilEndOfTurn")) return@on null
@@ -128,6 +130,10 @@ internal val tapLayerStateHandlers: Map<String, ActionHandler> = actionHandlers 
         if (rules.size != 1) return@on null
         when (rules[0].strField("_PermanentRule")) {
             "CantBeBlocked" -> call("GrantKeywordEffect", arg("AbilityFlag.CANT_BE_BLOCKED.name"), arg(Lit(tgt)))
+            "CantBeBlockedExceptByDefenders" -> {
+                val bf = cantBeBlockedExceptByFilter(rules[0]) ?: return@on null
+                call("Effects.GrantCantBeBlockedExceptBy", arg(Lit(tgt)), arg(Lit(bf)))
+            }
             else -> null
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CombatExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CombatExecutors.kt
@@ -16,6 +16,7 @@ class CombatExecutors(
         ForceBlockExecutor(),
         PreventDamageExecutor(amountEvaluator),
         GrantCantBeBlockedExceptByColorExecutor(),
+        GrantCantBeBlockedExceptByExecutor(),
         ReflectCombatDamageExecutor(),
         TauntExecutor(),
         CantAttackGroupExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/GrantCantBeBlockedExceptByExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/GrantCantBeBlockedExceptByExecutor.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.handlers.effects.combat
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.GrantCantBeBlockedExceptByEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [GrantCantBeBlockedExceptByEffect].
+ *
+ * Creates a Layer.ABILITY floating effect carrying [SerializableModification.CantBeBlockedExceptBy]
+ * for the targeted creature. That modification maps to the real
+ * [com.wingedsheep.engine.mechanics.layers.Modification.CantBeBlockedExceptBy], so the projector
+ * adds the filter to `cantBeBlockedExceptByFilters` and the existing
+ * [com.wingedsheep.engine.mechanics.combat.rules.CantBeBlockedExceptByRule] enforces it — no
+ * combat-specific wiring needed. The floating-effect, one-shot counterpart to the static
+ * `CantBeBlockedExceptBy` ability.
+ *
+ * For multi-target spells, wrap in ForEachTargetEffect with EffectTarget.ContextTarget(0).
+ */
+class GrantCantBeBlockedExceptByExecutor : EffectExecutor<GrantCantBeBlockedExceptByEffect> {
+
+    override val effectType: KClass<GrantCantBeBlockedExceptByEffect> = GrantCantBeBlockedExceptByEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: GrantCantBeBlockedExceptByEffect,
+        context: EffectContext
+    ): EffectResult {
+        val entityId = TargetResolutionUtils.resolveTarget(effect.target, context)
+            ?: return EffectResult.success(state)
+        state.getEntity(entityId)?.get<CardComponent>()
+            ?: return EffectResult.success(state)
+
+        val newState = state.addFloatingEffect(
+            layer = Layer.ABILITY,
+            modification = SerializableModification.CantBeBlockedExceptBy(effect.blockerFilter),
+            affectedEntities = setOf(entityId),
+            duration = effect.duration,
+            context = context
+        )
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
@@ -160,6 +160,17 @@ sealed interface SerializableModification {
     data object PreventAllCombatDamage : SerializableModification
 
     /**
+     * Blocking restriction: creature can only be blocked by creatures matching [blockerFilter]
+     * (floating, one-shot variant). The dynamic counterpart to the static
+     * [com.wingedsheep.sdk.scripting.CantBeBlockedExceptBy] ability — unlike
+     * [CantBeBlockedExceptByColor] it maps to a real Layer.ABILITY [Modification.CantBeBlockedExceptBy]
+     * so the existing `CantBeBlockedExceptByRule` enforces it through projected state.
+     * Used by Resilient Roadrunner's "{3}: can't be blocked except by creatures with haste".
+     */
+    @Serializable
+    data class CantBeBlockedExceptBy(val blockerFilter: GameObjectFilter) : SerializableModification
+
+    /**
      * Blocking restriction: creature can only be blocked by creatures of a specific color.
      * Used by Dread Charge and similar effects.
      */
@@ -453,6 +464,9 @@ fun SerializableModification.toModification(): Modification = when (this) {
     is SerializableModification.MustBlockSpecificAttacker -> Modification.NoOp
     // PreventDamageFromAttackingCreatures doesn't map to a layer modification - it's checked by CombatManager directly
     is SerializableModification.PreventDamageFromAttackingCreatures -> Modification.NoOp
+    // CantBeBlockedExceptBy maps to the real Layer.ABILITY modification, so it flows through the
+    // projector into `cantBeBlockedExceptByFilters` and is enforced by CantBeBlockedExceptByRule.
+    is SerializableModification.CantBeBlockedExceptBy -> Modification.CantBeBlockedExceptBy(blockerFilter)
     // CantBeBlockedExceptByColor doesn't map to a layer modification - it's checked by CombatManager directly
     is SerializableModification.CantBeBlockedExceptByColor -> Modification.NoOp
     // CantBeBlockedByColor doesn't map to a layer modification - it's checked by CombatManager directly

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ResilientRoadrunnerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ResilientRoadrunnerScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.ResilientRoadrunner
+import com.wingedsheep.mtg.sets.definitions.otj.OutlawsOfThunderJunctionSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContainIgnoringCase
+
+/**
+ * Tests for Resilient Roadrunner's activated ability:
+ *
+ * "{3}: This creature can't be blocked this turn except by creatures with haste."
+ *
+ * Exercises the new floating, one-shot [GrantCantBeBlockedExceptBy] grant: it routes through the
+ * same projected `cantBeBlockedExceptByFilters` channel the static ability uses, so the existing
+ * block-evasion rule enforces it. Blocker "with haste" = Ragavan (HASTE keyword); blocker without
+ * haste = Grizzly Bears.
+ */
+class ResilientRoadrunnerScenarioTest : FunSpec({
+
+    val abilityId = ResilientRoadrunner.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + OutlawsOfThunderJunctionSet.cards)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20), startingLife = 20)
+        return driver
+    }
+
+    /** Put Roadrunner attacking [opponent], having activated its ability this turn. */
+    fun GameTestDriver.setupAttackWithAbilityActive(blockerName: String): Triple<EntityId, EntityId, EntityId> {
+        val player = activePlayer!!
+        val opponent = getOpponent(player)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val roadrunner = putCreatureOnBattlefield(player, "Resilient Roadrunner")
+        removeSummoningSickness(roadrunner)
+        val blocker = putCreatureOnBattlefield(opponent, blockerName)
+        removeSummoningSickness(blocker)
+
+        // Activate "{3}: can't be blocked this turn except by creatures with haste."
+        giveMana(player, Color.RED, 3)
+        submit(ActivateAbility(playerId = player, sourceId = roadrunner, abilityId = abilityId))
+            .isSuccess shouldBe true
+        bothPass() // resolve the ability
+
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        declareAttackers(player, listOf(roadrunner), opponent).isSuccess shouldBe true
+        bothPass() // move to declare blockers
+        currentStep shouldBe Step.DECLARE_BLOCKERS
+        return Triple(roadrunner, blocker, opponent)
+    }
+
+    test("a creature without haste can't block the Roadrunner after the ability resolves") {
+        val driver = createDriver()
+        val (roadrunner, blocker, opponent) = driver.setupAttackWithAbilityActive("Grizzly Bears")
+
+        val result = driver.submitExpectFailure(
+            DeclareBlockers(opponent, mapOf(blocker to listOf(roadrunner)))
+        )
+
+        result.isSuccess shouldBe false
+        result.error shouldContainIgnoringCase "haste"
+        result.error shouldContainIgnoringCase "cannot block"
+    }
+
+    test("a creature with haste CAN block the Roadrunner after the ability resolves") {
+        val driver = createDriver()
+        val (roadrunner, blocker, opponent) =
+            driver.setupAttackWithAbilityActive("Ragavan, Nimble Pilferer")
+
+        driver.declareBlockers(opponent, mapOf(blocker to listOf(roadrunner)))
+            .isSuccess shouldBe true
+    }
+
+    test("without activating the ability, any creature can block (restriction is the floating grant)") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val roadrunner = driver.putCreatureOnBattlefield(player, "Resilient Roadrunner")
+        driver.removeSummoningSickness(roadrunner)
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.removeSummoningSickness(blocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(roadrunner), opponent).isSuccess shouldBe true
+        driver.bothPass()
+        driver.currentStep shouldBe Step.DECLARE_BLOCKERS
+
+        driver.declareBlockers(opponent, mapOf(blocker to listOf(roadrunner)))
+            .isSuccess shouldBe true
+    }
+})


### PR DESCRIPTION
## Card

**Resilient Roadrunner** — `{1}{R}` Creature — Bird, 2/2
> Haste, protection from Coyotes
> `{3}`: This creature can't be blocked this turn except by creatures with haste.

OTJ #141 (its only printing, so canonical lives in OTJ).

## Feature: floating one-shot `CantBeBlockedExceptBy` grant

Previously only the **static** `CantBeBlockedExceptBy` ability and the **color-specific** `GrantCantBeBlockedExceptByColorEffect` existed. This adds the general filter-based, until-end-of-turn grant:

- **SDK** — `Effects.GrantCantBeBlockedExceptBy(target, blockerFilter, duration = EndOfTurn)` (`GrantCantBeBlockedExceptByEffect`).
- **Engine** — `SerializableModification.CantBeBlockedExceptBy(blockerFilter)` maps to the real `Layer.ABILITY` `Modification.CantBeBlockedExceptBy`, so it flows through the projector into `cantBeBlockedExceptByFilters` and the **existing** `CantBeBlockedExceptByRule` enforces it — no new combat-rule code. `GrantCantBeBlockedExceptByExecutor` creates the floating effect (registered in `CombatExecutors`).

This routes the dynamic grant through the same channel the static ability uses, keeping enforcement in one place. Faithful to the ruling that activating after a non-haste creature is already blocking does **not** retroactively unblock — the restriction is only checked at block declaration.

## mtgish tooling

The emitter now renders `CreatePermanentRuleEffectUntil`'s `CantBeBlockedExceptByDefenders` rule as `Effects.GrantCantBeBlockedExceptBy`. A shared `cantBeBlockedExceptByFilter` helper recovers the blocker filter (defender idiom / single creature subtype / single keyword via `HasAbility`), declining on compound shapes so they scaffold rather than widen. Used by both the static ability and the new floating grant.

- `just coverage-fidelity --emit "Resilient Roadrunner"` → **AUTO** (whole card).
- POR / EOE emitter goldens unchanged (`EmitterGoldenTest` passes).

## Tests

`ResilientRoadrunnerScenarioTest` (rules-engine):
- a creature **without** haste can't block after the ability resolves;
- a creature **with** haste **can** block;
- without activating, any creature can block (proves the restriction is the floating grant).

`FearEvasionTest` / `UnblockableTest` still pass. OTJ card snapshot re-blessed (only the new card added). `docs/card-sdk-language-reference.md` updated.