### PR TITLE
Add Mourner's Surprise (OTJ) + token activated-ability support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -466,6 +466,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   resolution rather than a fixed integer, pass `dynamicCount = <DynamicAmount>` instead of `count` — the executor
   evaluates it (coerced to ≥ 0) and creates that many tokens (Lobelia Sackville-Baggins, LTR: "create X Treasure
   tokens, where X is the exiled card's power", via `DynamicAmount.EntityProperty(Target(0), Power)`).
+  For an *inline* token (not a registered `CardDefinition`) that has its own abilities, the raw
+  `CreateTokenEffect` constructor exposes `staticAbilities`, `triggeredAbilities`, **and**
+  `activatedAbilities` — each list is granted to every created token at resolution (permanent
+  duration) via `GameState.granted{Static,Triggered,Activated}Abilities`, so the legal-action
+  enumerator and `ActivateAbilityHandler` pick them up like any other granted ability. Example:
+  Mourner's Surprise's "1/1 red Mercenary creature token with \"{T}: Target creature you control
+  gets +1/+0 until end of turn. Activate only as a sorcery.\"" passes a single
+  `ActivatedAbility(cost = AbilityCost.Tap, effect = Effects.ModifyStats(1, 0), targetRequirements =
+  listOf(Targets.CreatureYouControl), timing = TimingRule.SorcerySpeed)`. (Remember a token is a
+  creature, so a `{T}` ability is summoning-sick the turn the token enters.)
 - `CreateDynamicToken(dynamicPower, dynamicToughness, colors?, creatureTypes, keywords?, count?, controller?, imageUri?)` —
   tokens whose P/T is computed at resolution (e.g. Pure Reflection's X/X Reflection where X = the cast spell's mana
   value, via `DynamicAmounts.triggeringManaValue()`). `controller` directs who gets the token (e.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Supertype
+import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.StaticAbility
 import com.wingedsheep.sdk.scripting.TriggeredAbility
@@ -61,6 +62,16 @@ data class CreateTokenEffect(
     val artifactToken: Boolean = false,
     val staticAbilities: List<StaticAbility> = emptyList(),
     val triggeredAbilities: List<TriggeredAbility> = emptyList(),
+    /**
+     * Activated abilities the token has, e.g. a Mercenary token with
+     * `"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."`
+     * (Mourner's Surprise). Each is granted to every created token at resolution via
+     * `GameState.grantedActivatedAbilities` (permanent duration) — the same path the engine
+     * already uses for granted activated abilities, so the legal-action enumerator and
+     * `ActivateAbilityHandler` pick them up for free. The sibling of [staticAbilities] /
+     * [triggeredAbilities] for the activated-ability shape.
+     */
+    val activatedAbilities: List<ActivatedAbility> = emptyList(),
     val exileAtStep: Step? = null,
     val sacrificeAtStep: Step? = null,
     /** Counters to place on the token when it enters the battlefield. */
@@ -114,12 +125,21 @@ data class CreateTokenEffect(
             append(" with ")
             append(keywords.joinToString(", ") { it.name.lowercase() })
         }
+        // Render granted activated abilities as quoted reminder text, e.g.
+        // `with "{T}: Target creature you control gets +1/+0 until end of turn."`.
+        for (ability in activatedAbilities) {
+            append(if (keywords.isEmpty()) " with " else " and ")
+            append("\"${ability.description}\"")
+        }
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): Effect {
         val newCount = count.applyTextReplacement(replacer)
         val newTypes = creatureTypes.map { replacer.replaceCreatureType(it) }.toSet()
-        return if (newCount !== count || newTypes != creatureTypes) copy(count = newCount, creatureTypes = newTypes) else this
+        val newAbilities = activatedAbilities.map { it.applyTextReplacement(replacer) }
+        val abilitiesChanged = newAbilities.zip(activatedAbilities).any { (a, b) -> a !== b }
+        return if (newCount !== count || newTypes != creatureTypes || abilitiesChanged)
+            copy(count = newCount, creatureTypes = newTypes, activatedAbilities = newAbilities) else this
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MournersSurprise.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/MournersSurprise.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Mourner's Surprise
+ * {1}{B}
+ * Sorcery
+ *
+ * Return up to one target creature card from your graveyard to your hand. Create a 1/1 red
+ * Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn.
+ * Activate only as a sorcery."
+ */
+val MournersSurprise = card("Mourner's Surprise") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return up to one target creature card from your graveyard to your hand. " +
+        "Create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets " +
+        "+1/+0 until end of turn. Activate only as a sorcery.\""
+
+    spell {
+        val creatureCard = target(
+            "creature card in your graveyard",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Creature.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+
+        effect = Effects.Move(creatureCard, Zone.HAND) then CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Mercenary"),
+            activatedAbilities = listOf(
+                ActivatedAbility(
+                    cost = AbilityCost.Tap,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    targetRequirements = listOf(Targets.CreatureYouControl),
+                    timing = TimingRule.SorcerySpeed
+                )
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Zuzanna Wużyk"
+        flavorText = "\"Y'all should've known better than to buy me a coffin!\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/980b0b68-7218-49c6-b6bf-022218f3abf4.jpg?1712355617"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -3551,6 +3551,91 @@
     ]
 }
 
+// Mourner's Surprise
+{
+    "name": "Mourner's Surprise",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return up to one target creature card from your graveyard to your hand. Create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature card in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Mercenary"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1712316319",
+                    "activatedAbilities": [
+                        {
+                            "id": "ability_1",
+                            "cost": "CostTap",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "timing": "SorcerySpeed"
+                        }
+                    ]
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "creature card in your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Zuzanna Wużyk",
+        "flavorText": "\"Y'all should've known better than to buy me a coffin!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/980b0b68-7218-49c6-b6bf-022218f3abf4.jpg?1712355617"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Oasis Gardener
 {
     "name": "Oasis Gardener",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -444,7 +444,7 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
         if (types.isEmpty()) return Call("TargetSpell")
         return null
     }
-    if (ttype == "TargetGraveyardCard") {
+    if (ttype == "TargetGraveyardCard" || ttype == "UptoOneTargetGraveyardCard") {
         val blob = compact(args)
         val types = targetTypes(args)
         val filt: Dsl = when {
@@ -458,7 +458,11 @@ internal fun EmitCtx.targetExpr(tnode: JsonObject, actionContext: List<JsonObjec
             types.size == 1 && types.first() in graveyardSingleTypeFilters -> graveyardFilter(graveyardSingleTypeFilters.getValue(types.first()), blob)
             else -> return null
         }
-        return Call("TargetObject", listOf(arg("filter", filt)))
+        // "Return up to one target … card from your graveyard …" (Mourner's Surprise) — the optional
+        // (zero-or-one) variant renders the same filter under `optional = true`.
+        val parts = mutableListOf(arg("filter", filt))
+        if (ttype == "UptoOneTargetGraveyardCard") parts.add(0, arg("optional", "true"))
+        return Call("TargetObject", parts)
     }
     return null
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TokenHandlers.kt
@@ -60,25 +60,40 @@ internal fun EmitCtx.createTokenDsl(spec: JsonObject, count: Int = 1): Dsl? {
             val subs = ((a.getOrNull(4) as? JsonObject)?.get("args").asArr ?: JsonArray(emptyList()))
                 .mapNotNull { it.asStr() }
             if (subs.isEmpty()) return null
-            // The token's ability list (a[5]). Every entry must be a single BARE keyword we can grant;
-            // a granted triggered/activated ability (e.g. a Pest token's "Whenever this token attacks,
-            // you gain 1 life") or a parameterized keyword carries structure CreateToken can't
-            // reproduce, so scaffold rather than silently drop it.
+            // The token's ability list (a[5]). A bare keyword is granted via `keywords = …`; an
+            // `Activated` / `ActivatedWithModifiers` rule (e.g. Mourner's Surprise's Mercenary token
+            // with "{T}: Target creature you control gets +1/+0 … Activate only as a sorcery.") renders
+            // as an inline `ActivatedAbility(…)` via [grantedActivatedAbilityExpr] and is passed through
+            // `CreateTokenEffect.activatedAbilities`. Any other shape (a granted *triggered* ability, a
+            // parameterized keyword, an activated ability we can't render whole) scaffolds rather than
+            // silently drop it.
             val tokenKeywords = mutableListOf<String>()
+            val tokenActivatedAbilities = mutableListOf<Dsl>()
             for (ability in ((a.getOrNull(5) as? JsonArray) ?: JsonArray(emptyList()))) {
                 val abilityRule = ability as? JsonObject ?: return null
                 val rname = abilityRule.strField("_Rule") ?: return null
+                if (rname == "Activated" || rname == "ActivatedWithModifiers") {
+                    tokenActivatedAbilities.add(grantedActivatedAbilityExpr(abilityRule) ?: return null)
+                    continue
+                }
                 if (abilityRule["args"] != null) return null  // TriggerA / parameterized -> SCAFFOLD
                 val kw = pascalToUpperSnake(rname)
                 if (kw !in keywords) return null
                 tokenKeywords.add(kw)
             }
+            // The `Effects.CreateToken` facade can't carry abilities — only the raw `CreateTokenEffect`
+            // constructor exposes `activatedAbilities`. Use it when an activated ability is present;
+            // otherwise keep the tidier facade.
+            val ctor = if (tokenActivatedAbilities.isEmpty()) "Effects.CreateToken" else "CreateTokenEffect"
             val parts = mutableListOf(arg("power", "$power"), arg("toughness", "$toughness"))
             if (colors.isNotEmpty()) parts.add(arg("colors", "setOf(${colors.joinToString(", ") { "Color.$it" }})"))
             parts.add(arg("creatureTypes", "setOf(${subs.joinToString(", ") { "\"$it\"" }})"))
             if (tokenKeywords.isNotEmpty()) parts.add(arg("keywords", "setOf(${tokenKeywords.joinToString(", ") { "Keyword.$it" }})"))
+            if (tokenActivatedAbilities.isNotEmpty()) {
+                parts.add(arg("activatedAbilities", Call("listOf", tokenActivatedAbilities.map { arg(it) })))
+            }
             if (count != 1) parts.add(arg("count", "$count"))
-            return Call("Effects.CreateToken", parts)
+            return Call(ctor, parts)
         }
     }
     return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -27,6 +27,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.event.GrantedActivatedAbility
 import com.wingedsheep.engine.event.GrantedTriggeredAbility
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
@@ -250,6 +251,26 @@ class CreateTokenExecutor(
                     )
                     newState = newState.copy(
                         grantedTriggeredAbilities = newState.grantedTriggeredAbilities + grant
+                    )
+                }
+            }
+        }
+
+        // If activated abilities are specified, grant them permanently to each created token.
+        // Mirrors the triggered-ability path: tokens have no CardDefinition, so their activated
+        // abilities live in GameState.grantedActivatedAbilities, which the legal-action
+        // enumerator and ActivateAbilityHandler already consult for any entity. Models e.g.
+        // Mourner's Surprise's Mercenary token with "{T}: Target creature you control gets +1/+0...".
+        if (effect.activatedAbilities.isNotEmpty()) {
+            for (tokenId in createdTokens) {
+                for (ability in effect.activatedAbilities) {
+                    val grant = GrantedActivatedAbility(
+                        entityId = tokenId,
+                        ability = ability,
+                        duration = Duration.Permanent
+                    )
+                    newState = newState.copy(
+                        grantedActivatedAbilities = newState.grantedActivatedAbilities + grant
                     )
                 }
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MournersSurpriseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MournersSurpriseScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.TimingRule
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mourner's Surprise — {1}{B} Sorcery
+ *
+ * "Return up to one target creature card from your graveyard to your hand. Create a 1/1 red
+ *  Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of
+ *  turn. Activate only as a sorcery.""
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.effects.CreateTokenEffect.activatedAbilities]
+ * field: the created token carries an activated ability, granted to it at resolution via
+ * `GameState.grantedActivatedAbilities`.
+ */
+class MournersSurpriseScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Mourner's Surprise") {
+
+            test("returns a creature card from the graveyard and creates a Mercenary token with its activated ability") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Mourner's Surprise")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val grizzlyInGraveyard = game.state.getGraveyard(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+
+                val cast = game.castSpellTargetingGraveyardCard(1, "Mourner's Surprise", listOf(grizzlyInGraveyard))
+                withClue("Casting Mourner's Surprise should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // Creature card returned from graveyard to hand.
+                withClue("Grizzly Bears should have left the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears").shouldBeFalse()
+                }
+                withClue("Grizzly Bears should be back in hand") {
+                    game.state.getHand(game.player1Id).any {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    } shouldBe true
+                }
+
+                // 1/1 red Mercenary token created.
+                val token = game.findPermanent("Mercenary Token").shouldNotBeNull()
+                val tokenCard = game.state.getEntity(token)!!.get<CardComponent>()!!
+                game.state.getEntity(token)!!.has<TokenComponent>() shouldBe true
+                tokenCard.colors shouldBe setOf(Color.RED)
+                val projected = projector.project(game.state)
+                projected.getPower(token) shouldBe 1
+                projected.getToughness(token) shouldBe 1
+
+                // The token's activated ability was granted to it, sorcery-speed.
+                val grant = game.state.grantedActivatedAbilities.firstOrNull { it.entityId == token }.shouldNotBeNull()
+                withClue("Token's tap ability must be sorcery-speed (\"Activate only as a sorcery\")") {
+                    grant.ability.timing shouldBe TimingRule.SorcerySpeed
+                }
+            }
+
+            test("up to one — casting with no graveyard target still creates the token") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Mourner's Surprise")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellTargetingGraveyardCard(1, "Mourner's Surprise", emptyList())
+                withClue("Casting with zero graveyard targets should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                game.findPermanent("Mercenary Token").shouldNotBeNull()
+            }
+
+            test("the token's {T} ability gives a creature you control +1/+0 until end of turn") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Mourner's Surprise")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(1, "Mourner's Surprise", emptyList())
+                game.resolveStack()
+
+                val token = game.findPermanent("Mercenary Token").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                // The token is a creature — its {T} ability is summoning-sick the turn it enters
+                // (CR 302.6). Clear it so we can exercise the ability itself.
+                game.state = game.state.withEntity(
+                    token, game.state.getEntity(token)!!.without<SummoningSicknessComponent>()
+                )
+
+                val abilityId = game.state.grantedActivatedAbilities.first { it.entityId == token }.ability.id
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = token,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("Activating the token's tap ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Activating a {T} ability taps the token") {
+                    game.state.getEntity(token)!!.has<TappedComponent>() shouldBe true
+                }
+                val projected = projector.project(game.state)
+                withClue("Grizzly Bears should be 3/2 after +1/+0") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Mourner's Surprise** (`{1}{B}` Sorcery, Outlaws of Thunder Junction):

> Return up to one target creature card from your graveyard to your hand. Create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."

The card needed a new engine capability: **tokens that carry an activated ability**. `CreateTokenEffect` could express static and triggered abilities on a token but not activated ones.

## Engine feature — `CreateTokenEffect.activatedAbilities`

- Added an `activatedAbilities: List<ActivatedAbility>` field (sibling of the existing `staticAbilities` / `triggeredAbilities`).
- `CreateTokenExecutor` grants each ability to every created token at resolution via `GameState.grantedActivatedAbilities` with `Duration.Permanent` — the same path the legal-action enumerator and `ActivateAbilityHandler` already consult for *any* entity (tokens have no `CardDefinition`, so their abilities live there). No new enumeration/handler code was needed.
- Cleanup is symmetric with granted triggered abilities: removed when the token leaves the battlefield (`ZoneTransitionService`) and preserved across end-of-turn for `Permanent` grants (`CleanupPhaseManager`).
- Rules-faithful: the token is a creature, so its `{T}` ability is summoning-sick the turn it enters (CR 302.6); the "Activate only as a sorcery" clause maps to `TimingRule.SorcerySpeed`; the graveyard return is genuinely *up to one* (optional target).

## mtgish tooling — auto-generation taught (fidelity tier **AUTO**)

- `UptoOneTargetGraveyardCard` target recovery — the optional "up to one target … card from your graveyard" variant, reusable across many cards.
- `createTokenDsl` now renders an embedded `Activated` / `ActivatedWithModifiers` rule on a creature token as an inline `ActivatedAbility(...)` through `CreateTokenEffect.activatedAbilities` (raw constructor, since the `Effects.CreateToken` facade carries no abilities), reusing the existing `grantedActivatedAbilityExpr`.
- The capability bridge already scored every tag — probe verdict is COVERABLE-NOW, no bridge change.

## Tests / verification

- New `MournersSurpriseScenarioTest`: graveyard return, token characteristics + granted sorcery-speed tap ability, the up-to-one (zero-target) case, and the +1/+0 pump.
- `CardDefinitionSnapshotTest` re-blessed (only Mourner's Surprise added to `OTJ.json`).
- Emitter regression: POR + EOE goldens unchanged (`EmitterGoldenTest`); `coverage-verify POR` gate still **158/158** compile + gameplay-tree match.
- `check-card-printing` confirms OTJ as the canonical (only) printing.
- Updated `docs/card-sdk-language-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)