### PR TITLE
Add Steer Clear with cast-time condition capture ("as you cast")

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2387,6 +2387,25 @@ Other gates available in both contexts:
   the enum name): `CastChoiceIs(ChoiceSlot.MODE, "Khans")`, `CastChoiceIs(ChoiceSlot.COLOR, "RED")`. The
   generic slot reader new cards should prefer over per-slot conditions; the §8 emitter target for
   mtgish's `TheChosenColor`/`TheChosenCreatureType` guards.
+- `CapturedAtCast("flag")` — the named **"as you cast this spell"** condition capture (CR 601.2i) was
+  true the moment the spell was cast. Pairs with the spell DSL `captureAtCast("flag", condition)`: the
+  engine evaluates `condition` (caster as controller) as the spell finishes being cast and freezes the
+  names whose condition held onto `SpellOnStackComponent.castTimeFlags`; this reads the frozen answer at
+  resolution, so a later board change can't flip the branch. Distinct from the player-choice slot guards
+  above — those read what the player *chose*, this reads whether a game condition *held*. Used by Steer
+  Clear ("deals 4 damage instead if you controlled a Mount as you cast this spell"):
+
+  ```kotlin
+  spell {
+      captureAtCast("controlledMount", Conditions.ControlCreatureOfType(Subtype("Mount")))
+      val creature = target("target", TargetPermanent(filter = TargetFilter.AttackingOrBlockingCreature))
+      effect = ConditionalEffect(
+          condition = Conditions.CapturedAtCast("controlledMount"),
+          effect = Effects.DealDamage(4, creature),
+          elseEffect = Effects.DealDamage(2, creature),
+      )
+  }
+  ```
 
 **Cast-choice slots (`ChoiceSlot`).** The choices an object locks in *as it is cast / as it enters*
 (CR 601.2b) — color, creature type, land type, mode, chosen creature, kicked-ness, blight amount — all

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1168,7 +1168,8 @@ class CardBuilder(private val name: String) {
             selfExileOnResolve = spellBuilder?.exilesOnResolve ?: false,
             selfAlternativeCost = selfAlternativeCost,
             xManaRestriction = spellBuilder?.xManaRestriction ?: emptySet(),
-            mayStartOnBattlefield = mayStartOnBattlefield
+            mayStartOnBattlefield = mayStartOnBattlefield,
+            castTimeCaptures = spellBuilder?.castTimeCaptures ?: emptyList()
         )
 
         // Build metadata
@@ -1325,6 +1326,24 @@ class SpellBuilder {
 
     internal val restrictions: List<CastRestriction>
         get() = castRestrictions.toList()
+
+    // Cast-time condition captures ("as you cast this spell")
+    private val castTimeCaptureList: MutableList<CastTimeCapture> = mutableListOf()
+
+    /**
+     * Capture, *as this spell is cast* (CR 601.2i), whether [condition] holds, storing the answer
+     * under [flag]. The spell's effect reads it back at resolution via
+     * `Conditions.CapturedAtCast(flag)` ([com.wingedsheep.sdk.scripting.conditions.CastTimeFlagSet]),
+     * so the branch reflects the cast-time board even if it has since changed.
+     *
+     * Used for "if you controlled a Mount as you cast this spell" (Steer Clear).
+     */
+    fun captureAtCast(flag: String, condition: Condition) {
+        castTimeCaptureList.add(CastTimeCapture(flag, condition))
+    }
+
+    internal val castTimeCaptures: List<CastTimeCapture>
+        get() = castTimeCaptureList.toList()
 
     /**
      * Declare a named target and get an EffectTarget reference to use in effects.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.sdk.scripting.conditions.WasKicked as WasKickedCondition
 import com.wingedsheep.sdk.scripting.conditions.BlightWasPaid as BlightWasPaidCondition
 import com.wingedsheep.sdk.scripting.conditions.CastChoiceMade as CastChoiceMadeCondition
 import com.wingedsheep.sdk.scripting.conditions.CastChoiceIs as CastChoiceIsCondition
+import com.wingedsheep.sdk.scripting.conditions.CastTimeFlagSet as CastTimeFlagSetCondition
 import com.wingedsheep.sdk.scripting.conditions.SourceMatches
 import com.wingedsheep.sdk.scripting.conditions.SourceIsRingBearer as SourceIsRingBearerCondition
 import com.wingedsheep.sdk.scripting.conditions.YouChoseOtherCreatureAsRingBearer as YouChoseOtherCreatureAsRingBearerCondition
@@ -507,6 +508,15 @@ object Conditions {
      */
     fun CastChoiceIs(slot: com.wingedsheep.sdk.scripting.ChoiceSlot, value: String): ConditionInterface =
         CastChoiceIsCondition(slot, value)
+
+    /**
+     * If the named cast-time capture [flag] was true *as the source spell was cast* (CR 601.2i).
+     * Pairs with the `captureAtCast(flag, condition)` spell DSL: the engine freezes the cast-time
+     * answer onto the spell, and this reads it back at resolution regardless of later board changes.
+     * Used by Steer Clear ("deals 4 damage instead if you controlled a Mount as you cast this spell").
+     */
+    fun CapturedAtCast(flag: String): ConditionInterface =
+        CastTimeFlagSetCondition(flag)
 
     /**
      * If specific colored mana was spent to cast this spell.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
@@ -247,7 +247,20 @@ data class CardScript(
      *
      * Wired via the `leyline()` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder].
      */
-    val mayStartOnBattlefield: Boolean = false
+    val mayStartOnBattlefield: Boolean = false,
+
+    /**
+     * "As you cast this spell" condition captures (CR 601.2i). Each is a named condition the engine
+     * evaluates the moment this spell finishes being cast; the names whose condition was true are
+     * frozen onto the spell on the stack and read back at resolution via
+     * [com.wingedsheep.sdk.scripting.conditions.CastTimeFlagSet]. Lets a spell branch on the
+     * cast-time board state rather than the (possibly changed) resolution-time board — e.g. Steer
+     * Clear "deals 4 damage instead if you controlled a Mount as you cast this spell".
+     *
+     * Declared with the `captureAtCast(flag, condition)` DSL on a spell. Empty for the vast
+     * majority of spells.
+     */
+    val castTimeCaptures: List<CastTimeCapture> = emptyList()
 ) {
     /**
      * Whether this card has any scripted behavior.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CastTimeCapture.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CastTimeCapture.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.sdk.scripting
+
+import com.wingedsheep.sdk.scripting.conditions.Condition
+import kotlinx.serialization.Serializable
+
+/**
+ * One "as you cast this spell" condition capture (CR 601.2i).
+ *
+ * A spell may carry a list of these. The engine evaluates each [condition] against the game state
+ * the moment the spell finishes being cast (after costs are paid, before it goes on the stack) with
+ * the caster as the controller, and records the [flag] names whose condition was true onto the spell
+ * on the stack. The spell's resolving effect then branches on the frozen answer via
+ * [com.wingedsheep.sdk.scripting.conditions.CastTimeFlagSet], so a later board change can't alter it.
+ *
+ * This is the cast-time sibling of the player-choice [ChoiceSlot] bag: those record what the player
+ * *chose* as they cast; this records whether a game [condition] *held* as they cast. Declared with
+ * the `captureAtCast(flag, condition)` DSL on a spell; read with `Conditions.CapturedAtCast(flag)`.
+ *
+ * Used by Steer Clear ("deals 4 damage instead if you controlled a Mount as you cast this spell").
+ *
+ * @property flag The capture name; the same name is read back by `CastTimeFlagSet`.
+ * @property condition The condition to evaluate at cast time (e.g. "you control a Mount").
+ */
+@Serializable
+data class CastTimeCapture(
+    val flag: String,
+    val condition: Condition
+)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
@@ -332,6 +332,29 @@ data class CastChoiceIs(
 }
 
 /**
+ * Condition: the named cast-time capture [flag] was true *as the source spell was cast* (CR 601.2i).
+ *
+ * The reader half of the cast-time condition-capture mechanic
+ * ([com.wingedsheep.sdk.scripting.CastTimeCapture]). A spell declares, via the `captureAtCast`
+ * DSL, one or more named conditions evaluated the moment it finishes being cast; the engine records
+ * the names that were true onto the spell on the stack. At resolution the spell's own effect reads
+ * the recorded flag through this condition, so "deals 4 damage instead if you controlled a Mount as
+ * you cast this spell" (Steer Clear) stays true even if the Mount has since left — the read is of
+ * the frozen cast-time answer, not the current board.
+ *
+ * Distinct from the player-choice slot conditions [CastChoiceMade] / [CastChoiceIs]: those read a
+ * value the player *chose* (a color, a mode); this reads whether an automatically-evaluated game
+ * condition *held* at cast time.
+ *
+ * @property flag The capture name to read (matches the name given to `captureAtCast`).
+ */
+@SerialName("CastTimeFlagSet")
+@Serializable
+data class CastTimeFlagSet(val flag: String) : Condition {
+    override val description: String = "if \"$flag\" was true as this spell was cast"
+}
+
+/**
  * Condition: "If a [subtype] was sacrificed this way"
  * Checks whether any permanent sacrificed as part of the cost had the given subtype
  * (using projected subtypes snapshotted at time of sacrifice).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SteerClear.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/SteerClear.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.otj.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Steer Clear
+ * {W}
+ * Instant
+ *
+ * Steer Clear deals 2 damage to target attacking or blocking creature. Steer Clear deals 4 damage
+ * to that creature instead if you controlled a Mount as you cast this spell.
+ *
+ * "As you cast this spell" is a cast-time condition capture (CR 601.2i): whether you controlled a
+ * Mount is locked in the moment the spell is cast and read back at resolution, so losing the Mount
+ * before resolution doesn't drop the damage to 2 (per the OTJ ruling). Modeled with the
+ * `captureAtCast` DSL + `Conditions.CapturedAtCast`; the [ConditionalEffect] picks the 4- or 2-damage
+ * branch against the frozen answer.
+ */
+val SteerClear = card("Steer Clear") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Steer Clear deals 2 damage to target attacking or blocking creature. Steer Clear " +
+        "deals 4 damage to that creature instead if you controlled a Mount as you cast this spell."
+
+    spell {
+        captureAtCast("controlledMount", Conditions.ControlCreatureOfType(Subtype("Mount")))
+        val creature = target("target", TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature))
+        effect = ConditionalEffect(
+            condition = Conditions.CapturedAtCast("controlledMount"),
+            effect = Effects.DealDamage(4, creature),
+            elseEffect = Effects.DealDamage(2, creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Edgar Sánchez Hidalgo"
+        flavorText = "\"Just because you can saddle a critter, doesn't mean it'll let you ride.\"\n—Annie Flash"
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/523a4d6e-122b-49b4-bf3d-17d29c0007fb.jpg?1712355352"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -4819,6 +4819,90 @@
     ]
 }
 
+// Steer Clear
+{
+    "name": "Steer Clear",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Steer Clear deals 2 damage to target attacking or blocking creature. Steer Clear deals 4 damage to that creature instead if you controlled a Mount as you cast this spell.",
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "CastTimeFlagSet",
+                    "flag": "controlledMount"
+                }
+            },
+            "then": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 4
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target"
+                }
+            },
+            "otherwise": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target"
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ],
+        "castTimeCaptures": [
+            {
+                "flag": "controlledMount",
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature Mount"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "artist": "Edgar Sánchez Hidalgo",
+        "flavorText": "\"Just because you can saddle a critter, doesn't mean it'll let you ride.\"\n—Annie Flash",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/523a4d6e-122b-49b4-bf3d-17d29c0007fb.jpg?1712355352"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Sterling Hound
 {
     "name": "Sterling Hound",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -75,6 +75,12 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     envelope("ChooseACreatureType", UNIVERSAL)
     envelope("ChooseAColor", UNIVERSAL)
     envelope("IfElse", UNIVERSAL)
+    // "[Effect]. [Bigger effect] instead if you controlled a [filter] as you cast this spell" — the OTJ
+    // cast-time condition capture (CR 601.2i). Structural: the capability is the nested condition
+    // (PlayerPassesFilter) and the two branch effects, scored on their own. The engine freezes the
+    // condition at cast via `captureAtCast` and reads it with `Conditions.CapturedAtCast`; the emitter's
+    // castTimeCaptureSpell renders the fixed-damage shape (Steer Clear) and scaffolds {X} arms.
+    envelope("Modal_IfElse", "envelope: 'as you cast this spell' cast-time condition capture (CR 601.2i)")
 
     // "As ~ enters the battlefield …" — a replacement-effect wrapper. It carries no capability itself;
     // each nested `_ReplacementActionWouldEnter` (enters tapped, enters with a counter, choose a type, …)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -327,7 +327,79 @@ private fun EmitCtx.youHaventCastASpellConditionDsl(cond: JsonObject?): String? 
     return null
 }
 
+/**
+ * The (target list, inner action list) of a mtgish `Targeted` action node, or null if it isn't a
+ * Targeted envelope. Mirrors [extractEnvelope]'s Targeted unpacking for a single known node.
+ */
+private fun targetedArms(node: JsonObject): Pair<List<JsonObject>?, List<JsonObject>>? {
+    if (node.strField("_Actions") != "Targeted") return null
+    val args = node["args"].asArr ?: return null
+    if (args.size < 2) return null
+    val targets = (args[0].asArr)?.filterIsInstance<JsonObject>()
+    val actions = (args[1] as? JsonObject)?.get("args").asArr?.filterIsInstance<JsonObject>() ?: return null
+    return targets to actions
+}
+
+/** A stable capture-flag name derived from a `ControlsA(IsCreatureType X)` condition — "controlledMount"
+ *  for Steer Clear — so the emitted `captureAtCast` / `CapturedAtCast` pair agrees on one name. */
+private fun castCaptureFlagName(cond: JsonObject): String {
+    val sub = Regex(""""IsCreatureType",\s*"args":\s*"(\w+)"""").find(compact(cond))?.groupValues?.get(1)
+    return if (sub != null) "controlled$sub" else "controlledMatchingPermanent"
+}
+
+/**
+ * "As you cast this spell" condition-capture spell (CR 601.2i): mtgish models it as a
+ * `SpellActions { Modal_IfElse(PlayerPassesFilter(You, ControlsA(filter)), <then Targeted>, <else
+ * Targeted>) }`. In this corpus that envelope is *always* an "as you cast this spell" capture (Steer
+ * Clear / Faerie Fencing / Flame Discharge), so it renders to the engine's cast-time capture
+ * (`captureAtCast` + `Conditions.CapturedAtCast`) — NOT a resolution-time `ConditionalEffect` over the
+ * current board, which would resolve the Mount/Faerie/modified test at the wrong time.
+ *
+ * Renders only the shapes we can express exactly: a `You + ControlsA(filter)` condition, one shared
+ * target across both arms, and both arms a renderable effect list. The {X}-valued arms (Faerie
+ * Fencing's -X/-X, Flame Discharge's X damage) decline through the inner [renderEffectList] ->
+ * SCAFFOLD, in step with the engine's still-sloppy cast-time-X handling. Steer Clear's fixed 2/4
+ * damage renders whole.
+ */
+private fun EmitCtx.castTimeCaptureSpell(card: JsonObject): List<Stmt>? {
+    val modal = (card["Rules"].asArr ?: return null).filterIsInstance<JsonObject>()
+        .firstNotNullOfOrNull { rule ->
+            (rule["args"] as? JsonObject)?.takeIf { it.strField("_Actions") == "Modal_IfElse" }
+        } ?: return null
+    val margs = modal["args"].asArr ?: return null
+    if (margs.size < 3) return null
+    val cond = margs[0] as? JsonObject ?: return null
+    val thenArm = margs[1] as? JsonObject ?: return null
+    val elseArm = margs[2] as? JsonObject ?: return null
+
+    // Condition: "you control a [filter]" — declines (-> SCAFFOLD) for anything else.
+    val condDsl = youControlConditionDsl(cond) ?: return null
+    val flag = castCaptureFlagName(cond)
+
+    val (thenTargets, thenActions) = targetedArms(thenArm) ?: return null
+    val (_, elseActions) = targetedArms(elseArm) ?: return null
+    // One shared target (both arms hit the same creature); render it once from the then-arm.
+    val (tnode, tvar) = spellTargetExpr(thenTargets, thenActions) ?: return null
+    if (tvar == null || tnode == null) return null
+    val thenEffect = renderEffectList(thenActions, tvar) ?: return null
+    val elseEffect = renderEffectList(elseActions, tvar) ?: return null
+
+    val stmts = mutableListOf<Stmt>()
+    stmts.add(RawLine("        captureAtCast(\"$flag\", $condDsl)"))
+    stmts.add(targetLocal(tnode))
+    stmts.add(Assign("effect", call(
+        "ConditionalEffect",
+        arg("condition", Lit("Conditions.CapturedAtCast(\"$flag\")")),
+        arg("effect", thenEffect),
+        arg("elseEffect", elseEffect),
+    )))
+    return listOf(Sub(Block("spell", stmts)))
+}
+
 internal fun EmitCtx.spellBlock(card: JsonObject): List<Stmt>? {
+    // "As you cast this spell" cast-time captures arrive as a `Modal_IfElse` envelope; render them
+    // (the cast-time form) before the generic modal guard below scaffolds everything `Modal_*`.
+    castTimeCaptureSpell(card)?.let { return it }
     // Modal spells ("Choose one —", "Choose up to four", …) carry a `Modal_*` envelope whose children
     // are the individual modes. The generic envelope path below would grab only the FIRST mode and
     // silently drop the rest, so scaffold the whole card rather than emit one arm of a modal spell.

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/CastTimeCaptureEmitterTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/CastTimeCaptureEmitterTest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.tooling.coverage
+
+import com.wingedsheep.tooling.coverage.emitter.Emitter
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Regression net for the `Modal_IfElse` "as you cast this spell" cast-time condition-capture handler
+ * (CR 601.2i). Hermetic: feeds Steer Clear's exact mtgish IR (no 29 MB corpus, no network) and pins
+ * that the emitter renders the cast-time form — `captureAtCast(...)` + `Conditions.CapturedAtCast(...)`
+ * over a `ConditionalEffect`, NOT a resolution-time conditional that would test the Mount at the wrong
+ * time. The two {X}-valued cards sharing the envelope (Faerie Fencing, Flame Discharge) intentionally
+ * decline to SCAFFOLD through the inner effect renderer, so this fixed-damage card is the AUTO case.
+ */
+class CastTimeCaptureEmitterTest : StringSpec({
+
+    val effects = Registry.loadEffectSerialNames()
+    val keywords = Registry.loadKeywords()
+
+    // Steer Clear's IR verbatim from the mtgish corpus.
+    val steerClearIr = """
+        {"_OracleCard":"Card","Name":"Steer Clear","Typeline":{"Supertypes":[],"Cardtypes":["Instant"],"Subtypes":[]},"ManaCost":[{"_ManaSymbol":"ManaCostW"}],"Rules":[{"_Rule":"SpellActions","args":{"_Actions":"Modal_IfElse","args":[{"_Condition":"PlayerPassesFilter","args":[{"_Player":"You"},{"_Players":"ControlsA","args":{"_Permanents":"IsCreatureType","args":"Mount"}}]},{"_Actions":"Targeted","args":[[{"_Target":"TargetPermanent","args":{"_Permanents":"And","args":[{"_Permanents":"Or","args":[{"_Permanents":"IsAttacking"},{"_Permanents":"IsBlocking"}]},{"_Permanents":"IsCardtype","args":"Creature"}]}}],{"_Actions":"ActionList","args":[{"_Action":"SpellDealsDamage","args":[{"_Spell":"ThisSpell"},{"_GameNumber":"Integer","args":4},{"_DamageRecipient":"Permanent","args":{"_Permanent":"Ref_TargetPermanent"}}]}]}]},{"_Actions":"Targeted","args":[[{"_Target":"TargetPermanent","args":{"_Permanents":"And","args":[{"_Permanents":"Or","args":[{"_Permanents":"IsAttacking"},{"_Permanents":"IsBlocking"}]},{"_Permanents":"IsCardtype","args":"Creature"}]}}],{"_Actions":"ActionList","args":[{"_Action":"SpellDealsDamage","args":[{"_Spell":"ThisSpell"},{"_GameNumber":"Integer","args":2},{"_DamageRecipient":"Permanent","args":{"_Permanent":"Ref_TargetPermanent"}}]}]}]}]}}]}
+    """.trimIndent()
+
+    "Steer Clear renders the cast-time capture form whole (AUTO)" {
+        val card = Json.parseToJsonElement(steerClearIr) as JsonObject
+        val result = Emitter.renderCard(card, scryfall = null, effects = effects, keywords = keywords)
+
+        result.complete shouldBe true
+        // The capture is declared as you cast, and read back at resolution — not a board re-check.
+        result.text shouldContain "captureAtCast(\"controlledMount\", Conditions.YouControl"
+        result.text shouldContain "withSubtype(\"Mount\")"
+        result.text shouldContain "condition = Conditions.CapturedAtCast(\"controlledMount\")"
+        // 4-damage then-branch, 2-damage else-branch, both on the one shared target.
+        result.text shouldContain "effect = DealDamageEffect(4, t)"
+        result.text shouldContain "elseEffect = DealDamageEffect(2, t)"
+        result.text shouldContain "TargetFilter.AttackingOrBlockingCreature"
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -66,6 +66,7 @@ import com.wingedsheep.sdk.scripting.conditions.SourceIsModified
 import com.wingedsheep.sdk.scripting.conditions.SourceChosenModeIs
 import com.wingedsheep.sdk.scripting.conditions.CastChoiceMade
 import com.wingedsheep.sdk.scripting.conditions.CastChoiceIs
+import com.wingedsheep.sdk.scripting.conditions.CastTimeFlagSet
 import com.wingedsheep.sdk.scripting.conditions.SourceMatches
 import com.wingedsheep.engine.state.components.battlefield.CastForImpendingComponent
 import com.wingedsheep.sdk.scripting.ChoiceSlot
@@ -310,6 +311,17 @@ class ConditionEvaluator(
                 val sourceId = ctx.sourceId
                 sourceId != null &&
                     castChoiceMatches(state.getEntity(sourceId), condition.slot, condition.value)
+            }
+            is CastTimeFlagSet -> {
+                // The "as you cast this spell" capture, frozen onto the spell on the stack at cast
+                // (CR 601.2i). Read here at resolution so the answer reflects the cast-time board
+                // even after a later change (Steer Clear). The spell entity keeps its id across the
+                // hand→stack boundary, so the resolving effect's sourceId locates it.
+                val sourceId = ctx.sourceId
+                sourceId != null &&
+                    state.getEntity(sourceId)
+                        ?.get<com.wingedsheep.engine.state.components.stack.SpellOnStackComponent>()
+                        ?.castTimeFlags?.contains(condition.flag) == true
             }
             is SacrificedPermanentHadSubtype -> ifResolution { evaluateSacrificedPermanentHadSubtype(condition, it) }
             is SacrificedPermanentWasLegendary -> ifResolution { evaluateSacrificedPermanentWasLegendary(it) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -2180,6 +2180,29 @@ class CastSpellHandler(
             action.modeTargetsOrdered
         }
 
+        // Evaluate "as you cast this spell" condition captures (CR 601.2i). The spell has finished
+        // being cast (costs paid) but isn't on the stack yet; freezing the answers now lets the
+        // resolving effect read the cast-time board even if it has since changed (Steer Clear's
+        // "if you controlled a Mount as you cast this spell"). The caster is the controller; the
+        // captured names are carried onto SpellOnStackComponent.castTimeFlags.
+        val castTimeScript = action.faceIndex?.let { cardDef?.cardFaces?.getOrNull(it)?.script } ?: cardDef?.script
+        val castTimeCaptures = castTimeScript?.castTimeCaptures.orEmpty()
+        val castTimeFlags: Set<String> = if (castTimeCaptures.isEmpty()) {
+            emptySet()
+        } else {
+            val captureContext = EffectContext(
+                sourceId = action.cardId,
+                controllerId = action.playerId,
+                opponentId = currentState.turnOrder.firstOrNull { it != action.playerId },
+                targets = emptyList(),
+                xValue = 0
+            )
+            castTimeCaptures
+                .filter { conditionEvaluator.evaluate(currentState, it.condition, captureContext) }
+                .map { it.flag }
+                .toSet()
+        }
+
         // Cast the spell
         val castResult = stackResolver.castSpell(
             currentState,
@@ -2213,7 +2236,8 @@ class CastSpellHandler(
             manaSpentColorless = manaSpentEvent?.colorless ?: 0,
             manaSpentOnXByColor = paymentResult.xManaSpentByColor,
             faceIndex = action.faceIndex,
-            paidWithTreasureMana = paymentResult.paidWithTreasureMana
+            paidWithTreasureMana = paymentResult.paidWithTreasureMana,
+            castTimeFlags = castTimeFlags
         )
 
         if (!castResult.isSuccess) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -129,7 +129,8 @@ class StackResolver(
         manaSpentColorless: Int = 0,
         manaSpentOnXByColor: Map<Color, Int> = emptyMap(),
         faceIndex: Int? = null,
-        paidWithTreasureMana: Boolean = false
+        paidWithTreasureMana: Boolean = false,
+        castTimeFlags: Set<String> = emptySet()
     ): ExecutionResult {
         val container = state.getEntity(cardId)
             ?: return ExecutionResult.error(state, "Card not found: $cardId")
@@ -190,7 +191,8 @@ class StackResolver(
                 manaSpentGreen = manaSpentGreen,
                 manaSpentColorless = manaSpentColorless,
                 manaSpentOnXByColor = manaSpentOnXByColor,
-                faceIndex = faceIndex
+                faceIndex = faceIndex,
+                castTimeFlags = castTimeFlags
             ))
             if (effectiveTargets.isNotEmpty()) {
                 updated = updated.with(TargetsComponent(effectiveTargets, effectiveTargetRequirements))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -64,7 +64,15 @@ data class SpellOnStackComponent(
      * can attach a [com.wingedsheep.engine.state.components.identity.RoomComponent] with
      * the correct face unlocked. `null` for normal single-face cards.
      */
-    val faceIndex: Int? = null
+    val faceIndex: Int? = null,
+    /**
+     * Names of the "as you cast this spell" condition captures (CR 601.2i) whose condition was true
+     * the moment this spell finished being cast. Frozen here so the resolving effect can branch on
+     * the cast-time board via [com.wingedsheep.sdk.scripting.conditions.CastTimeFlagSet] even after
+     * the board has changed (e.g. Steer Clear's "if you controlled a Mount as you cast this spell").
+     * Declared on the card via the `captureAtCast` DSL.
+     */
+    val castTimeFlags: Set<String> = emptySet()
 ) : Component
 
 /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SteerClearCastTimeCaptureTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SteerClearCastTimeCaptureTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.GiantBeaver
+import com.wingedsheep.mtg.sets.definitions.otj.cards.SteerClear
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Steer Clear: {W} Instant
+ * Steer Clear deals 2 damage to target attacking or blocking creature. Steer Clear deals 4 damage
+ * to that creature instead if you controlled a Mount as you cast this spell.
+ *
+ * Exercises the cast-time condition capture (CR 601.2i): whether the caster controlled a Mount is
+ * frozen the moment the spell is cast, so a later board change can't flip the 4-vs-2 branch. Per the
+ * OTJ ruling, losing the Mount before resolution still deals 4; gaining one after the cast still
+ * deals 2. The Mount is removed/added mid-stack via the trigger-free `moveToGraveyard` /
+ * `putCreatureOnBattlefield` test helpers.
+ */
+class SteerClearCastTimeCaptureTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SteerClear, GiantBeaver))
+        return driver
+    }
+
+    /** Attacker declares an attack; priority is handed to [caster] in the declare-attackers step. */
+    fun GameTestDriver.attackThenGiveCasterPriority(
+        attacker: EntityId,
+        caster: EntityId,
+        attackingCreature: EntityId,
+    ) {
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        declareAttackers(attacker, listOf(attackingCreature), caster)
+        // Active player holds priority first in the declare-attackers step; pass it to the caster.
+        passPriority(attacker)
+        state.priorityPlayerId shouldBe caster
+    }
+
+    fun GameTestDriver.onBattlefield(playerId: EntityId, entityId: EntityId): Boolean =
+        state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD)).contains(entityId)
+
+    test("controlled a Mount as cast: still deals 4 even though the Mount left before resolution") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val caster = driver.getOpponent(attacker)
+
+        // The attacker's 3/3 — survives 2 damage, dies to 4.
+        val courser = driver.putCreatureOnBattlefield(attacker, "Centaur Courser")
+        driver.removeSummoningSickness(courser)
+        // The caster controls a Mount and holds Steer Clear.
+        val mount = driver.putCreatureOnBattlefield(caster, "Giant Beaver")
+        val steer = driver.putCardInHand(caster, "Steer Clear")
+        driver.giveMana(caster, Color.WHITE, 1)
+
+        driver.attackThenGiveCasterPriority(attacker, caster, courser)
+
+        val cast = driver.submit(
+            CastSpell(
+                playerId = caster,
+                cardId = steer,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        (cast.error == null) shouldBe true
+
+        // The Mount leaves while Steer Clear is on the stack — the cast-time answer must hold.
+        driver.moveToGraveyard(mount)
+        driver.bothPass()
+
+        // 4 damage killed the 3/3.
+        driver.onBattlefield(attacker, courser) shouldBe false
+        driver.assertInGraveyard(attacker, "Centaur Courser")
+    }
+
+    test("no Mount as cast: deals only 2 — the 3/3 survives") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val caster = driver.getOpponent(attacker)
+
+        val courser = driver.putCreatureOnBattlefield(attacker, "Centaur Courser")
+        driver.removeSummoningSickness(courser)
+        // No Mount on the caster's side.
+        val steer = driver.putCardInHand(caster, "Steer Clear")
+        driver.giveMana(caster, Color.WHITE, 1)
+
+        driver.attackThenGiveCasterPriority(attacker, caster, courser)
+
+        val cast = driver.submit(
+            CastSpell(
+                playerId = caster,
+                cardId = steer,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        (cast.error == null) shouldBe true
+        driver.bothPass()
+
+        // Only 2 damage — the 3/3 is still on the battlefield (combat damage hasn't happened yet).
+        driver.onBattlefield(attacker, courser) shouldBe true
+        driver.getCardName(courser) shouldBe "Centaur Courser"
+    }
+
+    test("no Mount as cast: gaining a Mount before resolution still deals only 2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val caster = driver.getOpponent(attacker)
+
+        val courser = driver.putCreatureOnBattlefield(attacker, "Centaur Courser")
+        driver.removeSummoningSickness(courser)
+        val steer = driver.putCardInHand(caster, "Steer Clear")
+        driver.giveMana(caster, Color.WHITE, 1)
+
+        driver.attackThenGiveCasterPriority(attacker, caster, courser)
+
+        val cast = driver.submit(
+            CastSpell(
+                playerId = caster,
+                cardId = steer,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        (cast.error == null) shouldBe true
+
+        // A Mount enters after the cast — the frozen "no Mount" answer must hold.
+        driver.putCreatureOnBattlefield(caster, "Giant Beaver")
+        driver.bothPass()
+
+        driver.onBattlefield(attacker, courser) shouldBe true
+        driver.getCardName(courser) shouldBe "Centaur Courser"
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Steer Clear** ({W} Instant, Outlaws of Thunder Junction):

> Steer Clear deals 2 damage to target attacking or blocking creature. Steer Clear deals 4 damage to that creature instead **if you controlled a Mount as you cast this spell.**

The **"as you cast this spell"** clause is a genuine cast-time capture (CR 601.2i), not a resolution-time intervening-if. Per the [OTJ ruling](https://scryfall.com/card/otj/31), if you controlled a Mount *as you finished casting*, it still deals 4 even if the Mount is gone by the time the spell resolves. This required a new engine primitive.

## New SDK primitive — cast-time condition capture

- `CastTimeCapture(flag, condition)` + `CardScript.castTimeCaptures`
- `captureAtCast(flag, condition)` spell DSL
- `CastTimeFlagSet` condition + `Conditions.CapturedAtCast(flag)` reader

The sibling of the existing player-choice `ChoiceSlot` bag: those record what the player *chose* as they cast; this records whether a game *condition held* as they cast.

## Engine wiring

- `CastSpellHandler` evaluates each declared capture against the cast-time state (caster as controller, after costs are paid) and records the flags whose condition held
- `SpellOnStackComponent.castTimeFlags` freezes them on the spell
- `ConditionEvaluator` reads them back at resolution; the card's `ConditionalEffect` picks the 4- or 2-damage branch against the frozen answer

No continuations (synchronous gate), no cleanup (stack-scoped), no new events / DTO / frontend (the capture is automatic and invisible — the player just uses standard creature targeting).

## mtgish generator

The corpus models this as `Modal_IfElse(PlayerPassesFilter(You, ControlsA(filter)), then, else)`. All three cards using that envelope (Steer Clear, Faerie Fencing, Flame Discharge) are "as you cast" captures, so the tag maps reliably to the new mechanic.

- **Bridge:** `Modal_IfElse` envelope → these cards now score `COVERABLE-NOW`
- **Emitter:** new handler renders the fixed-damage shape (Steer Clear) as the cast-time form and declines the `{X}` arms (Faerie Fencing's -X/-X, Flame Discharge's X damage) to SCAFFOLD, matching the engine's still-sloppy cast-time-X handling

`just coverage-fidelity --emit "Steer Clear"` now tiers **AUTO**.

## Tests

- `SteerClearCastTimeCaptureTest` (rules-engine) proves the freeze in **both** directions: Mount leaves after cast → still 4; no Mount at cast then a Mount enters → still 2; plus the plain no-Mount → 2 path
- `CastTimeCaptureEmitterTest` (mtgish-tooling) pins the emitter render off Steer Clear's exact IR
- Card snapshot re-blessed (OTJ.json: only Steer Clear added)
- Full suites green: `:mtg-sdk` · `:rules-engine` · `:mtgish-tooling` · `:mtg-sets` · `:game-server`
- `docs/card-sdk-language-reference.md` updated with the new condition + DSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)