### PR TITLE
Fix Shadow Urchin may-play window leaking an extra turn

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
@@ -78,6 +78,16 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
      * Resolve which turn's cleanup will mark "the controller's next [step]" given the
      * current step and active player. The cleanup-driven removal is coarse — it runs once
      * per turn at cleanup — so we map any step in the turn to that turn's cleanup.
+     *
+     * The returned value is a *round* number, because [GameState.turnNumber] is round-based —
+     * it increments only when the starting player begins a new turn, so every player's turn
+     * within a round shares the same number. The cleanup expiry check disambiguates which
+     * player's turn it is by also requiring `activePlayerId == controllerId`; this function
+     * therefore only has to name the round in which the controller's next matching turn falls.
+     * Counting *player-turns* until the controller's turn (and adding them to a round-based
+     * number) over-counts whenever the grant happens on an opponent's turn — the bug that let
+     * "until your next end step" leak an extra full turn when a creature died on the opponent's
+     * turn (Shadow Urchin).
      */
     private fun resolveStepTurn(
         state: GameState,
@@ -87,22 +97,21 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
         val turnOrder = state.turnOrder
         val playerIndex = turnOrder.indexOf(controllerId)
         val activeIndex = turnOrder.indexOf(state.activePlayerId)
-        val playerCount = turnOrder.size
 
         val onControllerTurn = playerIndex == activeIndex
         val targetStep = expiry.step
         val targetReachedThisTurn = state.step.ordinal >= targetStep.ordinal
         val thisTurnStillCounts = onControllerTurn && expiry.includeCurrentTurn && !targetReachedThisTurn
 
-        return if (thisTurnStillCounts) {
-            state.turnNumber
-        } else {
-            val turnsUntilNext = if (onControllerTurn) {
-                1
-            } else {
-                (playerIndex - activeIndex + playerCount) % playerCount
-            }
-            state.turnNumber + turnsUntilNext
+        return when {
+            // This turn's matching step still counts — expire at this turn's cleanup.
+            thisTurnStillCounts -> state.turnNumber
+            // Controller's own turn, but this turn no longer counts — their next turn is next round.
+            onControllerTurn -> state.turnNumber + 1
+            // Opponent's turn: the controller still takes a turn *this* round if they come later in
+            // turn order; otherwise they already went and their next turn is in the next round.
+            playerIndex > activeIndex -> state.turnNumber
+            else -> state.turnNumber + 1
         }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShadowUrchinTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShadowUrchinTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ecl.cards.ShadowUrchin
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Shadow Urchin.
+ *
+ * Shadow Urchin {2}{B/R} — Creature — Ouphe 3/4
+ * Whenever a creature you control with one or more counters on it dies, exile that many cards from
+ * the top of your library. Until your next end step, you may play those cards.
+ *
+ * Regression guard for the reported bug: when the counter-bearing creature dies during the
+ * OPPONENT's turn, "until your next end step" must close at the controller's own next end step — not
+ * a full turn later. The expiry is driven by the cleanup step, and `GameState.turnNumber` is
+ * round-based (it only increments when the starting player begins a new turn), so counting
+ * player-turns until the controller's turn over-counted whenever the grant happened on an opponent's
+ * turn, leaking the may-play window across an extra turn ("second turn from then still playable").
+ */
+class ShadowUrchinTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ShadowUrchin))
+        return driver
+    }
+
+    /** Advance to the next turn's precombat main, stepping out via the END step first. */
+    fun advanceToNextTurnMain(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+    }
+
+    // P1 is the starting player; P2 controls Shadow Urchin. P2 sits *after* P1 in the round, so when
+    // Shadow Urchin dies on P1's turn, P2's next end step is still this same round — the case the old
+    // round-based math pushed a full turn too late.
+    test("may-play window closes at the controller's own next end step when granted on the opponent's turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        // P2's Shadow Urchin carries a -1/-1 counter (as its own blight would leave). It is a 2/3.
+        val urchin = driver.putCreatureOnBattlefield(p2, "Shadow Urchin")
+        driver.addComponent(urchin, CountersComponent(mapOf(CounterType.MINUS_ONE_MINUS_ONE to 1)))
+
+        // P1's turn: bolt the urchin so a counter-bearing creature P2 controls dies on P1's turn.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.state.activePlayerId shouldBe p1
+        driver.giveMana(p1, Color.RED, 1)
+        val bolt = driver.putCardInHand(p1, "Lightning Bolt")
+        driver.castSpell(p1, bolt, listOf(urchin)).isSuccess shouldBe true
+
+        // Resolve the bolt + the death trigger (exile top card, grant may-play) on P1's turn.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN, maxPasses = 200)
+        val exiled = driver.getExile(p2)
+        exiled.size shouldBe 1
+        val card = exiled.first()
+        driver.state.mayPlayPermissions.any { card in it.cardIds } shouldBe true
+
+        // P2's own turn (same round): "until your next end step" is still open here.
+        advanceToNextTurnMain(driver)
+        driver.state.activePlayerId shouldBe p2
+        driver.state.mayPlayPermissions.any { card in it.cardIds } shouldBe true
+
+        // P1's next turn (next round): the window closed at the cleanup of P2's turn above. Before the
+        // fix it leaked into here — the reported "second turn from then still playable" bug.
+        advanceToNextTurnMain(driver)
+        driver.state.activePlayerId shouldBe p1
+        driver.state.mayPlayPermissions.any { card in it.cardIds } shouldBe false
+    }
+})


### PR DESCRIPTION
## Bug

Shadow Urchin's exile-and-play effect grants *"Until your next end step, you may play those cards."* When the counter-bearing creature **dies during the opponent's turn**, the exiled cards stayed playable a full extra turn — *"second turn from then [the] exiled are still playable"* (reported).

## Root cause

`MayPlayExpiry.UntilNextEndStep` permissions are removed at the **cleanup** step, gated on the controller's own turn (`activePlayerId == controllerId`). `GameState.turnNumber` is **round-based** — it increments only when the starting player begins a new turn, so every player's turn within a round shares the same number; the `activePlayerId` check is what disambiguates whose turn it is.

`resolveStepTurn` (in `ExileTopCardMayPlayFreeExecutor`) instead counted **player-turns** until the controller's turn and added them to that round-based number:

```kotlin
(playerIndex - activeIndex + playerCount) % playerCount
```

When the grant happens on an **opponent's turn** and the controller comes **later** in turn order, this returns `turnNumber + 1` (next round) instead of `turnNumber` (this round) — so the permission survives an extra full turn. Shadow Urchin's death trigger fires on the opponent's turn, hitting exactly this path.

The grant-on-your-own-turn path (Burning Curiosity, Sizzling Changeling) was already correct and is unchanged.

## Fix

Compute the controller's next matching **round** directly instead of counting player-turns:

- grant still counts this turn → `turnNumber`
- controller's own turn but this turn no longer counts → `turnNumber + 1`
- opponent's turn, controller comes later in the round → `turnNumber` (this round)
- opponent's turn, controller already went → `turnNumber + 1` (next round)

## Test

Adds `ShadowUrchinTest` covering the opponent's-turn grant: a counter-bearing Shadow Urchin (controlled by the non-starting player) is bolted on the starting player's turn; the may-play window must close at the controller's own next end step, not a turn later. Verified the test **fails** against the old logic and **passes** with the fix. Existing own-turn regression tests (`BurningCuriosityTest`, `SizzlingChangelingTest`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)