### PR TITLE
Add Metamorphosis to Arabian Nights

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Metamorphosis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Metamorphosis.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Metamorphosis
+ * {G}
+ * Sorcery
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Add X mana of any one color, where X is 1 plus the sacrificed creature's mana value.
+ * Spend this mana only to cast creature spells.
+ *
+ * The sacrificed creature's mana value is read from the cost-payment snapshot
+ * (last-known information), since the creature is in the graveyard by resolution
+ * time — see [EntityReference.Sacrificed]. The produced mana is a single chosen
+ * color, added `1 + the sacrificed creature's mana value` times, carrying
+ * [ManaRestriction.CreatureSpellsOnly] so it can only pay for creature spells
+ * (including their additional costs such as Kicker, per the 2004 ruling).
+ */
+val Metamorphosis = card("Metamorphosis") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\n" +
+        "Add X mana of any one color, where X is 1 plus the sacrificed creature's mana value. " +
+        "Spend this mana only to cast creature spells."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Creature))
+
+    spell {
+        effect = Effects.AddAnyColorMana(
+            amount = DynamicAmount.Add(
+                DynamicAmount.Fixed(1),
+                DynamicAmount.EntityProperty(
+                    EntityReference.Sacrificed(0),
+                    EntityNumericProperty.ManaValue
+                )
+            ),
+            restriction = ManaRestriction.CreatureSpellsOnly
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Christopher Rush"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbc6cfc3-b232-40bf-bc0c-4618f6f5c9a5.jpg?1562942451"
+        ruling("2013-04-15", "You must sacrifice exactly one creature to cast this spell; you cannot cast it without sacrificing a creature, and you cannot sacrifice additional creatures.")
+        ruling("2004-10-04", "This mana may be used on additional costs to cast the spell, such as Kicker.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/MetamorphosisReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/MetamorphosisReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Metamorphosis reprint in PZ2 (Treasure Chest). Canonical CardDefinition lives in
+ * Arabian Nights (its earliest printing); this file contributes only presentation data.
+ */
+val MetamorphosisReprint = Printing(
+    oracleId = "7140d726-0136-43af-84b5-85005a66a186",
+    name = "Metamorphosis",
+    setCode = "PZ2",
+    collectorNumber = "65839",
+    scryfallId = "4d0776db-ebb3-472d-8a90-5bd149b97346",
+    artist = "Michael Sutfin",
+    imageUri = "https://cards.scryfall.io/normal/front/4/d/4d0776db-ebb3-472d-8a90-5bd149b97346.jpg?1562253906",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -2076,6 +2076,56 @@
     ]
 }
 
+// Metamorphosis
+{
+    "name": "Metamorphosis",
+    "manaCost": "{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature.\nAdd X mana of any one color, where X is 1 plus the sacrificed creature's mana value. Spend this mana only to cast creature spells.",
+    "script": {
+        "spellEffect": {
+            "type": "AddManaOfChoice",
+            "amount": {
+                "type": "Add",
+                "left": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "right": {
+                    "type": "EntityProperty",
+                    "entity": "Sacrificed",
+                    "numericProperty": "ManaValue"
+                }
+            },
+            "restriction": "CreatureSpellsOnly"
+        },
+        "additionalCosts": [
+            {
+                "type": "SacrificePermanent",
+                "filter": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Christopher Rush",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbc6cfc3-b232-40bf-bc0c-4618f6f5c9a5.jpg?1562942451",
+        "rulings": [
+            {
+                "date": "2013-04-15",
+                "text": "You must sacrifice exactly one creature to cast this spell; you cannot cast it without sacrificing a creature, and you cannot sacrifice additional creatures."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "This mana may be used on additional costs to cast the spell, such as Kicker."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Mijae Djinn
 {
     "name": "Mijae Djinn",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MetamorphosisScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MetamorphosisScenarioTest.kt
@@ -1,0 +1,190 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Metamorphosis (ARN) — {G} Sorcery.
+ *
+ * "As an additional cost to cast this spell, sacrifice a creature.
+ *  Add X mana of any one color, where X is 1 plus the sacrificed creature's mana value.
+ *  Spend this mana only to cast creature spells."
+ *
+ * This is the first card that pairs a SPELL additional-cost sacrifice with an
+ * [com.wingedsheep.sdk.scripting.values.EntityReference.Sacrificed] reference in the
+ * resolving effect, so the test pins three things at once:
+ *   - the dynamic amount resolves to 1 + the sacrificed creature's mana value, read from
+ *     the cost-payment snapshot (the creature is in the graveyard by resolution);
+ *   - the player picks a single color and gets X of it;
+ *   - every produced mana carries [ManaRestriction.CreatureSpellsOnly].
+ */
+class MetamorphosisScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Metamorphosis additional-cost sacrifice produces restricted mana") {
+
+            test("sacrificing a mana-value-2 creature yields 3 chosen-color creature-only mana") {
+                // Grizzly Bears is {1}{G} → mana value 2, so X = 1 + 2 = 3.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Metamorphosis")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Metamorphosis"
+                }
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        emptyList(),
+                        additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(bears))
+                    )
+                )
+                withClue("Cast sacrificing Grizzly Bears should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                // Sacrifice happened up front, before the spell is on the stack.
+                game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+
+                game.resolveStack()
+
+                // Resolving the AddManaOfChoice effect pauses for a single color choice.
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<ChooseColorDecision>()
+                game.submitDecision(ColorChosenResponse(decision.id, Color.RED))
+
+                val pool = game.state.getEntity(game.player1Id)!!.get<ManaPoolComponent>()!!
+                withClue("X = 1 + mana value 2 = 3 restricted mana entries") {
+                    pool.restrictedMana shouldHaveSize 3
+                }
+                pool.restrictedMana.forEach { entry ->
+                    entry.color shouldBe Color.RED
+                    entry.restriction shouldBe ManaRestriction.CreatureSpellsOnly
+                }
+            }
+
+            test("amount scales with the sacrificed creature's mana value") {
+                // Hill Giant is {3}{R} → mana value 4, so X = 1 + 4 = 5.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Metamorphosis")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Metamorphosis"
+                }
+
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        emptyList(),
+                        additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(giant))
+                    )
+                ).error shouldBe null
+
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<ChooseColorDecision>()
+                game.submitDecision(ColorChosenResponse(decision.id, Color.BLUE))
+
+                val pool = game.state.getEntity(game.player1Id)!!.get<ManaPoolComponent>()!!
+                withClue("X = 1 + mana value 4 = 5 restricted mana entries") {
+                    pool.restrictedMana shouldHaveSize 5
+                }
+                pool.restrictedMana.forEach { entry ->
+                    entry.color shouldBe Color.BLUE
+                    entry.restriction shouldBe ManaRestriction.CreatureSpellsOnly
+                }
+            }
+
+            test("produced mana pays a creature spell but not a noncreature spell") {
+                // Sacrifice Hill Giant (mana value 4) → 5 chosen-color creature-only mana.
+                // Glasses of Urza is a {1} artifact: red mana could cover its generic cost
+                // color-wise, so the only thing stopping it is CreatureSpellsOnly — which is
+                // exactly the restriction this test isolates. Hill Giant ({3}{R}) is a creature
+                // spell the same pool can pay (including its additional/colored pips).
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Metamorphosis")
+                    .withCardInHand(1, "Hill Giant")
+                    .withCardInHand(1, "Glasses of Urza")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sacFodder = game.findPermanent("Hill Giant")!!
+                val metamorphosis = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Metamorphosis"
+                }
+
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        metamorphosis,
+                        emptyList(),
+                        additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(sacFodder))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<ChooseColorDecision>()
+                game.submitDecision(ColorChosenResponse(decision.id, Color.RED))
+
+                // The {G} for Metamorphosis came from the only Forest, so the restricted pool
+                // is now the sole mana available.
+                val glasses = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Glasses of Urza"
+                }
+                val noncreatureCast = game.execute(
+                    CastSpell(game.player1Id, glasses, emptyList(), paymentStrategy = PaymentStrategy.FromPool)
+                )
+                withClue("CreatureSpellsOnly mana must NOT pay for the {1} artifact") {
+                    noncreatureCast.error shouldNotBe null
+                }
+
+                val handGiant = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Hill Giant"
+                }
+                val creatureCast = game.execute(
+                    CastSpell(game.player1Id, handGiant, emptyList(), paymentStrategy = PaymentStrategy.FromPool)
+                )
+                withClue("CreatureSpellsOnly mana pays the {3}{R} creature spell: ${creatureCast.error}") {
+                    creatureCast.error shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
{G} Sorcery. As an additional cost to cast, sacrifice a creature; add X mana of any one chosen color where X is 1 plus the sacrificed creature's mana value, spendable only on creature spells.

Composes existing primitives — additional-cost SacrificePermanent, the Sacrificed(0) entity reference + ManaValue (read from the cost-payment snapshot as last-known info), AddManaOfChoice over AnyColor with a dynamic 1 + MV amount, and the CreatureSpellsOnly mana restriction — so no engine changes were needed.

Scenario test pins the first spell-side pairing of an additional-cost sacrifice with a Sacrificed reference in the resolving effect: the amount scales with the sacrificed creature's mana value, the mana is single-color, and a functional case proves the produced mana pays a creature spell ({3}{R} Hill Giant) but is refused for a noncreature spell ({1} Glasses of Urza) — isolating CreatureSpellsOnly as the sole blocker. Adds the PZ2 (Treasure Chest) reprint row.