### PR TITLE
Make the mythic-era (2008-2023) booster division exact: 10 commons

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -142,10 +142,12 @@ Optional overrides commonly used by real sets:
 
 - `basicLandsFallback = OnslaughtSet` — point at another set's basics when yours has none.
 - `boosterStrategy = …` — override the era default for custom slots. The default follows
-  `releaseDate`: sets before Murders at Karlov Manor (2024-02-09) get the classic 15-card
-  `StandardBooster` (11C / 3U / 1R-or-mythic); later sets get the modern `PlayBooster`
-  division (7C / 3U / 1R-or-mythic at 12.5% / 2 any-rarity wildcards — 13 cards, since the
-  engine has no foils and supplies basics at deck building).
+  `releaseDate`: pre-mythic sets get the classic 15-card `StandardBooster` (11C / 3U / 1R);
+  Shards of Alara (2008-10-03) through 2023 get 10 commons (the paper land slot is supplied
+  at deck building) with the 12.5% mythic upgrade; Murders at Karlov Manor (2024-02-09)
+  onward gets the modern `PlayBooster` division (7C / 3U / 1R-or-mythic at 12.5% / 2
+  any-rarity wildcards — 13 cards, since the engine has no foils and supplies basics at
+  deck building).
 - `printings: List<Printing>` — register reprints whose canonical `CardDefinition` lives in an
   earlier set.
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/MtgSet.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/MtgSet.kt
@@ -41,14 +41,26 @@ interface MtgSet {
     /**
      * Strategy that turns the set's card pool into a single booster pack.
      *
-     * The default follows the set's era, derived from [releaseDate]: sets from
-     * Murders at Karlov Manor (2024-02-09) onward get the 14-card [PlayBooster]
-     * division; earlier sets (and sets without a release date) get the classic
-     * 15-card [StandardBooster] (11C / 3U / 1R-or-mythic). Sets override this to
+     * The default follows the set's era, derived from [releaseDate]:
+     *  - before Shards of Alara: classic 15-card [StandardBooster] (11C / 3U / 1R)
+     *  - Shards of Alara (2008-10-03) to Murders at Karlov Manor: [StandardBooster]
+     *    with 10 commons — paper packs swapped the 11th common for a basic land
+     *    (omitted here; the generator supplies basics at deck building) and
+     *    introduced the mythic upgrade on the rare slot
+     *  - Murders at Karlov Manor (2024-02-09) onward: the [PlayBooster] division
+     *
+     * Sets without a release date get the classic booster. Sets override this to
      * express custom slot rules (guaranteed legendary, commander draft, etc.).
      */
     val boosterStrategy: BoosterStrategy
-        get() = if ((releaseDate ?: "") >= PLAY_BOOSTER_ERA_START) PlayBooster() else StandardBooster()
+        get() {
+            val date = releaseDate ?: ""
+            return when {
+                date >= PLAY_BOOSTER_ERA_START -> PlayBooster()
+                date >= MYTHIC_BOOSTER_ERA_START -> StandardBooster(commons = 10)
+                else -> StandardBooster()
+            }
+        }
 
     /**
      * If this set has no basic lands of its own, the set whose lands should be
@@ -83,8 +95,15 @@ interface MtgSet {
 
     companion object {
         /**
+         * Release date of Shards of Alara, the first set with mythic rares and
+         * the 10-common booster (a basic land took the 11th common's slot).
+         * ISO dates compare correctly as strings.
+         */
+        const val MYTHIC_BOOSTER_ERA_START = "2008-10-03"
+
+        /**
          * Release date of Murders at Karlov Manor, the first set printed as
-         * 14-card Play Boosters. ISO dates compare correctly as strings.
+         * 14-card Play Boosters.
          */
         const val PLAY_BOOSTER_ERA_START = "2024-02-09"
     }

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/model/MtgSetBoosterEraTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/model/MtgSetBoosterEraTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.sdk.model
 import com.wingedsheep.sdk.limited.PlayBooster
 import com.wingedsheep.sdk.limited.StandardBooster
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class MtgSetBoosterEraTest : DescribeSpec({
@@ -16,9 +17,20 @@ class MtgSetBoosterEraTest : DescribeSpec({
 
     describe("MtgSet.boosterStrategy era default") {
 
-        it("uses the classic 15-card booster for pre-2024 sets") {
-            setWithReleaseDate("1997-05-01").boosterStrategy.shouldBeInstanceOf<StandardBooster>()
-            setWithReleaseDate("2023-11-17").boosterStrategy.shouldBeInstanceOf<StandardBooster>()
+        it("uses the classic 11-common booster for pre-mythic sets") {
+            val strategy = setWithReleaseDate("1997-05-01").boosterStrategy
+            strategy.shouldBeInstanceOf<StandardBooster>().commons shouldBe 11
+            setWithReleaseDate("2008-05-02").boosterStrategy
+                .shouldBeInstanceOf<StandardBooster>().commons shouldBe 11
+        }
+
+        it("uses the 10-common booster from Shards of Alara through 2023") {
+            setWithReleaseDate(MtgSet.MYTHIC_BOOSTER_ERA_START).boosterStrategy
+                .shouldBeInstanceOf<StandardBooster>().commons shouldBe 10
+            setWithReleaseDate("2015-07-17").boosterStrategy
+                .shouldBeInstanceOf<StandardBooster>().commons shouldBe 10
+            setWithReleaseDate("2023-11-17").boosterStrategy
+                .shouldBeInstanceOf<StandardBooster>().commons shouldBe 10
         }
 
         it("uses the Play Booster from Murders at Karlov Manor onward") {
@@ -28,7 +40,8 @@ class MtgSetBoosterEraTest : DescribeSpec({
         }
 
         it("falls back to the classic booster when the release date is unknown") {
-            setWithReleaseDate(null).boosterStrategy.shouldBeInstanceOf<StandardBooster>()
+            setWithReleaseDate(null).boosterStrategy
+                .shouldBeInstanceOf<StandardBooster>().commons shouldBe 11
         }
     }
 })

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/DominariaSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/DominariaSet.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.dom
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.limited.BoosterStrategy
 import com.wingedsheep.sdk.limited.GuaranteedLegendaryBooster
+import com.wingedsheep.sdk.limited.StandardBooster
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
 import com.wingedsheep.sdk.model.Printing
@@ -23,7 +24,8 @@ object DominariaSet : MtgSet {
     override val displayName = "Dominaria"
     override val releaseDate = "2018-04-27"
     override val sealedSupported = true
-    override val boosterStrategy: BoosterStrategy = GuaranteedLegendaryBooster()
+    // Mythic-era base (10 commons; the paper land slot is supplied at deck building).
+    override val boosterStrategy: BoosterStrategy = GuaranteedLegendaryBooster(StandardBooster(commons = 10))
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
@@ -9,10 +9,11 @@ import kotlin.random.Random
 /**
  * Generates booster packs and sealed pools from card sets.
  *
- * Pack composition is delegated to each set's [BoosterStrategy]: classic sets use
- * the 15-card [StandardBooster] (11C / 3U / 1R-or-mythic), Play-Booster-era sets
- * (Murders at Karlov Manor, 2024, onward) use [com.wingedsheep.sdk.limited.PlayBooster],
- * and sets can override with custom strategies (guaranteed legendary, commander draft).
+ * Pack composition is delegated to each set's [BoosterStrategy], which defaults by
+ * era: classic sets use the 15-card [StandardBooster] (11C / 3U / 1R), mythic-era
+ * sets (Shards of Alara, 2008, onward) drop to 10 commons, and Play-Booster-era sets
+ * (Murders at Karlov Manor, 2024, onward) use [com.wingedsheep.sdk.limited.PlayBooster].
+ * Sets can override with custom strategies (guaranteed legendary, commander draft).
  *
  * ## Scope
  *


### PR DESCRIPTION
## Summary

Follow-up to the Play Booster division (382a47931): make the middle era exact too.

Shards of Alara (2008-10-03) swapped the 11th common for a basic land and introduced the mythic upgrade on the rare slot. `MtgSet.boosterStrategy` now defaults across **three era tiers** derived from `releaseDate`:

| Era | Default | Engine pack |
|---|---|---|
| pre-Alara (and undated sets) | `StandardBooster()` | 11C / 3U / 1R — 15 cards |
| Alara → 2023 (`MYTHIC_BOOSTER_ERA_START`) | `StandardBooster(commons = 10)` | 10C / 3U / 1R-or-M (12.5%) — 14 cards |
| MKM 2024-02-09 onward (`PLAY_BOOSTER_ERA_START`) | `PlayBooster()` | 7C / 3U / 1R-or-M / 2 wildcards — 13 cards |

The paper land slot stays omitted in the engine, since the booster generator strips basics from the pool and supplies them free at deck building.

Dominaria (2018) explicitly overrides with `GuaranteedLegendaryBooster`, whose default base is the classic 11-common pack — its base is now `StandardBooster(commons = 10)` to match its printing era.

## Testing

- `MtgSetBoosterEraTest` extended to pin commons counts at the era boundaries (Shadowmoor 2008-05-02 → 11, Alara's exact date → 10, LCI 2023-11-17 → 10, MKM → PlayBooster, undated → 11).
- `PlayBoosterTest`, `BoosterGenerator*` tests, and `:mtg-sets:compileKotlin` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)