### PR TITLE
Default AI assistance off in tournaments; hide card ratings when off

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -257,9 +257,9 @@ class TournamentLobby(
      * false, the client hides the controls and the server rejects assist requests that carry this
      * lobby's id. This is an advisory toggle, not anti-cheat: the gate trusts the client-supplied
      * lobbyId (consistent with the other REST endpoints), so a modified client could still call the
-     * assist endpoints. Defaults on; a host can switch it off to signal that assistance is unwelcome.
+     * assist endpoints. Defaults off; a host can switch it on to allow assistance.
      */
-    var aiAssistEnabled: Boolean = true,
+    var aiAssistEnabled: Boolean = false,
 ) {
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -145,8 +145,8 @@ sealed interface ClientMessage {
         val maxPlayers: Int = 8,
         val pickTimeSeconds: Int = 45,     // Draft only
         val isPublic: Boolean = false,
-        /** Master switch for in-app AI assistance (Suggest Pick / Auto-build). Defaults on. */
-        val aiAssistEnabled: Boolean = true
+        /** Master switch for in-app AI assistance (Suggest Pick / Auto-build). Defaults off. */
+        val aiAssistEnabled: Boolean = false
     ) : ClientMessage
 
     /**

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/AiAssistControllerTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/AiAssistControllerTest.kt
@@ -35,6 +35,15 @@ class AiAssistControllerTest : FunSpec({
         aiAssistEnabled = assistEnabled,
     )
 
+    test("AI assistance defaults off for new tournament lobbies") {
+        val lobby = TournamentLobby(
+            setCodes = listOf("POR"),
+            setNames = listOf("Portal"),
+            boosterGenerator = BoosterGenerator(emptyMap()),
+        )
+        lobby.aiAssistEnabled shouldBe false
+    }
+
     test("suggest-pick returns scores when assistance is enabled") {
         val repo = InMemoryLobbyRepository()
         val lobby = lobby(assistEnabled = true)

--- a/web-client/src/components/draft/DraftPickOverlay.tsx
+++ b/web-client/src/components/draft/DraftPickOverlay.tsx
@@ -33,8 +33,11 @@ function DraftPicker({ draftState, settings }: { draftState: DraftState; setting
   const isHost = lobbyState?.isHost ?? false
 
   // AI "Suggest Pick" state — score badges + recommended-card highlight for the current pack.
-  const pickScores = useGameStore((s) => s.pickScores)
-  const recommendedPick = useGameStore((s) => s.recommendedPick)
+  // Hidden entirely (even if scores were already fetched) when the lobby has AI assistance off.
+  const storedPickScores = useGameStore((s) => s.pickScores)
+  const storedRecommendedPick = useGameStore((s) => s.recommendedPick)
+  const pickScores = settings.aiAssistEnabled ? storedPickScores : null
+  const recommendedPick = settings.aiAssistEnabled ? storedRecommendedPick : []
 
   // Build ordered player list in pack-passing order with pack counts
   const playerOrder = useMemo(() => {

--- a/web-client/src/components/sealed/DeckBuilderOverlay.tsx
+++ b/web-client/src/components/sealed/DeckBuilderOverlay.tsx
@@ -121,7 +121,7 @@ function WaitingForOpponent({ setName }: { setName: string }) {
 function DeckBuilder({ state }: { state: DeckBuildingState }) {
   const responsive = useResponsive()
   const addCardToDeck = useGameStore((s) => s.addCardToDeck)
-  const deckCardScores = useGameStore((s) => s.deckCardScores)
+  const storedDeckCardScores = useGameStore((s) => s.deckCardScores)
   const removeCardFromDeck = useGameStore((s) => s.removeCardFromDeck)
   const clearDeck = useGameStore((s) => s.clearDeck)
   const setLandCount = useGameStore((s) => s.setLandCount)
@@ -140,6 +140,10 @@ function DeckBuilder({ state }: { state: DeckBuildingState }) {
   const lobbyFormat = lobbyState?.settings.format
   const isCommanderShape = lobbyFormat === 'COMMANDER_DRAFT' || lobbyFormat === 'COMMANDER_SEALED'
   const commanderMinDeckSize = lobbyState?.settings.deckSizeMin ?? 60
+  // AI assistance is host-gated in lobbies; practice mode (no lobby) always allows it. When off,
+  // hide the controls AND any card score badges that were fetched before the host switched it off.
+  const aiAssistEnabled = lobbyState ? lobbyState.settings.aiAssistEnabled : true
+  const deckCardScores = aiAssistEnabled ? storedDeckCardScores : null
 
   const [hoveredCard, setHoveredCard] = useState<SealedCardInfo | null>(null)
   const [hoverPos, setHoverPos] = useState<{ x: number; y: number } | null>(null)
@@ -595,7 +599,7 @@ function DeckBuilder({ state }: { state: DeckBuildingState }) {
             </div>
           )}
 
-          {!isSubmitted && (lobbyState ? lobbyState.settings.aiAssistEnabled : true) && (
+          {!isSubmitted && aiAssistEnabled && (
             <AutoBuildControl hasCards={totalCount > 0} responsive={responsive} />
           )}
 

--- a/web-client/src/store/slices/handlers/lobbyHandlers.ts
+++ b/web-client/src/store/slices/handlers/lobbyHandlers.ts
@@ -21,7 +21,7 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
           lobbyId: msg.lobbyId,
           state: 'WAITING_FOR_PLAYERS',
           players: [],
-          settings: { setCodes: [], setNames: [], availableSets: [], format: 'SEALED', boosterCount: 6, boosterDistribution: {}, maxPlayers: 8, pickTimeSeconds: 45, picksPerRound: 1, gamesPerMatch: 1, isPublic: false, deckSizeMin: 60, allowDuplicates: true, commanderPreset: 'BRAWL', chaosBoosters: false, bannedCardNames: [], aiAssistEnabled: true },
+          settings: { setCodes: [], setNames: [], availableSets: [], format: 'SEALED', boosterCount: 6, boosterDistribution: {}, maxPlayers: 8, pickTimeSeconds: 45, picksPerRound: 1, gamesPerMatch: 1, isPublic: false, deckSizeMin: 60, allowDuplicates: true, commanderPreset: 'BRAWL', chaosBoosters: false, bannedCardNames: [], aiAssistEnabled: false },
           isHost: true,
           draftState: null,
           winstonDraftState: null,


### PR DESCRIPTION
## What

- **AI assistance now defaults to off** for newly created tournament lobbies. The host can still enable it via the existing On/Off toggle in lobby settings.
- **Card rating badges are hidden whenever AI assistance is not active**: the draft pick overlay and the deck builder gate the AI score badges (and the recommended-pick highlight) on `aiAssistEnabled`, so scores fetched before the host switches assistance off disappear immediately instead of lingering.

## Changes

- `ClientMessage.CreateTournamentLobby.aiAssistEnabled` default `true` → `false` (governs lobby creation — the client doesn't send the field).
- `TournamentLobby.aiAssistEnabled` default `true` → `false`.
- Client: the optimistic `onLobbyCreated` placeholder settings now start with `aiAssistEnabled: false`, matching the server (no flash of AI controls before the first `LobbyUpdate`).
- `DraftPickOverlay`: `pickScores` / `recommendedPick` are nulled out when `settings.aiAssistEnabled` is false.
- `DeckBuilderOverlay`: one `aiAssistEnabled` derivation (lobby setting; practice mode without a lobby stays allowed) now gates both the Auto-build/Score controls and the per-card score badges.

Deliberately unchanged:
- `PersistentLobby.aiAssistEnabled` keeps `= true` so lobbies persisted before the field existed retain their old behavior on reload; in-flight lobbies persist the field explicitly either way.
- `ServerMessage.LobbySettings` default is inert (always populated explicitly from the lobby).

## Testing

- New test in `AiAssistControllerTest` pins the lobby default to off; existing enable/disable 403-gating tests still pass (`./gradlew :game-server:test --tests "AiAssistControllerTest"` green).
- `npm run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)